### PR TITLE
add mistral reasoning True fix

### DIFF
--- a/cookbook/examples/apps/sql_agent/app.py
+++ b/cookbook/examples/apps/sql_agent/app.py
@@ -30,7 +30,8 @@ def main() -> None:
     # App header
     ####################################################################
     st.markdown(
-        "<h1 class='main-title'>SQrL: Text2SQL Reasoning Agent</h1>", unsafe_allow_html=True
+        "<h1 class='main-title'>SQrL: Text2SQL Reasoning Agent</h1>",
+        unsafe_allow_html=True,
     )
     st.markdown(
         "<p class='subtitle'>SQrL is an intelligent SQL Agent that can think, analyze and reason, powered by Agno</p>",

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -3532,16 +3532,30 @@ class Agent:
             # Get default reasoning agent
             reasoning_agent: Optional[Agent] = self.reasoning_agent
             if reasoning_agent is None:
-                reasoning_agent = get_default_reasoning_agent(
-                    reasoning_model=reasoning_model,
-                    min_steps=self.reasoning_min_steps,
-                    max_steps=self.reasoning_max_steps,
-                    tools=self.tools,
-                    use_json_mode=self.use_json_mode,
-                    monitoring=self.monitoring,
-                    telemetry=self.telemetry,
-                    debug_mode=self.debug_mode,
-                )
+                if reasoning_model.__class__.__name__ == "MistralChat":
+                    # Create the reasoning agent with use_json_mode=True for Mistral
+                    reasoning_agent = get_default_reasoning_agent(
+                        reasoning_model=reasoning_model,
+                        min_steps=self.reasoning_min_steps,
+                        max_steps=self.reasoning_max_steps,
+                        tools=self.tools,
+                        use_json_mode=True,  # Force JSON mode for Mistral
+                        monitoring=self.monitoring,
+                        telemetry=self.telemetry,
+                        debug_mode=self.debug_mode,
+                    )
+
+                else:
+                    reasoning_agent = get_default_reasoning_agent(
+                        reasoning_model=reasoning_model,
+                        min_steps=self.reasoning_min_steps,
+                        max_steps=self.reasoning_max_steps,
+                        tools=self.tools,
+                        use_json_mode=self.use_json_mode,
+                        monitoring=self.monitoring,
+                        telemetry=self.telemetry,
+                        debug_mode=self.debug_mode,
+                    )
 
             # Validate reasoning agent
             if reasoning_agent is None:

--- a/libs/agno/agno/memory/v2/db/redis.py
+++ b/libs/agno/agno/memory/v2/db/redis.py
@@ -3,7 +3,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 try:
-    from redis import Redis, ConnectionError
+    from redis import ConnectionError, Redis
 except ImportError:
     raise ImportError("`redis` not installed. Please install it using `pip install redis`")
 
@@ -66,8 +66,8 @@ class RedisMemoryDb(MemoryDb):
     def memory_exists(self, memory: MemoryRow) -> bool:
         """Check if a memory exists"""
         try:
-            key = self._get_key(memory.id) # type: ignore
-            return self.redis_client.exists(key) > 0 # type: ignore
+            key = self._get_key(memory.id)  # type: ignore
+            return self.redis_client.exists(key) > 0  # type: ignore
         except Exception as e:
             logger.error(f"Error checking memory existence: {e}")
             return False
@@ -86,7 +86,7 @@ class RedisMemoryDb(MemoryDb):
             for key in self.redis_client.scan_iter(match=pattern):
                 data_str = self.redis_client.get(key)
                 if data_str:
-                    data = json.loads(data_str) #type: ignore
+                    data = json.loads(data_str)  # type: ignore
 
                     # Filter by user_id if specified
                     if user_id is None or data.get("user_id") == user_id:
@@ -127,7 +127,7 @@ class RedisMemoryDb(MemoryDb):
             memory_data["updated_at"] = timestamp
 
             # Save to Redis
-            key = self._get_key(memory.id) # type: ignore
+            key = self._get_key(memory.id)  # type: ignore
             self.redis_client.set(key, json.dumps(memory_data))
             return memory
 

--- a/libs/agno/agno/models/mistral/mistral.py
+++ b/libs/agno/agno/models/mistral/mistral.py
@@ -77,7 +77,6 @@ def _format_messages(messages: List[Message]) -> List[MistralMessage]:
                 mistral_message = UserMessage(role="user", content=message.content)
         elif message.role == "assistant":
             if message.reasoning_content is not None:
-                message.role = "user"
                 mistral_message = UserMessage(role="user", content=message.content)
             elif message.tool_calls is not None:
                 mistral_message = AssistantMessage(
@@ -93,6 +92,12 @@ def _format_messages(messages: List[Message]) -> List[MistralMessage]:
             raise ValueError(f"Unknown role: {message.role}")
 
         mistral_messages.append(mistral_message)
+
+    # Check if the last message is an assistant message
+    if mistral_messages and hasattr(mistral_messages[-1], "role") and mistral_messages[-1].role == "assistant":
+        # Set prefix=True for the last assistant message to allow it as the last message
+        mistral_messages[-1].prefix = True
+
     return mistral_messages
 
 

--- a/libs/agno/agno/reasoning/default.py
+++ b/libs/agno/agno/reasoning/default.py
@@ -21,6 +21,18 @@ def get_default_reasoning_agent(
 ) -> Optional["Agent"]:  # type: ignore  # noqa: F821
     from agno.agent import Agent
 
+    # Special instructions for Mistral models
+    json_instructions = ""
+    if reasoning_model.__class__.__name__ == "MistralChat":
+        json_instructions = """
+        RESPONSE FORMAT INSTRUCTIONS:
+        - Return your response as a plain JSON object.
+        - DO NOT wrap your JSON in markdown code blocks.
+        - DO NOT use ```json or ``` tags.
+        - Return ONLY the raw JSON with no other text.
+        - For example, respond with {"reasoning_steps": [...]} directly, not ```json {"reasoning_steps": [...]} ```
+        """
+
     agent = Agent(
         model=reasoning_model,
         description="You are a meticulous, thoughtful, and logical Reasoning Agent who solves complex problems through clear, structured, step-by-step analysis.",
@@ -53,7 +65,7 @@ def get_default_reasoning_agent(
             - **validate**: When you reach a potential answer, signaling it's ready for validation.
             - **final_answer**: Only if you have confidently validated the solution.
             - **reset**: Immediately restart analysis if a critical error or incorrect result is identified.
-        6. **Confidence Score**: Provide a numeric confidence score (0.0–1.0) indicating your certainty in the step’s correctness and its outcome.
+        6. **Confidence Score**: Provide a numeric confidence score (0.0–1.0) indicating your certainty in the step's correctness and its outcome.
 
         Step 5 - Validation (mandatory before finalizing an answer):
         - Explicitly validate your solution by:
@@ -76,7 +88,8 @@ def get_default_reasoning_agent(
         - Always explicitly handle errors and mistakes by resetting or revising steps immediately.
         - Adhere strictly to a minimum of {min_steps} and maximum of {max_steps} steps to ensure effective task resolution.
         - Execute necessary tools proactively and without hesitation, clearly documenting tool usage.
-        - Only create a single instance of ReasoningSteps for your response.\
+        - Only create a single instance of ReasoningSteps for your response.
+        {json_instructions}\
         """),
         tools=tools,
         show_tool_calls=False,
@@ -86,7 +99,5 @@ def get_default_reasoning_agent(
         telemetry=telemetry,
         debug_mode=debug_mode,
     )
-
-    agent.model.show_tool_calls = False  # type: ignore
 
     return agent

--- a/libs/agno/agno/storage/redis.py
+++ b/libs/agno/agno/storage/redis.py
@@ -11,7 +11,7 @@ from agno.storage.session.workflow import WorkflowSession
 from agno.utils.log import log_debug, log_info, logger
 
 try:
-    from redis import Redis, ConnectionError
+    from redis import ConnectionError, Redis
 except ImportError:
     raise ImportError("`redis` not installed. Please install it using `pip install redis`")
 


### PR DESCRIPTION
## Summary

When using `MistralChat` with `reasoning=True` like this-
```py
reasoning_agent = Agent(model=MistralChat(id="mistral-large-latest"), reasoning=True, markdown=True, debug_mode=True)

reasoning_agent.print_response(
    "Give me steps to write a python script for fibonacci series",
    stream=True,
    stream_intermediate_steps=True,
    show_full_reasoning=True,
)
```

It gives these two errors-
![image](https://github.com/user-attachments/assets/8f8a8ee0-8840-43f7-9425-4298ca1ac84f)

1. Since it says Mistral needs to accept the last message as either User, Tool or Assistant with `prefix=True`, so in `mistral.py` `_format_messages` we make sure to pass `prefix=True` if the last message is from `Assistant`

2. Unexpected `None`, so after a few trials i figured that `Mistral` is not able to work with the `structured_output: `ReasoningSteps`. In default COT, we set the `response_model` as `ReasoningStep` and the model is parsing that and hence failing.

What I tried:
- in `reason()` in default COT part, I added a check if `if reasoning_model.__class__.__name__ == "MistralChat":` then we force `use_json_mode=True`
- In the `default.py` function `get_default_reasoning_agent()` added special instructions for the Mistral model
```py
json_instructions = """
        RESPONSE FORMAT INSTRUCTIONS:
        - Return your response as a plain JSON object.
        - DO NOT wrap your JSON in markdown code blocks.
        - DO NOT use ```json or ``` tags.
        - Return ONLY the raw JSON with no other text.
        - For example, respond with {"reasoning_steps": [...]} directly, not ```json {"reasoning_steps": [...]} ```
        """
```

Then appended this to the end of instructions passed to the agent. 

It works, but since the instructions remove formatting, the final response message is a bit non-markdown formatted and strictly json as well (This we'll have to fix to make the final response be formatted irrespective of reasoning.)

Also since we now specify model to respond with json and not use any ``` to wrap the json with, but sometimes it still does the markdown wrapping around json, ig that's the `non-deterministic` nature when we depend on a prompt based approach. 

But I'm open to discussing how else we can think about this.

Loom walkthrough- https://www.loom.com/share/b2015796fd7941e7b2824886294c31b1?sid=ae37018c-b6a9-469f-a173-a082f8dedc63

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
