### PR TITLE
fix(playground): stream response only if response is streamable

### DIFF
--- a/libs/agno/agno/playground/async_router.py
+++ b/libs/agno/agno/playground/async_router.py
@@ -327,7 +327,7 @@ def get_async_playground_router(
                     else:
                         raise HTTPException(status_code=400, detail="Unsupported file type")
 
-        if stream:
+        if stream and agent.is_streamable:
             return StreamingResponse(
                 chat_response_streamer(
                     agent,


### PR DESCRIPTION
## Summary

This extra check ensures the contextual response is streamable before trying to stream it (responses are **not** streamable if they are structured after a response model)