### PR TITLE
Feat: Normalize tool call identifiers

### DIFF
--- a/cookbook/agent_concepts/user_control_flows/external_tool_execution_async_responses.py
+++ b/cookbook/agent_concepts/user_control_flows/external_tool_execution_async_responses.py
@@ -1,0 +1,61 @@
+"""🤝 Human-in-the-Loop with OpenAI Responses API (gpt-4.1-mini)
+
+This example mirrors the external tool execution async example but uses
+OpenAIResponses with gpt-4.1-mini to validate tool-call id handling.
+
+Run `pip install openai agno` to install dependencies.
+"""
+
+import asyncio
+import subprocess
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools import tool
+from agno.utils import pprint
+
+
+# We have to create a tool with the correct name, arguments and docstring
+# for the agent to know what to call.
+@tool(external_execution=True)
+def execute_shell_command(command: str) -> str:
+    """Execute a shell command.
+
+    Args:
+        command (str): The shell command to execute
+
+    Returns:
+        str: The output of the shell command
+    """
+    if command.startswith("ls"):
+        return subprocess.check_output(command, shell=True).decode("utf-8")
+    else:
+        raise Exception(f"Unsupported command: {command}")
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-4.1-mini"),
+    tools=[execute_shell_command],
+    markdown=True,
+    debug_mode=True,
+    show_tool_calls=True,
+)
+
+run_response = asyncio.run(agent.arun("What files do I have in my current directory?"))
+if run_response.is_paused:  # Or agent.run_response.is_paused
+    for tool in run_response.tools_awaiting_external_execution:
+        if tool.tool_name == execute_shell_command.name:
+            print(f"Executing {tool.tool_name} with args {tool.tool_args} externally")
+            # We execute the tool ourselves. You can also execute something completely external here.
+            result = execute_shell_command.entrypoint(**tool.tool_args)
+            # We have to set the result on the tool execution object so that the agent can continue
+            tool.result = result
+
+    run_response = asyncio.run(agent.acontinue_run(run_response=run_response))
+    pprint.pprint_run_response(run_response)
+
+
+# Or for simple debug flow
+# agent.print_response("What files do I have in my current directory?")
+
+

--- a/cookbook/agent_concepts/user_control_flows/external_tool_execution_async_responses.py
+++ b/cookbook/agent_concepts/user_control_flows/external_tool_execution_async_responses.py
@@ -37,8 +37,6 @@ agent = Agent(
     model=OpenAIResponses(id="gpt-4.1-mini"),
     tools=[execute_shell_command],
     markdown=True,
-    debug_mode=True,
-    show_tool_calls=True,
 )
 
 run_response = asyncio.run(agent.arun("What files do I have in my current directory?"))

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -417,7 +417,6 @@ class OpenAIResponses(Model):
                     formatted_messages.append(
                         {
                             "type": "function_call",
-                            # Normalize: prefer call_id; fall back to id if needed
                             "id": tool_call.get("call_id", tool_call.get("id")),
                             "call_id": tool_call.get("call_id", tool_call.get("id")),
                             "name": tool_call["function"]["name"],
@@ -719,8 +718,6 @@ class OpenAIResponses(Model):
                     model_response.tool_calls = []
                 model_response.tool_calls.append(
                     {
-                        # Normalize: use call_id as the canonical identifier expected
-                        # by Responses API for function_call_output
                         "id": output.call_id,
                         "call_id": output.call_id,
                         "type": "function",
@@ -812,7 +809,6 @@ class OpenAIResponses(Model):
             item = stream_event.item
             if item.type == "function_call":
                 tool_use = {
-                    # Use call_id as canonical identifier expected by Responses API
                     "id": getattr(item, "call_id", None) or getattr(item, "id", None),
                     "call_id": item.call_id,
                     "type": "function",

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -372,9 +372,6 @@ class OpenAIResponses(Model):
                     previous_response_id = msg.provider_data["response_id"]
                     break
 
-        # If we are continuing with tool outputs, do not re-send prior function_call items
-        has_tool_output = any((getattr(m, "role", None) == "tool") and getattr(m, "tool_call_id", None) for m in messages)
-
         # Build a mapping from function_call id (fc_*) → call_id (call_*) from prior assistant tool_calls
         fc_id_to_call_id: Dict[str, str] = {}
         for msg in messages:

--- a/libs/agno/tests/integration/models/openai/responses/test_tool_use.py
+++ b/libs/agno/tests/integration/models/openai/responses/test_tool_use.py
@@ -154,18 +154,18 @@ def test_parallel_tool_calls():
 def test_multiple_tool_calls():
     """Test multiple different tool types with the responses API."""
     agent = Agent(
-        model=OpenAIResponses(id="gpt-4o-mini"),
+        model=OpenAIResponses(id="gpt-4.1-mini"),
         tools=[YFinanceTools(cache_results=True), DuckDuckGoTools(cache_results=True)],
         markdown=True,
         telemetry=False,
         monitoring=False,
     )
 
-    response = agent.run("What is the current price of TSLA and what is the latest news about it?")
+    response = agent.run("Find the latest price of TSLA. Then, based on the price, find the latest news about it.")
 
     # Verify tool usage
     tool_calls = [msg.tool_calls for msg in response.messages if msg.tool_calls]
-    assert len(tool_calls) >= 1  # At least one message has tool calls
+    assert len(tool_calls) >= 2  # At least two messages have tool calls
     assert sum(len(calls) for calls in tool_calls) >= 2  # Total of 2 tool calls made
     assert response.content is not None
     assert "TSLA" in response.content and "latest news" in response.content.lower()

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
@@ -1,0 +1,165 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from agno.models.message import Message
+from agno.models.openai.responses import OpenAIResponses
+from agno.models.response import ModelResponse
+from agno.models.base import MessageData
+
+
+class _FakeError:
+    def __init__(self, message: str):
+        self.message = message
+
+
+class _FakeOutputFunctionCall:
+    def __init__(self, *, _id: str, call_id: Optional[str], name: str, arguments: str):
+        self.type = "function_call"
+        self.id = _id
+        self.call_id = call_id
+        self.name = name
+        self.arguments = arguments
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        _id: str,
+        output: List[Any],
+        output_text: str = "",
+        usage: Optional[Dict[str, Any]] = None,
+        error: Optional[_FakeError] = None,
+    ):
+        self.id = _id
+        self.output = output
+        self.output_text = output_text
+        self.usage = usage
+        self.error = error
+
+
+class _FakeStreamItem:
+    def __init__(self, *, _id: str, call_id: Optional[str], name: str, arguments: str):
+        self.type = "function_call"
+        self.id = _id
+        self.call_id = call_id
+        self.name = name
+        self.arguments = arguments
+
+
+class _FakeStreamEvent:
+    def __init__(self, *, type: str, item: Optional[_FakeStreamItem] = None, delta: str = "", response: Any = None, annotation: Any = None):
+        self.type = type
+        self.item = item
+        self.delta = delta
+        self.response = response
+        self.annotation = annotation
+
+
+def test_format_messages_maps_tool_output_fc_to_call_id():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    # Assistant emitted a function_call with both fc_* and call_* ids
+    assistant_with_tool_call = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "fc_abc123",
+                "call_id": "call_def456",
+                "type": "function",
+                "function": {"name": "execute_shell_command", "arguments": "{\"command\": \"ls -la\"}"},
+            }
+        ],
+    )
+
+    # Tool output referring to the fc_* id should be normalized to call_*
+    tool_output = Message(role="tool", tool_call_id="fc_abc123", content="ok")
+
+    fm = model._format_messages(messages=[Message(role="system", content="s"), Message(role="user", content="u"), assistant_with_tool_call, tool_output])
+
+    # Expect one function_call and one function_call_output normalized
+    fc_items = [x for x in fm if x.get("type") == "function_call"]
+    out_items = [x for x in fm if x.get("type") == "function_call_output"]
+
+    assert len(fc_items) == 1
+    assert fc_items[0]["id"] == "fc_abc123"
+    assert fc_items[0]["call_id"] == "call_def456"
+
+    assert len(out_items) == 1
+    assert out_items[0]["call_id"] == "call_def456"
+
+
+def test_parse_provider_response_maps_ids():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    fake_resp = _FakeResponse(
+        _id="resp_1",
+        output=[_FakeOutputFunctionCall(_id="fc_abc123", call_id="call_def456", name="execute", arguments="{}")],
+        output_text="",
+        usage=None,
+        error=None,
+    )
+
+    mr: ModelResponse = model.parse_provider_response(fake_resp)  # type: ignore[arg-type]
+
+    assert mr.tool_calls is not None and len(mr.tool_calls) == 1
+    tc = mr.tool_calls[0]
+    assert tc["id"] == "fc_abc123"
+    assert tc["call_id"] == "call_def456"
+    assert mr.extra is not None and "tool_call_ids" in mr.extra and mr.extra["tool_call_ids"][0] == "call_def456"
+
+
+def test_process_stream_response_builds_tool_calls():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+    assistant_message = Message(role="assistant")
+    stream_data = MessageData()
+
+    # Simulate function_call added and then completed
+    added = _FakeStreamEvent(type="response.output_item.added", item=_FakeStreamItem(_id="fc_abc123", call_id="call_def456", name="execute", arguments="{}"))
+    mr, tool_use = model._process_stream_response(added, assistant_message, stream_data, {})
+    assert mr is None
+
+    # Optional: simulate args delta
+    delta_ev = _FakeStreamEvent(type="response.function_call_arguments.delta", delta='{"k":1}')
+    mr, tool_use = model._process_stream_response(delta_ev, assistant_message, stream_data, tool_use)
+    assert mr is None
+
+    done = _FakeStreamEvent(type="response.output_item.done")
+    mr, tool_use = model._process_stream_response(done, assistant_message, stream_data, tool_use)
+
+    assert mr is not None
+    assert mr.tool_calls is not None and len(mr.tool_calls) == 1
+    tc = mr.tool_calls[0]
+    assert tc["id"] == "fc_abc123"
+    assert tc["call_id"] == "call_def456"
+    assert assistant_message.tool_calls is not None and len(assistant_message.tool_calls) == 1
+
+
+def test_reasoning_previous_response_skips_prior_function_call_items(monkeypatch):
+    model = OpenAIResponses(id="o4-mini")  # reasoning
+
+    # Force _using_reasoning_model to True
+    monkeypatch.setattr(model, "_using_reasoning_model", lambda: True)
+
+    assistant_with_prev = Message(role="assistant")
+    assistant_with_prev.provider_data = {"response_id": "resp_123"}  # type: ignore[attr-defined]
+
+    assistant_with_tool_call = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "fc_abc123",
+                "call_id": "call_def456",
+                "type": "function",
+                "function": {"name": "execute_shell_command", "arguments": "{}"},
+            }
+        ],
+    )
+
+    fm = model._format_messages(messages=[Message(role="system", content="s"), Message(role="user", content="u"), assistant_with_prev, assistant_with_tool_call])
+
+    # Expect no re-sent function_call when previous_response_id is present for reasoning models
+    assert all(x.get("type") != "function_call" for x in fm)
+
+

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
@@ -1,6 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
-
-import pytest
+from typing import Any, Dict, List, Optional
 
 from agno.models.message import Message
 from agno.models.openai.responses import OpenAIResponses


### PR DESCRIPTION
## Summary

Normalizes tool call IDs to Responses API call_id (fixes gpt-4.1-mini external tool execution).

### What
- Normalize tool call identifiers to use call_id consistently in OpenAIResponses.
- Apply normalization in:
- _format_messages: set both id and call_id from call_id (fallback to id).
- parse_provider_response: set tool call id to call_id.
- _process_stream_response (streaming): set tool call id to call_id.

### Why
- The Responses API expects function_call_output to reference the prior call_id. We were using a different ID (fc_...) leading to:
> 400 “No tool output found for function call …” with gpt-4.1-mini.


(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
