### PR TITLE
fix: update mcp lib install instructions

### DIFF
--- a/cookbook/tools/mcp/mem0.py
+++ b/cookbook/tools/mcp/mem0.py
@@ -4,7 +4,7 @@
 This example demonstrates how to use Agno's MCP integration together with Mem0, to build a personalized code reviewer.
 
 - Run your Mem0 MCP server. Full instructions: https://github.com/mem0ai/mem0-mcp
-- Run: `pip install agno mcp-sdk` to install the dependencies
+- Run: `pip install agno mcp` to install the dependencies
 """
 
 import asyncio

--- a/cookbook/tools/mcp/pipedream_auth.py
+++ b/cookbook/tools/mcp/pipedream_auth.py
@@ -11,7 +11,7 @@ This is useful if your app is interfacing with the MCP servers in behalf of your
     - MCP_ACCESS_TOKEN: The access token you previously got
     - PIPEDREAM_PROJECT_ID: The project id of the Pipedream project you want to use
     - PIPEDREAM_ENVIRONMENT: The environment of the Pipedream project you want to use
-3. Install dependencies: pip install agno mcp-sdk
+3. Install dependencies: pip install agno mcp
 """
 
 import asyncio

--- a/cookbook/tools/mcp/pipedream_google_calendar.py
+++ b/cookbook/tools/mcp/pipedream_google_calendar.py
@@ -3,10 +3,10 @@
 
 This example shows how to use Pipedream MCP servers (in this case the Google Calendar one) with Agno Agents.
 
-1. Connect your Pipedream and Google Calendar accounts: https://mcp.pipedream.com/app/google-calendar
-2. Get your Pipedream MCP server url: https://mcp.pipedream.com/app/google-calendar
+1. Connect your Pipedream and Google Calendar accounts: https://mcp.pipedream.com/app/google_calendar
+2. Get your Pipedream MCP server url: https://mcp.pipedream.com/app/google_calendar
 3. Set the MCP_SERVER_URL environment variable to the MCP server url you got above
-4. Install dependencies: pip install agno mcp-sdk
+4. Install dependencies: pip install agno mcp
 """
 
 import asyncio

--- a/cookbook/tools/mcp/pipedream_linkedin.py
+++ b/cookbook/tools/mcp/pipedream_linkedin.py
@@ -6,7 +6,7 @@ This example shows how to use Pipedream MCP servers (in this case the LinkedIn o
 1. Connect your Pipedream and LinkedIn accounts: https://mcp.pipedream.com/app/linkedin
 2. Get your Pipedream MCP server url: https://mcp.pipedream.com/app/linkedin
 3. Set the MCP_SERVER_URL environment variable to the MCP server url you got above
-4. Install dependencies: pip install agno mcp-sdk
+4. Install dependencies: pip install agno mcp
 """
 
 import asyncio

--- a/cookbook/tools/mcp/pipedream_slack.py
+++ b/cookbook/tools/mcp/pipedream_slack.py
@@ -6,7 +6,7 @@ This example shows how to use Pipedream MCP servers (in this case the Slack one)
 1. Connect your Pipedream and Slack accounts: https://mcp.pipedream.com/app/slack
 2. Get your Pipedream MCP server url: https://mcp.pipedream.com/app/slack
 3. Set the MCP_SERVER_URL environment variable to the MCP server url you got above
-4. Install dependencies: pip install agno mcp-sdk
+4. Install dependencies: pip install agno mcp
 
 """
 

--- a/cookbook/tools/mcp/stripe.py
+++ b/cookbook/tools/mcp/stripe.py
@@ -6,7 +6,7 @@ This example demonstrates how to create an Agno agent that interacts with the St
 Setup:
 2. Install Python dependencies:
    ```bash
-   pip install agno mcp-sdk
+   pip install agno mcp
    ```
 3. Set Environment Variable: export STRIPE_SECRET_KEY=***.
 

--- a/cookbook/tools/mcp/supabase.py
+++ b/cookbook/tools/mcp/supabase.py
@@ -6,7 +6,7 @@ Setup:
 1. Install Python dependencies:
 
 ```bash
-pip install agno mcp-sdk
+pip install agno mcp
 ```
 
 2. Create a Supabase Access Token: https://supabase.com/dashboard/account/tokens and set it as the SUPABASE_ACCESS_TOKEN environment variable.


### PR DESCRIPTION
## Summary

The MCP library we use is now installed with `pip install mcp` instead of `pip install mcp-sdk`.