### PR TITLE
feat: add direct support for fallback models in openrouter

### DIFF
--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -17,6 +17,7 @@ class OpenRouter(OpenAILike):
         api_key (Optional[str]): The API key.
         base_url (str): The base URL. Defaults to "https://openrouter.ai/api/v1".
         max_tokens (int): The maximum number of tokens. Defaults to 1024.
+        models (Optional[list[str]]): A list of fallback models for openrouter to use if `id` fails. 
     """
 
     id: str = "gpt-4o"
@@ -26,3 +27,12 @@ class OpenRouter(OpenAILike):
     api_key: Optional[str] = getenv("OPENROUTER_API_KEY")
     base_url: str = "https://openrouter.ai/api/v1"
     max_tokens: int = 1024
+    models: Optional[list[str]] = None
+
+     def __post_init__(self):
+        super().__post_init__()
+        self.request_params = {
+            "extra_body": {
+                "models": self.models,
+            }
+        }


### PR DESCRIPTION
## Summary

Describe key changes, mention related issues or motivation for the 

This PR gives first class support to open router model fallback vs burying this option under openrouter's docs. 

Please see https://openrouter.ai/docs/features/model-routing#using-with-openai-sdk

(If applicable, issue number: #\_\_\_\_)

#3318 is related

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)

Will update PR with proper docs/formatting tomorrow. Just wrote this up in the github web editor