### PR TITLE
added a mapping for compatibility for switching between google and openai 

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -93,6 +93,7 @@ class OpenAIChat(Model):
         "user": "user",
         "assistant": "assistant",
         "tool": "tool",
+        "model":"assistant",
     }
 
     def _get_client_params(self) -> Dict[str, Any]:


### PR DESCRIPTION
# Add Google Gemini role mapping for compatibility with OpenAI ChatAPI

## Description
This PR adds a role mapping compatibility layer in the OpenAI chat implementation to support seamless switching between Google Gemini and OpenAI models. This addresses a critical interoperability issue when migrating between different model providers.

## Changes
- Added a new entry in the `role_map` dictionary that maps the "model" role to "assistant"
- This ensures that responses from different LLM providers maintain consistent role assignments when switching between providers
- Maintains backward compatibility with existing code

## Why this is important
When working with different model providers, role naming conventions can vary. This mapping ensures that applications can switch between Google and OpenAI models without requiring code changes to handle different role terminologies.

## Testing
The change has been tested with both OpenAI and Google model providers to ensure that role mapping works correctly in both directions.

## Related Issues
This change supports the ongoing effort to make our codebase provider-agnostic and simplify the developer experience when working with multiple LLM providers.