### PR TITLE
fix:whatsapp documentation change

### DIFF
--- a/cookbook/agent_os/interfaces/whatsapp/readme.md
+++ b/cookbook/agent_os/interfaces/whatsapp/readme.md
@@ -97,7 +97,7 @@ The WhatsApp API module provides integration between WhatsApp Business API and A
    ```
    3. Click on "Configure a webhook".
    4. Configure the webhook:
-      - URL: Your ngrok URL + "/webhook" (e.g., https://your-domain.ngrok-free.app/webhook)
+      - URL: Your ngrok URL + "/webhook" (e.g., https://your-domain.ngrok-free.app/whatsapp/webhook)
       - Verify Token: Same as WHATSAPP_VERIFY_TOKEN in your .envrc
    5. Run your app locally with `python <my-app>.py` and click "Verify and save".
    6. Subscribe to the 'messages' webhook field.


### PR DESCRIPTION
## Summary

For the new whatsapp interface the correct address of the webhook should be "your-domain/whatsapp/webhhok"
(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: readme updated

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
