### PR TITLE
fix(mcp): handle empty exclude_tools field

### DIFF
--- a/libs/agno/agno/tools/mcp.py
+++ b/libs/agno/agno/tools/mcp.py
@@ -136,7 +136,7 @@ class MCPTools(Toolkit):
             # Filter tools based on include/exclude lists
             filtered_tools = []
             for tool in available_tools.tools:
-                if tool.name in self.exclude_tools:
+                if self.exclude_tools and tool.name in self.exclude_tools:
                     continue
                 if self.include_tools is None or tool.name in self.include_tools:
                     filtered_tools.append(tool)
@@ -268,7 +268,7 @@ class MultiMCPTools(Toolkit):
             # Filter tools based on include/exclude lists
             filtered_tools = []
             for tool in available_tools.tools:
-                if tool.name in self.exclude_tools:
+                if self.exclude_tools and tool.name in self.exclude_tools:
                     continue
                 if self.include_tools is None or tool.name in self.include_tools:
                     filtered_tools.append(tool)


### PR DESCRIPTION
## Summary

The `tool.name in self.exclude_tools` check breaks by default as exclude_tools defaults to `None`. Adding a sanity check on `exclude_tools` to avoid
