### PR TITLE
feat(PDF): add proxy parameter

### DIFF
--- a/libs/agno/agno/document/reader/csv_reader.py
+++ b/libs/agno/agno/document/reader/csv_reader.py
@@ -133,11 +133,10 @@ class CSVReader(Reader):
 
 class CSVUrlReader(Reader):
     """Reader for CSV files"""
-    
+
     def __init__(self, proxy: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.proxy = proxy
-        
 
     def read(self, url: str) -> List[Document]:
         if not url:

--- a/libs/agno/agno/document/reader/csv_reader.py
+++ b/libs/agno/agno/document/reader/csv_reader.py
@@ -3,7 +3,7 @@ import csv
 import io
 import os
 from pathlib import Path
-from typing import IO, Any, List, Union
+from typing import IO, Any, List, Optional, Union
 from urllib.parse import urlparse
 
 from agno.utils.http import async_fetch_with_retry, fetch_with_retry
@@ -133,6 +133,11 @@ class CSVReader(Reader):
 
 class CSVUrlReader(Reader):
     """Reader for CSV files"""
+    
+    def __init__(self, proxy: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.proxy = proxy
+        
 
     def read(self, url: str) -> List[Document]:
         if not url:
@@ -140,7 +145,7 @@ class CSVUrlReader(Reader):
 
         logger.info(f"Reading: {url}")
         # Retry the request up to 3 times with exponential backoff
-        response = fetch_with_retry(url)
+        response = fetch_with_retry(url, proxy=self.proxy)
 
         parsed_url = urlparse(url)
         filename = os.path.basename(parsed_url.path) or "data.csv"
@@ -162,7 +167,8 @@ class CSVUrlReader(Reader):
 
         logger.info(f"Reading async: {url}")
 
-        async with httpx.AsyncClient() as client:
+        client_args = {"proxy": self.proxy} if self.proxy else {}
+        async with httpx.AsyncClient(**client_args) as client:
             response = await async_fetch_with_retry(url, client=client)
 
             parsed_url = urlparse(url)

--- a/libs/agno/agno/document/reader/pdf_reader.py
+++ b/libs/agno/agno/document/reader/pdf_reader.py
@@ -1,6 +1,5 @@
 import asyncio
 from pathlib import Path
-from time import sleep
 from typing import IO, Any, List, Optional, Union
 
 from agno.document.base import Document
@@ -169,20 +168,18 @@ class PDFUrlReader(BasePDFReader):
     def __init__(self, proxy: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.proxy = proxy
-        
+
     def read(self, url: str) -> List[Document]:
         if not url:
             raise ValueError("No url provided")
 
         from io import BytesIO
 
-        import httpx
-
         log_info(f"Reading: {url}")
-        
+
         # Retry the request up to 3 times with exponential backoff
         response = fetch_with_retry(url, proxy=self.proxy)
-        
+
         doc_name = url.split("/")[-1].split(".")[0].replace("/", "_").replace(" ", "_")
         doc_reader = DocumentReader(BytesIO(response.content))
 
@@ -298,7 +295,7 @@ class PDFUrlImageReader(BasePDFReader):
     def __init__(self, proxy: Optional[str] = None, **kwargs):
         super().__init__(**kwargs)
         self.proxy = proxy
-        
+
     def read(self, url: str) -> List[Document]:
         if not url:
             raise ValueError("No url provided")

--- a/libs/agno/agno/document/reader/website_reader.py
+++ b/libs/agno/agno/document/reader/website_reader.py
@@ -26,15 +26,16 @@ class WebsiteReader(Reader):
 
     _visited: Set[str] = field(default_factory=set)
     _urls_to_crawl: List[Tuple[str, int]] = field(default_factory=list)
-    
-    
-    def __init__(self, max_depth: int = 3, max_links: int = 10, timeout: int = 10, proxy: Optional[str] = None, **kwargs):
+
+    def __init__(
+        self, max_depth: int = 3, max_links: int = 10, timeout: int = 10, proxy: Optional[str] = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.max_depth = max_depth
         self.max_links = max_links
         self.proxy = proxy
         self.timeout = timeout
-        
+
         self._visited = set()
         self._urls_to_crawl = []
 
@@ -134,7 +135,11 @@ class WebsiteReader(Reader):
 
             try:
                 log_debug(f"Crawling: {current_url}")
-                response = httpx.get(current_url, timeout=self.timeout, proxy=self.proxy) if self.proxy else httpx.get(current_url, timeout=self.timeout)
+                response = (
+                    httpx.get(current_url, timeout=self.timeout, proxy=self.proxy)
+                    if self.proxy
+                    else httpx.get(current_url, timeout=self.timeout)
+                )
 
                 response.raise_for_status()
                 soup = BeautifulSoup(response.content, "html.parser")

--- a/libs/agno/agno/utils/http.py
+++ b/libs/agno/agno/utils/http.py
@@ -15,12 +15,13 @@ def fetch_with_retry(
     url: str,
     max_retries: int = DEFAULT_MAX_RETRIES,
     backoff_factor: int = DEFAULT_BACKOFF_FACTOR,
+    proxy: Optional[str] = None,
 ) -> httpx.Response:
     """Synchronous HTTP GET with retry logic."""
 
     for attempt in range(max_retries):
         try:
-            response = httpx.get(url)
+            response = httpx.get(url, proxy=proxy) if proxy else httpx.get(url)
             response.raise_for_status()
             return response
         except httpx.RequestError as e:
@@ -42,12 +43,14 @@ async def async_fetch_with_retry(
     client: Optional[httpx.AsyncClient] = None,
     max_retries: int = DEFAULT_MAX_RETRIES,
     backoff_factor: int = DEFAULT_BACKOFF_FACTOR,
+    proxy: Optional[str] = None,
 ) -> httpx.Response:
     """Asynchronous HTTP GET with retry logic."""
 
     async def _fetch():
         if client is None:
-            async with httpx.AsyncClient() as local_client:
+            client_args = {"proxy": proxy} if proxy else {}
+            async with httpx.AsyncClient(**client_args) as local_client:
                 return await local_client.get(url)
         else:
             return await client.get(url)


### PR DESCRIPTION
## Summary

Introduce `proxy` parameter for `PDFUrlReader` class to allow `httpx` to call url with proxy especially for workplace with strict network control.

(Issue number: #2801)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)
