### PR TITLE
[fix] Fix playground async router "Object of type ReasoningStep is not JSON serializable" error

### DIFF
--- a/libs/agno/agno/app/playground/async_router.py
+++ b/libs/agno/agno/app/playground/async_router.py
@@ -4,8 +4,8 @@ from typing import Any, AsyncGenerator, Dict, List, Optional, cast
 from uuid import uuid4
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
-from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from agno.agent.agent import Agent, RunResponse
 from agno.app.playground.operator import (
@@ -559,10 +559,7 @@ def get_async_playground_router(
             else:
                 # Return as a streaming response
                 return StreamingResponse(
-                    (
-                        json.dumps(jsonable_encoder(result))
-                        for result in new_workflow_instance.run(**body.input)
-                    ),
+                    (json.dumps(jsonable_encoder(result)) for result in new_workflow_instance.run(**body.input)),
                     media_type="text/event-stream",
                 )
         except Exception as e:

--- a/libs/agno/agno/app/playground/async_router.py
+++ b/libs/agno/agno/app/playground/async_router.py
@@ -1,11 +1,11 @@
 import json
-from dataclasses import asdict
 from io import BytesIO
 from typing import Any, AsyncGenerator, Dict, List, Optional, cast
 from uuid import uuid4
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.encoders import jsonable_encoder
 
 from agno.agent.agent import Agent, RunResponse
 from agno.app.playground.operator import (
@@ -559,7 +559,10 @@ def get_async_playground_router(
             else:
                 # Return as a streaming response
                 return StreamingResponse(
-                    (json.dumps(asdict(result)) for result in new_workflow_instance.run(**body.input)),
+                    (
+                        json.dumps(jsonable_encoder(result))
+                        for result in new_workflow_instance.run(**body.input)
+                    ),
                     media_type="text/event-stream",
                 )
         except Exception as e:


### PR DESCRIPTION
## Summary

calling workflow api , get TypeError:
caused by(asdict(ReasoningStep)):  
"/opt/homebrew/Caskroom/miniconda/base/envs/agent/lib/python3.13/site-packages/starlette/concurrency.py", line 49, in _next
    return next(iterator)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/agent/lib/python3.13/site-packages/agno/app/playground/async_router.py", line 562, in <genexpr>
    (json.dumps(asdict(result)) for result in new_workflow_instance.run(**body.input)),
     ~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/agent/lib/python3.13/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "/opt/homebrew/Caskroom/miniconda/base/envs/agent/lib/python3.13/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/agent/lib/python3.13/json/encoder.py", line 261, in iterencode
    return _iterencode(o, 0)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/agent/lib/python3.13/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
                    f'is not JSON serializable')
TypeError: Object of type ReasoningStep is not JSON serializable

There could be more place calling asdict(a Pydantic BaseModel class)?

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes