### PR TITLE
fix: Session state in streaming

### DIFF
--- a/cookbook/agent_concepts/state/session_state_user_id.py
+++ b/cookbook/agent_concepts/state/session_state_user_id.py
@@ -12,7 +12,6 @@ import json
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
-from agno.utils.log import log_info
 
 # In-memory database to store user shopping lists
 # Organized by user ID and session ID
@@ -86,7 +85,7 @@ agent.print_response(
     session_id="user_2_session_1",
 )
 agent.print_response(
-    "Add apples and grapesto the shopping list",
+    "Add apples and grapes to the shopping list",
     stream=True,
     user_id=user_id_3,
     session_id="user_3_session_1",

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1162,8 +1162,6 @@ class Agent:
                     )
                 else:
                     return self.run_response
-            finally:
-                self._reset_session_state()
 
         # If we get here, all retries failed
         if last_exception is not None:
@@ -1540,8 +1538,6 @@ class Agent:
                     )
                 else:
                     return self.run_response
-            finally:
-                self._reset_session_state()
 
         # If we get here, all retries failed
         if last_exception is not None:
@@ -1797,8 +1793,6 @@ class Agent:
                     return self.create_run_response(
                         run_state=RunStatus.cancelled, content="Operation cancelled by user", run_response=run_response
                     )
-            finally:
-                self._reset_session_state()
 
         # If we get here, all retries failed
         if last_exception is not None:
@@ -2196,8 +2190,6 @@ class Agent:
                     return self.create_run_response(
                         run_state=RunStatus.cancelled, content="Operation cancelled by user", run_response=run_response
                     )
-            finally:
-                self._reset_session_state()
 
         # If we get here, all retries failed
         if last_exception is not None:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -974,8 +974,6 @@ class Team:
                         from_run_response=run_response,
                         session_id=session_id,
                     )
-            finally:
-                self._reset_session_state()
 
         # If we get here, all retries failed
         if last_exception is not None:
@@ -1363,8 +1361,6 @@ class Team:
                         from_run_response=run_response,
                         session_id=session_id,
                     )
-            finally:
-                self._reset_session_state()
 
         # If we get here, all retries failed
         if last_exception is not None:

--- a/libs/agno/tests/integration/agent/test_agent_session_state.py
+++ b/libs/agno/tests/integration/agent/test_agent_session_state.py
@@ -26,8 +26,8 @@ def test_agent_session_state(chat_agent, agent_storage):
     assert response.run_id is not None
     assert chat_agent.session_id == session_id
     assert chat_agent.session_name == "my_test_session"
-    assert chat_agent.session_state == {"test_key": "test_value"}
-    assert chat_agent.team_session_state == {"team_test_key": "team_test_value"}
+    assert chat_agent.session_state == {"current_session_id": session_id, "test_key": "test_value"}
+    assert chat_agent.team_session_state == {"current_session_id": session_id, "team_test_key": "team_test_value"}
     session_from_storage = agent_storage.read(session_id=session_id)
     assert session_from_storage is not None
     assert session_from_storage.session_id == session_id
@@ -42,22 +42,41 @@ def test_agent_session_state(chat_agent, agent_storage):
     assert response.run_id is not None
     assert chat_agent.session_id == session_id
     assert chat_agent.session_name == "my_test_session"
-    assert chat_agent.session_state == {"test_key": "test_value"}
+    assert chat_agent.session_state == {"current_session_id": session_id, "test_key": "test_value"}
 
     # Run with a different session ID
     response = chat_agent.run("What can you do?", session_id="session_2")
     assert response.run_id is not None
     assert chat_agent.session_id == "session_2"
     assert chat_agent.session_name is None
-    assert chat_agent.session_state == {}
+    assert chat_agent.session_state == {"current_session_id": "session_2"}
 
     # Run again with original session ID
     response = chat_agent.run("What name should I call you?", session_id=session_id)
     assert response.run_id is not None
     assert chat_agent.session_id == session_id
     assert chat_agent.session_name == "my_test_session"
-    assert chat_agent.session_state == {"test_key": "test_value"}
+    assert chat_agent.session_state == {"current_session_id": session_id, "test_key": "test_value"}
 
+
+
+def test_agent_session_state_stream(chat_agent):
+    session_id = "session_1"
+
+    chat_agent.session_id = session_id
+    chat_agent.session_name = "my_test_session"
+    chat_agent.session_state = {"test_key": "test_value"}
+    chat_agent.team_session_state = {"team_test_key": "team_test_value"}
+
+    for _ in chat_agent.run("Hello, how are you?", stream=True):
+        pass
+    response = chat_agent.run_response
+    assert response.run_id is not None
+    assert chat_agent.session_id == session_id
+    assert chat_agent.session_name == "my_test_session"
+    assert chat_agent.session_state == {"current_session_id": session_id, "test_key": "test_value"}
+    assert chat_agent.team_session_state == {"current_session_id": session_id, "team_test_key": "team_test_value"}
+    
 
 def test_agent_session_state_switch_session_id(chat_agent):
     session_id_1 = "session_1"
@@ -71,21 +90,21 @@ def test_agent_session_state_switch_session_id(chat_agent):
     assert response.run_id is not None
     assert chat_agent.session_id == session_id_1
     assert chat_agent.session_name == "my_test_session"
-    assert chat_agent.session_state == {"test_key": "test_value"}
+    assert chat_agent.session_state == {"current_session_id": session_id_1, "test_key": "test_value"}
 
     # Second run with different session ID
     response = chat_agent.run("What can you do?", session_id=session_id_2)
     assert response.run_id is not None
     assert chat_agent.session_id == session_id_2
     assert chat_agent.session_name is None
-    assert chat_agent.session_state == {}
+    assert chat_agent.session_state == {"current_session_id": session_id_2}
 
     # Third run with the original session ID
     response = chat_agent.run("What can you do?", session_id=session_id_1)
     assert response.run_id is not None
     assert chat_agent.session_id == session_id_1
     assert chat_agent.session_name == "my_test_session"
-    assert chat_agent.session_state == {"test_key": "test_value"}
+    assert chat_agent.session_state == {"current_session_id": session_id_1, "test_key": "test_value"}
 
 
 def test_agent_session_state_on_run(chat_agent):
@@ -98,13 +117,13 @@ def test_agent_session_state_on_run(chat_agent):
     response = chat_agent.run("What can you do?", session_id=session_id_1, session_state={"test_key": "test_value"})
     assert response.run_id is not None
     assert chat_agent.session_id == session_id_1
-    assert chat_agent.session_state == {"test_key": "test_value"}
+    assert chat_agent.session_state == {"current_session_id": session_id_1, "test_key": "test_value"}
 
     # Second run with different session ID
     response = chat_agent.run("What can you do?", session_id=session_id_2)
     assert response.run_id is not None
     assert chat_agent.session_id == session_id_2
-    assert chat_agent.session_state == {}
+    assert chat_agent.session_state == {"current_session_id": session_id_2}
 
     # Third run with the original session ID
     response = chat_agent.run(
@@ -112,6 +131,6 @@ def test_agent_session_state_on_run(chat_agent):
     )
     assert response.run_id is not None
     assert chat_agent.session_id == session_id_1
-    assert chat_agent.session_state == {"test_key": "test_value", "something_else": "other_value"}, (
+    assert chat_agent.session_state == {"current_session_id": session_id_1, "test_key": "test_value", "something_else": "other_value"}, (
         "Merging session state should work"
     )

--- a/libs/agno/tests/integration/teams/test_team_session_state.py
+++ b/libs/agno/tests/integration/teams/test_team_session_state.py
@@ -30,8 +30,8 @@ def test_team_session_state(route_team, team_storage):
     assert response.run_id is not None
     assert route_team.session_id == session_id
     assert route_team.session_name == "my_test_session"
-    assert route_team.session_state == {"test_key": "test_value"}
-    assert route_team.team_session_state == {"team_test_key": "team_test_value"}
+    assert route_team.session_state == {"current_session_id": session_id, "test_key": "test_value"}
+    assert route_team.team_session_state == {"current_session_id": session_id, "team_test_key": "team_test_value"}
     session_from_storage = team_storage.read(session_id=session_id)
     assert session_from_storage is not None
     assert session_from_storage.session_id == session_id
@@ -46,21 +46,40 @@ def test_team_session_state(route_team, team_storage):
     assert response.run_id is not None
     assert route_team.session_id == session_id
     assert route_team.session_name == "my_test_session"
-    assert route_team.session_state == {"test_key": "test_value"}
+    assert route_team.session_state == {"current_session_id": session_id, "test_key": "test_value"}
 
     # Run with a different session ID
     response = route_team.run("What can you do?", session_id="session_2")
     assert response.run_id is not None
     assert route_team.session_id == "session_2"
     assert route_team.session_name is None
-    assert route_team.session_state == {}
+    assert route_team.session_state == {"current_session_id": "session_2"}
 
     # Run again with original session ID
     response = route_team.run("What name should I call you?", session_id=session_id)
     assert response.run_id is not None
     assert route_team.session_id == session_id
     assert route_team.session_name == "my_test_session"
-    assert route_team.session_state == {"test_key": "test_value"}
+    assert route_team.session_state == {"current_session_id": session_id, "test_key": "test_value"}
+
+
+
+def test_team_session_state_stream(route_team):
+    session_id = "session_1"
+
+    route_team.session_id = session_id
+    route_team.session_name = "my_test_session"
+    route_team.session_state = {"test_key": "test_value"}
+    route_team.team_session_state = {"team_test_key": "team_test_value"}
+
+    for _ in route_team.run("Hello, how are you?", stream=True):
+        pass
+    response = route_team.run_response
+    assert response.run_id is not None
+    assert route_team.session_id == session_id
+    assert route_team.session_name == "my_test_session"
+    assert route_team.session_state == {"current_session_id": session_id, "test_key": "test_value"}
+    assert route_team.team_session_state == {"current_session_id": session_id, "team_test_key": "team_test_value"}
 
 
 def test_team_session_state_switch_session_id(route_team):
@@ -75,21 +94,21 @@ def test_team_session_state_switch_session_id(route_team):
     assert response.run_id is not None
     assert route_team.session_id == session_id_1
     assert route_team.session_name == "my_test_session"
-    assert route_team.session_state == {"test_key": "test_value"}
+    assert route_team.session_state == {"current_session_id": session_id_1, "test_key": "test_value"}
 
     # Second run with different session ID
     response = route_team.run("What can you do?", session_id=session_id_2)
     assert response.run_id is not None
     assert route_team.session_id == session_id_2
     assert route_team.session_name is None
-    assert route_team.session_state == {}
+    assert route_team.session_state == {"current_session_id": session_id_2}
 
     # Third run with the original session ID
     response = route_team.run("What can you do?", session_id=session_id_1)
     assert response.run_id is not None
     assert route_team.session_id == session_id_1
     assert route_team.session_name == "my_test_session"
-    assert route_team.session_state == {"test_key": "test_value"}
+    assert route_team.session_state == {"current_session_id": session_id_1, "test_key": "test_value"}
 
 
 def test_team_session_state_on_run(route_team):
@@ -103,14 +122,14 @@ def test_team_session_state_on_run(route_team):
     assert response.run_id is not None
     assert route_team.session_id == session_id_1
     assert route_team.session_name == "my_test_session"  # Correctly set from the first run
-    assert route_team.session_state == {"test_key": "test_value"}
+    assert route_team.session_state == {"current_session_id": session_id_1, "test_key": "test_value"}
 
     # Second run with different session ID
     response = route_team.run("What can you do?", session_id=session_id_2)
     assert response.run_id is not None
     assert route_team.session_id == session_id_2
     assert route_team.session_name is None  # Should be unset, new session ID
-    assert route_team.session_state == {}
+    assert route_team.session_state == {"current_session_id": session_id_2}
 
     # Third run with the original session ID
     response = route_team.run(
@@ -119,6 +138,6 @@ def test_team_session_state_on_run(route_team):
     assert response.run_id is not None
     assert route_team.session_id == session_id_1
     assert route_team.session_name == "my_test_session"  # Should load what was set on the first run
-    assert route_team.session_state == {"test_key": "test_value", "something_else": "other_value"}, (
+    assert route_team.session_state == {"current_session_id": session_id_1, "test_key": "test_value", "something_else": "other_value"}, (
         "Merging session state should work"
     )


### PR DESCRIPTION
## Summary

Recent changes broke the current_session_id and current_user_id on streaming.
For now it is better to keep it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
