### PR TITLE
fix: use subprocess cwd instead of shell 'cd' to set working directory

### DIFF
--- a/libs/agno/agno/tools/shell.py
+++ b/libs/agno/agno/tools/shell.py
@@ -21,6 +21,7 @@ class ShellTools(Toolkit):
         Args:
             args (List[str]): The command to run as a list of strings.
             tail (int): The number of lines to return from the output.
+
         Returns:
             str: The output of the command.
         """
@@ -28,14 +29,16 @@ class ShellTools(Toolkit):
 
         try:
             log_info(f"Running shell command: {args}")
-            if self.base_dir:
-                args = ["cd", str(self.base_dir), ";"] + args
-            result = subprocess.run(args, capture_output=True, text=True)
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                cwd=str(self.base_dir) if self.base_dir else None,
+            )
             log_debug(f"Result: {result}")
             log_debug(f"Return code: {result.returncode}")
             if result.returncode != 0:
                 return f"Error: {result.stderr}"
-            # return only the last n lines of the output
             return "\n".join(result.stdout.split("\n")[-tail:])
         except Exception as e:
             logger.warning(f"Failed to run shell command: {e}")


### PR DESCRIPTION
## Summary

Refactored ShellTools.run_shell_command to correctly handle working directory changes by using the cwd parameter of subprocess.run() instead of prepending cd to the shell command. This resolves command execution failures caused by improper shell syntax in argument lists and improves robustness and cross-platform compatibility.

issue number: https://github.com/agno-agi/agno/issues/3218

