### PR TITLE
Mme/ag UI results

### DIFF
--- a/libs/agno/agno/app/agui/async_router.py
+++ b/libs/agno/agno/app/agui/async_router.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from agno.agent.agent import Agent
-from agno.app.agui.utils import async_stream_agno_response_as_agui_events, get_last_user_message
+from agno.app.agui.utils import async_stream_agno_response_as_agui_events, convert_agui_messages_to_agno_messages
 from agno.team.team import Team
 
 logger = logging.getLogger(__name__)
@@ -28,12 +28,12 @@ async def run_agent(agent: Agent, run_input: RunAgentInput) -> AsyncIterator[Bas
 
     try:
         # Preparing the input for the Agent and emitting the run started event
-        message = get_last_user_message(run_input.messages)
+        messages = convert_agui_messages_to_agno_messages(run_input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
         # Request streaming response from agent
         response_stream = await agent.arun(
-            message=message,
+            messages=messages,
             session_id=run_input.thread_id,
             stream=True,
             stream_intermediate_steps=True,
@@ -56,12 +56,12 @@ async def run_team(team: Team, input: RunAgentInput) -> AsyncIterator[BaseEvent]
     run_id = input.run_id or str(uuid.uuid4())
     try:
         # Extract the last user message for team execution
-        user_message = get_last_user_message(input.messages) if input.messages else ""
+        messages = convert_agui_messages_to_agno_messages(input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=input.thread_id, run_id=run_id)
 
         # Request streaming response from team
         response_stream = await team.arun(
-            message=user_message,
+            messages=messages,
             session_id=input.thread_id,
             stream=True,
             stream_intermediate_steps=True,

--- a/libs/agno/agno/app/agui/sync_router.py
+++ b/libs/agno/agno/app/agui/sync_router.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from agno.agent.agent import Agent
-from agno.app.agui.utils import stream_agno_response_as_agui_events, convert_agui_messages_to_agno_messages
+from agno.app.agui.utils import convert_agui_messages_to_agno_messages, stream_agno_response_as_agui_events
 from agno.team.team import Team
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ def run_team(team: Team, input: RunAgentInput) -> Iterator[BaseEvent]:
     run_id = input.run_id or str(uuid.uuid4())
     try:
         # Extract the last user message for team execution
-        messages = convert_agui_messages_to_agno_messages(run_input.messages or [])
+        messages = convert_agui_messages_to_agno_messages(input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=input.thread_id, run_id=run_id)
 
         # Request streaming response from team

--- a/libs/agno/agno/app/agui/sync_router.py
+++ b/libs/agno/agno/app/agui/sync_router.py
@@ -16,7 +16,7 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from agno.agent.agent import Agent
-from agno.app.agui.utils import get_last_user_message, stream_agno_response_as_agui_events
+from agno.app.agui.utils import stream_agno_response_as_agui_events, convert_agui_messages_to_agno_messages
 from agno.team.team import Team
 
 logger = logging.getLogger(__name__)
@@ -28,12 +28,12 @@ def run_agent(agent: Agent, run_input: RunAgentInput) -> Iterator[BaseEvent]:
 
     try:
         # Preparing the input for the Agent and emitting the run started event
-        message = get_last_user_message(run_input.messages)
+        messages = convert_agui_messages_to_agno_messages(run_input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
         # Request streaming response from agent
         response_stream = agent.run(
-            message=message,
+            messages=messages,
             session_id=run_input.thread_id,
             stream=True,
             stream_intermediate_steps=True,
@@ -56,12 +56,12 @@ def run_team(team: Team, input: RunAgentInput) -> Iterator[BaseEvent]:
     run_id = input.run_id or str(uuid.uuid4())
     try:
         # Extract the last user message for team execution
-        user_message = get_last_user_message(input.messages) if input.messages else ""
+        messages = convert_agui_messages_to_agno_messages(run_input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=input.thread_id, run_id=run_id)
 
         # Request streaming response from team
         response_stream = team.run(
-            message=user_message,
+            messages=messages,
             session_id=input.thread_id,
             stream=True,
             stream_intermediate_steps=True,

--- a/libs/agno/agno/app/agui/utils.py
+++ b/libs/agno/agno/app/agui/utils.py
@@ -18,15 +18,15 @@ from ag_ui.core import (
     TextMessageStartEvent,
     ToolCallArgsEvent,
     ToolCallEndEvent,
-    ToolCallStartEvent,
     ToolCallResultEvent,
+    ToolCallStartEvent,
 )
 from ag_ui.core.types import Message as AGUIMessage
 
+from agno.models.message import Message
 from agno.run.response import RunEvent, RunResponseContentEvent, RunResponseEvent
 from agno.run.team import RunResponseContentEvent as TeamRunResponseContentEvent
 from agno.run.team import TeamRunEvent, TeamRunResponseEvent
-from agno.models.message import Message
 
 
 @dataclass
@@ -66,31 +66,28 @@ class EventBuffer:
 
         return False
 
+
 def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
     """Convert AG-UI messages to Agno messages."""
     result = []
     for msg in messages:
         if msg.role == "tool":
-            result.append(Message(
-                role="tool",
-                tool_call_id=msg.tool_call_id,
-                content=msg.content
-            ))
+            result.append(Message(role="tool", tool_call_id=msg.tool_call_id, content=msg.content))
         elif msg.role == "assistant":
             tool_calls = None
             if msg.tool_calls:
                 tool_calls = [call.model_dump() for call in msg.tool_calls]
-            result.append(Message(
-                role="assistant",
-                content=msg.content,
-                tool_calls=tool_calls,
-            ))
+            result.append(
+                Message(
+                    role="assistant",
+                    content=msg.content,
+                    tool_calls=tool_calls,
+                )
+            )
         elif msg.role == "user":
-            result.append(Message(
-                role="user",
-                content=msg.content
-            ))
+            result.append(Message(role="user", content=msg.content))
     return result
+
 
 def extract_team_response_chunk_content(response: TeamRunResponseContentEvent) -> str:
     """Given a response stream chunk, find and extract the content."""
@@ -238,7 +235,7 @@ def _create_completion_events(
     if message_started:
         end_message_event = TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id)
         events_to_emit.append(end_message_event)
-    
+
     # emit frontend tool calls, i.e. external_execution=True
     if chunk.event == RunEvent.run_paused and chunk.tools:
         for tool in chunk.tools:
@@ -329,8 +326,14 @@ def stream_agno_response_as_agui_events(
 
     for chunk in response_stream:
         # Handle the lifecycle end event
-        if chunk.event == RunEvent.run_completed or chunk.event == TeamRunEvent.run_completed or chunk.event == RunEvent.run_paused:
-            completion_events = _create_completion_events(chunk, event_buffer, message_started, message_id, thread_id, run_id)
+        if (
+            chunk.event == RunEvent.run_completed
+            or chunk.event == TeamRunEvent.run_completed
+            or chunk.event == RunEvent.run_paused
+        ):
+            completion_events = _create_completion_events(
+                chunk, event_buffer, message_started, message_id, thread_id, run_id
+            )
             for event in completion_events:
                 events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
                 for emit_event in events_to_emit:
@@ -360,8 +363,14 @@ async def async_stream_agno_response_as_agui_events(
 
     async for chunk in response_stream:
         # Handle the lifecycle end event
-        if chunk.event == RunEvent.run_completed or chunk.event == TeamRunEvent.run_completed or chunk.event == RunEvent.run_paused:
-            completion_events = _create_completion_events(chunk, event_buffer, message_started, message_id, thread_id, run_id)
+        if (
+            chunk.event == RunEvent.run_completed
+            or chunk.event == TeamRunEvent.run_completed
+            or chunk.event == RunEvent.run_paused
+        ):
+            completion_events = _create_completion_events(
+                chunk, event_buffer, message_started, message_id, thread_id, run_id
+            )
             for event in completion_events:
                 events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
                 for emit_event in events_to_emit:


### PR DESCRIPTION
## Summary

1. Support frontend tool calls in AG-UI
e.g. via:

```
@tool(external_execution=True)
def change_background(background: str) -> str: # pylint: disable=unused-argument
    """
    Change the background color of the chat.

    Args:
        background: str: The background color to change to.
    """
```

2. Support surfacing backend tool calls in AG-UI

Enabled by sending the new `TOOL_CALL_RESULT` event.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [?] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Instead of sending only the last message, it is now sending all the messages from AG-UI to Agno.
