### PR TITLE
fix: Add a check to create a directory if it doesn't exist while saving an audio file

### DIFF
--- a/libs/agno/agno/utils/audio.py
+++ b/libs/agno/agno/utils/audio.py
@@ -1,16 +1,21 @@
 import base64
+import os
 
 from agno.utils.log import log_info
 
 
-def write_audio_to_file(audio, filename: str):
+def write_audio_to_file(audio, filepath: str):
     """
     Write base64 encoded audio file to disk.
 
     :param audio: Base64 encoded audio file
-    :param filename: The filename to save the audio to
+    :param filepath: The filepath to save the audio to
     """
     wav_bytes = base64.b64decode(audio)
-    with open(filename, "wb") as f:
+
+    # Create `filepath` directory if it doesn't exist.
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+
+    with open(filepath, "wb") as f:
         f.write(wav_bytes)
-    log_info(f"Audio file saved to {filename}")
+    log_info(f"Audio file saved to {filepath}")


### PR DESCRIPTION
## Summary

Makes sure that if the user passes an file path inside an intermediate directory to save an audio file in `write_audio_to_file()` from `agno.utils.audio`, It creates that intermediate path if it doesn't exist before writing the audio file.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)
