### PR TITLE
Fix running Mem0 Toolkit with local Mem0 config

### DIFF
--- a/libs/agno/agno/tools/mem0.py
+++ b/libs/agno/agno/tools/mem0.py
@@ -110,7 +110,6 @@ class Mem0Tools(Toolkit):
                 messages_list,
                 user_id=resolved_user_id,
                 infer=self.infer,
-                output_format="v1.1",
             )
             return json.dumps(result)
         except Exception as e:
@@ -131,7 +130,6 @@ class Mem0Tools(Toolkit):
             results = self.client.search(
                 query=query,
                 user_id=resolved_user_id,
-                output_format="v1.1",
             )
 
             if isinstance(results, dict) and "results" in results:
@@ -159,7 +157,6 @@ class Mem0Tools(Toolkit):
         try:
             results = self.client.get_all(
                 user_id=resolved_user_id,
-                output_format="v1.1",
             )
 
             if isinstance(results, dict) and "results" in results:


### PR DESCRIPTION
## Summary

Currently the Mem0Tools works only with Mem0 client due to the usage of `output_format` kwarg, which does not exist when using a local memo config `Memory()`.

Since this param is optional, I am removing it completely, which makes the toolkit work in both client and local moods.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
