### PR TITLE
handle empty responses from Gemini model

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -685,7 +685,7 @@ class Gemini(Model):
             model_response.role = self.role_map[response_message.role]
 
         # Add content
-        if response_message.parts is not None:
+        if response_message.parts is not None and len(response_message.parts) > 0:
             for part in response_message.parts:
                 # Extract text if present
                 if hasattr(part, "text") and part.text is not None:
@@ -743,6 +743,10 @@ class Gemini(Model):
                 "total_tokens": usage.total_token_count or 0,
                 "cached_tokens": usage.cached_content_token_count or 0,
             }
+
+        # If we have no content but have a role, add a default empty content
+        if model_response.role and not model_response.content and not model_response.tool_calls:
+            model_response.content = ""
 
         return model_response
 


### PR DESCRIPTION
## Summary

Fixed a bug where Gemini model responses with empty content caused 400 INVALID_ARGUMENT errors in subsequent API calls. The issue occurred when Gemini returned a response with just a role but no content, which led to empty parts being sent in the next request.

Issue: #3304 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)