### PR TITLE
feat: Qdrant hybrid search

### DIFF
--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -12,12 +12,19 @@ except ImportError:
 from agno.document import Document
 from agno.embedder import Embedder
 from agno.reranker.base import Reranker
-from agno.utils.log import log_debug, log_info, logger
+from agno.utils.log import log_debug, log_info
 from agno.vectordb.base import VectorDb
 from agno.vectordb.distance import Distance
+from agno.vectordb.search import SearchType
+
+DEFAULT_DENSE_VECTOR_NAME = "dense"
+DEFAULT_SPARSE_VECTOR_NAME = "sparse"
+DEFAULT_SPARSE_MODEL = "Qdrant/bm25"
 
 
 class Qdrant(VectorDb):
+    """Vector DB implementation powered by Qdrant - https://qdrant.tech/"""
+
     def __init__(
         self,
         collection: str,
@@ -35,8 +42,37 @@ class Qdrant(VectorDb):
         host: Optional[str] = None,
         path: Optional[str] = None,
         reranker: Optional[Reranker] = None,
+        search_type: SearchType = SearchType.vector,
+        dense_vector_name: str = DEFAULT_DENSE_VECTOR_NAME,
+        sparse_vector_name: str = DEFAULT_SPARSE_VECTOR_NAME,
+        hybrid_fusion_strategy: models.Fusion = models.Fusion.RRF,
+        fastembed_kwargs: Optional[dict] = None,
         **kwargs,
     ):
+        """
+        Args:
+            collection (str): Name of the Qdrant collection.
+            embedder (Optional[Embedder]): Optional embedder for automatic vector generation.
+            distance (Distance): Distance metric to use (default: cosine).
+            location (Optional[str]): `":memory:"` for in-memory, or str used as `url`. If `None`, use default host/port.
+            url (Optional[str]): Full URL (scheme, host, port, prefix). Overrides host/port if provided.
+            port (Optional[int]): REST API port (default: 6333).
+            grpc_port (int): gRPC interface port (default: 6334).
+            prefer_grpc (bool): Prefer gRPC over REST if True.
+            https (Optional[bool]): Use HTTPS if True.
+            api_key (Optional[str]): API key for Qdrant Cloud authentication.
+            prefix (Optional[str]): URL path prefix (e.g., "service/v1").
+            timeout (Optional[float]): Request timeout (REST: default 5s, gRPC: unlimited).
+            host (Optional[str]): Qdrant host (default: "localhost" if not specified).
+            path (Optional[str]): Path for local persistence (QdrantLocal).
+            reranker (Optional[Reranker]): Optional reranker for result refinement.
+            search_type (SearchType): Whether to use vector, keyword or hybrid search.
+            dense_vector_name (str): Dense vector name.
+            sparse_vector_name (str): Sparse vector name.
+            hybrid_fusion_strategy (models.Fusion): Strategy for hybrid fusion.
+            fastembed_kwargs (Optional[dict]): Keyword args for `fastembed.SparseTextEmbedding.__init__()`.
+            **kwargs: Keyword args for `qdrant_client.QdrantClient.__init__()`.
+        """
         # Collection attributes
         self.collection: str = collection
 
@@ -46,6 +82,7 @@ class Qdrant(VectorDb):
 
             embedder = OpenAIEmbedder()
             log_info("Embedder not provided, using OpenAIEmbedder as default.")
+
         self.embedder: Embedder = embedder
         self.dimensions: Optional[int] = self.embedder.dimensions
 
@@ -76,6 +113,26 @@ class Qdrant(VectorDb):
 
         # Qdrant client kwargs
         self.kwargs = kwargs
+
+        self.search_type = search_type
+        self.dense_vector_name = dense_vector_name
+        self.sparse_vector_name = sparse_vector_name
+        self.hybrid_fusion_strategy = hybrid_fusion_strategy
+
+        if self.search_type in [SearchType.keyword, SearchType.hybrid]:
+            try:
+                from fastembed import SparseTextEmbedding
+
+                default_kwargs = {"model_name": DEFAULT_SPARSE_MODEL}
+                if fastembed_kwargs:
+                    default_kwargs.update(fastembed_kwargs)
+
+                self.sparse_encoder = SparseTextEmbedding(**default_kwargs)
+
+            except ImportError as e:
+                raise ImportError(
+                    "To use keyword/hybrid search, install the `fastembed` extra with `pip install 'qdrant-client[fastembed]'`."
+                ) from e
 
     @property
     def client(self) -> QdrantClient:
@@ -130,7 +187,12 @@ class Qdrant(VectorDb):
             log_debug(f"Creating collection: {self.collection}")
             self.client.create_collection(
                 collection_name=self.collection,
-                vectors_config=models.VectorParams(size=self.dimensions, distance=_distance),
+                vectors_config={self.dense_vector_name: models.VectorParams(size=self.dimensions, distance=_distance)}
+                if self.search_type in [SearchType.vector, SearchType.hybrid]
+                else {},
+                sparse_vectors_config={self.sparse_vector_name: models.SparseVectorParams()}
+                if self.search_type in [SearchType.keyword, SearchType.hybrid]
+                else None,
             )
 
     async def async_create(self) -> None:
@@ -146,7 +208,12 @@ class Qdrant(VectorDb):
             log_debug(f"Creating collection asynchronously: {self.collection}")
             await self.async_client.create_collection(
                 collection_name=self.collection,
-                vectors_config=models.VectorParams(size=self.dimensions, distance=_distance),
+                vectors_config={self.dense_vector_name: models.VectorParams(size=self.dimensions, distance=_distance)}
+                if self.search_type in [SearchType.vector, SearchType.hybrid]
+                else {},
+                sparse_vectors_config={self.sparse_vector_name: models.SparseVectorParams()}
+                if self.search_type in [SearchType.keyword, SearchType.hybrid]
+                else None,
             )
 
     def doc_exists(self, document: Document) -> bool:
@@ -230,9 +297,16 @@ class Qdrant(VectorDb):
         log_debug(f"Inserting {len(documents)} documents")
         points = []
         for document in documents:
-            document.embed(embedder=self.embedder)
             cleaned_content = document.content.replace("\x00", "\ufffd")
             doc_id = md5(cleaned_content.encode()).hexdigest()
+
+            vector = {}
+            if self.search_type in [SearchType.vector, SearchType.hybrid]:
+                document.embed(embedder=self.embedder)
+                vector[self.dense_vector_name] = document.embedding
+
+            if self.search_type in [SearchType.keyword, SearchType.hybrid]:
+                vector[self.sparse_vector_name] = next(self.sparse_encoder.embed([document.content])).as_object()
 
             # Create payload with document properties
             payload = {
@@ -252,7 +326,7 @@ class Qdrant(VectorDb):
             points.append(
                 models.PointStruct(
                     id=doc_id,
-                    vector=document.embedding,
+                    vector=vector,
                     payload=payload,
                 )
             )
@@ -272,9 +346,17 @@ class Qdrant(VectorDb):
         log_debug(f"Inserting {len(documents)} documents asynchronously")
 
         async def process_document(document):
-            document.embed(embedder=self.embedder)
             cleaned_content = document.content.replace("\x00", "\ufffd")
             doc_id = md5(cleaned_content.encode()).hexdigest()
+
+            vector = {}
+
+            if self.search_type in [SearchType.vector, SearchType.hybrid]:
+                document.embed(embedder=self.embedder)
+                vector[self.dense_vector_name] = document.embedding
+
+            if self.search_type in [SearchType.keyword, SearchType.hybrid]:
+                vector[self.sparse_vector_name] = next(self.sparse_encoder.embed([document.content])).as_object()
 
             # Create payload with document properties
             payload = {
@@ -294,7 +376,7 @@ class Qdrant(VectorDb):
             log_debug(f"Inserted document asynchronously: {document.name} ({document.meta_data})")
             return models.PointStruct(
                 id=doc_id,
-                vector=document.embedding,
+                vector=vector,
                 payload=payload,
             )
 
@@ -316,108 +398,197 @@ class Qdrant(VectorDb):
             filters (Optional[Dict[str, Any]]): Filters to apply while upserting
         """
         log_debug("Redirecting the request to insert")
-        self.insert(documents)
+        self.insert(documents, filters)
 
     async def async_upsert(self, documents: List[Document], filters: Optional[Dict[str, Any]] = None) -> None:
         """Upsert documents asynchronously."""
         log_debug("Redirecting the async request to async_insert")
-        await self.async_insert(documents)
+        await self.async_insert(documents, filters)
 
     def search(self, query: str, limit: int = 5, filters: Optional[Dict[str, Any]] = None) -> List[Document]:
         """
-        Search for documents in the database.
+        Search for documents in the collection.
 
         Args:
             query (str): Query to search for
             limit (int): Number of search results to return
             filters (Optional[Dict[str, Any]]): Filters to apply while searching
         """
-        query_embedding = self.embedder.get_embedding(query)
-        if query_embedding is None:
-            logger.error(f"Error getting embedding for Query: {query}")
-            return []
+        filters = self._format_filters(filters)
+        if self.search_type == SearchType.vector:
+            results = self._run_vector_search_sync(query, limit, filters)
+        elif self.search_type == SearchType.keyword:
+            results = self._run_keyword_search_sync(query, limit, filters)
+        elif self.search_type == SearchType.hybrid:
+            results = self._run_hybrid_search_sync(query, limit, filters)
+        else:
+            raise ValueError(f"Unsupported search type: {self.search_type}")
 
-        # Build search parameters
-        search_params = {
-            "collection_name": self.collection,
-            "query_vector": query_embedding,
-            "with_vectors": True,
-            "with_payload": True,
-            "limit": limit,
-        }
-
-        # Handle filters if provided - normalize format for Qdrant
-        if filters:
-            filter_conditions = []
-            for key, value in filters.items():
-                # If key contains a dot already, assume it's in the correct format
-                # Otherwise, assume it's a metadata field and add the prefix
-                if "." not in key and not key.startswith("meta_data."):
-                    # This is a simple field name, assume it's metadata
-                    key = f"meta_data.{key}"
-
-                if isinstance(value, dict):
-                    # Handle nested dictionaries
-                    for sub_key, sub_value in value.items():
-                        filter_conditions.append(
-                            models.FieldCondition(key=f"{key}.{sub_key}", match=models.MatchValue(value=sub_value))
-                        )
-                else:
-                    # Handle direct key-value pairs
-                    filter_conditions.append(models.FieldCondition(key=key, match=models.MatchValue(value=value)))
-
-            if filter_conditions:
-                # Use query_filter instead of filter
-                search_params["query_filter"] = models.Filter(must=filter_conditions)
-
-        try:
-            # Execute search with parameters
-            results = self.client.search(**search_params)  # type: ignore
-        except Exception as e:
-            logger.error(f"Error searching for documents: {e}")
-            return []
-
-        # Build search results
-        search_results: List[Document] = []
-        for result in results:
-            if result.payload is None:
-                continue
-            search_results.append(
-                Document(
-                    name=result.payload["name"],
-                    meta_data=result.payload["meta_data"],
-                    content=result.payload["content"],
-                    embedder=self.embedder,
-                    embedding=result.vector,  # type: ignore
-                    usage=result.payload["usage"],
-                )
-            )
-
-        if self.reranker:
-            search_results = self.reranker.rerank(query=query, documents=search_results)
-
-        log_info(f"Found {len(search_results)} documents")
-        return search_results
+        return self._build_search_results(results, query)
 
     async def async_search(
         self, query: str, limit: int = 5, filters: Optional[Dict[str, Any]] = None
     ) -> List[Document]:
-        """Search for documents asynchronously."""
-        query_embedding = self.embedder.get_embedding(query)
-        if query_embedding is None:
-            logger.error(f"Error getting embedding for Query: {query}")
-            return []
+        filters = self._format_filters(filters)
+        if self.search_type == SearchType.vector:
+            results = await self._run_vector_search_async(query, limit, filters)
+        elif self.search_type == SearchType.keyword:
+            results = await self._run_keyword_search_async(query, limit, filters)
+        elif self.search_type == SearchType.hybrid:
+            results = await self._run_hybrid_search_async(query, limit, filters)
+        else:
+            raise ValueError(f"Unsupported search type: {self.search_type}")
 
-        # Build search parameters
-        search_params = {
-            "collection_name": self.collection,
-            "query_vector": query_embedding,
-            "with_vectors": True,
-            "with_payload": True,
-            "limit": limit,
-        }
+        return self._build_search_results(results, query)
 
-        # Handle filters if provided - normalize format for Qdrant
+    def _run_vector_search_sync(
+        self,
+        query: str,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[models.ScoredPoint]:
+        dense_embedding = self.embedder.get_embedding(query)
+        call = self.client.query_points(
+            collection_name=self.collection,
+            query=dense_embedding,
+            with_vectors=True,
+            with_payload=True,
+            limit=limit,
+            query_filter=filters,
+            using=self.dense_vector_name,
+        )
+        return call.points
+
+    def _run_keyword_search_sync(
+        self,
+        query: str,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[models.ScoredPoint]:
+        sparse_embedding = next(self.sparse_encoder.embed([query])).as_object()
+        call = self.client.query_points(
+            collection_name=self.collection,
+            query=models.SparseVector(**sparse_embedding),
+            with_vectors=True,
+            with_payload=True,
+            limit=limit,
+            using=self.sparse_vector_name,
+            query_filter=filters,
+        )
+        return call.points
+
+    def _run_hybrid_search_sync(
+        self,
+        query: str,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[models.ScoredPoint]:
+        dense_embedding = self.embedder.get_embedding(query)
+        sparse_embedding = next(self.sparse_encoder.embed([query])).as_object()
+        call = self.client.query_points(
+            collection_name=self.collection,
+            prefetch=[
+                models.Prefetch(
+                    query=models.SparseVector(**sparse_embedding),
+                    limit=limit,
+                    using=self.sparse_vector_name,
+                ),
+                models.Prefetch(query=dense_embedding, limit=limit, using=self.dense_vector_name),
+            ],
+            query=models.FusionQuery(fusion=self.hybrid_fusion_strategy),
+            with_vectors=True,
+            with_payload=True,
+            limit=limit,
+            query_filter=filters,
+        )
+        return call.points
+
+    async def _run_vector_search_async(
+        self,
+        query: str,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[models.ScoredPoint]:
+        dense_embedding = self.embedder.get_embedding(query)
+        call = await self.async_client.query_points(
+            collection_name=self.collection,
+            query=dense_embedding,
+            with_vectors=True,
+            with_payload=True,
+            limit=limit,
+            query_filter=filters,
+            using=self.dense_vector_name,
+        )
+        return call.points
+
+    async def _run_keyword_search_async(
+        self,
+        query: str,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[models.ScoredPoint]:
+        sparse_embedding = next(self.sparse_encoder.embed([query])).as_object()
+        call = await self.async_client.query_points(
+            collection_name=self.collection,
+            query=models.SparseVector(**sparse_embedding),
+            with_vectors=True,
+            with_payload=True,
+            limit=limit,
+            using=self.sparse_vector_name,
+            query_filter=filters,
+        )
+        return call.points
+
+    async def _run_hybrid_search_async(
+        self,
+        query: str,
+        limit: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[models.ScoredPoint]:
+        dense_embedding = self.embedder.get_embedding(query)
+        sparse_embedding = next(self.sparse_encoder.embed([query])).as_object()
+        call = await self.async_client.query_points(
+            collection_name=self.collection,
+            prefetch=[
+                models.Prefetch(
+                    query=models.SparseVector(**sparse_embedding),
+                    limit=limit,
+                    using=self.sparse_vector_name,
+                ),
+                models.Prefetch(query=dense_embedding, limit=limit, using=self.dense_vector_name),
+            ],
+            query=models.FusionQuery(fusion=self.hybrid_fusion_strategy),
+            with_vectors=True,
+            with_payload=True,
+            limit=limit,
+            query_filter=filters,
+        )
+        return call.points
+
+    def _build_search_results(self, results, query: str) -> List[Document]:
+        search_results: List[Document] = []
+
+        for result in results:
+            if result.payload is None:
+                continue
+            search_results.append(
+                Document(
+                    name=result.payload["name"],
+                    meta_data=result.payload["meta_data"],
+                    content=result.payload["content"],
+                    embedder=self.embedder,
+                    embedding=result.vector,  # type: ignore
+                    usage=result.payload["usage"],
+                )
+            )
+
+        if self.reranker:
+            search_results = self.reranker.rerank(query=query, documents=search_results)
+
+        log_info(f"Found {len(search_results)} documents")
+        return search_results
+
+    def _format_filters(self, filters: Optional[Dict[str, Any]]) -> Optional[models.Filter]:
         if filters:
             filter_conditions = []
             for key, value in filters.items():
@@ -438,37 +609,9 @@ class Qdrant(VectorDb):
                     filter_conditions.append(models.FieldCondition(key=key, match=models.MatchValue(value=value)))
 
             if filter_conditions:
-                # Use query_filter instead of filter
-                search_params["query_filter"] = models.Filter(must=filter_conditions)
+                return models.Filter(must=filter_conditions)
 
-        try:
-            # Execute search with parameters
-            results = await self.async_client.search(**search_params)  # type: ignore
-        except Exception as e:
-            logger.error(f"Error searching for documents: {e}")
-            return []
-
-        # Build search results
-        search_results: List[Document] = []
-        for result in results:
-            if result.payload is None:
-                continue
-            search_results.append(
-                Document(
-                    name=result.payload["name"],
-                    meta_data=result.payload["meta_data"],
-                    content=result.payload["content"],
-                    embedder=self.embedder,
-                    embedding=result.vector,  # type: ignore
-                    usage=result.payload["usage"],
-                )
-            )
-
-        if self.reranker:
-            search_results = self.reranker.rerank(query=query, documents=search_results)
-
-        log_info(f"Found {len(search_results)} documents")
-        return search_results
+        return None
 
     def drop(self) -> None:
         if self.exists():
@@ -482,23 +625,12 @@ class Qdrant(VectorDb):
             await self.async_client.delete_collection(self.collection)
 
     def exists(self) -> bool:
-        if self.client:
-            collections_response: models.CollectionsResponse = self.client.get_collections()
-            collections: List[models.CollectionDescription] = collections_response.collections
-            for collection in collections:
-                if collection.name == self.collection:
-                    # collection.status == models.CollectionStatus.GREEN
-                    return True
-        return False
+        """Check if the collection exists."""
+        return self.client.collection_exists(collection_name=self.collection)
 
     async def async_exists(self) -> bool:
         """Check if the collection exists asynchronously."""
-        collections_response = await self.async_client.get_collections()
-        collections: List[models.CollectionDescription] = collections_response.collections
-        for collection in collections:
-            if collection.name == self.collection:
-                return True
-        return False
+        return await self.async_client.collection_exists(collection_name=self.collection)
 
     def get_count(self) -> int:
         count_result: models.CountResult = self.client.count(collection_name=self.collection, exact=True)
@@ -508,4 +640,4 @@ class Qdrant(VectorDb):
         pass
 
     def delete(self) -> bool:
-        return False
+        return self.client.delete_collection(collection_name=self.collection)


### PR DESCRIPTION
## Summary

This PR adds support for hybrid searches when using Qdrant as the vector store.

[qdrant/fastembed](https://github.com/qdrant/fastembed)'s BM25 is used for sparse embeddings by default(Customizable).

Qdrant's hybrid search reference:
https://qdrant.tech/documentation/concepts/hybrid-queries/#hybrid-search

## Type of change

- [x] New feature

---------

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
