### PR TITLE
feat: log warning if using deprecated sse transport with mcp

### DIFF
--- a/libs/agno/agno/tools/mcp.py
+++ b/libs/agno/agno/tools/mcp.py
@@ -82,6 +82,9 @@ class MCPTools(Toolkit):
         """
         super().__init__(name="MCPTools", **kwargs)
 
+        if transport == "sse":
+            log_warning("SSE as a standalone transport is deprecated. Please use Streamable HTTP instead.")
+
         # Set these after `__init__` to bypass the `_check_tools_filters`
         # because tools are not available until `initialize()` is called.
         self.include_tools = include_tools
@@ -303,10 +306,14 @@ class MultiMCPTools(Toolkit):
         """
         super().__init__(name="MultiMCPTools", **kwargs)
 
+        if urls_transports is not None:
+            if "sse" in urls_transports:
+                log_warning("SSE as a standalone transport is deprecated. Please use Streamable HTTP instead.")
+
         if urls is not None:
             if urls_transports is None:
                 log_warning(
-                    "The default transport 'sse' will be used. You can explicitly set the transports by providing the urls_transports parameter."
+                    "The default transport 'streamable-http' will be used. You can explicitly set the transports by providing the urls_transports parameter."
                 )
             else:
                 if len(urls) != len(urls_transports):
@@ -355,7 +362,7 @@ class MultiMCPTools(Toolkit):
                         self.server_params_list.append(SSEClientParams(url=url))
             else:
                 for url in urls:
-                    self.server_params_list.append(SSEClientParams(url=url))
+                    self.server_params_list.append(StreamableHTTPClientParams(url=url))
 
         self._async_exit_stack = AsyncExitStack()
 


### PR DESCRIPTION
- Add warnings if using the deprecated SSE transport with our MCP integration
- Default to Streamable HTTP (instead of the deprecated SSE) with MultiMCPTools if no transports are specified