### PR TITLE
fix: readers set unique id

### DIFF
--- a/cookbook/observability/weave_op.py
+++ b/cookbook/observability/weave_op.py
@@ -7,7 +7,7 @@ Steps to get started with weave:
 3. Authentication:
  - Go to https://wandb.ai and copy your API key from https://wandb.ai/authorize
  - Enter your API key in terminal when prompted
- Or 
+ Or
  - Export your API key as an environment variable:
     - export WANDB_API_KEY=<your-api-key>
 """

--- a/libs/agno/agno/document/reader/csv_reader.py
+++ b/libs/agno/agno/document/reader/csv_reader.py
@@ -2,10 +2,10 @@ import asyncio
 import csv
 import io
 import os
-import uuid
 from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from agno.utils.http import async_fetch_with_retry, fetch_with_retry
 
@@ -44,7 +44,7 @@ class CSVReader(Reader):
             documents = [
                 Document(
                     name=csv_name,
-                    id=str({uuid.uuid4()}),
+                    id=str(uuid4()),
                     content=csv_content,
                 )
             ]
@@ -98,7 +98,7 @@ class CSVReader(Reader):
                 documents = [
                     Document(
                         name=csv_name,
-                        id=str({uuid.uuid4()}),
+                        id=str(uuid4()),
                         content=csv_content,
                     )
                 ]
@@ -114,7 +114,7 @@ class CSVReader(Reader):
 
                     return Document(
                         name=csv_name,
-                        id=f"{csv_name}_page{page_number}",
+                        id=str(uuid4()),
                         meta_data={"page": page_number, "start_row": start_row, "rows": len(page_rows)},
                         content=page_content,
                     )

--- a/libs/agno/agno/document/reader/csv_reader.py
+++ b/libs/agno/agno/document/reader/csv_reader.py
@@ -44,7 +44,7 @@ class CSVReader(Reader):
             documents = [
                 Document(
                     name=csv_name,
-                    id=f"{csv_name}_{uuid.uuid4()}",
+                    id=str({uuid.uuid4()}),
                     content=csv_content,
                 )
             ]
@@ -98,7 +98,7 @@ class CSVReader(Reader):
                 documents = [
                     Document(
                         name=csv_name,
-                        id=f"{csv_name}_{uuid.uuid4()}",
+                        id=str({uuid.uuid4()}),
                         content=csv_content,
                     )
                 ]

--- a/libs/agno/agno/document/reader/csv_reader.py
+++ b/libs/agno/agno/document/reader/csv_reader.py
@@ -2,6 +2,7 @@ import asyncio
 import csv
 import io
 import os
+import uuid
 from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 from urllib.parse import urlparse
@@ -43,7 +44,7 @@ class CSVReader(Reader):
             documents = [
                 Document(
                     name=csv_name,
-                    id=csv_name,
+                    id=f"{csv_name}_{uuid.uuid4()}",
                     content=csv_content,
                 )
             ]
@@ -97,7 +98,7 @@ class CSVReader(Reader):
                 documents = [
                     Document(
                         name=csv_name,
-                        id=csv_name,
+                        id=f"{csv_name}_{uuid.uuid4()}",
                         content=csv_content,
                     )
                 ]

--- a/libs/agno/agno/document/reader/docx_reader.py
+++ b/libs/agno/agno/document/reader/docx_reader.py
@@ -35,7 +35,7 @@ class DocxReader(Reader):
             documents = [
                 Document(
                     name=doc_name,
-                    id=f"{doc_name}_{uuid.uuid4()}",
+                    id=str({uuid.uuid4()}),
                     content=doc_content,
                 )
             ]

--- a/libs/agno/agno/document/reader/docx_reader.py
+++ b/libs/agno/agno/document/reader/docx_reader.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 from pathlib import Path
 from typing import IO, Any, List, Union
 
@@ -34,7 +35,7 @@ class DocxReader(Reader):
             documents = [
                 Document(
                     name=doc_name,
-                    id=doc_name,
+                    id=f"{doc_name}_{uuid.uuid4()}",
                     content=doc_content,
                 )
             ]

--- a/libs/agno/agno/document/reader/docx_reader.py
+++ b/libs/agno/agno/document/reader/docx_reader.py
@@ -1,7 +1,7 @@
 import asyncio
-import uuid
 from pathlib import Path
 from typing import IO, Any, List, Union
+from uuid import uuid4
 
 from agno.document.base import Document
 from agno.document.reader.base import Reader
@@ -35,7 +35,7 @@ class DocxReader(Reader):
             documents = [
                 Document(
                     name=doc_name,
-                    id=str({uuid.uuid4()}),
+                    id=str(uuid4()),
                     content=doc_content,
                 )
             ]

--- a/libs/agno/agno/document/reader/firecrawl_reader.py
+++ b/libs/agno/agno/document/reader/firecrawl_reader.py
@@ -11,18 +11,25 @@ try:
 except ImportError:
     raise ImportError("The `firecrawl` package is not installed. Please install it via `pip install firecrawl-py`.")
 
+
 @dataclass
 class FirecrawlReader(Reader):
     api_key: Optional[str] = None
     params: Optional[Dict] = None
     mode: Literal["scrape", "crawl"] = "scrape"
-    
-    def __init__(self, api_key: Optional[str] = None, params: Optional[Dict] = None, mode: Literal["scrape", "crawl"] = "scrape", *args, **kwargs) -> None:
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        params: Optional[Dict] = None,
+        mode: Literal["scrape", "crawl"] = "scrape",
+        *args,
+        **kwargs,
+    ) -> None:
         super().__init__(*args, **kwargs)
         self.api_key = api_key
         self.params = params
         self.mode = mode
-
 
     def scrape(self, url: str) -> List[Document]:
         """

--- a/libs/agno/agno/document/reader/json_reader.py
+++ b/libs/agno/agno/document/reader/json_reader.py
@@ -39,7 +39,7 @@ class JSONReader(Reader):
             documents = [
                 Document(
                     name=json_name,
-                    id=f"{json_name}_{page_number}_{uuid.uuid4()}",
+                    id=str({uuid.uuid4()}),
                     meta_data={"page": page_number},
                     content=json.dumps(content),
                 )

--- a/libs/agno/agno/document/reader/json_reader.py
+++ b/libs/agno/agno/document/reader/json_reader.py
@@ -1,9 +1,9 @@
 import asyncio
 import json
-import uuid
 from io import BytesIO
 from pathlib import Path
 from typing import IO, Any, List, Union
+from uuid import uuid4
 
 from agno.document.base import Document
 from agno.document.reader.base import Reader
@@ -39,7 +39,7 @@ class JSONReader(Reader):
             documents = [
                 Document(
                     name=json_name,
-                    id=str({uuid.uuid4()}),
+                    id=str(uuid4()),
                     meta_data={"page": page_number},
                     content=json.dumps(content),
                 )

--- a/libs/agno/agno/document/reader/json_reader.py
+++ b/libs/agno/agno/document/reader/json_reader.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import uuid
 from io import BytesIO
 from pathlib import Path
 from typing import IO, Any, List, Union
@@ -38,7 +39,7 @@ class JSONReader(Reader):
             documents = [
                 Document(
                     name=json_name,
-                    id=f"{json_name}_{page_number}",
+                    id=f"{json_name}_{page_number}_{uuid.uuid4()}",
                     meta_data={"page": page_number},
                     content=json.dumps(content),
                 )

--- a/libs/agno/agno/document/reader/pdf_reader.py
+++ b/libs/agno/agno/document/reader/pdf_reader.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 
@@ -96,11 +97,9 @@ class PDFReader(BasePDFReader):
     def read(self, pdf: Union[str, Path, IO[Any]]) -> List[Document]:
         try:
             if isinstance(pdf, str):
-                # Use the full path to ensure uniqueness
-                doc_name = pdf.replace("/", "_").replace(" ", "_")
+                doc_name = pdf.split("/")[-1].split(".")[0].replace(" ", "_")
             else:
-                # Use the full path for file objects as well
-                doc_name = pdf.name.replace("/", "_").replace(" ", "_")
+                doc_name = pdf.name.split(".")[0]
         except Exception:
             doc_name = "pdf"
 
@@ -117,7 +116,7 @@ class PDFReader(BasePDFReader):
             documents.append(
                 Document(
                     name=doc_name,
-                    id=f"{doc_name}_{page_number}",
+                    id=f"{doc_name}_{page_number}_{uuid.uuid4()}",
                     meta_data={"page": page_number},
                     content=page.extract_text(),
                 )
@@ -129,11 +128,9 @@ class PDFReader(BasePDFReader):
     async def async_read(self, pdf: Union[str, Path, IO[Any]]) -> List[Document]:
         try:
             if isinstance(pdf, str):
-                # Use the full path to ensure uniqueness
-                doc_name = pdf.replace("/", "_").replace(" ", "_")
+                doc_name = pdf.split("/")[-1].split(".")[0].replace(" ", "_")
             else:
-                # Use the full path for file objects as well
-                doc_name = pdf.name.replace("/", "_").replace(" ", "_")
+                doc_name = pdf.name.split(".")[0]
         except Exception:
             doc_name = "pdf"
 
@@ -148,7 +145,7 @@ class PDFReader(BasePDFReader):
         async def _process_document(doc_name: str, page_number: int, page: Any) -> Document:
             return Document(
                 name=doc_name,
-                id=f"{doc_name}_{page_number}",
+                id=f"{doc_name}_{page_number}_{uuid.uuid4()}",
                 meta_data={"page": page_number},
                 content=page.extract_text(),
             )

--- a/libs/agno/agno/document/reader/pdf_reader.py
+++ b/libs/agno/agno/document/reader/pdf_reader.py
@@ -116,7 +116,7 @@ class PDFReader(BasePDFReader):
             documents.append(
                 Document(
                     name=doc_name,
-                    id=f"{doc_name}_{page_number}_{uuid.uuid4()}",
+                    id=str({uuid.uuid4()}),
                     meta_data={"page": page_number},
                     content=page.extract_text(),
                 )
@@ -145,7 +145,7 @@ class PDFReader(BasePDFReader):
         async def _process_document(doc_name: str, page_number: int, page: Any) -> Document:
             return Document(
                 name=doc_name,
-                id=f"{doc_name}_{page_number}_{uuid.uuid4()}",
+                id=str({uuid.uuid4()}),
                 meta_data={"page": page_number},
                 content=page.extract_text(),
             )

--- a/libs/agno/agno/document/reader/pdf_reader.py
+++ b/libs/agno/agno/document/reader/pdf_reader.py
@@ -96,9 +96,11 @@ class PDFReader(BasePDFReader):
     def read(self, pdf: Union[str, Path, IO[Any]]) -> List[Document]:
         try:
             if isinstance(pdf, str):
-                doc_name = pdf.split("/")[-1].split(".")[0].replace(" ", "_")
+                # Use the full path to ensure uniqueness
+                doc_name = pdf.replace("/", "_").replace(" ", "_")
             else:
-                doc_name = pdf.name.split(".")[0]
+                # Use the full path for file objects as well
+                doc_name = pdf.name.replace("/", "_").replace(" ", "_")
         except Exception:
             doc_name = "pdf"
 
@@ -127,9 +129,11 @@ class PDFReader(BasePDFReader):
     async def async_read(self, pdf: Union[str, Path, IO[Any]]) -> List[Document]:
         try:
             if isinstance(pdf, str):
-                doc_name = pdf.split("/")[-1].split(".")[0].replace(" ", "_")
+                # Use the full path to ensure uniqueness
+                doc_name = pdf.replace("/", "_").replace(" ", "_")
             else:
-                doc_name = pdf.name.split(".")[0]
+                # Use the full path for file objects as well
+                doc_name = pdf.name.replace("/", "_").replace(" ", "_")
         except Exception:
             doc_name = "pdf"
 

--- a/libs/agno/agno/document/reader/pdf_reader.py
+++ b/libs/agno/agno/document/reader/pdf_reader.py
@@ -1,7 +1,7 @@
 import asyncio
-import uuid
 from pathlib import Path
 from typing import IO, Any, List, Optional, Union
+from uuid import uuid4
 
 from agno.document.base import Document
 from agno.document.reader.base import Reader
@@ -43,7 +43,7 @@ def process_image_page(doc_name: str, page_number: int, page: Any) -> Document:
     # Append the document
     return Document(
         name=doc_name,
-        id=f"{doc_name}_{page_number}",
+        id=str(uuid4()),
         meta_data={"page": page_number},
         content=content,
     )
@@ -77,7 +77,7 @@ async def async_process_image_page(doc_name: str, page_number: int, page: Any) -
 
     return Document(
         name=doc_name,
-        id=f"{doc_name}_{page_number}",
+        id=str(uuid4()),
         meta_data={"page": page_number},
         content=content,
     )
@@ -116,7 +116,7 @@ class PDFReader(BasePDFReader):
             documents.append(
                 Document(
                     name=doc_name,
-                    id=str({uuid.uuid4()}),
+                    id=str(uuid4()),
                     meta_data={"page": page_number},
                     content=page.extract_text(),
                 )
@@ -145,7 +145,7 @@ class PDFReader(BasePDFReader):
         async def _process_document(doc_name: str, page_number: int, page: Any) -> Document:
             return Document(
                 name=doc_name,
-                id=str({uuid.uuid4()}),
+                id=str(uuid4()),
                 meta_data={"page": page_number},
                 content=page.extract_text(),
             )

--- a/libs/agno/agno/document/reader/s3/pdf_reader.py
+++ b/libs/agno/agno/document/reader/s3/pdf_reader.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from typing import List
+from uuid import uuid4
 
 from agno.document.base import Document
 from agno.document.reader.base import Reader
@@ -30,7 +31,7 @@ class S3PDFReader(Reader):
             documents = [
                 Document(
                     name=doc_name,
-                    id=f"{doc_name}_{page_number}",
+                    id=str(uuid4()),
                     meta_data={"page": page_number},
                     content=page.extract_text(),
                 )

--- a/libs/agno/agno/document/reader/text_reader.py
+++ b/libs/agno/agno/document/reader/text_reader.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 from pathlib import Path
 from typing import IO, Any, List, Union
 
@@ -27,7 +28,7 @@ class TextReader(Reader):
             documents = [
                 Document(
                     name=file_name,
-                    id=file_name,
+                    id=f"{file_name}_{uuid.uuid4()}",
                     content=file_contents,
                 )
             ]
@@ -66,7 +67,7 @@ class TextReader(Reader):
 
             document = Document(
                 name=file_name,
-                id=file_name,
+                id=f"{file_name}_{uuid.uuid4()}",
                 content=file_contents,
             )
 

--- a/libs/agno/agno/document/reader/text_reader.py
+++ b/libs/agno/agno/document/reader/text_reader.py
@@ -28,7 +28,7 @@ class TextReader(Reader):
             documents = [
                 Document(
                     name=file_name,
-                    id=f"{file_name}_{uuid.uuid4()}",
+                    id=str({uuid.uuid4()}),
                     content=file_contents,
                 )
             ]
@@ -67,7 +67,7 @@ class TextReader(Reader):
 
             document = Document(
                 name=file_name,
-                id=f"{file_name}_{uuid.uuid4()}",
+                id=str({uuid.uuid4()}),
                 content=file_contents,
             )
 

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -52,7 +52,8 @@ def test_read_path(csv_reader, csv_file):
 
     assert len(documents) == 1
     assert documents[0].name == "test"
-    assert documents[0].id == "test_1"
+    assert documents[0].id.startswith("test_")
+    assert documents[0].id.endswith("_1")
 
     expected_content = "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago "
     assert documents[0].content == expected_content
@@ -66,7 +67,8 @@ def test_read_file_object(csv_reader):
 
     assert len(documents) == 1
     assert documents[0].name == "memory"
-    assert documents[0].id == "memory_1"
+    assert documents[0].id.startswith("memory_")
+    assert documents[0].id.endswith("_1")
 
     expected_content = "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago "
     assert documents[0].content == expected_content
@@ -76,7 +78,8 @@ def test_read_complex_csv(csv_reader, complex_csv_file):
     documents = csv_reader.read(complex_csv_file, delimiter=",", quotechar='"')
 
     assert len(documents) == 1
-    assert documents[0].id == "complex_1"
+    assert documents[0].id.startswith("complex_")
+    assert documents[0].id.endswith("_1")
 
     expected_content = "product, description with, comma, price Laptop, Pro, High performance, ultra-thin, 1200.99 Phone XL, 5G compatible, water resistant, 899.50 "
     assert documents[0].content == expected_content
@@ -102,9 +105,9 @@ def test_read_with_chunking(csv_reader, csv_file):
 
     assert len(documents) == 2
     assert documents[0].name == "test_chunk1"
-    assert documents[0].id == "test_chunk1"
+    assert documents[0].id.endswith("_chunk1")
     assert documents[1].name == "test_chunk2"
-    assert documents[1].id == "test_chunk2"
+    assert documents[1].id.endswith("_chunk2")
     assert documents[0].content == "Chunk 1 content"
     assert documents[1].content == "Chunk 2 content"
 
@@ -115,7 +118,8 @@ async def test_async_read_path(csv_reader, csv_file):
 
     assert len(documents) == 1
     assert documents[0].name == "test"
-    assert documents[0].id == "test_1"
+    assert documents[0].id.startswith("test_")
+    assert documents[0].id.endswith("_1")
     assert documents[0].content == "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago"
 
 
@@ -179,9 +183,9 @@ async def test_async_read_with_chunking(csv_reader, csv_file):
     documents = await csv_reader.async_read(csv_file)
 
     assert len(documents) == 2
-    assert documents[0].id == "test_chunk1"
+    assert documents[0].id.endswith("_chunk1")
     assert documents[0].name == "test_chunk1"
-    assert documents[1].id == "test_chunk2"
+    assert documents[1].id.endswith("_chunk2")
     assert documents[1].name == "test_chunk2"
 
 
@@ -204,7 +208,8 @@ def test_read_url(csv_url_reader):
 
     assert len(documents) == 2
     assert documents[0].name == "employees"
-    assert documents[0].id == "employees_1"
+    assert documents[0].id.startswith("employees_")
+    assert documents[0].id.endswith("_1")
 
     content = documents[0].content
     assert all(field in content for field in ["EmployeeID", "FirstName", "LastName", "Department"])

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -52,7 +52,6 @@ def test_read_path(csv_reader, csv_file):
 
     assert len(documents) == 1
     assert documents[0].name == "test"
-    assert documents[0].id.startswith("test_")
     assert documents[0].id.endswith("_1")
 
     expected_content = "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago "
@@ -67,7 +66,6 @@ def test_read_file_object(csv_reader):
 
     assert len(documents) == 1
     assert documents[0].name == "memory"
-    assert documents[0].id.startswith("memory_")
     assert documents[0].id.endswith("_1")
 
     expected_content = "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago "
@@ -78,7 +76,6 @@ def test_read_complex_csv(csv_reader, complex_csv_file):
     documents = csv_reader.read(complex_csv_file, delimiter=",", quotechar='"')
 
     assert len(documents) == 1
-    assert documents[0].id.startswith("complex_")
     assert documents[0].id.endswith("_1")
 
     expected_content = "product, description with, comma, price Laptop, Pro, High performance, ultra-thin, 1200.99 Phone XL, 5G compatible, water resistant, 899.50 "
@@ -118,7 +115,6 @@ async def test_async_read_path(csv_reader, csv_file):
 
     assert len(documents) == 1
     assert documents[0].name == "test"
-    assert documents[0].id.startswith("test_")
     assert documents[0].id.endswith("_1")
     assert documents[0].content == "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago"
 
@@ -208,7 +204,6 @@ def test_read_url(csv_url_reader):
 
     assert len(documents) == 2
     assert documents[0].name == "employees"
-    assert documents[0].id.startswith("employees_")
     assert documents[0].id.endswith("_1")
 
     content = documents[0].content
@@ -222,8 +217,7 @@ async def test_async_read_url(csv_url_reader):
 
     assert len(documents) == 2
     assert documents[0].name == "employees"
-    assert documents[0].id == "employees_page1_1"
-    assert documents[1].id == "employees_page1_2"
+    assert documents[0].id.endswith("_1")
 
     expected_first_row = "EmployeeID, FirstName, LastName, Department, Role, Age, Salary, StartDate"
     expected_second_row = "101, John, Doe, Engineering, Software Engineer, 28, 75000, 2018-06-15"

--- a/libs/agno/tests/unit/reader/test_docx_reader.py
+++ b/libs/agno/tests/unit/reader/test_docx_reader.py
@@ -32,7 +32,6 @@ def test_docx_reader_read_file(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test"
-        assert documents[0].id.startswith("test_")
         assert documents[0].id.endswith("_1")
         assert documents[0].content == "First paragraph Second paragraph"
 
@@ -48,7 +47,6 @@ async def test_docx_reader_async_read_file(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test"
-        assert documents[0].id.startswith("test_")
         assert documents[0].id.endswith("_1")
         assert documents[0].content == "First paragraph Second paragraph"
 
@@ -91,7 +89,6 @@ def test_docx_reader_bytesio(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test"
-        assert documents[0].id.startswith("test_")
         assert documents[0].id.endswith("_1")
         assert documents[0].content == "First paragraph Second paragraph"
 
@@ -127,7 +124,6 @@ async def test_async_docx_processing(mock_docx):
         assert len(results) == 3
         assert all(len(docs) == 1 for docs in results)
         assert all(docs[0].name == "test" for docs in results)
-        assert all(docs[0].id.startswith("test_") for docs in results)
         assert all(docs[0].id.endswith("_1") for docs in results)
         assert all(docs[0].content == "First paragraph Second paragraph" for docs in results)
 
@@ -172,5 +168,4 @@ def test_docx_reader_metadata(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test_doc"
-        assert documents[0].id.startswith("test_doc_")
         assert documents[0].id.endswith("_1")

--- a/libs/agno/tests/unit/reader/test_docx_reader.py
+++ b/libs/agno/tests/unit/reader/test_docx_reader.py
@@ -32,7 +32,8 @@ def test_docx_reader_read_file(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test"
-        assert documents[0].id == "test_1"
+        assert documents[0].id.startswith("test_")
+        assert documents[0].id.endswith("_1")
         assert documents[0].content == "First paragraph Second paragraph"
 
 
@@ -47,7 +48,8 @@ async def test_docx_reader_async_read_file(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test"
-        assert documents[0].id == "test_1"
+        assert documents[0].id.startswith("test_")
+        assert documents[0].id.endswith("_1")
         assert documents[0].content == "First paragraph Second paragraph"
 
 
@@ -89,7 +91,8 @@ def test_docx_reader_bytesio(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test"
-        assert documents[0].id == "test_1"
+        assert documents[0].id.startswith("test_")
+        assert documents[0].id.endswith("_1")
         assert documents[0].content == "First paragraph Second paragraph"
 
 
@@ -124,7 +127,8 @@ async def test_async_docx_processing(mock_docx):
         assert len(results) == 3
         assert all(len(docs) == 1 for docs in results)
         assert all(docs[0].name == "test" for docs in results)
-        assert all(docs[0].id == "test_1" for docs in results)
+        assert all(docs[0].id.startswith("test_") for docs in results)
+        assert all(docs[0].id.endswith("_1") for docs in results)
         assert all(docs[0].content == "First paragraph Second paragraph" for docs in results)
 
 
@@ -168,4 +172,5 @@ def test_docx_reader_metadata(mock_docx):
 
         assert len(documents) == 1
         assert documents[0].name == "test_doc"
-        assert documents[0].id == "test_doc_1"
+        assert documents[0].id.startswith("test_doc_")
+        assert documents[0].id.endswith("_1")

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -68,7 +68,7 @@ def test_chunking():
 
     assert len(documents) == 2
     assert all(doc.name.startswith("test_chunk_") for doc in documents)
-    assert all(doc.id.startswith("test_1_chunk_") for doc in documents)
+    assert all(doc.id.endswith("_chunk_0") or doc.id.endswith("_chunk_1") for doc in documents)
     assert all("chunk" in doc.meta_data for doc in documents)
 
 
@@ -214,7 +214,7 @@ async def test_async_chunking():
 
     assert len(documents) == 2
     assert all(doc.name.startswith("test_chunk_") for doc in documents)
-    assert all(doc.id.startswith("test_1_chunk_") for doc in documents)
+    assert all(doc.id.endswith("_chunk_0") or doc.id.endswith("_chunk_1") for doc in documents)
     assert all("chunk" in doc.meta_data for doc in documents)
 
 

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -151,7 +151,6 @@ def test_large_json():
 
     assert len(documents) == 1000
     assert all(doc.name == "large" for doc in documents)
-    assert all(doc.id.startswith("large_") for doc in documents)
 
 
 @pytest.mark.asyncio
@@ -266,4 +265,3 @@ async def test_async_large_json():
 
     assert len(documents) == 1000
     assert all(doc.name == "large" for doc in documents)
-    assert all(doc.id.startswith("large_") for doc in documents)

--- a/libs/agno/tests/unit/reader/test_pdf_reader.py
+++ b/libs/agno/tests/unit/reader/test_pdf_reader.py
@@ -43,7 +43,7 @@ def test_pdf_reader_read_file(sample_pdf_path):
     documents = reader.read(sample_pdf_path)
 
     assert len(documents) > 0
-    assert all(doc.name == "ThaiRecipes" for doc in documents)
+    assert all("ThaiRecipes" in doc.name for doc in documents)
     assert all(doc.content for doc in documents)
     assert all(isinstance(doc.meta_data.get("page"), int) for doc in documents)
 
@@ -54,7 +54,7 @@ async def test_pdf_reader_async_read_file(sample_pdf_path):
     documents = await reader.async_read(sample_pdf_path)
 
     assert len(documents) > 0
-    assert all(doc.name == "ThaiRecipes" for doc in documents)
+    assert all("ThaiRecipes" in doc.name for doc in documents)
     assert all(doc.content for doc in documents)
     assert all(isinstance(doc.meta_data.get("page"), int) for doc in documents)
 
@@ -145,7 +145,7 @@ async def test_async_pdf_processing(sample_pdf_path):
 
     assert len(results) == 3
     assert all(len(docs) > 0 for docs in results)
-    assert all(all(doc.name == "ThaiRecipes" for doc in docs) for docs in results)
+    assert all(all("ThaiRecipes" in doc.name for doc in docs) for docs in results)
 
 
 def test_pdf_reader_empty_pdf():

--- a/libs/agno/tests/unit/reader/test_text_reader.py
+++ b/libs/agno/tests/unit/reader/test_text_reader.py
@@ -57,7 +57,7 @@ def test_chunking():
 
     assert len(documents) == 2
     assert all(doc.name.startswith("test_chunk_") for doc in documents)
-    assert all(doc.id.startswith("test_chunk_") for doc in documents)
+    assert all(doc.id.endswith("_chunk_0") or doc.id.endswith("_chunk_1") for doc in documents)
     assert all("chunk" in doc.meta_data for doc in documents)
 
 
@@ -193,7 +193,11 @@ async def test_async_chunking():
 
     assert len(documents) == 2
     assert all(doc.name.startswith("test_chunk_") for doc in documents)
-    assert all(doc.id.startswith("test_chunk_") for doc in documents)
+    assert all(
+        doc.id.endswith("_chunk_0") or doc.id.endswith("_chunk_1")
+        # Check if the id ends with "_chunk_0" or "_chunk_1"
+        for doc in documents
+    )
     assert all("chunk" in doc.meta_data for doc in documents)
 
 
@@ -327,7 +331,7 @@ async def test_async_parallel_chunking():
         documents = await reader.async_read(text_bytes)
         assert len(documents) == 2  # Should return 2 chunks
         assert all(doc.name.startswith("test_chunk_") for doc in documents)
-        assert all(doc.id.startswith("test_chunk_") for doc in documents)
+        assert all(doc.id.endswith("_chunk_0") or doc.id.endswith("_chunk_1") for doc in documents)
         assert all("chunk" in doc.meta_data for doc in documents)
     finally:
         # Restore original processor


### PR DESCRIPTION
## Summary

Fix for issue- https://github.com/agno-agi/agno/issues/3081 and https://github.com/agno-agi/agno/issues/2887

If in a folder- you have pdf files and lets say two of the files are named like this: `Auksute_Ramanauskaite-Skokauskiene.-.Laisves_deklaracija_ir_jos_signatarai.2009.LT.pdf` and `Auksute_Ramanauskaite-Skokauskiene.-.Partizanu_vadas_generolas_Adolfas_Ramanauskas-Vanagas.2007.LT.pdf`

A part of their names overlap and the pdf reader split them based on `_` so the insertion was happening with same name `Auksute_Ramanauskaite-Skokauskiene` for both files which resulted in the error 
![image](https://github.com/user-attachments/assets/582ab094-a43e-4465-a860-8a06bc1e2ac0)

We now use unique id in the readers to make it strict-
```
Document(
    name=doc_name,
    id=f"{doc_name}_{page_number}_{uuid.uuid4()}",  # Here
    meta_data={"page": page_number},
    content=page.extract_text(),
)

```
After the fix-
![image](https://github.com/user-attachments/assets/e3ee4181-fb97-4cf4-9f23-a88abe51642b)


(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
