### PR TITLE
Handle playground router non-streaming cases better

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -508,6 +508,9 @@ class Agent:
         run_messages: RunMessages = self.get_run_messages(
             message=message, audio=audio, images=images, videos=videos, messages=messages, **kwargs
         )
+        if len(run_messages.messages) == 0:
+            logger.error("No messages to be sent to the model.")
+
         self.run_messages = run_messages
 
         # 5. Reason about the task if reasoning is enabled
@@ -991,6 +994,8 @@ class Agent:
         run_messages: RunMessages = self.get_run_messages(
             message=message, audio=audio, images=images, videos=videos, messages=messages, **kwargs
         )
+        if len(run_messages.messages) == 0:
+            logger.error("No messages to be sent to the model.")
         self.run_messages = run_messages
 
         # 5. Reason about the task if reasoning is enabled

--- a/libs/agno/agno/playground/async_router.py
+++ b/libs/agno/agno/playground/async_router.py
@@ -289,7 +289,7 @@ def get_async_playground_router(
                     stream=False,
                 ),
             )
-            return run_response
+            return run_response.to_dict()
 
     @playground_router.get("/agents/{agent_id}/sessions")
     async def get_all_agent_sessions(agent_id: str, user_id: str = Query(..., min_length=1)):

--- a/libs/agno/agno/playground/sync_router.py
+++ b/libs/agno/agno/playground/sync_router.py
@@ -285,7 +285,7 @@ def get_sync_playground_router(
                     stream=False,
                 ),
             )
-            return run_response
+            return run_response.to_dict()
 
     @playground_router.get("/agents/{agent_id}/sessions")
     def get_user_agent_sessions(agent_id: str, user_id: str = Query(..., min_length=1)):

--- a/libs/agno/agno/tools/decorator.py
+++ b/libs/agno/agno/tools/decorator.py
@@ -1,5 +1,5 @@
 from functools import update_wrapper, wraps
-from typing import Any, Callable, Optional, TypeVar, Union, overload, Dict
+from typing import Any, Callable, Dict, Optional, TypeVar, Union, overload
 
 from agno.tools.function import Function
 from agno.utils.log import logger

--- a/libs/agno/tests/unit/playground/test_image_support_file_upload.py
+++ b/libs/agno/tests/unit/playground/test_image_support_file_upload.py
@@ -12,6 +12,7 @@ from agno.agent import Agent
 from agno.media import Image
 from agno.models.openai import OpenAIChat
 from agno.playground import Playground
+from agno.run.response import RunResponse
 
 # --- Fixtures ---
 
@@ -34,7 +35,7 @@ def mock_agent():
         model=OpenAIChat(id="gpt-4"),
     )
     # Create mock run method
-    mock_run = Mock(return_value={"status": "ok", "response": "Mocked response"})
+    mock_run = Mock(return_value=RunResponse(content="Mocked response"))
     agent.run = mock_run
 
     # Create a copy of the agent that will be returned by deep_copy


### PR DESCRIPTION
## Description
If a user used the playground app and made non-streaming requests, it would break on serialization.

Fixes this case-> https://discord.com/channels/965734768803192842/1346111375600123945

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
