### PR TITLE
feat: enhance CSV reader to support multiple file encodings

### DIFF
--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -10,6 +10,11 @@ try:
 except ImportError:
     raise ImportError("`aiofiles` not installed. Please install it with `pip install aiofiles`")
 
+try:
+    import chardet
+except ImportError:
+    raise ImportError("`chardet` not installed. Please install it with `pip install chardet`")
+
 from agno.knowledge.chunking.row import RowChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
 from agno.knowledge.document.base import Document
@@ -39,6 +44,70 @@ class CSVReader(Reader):
     def get_supported_content_types(self) -> List[ContentType]:
         return [ContentType.CSV, ContentType.XLSX, ContentType.XLS]
 
+    def _detect_encoding(self, file_path: Path) -> str:
+        """
+        Detect the encoding of a file using chardet.
+        
+        Args:
+            file_path: Path to the file
+            
+        Returns:
+            Detected encoding or 'utf-8' as fallback
+        """
+        try:
+            with open(file_path, 'rb') as f:
+                raw_data = f.read(10000)  # Read first 10KB for detection
+                result = chardet.detect(raw_data)
+                encoding = result['encoding']
+                confidence = result['confidence']
+                
+                # If confidence is high enough, use detected encoding
+                if encoding and confidence > 0.7:
+                    logger.info(f"Detected encoding: {encoding} with confidence: {confidence}")
+                    return encoding
+                else:
+                    logger.info(f"Low confidence in detected encoding ({confidence}), falling back to utf-8")
+                    return 'utf-8'
+        except Exception as e:
+            logger.warning(f"Error detecting encoding, falling back to utf-8: {e}")
+            return 'utf-8'
+
+    def _read_file_with_encoding(self, file_path: Path, encoding: str) -> str:
+        """
+        Read file content with specified encoding, with fallback to other encodings if needed.
+        
+        Args:
+            file_path: Path to the file
+            encoding: Encoding to try first
+            
+        Returns:
+            File content as string
+        """
+        encodings_to_try = [encoding, 'utf-8', 'gbk', 'gb2312', 'latin-1']
+        
+        for enc in encodings_to_try:
+            try:
+                with open(file_path, 'r', encoding=enc) as f:
+                    content = f.read()
+                    if enc != encoding:
+                        logger.info(f"Successfully read file with fallback encoding: {enc}")
+                    return content
+            except UnicodeDecodeError:
+                logger.debug(f"Failed to read file with encoding: {enc}")
+                continue
+            except Exception as e:
+                logger.warning(f"Error reading file with encoding {enc}: {e}")
+                continue
+        
+        # If all encodings fail, try with errors='ignore'
+        try:
+            with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
+                logger.warning("Reading file with errors ignored, some characters may be lost")
+                return f.read()
+        except Exception as e:
+            logger.error(f"Failed to read file even with error ignoring: {e}")
+            raise
+
     def read(
         self, file: Union[Path, IO[Any]], delimiter: str = ",", quotechar: str = '"', name: Optional[str] = None
     ) -> List[Document]:
@@ -47,11 +116,32 @@ class CSVReader(Reader):
                 if not file.exists():
                     raise FileNotFoundError(f"Could not find file: {file}")
                 logger.info(f"Reading: {file}")
-                file_content = file.open(newline="", mode="r", encoding="utf-8")
+                
+                # Detect encoding
+                detected_encoding = self._detect_encoding(file)
+                file_content_str = self._read_file_with_encoding(file, detected_encoding)
+                file_content = io.StringIO(file_content_str)
             else:
                 logger.info(f"Reading retrieved file: {name or file.name}")
                 file.seek(0)
-                file_content = io.StringIO(file.read().decode("utf-8"))  # type: ignore
+                # Try to detect encoding for bytes content
+                if hasattr(file, 'read'):
+                    try:
+                        # Get current position
+                        pos = file.tell()
+                        raw_data = file.read(10000)  # Read first 10KB for detection
+                        file.seek(pos)  # Reset position
+                        
+                        result = chardet.detect(raw_data if isinstance(raw_data, bytes) else raw_data.encode() if isinstance(raw_data, str) else b'')
+                        encoding = result['encoding'] or 'utf-8'
+                        
+                        file_content = io.StringIO(file.read().decode(encoding))
+                    except Exception as e:
+                        logger.warning(f"Error detecting encoding for bytes content, using utf-8: {e}")
+                        file.seek(0)
+                        file_content = io.StringIO(file.read().decode("utf-8"))  # type: ignore
+                else:
+                    file_content = io.StringIO(file.read().decode("utf-8"))  # type: ignore
 
             csv_name = name or (
                 Path(file.name).stem
@@ -106,13 +196,53 @@ class CSVReader(Reader):
                 if not file.exists():
                     raise FileNotFoundError(f"Could not find file: {file}")
                 logger.info(f"Reading async: {file}")
-                async with aiofiles.open(file, mode="r", encoding="utf-8", newline="") as file_content:
-                    content = await file_content.read()
-                    file_content_io = io.StringIO(content)
+                
+                # Detect encoding
+                detected_encoding = self._detect_encoding(file)
+                
+                # Try to read with detected encoding
+                encodings_to_try = [detected_encoding, 'utf-8', 'gbk', 'gb2312', 'latin-1']
+                content = None
+                used_encoding = None
+                
+                for enc in encodings_to_try:
+                    try:
+                        async with aiofiles.open(file, mode="r", encoding=enc, newline="") as file_content:
+                            content = await file_content.read()
+                            used_encoding = enc
+                            if enc != detected_encoding:
+                                logger.info(f"Successfully read file with fallback encoding: {enc}")
+                            break
+                    except UnicodeDecodeError:
+                        logger.debug(f"Failed to read file with encoding: {enc}")
+                        continue
+                    except Exception as e:
+                        logger.warning(f"Error reading file with encoding {enc}: {e}")
+                        continue
+                
+                # If all encodings fail, try with errors='ignore'
+                if content is None:
+                    try:
+                        async with aiofiles.open(file, mode="r", encoding='utf-8', errors='ignore', newline="") as file_content:
+                            content = await file_content.read()
+                            used_encoding = 'utf-8'
+                            logger.warning("Reading file with errors ignored, some characters may be lost")
+                    except Exception as e:
+                        logger.error(f"Failed to read file even with error ignoring: {e}")
+                        raise
+                
+                file_content_io = io.StringIO(content)
             else:
                 logger.info(f"Reading retrieved file async: {file.name}")
                 file.seek(0)
-                file_content_io = io.StringIO(file.read().decode("utf-8"))  # type: ignore
+                # Try to detect encoding for bytes content
+                try:
+                    # For file-like objects, we'll assume UTF-8 for now in async context
+                    file_content_io = io.StringIO(file.read().decode("utf-8"))  # type: ignore
+                except Exception as e:
+                    logger.warning(f"Error decoding file content, using utf-8 with error handling: {e}")
+                    file.seek(0)
+                    file_content_io = io.StringIO(file.read().decode("utf-8", errors="ignore"))  # type: ignore
 
             csv_name = name or (
                 Path(file.name).stem

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -151,7 +151,7 @@ upstash = ["upstash-vector"]
 pdf = ["pypdf", "rapidocr_onnxruntime"]
 docx = ["python-docx"]
 text = ["aiofiles"]
-csv = ["aiofiles"]
+csv = ["aiofiles", "chardet"]
 markdown = ["unstructured", "markdown", "aiofiles"]
 chonkie = ["chonkie[st]", "chonkie"]
 


### PR DESCRIPTION
- Add chardet library dependency for automatic encoding detection
- Implement encoding detection functionality supporting UTF-8, GBK, GB2312, Latin-1 and more
- Add encoding fallback mechanism to try alternative encodings when primary fails
- Improve error handling and logging features
- Maintain backward compatibility without affecting existing APIs

This solves the issue where CSV reader could only handle UTF-8 encoded files, now it can automatically process CSV files with various encodings.

