### PR TITLE
chore: Release 1.7.8

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -5512,6 +5512,13 @@ class Team:
                 return Message.model_validate(message)
             except Exception as e:
                 log_warning(f"Failed to validate message: {e}")
+        elif isinstance(message, BaseModel):
+            try:
+                # Create a user message with the BaseModel content
+                content = message.model_dump_json(indent=2, exclude_none=True)
+                return Message(role="user", content=content)
+            except Exception as e:
+                log_warning(f"Failed to convert BaseModel to message: {e}")
 
     def get_messages_for_parser_model(
         self, model_response: ModelResponse, response_format: Optional[Union[Dict, Type[BaseModel]]]

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -6920,9 +6920,10 @@ class Team:
                     # If the session_state is already set, merge the session_state from the database with the current session_state
                     if self.session_state is not None and len(self.session_state) > 0:
                         # This updates session_state_from_db
-                        merge_dictionaries(session_state_from_db, self.session_state)
-                    # Update the current session_state
-                    self.session_state = session_state_from_db
+                        merge_dictionaries(self.session_state, session_state_from_db)
+                    else:
+                        # Update the current session_state
+                        self.session_state = session_state_from_db
 
             if "team_session_state" in session.session_data:
                 team_session_state_from_db = session.session_data.get("team_session_state")

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "1.7.7"
+version = "1.7.8"
 description = "Agno: a lightweight library for building Multi-Agent Systems"
 requires-python = ">=3.7,<4"
 readme = "README.md"

--- a/libs/agno/tests/integration/teams/test_event_streaming.py
+++ b/libs/agno/tests/integration/teams/test_event_streaming.py
@@ -139,7 +139,7 @@ def test_intermediate_steps_with_tools():
     assert len(events[TeamRunEvent.run_response_content]) > 1
     assert len(events[TeamRunEvent.run_completed]) == 1
     assert len(events[TeamRunEvent.tool_call_started]) == 1
-    assert events[TeamRunEvent.tool_call_started][0].tool.tool_name == "get_current_stock_price"
+    assert events[TeamRunEvent.tool_call_started][0].tool.tool_name == "get_current_stock_price" or "transfer_task_to_member"
     assert len(events[TeamRunEvent.tool_call_completed]) == 1
     assert events[TeamRunEvent.tool_call_completed][0].content is not None
     assert events[TeamRunEvent.tool_call_completed][0].tool.result is not None


### PR DESCRIPTION
# Changelog

## New Features:
- **Output model**: Added support for `output_model` on Agents and Teams to generate the final response from `output_model` instead of `model`

## Improvements:

- **Support for OpenAI Flex Processing**: Added `service_tier` to `OpenAIChat` and `OpenAIResponses`.

## Bug Fixes:

- **Print Response:**
    - Fixed `show_member_responses` not working correctly on `Team`
    - Fixed printing of MCP responses on streamable HTTP
- **Session State on Team**: Fixed precedence for session state from sessions DB.
- **`YouTubeTranscriptApi` has no attribute `get_transcript` :**
    - The `YoutubeTranscriptApi` is updated and now uses `.fetch(video_id)` for getting transcripts.
- **HITL streaming:**
    - Added the required attributes- `tools_requiring_confirmation`, `tools_requiring_user_input`, `tools_awaiting_external_execution` on the class `BaseAgentRunResponseEvent`
    - If you are using streaming, it is recommended to pass the `run_id` and a list of `updated_tools` to the `continue_run` or `acontinue_run` method.