### PR TITLE
Fix multiple issues with converting type hints to JSON Schema

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -5,9 +5,8 @@ from agno.utils.log import logger
 
 def is_origin_union_type(origin: Any) -> bool:
     import sys
-
     if sys.version_info.minor >= 10:
-        from types import UnionType
+        from types import UnionType  # type: ignore
 
         return origin in [Union, UnionType]
 

--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -3,6 +3,16 @@ from typing import Any, Dict, Optional, Union, get_args, get_origin
 from agno.utils.log import logger
 
 
+def is_origin_union_type(origin: Any) -> bool:
+    import sys
+
+    if sys.version_info.minor >= 10:
+        from types import UnionType
+
+        return origin in [Union, UnionType]
+    
+    return origin is Union
+
 def get_json_type_for_py_type(arg: str) -> str:
     """
     Get the JSON schema type for a given type.
@@ -43,16 +53,14 @@ def get_json_schema_for_arg(t: Any) -> Optional[Dict[str, Any]]:
             key_schema = get_json_schema_for_arg(type_args[0]) if type_args else {"type": "string"}
             value_schema = get_json_schema_for_arg(type_args[1]) if len(type_args) > 1 else {"type": "string"}
             return {"type": "object", "propertyNames": key_schema, "additionalProperties": value_schema}
-        elif type_origin is Union:
+        elif is_origin_union_type(type_origin):
             types = []
             for arg in type_args:
-                if arg is not type(None):
-                    try:
-                        schema = get_json_schema_for_arg(arg)
-                        if schema:
-                            types.append(schema)
-                    except Exception:
-                        continue
+                try:
+                    schema = get_json_schema_for_arg(arg)
+                    types.append(schema)
+                except Exception:
+                    continue
             return {"anyOf": types} if types else None
 
     return {"type": get_json_type_for_py_type(t.__name__)}
@@ -74,15 +82,6 @@ def get_json_schema(
             continue
 
         try:
-            # Check if type is Optional (Union with NoneType)
-            type_origin = get_origin(v)
-            type_args = get_args(v)
-            is_optional = type_origin is Union and len(type_args) == 2 and any(arg is type(None) for arg in type_args)
-
-            # Get the actual type if it's Optional
-            if is_optional:
-                v = next(arg for arg in type_args if arg is not type(None))
-
             # Handle cases with no type hint
             if v:
                 arg_json_schema = get_json_schema_for_arg(v)
@@ -90,13 +89,6 @@ def get_json_schema(
                 arg_json_schema = {}
 
             if arg_json_schema is not None:
-                if is_optional:
-                    # Handle null type for optional fields
-                    if isinstance(arg_json_schema["type"], list):
-                        arg_json_schema["type"].append("null")
-                    else:
-                        arg_json_schema["type"] = [arg_json_schema["type"], "null"]
-
                 # Add description
                 if param_descriptions and k in param_descriptions and param_descriptions[k]:
                     arg_json_schema["description"] = param_descriptions[k]

--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -10,8 +10,9 @@ def is_origin_union_type(origin: Any) -> bool:
         from types import UnionType
 
         return origin in [Union, UnionType]
-    
+
     return origin is Union
+
 
 def get_json_type_for_py_type(arg: str) -> str:
     """

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -254,6 +254,7 @@ module = [
   "lancedb.*",
   "langchain_core.*",
   "langchain.*",
+  "litellm.*",
   "llama_index.*",
   "mem0.*",
   "mcp.*",

--- a/libs/agno/tests/integration/agent/test_tool_parsing.py
+++ b/libs/agno/tests/integration/agent/test_tool_parsing.py
@@ -1,0 +1,155 @@
+from typing import List, Optional
+
+from git import Union
+
+from agno.agent import Agent, RunResponse  # noqa
+from agno.models.openai import OpenAIChat
+
+
+def test_tool_call_custom_tool_no_parameters():
+    def get_the_weather():
+        return "It is currently 70 degrees and cloudy in Tokyo"
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_the_weather],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False,
+    )
+
+    response = agent.run("What is the weather in Tokyo?")
+
+    # Verify tool usage
+    assert any(msg.tool_calls for msg in response.messages)
+    assert response.content is not None
+    assert "70" in response.content
+
+
+def test_tool_call_custom_tool_optional_parameters():
+    def get_the_weather(city: Optional[str] = None):
+        """
+        Get the weather in a city
+
+        Args:
+            city: The city to get the weather for
+        """
+        if city is None:
+            return "It is currently 70 degrees and cloudy in Tokyo"
+        else:
+            return f"It is currently 70 degrees and cloudy in {city}"
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_the_weather],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False,
+    )
+
+    response = agent.run("What is the weather in Paris?")
+
+    # Verify tool usage
+    assert any(msg.tool_calls for msg in response.messages)
+    assert response.content is not None
+    assert "70" in response.content
+
+
+def test_tool_call_custom_tool_untyped_parameters():
+    def get_the_weather(city):
+        """
+        Get the weather in a city
+
+        Args:
+            city: The city to get the weather for
+        """
+        if city is None:
+            return "It is currently 70 degrees and cloudy in Tokyo"
+        else:
+            return f"It is currently 70 degrees and cloudy in {city}"
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_the_weather],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False,
+    )
+
+    response = agent.run("What is the weather in Paris?")
+
+    # Verify tool usage
+    assert any(msg.tool_calls for msg in response.messages)
+    assert response.content is not None
+    assert "70" in response.content
+
+
+def test_tool_call_list_parameters():
+    def get_the_weather(cities: List[str]):
+        """
+        Get the weather in a city
+
+        Args:
+            cities: The cities to get the weather for
+        """
+        weather_str = ""
+        for city in cities:
+            weather_str += f"It is currently 70 degrees and cloudy in {city}\n"
+        return weather_str
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_the_weather],
+        instructions="Use a single tool call if possible",
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False,
+    )
+
+    response = agent.run("What is the weather in Tokyo and Paris?")
+
+    # Verify tool usage
+    assert any(msg.tool_calls for msg in response.messages)
+    tool_calls = []
+    for msg in response.messages:
+        if msg.tool_calls:
+            tool_calls.extend(msg.tool_calls)
+    for call in tool_calls:
+        assert call["function"]["name"] in ["get_the_weather"]
+    assert response.content is not None
+    assert "70" in response.content
+    assert "Tokyo" in response.content
+    assert "Paris" in response.content
+
+
+def test_tool_call_custom_tool_union_parameters():
+    def get_the_weather(city: str, degrees: Union[int, float], condition: str | None = None):
+        """
+        Get the weather in a city
+
+        Args:
+            city: The city to get the weather for
+            degrees: The temperature in degrees
+            condition: The weather condition (e.g., cloudy, sunny, rainy)
+        """
+        weather_condition = condition if condition else "cloudy"
+        return f"It is currently {degrees} degrees and {weather_condition} in {city}"
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_the_weather],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False,
+    )
+
+    response = agent.run("What is the weather in Paris?")
+
+    # Verify tool usage
+    assert any(msg.tool_calls for msg in response.messages)
+    assert response.content is not None


### PR DESCRIPTION
## Description

**Summary of changes**:

The main problem: newish syntax for unions with `|` supported by Python 3.10 are of [type](https://docs.python.org/3.10/library/types.html#types.UnionType) `types.UnionType`, and didn't match `Union`. There's a very recently [completed issue on CPython](https://github.com/python/cpython/issues/105499) that will unify both (apparently for 3.14). See also this [MyPy warning](https://mypy.readthedocs.io/en/stable/runtime_troubles.html#future-annotations-import-pep-563) about evaluating type hints.

Other problems:
- Only unions of two values were properly handled for optional values;
- Unions with more than two values and an optional one would only parse one of the values, dropping the others;
- Some code lines were never true (like `isinstance(arg_json_schema["type"], list)`);

The code is now simplified while handling new type annotation syntax and null/optional values.

Fixes #2441.

- **Related issues**: I didn't find any.
- **Motivation and context**: I was getting errors with a custom toolkit that uses the new type hinting syntax.
- **Environment or dependencies**: None.
- **Impact on metrics**: N/A.

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [x] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Linked in the description.
