### PR TITLE
improve-message-history-ag-2922

### DIFF
--- a/cookbook/models/openai/chat/basic.py
+++ b/cookbook/models/openai/chat/basic.py
@@ -7,7 +7,9 @@ agent = Agent(model=OpenAIChat(id="gpt-4o"), markdown=True)
 # run: RunResponse = agent.run("Share a 2 sentence horror story")
 # print(run.content)
 
+print(agent)
+
 # Print the response in the terminal
 agent.print_response("Share a 2 sentence horror story")
 
-agent.run_response.metrics
+print(agent)

--- a/cookbook/models/openai/chat/basic.py
+++ b/cookbook/models/openai/chat/basic.py
@@ -7,9 +7,5 @@ agent = Agent(model=OpenAIChat(id="gpt-4o"), markdown=True)
 # run: RunResponse = agent.run("Share a 2 sentence horror story")
 # print(run.content)
 
-print(agent)
-
 # Print the response in the terminal
 agent.print_response("Share a 2 sentence horror story")
-
-print(agent)

--- a/cookbook/playground/mcp_demo.py
+++ b/cookbook/playground/mcp_demo.py
@@ -1,18 +1,20 @@
 import asyncio
-import nest_asyncio
 from os import getenv
 from textwrap import dedent
-from mcp import StdioServerParameters
+
+import nest_asyncio
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.playground import Playground, serve_playground_app
 from agno.storage.agent.sqlite import SqliteAgentStorage
 from agno.tools.mcp import MCPTools
+from mcp import StdioServerParameters
 
 # Allow nested event loops
 nest_asyncio.apply()
 
 agent_storage_file: str = "tmp/agents.db"
+
 
 async def run_server() -> None:
     """Run the GitHub agent server."""
@@ -39,7 +41,9 @@ async def run_server() -> None:
             """),
             model=OpenAIChat(id="gpt-4o"),
             storage=SqliteAgentStorage(
-                table_name="basic_agent", db_file=agent_storage_file, auto_upgrade_schema=True
+                table_name="basic_agent",
+                db_file=agent_storage_file,
+                auto_upgrade_schema=True,
             ),
             add_history_to_messages=True,
             num_history_responses=3,
@@ -49,7 +53,7 @@ async def run_server() -> None:
 
         playground = Playground(agents=[agent])
         app = playground.get_app()
-        
+
         # Serve the app while keeping the MCPTools context manager alive
         serve_playground_app(app)
 

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -92,9 +92,9 @@ class Agent:
     memory: Optional[AgentMemory] = None
     # add_history_to_messages=true adds messages from the chat history to the messages list sent to the Model.
     add_history_to_messages: bool = False
-    # Soon to be deprecated in favor of num_history_runs: Number of historical responses to add to the messages
-    num_history_responses: int = 3
-    # Number of historical runs to include
+    # Deprecated in favor of num_history_runs: Number of historical responses to add to the messages
+    num_history_responses: Optional[int] = None
+    # Number of historical runs to include in the messages
     num_history_runs: int = 3
 
     # --- Agent Knowledge ---
@@ -266,7 +266,7 @@ class Agent:
         resolve_context: bool = True,
         memory: Optional[AgentMemory] = None,
         add_history_to_messages: bool = False,
-        num_history_responses: int = 3,
+        num_history_responses: Optional[int] = None,
         num_history_runs: int = 3,
         knowledge: Optional[AgentKnowledge] = None,
         add_references: bool = False,
@@ -343,7 +343,7 @@ class Agent:
         self.num_history_responses = num_history_responses
         self.num_history_runs = num_history_runs
 
-        if num_history_responses != 3:
+        if num_history_responses is not None:
             warnings.warn(
                 "num_history_responses is deprecated and will be removed in a future version. "
                 "Use num_history_runs instead.",

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -92,7 +92,9 @@ class Agent:
     memory: Optional[AgentMemory] = None
     # add_history_to_messages=true adds messages from the chat history to the messages list sent to the Model.
     add_history_to_messages: bool = False
-    # Number of historical responses to add to the messages.
+    # Soon to be deprecated in favor of num_history_runs: Number of historical responses to add to the messages
+    num_history_responses: int = 3
+    # Number of historical runs to include
     num_history_runs: int = 3
 
     # --- Agent Knowledge ---
@@ -198,6 +200,8 @@ class Agent:
     delay_between_retries: int = 1
     # Exponential backoff: if True, the delay between retries is doubled each time
     exponential_backoff: bool = False
+
+    # --- Agent Response Model Settings ---
     # Provide a response model to get the response as a Pydantic model
     response_model: Optional[Type[BaseModel]] = None
     # If True, the response from the Model is converted into the response_model
@@ -262,6 +266,7 @@ class Agent:
         resolve_context: bool = True,
         memory: Optional[AgentMemory] = None,
         add_history_to_messages: bool = False,
+        num_history_responses: int = 3,
         num_history_runs: int = 3,
         knowledge: Optional[AgentKnowledge] = None,
         add_references: bool = False,
@@ -335,7 +340,17 @@ class Agent:
 
         self.memory = memory
         self.add_history_to_messages = add_history_to_messages
+        self.num_history_responses = num_history_responses
         self.num_history_runs = num_history_runs
+
+        if num_history_responses != 3:
+            warnings.warn(
+                "num_history_responses is deprecated and will be removed in a future version. "
+                "Use num_history_runs instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.num_history_runs = num_history_responses
 
         self.knowledge = knowledge
         self.add_references = add_references

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -93,7 +93,7 @@ class Agent:
     # add_history_to_messages=true adds messages from the chat history to the messages list sent to the Model.
     add_history_to_messages: bool = False
     # Number of historical responses to add to the messages.
-    num_history_responses: int = 3
+    num_history_runs: int = 3
 
     # --- Agent Knowledge ---
     knowledge: Optional[AgentKnowledge] = None
@@ -262,7 +262,7 @@ class Agent:
         resolve_context: bool = True,
         memory: Optional[AgentMemory] = None,
         add_history_to_messages: bool = False,
-        num_history_responses: int = 3,
+        num_history_runs: int = 3,
         knowledge: Optional[AgentKnowledge] = None,
         add_references: bool = False,
         retriever: Optional[Callable[..., Optional[List[Dict]]]] = None,
@@ -335,7 +335,7 @@ class Agent:
 
         self.memory = memory
         self.add_history_to_messages = add_history_to_messages
-        self.num_history_responses = num_history_responses
+        self.num_history_runs = num_history_runs
 
         self.knowledge = knowledge
         self.add_references = add_references
@@ -2471,7 +2471,7 @@ class Agent:
             from copy import deepcopy
 
             history: List[Message] = self.memory.get_messages_from_last_n_runs(
-                last_n=self.num_history_responses, skip_role=self.system_message_role
+                last_n=self.num_history_runs, skip_role=self.system_message_role
             )
             if len(history) > 0:
                 # Create a deep copy of the history messages to avoid modifying the original messages
@@ -2483,13 +2483,6 @@ class Agent:
 
                 log_debug(f"Adding {len(history_copy)} messages from history")
 
-                if self.run_response.extra_data is None:
-                    self.run_response.extra_data = RunResponseExtraData(history=history_copy)
-                else:
-                    if self.run_response.extra_data.history is None:
-                        self.run_response.extra_data.history = history_copy
-                    else:
-                        self.run_response.extra_data.history.extend(history_copy)
                 run_messages.messages += history_copy
 
         # 4.Add user message to run_messages

--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -32,7 +32,6 @@ class RunEvent(str, Enum):
 class RunResponseExtraData:
     references: Optional[List[MessageReferences]] = None
     add_messages: Optional[List[Message]] = None
-    history: Optional[List[Message]] = None
     reasoning_steps: Optional[List[ReasoningStep]] = None
     reasoning_messages: Optional[List[Message]] = None
 
@@ -40,8 +39,6 @@ class RunResponseExtraData:
         _dict = {}
         if self.add_messages is not None:
             _dict["add_messages"] = [m.to_dict() for m in self.add_messages]
-        if self.history is not None:
-            _dict["history"] = [m.to_dict() for m in self.history]
         if self.reasoning_messages is not None:
             _dict["reasoning_messages"] = [m.to_dict() for m in self.reasoning_messages]
         if self.reasoning_steps is not None:

--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -68,7 +68,6 @@ class RunResponseExtraData:
 
         return cls(
             add_messages=add_messages,
-            history=history,
             reasoning_steps=reasoning_steps,
             reasoning_messages=reasoning_messages,
             references=references,

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -35,7 +35,7 @@ from agno.models.message import Citations, Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
 from agno.run.messages import RunMessages
-from agno.run.response import RunEvent, RunResponse, RunResponseExtraData
+from agno.run.response import RunEvent, RunResponse
 from agno.run.team import TeamRunResponse
 from agno.storage.base import Storage
 from agno.storage.session.team import TeamSession
@@ -3988,14 +3988,6 @@ class Team:
                     _msg.from_history = True
 
                 log_debug(f"Adding {len(history_copy)} messages from history")
-
-                if run_response.extra_data is None:
-                    run_response.extra_data = RunResponseExtraData(history=history_copy)
-                else:
-                    if run_response.extra_data.history is None:
-                        run_response.extra_data.history = history_copy
-                    else:
-                        run_response.extra_data.history.extend(history_copy)
 
                 # Extend the messages with the history
                 run_messages.messages += history_copy


### PR DESCRIPTION
## Description

 **Summary of changes**: 
- Removes history from `RunResponse.extra_data` as the messages are already stored in `RunResponse.messages` with a `from_history` tag. This makes storage of messages leaner
- Changed `num_history_responses` to `num_history_runs` to be more clear regarding the use of the variable. Since we add all messages from the number of runs specified, not just the responses.

Fixes #2500 
---

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update (Addition or modification of models)
- [ ] Other (please describe):

---

## Checklist

- [ ] Adherence to standards: Code complies with Agno’s style guidelines and best practices.
- [ ] Formatting and validation: You have run `./scripts/format.sh` and `./scripts/validate.sh` to ensure code is formatted and linted.
- [ ] Self-review completed: A thorough review has been performed by the contributor(s).
- [ ] Documentation: Docstrings and comments have been added or updated for any complex logic.
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable).
- [ ] Tested in a clean environment: Changes have been tested in a clean environment to confirm expected behavior.
- [ ] Tests (optional): Tests have been added or updated to cover any new or changed functionality.

---

## Additional Notes

Include any deployment notes, performance implications, security considerations, or other relevant information (e.g., screenshots or logs if applicable).
