### PR TITLE
[fix] Add missing time zone feature to Team and update default API for get_location

### DIFF
--- a/cookbook/agent_concepts/other/location_instructions.py
+++ b/cookbook/agent_concepts/other/location_instructions.py
@@ -7,4 +7,5 @@ agent = Agent(
     add_location_to_instructions=True,
     tools=[DuckDuckGoTools(cache_results=True)],
 )
+agent.print_response("What city am I in?")
 agent.print_response("What is current news about my city?")

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -157,6 +157,8 @@ class Team:
     add_datetime_to_instructions: bool = False
     # If True, add the current location to the instructions to give the team a sense of location
     add_location_to_instructions: bool = False
+    # Allows for custom timezone for datetime instructions following the TZ Database format (e.g. "Etc/UTC")
+    timezone_identifier: Optional[str] = None
     # If True, add the tools available to team members to the system message
     add_member_tools_to_system_message: bool = True
 
@@ -328,6 +330,7 @@ class Team:
         markdown: bool = False,
         add_datetime_to_instructions: bool = False,
         add_location_to_instructions: bool = False,
+        timezone_identifier: Optional[str] = None,
         add_member_tools_to_system_message: bool = True,
         system_message: Optional[Union[str, Callable, Message]] = None,
         system_message_role: str = "system",
@@ -411,6 +414,7 @@ class Team:
         self.markdown = markdown
         self.add_datetime_to_instructions = add_datetime_to_instructions
         self.add_location_to_instructions = add_location_to_instructions
+        self.timezone_identifier = timezone_identifier
         self.add_member_tools_to_system_message = add_member_tools_to_system_message
         self.system_message = system_message
         self.system_message_role = system_message_role
@@ -5308,7 +5312,19 @@ class Team:
         if self.add_datetime_to_instructions:
             from datetime import datetime
 
-            additional_information.append(f"The current time is {datetime.now()}")
+            tz = None
+
+            if self.timezone_identifier:
+                try:
+                    from zoneinfo import ZoneInfo
+
+                    tz = ZoneInfo(self.timezone_identifier)
+                except Exception:
+                    log_warning("Invalid timezone identifier")
+
+            time = datetime.now(tz) if tz else datetime.now()
+
+            additional_information.append(f"The current time is {time}.")
 
         # 1.3.3 Add the current location
         if self.add_location_to_instructions:

--- a/libs/agno/agno/utils/location.py
+++ b/libs/agno/agno/utils/location.py
@@ -10,10 +10,10 @@ def get_location() -> Dict[str, Any]:
     try:
         response = requests.get("https://api.ipify.org?format=json", timeout=5)
         ip = response.json()["ip"]
-        response = requests.get(f"https://ipapi.co/{ip}/json/", timeout=5)
+        response = requests.get(f"http://ip-api.com/json/{ip}", timeout=5)
         if response.status_code == 200:
             data = response.json()
-            return {"city": data.get("city"), "region": data.get("region"), "country": data.get("country_name")}
+            return {"city": data.get("city"), "region": data.get("region"), "country": data.get("country")}
     except Exception as e:
         log_warning(f"Failed to get location: {e}")
     return {}


### PR DESCRIPTION
## Summary

The Team class was missing the time zone identifier feature from the Agent class, so I added it by copying the implementation.

Additionally, the default API used in get_location() had strange limitations that blocked my VPS IP without explanation (I suspect running LLM agents was flagged as “strange activity”). I replaced it with a more stable API, which allows about 45 queries per minute (though I may be mistaken about the exact limit).

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
