### PR TITLE
fix: dont raise if no session when getting chat history

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -4518,6 +4518,7 @@ class Agent:
         session = self.get_session(session_id=session_id)  # type: ignore
 
         if session is None:
+            log_warning(f"Session {session_id} not found")
             return []
 
         # Only filter by agent_id if this is part of a team

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -4518,7 +4518,7 @@ class Agent:
         session = self.get_session(session_id=session_id)  # type: ignore
 
         if session is None:
-            raise Exception("Session not found")
+            return []
 
         # Only filter by agent_id if this is part of a team
         return session.get_messages_from_last_n_runs(

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -6040,7 +6040,7 @@ class Team:
         session = self.get_session(session_id=session_id)  # type: ignore
 
         if session is None:
-            raise Exception("Session not found")
+            return []
 
         # Only filter by agent_id if this is part of a team
         return session.get_messages_from_last_n_runs(

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -6040,6 +6040,7 @@ class Team:
         session = self.get_session(session_id=session_id)  # type: ignore
 
         if session is None:
+            log_warning(f"Session {session_id} not found")
             return []
 
         # Only filter by agent_id if this is part of a team


### PR DESCRIPTION
- We shouldn't raise in `get_messages_for_session` if the session is not found - that's expected in some cases