### PR TITLE
Ensure Python 3.8 compatibility by replacing dict[str, Any] with typing.Dict

### DIFF
--- a/libs/agno/agno/tools/decorator.py
+++ b/libs/agno/agno/tools/decorator.py
@@ -1,12 +1,12 @@
 from functools import update_wrapper, wraps
-from typing import Any, Callable, Optional, TypeVar, Union, overload
+from typing import Any, Callable, Optional, TypeVar, Union, overload, Dict
 
 from agno.tools.function import Function
 from agno.utils.log import logger
 
 # Type variable for better type hints
 F = TypeVar("F", bound=Callable[..., Any])
-ToolConfig = TypeVar("ToolConfig", bound=dict[str, Any])
+ToolConfig = TypeVar("ToolConfig", bound=Dict[str, Any])
 
 
 @overload


### PR DESCRIPTION
## Description

- **Summary of changes**: Small fix of using Dict instead of dict
- Fixes #2268 

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).