### PR TITLE
fix: hitl stream breaking

### DIFF
--- a/cookbook/agent_concepts/user_control_flows/confirmation_required_stream.py
+++ b/cookbook/agent_concepts/user_control_flows/confirmation_required_stream.py
@@ -78,7 +78,7 @@ for run_response in agent.run("Fetch the top 2 hackernews stories", stream=True)
             else:
                 # We update the tools in place
                 tool.confirmed = True
-        run_response = agent.continue_run(run_response=run_response, stream=True)
+        run_response = agent.continue_run(stream=True)
         pprint.pprint_run_response(run_response)
 
 # Or for simple debug flow

--- a/cookbook/agent_concepts/user_control_flows/confirmation_required_stream_async.py
+++ b/cookbook/agent_concepts/user_control_flows/confirmation_required_stream_async.py
@@ -84,9 +84,7 @@ async def main():
                 else:
                     # We update the tools in place
                     tool.confirmed = True
-            run_response = await agent.acontinue_run(
-                run_response=run_response, stream=True
-            )
+            run_response = await agent.acontinue_run(stream=True)
             async for resp in run_response:
                 print(resp.content, end="")
 

--- a/cookbook/agent_concepts/user_control_flows/external_tool_execution_stream.py
+++ b/cookbook/agent_concepts/user_control_flows/external_tool_execution_stream.py
@@ -52,7 +52,7 @@ for run_response in agent.run(
                 # We have to set the result on the tool execution object so that the agent can continue
                 tool.result = result
 
-        run_response = agent.continue_run(run_response=run_response, stream=True)
+        run_response = agent.continue_run(stream=True)
         pprint.pprint_run_response(run_response)
 
 

--- a/cookbook/agent_concepts/user_control_flows/external_tool_execution_stream_async.py
+++ b/cookbook/agent_concepts/user_control_flows/external_tool_execution_stream_async.py
@@ -54,7 +54,7 @@ async def main():
                     # We have to set the result on the tool execution object so that the agent can continue
                     tool.result = result
             run_response = await agent.acontinue_run(
-                run_response=run_response, stream=True
+                stream=True
             )
             async for resp in run_response:
                 print(resp.content, end="")

--- a/libs/agno/agno/run/response.py
+++ b/libs/agno/agno/run/response.py
@@ -99,6 +99,18 @@ class RunResponsePausedEvent(BaseAgentRunResponseEvent):
     def is_paused(self):
         return True
 
+    @property
+    def tools_requiring_confirmation(self):
+        return [t for t in self.tools if t.requires_confirmation] if self.tools else []
+
+    @property
+    def tools_requiring_user_input(self):
+        return [t for t in self.tools if t.requires_user_input] if self.tools else []
+
+    @property
+    def tools_awaiting_external_execution(self):
+        return [t for t in self.tools if t.external_execution_required] if self.tools else []
+
 
 @dataclass
 class RunResponseContinuedEvent(BaseAgentRunResponseEvent):


### PR DESCRIPTION
## Summary

HITL streaming cookbooks were breaking- 
<img width="720" height="99" alt="image" src="https://github.com/user-attachments/assets/dab1500c-cc81-448f-8d0a-330370fe8e13" />

<img width="720" height="109" alt="image" src="https://github.com/user-attachments/assets/154c5658-5c7d-4ad2-be9e-4949b7b51f1d" />


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
