### PR TITLE
Added base_url property in AzureOpenAI for non-default URLs

### DIFF
--- a/libs/agno/agno/models/azure/openai_chat.py
+++ b/libs/agno/agno/models/azure/openai_chat.py
@@ -27,6 +27,7 @@ class AzureOpenAI(OpenAILike):
         api_version (str): The API version to use.
         azure_endpoint (Optional[str]): The Azure endpoint to use.
         azure_deployment (Optional[str]): The Azure deployment to use.
+        base_url (Optional[str]): The base URL to use.
         azure_ad_token (Optional[str]): The Azure AD token to use.
         azure_ad_token_provider (Optional[Any]): The Azure AD token provider to use.
         organization (Optional[str]): The organization to use.
@@ -44,6 +45,7 @@ class AzureOpenAI(OpenAILike):
     api_version: Optional[str] = "2024-10-21"
     azure_endpoint: Optional[str] = None
     azure_deployment: Optional[str] = None
+    base_url: Optional[str] = None
     azure_ad_token: Optional[str] = None
     azure_ad_token_provider: Optional[Any] = None
 
@@ -62,6 +64,7 @@ class AzureOpenAI(OpenAILike):
             "organization": self.organization,
             "azure_endpoint": self.azure_endpoint,
             "azure_deployment": self.azure_deployment,
+            "base_url": self.base_url,
             "azure_ad_token": self.azure_ad_token,
             "azure_ad_token_provider": self.azure_ad_token_provider,
             "http_client": self.http_client,


### PR DESCRIPTION
## Fixes https://github.com/agno-agi/agno/issues/2265

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

In Agno you can't specify the `base_url` in the AzureOpenAI client. It is needed when the full URL is constructed differently

![Image](https://github.com/user-attachments/assets/98198720-5306-45eb-a361-db1afc157cb6)

And this forces the construction of the URL in this way:

![Image](https://github.com/user-attachments/assets/5bf01b3d-3a5e-4211-a630-81eb37e45dde)
