### PR TITLE
feat: log a warning msg when receiving input of unsupported type

### DIFF
--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -207,6 +207,10 @@ class AwsBedrock(Model):
                             )
                         else:
                             raise ValueError("Video content and format are required.")
+
+                if message.files is not None and len(message.files) > 0:
+                    log_warning("File input is currently unsupported.")
+
                 formatted_messages.append(formatted_message)
         # TODO: Add caching: https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html
         return formatted_messages, system_message

--- a/libs/agno/agno/models/azure/ai_foundry.py
+++ b/libs/agno/agno/models/azure/ai_foundry.py
@@ -61,6 +61,9 @@ def _format_message(message: Message) -> Dict[str, Any]:
     if message.audio is not None and len(message.audio) > 0:
         log_warning("Audio input is currently unsupported.")
 
+    if message.files is not None and len(message.files) > 0:
+        log_warning("File input is currently unsupported.")
+
     if message.videos is not None and len(message.videos) > 0:
         log_warning("Video input is currently unsupported.")
 

--- a/libs/agno/agno/models/cohere/chat.py
+++ b/libs/agno/agno/models/cohere/chat.py
@@ -86,6 +86,15 @@ def _format_messages(messages: List[Message]) -> List[Dict[str, Any]]:
                 if len(message_content_with_image) > 1:
                     message_dict["content"] = message_content_with_image
 
+        if message.videos is not None and len(message.videos) > 0:
+            log_warning("Video input is currently unsupported.")
+
+        if message.audio is not None and len(message.audio) > 0:
+            log_warning("Audio input is currently unsupported.")
+
+        if message.files is not None and len(message.files) > 0:
+            log_warning("File input is currently unsupported.")
+
         message_dict = {k: v for k, v in message_dict.items() if v is not None}
         formatted_messages.append(message_dict)
     return formatted_messages

--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -231,6 +231,9 @@ class Groq(Model):
                 message_dict["content"] = [{"type": "text", "text": message.content}]
                 message_dict["content"].extend(images_to_message(images=message.images))
 
+        if message.files is not None and len(message.files) > 0:
+            log_warning("File input is currently unsupported.")
+
         if message.audio is not None and len(message.audio) > 0:
             log_warning("Audio input is currently unsupported.")
 

--- a/libs/agno/agno/models/huggingface/huggingface.py
+++ b/libs/agno/agno/models/huggingface/huggingface.py
@@ -239,6 +239,18 @@ class HuggingFace(Model):
         if message.tool_calls is None or len(message.tool_calls) == 0:
             message_dict["tool_calls"] = None
 
+        if message.audio is not None and len(message.audio) > 0:
+            log_warning("Audio input is currently unsupported.")
+
+        if message.files is not None and len(message.files) > 0:
+            log_warning("File input is currently unsupported.")
+
+        if message.images is not None and len(message.images) > 0:
+            log_warning("Image input is currently unsupported.")
+
+        if message.videos is not None and len(message.videos) > 0:
+            log_warning("Video input is currently unsupported.")
+
         return message_dict
 
     def invoke(self, messages: List[Message]) -> Union[ChatCompletionOutput]:

--- a/libs/agno/agno/models/ibm/watsonx.py
+++ b/libs/agno/agno/models/ibm/watsonx.py
@@ -168,6 +168,16 @@ class WatsonX(Model):
         """
         if message.images is not None and isinstance(message.content, str):
             message = _format_images_for_message(message=message, images=message.images)
+
+        if message.audio is not None and len(message.audio) > 0:
+            log_warning("Audio input is currently unsupported.")
+
+        if message.files is not None and len(message.files) > 0:
+            log_warning("File input is currently unsupported.")
+
+        if message.videos is not None and len(message.videos) > 0:
+            log_warning("Video input is currently unsupported.")
+
         return message.to_dict()
 
     def invoke(self, messages: List[Message]) -> Any:

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -81,6 +81,18 @@ class LiteLLM(Model):
                 msg["tool_call_id"] = m.tool_call_id or ""
                 msg["name"] = m.name or ""
 
+                if m.audio is not None and len(m.audio) > 0:
+                    log_warning("Audio input is currently unsupported.")
+
+                if m.images is not None and len(m.images) > 0:
+                    log_warning("Image input is currently unsupported.")
+
+                if m.files is not None and len(m.files) > 0:
+                    log_warning("File input is currently unsupported.")
+
+                if m.videos is not None and len(m.videos) > 0:
+                    log_warning("Video input is currently unsupported.")
+
             formatted_messages.append(msg)
 
         return formatted_messages

--- a/libs/agno/agno/models/mistral/mistral.py
+++ b/libs/agno/agno/models/mistral/mistral.py
@@ -7,7 +7,7 @@ from agno.media import Image
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.models.response import ModelResponse
-from agno.utils.log import log_error
+from agno.utils.log import log_error, log_warning
 
 try:
     from mistralai import CompletionEvent
@@ -66,6 +66,15 @@ def _format_messages(messages: List[Message]) -> List[MistralMessage]:
     for message in messages:
         mistral_message: MistralMessage
         if message.role == "user":
+            if message.audio is not None and len(message.audio) > 0:
+                log_warning("Audio input is currently unsupported.")
+
+            if message.files is not None and len(message.files) > 0:
+                log_warning("File input is currently unsupported.")
+
+            if message.videos is not None and len(message.videos) > 0:
+                log_warning("Video input is currently unsupported.")
+
             if message.images is not None:
                 content: List[Any] = [TextChunk(type="text", text=message.content)]
                 for image in message.images:

--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -173,6 +173,16 @@ class Ollama(Model):
                         message_images.append(image.content)
                 if message_images:
                     _message["images"] = message_images
+
+            if message.audio is not None and len(message.audio) > 0:
+                log_warning("Audio input is currently unsupported.")
+
+            if message.files is not None and len(message.files) > 0:
+                log_warning("File input is currently unsupported.")
+
+            if message.videos is not None and len(message.videos) > 0:
+                log_warning("Video input is currently unsupported.")
+
         return _message
 
     def _prepare_request_kwargs_for_invoke(self) -> Dict[str, Any]:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agno.media import File, Image
 from agno.models.message import Message
-from agno.utils.log import log_error
+from agno.utils.log import log_error, log_warning
 
 try:
     from anthropic.types import (
@@ -205,6 +205,12 @@ def format_messages(messages: List[Message]) -> Tuple[List[Dict[str, str]], str]
                     file_content = _format_file_for_message(file)
                     if file_content:
                         content.append(file_content)
+
+            if message.audio is not None and len(message.audio) > 0:
+                log_warning("Audio input is currently unsupported.")
+
+            if message.videos is not None and len(message.videos) > 0:
+                log_warning("Video input is currently unsupported.")
 
         elif message.role == "assistant":
             content = []


### PR DESCRIPTION
Log warning messages when formatting input messages if they contain entities of unsupported format, e.g. video