### PR TITLE
fix: removed code that caused claude send all mcp tool args as required

### DIFF
--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -307,14 +307,6 @@ def format_tools_for_model(tools: Optional[List[Dict[str, Any]]] = None) -> Opti
         required: List[str] = parameters.get("required", [])
         required_params: List[str] = required
 
-        if not required_params:
-            for param_name, param_info in properties.items():
-                param_type = param_info.get("type", "")
-                param_type_list: List[str] = [param_type] if isinstance(param_type, str) else param_type or []
-
-                if "null" not in param_type_list:
-                    required_params.append(param_name)
-
         input_properties: Dict[str, Any] = {}
         for param_name, param_info in properties.items():
             # Preserve the complete schema structure for complex types


### PR DESCRIPTION
## Summary

  ## Problem
  Claude models were incorrectly marking all optional MCP tool parameters as required,
  causing validation errors when Claude generated invalid default values in the args

  ## Solution
  Removed the faulty auto-requirement logic in `format_tools_for_model()` function in
  `agno/utils/models/claude.py` that was making all non-nullable parameters required when no
   explicit required parameters existed.

  ## Changes
  - **File**: `agno/utils/models/claude.py`
  - **Lines**: 310-316
  - **Type**: Removed 7 lines of buggy logic

  ## Testing
  - Verified Claude agents now work correctly with MCP tools
  - Tool calls no longer include invalid default parameters
  - Schema now respects original tool author's intent for optional vs required parameters

## Type of change

- [V] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [V] Code complies with style guidelines
- [V] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---
