### PR TITLE
Fix AttributeError when extra_data is dict during deserialization

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -8056,6 +8056,10 @@ class Agent:
                 from agno.run.response import RunResponseExtraData
 
                 self.run_response.extra_data = RunResponseExtraData()
+            elif isinstance(self.run_response.extra_data, dict):
+                from agno.run.response import RunResponseExtraData
+
+                self.run_response.extra_data = RunResponseExtraData.from_dict(self.run_response.extra_data)
 
             if self.run_response.extra_data.reasoning_steps is None:
                 self.run_response.extra_data.reasoning_steps = []
@@ -8069,6 +8073,10 @@ class Agent:
                     from agno.run.response import RunResponseExtraData
 
                     self.run_response.extra_data = RunResponseExtraData()
+                elif isinstance(self.run_response.extra_data, dict):
+                    from agno.run.response import RunResponseExtraData
+
+                    self.run_response.extra_data = RunResponseExtraData.from_dict(self.run_response.extra_data)
 
                 # Initialize reasoning_messages if it doesn't exist
                 if self.run_response.extra_data.reasoning_messages is None:


### PR DESCRIPTION
Fixed AttributeError("'dict' object has no attribute 'reasoning_steps'")  in agent.py when `run_response.extra_data` is a dict instead of `RunResponseExtraData` object. This error occurred during session deserialization when loading agents from storage.

The issue happened because:
1. `RunResponseExtraData` objects are serialized to dictionaries when stored
2. When sessions are loaded from storage, `extra_data` comes back as a dict
3. Code tried to access attributes like `.reasoning_steps` on what was actually a dict

Added type checking and conversion logic in:
- `_add_reasoning_step_to_extra_data()` method
- `_add_reasoning_metrics_to_extra_data()` method


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

### Technical Details
- **Root Cause**: Serialization/deserialization cycle in session storage
- **Impact**: AttributeError only occurred when loading agents from persistent storage
- **Solution**: Added type checking with `isinstance(extra_data, dict)` and conversion using `RunResponseExtraData.from_dict()`
- **Files Modified**: `libs/agno/agno/agent/agent.py`