### PR TITLE
fix: show tool calls with no args on print and aprint

### DIFF
--- a/libs/agno/agno/utils/response.py
+++ b/libs/agno/agno/utils/response.py
@@ -65,13 +65,15 @@ def format_tool_calls(tool_calls: List[ToolExecution]) -> List[str]:
         List[str]: List of formatted tool call strings
     """
     formatted_tool_calls = []
+
     for tool_call in tool_calls:
-        if tool_call.tool_name and tool_call.tool_args:
+        if tool_call.tool_name is not None:
             tool_name = tool_call.tool_name
             args_str = ""
             if tool_call.tool_args is not None:
                 args_str = ", ".join(f"{k}={v}" for k, v in tool_call.tool_args.items())
             formatted_tool_calls.append(f"{tool_name}({args_str})")
+
     return formatted_tool_calls
 
 


### PR DESCRIPTION
Our `format_tool_calls` was dropping tool calls with no args. Ultimately this means users couldn't see those calls when using `show_tool_calls=True`.

This is how it no-args calls look like now:


<img width="1036" height="263" alt="image" src="https://github.com/user-attachments/assets/c6b83bf9-cdce-4e82-94c9-58f8c5e6b0a7" />
