### PR TITLE
Remove warning on deepcopy which gets triggered for some async knowledge bases

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -2594,7 +2594,7 @@ class Agent:
             return field_value.deep_copy()
 
         # For storage, model and reasoning_model, use a deep copy
-        elif field_name in ("storage", "model", "reasoning_model", "knowledge"):
+        elif field_name in ("storage", "model", "reasoning_model"):
             try:
                 return deepcopy(field_value)
             except Exception:

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -2594,7 +2594,7 @@ class Agent:
             return field_value.deep_copy()
 
         # For storage, model and reasoning_model, use a deep copy
-        elif field_name in ("storage", "model", "reasoning_model"):
+        elif field_name in ("storage", "model", "reasoning_model", "knowledge"):
             try:
                 return deepcopy(field_value)
             except Exception:
@@ -2620,7 +2620,6 @@ class Agent:
             try:
                 return field_value.model_copy(deep=True)
             except Exception as e:
-                log_warning(f"Failed to deepcopy field: {field_name} - {e}")
                 try:
                     return field_value.model_copy(deep=False)
                 except Exception as e:

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -2619,7 +2619,7 @@ class Agent:
         elif isinstance(field_value, BaseModel):
             try:
                 return field_value.model_copy(deep=True)
-            except Exception as e:
+            except Exception:
                 try:
                     return field_value.model_copy(deep=False)
                 except Exception as e:


### PR DESCRIPTION
## Summary

Sometimes knowledge base fails to deepcopy, but copy succeeds.

## Type of change

- [ ] Bug fix (If applicable, issue number: #____)
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other: _____________________

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
