### PR TITLE
feat: fetch messages from last 3 sessions

### DIFF
--- a/cookbook/agent_concepts/memory/17_builtin_memory_with_session_summary.py
+++ b/cookbook/agent_concepts/memory/17_builtin_memory_with_session_summary.py
@@ -31,7 +31,10 @@ agent.print_response("Hello! How are you today?", stream=True)
 
 agent.print_response("Explain what an LLM is.", stream=True)
 
-agent.print_response("I'm thinking about learning a new programming language. Any suggestions?", stream=True)
+agent.print_response(
+    "I'm thinking about learning a new programming language. Any suggestions?",
+    stream=True,
+)
 
 agent.print_response("Tell me an interesting fact about space.", stream=True)
 
@@ -47,12 +50,7 @@ pprint(
 agent.print_response("What have we been talking about?", stream=True)
 
 # -*- Print the messages used for the last response (only the last 3 is kept in history)
-pprint(
-    [
-        m.model_dump(include={"role", "content"})
-        for m in agent.run_response.messages
-    ]
-)
+pprint([m.model_dump(include={"role", "content"}) for m in agent.run_response.messages])
 
 # We can get the session summary from memory as well
 session_summary = agent.get_session_summary()


### PR DESCRIPTION
## Summary

- A tool for the agent, something like `get_previous_session_messages(number_of_sessions: int)` that returns a list of messages that the agent can analyse
- Switch on with search_previous_sessions_history

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
