### PR TITLE
[cookbook] Multi Agent Teams using Local Agentic RAG

### DIFF
--- a/cookbook/teams/team_with_local_agentic_rag.py
+++ b/cookbook/teams/team_with_local_agentic_rag.py
@@ -1,0 +1,63 @@
+"""
+pip install agno
+pip install fastembed, qdrant-client
+pip install ollama [ollama pull qwen2.5:7b]
+pip install pypdf
+"""
+
+from agno.agent import Agent
+from agno.team import Team
+from agno.models.ollama import Ollama
+from agno.vectordb.qdrant import Qdrant
+from agno.embedder.fastembed import FastEmbedEmbedder
+from agno.knowledge.pdf_url import PDFUrlKnowledgeBase
+
+collection_name = "science"
+physics_tb = "https://ncert.nic.in/textbook/pdf/keph101.pdf"
+chemistry_tb = "https://ncert.nic.in/textbook/pdf/lech101.pdf"
+
+vector_db = Qdrant(
+    path = "/tmp/qdrant",
+    collection=collection_name,
+    embedder=FastEmbedEmbedder(),
+)
+
+knowledge_base = PDFUrlKnowledgeBase(
+    urls = [physics_tb,chemistry_tb],
+    vector_db=vector_db,
+    num_documents = 4,
+)
+knowledge_base.load() # once the data is stored, comment this line
+
+physics_agent = Agent(
+    name = "Physics Agent",
+    role = "Expert in Physics",
+    instructions = "Answer questions based on the knowledge base",
+    model=Ollama(id="qwen2.5:7b"),
+    read_chat_history=True,
+    show_tool_calls=True,
+    markdown=True,
+)
+
+chemistry_agent = Agent(
+    name = "Chemistry Agent",
+    role = "Expert in Chemistry",
+    instructions = "Answer questions based on the knowledge base",
+    model=Ollama(id="qwen2.5:7b"),
+    read_chat_history=True,
+    show_tool_calls=True,
+    markdown=True,
+)
+
+science_master = Team(
+    name="Team with Knowledge",
+    members=[physics_agent,chemistry_agent],
+    model=Ollama(id="qwen2.5:7b"),
+    knowledge=knowledge_base,
+    search_knowledge=True,
+    show_members_responses=True,
+    markdown=True,
+)
+
+#science_master.print_response("give dimensional equation for volume, speed and force",stream=True)
+science_master.print_response("state Henry's law",stream=True)


### PR DESCRIPTION
## Science Agent - Physics and Chemistry Agent

tl;dr
- This is a multi-document Agentic RAG which routes to a specific Agent based on the knowledge base for the roleplay. 
- The Agentic RAG system is set up locally using Ollama, FastEmbed and Qdrant-Client.
- The same pipeline can be replaced to SambaNova or Groq instead of Ollama for faster LLM inference 