### PR TITLE
[fix] Fix quote escaping in string utility function. Ensure only unescaped …

### DIFF
--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -92,9 +92,14 @@ def parse_response_model_str(content: str, response_model: Type[BaseModel]) -> O
         def escape_quotes_in_values(match):
             key = match.group(1)
             value = match.group(2)
-            # Escape ONLY unescaped quotes
-            escaped_value = re.sub(r'(?<!\\)"', r'\\"', value)
-            return f'"{key.lower()}": "{escaped_value}"'
+            
+            if '\\"' in value:
+                unescaped_value = value.replace('\\"', '"')
+                escaped_value = unescaped_value.replace('"', '\\"')
+            else:
+                escaped_value = value.replace('"', '\\"')
+            
+            return f'"{key.lower()}": "{escaped_value}'
 
         # Find and escape quotes in field values
         content = re.sub(r'"(?P<key>[^"]+)"\s*:\s*"(?P<value>.*?)(?="\s*(?:,|\}))', escape_quotes_in_values, content)

--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -92,9 +92,9 @@ def parse_response_model_str(content: str, response_model: Type[BaseModel]) -> O
         def escape_quotes_in_values(match):
             key = match.group(1)
             value = match.group(2)
-            # Escape quotes in the value portion only
-            escaped_value = value.replace('"', '\\"')
-            return f'"{key.lower()}": "{escaped_value}'
+            # Escape ONLY unescaped quotes
+            escaped_value = re.sub(r'(?<!\\)"', r'\\"', value)
+            return f'"{key.lower()}": "{escaped_value}"'
 
         # Find and escape quotes in field values
         content = re.sub(r'"(?P<key>[^"]+)"\s*:\s*"(?P<value>.*?)(?="\s*(?:,|\}))', escape_quotes_in_values, content)

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -61,6 +62,14 @@ def test_parse_direct_json():
     assert result is not None
     assert result.name == "test"
     assert result.value == "123"
+
+def test_parse_already_escaped_string():
+    """Test parsing a clean JSON string directly"""
+    content = '{"name": "test", "value": "Already escaped \"quote\""}'
+    result = parse_response_model_str(content, MockModel)
+    assert result is not None
+    assert result.name == "test"
+    assert result.value == "Already escaped \"quote\""
 
 
 def test_parse_json_with_markdown_block():


### PR DESCRIPTION
Fix quote escaping in string utility function. Ensure only unescaped quotes are correctly escaped in JSON-like content. This prevents over-escaping and maintains proper formatting in the output.

## Summary

Describe key changes, mention related issues or motivation for the changes.

fixes: #3528 

## Type of change

- [x] Bug fix


---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---