### PR TITLE
feat: add vLLM model provider integration

### DIFF
--- a/cookbook/models/vllm/README.md
+++ b/cookbook/models/vllm/README.md
@@ -1,0 +1,44 @@
+# Vllm Cookbook
+
+> Note: Fork and clone this repository if needed
+
+### 1. Create and activate a virtual environment
+
+```shell
+python3 -m venv ~/.venvs/aienv
+source ~/.venvs/aienv/bin/activate
+```
+
+### 2. Export your `VLLM_BASE_URL`
+
+```shell
+export VLLM_BASE_URL="http://localhost:8000"
+```
+
+### 3. Install libraries
+
+```shell
+pip install -U openai duckduckgo-search duckdb yfinance agno
+```
+
+### 4. Run basic Agent
+
+- Streaming on
+
+```shell
+python cookbook/models/vllm/basic_stream.py
+```
+
+- Streaming off
+
+```shell
+python cookbook/models/vllm/basic.py
+```
+
+### 5. Run with Tools
+
+- DuckDuckGo Search
+
+```shell
+python cookbook/models/vllm/tool_use.py
+```

--- a/cookbook/models/vllm/async_basic.py
+++ b/cookbook/models/vllm/async_basic.py
@@ -1,0 +1,9 @@
+import asyncio
+
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+
+agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False), markdown=True
+)
+asyncio.run(agent.aprint_response("Share a 2 sentence horror story"))

--- a/cookbook/models/vllm/async_basic_stream.py
+++ b/cookbook/models/vllm/async_basic_stream.py
@@ -1,0 +1,9 @@
+import asyncio
+
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+
+agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False), markdown=True
+)
+asyncio.run(agent.aprint_response("Share a 2 sentence horror story", stream=True))

--- a/cookbook/models/vllm/async_tool_use.py
+++ b/cookbook/models/vllm/async_tool_use.py
@@ -1,0 +1,15 @@
+"""Run `pip install duckduckgo-search` to install dependencies."""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False),
+    tools=[DuckDuckGoTools()],
+    show_tool_calls=True,
+    markdown=True,
+)
+asyncio.run(agent.aprint_response("Whats happening in France?", stream=True))

--- a/cookbook/models/vllm/basic.py
+++ b/cookbook/models/vllm/basic.py
@@ -1,0 +1,8 @@
+from agno.agent import Agent, RunResponse  # noqa
+from agno.models.vllm import Vllm
+
+agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False), markdown=True
+)
+
+agent.print_response("Share a 2 sentence horror story")

--- a/cookbook/models/vllm/basic_stream.py
+++ b/cookbook/models/vllm/basic_stream.py
@@ -1,0 +1,7 @@
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+
+agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False), markdown=True
+)
+agent.print_response("Share a 2 sentence horror story", stream=True)

--- a/cookbook/models/vllm/finance_agent.py
+++ b/cookbook/models/vllm/finance_agent.py
@@ -1,0 +1,80 @@
+"""🗞️ Finance Agent - Your Personal Market Analyst!
+
+This example shows how to create a sophisticated financial analyst that provides
+comprehensive market insights using real-time data. The agent combines stock market data,
+analyst recommendations, company information, and latest news to deliver professional-grade
+financial analysis.
+
+Example prompts to try:
+- "What's the latest news and financial performance of Apple (AAPL)?"
+- "Give me a detailed analysis of Tesla's (TSLA) current market position"
+- "How are Microsoft's (MSFT) financials looking? Include analyst recommendations"
+- "Analyze NVIDIA's (NVDA) stock performance and future outlook"
+- "What's the market saying about Amazon's (AMZN) latest quarter?"
+
+Run: `pip install openai yfinance agno` to install the dependencies
+"""
+
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+from agno.tools.yfinance import YFinanceTools
+
+finance_agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False),
+    tools=[
+        YFinanceTools(
+            stock_price=True,
+            analyst_recommendations=True,
+            stock_fundamentals=True,
+            historical_prices=True,
+            company_info=True,
+            company_news=True,
+        )
+    ],
+    instructions=dedent(
+        """\
+        You are a seasoned Wall Street analyst with deep expertise in market analysis! 📊
+
+        Follow these steps for comprehensive financial analysis:
+        1. Market Overview
+           - Latest stock price
+           - 52-week high and low
+        2. Financial Deep Dive
+           - Key metrics (P/E, Market Cap, EPS)
+        3. Professional Insights
+           - Analyst recommendations breakdown
+           - Recent rating changes
+
+        4. Market Context
+           - Industry trends and positioning
+           - Competitive analysis
+           - Market sentiment indicators
+
+        Your reporting style:
+        - Begin with an executive summary
+        - Use tables for data presentation
+        - Include clear section headers
+        - Add emoji indicators for trends (📈 📉)
+        - Highlight key insights with bullet points
+        - Compare metrics to industry averages
+        - Include technical term explanations
+        - End with a forward-looking analysis
+
+        Risk Disclosure:
+        - Always highlight potential risk factors
+        - Note market uncertainties
+        - Mention relevant regulatory concerns
+    """
+    ),
+    add_datetime_to_instructions=True,
+    markdown=True,
+)
+
+# Example usage with detailed market analysis request
+finance_agent.print_response(
+    "Write a comprehensive report on TSLA",
+    stream=True,
+    stream_intermediate_steps=True,
+)

--- a/cookbook/models/vllm/reasoning_agent.py
+++ b/cookbook/models/vllm/reasoning_agent.py
@@ -1,0 +1,28 @@
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+from agno.tools.reasoning import ReasoningTools
+from agno.tools.yfinance import YFinanceTools
+
+reasoning_agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False),
+    tools=[
+        ReasoningTools(add_instructions=True, add_few_shot=True),
+        YFinanceTools(
+            stock_price=True,
+            analyst_recommendations=True,
+            company_info=True,
+            company_news=True,
+        ),
+    ],
+    instructions=[
+        "Use tables to display data",
+        "Only output the report, no other text",
+    ],
+    markdown=True,
+)
+reasoning_agent.print_response(
+    "Write a report on TSLA",
+    stream=True,
+    show_full_reasoning=True,
+    stream_intermediate_steps=True,
+)

--- a/cookbook/models/vllm/structured_output.py
+++ b/cookbook/models/vllm/structured_output.py
@@ -1,0 +1,41 @@
+import asyncio
+from typing import List
+
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+from agno.run.response import RunResponse
+from pydantic import BaseModel, Field
+from rich.pretty import pprint  # noqa
+
+
+class MovieScript(BaseModel):
+    name: str = Field(..., description="Give a name to this movie")
+    setting: str = Field(
+        ..., description="Provide a nice setting for a blockbuster movie."
+    )
+    ending: str = Field(
+        ...,
+        description="Ending of the movie. If not available, provide a happy ending.",
+    )
+    genre: str = Field(
+        ...,
+        description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
+    )
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(
+        ..., description="3 sentence storyline for the movie. Make it exciting!"
+    )
+
+
+# Agent that returns a structured output
+structured_output_agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False),
+    description="You write movie scripts.",
+    response_model=MovieScript,
+)
+
+# Run the agent synchronously
+structured_output_response: RunResponse = structured_output_agent.run(
+    "Llamas ruling the world"
+)
+pprint(structured_output_response.content)

--- a/cookbook/models/vllm/tool_use.py
+++ b/cookbook/models/vllm/tool_use.py
@@ -1,0 +1,13 @@
+"""Build a Web Search Agent using xAI."""
+
+from agno.agent import Agent
+from agno.models.vllm import Vllm
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+agent = Agent(
+    model=Vllm(id="Qwen/Qwen3-8B-FP8", top_k=20, enable_thinking=False),
+    tools=[DuckDuckGoTools()],
+    show_tool_calls=True,
+    markdown=True,
+)
+agent.print_response("Whats happening in France?", stream=True)

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -782,7 +782,7 @@ class Agent:
                         event=RunEvent.tool_call_started,
                         session_id=session_id,
                         run_response=run_response,
-                        )
+                    )
 
                 # If the model response is a tool_call_completed, update the existing tool call in the run_response
                 elif model_response_chunk.event == ModelResponseEvent.tool_call_completed.value:

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -65,6 +65,7 @@ class OpenAIChat(Model):
     top_p: Optional[float] = None
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
+    extra_body: Optional[Dict[str, Any]] = None
     request_params: Optional[Dict[str, Any]] = None
 
     # Client parameters
@@ -175,6 +176,7 @@ class OpenAIChat(Model):
             "top_p": self.top_p,
             "extra_headers": self.extra_headers,
             "extra_query": self.extra_query,
+            "extra_body": self.extra_body,
             "metadata": self.metadata,
         }
 
@@ -220,6 +222,7 @@ class OpenAIChat(Model):
                 "user": self.user,
                 "extra_headers": self.extra_headers,
                 "extra_query": self.extra_query,
+                "extra_body": self.extra_body,
             }
         )
         cleaned_dict = {k: v for k, v in model_dict.items() if v is not None}

--- a/libs/agno/agno/models/vllm/__init__.py
+++ b/libs/agno/agno/models/vllm/__init__.py
@@ -1,0 +1,5 @@
+from agno.models.vllm.vllm import Vllm
+
+__all__ = [
+    "Vllm",
+]

--- a/libs/agno/agno/models/vllm/vllm.py
+++ b/libs/agno/agno/models/vllm/vllm.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from os import getenv
+from typing import Any, Dict, Optional
+
+from agno.models.openai.like import OpenAILike
+
+
+@dataclass
+class Vllm(OpenAILike):
+    """
+    Class for interacting with vLLM models via OpenAI-compatible API.
+
+    Attributes:
+        id: Model identifier
+        name: API name
+        provider: API provider
+        base_url: vLLM server URL
+        temperature: Sampling temperature
+        top_p: Nucleus sampling probability
+        presence_penalty: Repetition penalty
+        top_k: Top-k sampling
+        enable_thinking: Special mode flag
+    """
+
+    id: str = "not-set"
+    name: str = "vLLM"
+    provider: str = "vLLM"
+
+    api_key: Optional[str] = getenv("VLLM_API_KEY") or "EMPTY"
+    base_url: str = getenv("VLLM_BASE_URL")
+
+    temperature: float = 0.7
+    top_p: float = 0.8
+    presence_penalty: float = 1.5
+    top_k: Optional[int] = None
+    enable_thinking: Optional[bool] = None
+
+    def __post_init__(self):
+        """Validate required configuration"""
+        if not self.base_url:
+            raise ValueError(
+                "VLLM_BASE_URL must be set via environment variable or explicit initialization"
+            )
+        if self.id == "not-set":
+            raise ValueError(
+                "Model ID must be set via environment variable or explicit initialization"
+            )
+
+    @property
+    def extra_body(self) -> Optional[Dict[str, Any]]:
+        """Dynamic parameters for vLLM API calls"""
+        body: Dict[str, Any] = {}
+        if self.top_k is not None:
+            body["top_k"] = self.top_k
+        if self.enable_thinking is not None:
+            body["chat_template_kwargs"] = {"enable_thinking": self.enable_thinking}
+        return body or None
+
+    @extra_body.setter
+    def extra_body(self, value: Any) -> None:
+        """Dummy setter to handle potential parent class expectations"""
+        pass  # Explicitly ignore assignment attempts

--- a/libs/agno/agno/playground/async_router.py
+++ b/libs/agno/agno/playground/async_router.py
@@ -72,6 +72,7 @@ async def chat_response_streamer(
             yield run_response_chunk.to_json()
     except Exception as e:
         import traceback
+
         traceback.print_exc(limit=3)
         error_response = RunResponse(
             content=str(e),


### PR DESCRIPTION
## Summary

This change introduces a new vLLM model provider into Agno, enabling users to connect to any locally‑hosted or remote vLLM server via the familiar OpenAI‑compatible chat API. vLLM is a high‑throughput, memory‑efficient inference engine that supports dynamic tensor and pipeline parallelism for distributed serving, plus advanced decoding algorithms (parallel sampling, beam search) and streaming outputs [GitHub](https://github.com/vllm-project/vllm?utm_source=chatgpt.com)
. By leveraging vLLM’s OpenAI‑compatible HTTP server, Agno can now serve models with minimal configuration simply point at your vLLM base URL [vLLM](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html?utm_source=chatgpt.com)
. Under the hood, this adapter also exposes optional features like `top_k` sampling and the `enable_thinking` mode, mapping directly to vLLM’s native generation parameters
(Related issue: #2256, #2482, #3112 )
## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

