### PR TITLE
fix get_embedding function return value not List[float] bug

### DIFF
--- a/libs/agno/agno/embedder/fastembed.py
+++ b/libs/agno/agno/embedder/fastembed.py
@@ -22,6 +22,8 @@ class FastEmbedEmbedder(Embedder):
         model = TextEmbedding(model_name=self.id)
         embeddings = model.embed(text)
         embedding_list = list(embeddings)[0]
+        if isinstance(embedding_list, np.ndarray):
+            return embedding_list.tolist()
 
         try:
             return list(embedding_list)

--- a/libs/agno/agno/embedder/fastembed.py
+++ b/libs/agno/agno/embedder/fastembed.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
-
+import numpy as np
 from agno.embedder.base import Embedder
 from agno.utils.log import logger
 

--- a/libs/agno/agno/embedder/fastembed.py
+++ b/libs/agno/agno/embedder/fastembed.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
-import numpy as np
 from agno.embedder.base import Embedder
 from agno.utils.log import logger
+
+try:
+    import numpy as np
+
+except ImportError:
+    raise ImportError("numpy not installed, use pip install numpy")
+
 
 try:
     from fastembed import TextEmbedding  # type: ignore


### PR DESCRIPTION


## Summary

Fix a Bug. The raw **embedding_list** is a numpy **ndarray**, but the function need return a  **List[float]**, so need to convert ndarry to normal list[float]


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

changed file is agno.embedder.fastembed.FastEmbedEmbedder
