### PR TITLE
Use the overrided stream value when necessary

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -845,7 +845,7 @@ class Agent:
         self,
         message: Optional[Union[str, List, Dict, Message]] = None,
         *,
-        stream: bool = False,
+        stream: Optional[bool] = None,
         audio: Optional[Sequence[Audio]] = None,
         images: Optional[Sequence[Image]] = None,
         videos: Optional[Sequence[Any]] = None,
@@ -860,6 +860,10 @@ class Agent:
         # If no retries are set, use the agent's default retries
         if retries is None:
             retries = self.retries
+
+        # Use stream overrided value when necessary
+        if stream is None:
+            stream = False if self.stream is None else self.stream
 
         last_exception = None
         num_attempts = retries + 1
@@ -1313,7 +1317,7 @@ class Agent:
         self,
         message: Optional[Union[str, List, Dict, Message]] = None,
         *,
-        stream: bool = False,
+        stream: Optional[bool] = None,
         audio: Optional[Sequence[Audio]] = None,
         images: Optional[Sequence[Image]] = None,
         videos: Optional[Sequence[Video]] = None,
@@ -1328,6 +1332,10 @@ class Agent:
         # If no retries are set, use the agent's default retries
         if retries is None:
             retries = self.retries
+
+        # Use stream overrided value when necessary
+        if stream is None:
+            stream = False if self.stream is None else self.stream
 
         last_exception = None
         num_attempts = retries + 1


### PR DESCRIPTION
## Description

- **Summary of changes**: Describe the key changes in this PR and their purpose.
Here is a setting that is unintuitive and in my opinion unexpected behavior before this change.

```
agent = Agent(stream=True, ...)
agent.run(...) # This will return a RunResponse
```
I would expect the `agent.run(...)` command to return a generator. The reason is because a default value was set for stream in the `run()` and `arun()) methods. This PR fixes this issue.
- **Related issues**: Mention if this PR fixes or is connected to any issues.
N/A
- **Motivation and context**: Explain the reason for the changes and the problem they solve.
This change was done to enforce expected behavior with the Agent flags
- **Environment or dependencies**: Specify any changes in dependencies or environment configurations required for this update.
N/A
- **Impact on metrics**: (If applicable) Describe changes in any metrics or performance benchmarks.
N/A

Fixes # (issue)

---

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [x] Other (please describe):
This change enforces expected behavior with the flags in `Agent` and `run`.

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [x] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [x] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
