### PR TITLE
fix(evals): better parsing for tool calls

### DIFF
--- a/evals/reliability/single_tool_calls/google/calculator.py
+++ b/evals/reliability/single_tool_calls/google/calculator.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from agno.agent import Agent
+from agno.eval.reliability import ReliabilityEval, ReliabilityResult
+from agno.models.google import Gemini
+from agno.run.response import RunResponse
+from agno.tools.calculator import CalculatorTools
+
+
+def factorial():
+    model = Gemini(id="gemini-1.5-flash")
+    agent = Agent(model=model, tools=[CalculatorTools(factorial=True)])
+    response: RunResponse = agent.run("What is 10!?")
+
+    evaluation = ReliabilityEval(
+        agent_response=response, expected_tool_calls=["factorial"]
+    )
+    result: Optional[ReliabilityResult] = evaluation.run(print_results=True)
+    result.assert_passed()
+
+
+if __name__ == "__main__":
+    factorial()

--- a/libs/agno/agno/eval/reliability.py
+++ b/libs/agno/agno/eval/reliability.py
@@ -105,7 +105,10 @@ class ReliabilityEval:
             failed_tool_calls = []
             passed_tool_calls = []
             for tool_call in actual_tool_calls:  # type: ignore
-                if tool_call.get("function", {}).get("name") not in self.expected_tool_calls:  # type: ignore
+                tool_name = tool_call.get("function", {}).get("name")
+                if not tool_name:
+                    continue
+                if tool_name and tool_name not in self.expected_tool_calls:  # type: ignore
                     failed_tool_calls.append(tool_call.get("function", {}).get("name"))
                 else:
                     passed_tool_calls.append(tool_call.get("function", {}).get("name"))


### PR DESCRIPTION
We were assuming a certain structure in `actual_tool_calls` here. A slight variance when using Gemini broke it. This change makes the reliability eval work for Gemini without breaking it for the other models.

Going forward a method like `parse_tool_calls` should exist in the Gemini model and we should consume tool calls through that method. Keeping that part of my coming work!