### PR TITLE
Add missing async method to Combined KB

### DIFF
--- a/libs/agno/agno/knowledge/agent.py
+++ b/libs/agno/agno/knowledge/agent.py
@@ -44,7 +44,7 @@ class AgentKnowledge(BaseModel):
         raise NotImplementedError
 
     @property
-    def async_document_lists(self) -> AsyncIterator[List[Document]]:
+    async def async_document_lists(self) -> AsyncIterator[List[Document]]:
         """Iterator that yields lists of documents in the knowledge base
         Each object yielded by the iterator is a list of documents.
         """

--- a/libs/agno/agno/knowledge/combined.py
+++ b/libs/agno/agno/knowledge/combined.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List
+from typing import AsyncIterator, Iterator, List
 
 from agno.document import Document
 from agno.knowledge.agent import AgentKnowledge
@@ -20,3 +20,17 @@ class CombinedKnowledgeBase(AgentKnowledge):
         for kb in self.sources:
             log_debug(f"Loading documents from {kb.__class__.__name__}")
             yield from kb.document_lists
+
+    @property
+    async def async_document_lists(self) -> AsyncIterator[List[Document]]:
+        """Iterate over knowledge bases and yield lists of documents.
+        Each object yielded by the iterator is a list of documents.
+
+        Returns:
+            Iterator[List[Document]]: Iterator yielding list of documents
+        """
+
+        for kb in self.sources:
+            log_debug(f"Loading documents from {kb.__class__.__name__}")
+            async for document in kb.async_document_lists:
+                yield document


### PR DESCRIPTION
## Summary

The CombinedKnowledgeBase is missing the implementation for the `async_document_lists` method.

Plus, the abstract method is not marked as `async`.


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

