### PR TITLE
Add `updated_at` to AgentSessionResponse, TeamSessionResponse

### DIFF
--- a/cookbook/agent_concepts/other/dynamic_instructions.py
+++ b/cookbook/agent_concepts/other/dynamic_instructions.py
@@ -1,7 +1,9 @@
 from agno.agent import Agent
 
+
 def get_instructions(agent: Agent):
-    return f"Make the story about {agent.session_state.get("current_user_id")}."
+    return f"Make the story about {agent.session_state.get('current_user_id')}."
+
 
 agent = Agent(instructions=get_instructions)
 agent.print_response("Write a 2 sentence story", user_id="john.doe")

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -4295,6 +4295,7 @@ class Agent:
             _instructions = self.instructions
             if callable(self.instructions):
                 import inspect
+
                 signature = inspect.signature(self.instructions)
                 if "agent" in signature.parameters:
                     _instructions = self.instructions(agent=self)
@@ -4305,7 +4306,7 @@ class Agent:
                 instructions.append(_instructions)
             elif isinstance(_instructions, list):
                 instructions.extend(_instructions)
-                
+
         # 3.1.1 Add instructions from the Model
         _model_instructions = self.model.get_instructions_for_model(self._tools_for_model)
         if _model_instructions is not None:

--- a/libs/agno/agno/app/playground/async_router.py
+++ b/libs/agno/agno/app/playground/async_router.py
@@ -501,6 +501,7 @@ def get_async_playground_router(
                     session_id=session.session_id,
                     session_name=session.session_data.get("session_name") if session.session_data else None,
                     created_at=session.created_at,
+                    updated_at=session.updated_at,
                 )
             )
         return agent_sessions
@@ -876,6 +877,7 @@ def get_async_playground_router(
                     session_id=session.session_id,
                     session_name=session.session_data.get("session_name") if session.session_data else None,
                     created_at=session.created_at,
+                    updated_at=session.updated_at,
                 )
             )
         return team_sessions

--- a/libs/agno/agno/app/playground/schemas.py
+++ b/libs/agno/agno/app/playground/schemas.py
@@ -91,6 +91,7 @@ class AgentSessionsResponse(BaseModel):
     session_id: Optional[str] = None
     session_name: Optional[str] = None
     created_at: Optional[int] = None
+    updated_at: Optional[int] = None
 
 
 class MemoryResponse(BaseModel):
@@ -212,6 +213,7 @@ class TeamSessionResponse(BaseModel):
     session_id: Optional[str] = None
     session_name: Optional[str] = None
     created_at: Optional[int] = None
+    updated_at: Optional[int] = None
 
 
 class TeamRenameRequest(BaseModel):

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -5052,6 +5052,7 @@ class Team:
             _instructions = self.instructions
             if callable(self.instructions):
                 import inspect
+
                 signature = inspect.signature(self.instructions)
                 if "team" in signature.parameters:
                     _instructions = self.instructions(team=self)


### PR DESCRIPTION
## Summary

Team and Agent sessions have a property `updated_at` that is not included in the sessions attributes when calling the Playground's `/team/{id}/sessions` and `/agents/{id}/sessions`.

This PR includes `updated_at` to the responses, which will allow for interfaces where the most recently updated sessions appear first, like in ChatGPT, Claude, and other chats.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] N/A Documentation updated (comments, docstrings)
- [ ] N/A Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (I don't think there are tests for these functions)
