### PR TITLE
fix: media artifact validation error

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -157,7 +157,7 @@ class Video(BaseModel):
 
     @classmethod
     def from_artifact(cls, artifact: VideoArtifact) -> "Video":
-        return cls(url=artifact.url)
+        return cls(url=artifact.url, content=artifact.content, format=artifact.mime_type)
 
 
 class Audio(BaseModel):
@@ -329,7 +329,7 @@ class Image(BaseModel):
 
     @classmethod
     def from_artifact(cls, artifact: ImageArtifact) -> "Image":
-        return cls(url=artifact.url)
+        return cls(url=artifact.url, content=artifact.content, format=artifact.mime_type)
 
 
 class File(BaseModel):


### PR DESCRIPTION
## Summary

- `from_artifact()` of `Image` was missing content in its return along with url, so if the generated image is not a url but a encoded content this would fail, or vice-versa. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
