### PR TITLE
OpenAIChat._format_messages(messages)

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -246,6 +246,12 @@ class OpenAIChat(Model):
         cleaned_dict = {k: v for k, v in model_dict.items() if v is not None}
         return cleaned_dict
 
+    def format_messages(self, messages: List[Message]) -> List[Dict[str, Any]]:
+        """
+        Format a list of messages into the format expected by OpenAI.
+        """
+        return [self._format_message(m) for m in messages]
+
     def _format_message(self, message: Message) -> Dict[str, Any]:
         """
         Format a message into the format expected by OpenAI.
@@ -329,7 +335,7 @@ class OpenAIChat(Model):
         try:
             return self.get_client().chat.completions.create(
                 model=self.id,
-                messages=[self._format_message(m) for m in messages],  # type: ignore
+                messages=self._format_messages(messages),
                 **self.get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice),
             )
         except RateLimitError as e:
@@ -389,7 +395,7 @@ class OpenAIChat(Model):
         try:
             return await self.get_async_client().chat.completions.create(
                 model=self.id,
-                messages=[self._format_message(m) for m in messages],  # type: ignore
+                messages=self._format_messages(messages),
                 **self.get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice),
             )
         except RateLimitError as e:
@@ -450,7 +456,7 @@ class OpenAIChat(Model):
         try:
             yield from self.get_client().chat.completions.create(
                 model=self.id,
-                messages=[self._format_message(m) for m in messages],  # type: ignore
+                messages=self._format_messages(messages),
                 stream=True,
                 stream_options={"include_usage": True},
                 **self.get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice),
@@ -513,7 +519,7 @@ class OpenAIChat(Model):
         try:
             async_stream = await self.get_async_client().chat.completions.create(
                 model=self.id,
-                messages=[self._format_message(m) for m in messages],  # type: ignore
+                messages=self.format_messages(messages),
                 stream=True,
                 stream_options={"include_usage": True},
                 **self.get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice),

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -246,7 +246,7 @@ class OpenAIChat(Model):
         cleaned_dict = {k: v for k, v in model_dict.items() if v is not None}
         return cleaned_dict
 
-    def format_messages(self, messages: List[Message]) -> List[Dict[str, Any]]:
+    def _format_messages(self, messages: List[Message]) -> List[Dict[str, Any]]:
         """
         Format a list of messages into the format expected by OpenAI.
         """
@@ -519,7 +519,7 @@ class OpenAIChat(Model):
         try:
             async_stream = await self.get_async_client().chat.completions.create(
                 model=self.id,
-                messages=self.format_messages(messages),
+                messages=self._format_messages(messages),
                 stream=True,
                 stream_options={"include_usage": True},
                 **self.get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice),


### PR DESCRIPTION
## Summary

Refactored to `OpenAIChat._format_messages()` as per `LiteLLM` so that our app can sub-class `LiteLLMOpenAI` and add prompt caching checkpoints as we were with `LiteLLM`:

```python
class CustomLLMOpenAI(LiteLLMOpenAI):
    @override
    def _format_messages(self, messages: List[Message]) -> List[Dict[str, Any]]:
      _prompt_caching(messages)
      formatted_messages = super()._format_messages(messages)
      return formatted_messages


def _prompt_caching(messages: List[Message]) -> None:
    for m in messages:
        if m.role == "system":
            m.content = [{"type": "text", "text": f"{m.content}", "cache_control": {"type": "ephemeral"}}]

    user_messages = [m for m in messages if m.role == "user"]

    if len(user_messages) >= 2:
        # mark for caching, so that this checkpoint can read from the previous cache
        _add_cache_control(user_messages[-2])

    if len(user_messages) >= 1:
        # The final turn is marked with cache-control, for continuing in follow-ups
        _add_cache_control(user_messages[-1])


def _add_cache_control(message: Message) -> None:
    # Note: LiteLLM converts to Bedrock's `{"cachePoint": {"type": "default"}}`
    if isinstance(message.content, str):
        message.content = [
            {
                "type": "text",
                "text": message.content,
                "cache_control": {"type": "ephemeral"},
            },
        ]
    elif isinstance(message.content, list) and message.content[-1].get("type") == "text":
        message.content[-1]["cache_control"] = {"type": "ephemeral"}
```



(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---
