### PR TITLE
[fix] Fix session metrics counting history messages multiple times

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -5398,7 +5398,7 @@ class Agent:
         session_metrics = SessionMetrics()
         assistant_message_role = self.model.assistant_message_role if self.model is not None else "assistant"
         for m in messages:
-            if m.role == assistant_message_role and m.metrics is not None:
+            if m.role == assistant_message_role and m.metrics is not None and m.from_history is False:
                 session_metrics += m.metrics
         return session_metrics
 

--- a/libs/agno/tests/integration/agent/test_metrics.py
+++ b/libs/agno/tests/integration/agent/test_metrics.py
@@ -58,3 +58,39 @@ def test_run_response_metrics():
 
     assert len(response1.metrics.get("total_tokens", [])) == 1
     assert len(response2.metrics.get("total_tokens", [])) == 1
+
+
+def test_session_metrics_with_add_history():
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        add_history_to_messages=True,
+        num_history_runs=3,
+        markdown=True,
+        telemetry=False,
+        monitoring=False,
+    )
+
+    response = agent.run("Hi, my name is John")
+
+    input_tokens = sum(response.metrics.get("input_tokens", []))
+    output_tokens = sum(response.metrics.get("output_tokens", []))
+    total_tokens = sum(response.metrics.get("total_tokens", []))
+
+    assert input_tokens > 0
+    assert output_tokens > 0
+    assert total_tokens > 0
+    assert total_tokens == input_tokens + output_tokens
+
+    assert agent.session_metrics.input_tokens == input_tokens
+    assert agent.session_metrics.output_tokens == output_tokens
+    assert agent.session_metrics.total_tokens == total_tokens
+
+    response = agent.run("What did I just tell you?")
+
+    input_tokens += sum(response.metrics.get("input_tokens", []))
+    output_tokens += sum(response.metrics.get("output_tokens", []))
+    total_tokens += sum(response.metrics.get("total_tokens", []))
+
+    assert agent.session_metrics.input_tokens == input_tokens
+    assert agent.session_metrics.output_tokens == output_tokens
+    assert agent.session_metrics.total_tokens == total_tokens


### PR DESCRIPTION
The calculate_metrics method was counting historical messages from previous runs, causing inflated token counts. Added check to exclude history messages to match the behavior of aggregate_metrics_from_messages.

## Summary

Fixed a bug where session metrics were counting tokens from historical messages multiple times. 
When add_history_to_messages=True is enabled, the calculate_metrics method was including messages
from previous runs, causing session metrics to show about 2x the actual token usage.

The fix adds a check to exclude historical messages, matching how aggregate_metrics_from_messages already works. 

Please, let me know if I understood the problem wrong.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

How to reproduce the bug:
  1. Create an agent with add_history_to_messages=True
  2. Send 3 messages (like "hello" three times)
  3. Check session metrics vs debug output - session metrics will be about 2x higher

  Example:
  - Debug shows: 9,133 input tokens, 181 output tokens
  - Session metrics shows: 18,122 input tokens, 371 output tokens

  The change is a one-line fix in libs/agno/agno/agent/agent.py line 5401. 
  Let me know if this makes sense or if I missed something.
