### PR TITLE
fix: add reranker in pgvector hybrid search

### DIFF
--- a/cookbook/agent_concepts/rag/agentic_rag_with_reranking.py
+++ b/cookbook/agent_concepts/rag/agentic_rag_with_reranking.py
@@ -28,6 +28,10 @@ knowledge_base = UrlKnowledge(
     ),
 )
 
+# Comment this out after first run
+knowledge_base.load(recreate=False)
+
+
 agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
     # Agentic RAG is enabled by default when `knowledge` is provided to the Agent.

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -766,6 +766,9 @@ class PgVector(VectorDb):
                     )
                 )
 
+            if self.reranker:
+                search_results = self.reranker.rerank(query=query, documents=search_results)
+
             log_info(f"Found {len(search_results)} documents")
             return search_results
         except Exception as e:

--- a/libs/agno/tests/integration/teams/test_event_streaming.py
+++ b/libs/agno/tests/integration/teams/test_event_streaming.py
@@ -139,7 +139,10 @@ def test_intermediate_steps_with_tools():
     assert len(events[TeamRunEvent.run_response_content]) > 1
     assert len(events[TeamRunEvent.run_completed]) == 1
     assert len(events[TeamRunEvent.tool_call_started]) == 1
-    assert events[TeamRunEvent.tool_call_started][0].tool.tool_name == "get_current_stock_price" or "transfer_task_to_member"
+    assert (
+        events[TeamRunEvent.tool_call_started][0].tool.tool_name == "get_current_stock_price"
+        or "transfer_task_to_member"
+    )
     assert len(events[TeamRunEvent.tool_call_completed]) == 1
     assert events[TeamRunEvent.tool_call_completed][0].content is not None
     assert events[TeamRunEvent.tool_call_completed][0].tool.result is not None

--- a/libs/agno/tests/integration/teams/test_team_session_state.py
+++ b/libs/agno/tests/integration/teams/test_team_session_state.py
@@ -1,4 +1,5 @@
 import uuid
+
 import pytest
 
 from agno.models.openai.chat import OpenAIChat
@@ -154,18 +155,19 @@ def test_session_state_db_precedence(route_team, team_storage):
     # Simulate a session in storage with a specific session_state
     db_state = {"db_key": "db_value", "shared_key": "db"}
     team_storage.upsert(
-        session=type("TeamSession", (), {
-            "session_id": session_id_1,
-            "session_data": {
-                "session_state": db_state.copy(),
-                "session_name": "db_session"
+        session=type(
+            "TeamSession",
+            (),
+            {
+                "session_id": session_id_1,
+                "session_data": {"session_state": db_state.copy(), "session_name": "db_session"},
+                "team_session_id": str(uuid.uuid4()),
+                "team_id": str(uuid.uuid4()),
+                "user_id": None,
+                "team_data": None,
+                "extra_data": None,
             },
-            "team_session_id": str(uuid.uuid4()),
-            "team_id": str(uuid.uuid4()),
-            "user_id": None,
-            "team_data": None,
-            "extra_data": None,
-        })()
+        )()
     )
 
     # Set agent's in-memory session_state to something different


### PR DESCRIPTION
## Summary

add missing reranker in pgvector hybrid search

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
