### PR TITLE
Added a parameter to configure auto_suggest in wikipedia.summary

### DIFF
--- a/libs/agno/agno/knowledge/wikipedia.py
+++ b/libs/agno/agno/knowledge/wikipedia.py
@@ -27,6 +27,6 @@ class WikipediaKnowledgeBase(AgentKnowledge):
                 Document(
                     name=topic,
                     meta_data={"topic": topic},
-                    content=wikipedia.summary(topic, auto_suggest=self.autosuggest),
+                    content=wikipedia.summary(topic, auto_suggest=self.auto_suggest),
                 )
             ]

--- a/libs/agno/agno/knowledge/wikipedia.py
+++ b/libs/agno/agno/knowledge/wikipedia.py
@@ -11,6 +11,7 @@ except ImportError:
 
 class WikipediaKnowledgeBase(AgentKnowledge):
     topics: List[str] = []
+    autosuggest: bool = True
 
     @property
     def document_lists(self) -> Iterator[List[Document]]:
@@ -26,6 +27,6 @@ class WikipediaKnowledgeBase(AgentKnowledge):
                 Document(
                     name=topic,
                     meta_data={"topic": topic},
-                    content=wikipedia.summary(topic),
+                    content=wikipedia.summary(topic, auto_suggest=self.autosuggest),
                 )
             ]

--- a/libs/agno/agno/knowledge/wikipedia.py
+++ b/libs/agno/agno/knowledge/wikipedia.py
@@ -11,7 +11,7 @@ except ImportError:
 
 class WikipediaKnowledgeBase(AgentKnowledge):
     topics: List[str] = []
-    autosuggest: bool = True
+    auto_suggest: bool = True
 
     @property
     def document_lists(self) -> Iterator[List[Document]]:


### PR DESCRIPTION
This way it doesn't change the user's provided topic when you set it to false.  Default is True to not change current behavior.

## Summary

Added a parameter to WikipediaKnowledgeBase


## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
