### PR TITLE
chore: Add token metric at openai responses API

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1088,4 +1088,10 @@ class OpenAIResponses(Model):
         metrics.output_tokens = response_usage.output_tokens or 0
         metrics.total_tokens = response_usage.total_tokens or 0
 
+        if input_tokens_details := response_usage.input_tokens_details:
+            metrics.cache_read_tokens = input_tokens_details.cached_tokens
+
+        if output_tokens_details := response_usage.output_tokens_details:
+            metrics.reasoning_tokens = output_tokens_details.reasoning_tokens
+
         return metrics


### PR DESCRIPTION
## Summary

Add parsing of OpenAI `response_usage` details to record `cache_read_tokens` and `reasoning_tokens` in `Metrics`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: Add metadata for metric

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

X
