### PR TITLE
chore: clarify eval cookbooks

### DIFF
--- a/cookbook/evals/accuracy/accuracy_basic.py
+++ b/cookbook/evals/accuracy/accuracy_basic.py
@@ -14,6 +14,7 @@ evaluation = AccuracyEval(
     input="What is 10*5 then to the power of 2? do it step by step",
     expected_output="2500",
     additional_guidelines="Agent output should include the steps and the final answer.",
+    num_iterations=3,
 )
 
 result: Optional[AccuracyResult] = evaluation.run(print_results=True)

--- a/cookbook/evals/accuracy/accuracy_with_given_answer.py
+++ b/cookbook/evals/accuracy/accuracy_with_given_answer.py
@@ -1,15 +1,12 @@
 from typing import Optional
 
-from agno.agent import Agent
 from agno.eval.accuracy import AccuracyEval, AccuracyResult
 from agno.models.openai import OpenAIChat
-from agno.tools.calculator import CalculatorTools
 
 evaluation = AccuracyEval(
     model=OpenAIChat(id="o4-mini"),
     input="What is 10*5 then to the power of 2? do it step by step",
     expected_output="2500",
-    num_iterations=1,
 )
 result_with_given_answer: Optional[AccuracyResult] = evaluation.run_with_output(
     output="2500", print_results=True


### PR DESCRIPTION
Small cookbooks clarification 

- Add `num_iterations` on the basic cookbook
- Remove `num_iterations` on the `run_with_output` cookbook as it's not used/relevant there
