### PR TITLE
feat: better MCP timeout handling

### DIFF
--- a/libs/agno/agno/tools/mcp.py
+++ b/libs/agno/agno/tools/mcp.py
@@ -165,21 +165,24 @@ class MCPTools(Toolkit):
             if "url" not in sse_params:
                 sse_params["url"] = self.url
             self._context = sse_client(**sse_params)
+            client_timeout = max(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
         elif self.transport == "streamable-http":
             streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}
             if "url" not in streamable_http_params:
                 streamable_http_params["url"] = self.url
             self._context = streamablehttp_client(**streamable_http_params)
-        elif self.transport == "stdio":
+            client_timeout = max(self.timeout_seconds, streamable_http_params.get("timeout", self.timeout_seconds))
+        else:
             if self.server_params is None:
                 raise ValueError("server_params must be provided when using stdio transport.")
             self._context = stdio_client(self.server_params)  # type: ignore
+            client_timeout = self.timeout_seconds
 
         session_params = await self._context.__aenter__()  # type: ignore
         read, write = session_params[0:2]
 
-        self._session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=self.timeout_seconds))  # type: ignore
-        self.session = await self._session_context.__aenter__()  # type: ignore
+        self._session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))
+        self.session = await self._session_context.__aenter__()
 
         # Initialize with the new session
         await self.initialize()

--- a/libs/agno/agno/tools/mcp.py
+++ b/libs/agno/agno/tools/mcp.py
@@ -165,13 +165,13 @@ class MCPTools(Toolkit):
             if "url" not in sse_params:
                 sse_params["url"] = self.url
             self._context = sse_client(**sse_params)
-            client_timeout = max(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
+            client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
         elif self.transport == "streamable-http":
             streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}
             if "url" not in streamable_http_params:
                 streamable_http_params["url"] = self.url
             self._context = streamablehttp_client(**streamable_http_params)
-            client_timeout = max(self.timeout_seconds, streamable_http_params.get("timeout", self.timeout_seconds))
+            client_timeout = min(self.timeout_seconds, streamable_http_params.get("timeout", self.timeout_seconds))
         else:
             if self.server_params is None:
                 raise ValueError("server_params must be provided when using stdio transport.")

--- a/libs/agno/agno/tools/mcp.py
+++ b/libs/agno/agno/tools/mcp.py
@@ -182,7 +182,7 @@ class MCPTools(Toolkit):
         read, write = session_params[0:2]
 
         self._session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))
-        self.session = await self._session_context.__aenter__()
+        self.session = await self._session_context.__aenter__()  # type: ignore
 
         # Initialize with the new session
         await self.initialize()


### PR DESCRIPTION
We were effectively ignoring the timeout value set in `SSEClientParms` or `StreamableHTTPClientParams` as we were not considering it when initializing the `ClientSession`. Now both ways to declare the read timeout work:

```python
# Approach 1, using the server params
server_params = SSEClientParams(url=server_url, timeout=10)

async def run_agent(message: str) -> None:
    async with MCPTools(server_params=server_params, transport="sse") as mcp_tools:
        ...


# Approach 2, using the MCPTools param
async def run_agent(message: str) -> None:
    async with MCPTools(server_params=server_params, transport="sse", timeout_seconds=10) as mcp_tools:
        ...
```

In case of collision we use the max.