### PR TITLE
fix: handle async tools when running async agents on playground

### DIFF
--- a/libs/agno/agno/app/playground/async_router.py
+++ b/libs/agno/agno/app/playground/async_router.py
@@ -138,7 +138,7 @@ def get_async_playground_router(
             return agent_list
 
         for agent in agents:
-            agent_tools = agent.get_tools(session_id=str(uuid4()))
+            agent_tools = agent.get_tools(session_id=str(uuid4()), async_mode=True)
             formatted_tools = format_tools(agent_tools)
 
             name = agent.model.name or agent.model.__class__.__name__ if agent.model else None


### PR DESCRIPTION
## Summary

Fixes a regression where using Agents with async tools (e.g. MCP tools) was breaking in the Playground. 

## Type of change

- [ x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

