### PR TITLE
remove use-tools param

### DIFF
--- a/cookbook/playground/upload_files.py
+++ b/cookbook/playground/upload_files.py
@@ -32,7 +32,7 @@ knowledge_base = CombinedKnowledgeBase(
     vector_db=PgVector(table_name="recipes_combined", db_url=db_url),
 )
 
-agent = Agent(knowledge=knowledge_base, use_tools=True, show_tool_calls=True)
+agent = Agent(knowledge=knowledge_base, show_tool_calls=True)
 
 app = Playground(agents=[agent]).get_app()
 


### PR DESCRIPTION
## Description


Fixes # (issue)
removed `use_tools` from cookbook/playground/upload_files.py
---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [x] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [x] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
