### PR TITLE
[fix] Update DashScope thinking parameters to keep thinking false by …

### DIFF
--- a/libs/agno/agno/models/dashscope/dashscope.py
+++ b/libs/agno/agno/models/dashscope/dashscope.py
@@ -20,7 +20,6 @@ class DashScope(OpenAILike):
         api_key (Optional[str]): The DashScope API key.
         base_url (str): The base URL. Defaults to "https://dashscope-intl.aliyuncs.com/compatible-mode/v1".
         enable_thinking (Optional[bool]): Enable thinking process (DashScope native parameter). Defaults to None.
-        include_thoughts (Optional[bool]): Include thinking process in response (alternative parameter). Defaults to None.
     """
 
     id: str = "qwen-plus"
@@ -31,7 +30,7 @@ class DashScope(OpenAILike):
     base_url: str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 
     # Thinking parameters
-    enable_thinking: Optional[bool] = None
+    enable_thinking: Optional[bool] = False
     include_thoughts: Optional[bool] = None
 
     # DashScope supports structured outputs
@@ -75,7 +74,7 @@ class DashScope(OpenAILike):
     ) -> Dict[str, Any]:
         params = super().get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice)
 
-        should_include_thoughts = self.enable_thinking or self.include_thoughts
-        if should_include_thoughts:
-            params["extra_body"] = {"enable_thinking": True}
+        thinking_value = self.enable_thinking if self.enable_thinking is not None else False
+        params["extra_body"] = {"enable_thinking": thinking_value}
+
         return params


### PR DESCRIPTION
## Summary

Set thinking to false by default. Solves #4290 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)
