### PR TITLE
[fix] incorrect emit order for AG-UI events

### DIFF
--- a/libs/agno/agno/app/agui/async_router.py
+++ b/libs/agno/agno/app/agui/async_router.py
@@ -2,7 +2,7 @@
 
 import logging
 import uuid
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Optional, cast
 
 from ag_ui.core import (
     BaseEvent,
@@ -10,6 +10,7 @@ from ag_ui.core import (
     RunAgentInput,
     RunErrorEvent,
     RunStartedEvent,
+    RunFinishedEvent
 )
 from ag_ui.encoder import EventEncoder
 from fastapi import APIRouter
@@ -41,9 +42,11 @@ async def run_agent(agent: Agent, run_input: RunAgentInput) -> AsyncIterator[Bas
 
         # Stream the response content in AG-UI format
         async for event in async_stream_agno_response_as_agui_events(
-            response_stream=response_stream, thread_id=run_input.thread_id, run_id=run_id
+            response_stream=response_stream
         ):
             yield event
+
+        yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=run_input.thread_id, run_id=run_id)
 
     # Emit a RunErrorEvent if any error occurs
     except Exception as e:
@@ -59,9 +62,11 @@ async def run_team(team: Team, input: RunAgentInput) -> AsyncIterator[BaseEvent]
         messages = convert_agui_messages_to_agno_messages(input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=input.thread_id, run_id=run_id)
 
-        # Request streaming response from team
+        # Request streaming response from team.
+        # Team.arun() does not handle list[Message] type, join the messages
+        str_messages = list(map(lambda msg: cast(str, msg.content), messages))
         response_stream = await team.arun(
-            message=messages,
+            message=str_messages,
             session_id=input.thread_id,
             stream=True,
             stream_intermediate_steps=True,
@@ -69,9 +74,11 @@ async def run_team(team: Team, input: RunAgentInput) -> AsyncIterator[BaseEvent]
 
         # Stream the response content in AG-UI format
         async for event in async_stream_agno_response_as_agui_events(
-            response_stream=response_stream, thread_id=input.thread_id, run_id=run_id
+            response_stream=response_stream
         ):
             yield event
+
+        yield RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=input.thread_id, run_id=run_id)
 
     except Exception as e:
         logger.error(f"Error running team: {e}", exc_info=True)


### PR DESCRIPTION
## Summary

Reception of message stream in CopilotKit connecting to an Agno Team via AG-UI protocol ends prematurely when interacting with a Team. This is most likely due to how AGUIApp emits AG-UI completion events even though there are still agents in the team left to process the messages. Also, tool calls that happen after the first agent finishes its response cause the output to disappear on CopilotKit.

This pull request patches the AGUIApp implementation which will fix the problem described above, and resolves #4157.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The fix also includes a hotfix for Team.arun() not handling list[Message] type even though convert_agui_messages_to_agno_messages returns a list[Message] type. This is due to Team.arun() expecting only strings when message parameter is of list type, carelessly calling str.join("\n") on the message parameter. This hotfix should removed in a future patch when Team.arun() correctly handles list[Message] type correctly.
