### PR TITLE
Fix the cal tool to make the email param optional

### DIFF
--- a/phi/tools/calcom.py
+++ b/phi/tools/calcom.py
@@ -163,7 +163,7 @@ class CalCom(Toolkit):
         """Get all upcoming bookings for an attendee.
 
         Args:
-            email: Optional Attendee's email
+            email (str): Attendee's email [Optional]
 
         Returns:
             str: List of upcoming bookings or error message

--- a/phi/tools/calcom.py
+++ b/phi/tools/calcom.py
@@ -159,18 +159,20 @@ class CalCom(Toolkit):
             logger.error(f"Error creating booking: {e}")
             return f"Error: {str(e)}"
 
-    def get_upcoming_bookings(self, email: str) -> str:
+    def get_upcoming_bookings(self, email: Optional[str] = None) -> str:
         """Get all upcoming bookings for an attendee.
 
         Args:
-            email: Attendee's email
+            email: Optional Attendee's email
 
         Returns:
             str: List of upcoming bookings or error message
         """
         try:
             url = "https://api.cal.com/v2/bookings"
-            querystring = {"status": "upcoming", "attendeeEmail": email}
+            querystring = {"status": "upcoming"}
+            if email:
+                querystring["attendeeEmail"] = email
 
             response = requests.get(url, headers=self._get_headers(), params=querystring)
             if response.status_code == 200:


### PR DESCRIPTION
## Description

Made changes to the `get_upcoming_bookings` function in cal-tool by making the email parameter optional so that user doesn't have to pass the attendee's email id to get their upcoming bookings.

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [x] I have added cookbook examples for my new addition (if needed)
- [x] I have updated requirements.txt/pyproject.toml (if needed)
- [x] I have verified my changes in a clean environment

