### PR TITLE
fix: Remove argument sanitization

### DIFF
--- a/libs/agno/agno/tools/apify.py
+++ b/libs/agno/agno/tools/apify.py
@@ -156,7 +156,7 @@ Returns:
             actor_function.__doc__ = docstring
 
             # Register the function with the toolkit
-            self.register(actor_function, sanitize_arguments=False)
+            self.register(actor_function)
             # Fix params schema
             self.functions[tool_name].parameters = props_to_json_schema(properties, required)
             log_info(f"Registered Apify Actor '{actor_id}' as function '{tool_name}'")

--- a/libs/agno/agno/tools/decorator.py
+++ b/libs/agno/agno/tools/decorator.py
@@ -48,7 +48,7 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
         name: Optional[str] - Override for the function name
         description: Optional[str] - Override for the function description
         strict: Optional[bool] - Flag for strict parameter checking
-        sanitize_arguments: Optional[bool] - If True, arguments are sanitized before passing to function
+        sanitize_arguments: Optional[bool] - If True, arguments are sanitized before passing to function (Deprecated)
         instructions: Optional[str] - Instructions for using the tool
         add_instructions: bool - If True, add instructions to the system message
         show_result: Optional[bool] - If True, shows the result after function call

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -83,8 +83,8 @@ class Function(BaseModel):
     entrypoint: Optional[Callable] = None
     # If True, the entrypoint processing is skipped and the Function is used as is.
     skip_entrypoint_processing: bool = False
-    # If True, the arguments are sanitized before being passed to the function.
-    sanitize_arguments: bool = True
+    # If True, the arguments are sanitized before being passed to the function. (Deprecated)
+    sanitize_arguments: bool = False
     # If True, the function call will show the result along with sending it to the model.
     show_result: bool = False
     # If True, the agent will stop after the function call.

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -105,12 +105,11 @@ class Toolkit:
         for tool in self.tools:
             self.register(tool)
 
-    def register(self, function: Callable[..., Any], sanitize_arguments: bool = True, name: Optional[str] = None):
+    def register(self, function: Callable[..., Any], name: Optional[str] = None):
         """Register a function with the toolkit.
 
         Args:
             function: The callable to register
-            sanitize_arguments: Whether to sanitize arguments before passing to the function
             name: Optional custom name for the function
 
         Returns:
@@ -126,7 +125,6 @@ class Toolkit:
             f = Function(
                 name=tool_name,
                 entrypoint=function,
-                sanitize_arguments=sanitize_arguments,
                 cache_results=self.cache_results,
                 cache_dir=self.cache_dir,
                 cache_ttl=self.cache_ttl,

--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -28,14 +28,11 @@ def get_function_call(
         function_call.call_id = call_id
     if arguments is not None and arguments != "":
         try:
-            if function_to_call.sanitize_arguments:
-                if "None" in arguments:
-                    arguments = arguments.replace("None", "null")
-                if "True" in arguments:
-                    arguments = arguments.replace("True", "true")
-                if "False" in arguments:
-                    arguments = arguments.replace("False", "false")
-            _arguments = json.loads(arguments)
+            try:
+                _arguments = json.loads(arguments)
+            except Exception as e:
+                import ast
+                _arguments = ast.literal_eval(arguments)
         except Exception as e:
             log_error(f"Unable to decode function arguments:\n{arguments}\nError: {e}")
             function_call.error = (

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -533,7 +533,6 @@ def test_tool_decorator_with_config():
         strict=True,
         instructions="Custom instructions",
         add_instructions=False,
-        sanitize_arguments=False,
         show_result=True,
         stop_after_tool_call=True,
         requires_confirmation=True,
@@ -551,7 +550,6 @@ def test_tool_decorator_with_config():
     assert configured_func.strict is True
     assert configured_func.instructions == "Custom instructions"
     assert configured_func.add_instructions is False
-    assert configured_func.sanitize_arguments is False
     assert configured_func.show_result is True
     assert configured_func.stop_after_tool_call is True
     assert configured_func.requires_confirmation is True

--- a/libs/agno/tests/unit/utils/test_functions.py
+++ b/libs/agno/tests/unit/utils/test_functions.py
@@ -1,0 +1,177 @@
+import json
+import pytest
+from typing import Dict, Optional
+
+from agno.tools.function import Function, FunctionCall
+from agno.utils.functions import get_function_call
+
+
+@pytest.fixture
+def sample_functions() -> Dict[str, Function]:
+    return {
+        "test_function": Function(
+            name="test_function",
+            description="A test function",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "param1": {"type": "string"},
+                    "param2": {"type": "integer"},
+                    "param3": {"type": "boolean"},
+                },
+            },
+        )
+    }
+
+
+def test_get_function_call_basic(sample_functions):
+    """Test basic function call creation with valid arguments."""
+    arguments = json.dumps({"param1": "test", "param2": 42, "param3": True})
+    call_id = "test-call-123"
+
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        call_id=call_id,
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert isinstance(result, FunctionCall)
+    assert result.function == sample_functions["test_function"]
+    assert result.call_id == call_id
+    assert result.arguments == {"param1": "test", "param2": 42, "param3": True}
+    assert result.error is None
+
+
+def test_get_function_call_invalid_name(sample_functions):
+    """Test function call with non-existent function name."""
+    result = get_function_call(
+        name="non_existent_function",
+        arguments='{"param1": "test"}',
+        functions=sample_functions,
+    )
+
+    assert result is None
+
+
+def test_get_function_call_no_functions():
+    """Test function call with no functions dictionary."""
+    result = get_function_call(
+        name="test_function",
+        arguments='{"param1": "test"}',
+        functions=None,
+    )
+
+    assert result is None
+
+
+def test_get_function_call_invalid_json(sample_functions):
+    """Test function call with invalid JSON arguments."""
+    result = get_function_call(
+        name="test_function",
+        arguments="invalid json",
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.error is not None
+    assert "Error while decoding function arguments" in result.error
+
+
+def test_get_function_call_non_dict_arguments(sample_functions):
+    """Test function call with non-dictionary arguments."""
+    result = get_function_call(
+        name="test_function",
+        arguments='["not", "a", "dict"]',
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.error is not None
+    assert "Function arguments are not a valid JSON object" in result.error
+
+
+def test_get_function_call_argument(sample_functions):
+    """Test argument sanitization for boolean and null values."""
+    arguments = json.dumps({
+        "param1": "None",
+        "param2": "True",
+        "param3": "False",
+        "param4": "  test  ",
+    })
+
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.arguments == {
+        "param1": None,
+        "param2": True,
+        "param3": False,
+        "param4": "test",
+    }
+
+
+def test_get_function_call_argument_2(sample_functions):
+    """Test function call without argument sanitization."""
+    arguments = '{"param1": None, "param2": True, "param3": False, "param4": "test"}'
+
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.arguments == {
+        "param1": None,
+        "param2": True,
+        "param3": False,
+        "param4": "test",
+    }
+
+    arguments = '{"param1": "none", "param2": "false", "param3": "true", "param4": "test"}'
+
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.arguments == {
+        "param1": None,
+        "param2": False,
+        "param3": True,
+        "param4": "test",
+    }
+
+
+def test_get_function_call_empty_arguments(sample_functions):
+    """Test function call with empty arguments."""
+    result = get_function_call(
+        name="test_function",
+        arguments="",
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.arguments is None
+    assert result.error is None
+
+
+def test_get_function_call_no_arguments(sample_functions):
+    """Test function call with no arguments provided."""
+    result = get_function_call(
+        name="test_function",
+        arguments=None,
+        functions=sample_functions,
+    )
+
+    assert result is not None
+    assert result.arguments is None
+    assert result.error is None


### PR DESCRIPTION
## Summary

Found a safer way to do this that won't break arguments that shouldn't be sanitized

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
