### PR TITLE
[refactor] Update E2B tool to use Sandbox.create

### DIFF
--- a/libs/agno/agno/tools/e2b.py
+++ b/libs/agno/agno/tools/e2b.py
@@ -58,7 +58,7 @@ class E2BTools(Toolkit):
 
         # According to official docs, the parameter is 'timeout' (in seconds), not 'timeout_ms'
         try:
-            self.sandbox = Sandbox(api_key=self.api_key, timeout=timeout, **self.sandbox_options)
+            self.sandbox = Sandbox.create(api_key=self.api_key, timeout=timeout, **self.sandbox_options)
         except Exception as e:
             logger.error(f"Warning: Could not create sandbox: {e}")
             raise e


### PR DESCRIPTION
## Summary

Update the E2BTools class to use Sandbox.create() from the latest e2b_code_interpreter SDK, replacing the deprecated Sandbox() initialization. No other functionality changed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---
