### PR TITLE
[FIX] Accept empty array of pdf urls

### DIFF
--- a/libs/agno/agno/knowledge/pdf_url.py
+++ b/libs/agno/agno/knowledge/pdf_url.py
@@ -14,7 +14,7 @@ class PDFUrlKnowledgeBase(AgentKnowledge):
     @property
     def document_lists(self) -> Iterator[List[Document]]:
         """Iterate over PDF URLs and yield lists of documents."""
-        if not self.urls:
+        if self.urls is None:
             raise ValueError("URLs are not set")
 
         for item in self.urls:


### PR DESCRIPTION

## Summary

If we don't accept empty arrays, it will only work when we have pdf data to add to the knowledge and not when we just want to query

(If applicable, issue number: #____)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
