### PR TITLE
fix: insert in vector db passes only last chunk meta_data

### DIFF
--- a/cookbook/agent_concepts/state/last_n_session_messages.py
+++ b/cookbook/agent_concepts/state/last_n_session_messages.py
@@ -13,8 +13,8 @@ agent = Agent(
     storage=SqliteStorage(table_name="agent_sessions_new", db_file="tmp/data.db"),
     add_history_to_messages=True,
     num_history_runs=3,
-    search_previous_sessions_history=True, # allow searching previous sessions
-    num_history_sessions=2, # only include the last 2 sessions in the search to avoid context length issues
+    search_previous_sessions_history=True,  # allow searching previous sessions
+    num_history_sessions=2,  # only include the last 2 sessions in the search to avoid context length issues
     show_tool_calls=True,
 )
 

--- a/cookbook/reasoning/teams/finance_team_chain_of_thought.py
+++ b/cookbook/reasoning/teams/finance_team_chain_of_thought.py
@@ -60,9 +60,9 @@ async def run_team(task: str):
 
 
 if __name__ == "__main__":
-
-    asyncio.run(run_team(
-        dedent("""\
+    asyncio.run(
+        run_team(
+            dedent("""\
     Analyze the impact of recent US tariffs on market performance across these key sectors:
     - Steel & Aluminum: (X, NUE, AA)
     - Technology Hardware: (AAPL, DELL, HPQ)
@@ -75,4 +75,5 @@ if __name__ == "__main__":
     3. Analyze companies' strategic responses (reshoring, price adjustments, supplier diversification)
     4. Assess analyst outlook changes directly attributed to tariff policies
     """)
-    ))
+        )
+    )

--- a/libs/agno/agno/knowledge/agent.py
+++ b/libs/agno/agno/knowledge/agent.py
@@ -123,7 +123,8 @@ class AgentKnowledge(BaseModel):
 
             # Upsert documents if upsert is True and vector db supports upsert
             if upsert and self.vector_db.upsert_available():
-                self.vector_db.upsert(documents=document_list, filters=doc.meta_data)
+                for doc in document_list:
+                    self.vector_db.upsert(documents=[doc], filters=doc.meta_data)
             # Insert documents
             else:
                 # Filter out documents which already exist in the vector db
@@ -132,7 +133,8 @@ class AgentKnowledge(BaseModel):
                     documents_to_load = self.filter_existing_documents(document_list)
 
                 if documents_to_load:
-                    self.vector_db.insert(documents=documents_to_load, filters=doc.meta_data)
+                    for doc in documents_to_load:
+                        self.vector_db.insert(documents=[doc], filters=doc.meta_data)
 
             num_documents += len(documents_to_load)
             log_info(f"Added {len(documents_to_load)} documents to knowledge base")
@@ -174,7 +176,8 @@ class AgentKnowledge(BaseModel):
 
             # Upsert documents if upsert is True and vector db supports upsert
             if upsert and self.vector_db.upsert_available():
-                await self.vector_db.async_upsert(documents=document_list, filters=doc.meta_data)
+                for doc in document_list:
+                    await self.vector_db.async_upsert(documents=[doc], filters=doc.meta_data)
             # Insert documents
             else:
                 # Filter out documents which already exist in the vector db
@@ -183,7 +186,8 @@ class AgentKnowledge(BaseModel):
                     documents_to_load = self.filter_existing_documents(document_list)
 
                 if documents_to_load:
-                    await self.vector_db.async_insert(documents=documents_to_load, filters=doc.meta_data)
+                    for doc in documents_to_load:
+                        await self.vector_db.async_insert(documents=[doc], filters=doc.meta_data)
 
             num_documents += len(documents_to_load)
             log_info(f"Added {len(documents_to_load)} documents to knowledge base")


### PR DESCRIPTION
## Summary

insert in vector db passes only last chunk meta_data
Issue- https://discord.com/channels/965734768803192842/1219054452221153463/1376631140047130649

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
