### PR TITLE
fix: Teams - Ensure we use UUID as a backup member_id

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -6166,10 +6166,9 @@ class Team:
         """
         # First check direct members
         for i, member in enumerate(self.members):
-            if member.name or member.agent_id is not None:
-                url_safe_member_id = self._get_member_id(member)
-                if url_safe_member_id == member_id:
-                    return i, member
+            url_safe_member_id = self._get_member_id(member)
+            if url_safe_member_id == member_id:
+                return i, member
 
             # If this member is a team, search its members recursively
             if isinstance(member, Team):

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -4758,6 +4758,8 @@ class Team:
                 if member.name is not None:
                     system_message_content += f"{indent * ' '}   - ID: {url_safe_member_id}\n"
                     system_message_content += f"{indent * ' '}   - Name: {member.name}\n"
+                else:
+                    system_message_content += f"{indent * ' '}   - ID: {member.agent_id}\n"
                 if member.role is not None:
                     system_message_content += f"{indent * ' '}   - Role: {member.role}\n"
                 if member.tools is not None and self.add_member_tools_to_system_message:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -6133,6 +6133,11 @@ class Team:
     def _get_member_id(self, member: Union[Agent, "Team"]) -> str:
         """
         Get the ID of a member
+        
+        If the member has an agent_id or team_id, use that if it is not a valid UUID.
+        Then if the member has a name, convert that to a URL safe string.
+        Then if the member has the default UUID ID, use that.
+        Otherwise, return None.
         """
         if isinstance(member, Agent) and member.agent_id is not None and (not is_valid_uuid(member.agent_id)):
             url_safe_member_id = url_safe_string(member.agent_id)
@@ -6140,6 +6145,10 @@ class Team:
             url_safe_member_id = url_safe_string(member.team_id)
         elif member.name is not None:
             url_safe_member_id = url_safe_string(member.name)
+        elif isinstance(member, Agent) and member.agent_id is not None:
+            url_safe_member_id = member.agent_id
+        elif isinstance(member, Team) and member.team_id is not None:
+            url_safe_member_id = member.team_id
         else:
             url_safe_member_id = None
         return url_safe_member_id

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -548,8 +548,6 @@ class Team:
             member.parent_team_id = self.team_id
             for sub_member in member.members:
                 self._initialize_member(sub_member, session_id)
-        if member.name is None:
-            log_warning("Team member name is undefined.")
 
     def _set_default_model(self) -> None:
         # Set the default model
@@ -4755,11 +4753,10 @@ class Team:
                     system_message_content += member.get_members_system_message_content(indent=indent + 2)
             else:
                 system_message_content += f"{indent * ' '} - Agent {idx + 1}:\n"
-                if member.name is not None:
+                if url_safe_member_id is not None:
                     system_message_content += f"{indent * ' '}   - ID: {url_safe_member_id}\n"
+                if member.name is not None:
                     system_message_content += f"{indent * ' '}   - Name: {member.name}\n"
-                else:
-                    system_message_content += f"{indent * ' '}   - ID: {member.agent_id}\n"
                 if member.role is not None:
                     system_message_content += f"{indent * ' '}   - Role: {member.role}\n"
                 if member.tools is not None and self.add_member_tools_to_system_message:
@@ -6169,7 +6166,7 @@ class Team:
         """
         # First check direct members
         for i, member in enumerate(self.members):
-            if member.name is not None:
+            if member.name or member.agent_id is not None:
                 url_safe_member_id = self._get_member_id(member)
                 if url_safe_member_id == member_id:
                     return i, member

--- a/libs/agno/tests/unit/team/test_team.py
+++ b/libs/agno/tests/unit/team/test_team.py
@@ -72,6 +72,8 @@ def test_get_member_id():
     assert Team(members=[member])._get_member_id(member) == "123"
     member = Agent(name="Test Agent", agent_id=str(uuid.uuid4()))
     assert Team(members=[member])._get_member_id(member) == "test-agent"
+    member = Agent(agent_id=str(uuid.uuid4()))
+    assert Team(members=[member])._get_member_id(member) == member.agent_id
 
     member = Agent(name="Test Agent")
     inner_team = Team(name="Test Team", members=[member])
@@ -80,3 +82,5 @@ def test_get_member_id():
     assert Team(members=[inner_team])._get_member_id(inner_team) == "123"
     inner_team = Team(name="Test Team", team_id=str(uuid.uuid4()), members=[member])
     assert Team(members=[inner_team])._get_member_id(inner_team) == "test-team"
+    inner_team = Team(team_id=str(uuid.uuid4()), members=[member])
+    assert Team(members=[inner_team])._get_member_id(inner_team) == inner_team.team_id


### PR DESCRIPTION
## Summary

Ensure that teams will still work if the user doesn't supply an agent/team ID or name to members.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
