### PR TITLE
fix: Add mistral structured output and tool use parsing

### DIFF
--- a/cookbook/models/mistral/structured_output_with_tool_use.py
+++ b/cookbook/models/mistral/structured_output_with_tool_use.py
@@ -1,0 +1,33 @@
+from agno.models.mistral import MistralChat
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.agent import Agent
+
+from pydantic import BaseModel
+
+
+class Person(BaseModel):
+    name: str
+    description: str
+
+
+model = MistralChat(
+    id="mistral-medium-latest",
+    temperature=0.0,
+)
+
+researcher = Agent(
+    name="Researcher",
+    model=model,
+    role="You find people with a specific role at a provided company.",
+    instructions=[
+        "- Search the web for the person described"
+        "- Find out if they have public contact details"
+        "- Return the information in a structured format"
+    ],
+    show_tool_calls=True,
+    tools=[DuckDuckGoTools()],
+    response_model=Person,
+    add_datetime_to_instructions=True,
+)
+
+researcher.print_response("Find information about Elon Musk")

--- a/libs/agno/agno/models/mistral/mistral.py
+++ b/libs/agno/agno/models/mistral/mistral.py
@@ -26,6 +26,7 @@ try:
     from mistralai.models.chatcompletionresponse import ChatCompletionResponse
     from mistralai.models.deltamessage import DeltaMessage
     from mistralai.types.basemodel import Unset
+    from mistralai.extra import response_format_from_pydantic_model
 
     MistralMessage = Union[UserMessage, AssistantMessage, SystemMessage, ToolMessage]
 
@@ -176,10 +177,10 @@ class MistralChat(Model):
                 and isinstance(response_format, type)
                 and issubclass(response_format, BaseModel)
             ):
-                response = self.get_client().chat.parse(
+                response = self.get_client().chat.complete(
                     model=self.id,
                     messages=mistral_messages,
-                    response_format=response_format,  # type: ignore
+                    response_format=response_format_from_pydantic_model(response_format),
                     **self.get_request_kwargs(tools=tools, tool_choice=tool_choice),
                 )
             else:
@@ -243,7 +244,7 @@ class MistralChat(Model):
                 response = await self.get_client().chat.parse_async(
                     model=self.id,
                     messages=mistral_messages,
-                    response_format=response_format,  # type: ignore
+                    response_format=response_format_from_pydantic_model(response_format),
                     **self.get_request_kwargs(tools=tools, tool_choice=tool_choice),
                 )
             else:

--- a/libs/agno/tests/integration/models/mistral/test_tool_use.py
+++ b/libs/agno/tests/integration/models/mistral/test_tool_use.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import pytest
+from pydantic import BaseModel, Field
 
 from agno.agent import Agent, RunResponse  # noqa
 from agno.models.mistral import MistralChat
@@ -56,6 +57,26 @@ def test_tool_use_stream():
         full_content += r.content or ""
     assert "TSLA" in full_content
 
+
+def test_tool_use_with_native_structured_outputs():
+    class StockPrice(BaseModel):
+        price: float = Field(..., description="The price of the stock")
+        currency: str = Field(..., description="The currency of the stock")
+
+    agent = Agent(
+        model=MistralChat(id="mistral-large-latest"),
+        tools=[YFinanceTools(cache_results=True)],
+        show_tool_calls=True,
+        markdown=True,
+        response_model=StockPrice,
+        telemetry=False,
+        monitoring=False,
+    )
+    response = agent.run("What is the current price of TSLA?")
+    assert isinstance(response.content, StockPrice)
+    assert response.content is not None
+    assert response.content.price is not None
+    assert response.content.currency is not None
 
 @pytest.mark.asyncio
 async def test_async_tool_use():


### PR DESCRIPTION
## Summary

Fixed an issue where Mistral failed to parse structured output with tool calls

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
