### PR TITLE
Fix WebsiteReader initialization to include chunking strategy

### DIFF
--- a/libs/agno/agno/knowledge/website.py
+++ b/libs/agno/agno/knowledge/website.py
@@ -19,7 +19,8 @@ class WebsiteKnowledgeBase(AgentKnowledge):
     @model_validator(mode="after")
     def set_reader(self) -> "WebsiteKnowledgeBase":
         if self.reader is None:
-            self.reader = WebsiteReader(max_depth=self.max_depth, max_links=self.max_links)
+            self.reader = WebsiteReader(max_depth=self.max_depth, max_links=self.max_links,
+                                        chunking_strategy=self.chunking_strategy)
         return self
 
     @property


### PR DESCRIPTION
WebsiteKnowledgeBase doesn't pass chunking strategy to WebsiteReader making it impossible to use any other strategy in WKB.

This PR adds passing WKB strategy to reader ctor.