### PR TITLE
[fix] update parameter name in Google search function for consistency

### DIFF
--- a/libs/agno/agno/tools/googlesearch.py
+++ b/libs/agno/agno/tools/googlesearch.py
@@ -82,7 +82,7 @@ class GoogleSearchTools(Toolkit):
         log_debug(f"Searching Google [{language}] for: {query}")
 
         # Perform Google search using the googlesearch-python package
-        results = list(search(query, num=max_results, lang=language))
+        results = list(search(query, num_results=max_results, lang=language))
 
         # Collect the search results
         res: List[Dict[str, str]] = []


### PR DESCRIPTION
## Summary

This PR fixes a parameter name issue in the Google search function. The change updates the parameter from num to num_results when calling the search function from the googlesearch-python package, which is the correct parameter name according to the library's API. This small but important fix prevents potential runtime errors when using Google search functionality and ensures compatibility with the googlesearch library.

This PR fixes the issue, issue number: #4593

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

