### PR TITLE
Enhance context propagation: user_id & session_id forwarding

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -629,7 +629,7 @@ class Agent:
 
         # 5. Reason about the task if reasoning is enabled
         if self.reasoning or self.reasoning_model is not None:
-            reasoning_generator = self.reason(run_messages=run_messages, session_id=session_id)
+            reasoning_generator = self.reason(run_messages=run_messages, user_id=user_id, session_id=session_id)
 
             if self.stream:
                 yield from reasoning_generator
@@ -652,7 +652,7 @@ class Agent:
         reasoning_time_taken = 0.0
         if self.stream:
             model_response = ModelResponse()
-            for model_response_chunk in self.model.response_stream(messages=run_messages.messages):
+            for model_response_chunk in self.model.response_stream(messages=run_messages.messages, user_id=user_id, session_id=session_id):
                 # If the model response is an assistant_response, yield a RunResponse
                 if model_response_chunk.event == ModelResponseEvent.assistant_response.value:
                     # Process content and thinking
@@ -808,7 +808,7 @@ class Agent:
                         )
         else:
             # Get the model response
-            model_response = self.model.response(messages=run_messages.messages)
+            model_response = self.model.response(messages=run_messages.messages, user_id=user_id, session_id=session_id)
             # Format tool calls if they exist
             if model_response.tool_calls:
                 self.run_response.formatted_tool_calls = format_tool_calls(model_response.tool_calls)
@@ -1303,7 +1303,11 @@ class Agent:
         self.model = cast(Model, self.model)
         if stream and self.is_streamable:
             model_response = ModelResponse(content="")
-            model_response_stream = self.model.aresponse_stream(messages=run_messages.messages)  # type: ignore
+            model_response_stream = self.model.aresponse_stream(
+                messages=run_messages.messages,
+                user_id=user_id,
+                session_id=session_id,
+            )  # type: ignore
             async for model_response_chunk in model_response_stream:  # type: ignore
                 # If the model response is an assistant_response, yield a RunResponse
                 if model_response_chunk.event == ModelResponseEvent.assistant_response.value:
@@ -1456,7 +1460,11 @@ class Agent:
                         )
         else:
             # Get the model response
-            model_response = await self.model.aresponse(messages=run_messages.messages)
+            model_response = await self.model.aresponse(
+                user_id=user_id,
+                session_id=session_id,
+                messages=run_messages.messages
+            )
             # Format tool calls if they exist
             if model_response.tool_calls:
                 self.run_response.formatted_tool_calls = format_tool_calls(model_response.tool_calls)

--- a/libs/agno/tests/integration/agent/test_tool_params_forwarding.py
+++ b/libs/agno/tests/integration/agent/test_tool_params_forwarding.py
@@ -1,0 +1,116 @@
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+
+# Define a custom tool that forwards the agent context to the tool
+def params_forwarding_tool(user_id: str, session_id: str, agent: Agent):
+    return f"Tool called with agent ID: {agent.agent_id}, user ID: {user_id}, session ID: {session_id}"
+
+# Test that user_id and session_id are forwarded to the tool on run call with streaming response
+def test_run_user_and_session_id_forwarding_to_tool_streaming():
+    """
+    Test that agent is forwarded to the tool
+    """
+
+    agent = Agent(
+        agent_id="test-agent",
+        name="Test Agent",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[params_forwarding_tool],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False
+    )
+
+    # Run the agent with the tool, providing a user ID and session ID that should be included in the tool call response
+    run_response = agent.run(
+        stream=True,
+        user_id="test-user",
+        session_id="test-session",
+        message="Please invoke the params_forwarding_tool to retrieve context. Return directly the response from the tool without any additional formatting or modification."
+    )
+
+
+    
+
+    content = ""
+
+    # Get the response from the run
+    for response in run_response:
+        content += response.content
+
+    # Verify tool usage by checking if the agent ID, user ID, and session ID are included in the response
+    assert "test-agent" in content
+    assert "test-user" in content
+    assert "test-session" in content
+
+
+# Test that user_id and session_id are forwarded to the tool on run call with non-streaming response
+def test_run_user_and_session_id_forwarding_to_tool():
+    """
+    Test that agent is forwarded to the tool
+    """
+
+    agent = Agent(
+        agent_id="test-agent",
+        name="Test Agent",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[params_forwarding_tool],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False
+    )
+
+    # Run the agent with the tool, providing a user ID and session ID that should be included in the tool call response
+    run_response = agent.run(
+        user_id="test-user",
+        session_id="test-session",
+        message="Please invoke the params_forwarding_tool to retrieve context. Return directly the response from the tool without any additional formatting or modification."
+    )
+
+    # Get the response from the run
+
+    # Verify tool usage
+    assert any(msg.tool_calls for msg in run_response.messages)
+    assert run_response.content is not None
+
+     # Verify the agent ID is included in the response, indicating that the tool was called with the agent context
+    assert "test-agent" in run_response.content
+    assert "test-user" in run_response.content
+    assert "test-session" in run_response.content
+
+# Test that user_id and session_id are forwarded to the tool on call without user_id and session_id on run but on Agent creation
+def test_agent_user_and_session_id_forwarding_to_tool():
+    """
+    Test that agent is forwarded to the tool
+    """
+
+    agent = Agent(
+        user_id="test-user",
+        session_id="test-session",
+        agent_id="test-agent",
+        name="Test Agent",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[params_forwarding_tool],
+        show_tool_calls=True,
+        markdown=True,
+        telemetry=False,
+        monitoring=False
+    )
+
+    # Run the agent with the tool, providing a user ID and session ID that should be included in the tool call response
+    run_response = agent.run(
+        message="Please invoke the params_forwarding_tool to retrieve context. Return directly the response from the tool without any additional formatting or modification."
+    )
+
+    # Get the response from the run
+    assert "test-agent" in run_response.content
+    assert "test-user" in run_response.content
+    assert "test-session" in run_response.content
+
+    
+    
+
+


### PR DESCRIPTION
## Summary

Enhance context propagation: user_id & session_id forwarding to tools.

Currently, on tools, only Agent is accessible, if an agent:Agent is defined as an argument. This allows to access the **user_id** and the **session_id** defined on the construction of the Agent.

However **agent.run** and **agent.arun** can receive as a parameter user_id and session_id

This PR improves this as follows:

- If a tool has as arguments session_id and/or user_id, on calling, the user_id and the session_id are forwarded.
- The user_id and session_id defined on run or arun take preceded over the one defined in agent constructor.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [X] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
