### PR TITLE
insert/upsert/log_info only if there are documents from reader

### DIFF
--- a/libs/agno/agno/knowledge/website.py
+++ b/libs/agno/agno/knowledge/website.py
@@ -87,16 +87,16 @@ class WebsiteKnowledgeBase(AgentKnowledge):
                     urls_to_read.remove(url)
 
         for url in urls_to_read:
-            document_list = self.reader.read(url=url)
-            # Filter out documents which already exist in the vector db
-            if not recreate:
-                document_list = [document for document in document_list if not self.vector_db.doc_exists(document)]
-            if upsert and self.vector_db.upsert_available():
-                self.vector_db.upsert(documents=document_list, filters=filters)
-            else:
-                self.vector_db.insert(documents=document_list, filters=filters)
-            num_documents += len(document_list)
-            log_info(f"Loaded {num_documents} documents to knowledge base")
+            if document_list := self.reader.read(url=url):
+                # Filter out documents which already exist in the vector db
+                if not recreate:
+                    document_list = [document for document in document_list if not self.vector_db.doc_exists(document)]
+                if upsert and self.vector_db.upsert_available():
+                    self.vector_db.upsert(documents=document_list, filters=filters)
+                else:
+                    self.vector_db.insert(documents=document_list, filters=filters)
+                num_documents += len(document_list)
+                log_info(f"Loaded {num_documents} documents to knowledge base")
 
         if self.optimize_on is not None and num_documents > self.optimize_on:
             log_debug("Optimizing Vector DB")


### PR DESCRIPTION
## Summary

When some documents processed by Reader have no content, those urls produce empty `document_list` array and it it attempted to be insert.upserted by KnowledgeBase.load() method and it results in error 400 from Pinecone API.

If there are no Documents it is illogical to even attemp to insert or log-report number of documents, thus wrapping this whole block in check if array is not empty.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

```Traceback (most recent call last):
  File "/Users/user/agno-forked-clean/batch-help-to-pinecone.py", line 28, in <module>
    knowledge_base.load(recreate=False)
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/agno/knowledge/website.py", line 95, in load
    self.vector_db.upsert(documents=document_list, filters=filters)
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/agno/vectordb/pineconedb/pineconedb.py", line 249, in upsert
    self.index.upsert(
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/utils/error_handling.py", line 11, in inner_func
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/data/index.py", line 218, in upsert
    return self._upsert_batch(vectors, namespace, _check_type, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/data/index.py", line 247, in _upsert_batch
    return self._vector_api.upsert(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/api_client.py", line 821, in __call__
    return self.callable(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/data/api/data_plane_api.py", line 811, in __upsert
    return self.call_with_http_info(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/api_client.py", line 879, in call_with_http_info
    return self.api_client.call_api(
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/api_client.py", line 431, in call_api
    return self.__call_api(
           ^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/api_client.py", line 216, in __call_api
    raise e
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/api_client.py", line 204, in __call_api
    response_data = self.request(
                    ^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/api_client.py", line 518, in request
    return self.rest_client.POST(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/rest.py", line 345, in POST
    return self.request(
           ^^^^^^^^^^^^^
  File "/Users/user/agno-forked-clean/.venv/lib/python3.12/site-packages/pinecone/core/openapi/shared/rest.py", line 279, in request
    raise PineconeApiException(http_resp=r)
pinecone.core.openapi.shared.exceptions.PineconeApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'content-type': 'application/json', 'date': 'Thu, 17 Apr 2025 14:00:27 GMT', 'x-envoy-upstream-service-time': '0', 'content-length': '55', 'server': 'envoy'})
HTTP response body: {"code":3,"message":"No vectors provided","details":[]}```