### PR TITLE
[feat] allow OpenAIChat to accept both httpx.Client and httpx.AsyncClient

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -123,8 +123,11 @@ class OpenAIChat(Model):
             OpenAIClient: An instance of the OpenAI client.
         """
         client_params: Dict[str, Any] = self._get_client_params()
-        if self.http_client is not None:
-            client_params["http_client"] = self.http_client
+        if self.http_client:
+            if isinstance(self.http_client, httpx.Client):
+                client_params["http_client"] = self.http_client
+            else:
+                log_warning("http_client is not an instance of httpx.Client.")
         return OpenAIClient(**client_params)
 
     def get_async_client(self) -> AsyncOpenAIClient:
@@ -135,8 +138,15 @@ class OpenAIChat(Model):
             AsyncOpenAIClient: An instance of the asynchronous OpenAI client.
         """
         client_params: Dict[str, Any] = self._get_client_params()
-        if self.http_client and isinstance(self.http_client, httpx.AsyncClient):
-            client_params["http_client"] = self.http_client
+        if self.http_client:
+            if isinstance(self.http_client, httpx.AsyncClient):
+                client_params["http_client"] = self.http_client
+            else:
+                log_warning("http_client is not an instance of httpx.AsyncClient. Using default httpx.AsyncClient.")
+                # Create a new async HTTP client with custom limits
+                client_params["http_client"] = httpx.AsyncClient(
+                    limits=httpx.Limits(max_connections=1000, max_keepalive_connections=100)
+                )
         else:
             # Create a new async HTTP client with custom limits
             client_params["http_client"] = httpx.AsyncClient(

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -77,7 +77,7 @@ class OpenAIChat(Model):
     max_retries: Optional[int] = None
     default_headers: Optional[Any] = None
     default_query: Optional[Any] = None
-    http_client: Optional[httpx.Client] = None
+    http_client: Optional[Union[httpx.Client, httpx.AsyncClient]] = None
     client_params: Optional[Dict[str, Any]] = None
 
     # The role to map the message role to.
@@ -135,7 +135,7 @@ class OpenAIChat(Model):
             AsyncOpenAIClient: An instance of the asynchronous OpenAI client.
         """
         client_params: Dict[str, Any] = self._get_client_params()
-        if self.http_client:
+        if self.http_client and isinstance(self.http_client, httpx.AsyncClient):
             client_params["http_client"] = self.http_client
         else:
             # Create a new async HTTP client with custom limits


### PR DESCRIPTION
feat(openai): support both httpx.Client and httpx.AsyncClient in OpenAIChat

## Summary
Updated OpenAIChat to allow passing either httpx.Client or httpx.AsyncClient to the `http_client` parameter. This improves flexibility and aligns behavior with the official OpenAI client, where sync clients can accept both sync and async httpx clients.

## Type of change
- [x] Improvement

## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated
- [ ] Tests added/updated (if applicable)

## Additional Notes
Maintains backward compatibility. Users can now pass either sync or async httpx clients depending on their needs.
