### PR TITLE
fix(replicate): handle FileOutput and list of FileOutput

### DIFF
--- a/libs/agno/agno/tools/replicate.py
+++ b/libs/agno/agno/tools/replicate.py
@@ -1,6 +1,6 @@
 import os
 from os import getenv
-from typing import Optional, Union
+from typing import Iterable, Iterator, Optional, Union
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -39,8 +39,33 @@ class ReplicateTools(Toolkit):
         Returns:
             str: Return a URI to the generated video or image.
         """
-        output: FileOutput = replicate.run(ref=self.model, input={"prompt": prompt})
+        if not self.api_key:
+            logger.error("API key is not set. Please provide a valid API key.")
+            return "API key is not set."
 
+        outputs = replicate.run(ref=self.model, input={"prompt": prompt})
+        if isinstance(outputs, FileOutput):
+            outputs = [outputs]
+        elif isinstance(outputs, (Iterable, Iterator)) and not isinstance(outputs, str):
+            outputs = list(outputs)
+        else:
+            logger.error(f"Unexpected output type: {type(outputs)}")
+            return f"Unexpected output type: {type(outputs)}"
+
+        results = []
+        for output in outputs:
+            if not isinstance(output, FileOutput):
+                logger.error(f"Unexpected output type: {type(output)}")
+                return f"Unexpected output type: {type(output)}"
+
+            result = self._parse_output(agent, output)
+            results.append(result)
+        return "\n".join(results)
+
+    def _parse_output(self, agent: Union[Agent, Team], output: FileOutput) -> str:
+        """
+        Parse the outputs from the replicate model.
+        """
         # Parse the URL to extract the file extension
         parsed_url = urlparse(output.url)
         path = parsed_url.path


### PR DESCRIPTION
## Summary

Add support for both single FileOutput and iterable outputs from replicate.run. Improve error handling for unexpected output types.


The issue was:

The `replicate.run` returns a list of FileOutput rather than FileOutput

<img width="1865" alt="image" src="https://github.com/user-attachments/assets/b03b5b4c-38c1-4c5d-a079-8072e85234c0" />



## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

