### PR TITLE
[fix] Remove get_request_params argument from ollama chat() API call

### DIFF
--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -94,11 +94,7 @@ class Ollama(Model):
         Returns:
             Dict[str, Any]: The API kwargs for the model.
         """
-        base_params = {
-            "format": self.format,
-            "options": self.options,
-            "keep_alive": self.keep_alive
-        }
+        base_params = {"format": self.format, "options": self.options, "keep_alive": self.keep_alive}
         # Filter out None values
         request_params = {k: v for k, v in base_params.items() if v is not None}
         # Add tools

--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -97,8 +97,7 @@ class Ollama(Model):
         base_params = {
             "format": self.format,
             "options": self.options,
-            "keep_alive": self.keep_alive,
-            "request_params": self.request_params,
+            "keep_alive": self.keep_alive
         }
         # Filter out None values
         request_params = {k: v for k, v in base_params.items() if v is not None}

--- a/libs/agno/agno/models/ollama/tools.py
+++ b/libs/agno/agno/models/ollama/tools.py
@@ -61,8 +61,7 @@ class OllamaTools(Ollama):
         base_params: Dict[str, Any] = {
             "format": self.format,
             "options": self.options,
-            "keep_alive": self.keep_alive,
-            "request_params": self.request_params,
+            "keep_alive": self.keep_alive
         }
         request_params: Dict[str, Any] = {k: v for k, v in base_params.items() if v is not None}
         # Add additional request params if provided

--- a/libs/agno/agno/models/ollama/tools.py
+++ b/libs/agno/agno/models/ollama/tools.py
@@ -58,11 +58,7 @@ class OllamaTools(Ollama):
         Returns:
             Dict[str, Any]: The API kwargs for the model.
         """
-        base_params: Dict[str, Any] = {
-            "format": self.format,
-            "options": self.options,
-            "keep_alive": self.keep_alive
-        }
+        base_params: Dict[str, Any] = {"format": self.format, "options": self.options, "keep_alive": self.keep_alive}
         request_params: Dict[str, Any] = {k: v for k, v in base_params.items() if v is not None}
         # Add additional request params if provided
         if self.request_params:


### PR DESCRIPTION
## Summary

Fixed an issue in the ollama integration where the `chat()` API was incorrectly passing the `get_request_params` keyword argument, which is [not supported by the ollama python client](https://github.com/ollama/ollama-python/blob/63ca74762284100b2f0ad207bc00fa3d32720fbd/ollama/_client.py#L297-L308).

fixes #3462 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

This is my first PR, so please let me know if there are any additional steps I should take as I'm still learning the process.