### PR TITLE
Prevent json from loading dict

### DIFF
--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -330,7 +330,12 @@ class Message(BaseModel):
                 tool_call_arguments = tool_call.get("function", {}).get("arguments")
                 if tool_call_arguments:
                     try:
-                        arguments = ", ".join(f"{k}: {v}" for k, v in json.loads(tool_call_arguments).items())
+                        tool_call_args: dict = (
+                            tool_call_arguments
+                            if isinstance(tool_call_arguments, dict)
+                            else json.loads(tool_call_arguments)
+                        )
+                        arguments = ", ".join(f"{k}: {v}" for k, v in tool_call_args.items())
                         tool_calls_list.append(f"    Arguments: '{arguments}'")
                     except json.JSONDecodeError:
                         tool_calls_list.append("    Arguments: 'Invalid JSON format'")


### PR DESCRIPTION
Sometimes the `tool_call_arguments` is already a dict. Pass it thru directly.

## Summary

Sometime `tool_call_arguments` is already a `dict` - pass it thru directly to prevent json to load it again.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)