### PR TITLE
Fix CalComTools event_type_id initialization

### DIFF
--- a/libs/agno/agno/tools/calcom.py
+++ b/libs/agno/agno/tools/calcom.py
@@ -36,7 +36,12 @@ class CalComTools(Toolkit):
         # Get credentials from environment if not provided
         self.api_key = api_key or getenv("CALCOM_API_KEY")
         event_type_str = getenv("CALCOM_EVENT_TYPE_ID")
-        self.event_type_id = event_type_id or int(event_type_str) if event_type_str is not None else 0
+        if event_type_id is not None:
+            self.event_type_id = int(event_type_id)
+        elif event_type_str is not None:
+            self.event_type_id = int(event_type_str)
+        else:
+            self.event_type_id = 0
 
         if not self.api_key:
             logger.error("CALCOM_API_KEY not set. Please set the CALCOM_API_KEY environment variable.")

--- a/libs/agno/agno/tools/calcom.py
+++ b/libs/agno/agno/tools/calcom.py
@@ -38,10 +38,8 @@ class CalComTools(Toolkit):
         event_type_str = getenv("CALCOM_EVENT_TYPE_ID")
         if event_type_id is not None:
             self.event_type_id = int(event_type_id)
-        elif event_type_str is not None:
-            self.event_type_id = int(event_type_str)
         else:
-            self.event_type_id = 0
+            self.event_type_id = int(event_type_str) if event_type_str is not None else 0
 
         if not self.api_key:
             logger.error("CALCOM_API_KEY not set. Please set the CALCOM_API_KEY environment variable.")


### PR DESCRIPTION
## Description

- **Summary of changes**: Fixed the event_type_id initialization logic in CalComTools to properly prioritize the explicitly passed parameter over environment variables. This ensures that when users specify an event_type_id directly, it will be used correctly in API requests.
- **Related issues**: -.
- **Motivation and context**: Previously, when users passed an event_type_id to the CalComTools constructor but had no CALCOM_EVENT_TYPE_ID environment variable set, the passed value would be ignored and the default value of 0 would be used instead.
- **Environment or dependencies**: -.
- **Impact on metrics**: -.

Fixes # (issue)

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Looking at the test logs, I can see that the integration tests are failing. The error appears to be related to network connectivity rather than the pull request code change. The logs show a LocalProtocolError which typically indicates an issue with HTTP connections during the tests.
`.venv/lib/python3.12/site-packages/httpcore/_sync/http11.py:144: in _send_request_headers
    with map_exceptions({h11.LocalProtocolError: LocalProtocolError}):`
