### PR TITLE
Fix(gemini): Prevent TypeError when parsing null grounding_chunks

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -659,16 +659,12 @@ class Gemini(Model):
                 citations.raw = grounding_metadata
 
                 # Extract url and title
-                chunks = grounding_metadata.pop("grounding_chunks", [])
-                citation_pairs = (
-                    [
-                        (chunk.get("web", {}).get("uri"), chunk.get("web", {}).get("title"))
-                        for chunk in chunks
-                        if chunk.get("web", {}).get("uri")
-                    ]
-                    if chunks
-                    else []
-                )
+                chunks = grounding_metadata.pop("grounding_chunks", None) or []
+                citation_pairs = [
+                    (chunk.get("web", {}).get("uri"), chunk.get("web", {}).get("title"))
+                    for chunk in chunks
+                    if chunk.get("web", {}).get("uri")
+                ]
 
                 # Create citation objects from filtered pairs
                 citations.urls = [UrlCitation(url=url, title=title) for url, title in citation_pairs]
@@ -726,7 +722,7 @@ class Gemini(Model):
             citations.raw = grounding_metadata
 
             # Extract url and title
-            chunks = grounding_metadata.pop("grounding_chunks", [])
+            chunks = grounding_metadata.pop("grounding_chunks", None) or []
             citation_pairs = [
                 (chunk.get("web", {}).get("uri"), chunk.get("web", {}).get("title"))
                 for chunk in chunks


### PR DESCRIPTION
## Summary

Fixes a `TypeError: 'NoneType' object is not iterable` that occurs during streaming response parsing in `agno.models.google.gemini.parse_provider_response_delta`.

The error happens when the Gemini API returns `null` for the `"grounding_chunks"` key within grounding metadata. This PR ensures the `chunks` variable, holding the grounding chunks, is always an iterable list before being used in subsequent list comprehensions or iterations, preventing the error.

This issue is separate from the schema conversion problem addressed in PR #2686.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other: _____________________

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

**Root Cause:**

This `TypeError` happens when the API response includes grounding metadata where `"grounding_chunks"` has a value of `null`. The current code uses `chunks = grounding_metadata.pop("grounding_chunks", [])`. If the key exists with a `null` value, `pop` correctly returns `None`. However, subsequent code (specifically in the streaming `parse_provider_response_delta` function) attempts to iterate directly over this `None` value, causing the TypeError.

**Solution Implemented:**

This PR introduces a simple check immediately after the `pop` operation within the `parse_provider_response_delta` function:

```python
# In parse_provider_response_delta:
chunks = grounding_metadata.pop("grounding_chunks", [])
if chunks is None: # Ensure chunks is iterable even if API returns null
    chunks = []
# Now safe to iterate over chunks in subsequent list comprehensions
# citation_pairs = [...] # Code that iterates over chunks
