### PR TITLE
Extracting website main content should return content as text if all else fails

### DIFF
--- a/libs/agno/agno/document/reader/website_reader.py
+++ b/libs/agno/agno/document/reader/website_reader.py
@@ -76,7 +76,7 @@ class WebsiteReader(Reader):
             if element:
                 return element.get_text(strip=True, separator=" ")
 
-        return ""
+        return soup.get_text(strip=True, separator=" ")
 
     def crawl(self, url: str, starting_depth: int = 1) -> Dict[str, str]:
         """


### PR DESCRIPTION
## Summary

This fixes the problem with website reader where if the content does not have "content" tag the result would be empty. We want instead to return the page as text so that we return at least something. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

This should not break any existing code. 