### PR TITLE
fix: mangled litellm multiple streaming tool calls

### DIFF
--- a/cookbook/tools/mem0_tools.py
+++ b/cookbook/tools/mem0_tools.py
@@ -3,7 +3,7 @@ This example demonstrates how to use the Mem0 toolkit with Agno agents.
 
 To get started, please export your Mem0 API key as an environment variable. You can get your Mem0 API key from https://app.mem0.ai/dashboard/api-keys
 
-export MEM0_API_KEY=<your-mem0-api-key> 
+export MEM0_API_KEY=<your-mem0-api-key>
 export MEM0_ORG_ID=<your-mem0-org-id> (Optional)
 export MEM0_PROJECT_ID=<your-mem0-project-id> (Optional)
 """

--- a/cookbook/workflows/async_blog_post_generator.py
+++ b/cookbook/workflows/async_blog_post_generator.py
@@ -485,7 +485,7 @@ if __name__ == "__main__":
         )
     )
     pprint_run_response(blog_post, markdown=True)
-    
+
     # or run it synchronously
     # blog_post: RunResponse = generate_blog_post.run(
     #     topic=topic,

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -236,9 +236,12 @@ class LiteLLM(Model):
 
                 if hasattr(choice_delta, "tool_calls") and choice_delta.tool_calls:
                     processed_tool_calls = []
-                    for i, tool_call in enumerate(choice_delta.tool_calls):
-                        # Create a basic structure with index
-                        tool_call_dict = {"index": i, "type": "function"}
+                    for tool_call in choice_delta.tool_calls:
+                        # Get the actual index from the tool call, defaulting to 0 if not available
+                        actual_index = getattr(tool_call, "index", 0) if hasattr(tool_call, "index") else 0
+
+                        # Create a basic structure with the correct index
+                        tool_call_dict = {"index": actual_index, "type": "function"}
 
                         # Extract ID if available
                         if hasattr(tool_call, "id") and tool_call.id is not None:

--- a/libs/agno/agno/tools/linkup.py
+++ b/libs/agno/agno/tools/linkup.py
@@ -45,7 +45,9 @@ class LinkupTools(Toolkit):
         """
         try:
             response = self.linkup.search(
-                query=query, depth=depth or self.depth, output_type=output_type or self.output_type  # type: ignore
+                query=query,
+                depth=depth or self.depth,
+                output_type=output_type or self.output_type,  # type: ignore
             )
             return response
         except Exception as e:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -422,7 +422,7 @@ class Workflow:
         if self.__class__.arun is not Workflow.arun:
             self._subclass_arun = self.__class__.arun.__get__(self)
             run_type = "coroutine"
-            
+
             # Get the parameters of the async run method
             sig = inspect.signature(self.__class__.arun)
 
@@ -478,7 +478,7 @@ class Workflow:
             # the Workflow.run() method will be called and will log an error
             self._subclass_run = self.run
             self._subclass_arun = self.arun
-            
+
             self._run_parameters = {}
             self._run_return_type = None
 

--- a/libs/agno/tests/integration/models/litellm/test_tool_use.py
+++ b/libs/agno/tests/integration/models/litellm/test_tool_use.py
@@ -71,9 +71,8 @@ def test_tool_use_stream():
     for chunk in response_stream:
         responses.append(chunk)
         print(chunk.content)
-        if chunk.tools:
-            if any(tc.tool_name for tc in chunk.tools):
-                tool_call_seen = True
+        if hasattr(chunk, "event") and chunk.event in ["ToolCallStarted", "ToolCallCompleted"]:
+            tool_call_seen = True
 
     assert len(responses) > 0
     assert tool_call_seen, "No tool calls observed in stream"
@@ -126,9 +125,8 @@ async def test_async_tool_use_streaming():
 
     async for chunk in response_stream:
         responses.append(chunk)
-        if chunk.tools:
-            if any(tc.tool_name for tc in chunk.tools):
-                tool_call_seen = True
+        if hasattr(chunk, "event") and chunk.event in ["ToolCallStarted", "ToolCallCompleted"]:
+            tool_call_seen = True
 
     assert len(responses) > 0
     assert tool_call_seen, "No tool calls observed in stream"

--- a/libs/agno/tests/integration/workflows/test_async_workflows.py
+++ b/libs/agno/tests/integration/workflows/test_async_workflows.py
@@ -18,110 +18,82 @@ from agno.workflow import Workflow
 
 class SimpleAsyncWorkflow(Workflow):
     """Simple async workflow that returns a RunResponse."""
-    
+
     description: str = "A simple async workflow for testing"
-    
+
     agent = Agent(model=OpenAIChat(id="gpt-4o-mini"))
-    
+
     async def arun(self, message: str) -> RunResponse:
-        return RunResponse(
-            run_id=self.run_id,
-            content=f"Async response: {message}"
-        )
+        return RunResponse(run_id=self.run_id, content=f"Async response: {message}")
 
 
 class AsyncGeneratorWorkflow(Workflow):
     """Async workflow that yields multiple RunResponse events."""
-    
+
     description: str = "An async generator workflow for testing"
-    
+
     agent = Agent(model=OpenAIChat(id="gpt-4o-mini"))
-    
+
     async def arun(self, message: str) -> AsyncIterator[RunResponse]:
         # Yield multiple responses
-        yield RunResponse(
-            run_id=self.run_id,
-            content=f"First async response: {message}"
-        )
-        yield RunResponse(
-            run_id=self.run_id,
-            content=f"Second async response: {message}"
-        )
-        yield WorkflowCompletedEvent(
-            run_id=self.run_id,
-            content=f"Workflow completed: {message}"
-        )
+        yield RunResponse(run_id=self.run_id, content=f"First async response: {message}")
+        yield RunResponse(run_id=self.run_id, content=f"Second async response: {message}")
+        yield WorkflowCompletedEvent(run_id=self.run_id, content=f"Workflow completed: {message}")
 
 
 class MixedWorkflow(Workflow):
     """Workflow with both sync and async methods."""
-    
+
     description: str = "A workflow with both sync and async methods"
-    
+
     agent = Agent(model=OpenAIChat(id="gpt-4o-mini"))
-    
+
     def run(self, message: str) -> RunResponse:
-        return RunResponse(
-            run_id=self.run_id,
-            content=f"Sync response: {message}"
-        )
-    
+        return RunResponse(run_id=self.run_id, content=f"Sync response: {message}")
+
     async def arun(self, message: str) -> RunResponse:
-        return RunResponse(
-            run_id=self.run_id,
-            content=f"Async response: {message}"
-        )
+        return RunResponse(run_id=self.run_id, content=f"Async response: {message}")
 
 
 class AsyncGeneratorWithStateWorkflow(Workflow):
     """Async generator workflow that maintains state."""
-    
+
     description: str = "An async generator workflow with state management"
-    
+
     agent = Agent(model=OpenAIChat(id="gpt-4o-mini"))
-    
+
     async def arun(self, message: str) -> AsyncIterator[RunResponse]:
         # Initialize state
         if "counter" not in self.session_state:
             self.session_state["counter"] = 0
-        
+
         # Increment counter
         self.session_state["counter"] += 1
-        
-        yield RunResponse(
-            run_id=self.run_id,
-            content=f"Step {self.session_state['counter']}: {message}"
-        )
-        
+
+        yield RunResponse(run_id=self.run_id, content=f"Step {self.session_state['counter']}: {message}")
+
         # Simulate some async work
         await asyncio.sleep(0.01)
-        
-        yield RunResponse(
-            run_id=self.run_id,
-            content=f"Step {self.session_state['counter'] + 1}: Processing complete"
-        )
-        
+
+        yield RunResponse(run_id=self.run_id, content=f"Step {self.session_state['counter'] + 1}: Processing complete")
+
         yield WorkflowCompletedEvent(
-            run_id=self.run_id,
-            content=f"Workflow completed with {self.session_state['counter'] + 1} steps"
+            run_id=self.run_id, content=f"Workflow completed with {self.session_state['counter'] + 1} steps"
         )
 
 
 class ErrorHandlingAsyncWorkflow(Workflow):
     """Async workflow that tests error handling."""
-    
+
     description: str = "An async workflow for testing error handling"
-    
+
     agent = Agent(model=OpenAIChat(id="gpt-4o-mini"))
-    
+
     async def arun(self, should_error: bool = False) -> RunResponse:
         if should_error:
             raise ValueError("Test error from async workflow")
-        
-        return RunResponse(
-            run_id=self.run_id,
-            content="Async workflow completed successfully"
-        )
+
+        return RunResponse(run_id=self.run_id, content="Async workflow completed successfully")
 
 
 # Basic async workflow tests
@@ -130,7 +102,7 @@ async def test_simple_async_workflow():
     """Test basic async workflow functionality."""
     workflow = SimpleAsyncWorkflow()
     response = await workflow.arun(message="Hello, async world!")
-    
+
     assert response is not None
     assert response.content == "Async response: Hello, async world!"
     assert response.run_id is not None
@@ -143,10 +115,10 @@ async def test_simple_async_workflow_with_storage(workflow_storage):
     """Test async workflow with storage."""
     workflow = SimpleAsyncWorkflow(storage=workflow_storage)
     response = await workflow.arun(message="Hello, async world!")
-    
+
     assert response is not None
     assert response.content == "Async response: Hello, async world!"
-    
+
     # Verify storage was used
     stored_session = workflow_storage.read(session_id=workflow.session_id)
     assert stored_session is not None
@@ -159,16 +131,16 @@ async def test_async_generator_workflow():
     """Test async generator workflow functionality."""
     workflow = AsyncGeneratorWorkflow()
     responses = []
-    
+
     async for response in workflow.arun(message="Hello, generator!"):
         responses.append(response)
-    
+
     assert len(responses) == 3
     assert responses[0].content == "First async response: Hello, generator!"
     assert responses[1].content == "Second async response: Hello, generator!"
     assert responses[2].content == "Workflow completed: Hello, generator!"
     assert isinstance(responses[2], WorkflowCompletedEvent)
-    
+
     # Verify all responses have the same run_id
     run_ids = {r.run_id for r in responses}
     assert len(run_ids) == 1
@@ -180,12 +152,12 @@ async def test_async_generator_workflow_with_storage(workflow_storage):
     """Test async generator workflow with storage."""
     workflow = AsyncGeneratorWorkflow(storage=workflow_storage)
     responses = []
-    
+
     async for response in workflow.arun(message="Hello, generator!"):
         responses.append(response)
-    
+
     assert len(responses) == 3
-    
+
     # Verify storage was used
     stored_session = workflow_storage.read(session_id=workflow.session_id)
     assert stored_session is not None
@@ -197,15 +169,15 @@ async def test_async_generator_with_state(workflow_storage):
     """Test async generator workflow with state management."""
     workflow = AsyncGeneratorWithStateWorkflow(storage=workflow_storage)
     responses = []
-    
+
     async for response in workflow.arun(message="State test"):
         responses.append(response)
-    
+
     assert len(responses) == 3
     assert "Step 1: State test" in responses[0].content
     assert "Step 2: Processing complete" in responses[1].content
     assert "Workflow completed with 2 steps" in responses[2].content
-    
+
     # Verify state was persisted
     stored_session = workflow_storage.read(session_id=workflow.session_id)
     assert stored_session is not None
@@ -218,7 +190,7 @@ async def test_mixed_workflow_async():
     """Test mixed workflow using async method."""
     workflow = MixedWorkflow()
     response = await workflow.arun(message="Mixed async")
-    
+
     assert response.content == "Async response: Mixed async"
 
 
@@ -226,7 +198,7 @@ def test_mixed_workflow_sync():
     """Test mixed workflow using sync method."""
     workflow = MixedWorkflow()
     response = workflow.run(message="Mixed sync")
-    
+
     assert response.content == "Sync response: Mixed sync"
 
 
@@ -235,11 +207,11 @@ def test_mixed_workflow_sync():
 async def test_async_workflow_error_handling():
     """Test error handling in async workflows."""
     workflow = ErrorHandlingAsyncWorkflow()
-    
+
     # Test successful execution
     response = await workflow.arun(should_error=False)
     assert response.content == "Async workflow completed successfully"
-    
+
     # Test error handling
     with pytest.raises(ValueError, match="Test error from async workflow"):
         await workflow.arun(should_error=True)
@@ -248,36 +220,37 @@ async def test_async_workflow_error_handling():
 @pytest.mark.asyncio
 async def test_async_generator_error_handling():
     """Test error handling in async generators."""
+
     class ErrorGeneratorWorkflow(Workflow):
         description: str = "Async generator with error"
-        
+
         async def arun(self, should_error: bool = False) -> AsyncIterator[RunResponse]:
             yield RunResponse(run_id=self.run_id, content="Starting...")
-            
+
             if should_error:
                 raise ValueError("Error in generator")
-            
+
             yield RunResponse(run_id=self.run_id, content="Completed")
-    
+
     workflow = ErrorGeneratorWorkflow()
-    
+
     # Test successful execution
     responses = []
     async for response in workflow.arun(should_error=False):
         responses.append(response)
-    
+
     assert len(responses) == 2
     assert responses[0].content == "Starting..."
     assert responses[1].content == "Completed"
-    
+
     # Test error handling
     workflow = ErrorGeneratorWorkflow()
     responses = []
-    
+
     with pytest.raises(ValueError, match="Error in generator"):
         async for response in workflow.arun(should_error=True):
             responses.append(response)
-    
+
     # Should have received the first response before the error
     assert len(responses) == 1
     assert responses[0].content == "Starting..."
@@ -288,26 +261,23 @@ async def test_async_generator_error_handling():
 async def test_workflow_session_persistence(workflow_storage):
     """Test that workflow sessions are properly persisted."""
     workflow = AsyncGeneratorWithStateWorkflow(storage=workflow_storage)
-    
+
     # First run
     responses = []
     async for response in workflow.arun(message="First run"):
         responses.append(response)
-    
+
     session_id = workflow.session_id
     assert session_id is not None
-    
+
     # Create new workflow instance with same session
-    workflow2 = AsyncGeneratorWithStateWorkflow(
-        storage=workflow_storage,
-        session_id=session_id
-    )
-    
+    workflow2 = AsyncGeneratorWithStateWorkflow(storage=workflow_storage, session_id=session_id)
+
     # Second run - should continue from previous state
     responses2 = []
     async for response in workflow2.arun(message="Second run"):
         responses2.append(response)
-    
+
     # Counter should be 2 (incremented from 1)
     assert "Step 2: Second run" in responses2[0].content
     assert "Step 3: Processing complete" in responses2[1].content
@@ -319,15 +289,12 @@ async def test_workflow_session_persistence(workflow_storage):
 async def test_concurrent_async_workflows():
     """Test running multiple async workflows concurrently."""
     workflows = [SimpleAsyncWorkflow() for _ in range(3)]
-    
+
     # Run all workflows concurrently
-    tasks = [
-        workflow.arun(message=f"Concurrent test {i}")
-        for i, workflow in enumerate(workflows)
-    ]
-    
+    tasks = [workflow.arun(message=f"Concurrent test {i}") for i, workflow in enumerate(workflows)]
+
     responses = await asyncio.gather(*tasks)
-    
+
     assert len(responses) == 3
     for i, response in enumerate(responses):
         assert response.content == f"Async response: Concurrent test {i}"
@@ -337,28 +304,24 @@ async def test_concurrent_async_workflows():
 async def test_concurrent_async_generators():
     """Test running multiple async generators concurrently."""
     workflows = [AsyncGeneratorWorkflow() for _ in range(2)]
-    
+
     async def collect_responses(workflow, message):
         responses = []
         async for response in workflow.arun(message=message):
             responses.append(response)
         return responses
-    
+
     # Run all workflows concurrently
-    tasks = [
-        collect_responses(workflow, f"Generator test {i}")
-        for i, workflow in enumerate(workflows)
-    ]
-    
+    tasks = [collect_responses(workflow, f"Generator test {i}") for i, workflow in enumerate(workflows)]
+
     all_responses = await asyncio.gather(*tasks)
-    
+
     assert len(all_responses) == 2
     for i, responses in enumerate(all_responses):
         assert len(responses) == 3
         assert f"Generator test {i}" in responses[0].content
 
 
-
 if __name__ == "__main__":
     # Run tests directly for debugging
-    pytest.main([__file__, "-v"]) 
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

When Agno is run through LiteLLM against OpenAI chat models (eg. GPT4.1), multiple streamed tool_calls lose their individual argument streams. Each call’s index arrives correctly from OpenAI, but Agno drops that index while converting LiteLLM deltas, so every chunk is treated as index: 0. The argument strings for different tools are then concatenated, producing invalid JSON.

Example to test-
```py
import asyncio

from agno.agent import Agent
from agno.models.litellm import LiteLLM
from agno.tools.exa import ExaTools

agent = Agent(
    tools=[ExaTools()],
    model=LiteLLM(
        id="gpt-4.1-2025-04-14",
    ),
    add_history_to_messages=False,
    stream_intermediate_steps=True,
    show_tool_calls=True,
    debug_mode=True,
    markdown=True,
)

asyncio.run(
    agent.aprint_response(
        "Write a detailed analysis on Trumps tariffs. What is sellside's reaction? How would it impact our portfolio",
        stream=True,
        show_full_reasoning=True,
        stream_intermediate_steps=True,
        show_tool_calls=True,
    )
)

```

Error SS

<img width="715" height="872" alt="image" src="https://github.com/user-attachments/assets/2e0779ca-a367-4160-84d2-d952bff8d7b5" />

Fixes: https://github.com/agno-agi/agno/issues/3826

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
