### PR TITLE
fix: updating to json to support user defined default parsers

### DIFF
--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -152,12 +152,12 @@ class RunResponse:
 
         return _dict
 
-    def to_json(self) -> str:
+    def to_json(self, indent: int = 2, **kwargs) -> str:
         import json
 
         _dict = self.to_dict()
 
-        return json.dumps(_dict, indent=2)
+        return json.dumps(_dict, indent=indent, **kwargs)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "RunResponse":


### PR DESCRIPTION
## Summary

I am getting errors on the RunResponse to_json() function when I have non-json serializable values in my run response. See example error:
```
TypeError: Object of type datetime is not JSON serializable
```

To address this I added optional kwargs to the to_json function allowing passing all of the parameters the json library supports to the json.dumps() call. This allows me to at runtime handle specific data types I need to handle before sending the json output to storage by exposing all of the kwargs that the json library supports

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- NA Tests added/updated (if applicable) 

---

## Additional Notes

N/A
