### PR TITLE
[fix] Remove @dataclass decorator from Streamlit class to resolve AwsApp parameter inheritance

### DIFF
--- a/libs/agno_infra/agno/aws/app/streamlit/streamlit.py
+++ b/libs/agno_infra/agno/aws/app/streamlit/streamlit.py
@@ -1,10 +1,8 @@
-from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 from agno.aws.app.base import AwsApp, AwsBuildContext, ContainerContext  # noqa: F401
 
 
-@dataclass
 class Streamlit(AwsApp):
     # -*- App Name
     name: str = "streamlit"


### PR DESCRIPTION
## Summary

The Streamlit class uses `@dataclass` decorator while inheriting from AwsApp (a Pydantic model), causing initialization conflicts that prevent recognition of inherited parameters like `ecs_cluster`.

Users get: `TypeError: Streamlit.__init__() got an unexpected keyword argument 'ecs_cluster'`

### Root Cause
- AwsApp is a Pydantic model with its own field validation system
- `@dataclass` generates its own __init__ method that conflicts with Pydantic's initialization
- This prevents inherited AwsApp fields from being recognized

### Solution
- Remove `@dataclass` decorator from Streamlit class
- Use regular class inheritance like FastApi already does
- Maintains all existing functionality while fixing parameter inheritance

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
