### PR TITLE
Add ability for models to forget older tool calls

### DIFF
--- a/cookbook/tools/mcp/playwright.py
+++ b/cookbook/tools/mcp/playwright.py
@@ -1,0 +1,39 @@
+import asyncio
+import os
+
+from agno.agent import Agent
+from agno.models.anthropic import Claude
+from agno.tools.mcp import MCPTools
+
+from mcp import StdioServerParameters
+
+async def run_agent(message: str) -> None:
+    """Run the Playwright agent with the given message."""
+
+    server_params = StdioServerParameters(
+        command="npx",
+        args=[
+            "@playwright/mcp@latest",
+        ],
+    )
+
+    async with MCPTools(server_params=server_params, include_tools=["browser_navigate", "browser_click"]) as mcp_tools:
+        agent = Agent(
+            model=Claude(id="claude-3-7-sonnet-latest"),
+            tools=[mcp_tools],
+            role="Your task is to use your web browsing capabilities to find information and take actions on the web.",
+            markdown=True,
+            show_tool_calls=True,
+            exponential_backoff=True,
+            num_tools_calls_to_include=3,  # Required because the number of tool calls gets too much for the context
+        )
+
+        await agent.aprint_response(message=message, stream=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(
+        run_agent(
+            "Look for a personality test on the web and take it. Then, summarize the results of the test and provide a link to the test you took.",
+        )
+    )

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -143,6 +143,9 @@ class Agent:
     #   forces the model to call that tool.
     # "none" is the default when no tools are present. "auto" is the default if tools are present.
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    
+    # If set, limits the number of tool call and tool result pairs included in messages sent to the model (i.e. older ones are dropped)
+    num_tools_calls_to_include: Optional[int] = None
 
     # --- Agent Reasoning ---
     # Enable reasoning by working through the problem step by step.
@@ -299,6 +302,7 @@ class Agent:
         show_tool_calls: bool = True,
         tool_call_limit: Optional[int] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        num_tools_calls_to_include: Optional[int] = None,
         reasoning: bool = False,
         reasoning_model: Optional[Model] = None,
         reasoning_agent: Optional[Agent] = None,
@@ -391,7 +395,8 @@ class Agent:
         self.show_tool_calls = show_tool_calls
         self.tool_call_limit = tool_call_limit
         self.tool_choice = tool_choice
-
+        self.num_tools_calls_to_include = num_tools_calls_to_include
+        
         self.reasoning = reasoning
         self.reasoning_model = reasoning_model
         self.reasoning_agent = reasoning_agent
@@ -1974,6 +1979,10 @@ class Agent:
         # Set tool_choice on the Model
         if self.tool_choice is not None:
             self.model.tool_choice = self.tool_choice
+
+        # Set num_tools_calls_to_include on the Model
+        if self.num_tools_calls_to_include is not None:
+            self.model.num_tools_calls_to_include = self.num_tools_calls_to_include
 
         # Set tool_call_limit on the Model
         if self.tool_call_limit is not None:

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -38,7 +38,7 @@ class Claude(Model):
     id: str = "claude-3-5-sonnet-20241022"
     name: str = "Claude"
     provider: str = "Anthropic"
-
+    
     # Request parameters
     max_tokens: Optional[int] = 4096
     thinking: Optional[Dict[str, Any]] = None
@@ -348,7 +348,7 @@ class Claude(Model):
                         "content": str(_fc_message.content),
                     }
                 )
-            messages.append(Message(role="user", content=fc_responses))
+            messages.append(Message(role="tool", content=fc_responses))
 
     def get_system_message_for_model(self) -> Optional[str]:
         if self._functions is not None and len(self._functions) > 0:

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -64,6 +64,9 @@ class Model(ABC):
     # "none" is the default when no functions are present. "auto" is the default if functions are present.
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None
 
+    # If set, limits the number of tool call and tool result pairs included in messages sent to the model (i.e. older ones are dropped)
+    num_tools_calls_to_include: Optional[int] = None
+    
     # If True, shows function calls in the response. Disabled when response_model is used.
     show_tool_calls: Optional[bool] = None
     # Maximum number of tool calls allowed.
@@ -79,6 +82,7 @@ class Model(ABC):
     _functions: Optional[Dict[str, Function]] = None
     # Function call stack.
     _function_call_stack: Optional[List[FunctionCall]] = None
+    
 
     # System prompt from the model added to the Agent.
     system_prompt: Optional[str] = None
@@ -298,6 +302,35 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Async Response End", center=True, symbol="-")
         return model_response
 
+    def _filter_messages(self, messages: List[Message]) -> List[Message]:
+        """
+        Filter messages to include only the most recent tool calls while preserving message order.
+        
+        This keeps all non-tool related messages and only the most recent tool call pairs
+        (assistant message with tool calls + corresponding tool response messages).
+        """
+        # First pass: identify all tool-related messages
+        filtered_messages = []
+        count_tool_msg = 0
+        reverse_messages = messages[::-1]
+        for msg in reverse_messages:
+            if ((msg.role == self.assistant_message_role and 
+                hasattr(msg, 'tool_calls') and 
+                msg.tool_calls) or 
+                msg.role == self.tool_message_role):
+                # This is a tool-related message
+                if count_tool_msg < self.num_tools_calls_to_include * 2:
+                    filtered_messages.append(msg)
+                    count_tool_msg += 1
+            else:
+                # This is a normal message we'll keep
+                filtered_messages.append(msg)
+        
+        # Restore the original order
+        filtered_messages = filtered_messages[::-1]
+        
+        return filtered_messages
+
     def _process_model_response(
         self,
         messages: List[Message],
@@ -311,6 +344,10 @@ class Model(ABC):
         """
         # Create assistant message
         assistant_message = Message(role=self.assistant_message_role)
+        
+        if self.num_tools_calls_to_include is not None:
+            # Filter messages to include only the most recent tool calls
+            messages = self._filter_messages(messages=messages)
 
         # Generate response
         assistant_message.metrics.start_timer()
@@ -369,6 +406,9 @@ class Model(ABC):
         """
         # Create assistant message
         assistant_message = Message(role=self.assistant_message_role)
+
+        if self.num_tools_calls_to_include is not None:
+            messages = self._filter_messages(messages=messages)
 
         # Generate response
         assistant_message.metrics.start_timer()
@@ -483,6 +523,10 @@ class Model(ABC):
         """
         Process a streaming response from the model.
         """
+        # Apply message filtering if needed
+        if self.num_tools_calls_to_include is not None:
+            messages = self._filter_messages(messages=messages)
+
         for response_delta in self.invoke_stream(messages=messages):
             model_response_delta = self.parse_provider_response_delta(response_delta)
             yield from self._populate_stream_data_and_assistant_message(
@@ -577,6 +621,10 @@ class Model(ABC):
         """
         Process a streaming response from the model.
         """
+        # Apply message filtering if needed
+        if self.num_tools_calls_to_include is not None:
+            messages = self._filter_messages(messages=messages)
+            
         async for response_delta in self.ainvoke_stream(messages=messages):  # type: ignore
             model_response_delta = self.parse_provider_response_delta(response_delta)
             for model_response in self._populate_stream_data_and_assistant_message(

--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -25,4 +25,3 @@ class OpenRouter(OpenAILike):
 
     api_key: Optional[str] = getenv("OPENROUTER_API_KEY")
     base_url: str = "https://openrouter.ai/api/v1"
-    max_tokens: int = 1024

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -246,6 +246,6 @@ def format_messages(messages: List[Message]) -> Tuple[List[Dict[str, str]], str]
                             type="tool_use",
                         )
                     )
-
         chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
+    
     return chat_messages, " ".join(system_messages)

--- a/libs/agno/tests/integration/models/openrouter/test_basic.py
+++ b/libs/agno/tests/integration/models/openrouter/test_basic.py
@@ -104,7 +104,7 @@ def test_response_model():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=OpenRouter(id="anthropic/claude-3-sonnet"),
+        model=OpenRouter(id="openai/o4-mini"),
         markdown=True,
         telemetry=False,
         monitoring=False,


### PR DESCRIPTION
## Summary

Sometimes we don't need to send the entire tool call history to the model for looooong running requests. This enables that.

(If applicable, issue number: #2861 )

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
