### PR TITLE
fix: use content hash as id in upsert

### DIFF
--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -154,7 +154,7 @@ class PgVector(VectorDb):
             Column("usage", postgresql.JSONB),
             Column("created_at", DateTime(timezone=True), server_default=func.now()),
             Column("updated_at", DateTime(timezone=True), onupdate=func.now()),
-            Column("content_hash", String, index=True),
+            Column("content_hash", String),
             extend_existing=True,
         )
 

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -154,7 +154,7 @@ class PgVector(VectorDb):
             Column("usage", postgresql.JSONB),
             Column("created_at", DateTime(timezone=True), server_default=func.now()),
             Column("updated_at", DateTime(timezone=True), onupdate=func.now()),
-            Column("content_hash", String),
+            Column("content_hash", String, index=True),
             extend_existing=True,
         )
 
@@ -387,9 +387,8 @@ class PgVector(VectorDb):
                                 doc.embed(embedder=self.embedder)
                                 cleaned_content = self._clean_content(doc.content)
                                 content_hash = md5(cleaned_content.encode()).hexdigest()
-                                _id = doc.id or content_hash
                                 record = {
-                                    "id": _id,
+                                    "id": content_hash,  # use content_hash as a reproducible id to avoid duplicates while upsert
                                     "name": doc.name,
                                     "meta_data": doc.meta_data,
                                     "filters": filters,
@@ -406,15 +405,15 @@ class PgVector(VectorDb):
                         insert_stmt = postgresql.insert(self.table).values(batch_records)
                         upsert_stmt = insert_stmt.on_conflict_do_update(
                             index_elements=["id"],
-                            set_=dict(
-                                name=insert_stmt.excluded.name,
-                                meta_data=insert_stmt.excluded.meta_data,
-                                filters=insert_stmt.excluded.filters,
-                                content=insert_stmt.excluded.content,
-                                embedding=insert_stmt.excluded.embedding,
-                                usage=insert_stmt.excluded.usage,
-                                content_hash=insert_stmt.excluded.content_hash,
-                            ),
+                            set_={
+                                "name": insert_stmt.excluded.name,
+                                "meta_data": insert_stmt.excluded.meta_data,
+                                "filters": insert_stmt.excluded.filters,
+                                "content": insert_stmt.excluded.content,
+                                "embedding": insert_stmt.excluded.embedding,
+                                "usage": insert_stmt.excluded.usage,
+                                "content_hash": insert_stmt.excluded.content_hash,
+                            },
                         )
                         sess.execute(upsert_stmt)
                         sess.commit()  # Commit batch independently


### PR DESCRIPTION
## Summary

use reproducible content_hash in upsert as id

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
