### PR TITLE
Release 1.2.5

### DIFF
--- a/cookbook/playground/teams_demo.py
+++ b/cookbook/playground/teams_demo.py
@@ -1,15 +1,15 @@
 from textwrap import dedent
 
 from agno.agent import Agent
-from agno.models.openai import OpenAIChat
+from agno.models.anthropic import Claude
 from agno.models.google.gemini import Gemini
+from agno.models.openai import OpenAIChat
 from agno.playground import Playground, serve_playground_app
 from agno.storage.postgres import PostgresStorage
 from agno.team.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.exa import ExaTools
 from agno.tools.yfinance import YFinanceTools
-from agno.models.anthropic import Claude
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 
@@ -158,7 +158,14 @@ multimodal_team = Team(
 agent_team = Team(
     name="Financial News Team",
     description="A team of agents that search the web for financial news and analyze it.",
-    members=[web_agent, finance_agent, research_agent, file_agent, audio_agent, video_agent],
+    members=[
+        web_agent,
+        finance_agent,
+        research_agent,
+        file_agent,
+        audio_agent,
+        video_agent,
+    ],
     model=OpenAIChat(id="gpt-4o"),
     mode="route",
     team_id="financial_news_team",

--- a/cookbook/teams/modes/route.py
+++ b/cookbook/teams/modes/route.py
@@ -95,7 +95,6 @@ if __name__ == "__main__":
         multi_language_team.aprint_response(
             "Comment allez-vous?",
             stream=True,  # French
-            stream_intermediate_steps=True,
         )
     )
 

--- a/cookbook/teams/streaming.py
+++ b/cookbook/teams/streaming.py
@@ -40,7 +40,4 @@ team = Team(
     show_members_responses=True,
 )
 
-team.print_response(
-    "What is the current stock price of NVDA?",
-    stream=True
-)
+team.print_response("What is the current stock price of NVDA?", stream=True)

--- a/cookbook/teams/streaming_async.py
+++ b/cookbook/teams/streaming_async.py
@@ -43,8 +43,5 @@ team = Team(
 
 if __name__ == "__main__":
     asyncio.run(
-        team.aprint_response(
-            "What is the current stock price of NVDA?",
-            stream=True
-        )
+        team.aprint_response("What is the current stock price of NVDA?", stream=True)
     )

--- a/libs/agno/agno/playground/async_router.py
+++ b/libs/agno/agno/playground/async_router.py
@@ -7,7 +7,8 @@ from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from agno.agent.agent import Agent, RunResponse
-from agno.media import Audio, File as FileMedia, Image, Video
+from agno.media import Audio, Image, Video
+from agno.media import File as FileMedia
 from agno.playground.operator import (
     format_tools,
     get_agent_by_id,
@@ -179,13 +180,13 @@ def get_async_playground_router(
         if not content:
             raise HTTPException(status_code=400, detail="Empty file")
         return Video(content=content, format=file.content_type)
-    
+
     async def process_document(file: UploadFile) -> Optional[FileMedia]:
         try:
             content = await file.read()
             if not content:
                 raise HTTPException(status_code=400, detail="Empty file")
-                        
+
             return FileMedia(content=content, mime_type=file.content_type)
         except Exception as e:
             logger.error(f"Error processing document {file.filename}: {e}")
@@ -633,14 +634,20 @@ def get_async_playground_router(
                         base64_videos.append(base64_video)
                     except Exception as e:
                         logger.error(f"Error processing video {file.filename}: {e}")
-                        continue    
-                elif file.content_type in ["application/pdf", "text/csv", "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "text/plain", "application/json"]:
+                        continue
+                elif file.content_type in [
+                    "application/pdf",
+                    "text/csv",
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                    "text/plain",
+                    "application/json",
+                ]:
                     document_file = await process_document(file)
                     if document_file is not None:
                         document_files.append(document_file)
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
-                    
+
         if stream:
             return StreamingResponse(
                 team_chat_response_streamer(

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1579,6 +1579,7 @@ class Team:
         message: Optional[Union[List, Dict, str, Message]] = None,
         *,
         stream: bool = False,
+        stream_intermediate_steps: bool = False,
         show_message: bool = True,
         show_reasoning: bool = True,
         show_reasoning_verbose: bool = False,
@@ -1615,6 +1616,7 @@ class Team:
                 videos=videos,
                 files=files,
                 markdown=markdown,
+                stream_intermediate_steps=stream_intermediate_steps,
                 **kwargs,
             )
         else:
@@ -1859,6 +1861,7 @@ class Team:
         videos: Optional[Sequence[Video]] = None,
         files: Optional[Sequence[File]] = None,
         markdown: bool = False,
+        stream_intermediate_steps: bool = False,
         **kwargs: Any,
     ) -> None:
         from rich.console import Group
@@ -1870,6 +1873,8 @@ class Team:
 
         if not tags_to_include_in_markdown:
             tags_to_include_in_markdown = {"think", "thinking"}
+
+        stream_intermediate_steps = True  # With streaming print response, we need to stream intermediate steps
 
         _response_content: str = ""
         _response_thinking: str = ""
@@ -1900,7 +1905,18 @@ class Team:
 
             # Get response from the team
             stream_resp = self.run(  # type: ignore
+<<<<<<< Updated upstream
                 message=message, audio=audio, images=images, videos=videos, files=files, stream=True, **kwargs
+=======
+                message=message,
+                audio=audio,
+                images=images,
+                videos=videos,
+                files=files,
+                stream=True,
+                stream_intermediate_steps=stream_intermediate_steps,
+                **kwargs,
+>>>>>>> Stashed changes
             )
 
             team_markdown = None
@@ -2088,6 +2104,7 @@ class Team:
         message: Optional[Union[List, Dict, str, Message]] = None,
         *,
         stream: bool = False,
+        stream_intermediate_steps: bool = False,
         show_message: bool = True,
         show_reasoning: bool = True,
         show_reasoning_verbose: bool = False,
@@ -2124,6 +2141,7 @@ class Team:
                 videos=videos,
                 files=files,
                 markdown=markdown,
+                stream_intermediate_steps=stream_intermediate_steps,
                 **kwargs,
             )
         else:
@@ -2365,6 +2383,7 @@ class Team:
         videos: Optional[Sequence[Video]] = None,
         files: Optional[Sequence[File]] = None,
         markdown: bool = False,
+        stream_intermediate_steps: bool = False,
         **kwargs: Any,
     ) -> None:
         from rich.console import Group
@@ -2376,6 +2395,8 @@ class Team:
 
         if not tags_to_include_in_markdown:
             tags_to_include_in_markdown = {"think", "thinking"}
+
+        stream_intermediate_steps = True  # With streaming print response, we need to stream intermediate steps
 
         self.run_response = cast(TeamRunResponse, self.run_response)
 
@@ -2408,7 +2429,18 @@ class Team:
 
             # Get response from the team
             stream_resp = await self.arun(  # type: ignore
+<<<<<<< Updated upstream
                 message=message, audio=audio, images=images, videos=videos, files=files, stream=True, **kwargs
+=======
+                message=message,
+                audio=audio,
+                images=images,
+                videos=videos,
+                files=files,
+                stream=True,
+                stream_intermediate_steps=stream_intermediate_steps,
+                **kwargs,
+>>>>>>> Stashed changes
             )
             team_markdown = None
             member_markdown = {}

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1026,7 +1026,6 @@ class Team:
         """Run the Team asynchronously and return the response."""
         self._initialize_team()
 
-
         retries = retries or 3
         if retries < 1:
             raise ValueError("Retries must be at least 1")
@@ -1975,7 +1974,7 @@ class Team:
                 videos=videos,
                 files=files,
                 stream=True,
-                stream_intermediate_steps=True,
+                stream_intermediate_steps=stream_intermediate_steps,
                 **kwargs,
             )
 

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "1.2.4"
+version = "1.2.5"
 description = "Agno: a lightweight framework for building multi-modal Agents"
 requires-python = ">=3.7,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## New Features:

- **E2B Tools:** Added E2B Tools to run code in E2B Sandbox

## Improvements:

- **Teams Tools**: Add `tools` and `tool_call_limit` to `Team`. This means the team leader itself can also have tools provided by the user, so it can act as an agent.
- **Teams Instructions:** Improved instructions around attached images, audio, videos, and files. This should increase success when attaching artifacts to prompts meant for member agents.
- **MCP Include/Exclude Tools**: Expanded `MCPTools` to allow you to specify tools to specifically include or exclude from all the available tools on an MCP server. This is very useful for limiting which tools the model has access to.
- **Tool Decorator Async Support**: The `@tool()` decorator now supports async functions, including async pre and post-hooks.

## Bug Fixes:

- **Default Chain-of-Thought Reasoning:** Fixed issue where reasoning would not default to manual CoT if the provided reasoning model was not capable of reasoning.
- **Teams non-markdown responses**: Fixed issue with non-markdown responses in teams.
- **Ollama tool choice:** Removed `tool_choice` from Ollama usage as it is not supported.
- Worklow session retrieval from storage: Fixed `entity_id` mappings