### PR TITLE
[docs] pass tracer provider as argument in openinference cookbooks

### DIFF
--- a/cookbook/observability/langfuse_via_openinference.py
+++ b/cookbook/observability/langfuse_via_openinference.py
@@ -34,10 +34,9 @@ os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}
 
 tracer_provider = TracerProvider()
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
-trace_api.set_tracer_provider(tracer_provider=tracer_provider)
 
 # Start instrumenting agno
-AgnoInstrumentor().instrument()
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
 
 
 agent = Agent(

--- a/cookbook/observability/langfuse_via_openinference_response_model.py
+++ b/cookbook/observability/langfuse_via_openinference_response_model.py
@@ -37,10 +37,9 @@ os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}
 
 tracer_provider = TracerProvider()
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
-trace_api.set_tracer_provider(tracer_provider=tracer_provider)
 
 # Start instrumenting agno
-AgnoInstrumentor().instrument()
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
 
 
 class MarketArea(Enum):

--- a/cookbook/observability/langsmith_via_openinference.py
+++ b/cookbook/observability/langsmith_via_openinference.py
@@ -32,10 +32,9 @@ tracer_provider = TracerProvider()
 tracer_provider.add_span_processor(
     SimpleSpanProcessor(OTLPSpanExporter(endpoint=endpoint, headers=headers))
 )
-trace_api.set_tracer_provider(tracer_provider=tracer_provider)
 
 # Start instrumenting agno
-AgnoInstrumentor().instrument()
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
 
 agent = Agent(
     name="Stock Market Agent",

--- a/cookbook/observability/teams/langfuse_via_openinference_async_team.py
+++ b/cookbook/observability/teams/langfuse_via_openinference_async_team.py
@@ -28,10 +28,9 @@ os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}
 
 tracer_provider = TracerProvider()
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
-trace_api.set_tracer_provider(tracer_provider=tracer_provider)
 
 # Start instrumenting agno
-AgnoInstrumentor().instrument()
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
 
 # First agent for market data
 market_data_agent = Agent(

--- a/cookbook/observability/teams/langfuse_via_openinference_team.py
+++ b/cookbook/observability/teams/langfuse_via_openinference_team.py
@@ -27,10 +27,9 @@ os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = f"Authorization=Basic {LANGFUSE_AUTH}
 
 tracer_provider = TracerProvider()
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
-trace_api.set_tracer_provider(tracer_provider=tracer_provider)
 
 # Start instrumenting agno
-AgnoInstrumentor().instrument()
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
 
 # First agent for market data
 market_data_agent = Agent(


### PR DESCRIPTION
## Summary

This pull request updates the telemetry-related cookbooks to avoid setting `TracerProvider` globally.

While testing Langfuse integration via Openinference on an A2A application, I found that the traces of my Agno agent were not being sent to the Langfuse instance, and was instead only receiving A2A events.

This was due to A2A SDK enabling telemetry by default when opentelemetry package is available in the environment, and it uses the global tracer provider. I fixed it by passing the `TracerProvider` instance directly into the instrumentor instead of setting it globally.

I have hence updated the cookbooks to reflect that.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

