### PR TITLE
Fix Structured Output Logic, Add Optional json_object for supporting o1 Models, and Disable Streaming for Pydantic Models

### DIFF
--- a/phi/model/base.py
+++ b/phi/model/base.py
@@ -58,6 +58,8 @@ class Model(BaseModel):
     structured_outputs: Optional[bool] = None
     # Whether the Model supports structured outputs.
     supports_structured_outputs: bool = False
+    # Whether the Model supports json_object output.
+    supports_json_output: bool = True
     # Whether to add images to the message content.
     add_images_to_message_content: bool = False
 

--- a/phi/model/openai/chat.py
+++ b/phi/model/openai/chat.py
@@ -99,6 +99,8 @@ class OpenAIChat(Model):
         async_client (Optional[AsyncOpenAIClient]): The asynchronous OpenAI client instance.
         structured_outputs (bool): Whether to use the structured outputs from the Model. Default is False.
         supports_structured_outputs (bool): Whether the Model supports structured outputs. Default is True.
+        supports_json_output (bool): Whether the Model supports json_object output. Default is True.
+        add_images_to_message_content (bool): Whether to add images to the message content. Default is True.
     """
 
     id: str = "gpt-4o"
@@ -143,6 +145,8 @@ class OpenAIChat(Model):
     structured_outputs: bool = False
     # Whether the Model supports structured outputs.
     supports_structured_outputs: bool = True
+    # Whether the Model supports json_object output.
+    supports_json_output: bool = True
     # Whether to add images to the message content.
     add_images_to_message_content: bool = True
 

--- a/phi/playground/router.py
+++ b/phi/playground/router.py
@@ -279,7 +279,9 @@ def get_async_playground_router(agents: List[Agent]) -> APIRouter:
         if body.image:
             base64_image = await process_image(body.image)
 
-        if body.stream:
+        # Streaming is not supported by pydantic models
+        stream = body.stream and new_agent_instance.response_model is None
+        if stream:
             return StreamingResponse(
                 chat_response_streamer(new_agent_instance, body.message, base64_image),
                 media_type="text/event-stream",
@@ -288,7 +290,7 @@ def get_async_playground_router(agents: List[Agent]) -> APIRouter:
             run_response = cast(
                 RunResponse, await new_agent_instance.arun(body.message, images=base64_image, stream=False)
             )
-            return run_response.model_dump_json()
+            return run_response.model_dump()
 
     @playground_router.post("/agent/sessions/all")
     async def get_agent_sessions(body: AgentSessionsRequest):


### PR DESCRIPTION
- New `supports_json_output` Property: Adds a property to models to specify if `json_object` mode is supported.
- Improved Fallback Logic for Structured Output: Fixes an issue where fallback logic for structured outputs would return `None` instead of a valid output.
- Disables Streaming for Pydantic Response Models: Updates the agent to avoid returning a stream when a `response_model` (using Pydantic) is specified, as streaming is incompatible with Pydantic models. The UI currently expects streaming, and adjustments will be required to support this change.