### PR TITLE
feat(agent): add support for async cli app

### DIFF
--- a/cookbook/tools/mcp/cli.py
+++ b/cookbook/tools/mcp/cli.py
@@ -1,0 +1,47 @@
+"""Show how to run an interactive CLI to interact with an agent equipped with MCP tools.
+
+This example uses the MCP GitHub Agent. Example prompts to try:
+- "List open issues in the repository"
+- "Show me recent pull requests"
+- "What are the repository statistics?"
+- "Find issues labeled as bugs"
+- "Show me contributor activity"
+
+Run: `pip install agno mcp openai` to install the dependencies
+"""
+
+import asyncio
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.tools.mcp import MCPTools
+
+
+async def run_agent(message: str) -> None:
+    """Run an interactive CLI for the GitHub agent with the given message."""
+
+    # Create a client session to connect to the MCP server
+    async with MCPTools("npx -y @modelcontextprotocol/server-github") as mcp_tools:
+        agent = Agent(
+            tools=[mcp_tools],
+            instructions=dedent("""\
+                You are a GitHub assistant. Help users explore repositories and their activity.
+
+                - Use headings to organize your responses
+                - Be concise and focus on relevant information\
+            """),
+            markdown=True,
+            show_tool_calls=True,
+        )
+
+        # Run an interactive command-line interface to interact with the agent.
+        await agent.acli_app(message=message, stream=True)
+
+
+if __name__ == "__main__":
+    # Pull request example
+    asyncio.run(
+        run_agent(
+            "Tell me about Agno. Github repo: https://github.com/agno-agi/agno. You can read the README for more information."
+        )
+    )


### PR DESCRIPTION
Our `agent.cli_app` method wasn't working for agents equipped with the MCP tools, because they are strictly async right now. Ideally we introduce a way to handle the full MCP stack synchronously. In the meantime I think it's fair to support a CLI running async logic.

- Update `agent.cli_app()` to raise if the contextual agent is equipped with (async) MCP tools, instead of failing silently / hanging.
- Add `agent.acli_app()` to introduce a way to interact with agents in the CLI when they depend on async logic.
- Add MCP cookbook to clarify how to run an agent using MCP tools as a CLI app