### PR TITLE
fix: handle receiving a list of Message as input for team arun

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -5645,7 +5645,7 @@ class Team:
                 if isinstance(message, str):
                     user_message_content = message
                 else:
-                    user_message_content = "\n".join(message)
+                    user_message_content = "\n".join(str(message))
 
             # Add references to user message
             if (


### PR DESCRIPTION
Receiving a list of `Message` as input of `Team.arun` was valid based on the type signature, but broke when getting the user message