### PR TITLE
feat: add support for stop after tool in Toolkits

### DIFF
--- a/cookbook/agent_concepts/tool_concepts/toolkits/stop_after_tool_function.py
+++ b/cookbook/agent_concepts/tool_concepts/toolkits/stop_after_tool_function.py
@@ -1,0 +1,17 @@
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.googlesearch import GoogleSearchTools
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4.5-preview"),
+    tools=[
+        GoogleSearchTools(
+            stop_after_tool_function=["google_search"],
+            show_result=True,
+        )
+    ],
+    show_tool_calls=True,
+    debug_mode=True,
+)
+
+agent.print_response("Whats the latest about gpt 4.5?", markdown=True)

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from agno.tools.function import Function
 from agno.utils.log import log_debug, logger
@@ -18,6 +18,8 @@ class Toolkit:
         cache_ttl: int = 3600,
         cache_dir: Optional[str] = None,
         auto_register: bool = True,
+        stop_after_tool_function: Optional[List[str]] = None,
+        show_result: Optional[bool] = False,
     ):
         """Initialize a new Toolkit.
 
@@ -32,12 +34,16 @@ class Toolkit:
             cache_ttl (int): Time-to-live for cached results in seconds.
             cache_dir (Optional[str]): Directory to store cache files. Defaults to system temp dir.
             auto_register (bool): Whether to automatically register all methods in the class.
+            stop_after_tool_function (Optional[List[str]]): List of function names that should stop the agent after execution.
+            show_result (Optional(bool)): If True, show results for all functions in this toolkit.
         """
         self.name: str = name
         self.tools: List[Callable] = tools
         self.functions: Dict[str, Function] = OrderedDict()
         self.instructions: Optional[str] = instructions
         self.add_instructions: bool = add_instructions
+        self.stop_after_tool_function = stop_after_tool_function or []
+        self.show_result = show_result
 
         self._check_tools_filters(
             available_tools=[tool.__name__ for tool in tools], include_tools=include_tools, exclude_tools=exclude_tools
@@ -102,6 +108,8 @@ class Toolkit:
                 cache_results=self.cache_results,
                 cache_dir=self.cache_dir,
                 cache_ttl=self.cache_ttl,
+                stop_after_tool_call=tool_name in self.stop_after_tool_function,
+                show_result=self.show_result,
             )
             self.functions[f.name] = f
             log_debug(f"Function: {f.name} registered with {self.name}")


### PR DESCRIPTION
## Summary

`stop_after_tool_call` and `show_result` for Toolkits

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
