### PR TITLE
Fix validation of MIME types for files

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, model_validator
 
 
 class Media(BaseModel):

--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -261,22 +261,22 @@ class File(BaseModel):
     url: Optional[str] = None
     filepath: Optional[Union[Path, str]] = None
     content: Optional[Any] = None
-    mime_type: Optional[str] = None
-
-    VALID_MIME_TYPES: List[str] = [
-        "application/pdf",
-        "application/x-javascript",
-        "text/javascript",
-        "application/x-python",
-        "text/x-python",
-        "text/plain",
-        "text/html",
-        "text/css",
-        "text/md",
-        "text/csv",
-        "text/xml",
-        "text/rtf",
-    ]
+    mime_type: Optional[
+        Literal[
+            "application/pdf",
+            "application/x-javascript",
+            "text/javascript",
+            "application/x-python",
+            "text/x-python",
+            "text/plain",
+            "text/html",
+            "text/css",
+            "text/md",
+            "text/csv",
+            "text/xml",
+            "text/rtf",
+        ]
+    ] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -285,14 +285,6 @@ class File(BaseModel):
         if isinstance(data, dict) and not any(data.get(field) for field in ["url", "filepath", "content"]):
             raise ValueError("At least one of url, filepath, or content must be provided")
         return data
-
-    @field_validator("mime_type")
-    @classmethod
-    def validate_mime_type(cls, v):
-        """Validate that the mime_type is one of the allowed types."""
-        if v is not None and v not in cls.VALID_MIME_TYPES:
-            raise ValueError(f"Invalid MIME type: {v}. Must be one of: {cls.VALID_MIME_TYPES}")
-        return v
 
     @property
     def file_url_content(self) -> Optional[Tuple[bytes, str]]:

--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 from pydantic import BaseModel, field_validator, model_validator
 


### PR DESCRIPTION
## Description

- **Summary of changes**: use a Literal list of allowed MIME types instead of a class attribute, which doesn't work
- **Related issues**: Following up on https://github.com/agno-agi/agno/pull/2325, that introduced file handling for Claude and Gemini

The code currently fails with invalid attribute for `cls.VALID_MIME_TYPES`.

The simplest solution is to use a Literal type and let pydantic validate the value.

Potential but not concrete drawbacks:
* The exception raised changes from ValueError to ValidationError;
* In case someone wants to know which MIME types are supported, they'll have to use something like `typing.get_args(File.mime_type)` instead of `File.VALID_MIME_TYPES`. However, it should be noted that right now this list is not truly reflecting the supported types for a model (example: Claude only supports `application/pdf`).

Fixes #(issue)

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.
