### PR TITLE
fix: pineconedb use namespace value from global variable

### DIFF
--- a/libs/agno/agno/vectordb/pineconedb/pineconedb.py
+++ b/libs/agno/agno/vectordb/pineconedb/pineconedb.py
@@ -316,7 +316,7 @@ class PineconeDb(VectorDb):
                 vector=hdense,
                 sparse_vector=hsparse,
                 top_k=limit,
-                namespace=namespace,
+                namespace=namespace or self.namespace,
                 filter=filters,
                 include_values=include_values,
                 include_metadata=True,
@@ -325,7 +325,7 @@ class PineconeDb(VectorDb):
             response = self.index.query(
                 vector=dense_embedding,
                 top_k=limit,
-                namespace=namespace,
+                namespace=namespace or self.namespace,
                 filter=filters,
                 include_values=include_values,
                 include_metadata=True,


### PR DESCRIPTION
## Description

- **Summary of changes**: Describe the key changes in this PR and their purpose. modified PineconeDb class on searching namespaces to use namespace value from the global variable
- **Related issues**: 
- **Motivation and context**: so user can use pineconedb to search by their defined namespace value instead ( default ) namespace.
- **Environment or dependencies**:
- **Impact on metrics**: 

Fixes # (issue)

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
