### PR TITLE
fix: display non-ascii chars correctly in ExaTools result

### DIFF
--- a/libs/agno/agno/tools/exa.py
+++ b/libs/agno/agno/tools/exa.py
@@ -143,7 +143,7 @@ class ExaTools(Toolkit):
                     log_debug(f"Failed to get highlights {e}")
                     result_dict["highlights"] = f"Failed to get highlights {e}"
             exa_results_parsed.append(result_dict)
-        return json.dumps(exa_results_parsed, indent=4)
+        return json.dumps(exa_results_parsed, indent=4, ensure_ascii=False)
 
     def search_exa(self, query: str, num_results: int = 5, category: Optional[str] = None) -> str:
         """Use this function to search Exa (a web search engine) for a query.


### PR DESCRIPTION
## Summary

Currently, `ExaTools` is using `json.dumps` with its default `ensure_ascii=True` option, which renders non-ASCII characters as something like \uffff, unnecessarily burdening the LLM to parse those characters.

This PR fixes that in [2127cf5](https://github.com/agno-agi/agno/pull/3732/commits/2127cf568cda354ae8ffa3dee0e41dbfc793d358)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ NOT APPLICABLE ] Documentation updated (comments, docstrings)
- [ NOT APPLICABLE ]  Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ NOT APPLICABLE ]  Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
