### PR TITLE
[bug-fix] Google Embedder dimensions to be 1536

### DIFF
--- a/libs/agno/agno/embedder/google.py
+++ b/libs/agno/agno/embedder/google.py
@@ -18,7 +18,7 @@ class GeminiEmbedder(Embedder):
     id: str = "text-embedding-004"
     task_type: str = "RETRIEVAL_QUERY"
     title: Optional[str] = None
-    dimensions: Optional[int] = 768
+    dimensions: Optional[int] = 1536
     api_key: Optional[str] = None
     request_params: Optional[Dict[str, Any]] = None
     client_params: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
## Description

Azure OpenAI and OpenAI embeddings work good with Agentic RAG, but when it comes to Google Embedder, the issue is with dimensions size, despite giving 1536 in the arguments, its not accepted and giving this error:

```
ERROR    Error searching for documents: Unexpected Response: 400 (Bad Request)                                                                                                                            
         Raw response content:                                                                                                                                                                            
         b'{"status":{"error":"Wrong input: Vector dimension error: expected dim: 1536, got 768"},"time":0.000600541}'   
```

Fixes # (issue)

---

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [x] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [x] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [x] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [x] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
