### PR TITLE
fix: Do not leak the full host env vars into MCP tools

### DIFF
--- a/libs/agno/agno/tools/mcp.py
+++ b/libs/agno/agno/tools/mcp.py
@@ -1,7 +1,6 @@
 from contextlib import AsyncExitStack
 from dataclasses import asdict, dataclass
 from datetime import timedelta
-from os import environ
 from types import TracebackType
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -13,7 +12,7 @@ from agno.utils.mcp import get_entrypoint_for_tool
 try:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.sse import sse_client
-    from mcp.client.stdio import stdio_client
+    from mcp.client.stdio import get_default_environment, stdio_client
     from mcp.client.streamable_http import streamablehttp_client
 except (ImportError, ModuleNotFoundError):
     raise ImportError("`mcp` not installed. Please install using `pip install mcp`")
@@ -129,11 +128,11 @@ class MCPTools(Toolkit):
         # Merge provided env with system env
         if env is not None:
             env = {
-                **environ,
+                **get_default_environment(),
                 **env,
             }
         else:
-            env = {**environ}
+            env = get_default_environment()
 
         if command is not None and transport not in ["sse", "streamable-http"]:
             from shlex import split
@@ -330,11 +329,11 @@ class MultiMCPTools(Toolkit):
         # Merge provided env with system env
         if env is not None:
             env = {
-                **environ,
+                **get_default_environment(),
                 **env,
             }
         else:
-            env = {**environ}
+            env = get_default_environment()
 
         if commands is not None:
             from shlex import split


### PR DESCRIPTION
## Summary

When running MCP with stdio, the environment variables passed to the server/client should not include the whole environment of the caller, as it creates a serious security issue.

The `mcp` client implementation already addressed the issue: https://github.com/modelcontextprotocol/python-sdk/issues/99.

The simplest solution is to just use their utility function for filtering the environment instead of dumping the whole `os.environ` to the MCP client.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)
