### PR TITLE
chore: update retriever cookbooks

### DIFF
--- a/cookbook/agent_concepts/knowledge/custom/async_retriever.py
+++ b/cookbook/agent_concepts/knowledge/custom/async_retriever.py
@@ -12,7 +12,9 @@ from qdrant_client import AsyncQdrantClient
 # Define the embedder
 embedder = OpenAIEmbedder(id="text-embedding-3-small")
 # Initialize vector database connection
-vector_db = Qdrant(collection="thai-recipes", path="tmp/qdrant", embedder=embedder)
+vector_db = Qdrant(
+    collection="thai-recipes", url="http://localhost:6333", embedder=embedder
+)
 # Load the knowledge base
 knowledge_base = PDFUrlKnowledgeBase(
     urls=["https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"],
@@ -20,7 +22,7 @@ knowledge_base = PDFUrlKnowledgeBase(
 )
 
 # Load the knowledge base
-# knowledge_base.load(recreate=True)  # Comment out after first run
+# knowledge_base.aload(recreate=True)  # Comment out after first run
 # Knowledge base is now loaded
 # ---------------------------------------------------------
 
@@ -43,7 +45,7 @@ async def retriever(
         Optional[list[dict]]: List of retrieved documents or None if search fails
     """
     try:
-        qdrant_client = AsyncQdrantClient(path="tmp/qdrant")
+        qdrant_client = AsyncQdrantClient(url="http://localhost:6333")
         query_embedding = embedder.get_embedding(query)
         results = await qdrant_client.query_points(
             collection_name="thai-recipes",
@@ -67,7 +69,6 @@ async def amain():
     # search_knowledge=True is default when you add a knowledge base but is needed here
     agent = Agent(
         retriever=retriever,
-        knowledge=knowledge_base,
         search_knowledge=True,
         instructions="Search the knowledge base for information",
         show_tool_calls=True,

--- a/cookbook/agent_concepts/knowledge/custom/retriever.py
+++ b/cookbook/agent_concepts/knowledge/custom/retriever.py
@@ -11,7 +11,9 @@ from qdrant_client import QdrantClient
 # Define the embedder
 embedder = OpenAIEmbedder(id="text-embedding-3-small")
 # Initialize vector database connection
-vector_db = Qdrant(collection="thai-recipes", path="tmp/qdrant", embedder=embedder)
+vector_db = Qdrant(
+    collection="thai-recipes", url="http://localhost:6333", embedder=embedder
+)
 # Load the knowledge base
 knowledge_base = PDFUrlKnowledgeBase(
     urls=["https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"],
@@ -42,7 +44,7 @@ def retriever(
         Optional[list[dict]]: List of retrieved documents or None if search fails
     """
     try:
-        qdrant_client = QdrantClient(path="tmp/qdrant")
+        qdrant_client = QdrantClient(url="http://localhost:6333")
         query_embedding = embedder.get_embedding(query)
         results = qdrant_client.query_points(
             collection_name="thai-recipes",

--- a/cookbook/agent_concepts/knowledge/custom/retriever.py
+++ b/cookbook/agent_concepts/knowledge/custom/retriever.py
@@ -68,7 +68,6 @@ def main():
     # search_knowledge=True is default when you add a knowledge base but is needed here
     agent = Agent(
         retriever=retriever,
-        knowledge=knowledge_base,
         search_knowledge=True,
         instructions="Search the knowledge base for information",
         show_tool_calls=True,


### PR DESCRIPTION
## Summary

update retriever cookbooks:
- the `knowledge_base` param need not be passed while using a custom retriever
- instead of local qdrant path usage, use it with docker, the local one keeps losing connections and does not work asynchronously.

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
