### PR TITLE
NVIDIARerank from langchain

### DIFF
--- a/libs/agno/agno/reranker/nvidia.py
+++ b/libs/agno/agno/reranker/nvidia.py
@@ -1,0 +1,72 @@
+from typing import List, Optional
+
+
+from agno.document import Document
+from agno.reranker.base import Reranker
+from agno.utils.log import logger
+
+try:
+    from langchain_nvidia_ai_endpoints import NVIDIARerank
+except ImportError:
+    raise ImportError(
+        "langchain_nvidia_ai_endpoints is not installed, please run pip install langchain-nvidia-ai-endpoint"
+    )
+
+try:
+    from langchain.docstore.document import Document as LCDocument
+except ImportError:
+    raise ImportError(
+        "langchain is not installed, please run pip install langchain"
+    )
+
+class NVIDIALangchainReranker(Reranker):
+    model: str = "nvidia/llama-3.2-nv-rerankqa-1b-v2"
+    api_key: Optional[str] = None
+    top_n: Optional[int] = None
+
+    def _rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        # Validate input documents and top_n
+        if not documents:
+            return []
+
+        top_n = self.top_n
+        if top_n and not (0 < top_n):
+            logger.warning(f"top_n should be a positive integer, got {self.top_n}, setting top_n to None")
+            top_n = None
+
+        # Create a list of Documents in the langchain format
+        lc_docs: list[LCDocuments] = []
+        for doc in documents:
+            lc_docs.append(
+                LCDocument(
+                    page_content=doc.content,
+                )
+            )
+
+        # Rerank using the NVIDIARerank from langchain
+        reranker = NVIDIARerank(model=self.model)
+        response = reranker.compress_documents(query=query, documents=lc_docs)
+
+        # convert back to Agno's Document format
+        compressed_docs: list[Document] = []
+        for r in response:
+            compressed_docs.append(Document(content=r.page_content, reranking_score=r.metadata["relevance_score"]))
+
+        # Order by relevance score
+        compressed_docs.sort(
+            key=lambda x: x.reranking_score if x.reranking_score is not None else float("-inf"),
+            reverse=True,
+        )
+
+        # Limit to top_n if specified
+        if top_n:
+            compressed_docs = compressed_docs[:top_n]
+
+        return compressed_docs
+
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        try:
+            return self._rerank(query=query, documents=documents)
+        except Exception as e:
+            logger.error(f"Error reranking documents: {e}. Returning original documents")
+            return documents


### PR DESCRIPTION
## Description

- **Summary of changes**: Describe the key changes in this PR and their purpose.
A new rerank class to add NVIDIARerank using langchain-nvidia-ai-endpoints module

- **Related issues**: Mention if this PR fixes or is connected to any issues.
- **Motivation and context**: Explain the reason for the changes and the problem they solve.
I have an AWS instance running the llama-3.2-nv-rerankqa-1b-v2 model from NVidia in a docker container. 

- **Environment or dependencies**: Specify any changes in dependencies or environment configurations required for this update.
Need to pip install langchain-nvidia-ai-endpoints

- **Impact on metrics**: (If applicable) Describe changes in any metrics or performance benchmarks.

Fixes # (issue)

---

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ √] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [√ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ √] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [√ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
