### PR TITLE
[fix] searxng toolkit import for tool initialization

### DIFF
--- a/cookbook/tools/searxng_tools.py
+++ b/cookbook/tools/searxng_tools.py
@@ -1,8 +1,8 @@
 from agno.agent import Agent
-from agno.tools.searxng import Searxng
+from agno.tools.searxng import SearxngTools
 
 # Initialize Searxng with your Searxng instance URL
-searxng = Searxng(
+searxng = SearxngTools(
     host="http://localhost:53153",
     engines=[],
     fixed_max_results=5,

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -223,7 +223,6 @@ class Model(ABC):
     # True if the Model requires a json_schema for structured outputs (e.g. LMStudio)
     supports_json_schema_outputs: bool = False
 
-
     # Controls which (if any) function is called by the model.
     # "none" means the model will not call a function and instead generates a message.
     # "auto" means the model can pick between generating a message or calling a function.

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -142,9 +142,7 @@ class Searxng(Toolkit):
         """
         return self._search(query, "videos", max_results)
 
-    def _search(
-        self, query: str, category: Optional[str] = None, max_results: int = 5
-    ) -> str:
+    def _search(self, query: str, category: Optional[str] = None, max_results: int = 5) -> str:
         encoded_query = urllib.parse.quote(query)
         url = f"{self.host}/search?format=json&q={encoded_query}"
 
@@ -161,3 +159,7 @@ class Searxng(Toolkit):
             return json.dumps(resp)
         except Exception as e:
             return f"Error fetching results from searxng: {e}"
+
+
+# Alias for consistency with other tools
+SearxngTools = Searxng

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -4,7 +4,7 @@ from typing import Any, List, Optional
 
 import httpx
 
-from agno.tools.toolkit import Toolkit
+from agno.tools import Toolkit
 from agno.utils.log import log_info
 
 
@@ -142,7 +142,9 @@ class Searxng(Toolkit):
         """
         return self._search(query, "videos", max_results)
 
-    def _search(self, query: str, category: Optional[str] = None, max_results: int = 5) -> str:
+    def _search(
+        self, query: str, category: Optional[str] = None, max_results: int = 5
+    ) -> str:
         encoded_query = urllib.parse.quote(query)
         url = f"{self.host}/search?format=json&q={encoded_query}"
 


### PR DESCRIPTION
## Summary

Updated import from `from agno.tools.toolkit import Toolkit` to `from agno.tools import Toolkit` since it was causing the incorrect initialization of the tool causing an `AttributeError: 'Searxng' object has no attribute 'include_tools'`

Fixes an issue I talked about in #3423 also

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
