### PR TITLE
feat: allow custom role map for OpenAIChat

### DIFF
--- a/cookbook/models/openai/chat/custom_role_map.py
+++ b/cookbook/models/openai/chat/custom_role_map.py
@@ -1,0 +1,38 @@
+"""This example shows how to use a custom role map with the OpenAIChat class.
+
+This is useful when using a custom model that doesn't support the default role map.
+
+To run this example:
+- Set the MISTRAL_API_KEY environment variable.
+- Run `pip install openai agno` to install dependencies.
+"""
+
+from os import getenv
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+# Using these Mistral model and url as an example.
+model_id = "mistral-medium-2505"
+base_url = "https://api.mistral.ai/v1"
+api_key = getenv("MISTRAL_API_KEY")
+mistral_role_map = {
+    "system": "system",
+    "user": "user",
+    "assistant": "assistant",
+    "tool": "tool",
+    "model": "assistant",
+}
+
+# When initializing the model, we pass our custom role map.
+model = OpenAIChat(
+    id=model_id,
+    base_url=base_url,
+    api_key=api_key,
+    role_map=mistral_role_map,
+)
+
+agent = Agent(model=model, markdown=True)
+
+# Running the agent with a custom role map.
+res = agent.print_response("Hey, how are you doing?")

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -66,6 +66,7 @@ class OpenAIChat(Model):
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
     request_params: Optional[Dict[str, Any]] = None
+    role_map: Optional[Dict[str, str]] = None
 
     # Client parameters
     api_key: Optional[str] = None
@@ -79,7 +80,7 @@ class OpenAIChat(Model):
     client_params: Optional[Dict[str, Any]] = None
 
     # The role to map the message role to.
-    role_map = {
+    default_role_map = {
         "system": "developer",
         "user": "user",
         "assistant": "assistant",
@@ -236,7 +237,7 @@ class OpenAIChat(Model):
             Dict[str, Any]: The formatted message.
         """
         message_dict: Dict[str, Any] = {
-            "role": self.role_map[message.role],
+            "role": self.role_map[message.role] if self.role_map else self.default_role_map[message.role],
             "content": message.content,
             "name": message.name,
             "tool_call_id": message.tool_call_id,
@@ -317,7 +318,6 @@ class OpenAIChat(Model):
                     messages=[self._format_message(m) for m in messages],  # type: ignore
                     **self.get_request_kwargs(response_format=response_format, tools=tools, tool_choice=tool_choice),
                 )
-
             return self.get_client().chat.completions.create(
                 model=self.id,
                 messages=[self._format_message(m) for m in messages],  # type: ignore


### PR DESCRIPTION
## Summary

Allow using a custom role map with the `OpenAIChat` class. 
Adding this because default role map fails for some OpenAI-like APIs, like Mistral's.

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [ x ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)
