### PR TITLE
Update Gemini for structured outputs with tools

### DIFF
--- a/cookbook/models/google/gemini/structured_output.py
+++ b/cookbook/models/google/gemini/structured_output.py
@@ -32,12 +32,3 @@ structured_output_agent = Agent(
 )
 
 structured_output_agent.print_response("New York")
-
-
-# json_agent = Agent(
-#     model=Gemini(id="gemini-2.0-flash-exp"),
-#     description="You help people write movie scripts.",
-#     response_model=MovieScript,
-# )
-#
-# json_agent.print_response("New York")

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -288,14 +288,7 @@ class Gemini(Model):
 
         if system_message is not None:
             config["system_instruction"] = system_message  # type: ignore
-
-        if (
-            self.response_format is not None
-            and isinstance(self.response_format, type)
-            and issubclass(self.response_format, BaseModel)
-        ):
-            config["response_mime_type"] = "application/json"  # type: ignore
-            config["response_schema"] = self.response_format
+            
 
         if self.grounding and self.search:
             log_info("Both grounding and search are enabled. Grounding will take precedence.")
@@ -319,6 +312,18 @@ class Gemini(Model):
 
         elif self._tools:
             config["tools"] = [_format_function_definitions(self._tools)]
+
+        
+        if (
+            self.response_format is not None
+            and isinstance(self.response_format, type)
+            and issubclass(self.response_format, BaseModel)
+        ):
+            config["response_mime_type"] = "application/json"  # type: ignore
+            config["response_schema"] = self.response_format
+            
+            if config["tools"] is not None and len(config["tools"]) > 0:
+                log_warning("The current google-genai version does not support structured outputs with tools. Use `use_json_mode=True` to force JSON mode.")
 
         config = {k: v for k, v in config.items() if v is not None}
 

--- a/libs/agno/tests/integration/models/google/test_basic.py
+++ b/libs/agno/tests/integration/models/google/test_basic.py
@@ -286,12 +286,12 @@ def test_custom_client_params():
     agent = Agent(
         model=Gemini(
             id="gemini-1.5-flash",
-            exponential_backoff=True,
             vertexai=True,
             location="us-central1",
             generation_config=generation_config,
             safety_settings=safety_settings,
         ),
+        exponential_backoff=True,
         telemetry=False,
         monitoring=False,
     )

--- a/libs/agno/tests/integration/models/google/test_tool_use.py
+++ b/libs/agno/tests/integration/models/google/test_tool_use.py
@@ -128,6 +128,28 @@ def test_tool_use_with_native_structured_outputs():
     assert response.content.price is not None
     assert response.content.currency is not None
 
+def test_tool_use_with_json_structured_outputs():
+    class StockPrice(BaseModel):
+        price: float = Field(..., description="The price of the stock")
+        currency: str = Field(..., description="The currency of the stock")
+
+    agent = Agent(
+        model=Gemini(id="gemini-2.0-flash-exp"),
+        tools=[YFinanceTools(cache_results=True)],
+        show_tool_calls=True,
+        markdown=True,
+        response_model=StockPrice,
+        use_json_mode=True,
+        telemetry=False,
+        monitoring=False,
+    )
+    # Gemini does not support structured outputs for tool calls at this time
+    response = agent.run("What is the current price of TSLA?")
+    assert isinstance(response.content, StockPrice)
+    assert response.content is not None
+    assert response.content.price is not None
+    assert response.content.currency is not None
+
 
 def test_parallel_tool_calls():
     agent = Agent(


### PR DESCRIPTION
## Summary

Gemini still can't handle native structured outputs and tool calls simultaneously, but it can with JSON mode. 

## Type of change

- [ ] Bug fix (If applicable, issue number: #____)
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other: _____________________

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
