### PR TITLE
Add SerpApi Google Light

### DIFF
--- a/phi/tools/serpapi_tools.py
+++ b/phi/tools/serpapi_tools.py
@@ -21,15 +21,16 @@ class SerpApiTools(Toolkit):
 
         self.api_key = api_key or getenv("SERP_API_KEY")
         if not self.api_key:
-            logger.warning("No Serpapi API key provided")
+            logger.warning("No SerpApi API key provided")
 
         self.register(self.search_google)
+        self.register(self.search_google_light)
         if search_youtube:
             self.register(self.search_youtube)
 
     def search_google(self, query: str, num_results: int = 10) -> str:
         """
-        Search Google using the Serpapi API. Returns the search results.
+        Search Google using the SerpApi API. Returns the search results.
 
         Args:
             query(str): The query to search for.
@@ -39,6 +40,8 @@ class SerpApiTools(Toolkit):
             str: The search results from Google.
                 Keys:
                     - 'search_results': List of organic search results.
+                    - 'answer_box': Answer box result.
+                    - 'top_stories': List of top stories results.
                     - 'recipes_results': List of recipes search results.
                     - 'shopping_results': List of shopping search results.
                     - 'knowledge_graph': The knowledge graph.
@@ -60,6 +63,8 @@ class SerpApiTools(Toolkit):
 
             filtered_results = {
                 "search_results": results.get("organic_results", ""),
+                "answer_box": results.get("answer_box", ""),
+                "top_stories": results.get("top_stories", ""),
                 "recipes_results": results.get("recipes_results", ""),
                 "shopping_results": results.get("shopping_results", ""),
                 "knowledge_graph": results.get("knowledge_graph", ""),
@@ -70,10 +75,56 @@ class SerpApiTools(Toolkit):
 
         except Exception as e:
             return f"Error searching for the query {query}: {e}"
+        
+    def search_google_light(self, query: str, num_results: int = 10) -> str:
+        """
+        Search Google with faster response time using the SerpApi Google Light API. Returns the search results.
+
+        Args:
+            query(str): The query to search for.
+            num_results(int): The number of results to return.
+
+        Returns:
+            str: The search results from Google.
+                Keys:
+                    - 'search_results': List of organic search results.
+                    - 'answer_box': Answer box result.
+                    - 'top_stories': List of top stories results.
+                    - 'knowledge_graph': The knowledge graph.
+                    - 'related_questions': List of related questions.
+                    - 'related_searches': List of related searches.
+        """
+
+        try:
+            if not self.api_key:
+                return "Please provide an API key"
+            if not query:
+                return "Please provide a query to search for"
+
+            logger.info(f"Searching Google for: {query}")
+
+            params = {"q": query, "api_key": self.api_key, "num": num_results}
+
+            search = serpapi.SerpApiClient(params, "google_light")
+            results = search.get_dict()
+
+            filtered_results = {
+                "search_results": results.get("organic_results", ""),
+                "answer_box": results.get("answer_box", ""),
+                "top_stories": results.get("top_stories", ""),
+                "knowledge_graph": results.get("knowledge_graph", ""),
+                "related_questions": results.get("related_questions", ""),
+                "related_searches": results.get("related_searches", ""),
+            }
+
+            return json.dumps(filtered_results)
+
+        except Exception as e:
+            return f"Error searching for the query {query}: {e}"
 
     def search_youtube(self, query: str) -> str:
         """
-        Search Youtube using the Serpapi API. Returns the search results.
+        Search Youtube using the SerpApi API. Returns the search results.
 
         Args:
             query(str): The query to search for.


### PR DESCRIPTION
Adding SerpApi Google Light API which perform ~3x faster than regular Google Search API. If you need a few of the essential data (organic results, related questions, knowledge graph, etc), this is a great pick.

<img width="1077" alt="Screenshot 2025-01-23 at 1 20 38 PM" src="https://github.com/user-attachments/assets/7f6d180f-fa0a-4e94-8be3-d6094f009c52" />

<img width="1075" alt="Screenshot 2025-01-23 at 1 20 27 PM" src="https://github.com/user-attachments/assets/a87e2487-95c5-4b02-ad6c-cdea7e72dc0e" />

- [x] New feature (non-breaking change which adds functionality)
