### PR TITLE
[fix] Memories when user_input_schema is None

### DIFF
--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -69,7 +69,9 @@ class ToolExecution:
             confirmed=data.get("confirmed"),
             confirmation_note=data.get("confirmation_note"),
             requires_user_input=data.get("requires_user_input"),
-            user_input_schema=[UserInputField.from_dict(field) for field in data.get("user_input_schema") or []],
+            user_input_schema=[UserInputField.from_dict(field) for field in data.get("user_input_schema")]
+            if data.get("user_input_schema") is not None
+            else [],
             external_execution_required=data.get("external_execution_required"),
             metrics=MessageMetrics(**(data.get("metrics", {}) or {})),
         )

--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -69,9 +69,11 @@ class ToolExecution:
             confirmed=data.get("confirmed"),
             confirmation_note=data.get("confirmation_note"),
             requires_user_input=data.get("requires_user_input"),
-            user_input_schema=[UserInputField.from_dict(field) for field in data.get("user_input_schema")]
-            if data.get("user_input_schema") is not None
-            else [],
+            user_input_schema=(
+                [UserInputField.from_dict(field) for field in schema_data]
+                if (schema_data := data.get("user_input_schema")) is not None
+                else []
+            ),
             external_execution_required=data.get("external_execution_required"),
             metrics=MessageMetrics(**(data.get("metrics", {}) or {})),
         )


### PR DESCRIPTION
## Summary
There is an issue when collecting memories from Storage (using MongoDB in my case), where certain memories that used tools had a value of `None` for `user_input_schema`. As with the current code, this meant that you would get an error `NoneType is not iterable` in that case, losing the memories. This change checks for `None` values and makes a decision accordingly. 
Issue number: #3449 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
