### PR TITLE
[fix] Reset _tool_instructions in Agent and Team classes while calling 'determine_tools_for_model'.

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -3593,6 +3593,7 @@ class Agent:
 
             self._tools_for_model = []
             self._functions_for_model = {}
+            self._tool_instructions = []
 
             # Get Agent tools
             if agent_tools is not None and len(agent_tools) > 0:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -4522,6 +4522,7 @@ class Team:
 
         self._functions_for_model = {}
         self._tools_for_model = []
+        self._tool_instructions = []
 
         # Get Agent tools
         if len(_tools) > 0:


### PR DESCRIPTION
## Summary

fix issue #3555 

This PR addresses a bug where tool instructions were not being properly reset between runs, leading to the potential use of stale instructions.

Changes:
- In agno/agent/agent.py, self._tool_instructions is now cleared within the determine_tools_for_model method when tools are rebuilt.
- A consistent change has been applied to agno/team/team.py to also clear self._tool_instructions in its determine_tools_for_model method.

This ensures that tool instructions are correctly synchronized with the available tools for both individual agents and teams in each run.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---
