### PR TITLE
fix: preserve field name case in structured output parsing

### DIFF
--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -108,7 +108,7 @@ def _clean_json_content(content: str) -> str:
         else:
             escaped_value = value.replace('"', '\\"')
 
-        return f'"{key.lower()}": "{escaped_value}'
+        return f'"{key}": "{escaped_value}'
 
     # Find and escape quotes in field values
     content = re.sub(r'"(?P<key>[^"]+)"\s*:\s*"(?P<value>.*?)(?="\s*(?:,|\}))', escape_quotes_in_values, content)

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -265,3 +265,57 @@ def test_parse_json_with_prefix_suffix_noise():
     assert result is not None
     assert len(result.reasoning_steps) == 1
     assert result.reasoning_steps[0].title == "Only Step"
+
+
+def test_parse_preserves_field_name_case():
+    """Test that field names with mixed case are preserved correctly"""
+    
+    class MixedCaseModel(BaseModel):
+        Supplier_name: str
+        newData: str
+        camelCase: str
+        UPPER_CASE: str
+
+    content = '{"Supplier_name": "test supplier", "newData": "some data", "camelCase": "camel value", "UPPER_CASE": "upper value"}'
+    result = parse_response_model_str(content, MixedCaseModel)
+    
+    assert result is not None
+    assert result.Supplier_name == "test supplier"
+    assert result.newData == "some data"
+    assert result.camelCase == "camel value"
+    assert result.UPPER_CASE == "upper value"
+
+
+def test_parse_preserves_field_name_case_with_cleanup_path():
+    """Test that field names with mixed case are preserved when going through the cleanup path"""
+    
+    class MixedCaseModel(BaseModel):
+        Supplier_name: str
+        newData: str
+
+    content = '{"Supplier_name": "test \\"quoted\\" supplier", "newData": "some \\"quoted\\" data"}'
+    result = parse_response_model_str(content, MixedCaseModel)
+    
+    assert result is not None
+    assert result.Supplier_name == 'test "quoted" supplier'
+    assert result.newData == 'some "quoted" data'
+
+
+def test_parse_preserves_field_name_case_with_markdown():
+    """Test that field names with mixed case are preserved when parsing from markdown blocks with special formatting"""
+    
+    class MixedCaseModel(BaseModel):
+        Supplier_name: str
+        newData: str
+
+    content = '''```json
+    {
+        "Supplier_name": "test "quoted" supplier",
+        "newData": "some "quoted" data"
+    }
+    ```'''
+    result = parse_response_model_str(content, MixedCaseModel)
+    
+    assert result is not None
+    assert result.Supplier_name == 'test "quoted" supplier'
+    assert result.newData == 'some "quoted" data'


### PR DESCRIPTION
## Summary

Fixes a critical bug in `parse_response_model_str` where field names were incorrectly converted to lowercase during the cleanup phase, especially when JSON values included quotes. This impacted models relying on mixed-case field names (e.g., `Supplier_name`, `newData`) and broke structured output parsing. The bug was traced to the `escape_quotes_in_values` function in `string.py`, which called `.lower()` on keys unnecessarily.

issue number: #3493 

## Type of change

- [x] Bug fix  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Improvement  
- [ ] Model update  
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines  
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)  
- [x] Self-review completed  
- [x] Documentation updated (comments, docstrings)  
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)  
- [x] Tested in clean environment  
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### Testing

Ran:
```bash
python3 -m pytest tests/unit/utils/test_string.py -v
