### PR TITLE
fix: Get embeddings from the correct URI path

### DIFF
--- a/libs/agno/agno/embedder/ollama.py
+++ b/libs/agno/agno/embedder/ollama.py
@@ -60,7 +60,7 @@ class OllamaEmbedder(Embedder):
             response = self._response(text=text)
             if response is None:
                 return []
-            return response.get("embedding", [])
+            return response.get("embeddings", [])
         except Exception as e:
             logger.warning(e)
             return []


### PR DESCRIPTION
This fixes agno-agi/agno#2248, thanks to the reporter in that issue for the fix.

## Description
- Fixes the ollama `embedding` param to `embeddings`.
Fixes # (#2248 )

---


