### PR TITLE
fix-claude-tool-call-bug-ag-3287

### DIFF
--- a/libs/agno/agno/utils/models/aws_claude.py
+++ b/libs/agno/agno/utils/models/aws_claude.py
@@ -152,7 +152,8 @@ def format_messages(messages: List[Message]) -> Tuple[List[Dict[str, str]], str]
             content = []
 
             if isinstance(message.content, str) and message.content:
-                content.append(TextBlock(text=message.content, type="text"))
+                if message.content != " ":
+                    content.append(TextBlock(text=message.content, type="text"))
 
             if message.tool_calls:
                 for tool_call in message.tool_calls:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agno.media import File, Image
 from agno.models.message import Message
-from agno.utils.log import log_error, log_warning
+from agno.utils.log import log_error, log_info, log_warning
 
 try:
     from anthropic.types import (
@@ -232,7 +232,8 @@ def format_messages(messages: List[Message]) -> Tuple[List[Dict[str, str]], str]
                 content.append(RedactedThinkingBlock(data=message.redacted_thinking, type="redacted_thinking"))
 
             if isinstance(message.content, str) and message.content:
-                content.append(TextBlock(text=message.content, type="text"))
+                if message.content != " ":
+                    content.append(TextBlock(text=message.content, type="text"))
 
             if message.tool_calls:
                 for tool_call in message.tool_calls:


### PR DESCRIPTION
## Summary

Claude tool call bug fix for when tool calls are accompanied with a Textblock with `" "` 

Issue number: #3137 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
