### PR TITLE
Fix OllamaEmbedder: get_embedding() 

### DIFF
--- a/libs/agno/agno/embedder/ollama.py
+++ b/libs/agno/agno/embedder/ollama.py
@@ -60,7 +60,7 @@ class OllamaEmbedder(Embedder):
             response = self._response(text=text)
             if response is None:
                 return []
-            return response.get("embeddings", [])
+            return response.get("embeddings", [])[0]
         except Exception as e:
             logger.warning(e)
             return []


### PR DESCRIPTION
I found a bug from OllamaEmbedder

Basically, the `get_embedding()` function is expected to return `list[float]` but currently it returns `list[list[float]]`

You can reproduce this bug by this minimal example
```python
from agno.document.chunking.semantic import SemanticChunking
from agno.embedder.ollama import OllamaEmbedder
from agno.embedder.sentence_transformer import SentenceTransformerEmbedder
from agno.knowledge.text import TextKnowledgeBase
from agno.vectordb.milvus.milvus import Milvus

embedder = OllamaEmbedder(id='jeffh/intfloat-multilingual-e5-large-instruct:f16', dimensions=1024)
chonkie_embedder = SentenceTransformerEmbedder(id='intfloat/multilingual-e5-large-instruct', dimensions=1024)

knowledge_base = TextKnowledgeBase(
  path='news',
  formats=['.md'],
  vector_db=Milvus(collection='semantic_chunking_col', embedder=embedder, uri='news.db'),
  chunking_strategy=SemanticChunking(embedder=chonkie_embedder, chunk_size=100),
)

knowledge_base.load()
```
You would run into this error
```
[insert_rows], <DataNotMatchException: (code=1, message=The Input data type is inconsistent with defined schema, {vector} field should be a float_vector, but got a {<class 'list'>} instead.)>
```