### PR TITLE
converting defaultdict to dict in RunResponse.to_dict()

### DIFF
--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -72,7 +72,9 @@ class RunResponse:
     created_at: int = field(default_factory=lambda: int(time()))
 
     def to_dict(self) -> Dict[str, Any]:
-        self.metrics = dict(self.metrics)
+        if self.metrics is not None:
+            self.metrics = dict(self.metrics)
+
         _dict = {k: v for k, v in asdict(self).items() if v is not None and k != "messages"}
         if self.messages is not None:
             _dict["messages"] = [m.to_dict() for m in self.messages]

--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -72,6 +72,7 @@ class RunResponse:
     created_at: int = field(default_factory=lambda: int(time()))
 
     def to_dict(self) -> Dict[str, Any]:
+        self.metrics = dict(self.metrics)
         _dict = {k: v for k, v in asdict(self).items() if v is not None and k != "messages"}
         if self.messages is not None:
             _dict["messages"] = [m.to_dict() for m in self.messages]


### PR DESCRIPTION
asdict doesn't support defaultdict in Python 3.11. So converting RunResponse.metrics to dict before running asdict.

## Description

- **Summary of changes**:  Converting RunResponse.metrics to dict in RunResponse.to_dict()
- **Related issues**:  https://github.com/python/cpython/pull/32056
- **Motivation and context**: asdict doesn't support defaultdict in Python 3.11. So RunResponse.to_dict() doesn't work.
- **Environment or dependencies**: None
- **Impact on metrics**: (If applicable) None

Fixes # (issue)

asdict doesn't support defaultdict in Python 3.11. So RunResponse.to_dict() doesn't work.
https://github.com/python/cpython/pull/32056c
---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
