### PR TITLE
Improve the response parsing from team members

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -2217,10 +2217,10 @@ class Agent:
             system_message_content += f"{self.description}\n\n"
         # 3.3.2 Then add the Agent goal if provided
         if self.goal is not None:
-            system_message_content += f"<your_goal>\n{self.goal}\n</your_goal>\n\n"
+            system_message_content += f"\n<your_goal>\n{self.goal}\n</your_goal>\n\n"
         # 3.3.3 Then add the Agent role if provided
         if self.role is not None:
-            system_message_content += f"<your_role>\n{self.role}\n</your_role>\n\n"
+            system_message_content += f"\n<your_role>\n{self.role}\n</your_role>\n\n"
         # 3.3.4 Then add instructions for transferring tasks to team members
         if self.has_team and self.add_transfer_instructions:
             system_message_content += (

--- a/libs/agno/agno/reasoning/step.py
+++ b/libs/agno/agno/reasoning/step.py
@@ -10,6 +10,7 @@ class NextAction(str, Enum):
     FINAL_ANSWER = "final_answer"
     RESET = "reset"
 
+
 class ReasoningStep(BaseModel):
     title: Optional[str] = Field(None, description="A concise title summarizing the step's purpose")
     action: Optional[str] = Field(

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -586,8 +586,9 @@ class Team:
 
             except ModelProviderError as e:
                 import time
+
                 log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}")
-                
+
                 last_exception = e
                 if attempt < num_attempts - 1:
                     time.sleep(2**attempt)
@@ -4311,7 +4312,10 @@ class Team:
                         check_if_run_cancelled(member_agent_run_response_chunk)
                         if member_agent_run_response_chunk.content is not None:
                             yield member_agent_run_response_chunk.content
-                        elif member_agent_run_response_chunk.tools is not None and len(member_agent_run_response_chunk.tools) > 0:
+                        elif (
+                            member_agent_run_response_chunk.tools is not None
+                            and len(member_agent_run_response_chunk.tools) > 0
+                        ):
                             yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
                 else:
                     member_agent_run_response = member_agent.run(
@@ -4320,7 +4324,9 @@ class Team:
 
                     check_if_run_cancelled(member_agent_run_response)
 
-                    if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
+                    if member_agent_run_response.content is None and (
+                        member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0
+                    ):
                         yield f"Agent {member_agent.name}: No response from the member agent."
                     elif isinstance(member_agent_run_response.content, str):
                         if len(member_agent_run_response.content.strip()) > 0:
@@ -4543,7 +4549,10 @@ class Team:
                     check_if_run_cancelled(member_agent_run_response_chunk)
                     if member_agent_run_response_chunk.content is not None:
                         yield member_agent_run_response_chunk.content
-                    elif member_agent_run_response_chunk.tools is not None and len(member_agent_run_response_chunk.tools) > 0:
+                    elif (
+                        member_agent_run_response_chunk.tools is not None
+                        and len(member_agent_run_response_chunk.tools) > 0
+                    ):
                         yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
             else:
                 member_agent_run_response = member_agent.run(
@@ -4552,7 +4561,9 @@ class Team:
 
                 check_if_run_cancelled(member_agent_run_response)
 
-                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
+                if member_agent_run_response.content is None and (
+                    member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0
+                ):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
                     if len(member_agent_run_response.content.strip()) > 0:
@@ -4561,7 +4572,7 @@ class Team:
                     # If the content is empty but we have tool calls
                     elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
                         yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
-                        
+
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
                         yield member_agent_run_response.content.model_dump_json(indent=2)
@@ -4652,15 +4663,20 @@ class Team:
                     check_if_run_cancelled(member_agent_run_response_chunk)
                     if member_agent_run_response_chunk.content is not None:
                         yield member_agent_run_response_chunk.content
-                    elif member_agent_run_response_chunk.tools is not None and len(member_agent_run_response_chunk.tools) > 0:
+                    elif (
+                        member_agent_run_response_chunk.tools is not None
+                        and len(member_agent_run_response_chunk.tools) > 0
+                    ):
                         yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
             else:
                 member_agent_run_response = await member_agent.arun(
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
                 )
                 check_if_run_cancelled(member_agent_run_response)
-                
-                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
+
+                if member_agent_run_response.content is None and (
+                    member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0
+                ):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
                     if len(member_agent_run_response.content.strip()) > 0:
@@ -4800,7 +4816,9 @@ class Team:
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
                 )
 
-                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
+                if member_agent_run_response.content is None and (
+                    member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0
+                ):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
                     if len(member_agent_run_response.content.strip()) > 0:
@@ -4889,7 +4907,9 @@ class Team:
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
                 )
 
-                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
+                if member_agent_run_response.content is None and (
+                    member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0
+                ):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
                     if len(member_agent_run_response.content.strip()) > 0:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -586,8 +586,8 @@ class Team:
 
             except ModelProviderError as e:
                 import time
-
                 log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}")
+                
                 last_exception = e
                 if attempt < num_attempts - 1:
                     time.sleep(2**attempt)
@@ -4309,7 +4309,10 @@ class Team:
                     )
                     for member_agent_run_response_chunk in member_agent_run_response_stream:
                         check_if_run_cancelled(member_agent_run_response_chunk)
-                        yield member_agent_run_response_chunk.content or ""
+                        if member_agent_run_response_chunk.content is not None:
+                            yield member_agent_run_response_chunk.content
+                        elif member_agent_run_response_chunk.tools is not None and len(member_agent_run_response_chunk.tools) > 0:
+                            yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
                 else:
                     member_agent_run_response = member_agent.run(
                         member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
@@ -4317,22 +4320,25 @@ class Team:
 
                     check_if_run_cancelled(member_agent_run_response)
 
-                    if member_agent_run_response.content is None:
-                        yield "No response from the member agent."
+                    if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
+                        yield f"Agent {member_agent.name}: No response from the member agent."
                     elif isinstance(member_agent_run_response.content, str):
-                        yield member_agent_run_response.content
+                        if len(member_agent_run_response.content.strip()) > 0:
+                            yield f"Agent {member_agent.name}: {member_agent_run_response.content}"
+                        elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
+                            yield f"Agent {member_agent.name}: {','.join([tool.get('content') for tool in member_agent_run_response.tools])}"
                     elif issubclass(type(member_agent_run_response.content), BaseModel):
                         try:
-                            yield member_agent_run_response.content.model_dump_json(indent=2)  # type: ignore
+                            yield f"Agent {member_agent.name}: {member_agent_run_response.content.model_dump_json(indent=2)}"  # type: ignore
                         except Exception as e:
-                            yield str(e)
+                            yield f"Agent {member_agent.name}: Error - {str(e)}"
                     else:
                         try:
                             import json
 
-                            yield json.dumps(member_agent_run_response.content, indent=2)
+                            yield f"Agent {member_agent.name}: {json.dumps(member_agent_run_response.content, indent=2)}"
                         except Exception as e:
-                            yield str(e)
+                            yield f"Agent {member_agent.name}: Error - {str(e)}"
 
                 # Update the memory
                 member_name = member_agent.name if member_agent.name else f"agent_{member_agent_index}"
@@ -4424,10 +4430,13 @@ class Team:
                     # Update the team state
                     self._update_team_state(agent.run_response)
 
-                    if response.content is None:
+                    if response.content is None and (response.tools is None or len(response.tools) == 0):
                         return f"Agent {member_name}: No response from the member agent."
                     elif isinstance(response.content, str):
-                        return f"Agent {member_name}: {response.content}"
+                        if len(response.content.strip()) > 0:
+                            return f"Agent {member_name}: {response.content}"
+                        elif response.tools is not None and len(response.tools) > 0:
+                            return f"Agent {member_name}: {','.join([tool.get('content') for tool in response.tools])}"
                     elif issubclass(type(response.content), BaseModel):
                         try:
                             return f"Agent {member_name}: {response.content.model_dump_json(indent=2)}"  # type: ignore
@@ -4532,7 +4541,10 @@ class Team:
                 )
                 for member_agent_run_response_chunk in member_agent_run_response_stream:
                     check_if_run_cancelled(member_agent_run_response_chunk)
-                    yield member_agent_run_response_chunk.content or ""
+                    if member_agent_run_response_chunk.content is not None:
+                        yield member_agent_run_response_chunk.content
+                    elif member_agent_run_response_chunk.tools is not None and len(member_agent_run_response_chunk.tools) > 0:
+                        yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
             else:
                 member_agent_run_response = member_agent.run(
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
@@ -4540,10 +4552,16 @@ class Team:
 
                 check_if_run_cancelled(member_agent_run_response)
 
-                if member_agent_run_response.content is None:
+                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
-                    yield member_agent_run_response.content
+                    if len(member_agent_run_response.content.strip()) > 0:
+                        yield member_agent_run_response.content
+
+                    # If the content is empty but we have tool calls
+                    elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
+                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
+                        
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
                         yield member_agent_run_response.content.model_dump_json(indent=2)
@@ -4632,16 +4650,25 @@ class Team:
                 )
                 async for member_agent_run_response_chunk in member_agent_run_response_stream:
                     check_if_run_cancelled(member_agent_run_response_chunk)
-                    yield member_agent_run_response_chunk.content or ""
+                    if member_agent_run_response_chunk.content is not None:
+                        yield member_agent_run_response_chunk.content
+                    elif member_agent_run_response_chunk.tools is not None and len(member_agent_run_response_chunk.tools) > 0:
+                        yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
             else:
                 member_agent_run_response = await member_agent.arun(
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
                 )
                 check_if_run_cancelled(member_agent_run_response)
-                if member_agent_run_response.content is None:
+                
+                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
-                    yield member_agent_run_response.content
+                    if len(member_agent_run_response.content.strip()) > 0:
+                        yield member_agent_run_response.content
+
+                    # If the content is empty but we have tool calls
+                    elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
+                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
                         yield member_agent_run_response.content.model_dump_json(indent=2)
@@ -4773,10 +4800,15 @@ class Team:
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
                 )
 
-                if member_agent_run_response.content is None:
+                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
-                    yield member_agent_run_response.content
+                    if len(member_agent_run_response.content.strip()) > 0:
+                        yield member_agent_run_response.content
+
+                    # If the content is empty but we have tool calls
+                    elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
+                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
                         yield member_agent_run_response.content.model_dump_json(indent=2)
@@ -4857,10 +4889,15 @@ class Team:
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
                 )
 
-                if member_agent_run_response.content is None:
+                if member_agent_run_response.content is None and (member_agent_run_response.tools is None or len(member_agent_run_response.tools) == 0):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
-                    yield member_agent_run_response.content
+                    if len(member_agent_run_response.content.strip()) > 0:
+                        yield member_agent_run_response.content
+
+                    # If the content is empty but we have tool calls
+                    elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
+                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
                         yield member_agent_run_response.content.model_dump_json(indent=2)

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -4316,7 +4316,7 @@ class Team:
                             member_agent_run_response_chunk.tools is not None
                             and len(member_agent_run_response_chunk.tools) > 0
                         ):
-                            yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
+                            yield ",".join([tool.get("content", "") for tool in member_agent_run_response_chunk.tools])
                 else:
                     member_agent_run_response = member_agent.run(
                         member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
@@ -4332,7 +4332,7 @@ class Team:
                         if len(member_agent_run_response.content.strip()) > 0:
                             yield f"Agent {member_agent.name}: {member_agent_run_response.content}"
                         elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
-                            yield f"Agent {member_agent.name}: {','.join([tool.get('content') for tool in member_agent_run_response.tools])}"
+                            yield f"Agent {member_agent.name}: {','.join([tool.get('content', '') for tool in member_agent_run_response.tools])}"
                     elif issubclass(type(member_agent_run_response.content), BaseModel):
                         try:
                             yield f"Agent {member_agent.name}: {member_agent_run_response.content.model_dump_json(indent=2)}"  # type: ignore
@@ -4456,6 +4456,8 @@ class Team:
                         except Exception as e:
                             return f"Agent {member_name}: Error - {str(e)}"
 
+                    return f"Agent {member_name}: No Response"
+
                 tasks.append(run_member_agent)
 
             # Need to collect and process yielded values from each task
@@ -4553,7 +4555,7 @@ class Team:
                         member_agent_run_response_chunk.tools is not None
                         and len(member_agent_run_response_chunk.tools) > 0
                     ):
-                        yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
+                        yield ",".join([tool.get("content", "") for tool in member_agent_run_response_chunk.tools])
             else:
                 member_agent_run_response = member_agent.run(
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
@@ -4571,11 +4573,11 @@ class Team:
 
                     # If the content is empty but we have tool calls
                     elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
-                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
+                        yield ",".join([tool.get("content", "") for tool in member_agent_run_response.tools])
 
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
-                        yield member_agent_run_response.content.model_dump_json(indent=2)
+                        yield member_agent_run_response.content.model_dump_json(indent=2)  # type: ignore
                     except Exception as e:
                         yield str(e)
                 else:
@@ -4667,7 +4669,7 @@ class Team:
                         member_agent_run_response_chunk.tools is not None
                         and len(member_agent_run_response_chunk.tools) > 0
                     ):
-                        yield ",".join([tool.get("content") for tool in member_agent_run_response_chunk.tools])
+                        yield ",".join([tool.get("content", "") for tool in member_agent_run_response_chunk.tools])
             else:
                 member_agent_run_response = await member_agent.arun(
                     member_agent_task, images=images, videos=videos, audio=audio, files=files, stream=False
@@ -4684,10 +4686,10 @@ class Team:
 
                     # If the content is empty but we have tool calls
                     elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
-                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
+                        yield ",".join([tool.get("content", "") for tool in member_agent_run_response.tools])
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
-                        yield member_agent_run_response.content.model_dump_json(indent=2)
+                        yield member_agent_run_response.content.model_dump_json(indent=2)  # type: ignore
                     except Exception as e:
                         yield str(e)
                 else:
@@ -4826,10 +4828,10 @@ class Team:
 
                     # If the content is empty but we have tool calls
                     elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
-                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
+                        yield ",".join([tool.get("content", "") for tool in member_agent_run_response.tools])
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
-                        yield member_agent_run_response.content.model_dump_json(indent=2)
+                        yield member_agent_run_response.content.model_dump_json(indent=2)  # type: ignore
                     except Exception as e:
                         yield str(e)
                 else:
@@ -4917,10 +4919,10 @@ class Team:
 
                     # If the content is empty but we have tool calls
                     elif member_agent_run_response.tools is not None and len(member_agent_run_response.tools) > 0:
-                        yield ",".join([tool.get("content") for tool in member_agent_run_response.tools])
+                        yield ",".join([tool.get("content", "") for tool in member_agent_run_response.tools])
                 elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
-                        yield member_agent_run_response.content.model_dump_json(indent=2)
+                        yield member_agent_run_response.content.model_dump_json(indent=2)  # type: ignore
                     except Exception as e:
                         yield str(e)
                 else:

--- a/libs/agno/tests/integration/models/openai/responses/test_basic.py
+++ b/libs/agno/tests/integration/models/openai/responses/test_basic.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import pytest
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
## Summary

There were various cases where weaker models would have the tools in the run response, but no response content. This makes sure we can handle that.

Fixes #2595 

## Type of change

- [ ] Bug fix (If applicable, issue number: #____)
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other: _____________________

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
