### PR TITLE
Loading Memory fails

### DIFF
--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -69,7 +69,7 @@ class ToolExecution:
             confirmed=data.get("confirmed"),
             confirmation_note=data.get("confirmation_note"),
             requires_user_input=data.get("requires_user_input"),
-            user_input_schema=[UserInputField.from_dict(field) for field in data.get("user_input_schema", [])],
+            user_input_schema=[UserInputField.from_dict(field) for field in (data.get("user_input_schema") or [])],
             external_execution_required=data.get("external_execution_required"),
             metrics=MessageMetrics(**data.get("metrics", {})),
         )


### PR DESCRIPTION
## Summary

I kept having "WARNING  Failed to load runs from memory: 'NoneType' object is not iterable  " when the agent was trying to load data from the session making the session runs to not be stored correctly in DB.
I was using MongoDB, didn't try with other storage

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
