### PR TITLE
[fix] fix history check in member task run

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -5289,7 +5289,7 @@ class Team:
             member_session_state_copy = copy(session_state)
             if stream:
                 member_agent_run_response_stream = member_agent.run(
-                    input=member_agent_task if history is None else history,
+                    input=member_agent_task if not history else history,
                     user_id=user_id,
                     # All members have the same session_id
                     session_id=session.session_id,
@@ -5324,7 +5324,7 @@ class Team:
                     yield member_agent_run_output_event
             else:
                 member_agent_run_response = member_agent.run(  # type: ignore
-                    input=member_agent_task if history is None else history,
+                    input=member_agent_task if not history else history,
                     user_id=user_id,
                     # All members have the same session_id
                     session_id=session.session_id,
@@ -5408,7 +5408,7 @@ class Team:
             member_session_state_copy = copy(session_state)
             if stream:
                 member_agent_run_response_stream = member_agent.arun(  # type: ignore
-                    input=member_agent_task if history is None else history,
+                    input=member_agent_task if not history else history,
                     user_id=user_id,
                     # All members have the same session_id
                     session_id=session.session_id,
@@ -5443,7 +5443,7 @@ class Team:
                     yield member_agent_run_response_event
             else:
                 member_agent_run_response = await member_agent.arun(  # type: ignore
-                    input=member_agent_task if history is None else history,
+                    input=member_agent_task if not history else history,
                     user_id=user_id,
                     # All members have the same session_id
                     session_id=session.session_id,
@@ -5517,7 +5517,7 @@ class Team:
                 member_session_state_copy = copy(session_state)
                 if stream:
                     member_agent_run_response_stream = member_agent.run(
-                        input=member_agent_task if history is None else history,
+                        input=member_agent_task if not history else history,
                         user_id=user_id,
                         # All members have the same session_id
                         session_id=session.session_id,
@@ -5553,7 +5553,7 @@ class Team:
 
                 else:
                     member_agent_run_response = member_agent.run(  # type: ignore
-                        input=member_agent_task if history is None else history,
+                        input=member_agent_task if not history else history,
                         user_id=user_id,
                         # All members have the same session_id
                         session_id=session.session_id,
@@ -5627,7 +5627,7 @@ class Team:
                     member_session_state_copy = copy(session_state)
 
                     member_stream = agent.arun(  # type: ignore
-                        input=member_agent_task if history is None else history,
+                        input=member_agent_task if not history else history,
                         user_id=user_id,
                         session_id=session.session_id,
                         session_state=member_session_state_copy,  # Send a copy to the agent
@@ -5700,7 +5700,7 @@ class Team:
                     async def run_member_agent(agent=current_agent) -> str:
                         member_session_state_copy = copy(session_state)
                         member_agent_run_response = await agent.arun(
-                            input=member_agent_task if history is None else history,
+                            input=member_agent_task if not history else history,
                             user_id=user_id,
                             # All members have the same session_id
                             session_id=session.session_id,


### PR DESCRIPTION
## Summary

I was hitting an issue where "history" was and empty array []. But since we are checking for None here, it was passing the empty array in instead of the member task - this results in a bug where member task isn't actually being passed in