### PR TITLE
Fix JSON schema error when using tools with anyOf instead of type

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -271,13 +271,15 @@ class Claude(Model):
                 if "null" not in param_type_list:
                     required_params.append(param_name)
 
-            input_properties: Dict[str, Dict[str, Union[str, List[str]]]] = {
-                param_name: {
-                    "type": param_info.get("type", ""),
+            input_properties: Dict[str, Dict[str, Union[str, List[str]]]] = {}
+            for param_name, param_info in properties.items():
+                input_properties[param_name] = {
                     "description": param_info.get("description", ""),
                 }
-                for param_name, param_info in properties.items()
-            }
+                if "type" not in param_info and "anyOf" in param_info:
+                    input_properties[param_name]["anyOf"] = param_info["anyOf"]
+                else:
+                    input_properties[param_name]["type"] = param_info.get("type", "")
 
             tool = {
                 "name": func_name,


### PR DESCRIPTION
## Description

- **Summary of changes**: handle case where properties of the input schema of a tool doesn't have `type` but uses `anyOf`
- **Motivation and context**: Using Agno, Claude, Composio, and trying to send an email with Gmail, breaks with JSON schema error

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

