### PR TITLE
Remove tool descriptions from team

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -3781,24 +3781,6 @@ class Team:
                     system_message_content += f"{indent * ' '}   - Role: {member.role}\n"
                 if member.description is not None:
                     system_message_content += f"{indent * ' '}   - Description: {member.description}\n"
-                if member.tools is not None:
-                    system_message_content += f"{indent * ' '}   - Available tools:\n"
-                    tool_name_and_description = []
-
-                    for _tool in member.tools:
-                        if isinstance(_tool, Toolkit):
-                            for _func in _tool.functions.values():
-                                if _func.entrypoint:
-                                    tool_name_and_description.append(
-                                        (_func.name, get_entrypoint_docstring(_func.entrypoint))
-                                    )
-                        elif isinstance(_tool, Function) and _tool.entrypoint:
-                            tool_name_and_description.append((_tool.name, get_entrypoint_docstring(_tool.entrypoint)))
-                        elif callable(_tool):
-                            tool_name_and_description.append((_tool.__name__, get_entrypoint_docstring(_tool)))
-
-                    for _tool_name, _tool_description in tool_name_and_description:
-                        system_message_content += f"{indent * ' '}    - {_tool_name}: {_tool_description}\n"
 
         return system_message_content
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -39,7 +39,6 @@ from agno.run.response import RunEvent, RunResponse
 from agno.run.team import TeamRunResponse
 from agno.storage.base import Storage
 from agno.storage.session.team import TeamSession
-from agno.tools.function import Function, get_entrypoint_docstring
 from agno.tools.toolkit import Toolkit
 from agno.utils.log import (
     log_debug,


### PR DESCRIPTION
## Summary

Removes tool descriptions from team system prompt.

- Tool descriptions are already included in tool block
- Tool descriptions make system prompt massive if they are included

## Type of change

- [ ] Bug fix (If applicable, issue number: #____)
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other: _____________________

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)

Closes #2749 