### PR TITLE
Add `extra_body`  passthrough to OpenAI model for custom backend par…

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -65,6 +65,7 @@ class OpenAIChat(Model):
     top_p: Optional[float] = None
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
+    extra_body: Optional[Dict[str, Any]] = None
     request_params: Optional[Dict[str, Any]] = None
 
     # Client parameters
@@ -175,6 +176,7 @@ class OpenAIChat(Model):
             "top_p": self.top_p,
             "extra_headers": self.extra_headers,
             "extra_query": self.extra_query,
+            "extra_body": self.extra_body,
             "metadata": self.metadata,
         }
 
@@ -220,6 +222,7 @@ class OpenAIChat(Model):
                 "user": self.user,
                 "extra_headers": self.extra_headers,
                 "extra_query": self.extra_query,
+                "extra_body": self.extra_body,
             }
         )
         cleaned_dict = {k: v for k, v in model_dict.items() if v is not None}


### PR DESCRIPTION
## Summary

This PR adds support for passing custom backend-specific parameters to OpenAI-compatible models via a new `extra_body: Optional[Dict[str, Any]] = None` field in the `OpenAI` model.

This change aims to enable seamless integration with powerful LLM serving backends like **vLLM** (e.g., for Qwen3), which support advanced generation parameters such as `top_k`, `chat_template_kwargs`, and others not included in the standard OpenAI API spec.

This enhancement allows developers to easily supply such custom fields without modifying core library logic or introducing hacks, making `agno` more extensible and production-friendly for modern inference setups.

---

## Type of change

- [ ] Bug fix  
- [x] New feature  
- [ ] Breaking change  
- [x] Improvement  
- [ ] Model update  
- [ ] Other:

---

## Checklist

- [] Code complies with style guidelines  
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)  
- [x] Self-review completed  
- [] Documentation updated (comments, docstrings)  
- [] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)  
- [x] Tested in clean environment  
- [] Tests added/updated (if applicable)  

---

## Additional Notes

### Example usage with Qwen3 (vLLM):

```python
from agno.agent import Agent
from agno.models.openai import OpenAILike
from agno.tools.googlesearch import GoogleSearchTools

agent = Agent(
    model=OpenAILike(
        id="Qwen/Qwen3-8B-FP8",
        base_url="http://host:port/v1/",
        api_key="EMPTY",
        temperature=0.7,
        top_p=0.8,
        presence_penalty=1.5,
        extra_body={
            "top_k": 20,
            "chat_template_kwargs": {"enable_thinking": False},
        },
    ),
    tools=[GoogleSearchTools()],
    description="You are a news agent that helps users find the latest news.",
    instructions=[
        "Given a topic by the user, respond with 4 latest news items about that topic.",
        "Search for 10 news items and select the top 4 unique items.",
        "Search in English and in French.",
    ],
    show_tool_calls=True,
    debug_mode=True,
)

agent.print_response("Mistral AI", markdown=True)
```
This pattern now enables injecting custom parameters into the request payload directly, unlocking advanced features in next-gen model backends like Qwen3 and Mistral hosted via vLLM.

No breaking changes were introduced default behavior remains unchanged when extra_body=None.
