### PR TITLE
fix: HF custom embedder

### DIFF
--- a/libs/agno/agno/embedder/huggingface.py
+++ b/libs/agno/agno/embedder/huggingface.py
@@ -17,9 +17,8 @@ except ImportError:
 class HuggingfaceCustomEmbedder(Embedder):
     """Huggingface Custom Embedder"""
 
-    id: str = "jinaai/jina-embeddings-v2-base-code"
+    id: str = "intfloat/multilingual-e5-large"
     api_key: Optional[str] = getenv("HUGGINGFACE_API_KEY")
-    task: str = "feature-extraction"
     client_params: Optional[Dict[str, Any]] = None
     huggingface_client: Optional[InferenceClient] = None
 
@@ -36,16 +35,21 @@ class HuggingfaceCustomEmbedder(Embedder):
         return self.huggingface_client
 
     def _response(self, text: str):
-        return self.client.post(json={"inputs": text}, model=self.id, task=self.task)
+        return self.client.feature_extraction(text=text, model=self.id)
 
     def get_embedding(self, text: str) -> List[float]:
         response = self._response(text=text)
         try:
-            decoded_string = response.decode("utf-8")
-            return json.loads(decoded_string)
-
+            # If already a list, return directly
+            if isinstance(response, list):  
+                return response
+            # If numpy array, convert to list
+            elif hasattr(response, 'tolist'):  
+                return response.tolist()
+            else:
+                return list(response)
         except Exception as e:
-            logger.warning(e)
+            logger.warning(f"Failed to process embeddings: {e}")
             return []
 
     def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:


### PR DESCRIPTION
## Summary

It turns out that HF has changed some things on their API and they've deprecated .post on their InferenceClient()- https://discuss.huggingface.co/t/getting-error-attributeerror-inferenceclient-object-has-no-attribute-post/156682

Also we can no longer use- `id: str = "jinaai/jina-embeddings-v2-base-code"` as these models are no longer provided by the `HF Inference API`

So i'm changing the default to- `id: str = "intfloat/multilingual-e5-large"` this is supported.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
