### PR TITLE
fix: change gemini utils from array to agno

### DIFF
--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -114,7 +114,7 @@ def convert_schema(schema_dict: Dict[str, Any]) -> Optional[Schema]:
         else:
             return Schema(type=Type.OBJECT, description=description, default=default)
 
-    elif schema_type == "array" and "items" in schema_dict:
+    elif schema_type == "list" and "items" in schema_dict:
         items = convert_schema(schema_dict["items"])
         return Schema(type=Type.ARRAY, description=description, items=items)
 


### PR DESCRIPTION
## Summary

Not exactly sure if "array" is a valid Python 3 type.

https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range

Trying to fix my integration with https://github.com/superfaceai/sdk, and seems like "list" is the valid type for Python - https://github.com/superfaceai/sdk/blob/main/python/src/superface/agno/superface.py#L74.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
