### PR TITLE
fix: mistral initialization

### DIFF
--- a/libs/agno/agno/embedder/mistral.py
+++ b/libs/agno/agno/embedder/mistral.py
@@ -42,7 +42,7 @@ class MistralEmbedder(Embedder):
             if self.client_params:
                 _client_params.update(self.client_params)
             
-            self.mistral_client = Mistral(**_client_params)  # Cache the instance
+            self.mistral_client = Mistral(**_client_params) 
 
         return self.mistral_client
 

--- a/libs/agno/agno/embedder/mistral.py
+++ b/libs/agno/agno/embedder/mistral.py
@@ -29,21 +29,23 @@ class MistralEmbedder(Embedder):
 
     @property
     def client(self) -> Mistral:
-        if self.mistral_client:
-            return self.mistral_client
+        if not self.mistral_client:
+            _client_params: Dict[str, Any] = {}
+            if self.api_key:
+                _client_params["api_key"] = self.api_key
+            if self.endpoint:
+                _client_params["endpoint"] = self.endpoint
+            if self.max_retries is not None:
+                _client_params["max_retries"] = self.max_retries
+            if self.timeout is not None:
+                _client_params["timeout"] = self.timeout
+            if self.client_params:
+                _client_params.update(self.client_params)
+            
+            self.mistral_client = Mistral(**_client_params)  # Cache the instance
 
-        _client_params: Dict[str, Any] = {}
-        if self.api_key:
-            _client_params["api_key"] = self.api_key
-        if self.endpoint:
-            _client_params["endpoint"] = self.endpoint
-        if self.max_retries:
-            _client_params["max_retries"] = self.max_retries
-        if self.timeout:
-            _client_params["timeout"] = self.timeout
-        if self.client_params:
-            _client_params.update(self.client_params)
-        return Mistral(**_client_params)
+        return self.mistral_client
+
 
     def _response(self, text: str) -> EmbeddingResponse:
         _request_params: Dict[str, Any] = {


### PR DESCRIPTION
## Description

- **Summary of changes**: Issue initializing mistral that threw the error :
```
Expected sequence of size 1024 for vector of type float and dimension 1024, observed sequence of length 0
ask
```
on running:
`cookbook/agent_concepts/knowledge/vector_dbs/cassandra_db.py`

---

## Type of change

Please check the options that are relevant:

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
