### PR TITLE
fix: Gemini type fix for integers

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -13,8 +13,9 @@ from agno.media import Audio, File, ImageArtifact, Video
 from agno.models.base import Model
 from agno.models.message import Citations, Message, MessageMetrics, UrlCitation
 from agno.models.response import ModelResponse
-from agno.utils.gemini import format_function_definitions, format_image_for_message
+from agno.utils.gemini import format_function_definitions, format_image_for_message, convert_schema
 from agno.utils.log import log_error, log_info, log_warning
+from agno.utils.models.schema_utils import get_response_schema_for_provider
 
 try:
     from google import genai
@@ -179,7 +180,12 @@ class Gemini(Model):
 
         if response_format is not None and isinstance(response_format, type) and issubclass(response_format, BaseModel):
             config["response_mime_type"] = "application/json"  # type: ignore
-            config["response_schema"] = response_format
+            # Convert Pydantic model to JSON schema, then normalize for Gemini, then convert to Gemini schema format
+            
+            # Get the normalized schema for Gemini
+            normalized_schema = get_response_schema_for_provider(response_format, "gemini")
+            gemini_schema = convert_schema(normalized_schema)
+            config["response_schema"] = gemini_schema
 
         if self.grounding and self.search:
             log_info("Both grounding and search are enabled. Grounding will take precedence.")

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -11,7 +11,8 @@ from agno.models.base import MessageData, Model, _add_usage_metrics_to_assistant
 from agno.models.message import Citations, Message, UrlCitation
 from agno.models.response import ModelResponse
 from agno.utils.log import log_debug, log_error, log_warning
-from agno.utils.models.openai_responses import images_to_message, sanitize_response_schema
+from agno.utils.models.openai_responses import images_to_message
+from agno.utils.models.schema_utils import get_response_schema_for_provider
 
 try:
     from openai import APIConnectionError, APIStatusError, AsyncOpenAI, OpenAI, RateLimitError
@@ -177,9 +178,7 @@ class OpenAIResponses(Model):
         # Set the response format
         if response_format is not None:
             if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-                schema = response_format.model_json_schema()
-                # Sanitize the schema to ensure it complies with OpenAI's requirements
-                sanitize_response_schema(schema)
+                schema = get_response_schema_for_provider(response_format, "openai")
                 base_params["text"] = {
                     "format": {
                         "type": "json_schema",

--- a/libs/agno/agno/utils/models/schema_utils.py
+++ b/libs/agno/agno/utils/models/schema_utils.py
@@ -1,0 +1,151 @@
+"""
+Utility functions for handling JSON schemas across different model providers.
+This module provides model-agnostic schema transformations and validations.
+"""
+
+from typing import Any, Dict, Type
+from pydantic import BaseModel
+
+
+def is_dict_field(schema: Dict[str, Any]) -> bool:
+    """
+    Check if a schema represents a Dict[str, T] field.
+    
+    Args:
+        schema: JSON schema dictionary
+        
+    Returns:
+        bool: True if the schema represents a Dict field
+    """
+    return (
+        schema.get("type") == "object" 
+        and "additionalProperties" in schema 
+        and isinstance(schema["additionalProperties"], dict)
+        and "type" in schema["additionalProperties"]
+        and "properties" not in schema
+    )
+
+
+def get_dict_value_type(schema: Dict[str, Any]) -> str:
+    """
+    Extract the value type from a Dict field schema.
+    
+    Args:
+        schema: JSON schema dictionary for a Dict field
+        
+    Returns:
+        str: The type of values in the dictionary (e.g., "integer", "string")
+    """
+    if is_dict_field(schema):
+        return schema["additionalProperties"]["type"]
+    return "string"
+
+
+def normalize_schema_for_provider(schema: Dict[str, Any], provider: str) -> Dict[str, Any]:
+    """
+    Normalize a Pydantic-generated schema for a specific model provider.
+    
+    Args:
+        schema: Original Pydantic JSON schema
+        provider: Model provider name ("openai", "gemini", "anthropic", etc.)
+        
+    Returns:
+        Dict[str, Any]: Normalized schema for the provider
+    """
+    # Make a deep copy to avoid modifying the original
+    import copy
+    normalized = copy.deepcopy(schema)
+    
+    if provider.lower() == "openai":
+        return _normalize_for_openai(normalized)
+    elif provider.lower() == "gemini":
+        return _normalize_for_gemini(normalized)
+    else:
+        # Default normalization for other providers
+        return _normalize_generic(normalized)
+
+
+def _normalize_for_openai(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize schema for OpenAI structured outputs."""
+    from agno.utils.models.openai_responses import sanitize_response_schema
+    sanitize_response_schema(schema)
+    return schema
+
+
+def _normalize_for_gemini(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Normalize schema for Gemini.
+    Gemini has specific requirements for object types and doesn't support
+    additionalProperties in the same way as JSON Schema.
+    """
+    def _process_schema(s: Dict[str, Any]) -> None:
+        if isinstance(s, dict):
+            # Handle Dict fields - preserve additionalProperties info for convert_schema
+            if is_dict_field(s):
+                # For Gemini, we need to preserve the additionalProperties info
+                # so that convert_schema can create appropriate placeholder properties
+                value_type = get_dict_value_type(s)
+                
+                # Update description to indicate this is a dictionary
+                current_desc = s.get("description", "")
+                if current_desc:
+                    s["description"] = f"{current_desc} (Dictionary with {value_type} values)"
+                else:
+                    s["description"] = f"Dictionary with {value_type} values"
+                
+                # Keep additionalProperties for convert_schema to process
+                # Don't remove it here - let convert_schema handle the conversion
+            
+            # Recursively process nested schemas
+            for value in s.values():
+                if isinstance(value, dict):
+                    _process_schema(value)
+                elif isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict):
+                            _process_schema(item)
+    
+    _process_schema(schema)
+    return schema
+
+
+def _normalize_generic(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Generic normalization for other providers."""
+    def _process_schema(s: Dict[str, Any]) -> None:
+        if isinstance(s, dict):
+            # Remove null defaults
+            if "default" in s and s["default"] is None:
+                s.pop("default")
+            
+            # Recursively process nested schemas
+            for value in s.values():
+                if isinstance(value, dict):
+                    _process_schema(value)
+                elif isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict):
+                            _process_schema(item)
+    
+    _process_schema(schema)
+    return schema
+
+
+def get_response_schema_for_provider(
+    response_model: Type[BaseModel], 
+    provider: str
+) -> Dict[str, Any]:
+    """
+    Get a properly formatted response schema for a specific model provider.
+    
+    Args:
+        response_model: Pydantic BaseModel class
+        provider: Model provider name
+        
+    Returns:
+        Dict[str, Any]: Provider-specific schema
+    """
+    # Generate the base schema
+    base_schema = response_model.model_json_schema()
+    
+    # Normalize for the specific provider
+    return normalize_schema_for_provider(base_schema, provider) 

--- a/libs/agno/agno/utils/whatsapp.py
+++ b/libs/agno/agno/utils/whatsapp.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Optional, Union
 
 import httpx
 import requests
@@ -21,7 +21,7 @@ def get_phone_number_id() -> str:
     return phone_number_id
 
 
-def get_media(media_id: str) -> dict:
+def get_media(media_id: str) -> Union[dict, bytes]:
     """
     Sends a GET request to the Facebook Graph API to retrieve media information.
 
@@ -51,7 +51,7 @@ def get_media(media_id: str) -> dict:
         return {"error": str(e)}
 
 
-async def get_media_async(media_id: str) -> dict:
+async def get_media_async(media_id: str) -> Union[dict, bytes]:
     """
     Sends a GET request to the Facebook Graph API to retrieve media information.
 

--- a/libs/agno/agno/workspace/helpers.py
+++ b/libs/agno/agno/workspace/helpers.py
@@ -39,7 +39,11 @@ def get_workspace_dir_path(ws_root_path: Path) -> Path:
         agno_conf = read_pyproject_agno(ws_pyproject_toml)
         if agno_conf is not None:
             agno_conf_workspace_dir_str = agno_conf.get("workspace", None)
-            agno_conf_workspace_dir_path = ws_root_path.joinpath(agno_conf_workspace_dir_str)
+            if agno_conf_workspace_dir_str is not None:
+                agno_conf_workspace_dir_path = ws_root_path.joinpath(agno_conf_workspace_dir_str)
+            else:
+                logger.error(f"Workspace directory not specified in pyproject.toml")
+                exit(0)
             logger.debug(f"Searching {agno_conf_workspace_dir_path}")
             if agno_conf_workspace_dir_path.exists() and agno_conf_workspace_dir_path.is_dir():
                 return agno_conf_workspace_dir_path

--- a/libs/agno/agno/workspace/helpers.py
+++ b/libs/agno/agno/workspace/helpers.py
@@ -42,7 +42,7 @@ def get_workspace_dir_path(ws_root_path: Path) -> Path:
             if agno_conf_workspace_dir_str is not None:
                 agno_conf_workspace_dir_path = ws_root_path.joinpath(agno_conf_workspace_dir_str)
             else:
-                logger.error(f"Workspace directory not specified in pyproject.toml")
+                logger.error("Workspace directory not specified in pyproject.toml")
                 exit(0)
             logger.debug(f"Searching {agno_conf_workspace_dir_path}")
             if agno_conf_workspace_dir_path.exists() and agno_conf_workspace_dir_path.is_dir():

--- a/libs/agno/tests/integration/models/google/test_structured_response.py
+++ b/libs/agno/tests/integration/models/google/test_structured_response.py
@@ -28,7 +28,7 @@ class MovieScript(BaseModel):
         description="Your own rating of the movie. 1-10. Return a dictionary with the keys 'story' and 'acting'.",
     )
 
-def test_structured_response_with_integer_field():
+def test_structured_response_with_dict_fields():
     structured_output_agent = Agent(
         model=Gemini(id="gemini-2.0-flash"),
         description="You help people write movie scripts.",
@@ -37,5 +37,11 @@ def test_structured_response_with_integer_field():
     response = structured_output_agent.run("New York")
     assert response.content is not None
     assert isinstance(response.content.rating, Dict)
+    assert isinstance(response.content.setting, str)
+    assert isinstance(response.content.ending, str)
+    assert isinstance(response.content.genre, str)
+    assert isinstance(response.content.name, str)
+    assert isinstance(response.content.characters, List)
+    assert isinstance(response.content.storyline, str)
 
 

--- a/libs/agno/tests/integration/models/google/test_structured_response.py
+++ b/libs/agno/tests/integration/models/google/test_structured_response.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from agno.agent import Agent, RunResponse  # noqa
-from agno.models.openai import OpenAIChat
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -28,28 +28,14 @@ class MovieScript(BaseModel):
         description="Your own rating of the movie. 1-10. Return a dictionary with the keys 'story' and 'acting'.",
     )
 
-
-# Agent that uses JSON mode
-json_mode_agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    description="You write movie scripts.",
-    response_model=MovieScript,
-    use_json_mode=True,
-)
-
-# Agent that uses structured outputs
-structured_output_agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    description="You write movie scripts.",
-    response_model=MovieScript,
-)
+def test_structured_response_with_integer_field():
+    structured_output_agent = Agent(
+        model=Gemini(id="gemini-2.0-flash"),
+        description="You help people write movie scripts.",
+        response_model=MovieScript,
+    )
+    response = structured_output_agent.run("New York")
+    assert response.content is not None
+    assert isinstance(response.content.rating, Dict)
 
 
-# Get the response in a variable
-# json_mode_response: RunResponse = json_mode_agent.run("New York")
-# pprint(json_mode_response.content)
-# structured_output_response: RunResponse = structured_output_agent.run("New York")
-# pprint(structured_output_response.content)
-
-json_mode_agent.print_response("New York")
-structured_output_agent.print_response("New York")

--- a/libs/agno/tests/integration/models/openai/chat/test_structured_response.py
+++ b/libs/agno/tests/integration/models/openai/chat/test_structured_response.py
@@ -28,7 +28,7 @@ class MovieScript(BaseModel):
         description="Your own rating of the movie. 1-10. Return a dictionary with the keys 'story' and 'acting'.",
     )
 
-def test_structured_response_with_integer_field():
+def test_structured_response_with_dict_fields():
     structured_output_agent = Agent(
         model=OpenAIChat(id="gpt-4o-mini"),
         description="You help people write movie scripts.",
@@ -37,5 +37,11 @@ def test_structured_response_with_integer_field():
     response = structured_output_agent.run("New York")
     assert response.content is not None
     assert isinstance(response.content.rating, Dict)
+    assert isinstance(response.content.setting, str)
+    assert isinstance(response.content.ending, str)
+    assert isinstance(response.content.genre, str)
+    assert isinstance(response.content.name, str)
+    assert isinstance(response.content.characters, List)
+    assert isinstance(response.content.storyline, str)
 
 

--- a/libs/agno/tests/integration/models/openai/chat/test_structured_response.py
+++ b/libs/agno/tests/integration/models/openai/chat/test_structured_response.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from agno.agent import Agent, RunResponse  # noqa
-from agno.models.openai import OpenAIChat
+from agno.models.openai.chat import OpenAIChat
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -28,28 +28,14 @@ class MovieScript(BaseModel):
         description="Your own rating of the movie. 1-10. Return a dictionary with the keys 'story' and 'acting'.",
     )
 
-
-# Agent that uses JSON mode
-json_mode_agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    description="You write movie scripts.",
-    response_model=MovieScript,
-    use_json_mode=True,
-)
-
-# Agent that uses structured outputs
-structured_output_agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    description="You write movie scripts.",
-    response_model=MovieScript,
-)
+def test_structured_response_with_integer_field():
+    structured_output_agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        description="You help people write movie scripts.",
+        response_model=MovieScript,
+    )
+    response = structured_output_agent.run("New York")
+    assert response.content is not None
+    assert isinstance(response.content.rating, Dict)
 
 
-# Get the response in a variable
-# json_mode_response: RunResponse = json_mode_agent.run("New York")
-# pprint(json_mode_response.content)
-# structured_output_response: RunResponse = structured_output_agent.run("New York")
-# pprint(structured_output_response.content)
-
-json_mode_agent.print_response("New York")
-structured_output_agent.print_response("New York")

--- a/libs/agno/tests/integration/models/openai/responses/test_structured_response.py
+++ b/libs/agno/tests/integration/models/openai/responses/test_structured_response.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from agno.agent import Agent, RunResponse  # noqa
-from agno.models.openai import OpenAIChat
+from agno.models.openai import OpenAIResponses
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -28,28 +28,14 @@ class MovieScript(BaseModel):
         description="Your own rating of the movie. 1-10. Return a dictionary with the keys 'story' and 'acting'.",
     )
 
-
-# Agent that uses JSON mode
-json_mode_agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    description="You write movie scripts.",
-    response_model=MovieScript,
-    use_json_mode=True,
-)
-
-# Agent that uses structured outputs
-structured_output_agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
-    description="You write movie scripts.",
-    response_model=MovieScript,
-)
+def test_structured_response_with_integer_field():
+    structured_output_agent = Agent(
+        model=OpenAIResponses(id="gpt-4o-mini"),
+        description="You help people write movie scripts.",
+        response_model=MovieScript,
+    )
+    response = structured_output_agent.run("New York")
+    assert response.content is not None
+    assert isinstance(response.content.rating, Dict)
 
 
-# Get the response in a variable
-# json_mode_response: RunResponse = json_mode_agent.run("New York")
-# pprint(json_mode_response.content)
-# structured_output_response: RunResponse = structured_output_agent.run("New York")
-# pprint(structured_output_response.content)
-
-json_mode_agent.print_response("New York")
-structured_output_agent.print_response("New York")

--- a/libs/agno/tests/unit/utils/test_gemini_dict_support.py
+++ b/libs/agno/tests/unit/utils/test_gemini_dict_support.py
@@ -1,0 +1,228 @@
+"""Tests for Gemini Dict field support in convert_schema"""
+
+from agno.utils.gemini import convert_schema
+
+
+def test_convert_schema_dict_field_integer():
+    """Test converting Dict[str, int] field creates placeholder properties"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "description": "Rating dictionary"
+    }
+    
+    result = convert_schema(dict_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    assert result.properties is not None
+    
+    # Should have placeholder property
+    assert "example_key" in result.properties
+    placeholder = result.properties["example_key"]
+    assert placeholder.type == "INTEGER"
+    assert "integer values" in placeholder.description.lower()
+
+
+def test_convert_schema_dict_field_string():
+    """Test converting Dict[str, str] field creates string placeholder"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "string"},
+        "description": "Metadata dictionary"
+    }
+    
+    result = convert_schema(dict_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    
+    # Should have string placeholder
+    placeholder = result.properties["example_key"]
+    assert placeholder.type == "STRING"
+    assert "string values" in placeholder.description.lower()
+
+
+def test_convert_schema_dict_field_number():
+    """Test converting Dict[str, float] field creates number placeholder"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "number"},
+        "description": "Score dictionary"
+    }
+    
+    result = convert_schema(dict_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    
+    # Should have number placeholder
+    placeholder = result.properties["example_key"]
+    assert placeholder.type == "NUMBER"
+    assert "number values" in placeholder.description.lower()
+
+
+def test_convert_schema_dict_field_with_description():
+    """Test Dict field preserves original description"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "description": "User ratings for movies"
+    }
+    
+    result = convert_schema(dict_schema)
+    
+    assert result is not None
+    # Should preserve original description (enhancement happens in schema_utils normalization)
+    assert "User ratings for movies" in result.description
+    # The placeholder property should have descriptive text about the type
+    placeholder = result.properties["example_key"]
+    assert "integer values" in placeholder.description.lower()
+
+
+def test_convert_schema_dict_field_without_description():
+    """Test Dict field gets default description when none provided"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "string"}
+    }
+    
+    result = convert_schema(dict_schema)
+    
+    assert result is not None
+    # Should have default description
+    assert "Dictionary with string values" in result.description
+    assert "key-value pairs" in result.description
+
+
+def test_convert_schema_regular_object_still_works():
+    """Test that regular objects with properties still work normally"""
+    object_schema = {
+        "type": "object",
+        "description": "A regular object",
+        "properties": {
+            "name": {"type": "string", "description": "Name field"},
+            "age": {"type": "integer", "description": "Age field"}
+        },
+        "required": ["name"]
+    }
+    
+    result = convert_schema(object_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    assert result.description == "A regular object"
+    
+    # Should have actual properties, not placeholders
+    assert "name" in result.properties
+    assert "age" in result.properties
+    assert "example_key" not in result.properties
+    
+    assert result.properties["name"].type == "STRING"
+    assert result.properties["age"].type == "INTEGER"
+    assert "name" in result.required
+
+
+def test_convert_schema_object_with_additional_properties_false():
+    """Test object with additionalProperties: false works normally"""
+    object_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"}
+        },
+        "additionalProperties": False
+    }
+    
+    result = convert_schema(object_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    
+    # Should process as regular object, not Dict
+    assert "name" in result.properties
+    assert "example_key" not in result.properties
+
+
+def test_convert_schema_object_with_additional_properties_true():
+    """Test object with additionalProperties: true (not a typed Dict)"""
+    object_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"}
+        },
+        "additionalProperties": True
+    }
+    
+    result = convert_schema(object_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    
+    # Should process as regular object since additionalProperties is not a schema
+    assert "name" in result.properties
+    assert "example_key" not in result.properties
+
+
+def test_convert_schema_empty_object():
+    """Test empty object without properties or additionalProperties"""
+    object_schema = {
+        "type": "object",
+        "description": "Empty object"
+    }
+    
+    result = convert_schema(object_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    assert result.description == "Empty object"
+
+
+def test_convert_schema_nested_dict_in_properties():
+    """Test object with both regular properties and Dict fields"""
+    complex_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Name field"},
+            "metadata": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": "Dynamic metadata"
+            }
+        },
+        "required": ["name"]
+    }
+    
+    result = convert_schema(complex_schema)
+    
+    assert result is not None
+    assert result.type == "OBJECT"
+    
+    # Should have regular property
+    assert "name" in result.properties
+    assert result.properties["name"].type == "STRING"
+    
+    # Should have converted Dict property
+    assert "metadata" in result.properties
+    metadata_result = result.properties["metadata"]
+    assert metadata_result.type == "OBJECT"
+    
+    # The metadata object should have placeholder properties
+    assert metadata_result.properties is not None
+    assert "example_key" in metadata_result.properties
+    assert metadata_result.properties["example_key"].type == "STRING"
+
+
+def test_convert_schema_dict_field_case_insensitive_type():
+    """Test that type conversion handles different cases properly"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "description": "Test dict"
+    }
+    
+    result = convert_schema(dict_schema)
+    
+    assert result is not None
+    placeholder = result.properties["example_key"]
+    # Should convert to uppercase for Gemini
+    assert placeholder.type == "INTEGER" 

--- a/libs/agno/tests/unit/utils/test_openai_responses.py
+++ b/libs/agno/tests/unit/utils/test_openai_responses.py
@@ -1,0 +1,233 @@
+"""Tests for openai_responses module"""
+
+import copy
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+from agno.utils.models.openai_responses import sanitize_response_schema
+
+
+class SimpleModel(BaseModel):
+    name: str = Field(..., description="Name field")
+    age: int = Field(..., description="Age field")
+
+
+class DictModel(BaseModel):
+    name: str = Field(..., description="Name field")
+    rating: Dict[str, int] = Field(..., description="Rating dictionary")
+    scores: Dict[str, float] = Field(..., description="Score dictionary")
+
+
+class OptionalModel(BaseModel):
+    name: str = Field(..., description="Name field")
+    optional_field: Optional[str] = Field(None, description="Optional field")
+
+
+def test_sanitize_response_schema_dict_fields_excluded_from_required():
+    """Test that Dict fields are excluded from the required array"""
+    original_schema = DictModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    required_fields = schema.get("required", [])
+    
+    # Regular field should be required
+    assert "name" in required_fields
+    
+    # Dict fields should NOT be required
+    assert "rating" not in required_fields
+    assert "scores" not in required_fields
+
+
+def test_sanitize_response_schema_preserves_dict_additional_properties():
+    """Test that Dict fields preserve their additionalProperties schema"""
+    original_schema = DictModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    # Dict fields should preserve additionalProperties
+    rating_field = schema["properties"]["rating"]
+    assert "additionalProperties" in rating_field
+    assert rating_field["additionalProperties"]["type"] == "integer"
+    
+    scores_field = schema["properties"]["scores"]
+    assert "additionalProperties" in scores_field
+    assert scores_field["additionalProperties"]["type"] == "number"
+
+
+def test_sanitize_response_schema_sets_root_additional_properties_false():
+    """Test that root level additionalProperties is set to false"""
+    original_schema = SimpleModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    assert schema.get("additionalProperties") is False
+
+
+def test_sanitize_response_schema_regular_fields_required():
+    """Test that regular fields are included in required array"""
+    original_schema = SimpleModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    assert "age" in required_fields
+
+
+def test_sanitize_response_schema_removes_null_defaults():
+    """Test that null defaults are removed"""
+    original_schema = OptionalModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    optional_field = schema["properties"]["optional_field"]
+    
+    # Should not have default: null
+    assert "default" not in optional_field or optional_field.get("default") is not None
+
+
+def test_sanitize_response_schema_nested_objects():
+    """Test sanitization works with nested objects"""
+    
+    class NestedModel(BaseModel):
+        name: str = Field(..., description="Name")
+        nested: Dict[str, Dict[str, int]] = Field(..., description="Nested dict")
+    
+    original_schema = NestedModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    # Top level Dict should not be required
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    assert "nested" not in required_fields
+    
+    # Nested additionalProperties should be preserved
+    nested_field = schema["properties"]["nested"]
+    assert "additionalProperties" in nested_field
+
+
+def test_sanitize_response_schema_array_items():
+    """Test sanitization works with array items"""
+    
+    class ArrayModel(BaseModel):
+        name: str = Field(..., description="Name")
+        items: List[Dict[str, int]] = Field(..., description="Array of dicts")
+    
+    original_schema = ArrayModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+    
+    sanitize_response_schema(schema)
+    
+    # Regular field should be required
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    assert "items" in required_fields  # List itself should be required
+    
+    # Array items should preserve Dict structure
+    items_field = schema["properties"]["items"]
+    assert items_field["type"] == "array"
+    
+    # The items within the array should preserve additionalProperties
+    array_items = items_field.get("items", {})
+    if "additionalProperties" in array_items:
+        assert array_items["additionalProperties"]["type"] == "integer"
+
+
+def test_sanitize_response_schema_mixed_object_with_properties_and_additional():
+    """Test object that has both properties and additionalProperties"""
+    
+    # Create a schema that has both properties and additionalProperties
+    mixed_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Fixed property"},
+            "metadata": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+                "description": "Dynamic metadata"
+            }
+        },
+        "required": ["name", "metadata"]
+    }
+    
+    schema = copy.deepcopy(mixed_schema)
+    sanitize_response_schema(schema)
+    
+    # Regular field should be required
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    
+    # Dict field should NOT be required  
+    assert "metadata" not in required_fields
+    
+    # Dict field should preserve additionalProperties
+    metadata_field = schema["properties"]["metadata"]
+    assert "additionalProperties" in metadata_field
+    assert metadata_field["additionalProperties"]["type"] == "string"
+
+
+def test_sanitize_response_schema_object_without_additional_properties():
+    """Test regular object without additionalProperties gets additionalProperties: false"""
+    
+    regular_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"}
+        }
+    }
+    
+    schema = copy.deepcopy(regular_schema)
+    sanitize_response_schema(schema)
+    
+    # Should add additionalProperties: false
+    assert schema.get("additionalProperties") is False
+    
+    # Should make all properties required
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    assert "age" in required_fields
+
+
+def test_sanitize_response_schema_object_with_additional_properties_true():
+    """Test object with additionalProperties: true gets converted to false"""
+    
+    loose_schema = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"}
+        },
+        "additionalProperties": True
+    }
+    
+    schema = copy.deepcopy(loose_schema)
+    sanitize_response_schema(schema)
+    
+    # Should convert True to False
+    assert schema.get("additionalProperties") is False
+
+
+def test_sanitize_response_schema_preserves_non_object_types():
+    """Test that non-object types are preserved unchanged"""
+    
+    string_schema = {"type": "string", "description": "A string"}
+    array_schema = {"type": "array", "items": {"type": "integer"}}
+    
+    schema1 = copy.deepcopy(string_schema)
+    schema2 = copy.deepcopy(array_schema)
+    
+    sanitize_response_schema(schema1)
+    sanitize_response_schema(schema2)
+    
+    # Should be unchanged except for removed null defaults
+    assert schema1["type"] == "string"
+    assert schema2["type"] == "array"
+    assert schema2["items"]["type"] == "integer" 

--- a/libs/agno/tests/unit/utils/test_schema_utils.py
+++ b/libs/agno/tests/unit/utils/test_schema_utils.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 from agno.utils.models.schema_utils import (
     is_dict_field,
     get_dict_value_type,
-    normalize_schema_for_provider,
     get_response_schema_for_provider,
     _normalize_for_openai,
     _normalize_for_gemini,

--- a/libs/agno/tests/unit/utils/test_schema_utils.py
+++ b/libs/agno/tests/unit/utils/test_schema_utils.py
@@ -1,0 +1,243 @@
+"""Tests for schema_utils module"""
+
+from typing import Dict, List, Optional
+from pydantic import BaseModel, Field
+
+from agno.utils.models.schema_utils import (
+    is_dict_field,
+    get_dict_value_type,
+    normalize_schema_for_provider,
+    get_response_schema_for_provider,
+    _normalize_for_openai,
+    _normalize_for_gemini,
+)
+
+
+class SimpleModel(BaseModel):
+    name: str = Field(..., description="Name field")
+    age: int = Field(..., description="Age field")
+
+
+class DictModel(BaseModel):
+    name: str = Field(..., description="Name field")
+    rating: Dict[str, int] = Field(..., description="Rating dictionary")
+    scores: Dict[str, float] = Field(..., description="Score dictionary")
+    metadata: Dict[str, str] = Field(..., description="Metadata dictionary")
+
+
+class ComplexModel(BaseModel):
+    name: str = Field(..., description="Name field")
+    rating: Dict[str, int] = Field(..., description="Rating dictionary")
+    tags: List[str] = Field(..., description="List of tags")
+    optional_field: Optional[str] = Field(None, description="Optional field")
+
+
+def test_is_dict_field_positive():
+    """Test is_dict_field correctly identifies Dict fields"""
+    dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "description": "Rating dictionary"
+    }
+    
+    assert is_dict_field(dict_schema) is True
+
+
+def test_is_dict_field_negative_regular_object():
+    """Test is_dict_field correctly rejects regular objects"""
+    object_schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"]
+    }
+    
+    assert is_dict_field(object_schema) is False
+
+
+def test_is_dict_field_negative_additional_properties_false():
+    """Test is_dict_field correctly rejects objects with additionalProperties: false"""
+    object_schema = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {"name": {"type": "string"}}
+    }
+    
+    assert is_dict_field(object_schema) is False
+
+
+def test_is_dict_field_negative_no_additional_properties():
+    """Test is_dict_field correctly rejects objects without additionalProperties"""
+    object_schema = {
+        "type": "object",
+        "description": "Regular object"
+    }
+    
+    assert is_dict_field(object_schema) is False
+
+
+def test_get_dict_value_type():
+    """Test get_dict_value_type extracts correct value types"""
+    int_dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "integer"}
+    }
+    
+    float_dict_schema = {
+        "type": "object", 
+        "additionalProperties": {"type": "number"}
+    }
+    
+    string_dict_schema = {
+        "type": "object",
+        "additionalProperties": {"type": "string"}
+    }
+    
+    assert get_dict_value_type(int_dict_schema) == "integer"
+    assert get_dict_value_type(float_dict_schema) == "number"
+    assert get_dict_value_type(string_dict_schema) == "string"
+
+
+def test_get_dict_value_type_non_dict():
+    """Test get_dict_value_type returns default for non-Dict fields"""
+    regular_schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}}
+    }
+    
+    assert get_dict_value_type(regular_schema) == "string"
+
+
+def test_normalize_for_openai():
+    """Test OpenAI normalization excludes Dict fields from required array"""
+    original_schema = DictModel.model_json_schema()
+    normalized = _normalize_for_openai(original_schema.copy())
+    
+    # Should exclude Dict fields from required
+    required_fields = normalized.get("required", [])
+    assert "name" in required_fields  # Regular field should be required
+    assert "rating" not in required_fields  # Dict field should not be required
+    assert "scores" not in required_fields  # Dict field should not be required
+    
+    # Should preserve additionalProperties for Dict fields
+    rating_field = normalized["properties"]["rating"]
+    assert "additionalProperties" in rating_field
+    assert rating_field["additionalProperties"]["type"] == "integer"
+    
+    # Should set additionalProperties: false at root level
+    assert normalized.get("additionalProperties") is False
+
+
+def test_normalize_for_gemini():
+    """Test Gemini normalization preserves Dict field info for conversion"""
+    original_schema = DictModel.model_json_schema()
+    normalized = _normalize_for_gemini(original_schema.copy())
+    
+    # Should preserve additionalProperties for Dict fields
+    rating_field = normalized["properties"]["rating"]
+    assert "additionalProperties" in rating_field
+    assert rating_field["additionalProperties"]["type"] == "integer"
+    
+    # Should enhance description for Dict fields
+    assert "Dictionary with integer values" in rating_field["description"]
+
+
+def test_get_response_schema_for_provider_openai():
+    """Test getting OpenAI-specific schema"""
+    schema = get_response_schema_for_provider(DictModel, "openai")
+    
+    # Should exclude Dict fields from required
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    assert "rating" not in required_fields
+    assert "scores" not in required_fields
+    
+    # Should preserve Dict field structure
+    rating_field = schema["properties"]["rating"]
+    assert "additionalProperties" in rating_field
+    assert rating_field["additionalProperties"]["type"] == "integer"
+
+
+def test_get_response_schema_for_provider_gemini():
+    """Test getting Gemini-specific schema"""
+    schema = get_response_schema_for_provider(DictModel, "gemini")
+    
+    # Should preserve additionalProperties for convert_schema
+    rating_field = schema["properties"]["rating"]
+    assert "additionalProperties" in rating_field
+    assert rating_field["additionalProperties"]["type"] == "integer"
+    
+    # Should have enhanced description
+    assert "Dictionary with integer values" in rating_field["description"]
+
+
+def test_get_response_schema_for_provider_unknown():
+    """Test getting schema for unknown provider uses generic normalization"""
+    schema = get_response_schema_for_provider(ComplexModel, "unknown_provider")
+    
+    # Should have basic structure
+    assert "properties" in schema
+    assert "required" in schema
+    
+    # Should remove null defaults
+    optional_field = schema["properties"]["optional_field"]
+    assert "default" not in optional_field or optional_field.get("default") is not None
+
+
+def test_complex_model_schema_handling():
+    """Test schema handling with mixed field types"""
+    schema = get_response_schema_for_provider(ComplexModel, "openai")
+    
+    required_fields = schema.get("required", [])
+    
+    # Regular fields should be required
+    assert "name" in required_fields
+    assert "tags" in required_fields
+    
+    # Dict field should not be required
+    assert "rating" not in required_fields
+    
+    # Optional field handling depends on implementation
+    # (could be required or not based on OpenAI's strict mode requirements)
+    
+    # Dict field should preserve structure
+    rating_field = schema["properties"]["rating"]
+    assert is_dict_field(rating_field)
+    assert get_dict_value_type(rating_field) == "integer"
+
+
+def test_simple_model_schema_handling():
+    """Test schema handling with no Dict fields"""
+    schema = get_response_schema_for_provider(SimpleModel, "openai")
+    
+    required_fields = schema.get("required", [])
+    
+    # All regular fields should be required
+    assert "name" in required_fields
+    assert "age" in required_fields
+    
+    # Should have additionalProperties: false
+    assert schema.get("additionalProperties") is False
+
+
+def test_multiple_dict_types():
+    """Test handling of multiple Dict field types"""
+    schema = get_response_schema_for_provider(DictModel, "openai")
+    
+    # Check all Dict fields are properly handled
+    rating_field = schema["properties"]["rating"]
+    scores_field = schema["properties"]["scores"]
+    metadata_field = schema["properties"]["metadata"]
+    
+    assert is_dict_field(rating_field)
+    assert is_dict_field(scores_field)
+    assert is_dict_field(metadata_field)
+    
+    assert get_dict_value_type(rating_field) == "integer"
+    assert get_dict_value_type(scores_field) == "number"
+    assert get_dict_value_type(metadata_field) == "string"
+    
+    # None should be in required array
+    required_fields = schema.get("required", [])
+    assert "rating" not in required_fields
+    assert "scores" not in required_fields
+    assert "metadata" not in required_fields 


### PR DESCRIPTION
## Summary

We had a user that needed to use a Dict type in structured outputs.
https://discord.com/channels/965734768803192842/1374774799351677009/1376519071910203473
The user was testing with Gemini, but I found the same issue in OpenAI.

**Problem:**
Pydantic models with Dict[str, int] fields (and other Dict types) were failing when used as response_schema for both OpenAI and Gemini models due to schema format incompatibilities.

**OpenAI Issue**

Error: "Extra required key 'rating' supplied"
Root Cause: The sanitize_response_schema function was incorrectly adding Dict fields to the required array, but OpenAI's structured outputs don't expect Dict fields (which use additionalProperties) to be listed as required
Solution: Modified sanitize_response_schema to exclude Dict fields from the required array while preserving their additionalProperties schema

**Gemini Issue**

Error: "properties should be non-empty" for Dict fields
Root Cause: The convert_schema function couldn't handle objects with only additionalProperties (no properties), resulting in empty objects that Gemini rejects
Solution: Enhanced convert_schema to detect Dict fields and create placeholder properties with appropriate type information that Gemini can understand
Implementation
Created model-agnostic schema_utils.py for consistent schema handling across providers
Updated both OpenAI Chat and Gemini models to use the new schema utilities
Preserved backward compatibility while fixing Dict field support

**Result**
✅ Dict[str, int], Dict[str, float], Dict[str, str] and other Dict types now work correctly with both OpenAI and Gemini structured outputs.

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
