### PR TITLE
fix: print_response_stream display correct step number in case of nested workflow steps 

### DIFF
--- a/cookbook/workflows_2/async/01_basic_workflows/step_with_function_additional_data.py
+++ b/cookbook/workflows_2/async/01_basic_workflows/step_with_function_additional_data.py
@@ -3,13 +3,13 @@ from typing import AsyncIterator, Union
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
+from agno.run.v2.workflow import WorkflowRunResponseEvent
 from agno.storage.sqlite import SqliteStorage
 from agno.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.hackernews import HackerNewsTools
 from agno.workflow.v2.step import Step, StepInput, StepOutput
 from agno.workflow.v2.workflow import Workflow
-from agno.run.v2.workflow import WorkflowRunResponseEvent
 
 # Define agents
 hackernews_agent = Agent(
@@ -44,14 +44,16 @@ content_planner = Agent(
 )
 
 
-async def custom_content_planning_function(step_input: StepInput) -> AsyncIterator[Union[WorkflowRunResponseEvent, StepOutput]]:
+async def custom_content_planning_function(
+    step_input: StepInput,
+) -> AsyncIterator[Union[WorkflowRunResponseEvent, StepOutput]]:
     """
     Custom function that does intelligent content planning with context awareness
     Now also uses additional_data for extra context
     """
     message = step_input.message
     previous_step_content = step_input.previous_step_content
-    
+
     # Access additional_data that was passed with the workflow
     additional_data = step_input.additional_data or {}
     user_email = additional_data.get("user_email", "No email provided")
@@ -82,8 +84,10 @@ async def custom_content_planning_function(step_input: StepInput) -> AsyncIterat
         Please create a detailed, actionable content plan.
     """
 
-    try:    
-        response_iterator = await content_planner.arun(planning_prompt, stream=True, stream_intermediate_steps=True)
+    try:
+        response_iterator = await content_planner.arun(
+            planning_prompt, stream=True, stream_intermediate_steps=True
+        )
         async for event in response_iterator:
             yield event
         response = content_planner.run_response
@@ -144,18 +148,20 @@ if __name__ == "__main__":
         ),
         steps=[research_step, content_planning_step],
     )
-    
+
     # Run workflow with additional_data
-    asyncio.run(content_creation_workflow.aprint_response(
-        message="AI trends in 2024",
-        additional_data={
-            "user_email": "kaustubh@agno.com",
-            "priority": "high",
-            "client_type": "enterprise"
-        },
-        markdown=True,
-        stream=True,
-        stream_intermediate_steps=True,
-    ))
+    asyncio.run(
+        content_creation_workflow.aprint_response(
+            message="AI trends in 2024",
+            additional_data={
+                "user_email": "kaustubh@agno.com",
+                "priority": "high",
+                "client_type": "enterprise",
+            },
+            markdown=True,
+            stream=True,
+            stream_intermediate_steps=True,
+        )
+    )
 
     print("\n" + "=" * 60 + "\n")

--- a/cookbook/workflows_2/async/04_workflows_parallel_execution/parallel_and_condition_steps_stream.py
+++ b/cookbook/workflows_2/async/04_workflows_parallel_execution/parallel_and_condition_steps_stream.py
@@ -1,0 +1,158 @@
+import asyncio
+
+from agno.agent.agent import Agent
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.tools.exa import ExaTools
+from agno.tools.hackernews import HackerNewsTools
+from agno.workflow.v2.condition import Condition
+from agno.workflow.v2.parallel import Parallel
+from agno.workflow.v2.step import Step
+from agno.workflow.v2.types import StepInput
+from agno.workflow.v2.workflow import Workflow
+
+# === AGENTS ===
+hackernews_agent = Agent(
+    name="HackerNews Researcher",
+    instructions="Research tech news and trends from Hacker News",
+    tools=[HackerNewsTools()],
+)
+
+web_agent = Agent(
+    name="Web Researcher",
+    instructions="Research general information from the web",
+    tools=[DuckDuckGoTools()],
+)
+
+exa_agent = Agent(
+    name="Exa Search Researcher",
+    instructions="Research using Exa advanced search capabilities",
+    tools=[ExaTools()],
+)
+
+content_agent = Agent(
+    name="Content Creator",
+    instructions="Create well-structured content from research data",
+)
+
+# === RESEARCH STEPS ===
+research_hackernews_step = Step(
+    name="ResearchHackerNews",
+    description="Research tech news from Hacker News",
+    agent=hackernews_agent,
+)
+
+research_web_step = Step(
+    name="ResearchWeb",
+    description="Research general information from web",
+    agent=web_agent,
+)
+
+research_exa_step = Step(
+    name="ResearchExa",
+    description="Research using Exa search",
+    agent=exa_agent,
+)
+
+prepare_input_for_write_step = Step(
+    name="PrepareInput",
+    description="Prepare and organize research data for writing",
+    agent=content_agent,
+)
+
+write_step = Step(
+    name="WriteContent",
+    description="Write the final content based on research",
+    agent=content_agent,
+)
+
+
+# === CONDITION EVALUATORS ===
+def should_conduct_research(step_input: StepInput) -> bool:
+    """Check if we should conduct comprehensive research"""
+    topic = step_input.message or step_input.previous_step_content or ""
+
+    # Keywords that indicate research is needed
+    research_keywords = [
+        "ai",
+        "machine learning",
+        "programming",
+        "software",
+        "tech",
+        "startup",
+        "coding",
+        "news",
+        "information",
+        "research",
+        "facts",
+        "data",
+        "analysis",
+        "comprehensive",
+        "trending",
+        "viral",
+        "social",
+        "discussion",
+        "opinion",
+        "developments",
+    ]
+
+    # If the topic contains any research-worthy keywords, conduct research
+    return any(keyword in topic.lower() for keyword in research_keywords)
+
+
+def is_tech_related(step_input: StepInput) -> bool:
+    """Check if the topic is tech-related for additional tech research"""
+    topic = step_input.message or step_input.previous_step_content or ""
+    tech_keywords = ["ai", "machine learning", "programming", "software", "tech", "startup", "coding"]
+    return any(keyword in topic.lower() for keyword in tech_keywords)
+
+
+if __name__ == "__main__":
+    workflow = Workflow(
+        name="Conditional Research Workflow",
+        description="Conditionally execute parallel research based on topic relevance",
+        steps=[
+            # Main research condition - if topic needs research, run parallel research steps
+            Condition(
+                name="ResearchCondition",
+                description="Check if comprehensive research is needed for this topic",
+                evaluator=should_conduct_research,
+                steps=[
+                    Parallel(
+                        research_hackernews_step,
+                        research_web_step,
+                        name="ComprehensiveResearch",
+                        description="Run multiple research sources in parallel",
+                    ),
+                    research_exa_step,
+                ],
+            ),
+            # # Additional tech-specific research if needed
+            Condition(
+                name="TechResearchCondition",
+                description="Additional tech-focused research if topic is tech-related",
+                evaluator=is_tech_related,
+                steps=[
+                    Step(
+                        name="TechAnalysis",
+                        description="Deep dive tech analysis and trend identification",
+                        agent=content_agent,
+                    ),
+                ],
+            ),
+            # Content preparation and writing
+            prepare_input_for_write_step,
+            # write_step,
+        ],
+    )
+
+    try:
+        asyncio.run(
+            workflow.aprint_response(
+                message="Latest AI developments in machine learning",
+                stream=True,
+                stream_intermediate_steps=True,
+            )
+        )
+    except Exception as e:
+        print(f"❌ Error: {e}")
+    print()

--- a/cookbook/workflows_2/sync/01_basic_workflows/step_with_function_additional_data.py
+++ b/cookbook/workflows_2/sync/01_basic_workflows/step_with_function_additional_data.py
@@ -47,7 +47,7 @@ def custom_content_planning_function(step_input: StepInput) -> StepOutput:
     """
     message = step_input.message
     previous_step_content = step_input.previous_step_content
-    
+
     # Access additional_data that was passed with the workflow
     additional_data = step_input.additional_data or {}
     user_email = additional_data.get("user_email", "No email provided")
@@ -137,14 +137,14 @@ if __name__ == "__main__":
         ),
         steps=[research_step, content_planning_step],
     )
-    
+
     # Run workflow with additional_data
     content_creation_workflow.print_response(
         message="AI trends in 2024",
         additional_data={
             "user_email": "kaustubh@agno.com",
             "priority": "high",
-            "client_type": "enterprise"
+            "client_type": "enterprise",
         },
         markdown=True,
         stream=True,

--- a/cookbook/workflows_2/sync/04_workflows_parallel_execution/parallel_and_condition_steps_stream.py
+++ b/cookbook/workflows_2/sync/04_workflows_parallel_execution/parallel_and_condition_steps_stream.py
@@ -1,0 +1,164 @@
+from typing import List, Union
+
+from agno.agent.agent import Agent
+from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.tools.exa import ExaTools
+from agno.tools.hackernews import HackerNewsTools
+from agno.workflow.v2.condition import Condition
+from agno.workflow.v2.parallel import Parallel
+from agno.workflow.v2.step import Step
+from agno.workflow.v2.types import StepInput
+from agno.workflow.v2.workflow import Workflow
+
+# === AGENTS ===
+hackernews_agent = Agent(
+    name="HackerNews Researcher",
+    instructions="Research tech news and trends from Hacker News",
+    tools=[HackerNewsTools()],
+)
+
+web_agent = Agent(
+    name="Web Researcher",
+    instructions="Research general information from the web",
+    tools=[DuckDuckGoTools()],
+)
+
+exa_agent = Agent(
+    name="Exa Search Researcher",
+    instructions="Research using Exa advanced search capabilities",
+    tools=[ExaTools()],
+)
+
+content_agent = Agent(
+    name="Content Creator",
+    instructions="Create well-structured content from research data",
+)
+
+# === RESEARCH STEPS ===
+research_hackernews_step = Step(
+    name="ResearchHackerNews",
+    description="Research tech news from Hacker News",
+    agent=hackernews_agent,
+)
+
+research_web_step = Step(
+    name="ResearchWeb",
+    description="Research general information from web",
+    agent=web_agent,
+)
+
+research_exa_step = Step(
+    name="ResearchExa",
+    description="Research using Exa search",
+    agent=exa_agent,
+)
+
+prepare_input_for_write_step = Step(
+    name="PrepareInput",
+    description="Prepare and organize research data for writing",
+    agent=content_agent,
+)
+
+write_step = Step(
+    name="WriteContent",
+    description="Write the final content based on research",
+    agent=content_agent,
+)
+
+
+# === CONDITION EVALUATORS ===
+def should_conduct_research(step_input: StepInput) -> bool:
+    """Check if we should conduct comprehensive research"""
+    topic = step_input.message or step_input.previous_step_content or ""
+
+    # Keywords that indicate research is needed
+    research_keywords = [
+        "ai",
+        "machine learning",
+        "programming",
+        "software",
+        "tech",
+        "startup",
+        "coding",
+        "news",
+        "information",
+        "research",
+        "facts",
+        "data",
+        "analysis",
+        "comprehensive",
+        "trending",
+        "viral",
+        "social",
+        "discussion",
+        "opinion",
+        "developments",
+    ]
+
+    # If the topic contains any research-worthy keywords, conduct research
+    return any(keyword in topic.lower() for keyword in research_keywords)
+
+
+def is_tech_related(step_input: StepInput) -> bool:
+    """Check if the topic is tech-related for additional tech research"""
+    topic = step_input.message or step_input.previous_step_content or ""
+    tech_keywords = [
+        "ai",
+        "machine learning",
+        "programming",
+        "software",
+        "tech",
+        "startup",
+        "coding",
+    ]
+    return any(keyword in topic.lower() for keyword in tech_keywords)
+
+
+if __name__ == "__main__":
+    workflow = Workflow(
+        name="Conditional Research Workflow",
+        description="Conditionally execute parallel research based on topic relevance",
+        steps=[
+            # Main research condition - if topic needs research, run parallel research steps
+            Condition(
+                name="ResearchCondition",
+                description="Check if comprehensive research is needed for this topic",
+                evaluator=should_conduct_research,
+                steps=[
+                    Parallel(
+                        research_hackernews_step,
+                        research_web_step,
+                        name="ComprehensiveResearch",
+                        description="Run multiple research sources in parallel",
+                    ),
+                    research_exa_step,
+                ],
+            ),
+            # # Additional tech-specific research if needed
+            Condition(
+                name="TechResearchCondition",
+                description="Additional tech-focused research if topic is tech-related",
+                evaluator=is_tech_related,
+                steps=[
+                    Step(
+                        name="TechAnalysis",
+                        description="Deep dive tech analysis and trend identification",
+                        agent=content_agent,
+                    ),
+                ],
+            ),
+            # Content preparation and writing
+            prepare_input_for_write_step,
+            # write_step,
+        ],
+    )
+
+    try:
+        workflow.print_response(
+            message="Latest AI developments in machine learning",
+            stream=True,
+            stream_intermediate_steps=True,
+        )
+    except Exception as e:
+        print(f"❌ Error: {e}")
+    print()

--- a/libs/agno/agno/workflow/v2/condition.py
+++ b/libs/agno/agno/workflow/v2/condition.py
@@ -266,6 +266,15 @@ class Condition:
         for i, step in enumerate(self.steps):
             try:
                 step_outputs_for_step = []
+
+                # Create child index for each step within condition
+                if step_index is None or isinstance(step_index, int):
+                    # Condition is a main step - child steps get x.1, x.2, x.3 format
+                    child_step_index = (step_index if step_index is not None else 1, i)
+                else:
+                    # Condition is already a child step - child steps get same parent number: x.y, x.y, x.y
+                    child_step_index = step_index
+
                 # Stream step execution
                 for event in step.execute_stream(
                     current_step_input,
@@ -273,7 +282,7 @@ class Condition:
                     user_id=user_id,
                     stream_intermediate_steps=stream_intermediate_steps,
                     workflow_run_response=workflow_run_response,
-                    step_index=step_index,
+                    step_index=child_step_index,
                 ):
                     if isinstance(event, StepOutput):
                         step_outputs_for_step.append(event)
@@ -463,6 +472,14 @@ class Condition:
             try:
                 step_outputs_for_step = []
 
+                # Create child index for each step within condition
+                if step_index is None or isinstance(step_index, int):
+                    # Condition is a main step - child steps get x.1, x.2, x.3 format
+                    child_step_index = (step_index if step_index is not None else 1, i)
+                else:
+                    # Condition is already a child step - child steps get same parent number: x.y, x.y, x.y
+                    child_step_index = step_index
+
                 # Stream step execution - mirroring Loop logic
                 async for event in step.aexecute_stream(
                     current_step_input,
@@ -470,7 +487,7 @@ class Condition:
                     user_id=user_id,
                     stream_intermediate_steps=stream_intermediate_steps,
                     workflow_run_response=workflow_run_response,
-                    step_index=step_index,
+                    step_index=child_step_index,
                 ):
                     if isinstance(event, StepOutput):
                         step_outputs_for_step.append(event)

--- a/libs/agno/agno/workflow/v2/loop.py
+++ b/libs/agno/agno/workflow/v2/loop.py
@@ -251,13 +251,13 @@ class Loop:
             for i, step in enumerate(self.steps):
                 step_outputs_for_iteration = []
 
-                # Create composite step index for loop sub-steps: (parent_step_index, sub_step_index)
-                if isinstance(step_index, tuple):
-                    # Handle nested loops/parallel - extend the tuple
-                    composite_step_index = step_index + (i,)
+                # Loop children always get sequential sub-indices: parent_index.1, parent_index.2, etc.
+                if step_index is None or isinstance(step_index, int):
+                    # Loop is a main step
+                    composite_step_index = (step_index if step_index is not None else 0, i)
                 else:
-                    # Create new tuple for loop sub-steps
-                    composite_step_index = (step_index, i) if step_index is not None else (0, i)
+                    # Loop is a nested step - extend the tuple
+                    composite_step_index = step_index + (i,)
 
                 # Stream step execution
                 for event in step.execute_stream(
@@ -490,13 +490,13 @@ class Loop:
             for i, step in enumerate(self.steps):
                 step_outputs_for_iteration = []
 
-                # Create composite step index for loop sub-steps: (parent_step_index, sub_step_index)
-                if isinstance(step_index, tuple):
-                    # Handle nested loops/parallel - extend the tuple
-                    composite_step_index = step_index + (i,)
+                # Loop children always get sequential sub-indices: parent_index.1, parent_index.2, etc.
+                if step_index is None or isinstance(step_index, int):
+                    # Loop is a main step
+                    composite_step_index = (step_index if step_index is not None else 0, i)
                 else:
-                    # Create new tuple for loop sub-steps
-                    composite_step_index = (step_index, i) if step_index is not None else (0, i)
+                    # Loop is a nested step - extend the tuple
+                    composite_step_index = step_index + (i,)
 
                 # Stream step execution - mirroring workflow logic
                 async for event in step.aexecute_stream(

--- a/libs/agno/agno/workflow/v2/parallel.py
+++ b/libs/agno/agno/workflow/v2/parallel.py
@@ -320,10 +320,16 @@ class Parallel:
             index, step = step_with_index
             try:
                 events = []
-                if isinstance(step_index, tuple):
-                    sub_step_index = index
+
+                # If step_index is None or integer (main step): create (step_index, sub_index)
+                # If step_index is tuple (child step): all parallel sub-steps get same index
+                if step_index is None or isinstance(step_index, int):
+                    # Parallel is a main step - sub-steps get sequential numbers: 1.1, 1.2, 1.3
+                    sub_step_index = (step_index if step_index is not None else 0, index)
                 else:
-                    sub_step_index = (step_index, index)
+                    # Parallel is a child step - all sub-steps get the same parent number: 1.1, 1.1, 1.1
+                    sub_step_index = step_index
+
                 # All workflow step types have execute_stream() method
                 for event in step.execute_stream(
                     step_input,
@@ -541,10 +547,16 @@ class Parallel:
             index, step = step_with_index
             try:
                 events = []
-                if isinstance(step_index, tuple):
-                    sub_step_index = index
+
+                # If step_index is None or integer (main step): create (step_index, sub_index)
+                # If step_index is tuple (child step): all parallel sub-steps get same index
+                if step_index is None or isinstance(step_index, int):
+                    # Parallel is a main step - sub-steps get sequential numbers: 1.1, 1.2, 1.3
+                    sub_step_index = (step_index if step_index is not None else 0, index)
                 else:
-                    sub_step_index = (step_index, index)
+                    # Parallel is a child step - all sub-steps get the same parent number: 1.1, 1.1, 1.1
+                    sub_step_index = step_index
+
                 # All workflow step types have aexecute_stream() method
                 async for event in step.aexecute_stream(
                     step_input,

--- a/libs/agno/agno/workflow/v2/workflow.py
+++ b/libs/agno/agno/workflow/v2/workflow.py
@@ -1794,82 +1794,42 @@ class Workflow:
         step_display_cache = {}
 
         def get_step_display_number(step_index: Union[int, tuple], step_name: str = "") -> str:
-            """Generate smart step numbering based on current context"""
+            """Generate clean two-level step numbering: x.y format only"""
 
-            # Handle tuple format for nested parallel/loop sub-steps
+            # Handle tuple format for child steps
             if isinstance(step_index, tuple):
-                if len(step_index) == 2:
-                    parent_idx, sub_idx = step_index
+                if len(step_index) >= 2:
+                    parent_idx, sub_idx = step_index[0], step_index[1]
 
-                    # Extract the base parent index if it's nested
+                    # Extract base parent index if it's nested
                     if isinstance(parent_idx, tuple):
-                        # For deeply nested cases, extract the root index
                         base_idx = parent_idx[0] if len(parent_idx) > 0 else 0
                         while isinstance(base_idx, tuple) and len(base_idx) > 0:
                             base_idx = base_idx[0]
                     else:
                         base_idx = parent_idx
 
-                    # Check context for special formatting
-                    if current_primitive_context:
-                        context_type = current_primitive_context["type"]
-
-                        if context_type == "loop":
-                            iteration = current_primitive_context.get("current_iteration", 1)
-                            return f"Step {base_idx + 1}.{sub_idx + 1} (Iteration {iteration})"
-                        elif context_type == "parallel":
-                            # For parallel steps if inside some other nested step, all use the same parent number (your preferred approach)
-                            # Step 1.1, Step 1.1, Step 1.1 instead of Step 1.1, Step 1.2, Step 1.3
-                            return f"Step {base_idx + 1}.{sub_idx + 1}"
-
-                    # Default: regular hierarchical numbering
-                    return f"Step {base_idx + 1}.{sub_idx + 1}"
+                    # Check context for parallel special case
+                    if current_primitive_context and current_primitive_context["type"] == "parallel":
+                        # For parallel child steps, all get the same number
+                        return f"Step {base_idx + 1}.1"
+                    elif current_primitive_context and current_primitive_context["type"] == "loop":
+                        iteration = current_primitive_context.get("current_iteration", 1)
+                        return f"Step {base_idx + 1}.{sub_idx + 1} (Iteration {iteration})"
+                    else:
+                        # Regular child step numbering
+                        return f"Step {base_idx + 1}.{sub_idx + 1}"
                 else:
-                    # Fallback for other tuple formats
+                    # Single element tuple - treat as main step
                     return f"Step {step_index[0] + 1}"
 
-            # Handle simple integer step_index
-            step_key = f"{step_index}:{step_name}"
-
-            # Return cached value if we've already computed it
-            if step_key in step_display_cache:
-                return step_display_cache[step_key]
-
+            # Handle integer step_index - main step
             if not current_primitive_context:
-                # Regular sequential step
-                display_number = f"Step {step_index + 1}"
+                # Regular main step
+                return f"Step {step_index + 1}"
             else:
-                primitive_type = current_primitive_context["type"]
-                primitive_step_index = current_primitive_context["step_index"]
-
-                # Extract integer from primitive_step_index if it's a tuple
-                if isinstance(primitive_step_index, tuple):
-                    base_primitive_idx = primitive_step_index[0]
-                    while isinstance(base_primitive_idx, tuple) and len(base_primitive_idx) > 0:
-                        base_primitive_idx = base_primitive_idx[0]
-                else:
-                    base_primitive_idx = primitive_step_index
-
-                if primitive_type == "parallel":
-                    # For parallel: All parallel steps get the same number
-                    display_number = f"Step {base_primitive_idx + 1}.1"
-
-                elif primitive_type == "loop":
-                    # For loop: Step 1.1 (Iteration 1), Step 1.2 (Iteration 1), etc.
-                    iteration = current_primitive_context.get("current_iteration", 1)
-                    existing_loop_keys = [
-                        k for k in step_display_cache.keys() if k.startswith(f"loop:{base_primitive_idx}:")
-                    ]
-                    sub_index = len(existing_loop_keys) + 1
-                    display_number = f"Step {base_primitive_idx + 1}.{sub_index} (Iteration {iteration})"
-
-                else:
-                    # Fallback
-                    display_number = f"Step {step_index + 1}"
-
-            # Cache the result
-            step_display_cache[step_key] = display_number
-            return display_number
+                # This shouldn't happen with the new logic, but fallback
+                return f"Step {step_index + 1}"
 
         with Live(console=console, refresh_per_second=10) as live_log:
             status = Status("Starting workflow...", spinner="dots")
@@ -2607,82 +2567,42 @@ class Workflow:
         step_display_cache = {}
 
         def get_step_display_number(step_index: Union[int, tuple], step_name: str = "") -> str:
-            """Generate smart step numbering based on current context"""
+            """Generate clean two-level step numbering: x.y format only"""
 
-            # Handle tuple format for nested parallel/loop sub-steps
+            # Handle tuple format for child steps
             if isinstance(step_index, tuple):
-                if len(step_index) == 2:
-                    parent_idx, sub_idx = step_index
+                if len(step_index) >= 2:
+                    parent_idx, sub_idx = step_index[0], step_index[1]
 
-                    # Extract the base parent index if it's nested
+                    # Extract base parent index if it's nested
                     if isinstance(parent_idx, tuple):
-                        # For deeply nested cases, extract the root index
                         base_idx = parent_idx[0] if len(parent_idx) > 0 else 0
                         while isinstance(base_idx, tuple) and len(base_idx) > 0:
                             base_idx = base_idx[0]
                     else:
                         base_idx = parent_idx
 
-                    # Check context for special formatting
-                    if current_primitive_context:
-                        context_type = current_primitive_context["type"]
-
-                        if context_type == "loop":
-                            iteration = current_primitive_context.get("current_iteration", 1)
-                            return f"Step {base_idx + 1}.{sub_idx + 1} (Iteration {iteration})"
-                        elif context_type == "parallel":
-                            # For parallel steps if inside some other nested step, all use the same parent number (your preferred approach)
-                            # Step 1.1, Step 1.1, Step 1.1 instead of Step 1.1, Step 1.2, Step 1.3
-                            return f"Step {base_idx + 1}.{sub_idx + 1}"
-
-                    # Default: regular hierarchical numbering
-                    return f"Step {base_idx + 1}.{sub_idx + 1}"
+                    # Check context for parallel special case
+                    if current_primitive_context and current_primitive_context["type"] == "parallel":
+                        # For parallel child steps, all get the same number
+                        return f"Step {base_idx + 1}.1"
+                    elif current_primitive_context and current_primitive_context["type"] == "loop":
+                        iteration = current_primitive_context.get("current_iteration", 1)
+                        return f"Step {base_idx + 1}.{sub_idx + 1} (Iteration {iteration})"
+                    else:
+                        # Regular child step numbering
+                        return f"Step {base_idx + 1}.{sub_idx + 1}"
                 else:
-                    # Fallback for other tuple formats
+                    # Single element tuple - treat as main step
                     return f"Step {step_index[0] + 1}"
 
-            # Handle simple integer step_index
-            step_key = f"{step_index}:{step_name}"
-
-            # Return cached value if we've already computed it
-            if step_key in step_display_cache:
-                return step_display_cache[step_key]
-
+            # Handle integer step_index - main step
             if not current_primitive_context:
-                # Regular sequential step
-                display_number = f"Step {step_index + 1}"
+                # Regular main step
+                return f"Step {step_index + 1}"
             else:
-                primitive_type = current_primitive_context["type"]
-                primitive_step_index = current_primitive_context["step_index"]
-
-                # Extract integer from primitive_step_index if it's a tuple
-                if isinstance(primitive_step_index, tuple):
-                    base_primitive_idx = primitive_step_index[0]
-                    while isinstance(base_primitive_idx, tuple) and len(base_primitive_idx) > 0:
-                        base_primitive_idx = base_primitive_idx[0]
-                else:
-                    base_primitive_idx = primitive_step_index
-
-                if primitive_type == "parallel":
-                    # For parallel: All parallel steps get the same number
-                    display_number = f"Step {base_primitive_idx + 1}.1"
-
-                elif primitive_type == "loop":
-                    # For loop: Step 1.1 (Iteration 1), Step 1.2 (Iteration 1), etc.
-                    iteration = current_primitive_context.get("current_iteration", 1)
-                    existing_loop_keys = [
-                        k for k in step_display_cache.keys() if k.startswith(f"loop:{base_primitive_idx}:")
-                    ]
-                    sub_index = len(existing_loop_keys) + 1
-                    display_number = f"Step {base_primitive_idx + 1}.{sub_index} (Iteration {iteration})"
-
-                else:
-                    # Fallback
-                    display_number = f"Step {step_index + 1}"
-
-            # Cache the result
-            step_display_cache[step_key] = display_number
-            return display_number
+                # This shouldn't happen with the new logic, but fallback
+                return f"Step {step_index + 1}"
 
         with Live(console=console, refresh_per_second=10) as live_log:
             status = Status("Starting async workflow...", spinner="dots")
@@ -3073,8 +2993,9 @@ class Workflow:
 
                             # Live update the step panel with streaming content
                             if show_step_details and not step_started_printed:
-                                # For callable functions, show different title during streaming
-                                title = f"Step {current_step_index + 1}: {current_step_name} (Streaming...)"
+                                # Generate smart step number for streaming title (will use cached value)
+                                step_display = get_step_display_number(current_step_index, current_step_name)
+                                title = f"{step_display}: {current_step_name} (Streaming...)"
                                 if is_callable_function:
                                     title = "Custom Function (Streaming...)"
 


### PR DESCRIPTION
## Summary

`print_response_stream` display correct step number in case of nested workflow steps 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
