### PR TITLE
raise error: instead of defaulting any model

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -493,7 +493,7 @@ class Agent:
 
         logger.debug(f"*********** Agent Run Start: {self.run_response.run_id} ***********")
 
-        # 2. Update the Model and resolve context
+        # 2. raise the error to provide the model instead of defaulting any model and resolve context
         self.update_model()
         self.run_response.model = self.model.id if self.model is not None else None
         if self.context is not None and self.resolve_context:
@@ -927,7 +927,7 @@ class Agent:
 
         logger.debug(f"*********** Async Agent Run Start: {self.run_response.run_id} ***********")
 
-        # 2. Update the Model and resolve context
+        # 2. raise the error to provide the model instead of defaulting any model and resolve context
         self.update_model()
         self.run_response.model = self.model.id if self.model is not None else None
         if self.context is not None and self.resolve_context:
@@ -1405,18 +1405,13 @@ class Agent:
                 model.set_functions(functions=self._functions_for_model)
 
     def update_model(self) -> None:
-        # Use the default Model (OpenAIChat) if no model is provided
+        #raise the error to provide the model instead of defaulting any model
         if self.model is None:
-            try:
-                from agno.models.openai import OpenAIChat
-            except ModuleNotFoundError as e:
-                logger.exception(e)
-                logger.error(
-                    "Agno agents use `openai` as the default model provider. "
-                    "Please provide a `model` or install `openai`."
-                )
-                exit(1)
-            self.model = OpenAIChat(id="gpt-4o")
+            logger.error(
+                "No model provided. Please specify a model when initializing the agent.\n"
+                "Example: YourAgent(model=YourModelClass(id='your-model-id'))"
+            )
+            exit(1)
 
         # Update the response_format on the Model
         if self.response_model is not None:


### PR DESCRIPTION
## Description

- **Summary of changes**: Removed automatic fallback to OpenAI model and enforced explicit model specification
- **Related issues**: fixes 
- **Motivation and context**: Given that Agno is designed to support multiple models, forcing OpenAI as the default model is not ideal.
  - Ensures intentional model selection by users
  - Improves error messaging for missing configuration
  - Increases framework flexibility by removing default model assumption

- **Environment or dependencies**: Removes implicit requirement for `openai` package
- **Impact on metrics**: N/A (configuration change rather than model performance change)

Fixes # (issue)

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [x] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
