### PR TITLE
allow use of embedders other than openai

### DIFF
--- a/cookbook/knowledge/chunking/README.md
+++ b/cookbook/knowledge/chunking/README.md
@@ -9,6 +9,7 @@ pip install agno openai
 ```
 
 Set your OpenAI API key:
+
 ```bash
 export OPENAI_API_KEY=your_api_key
 ```
@@ -18,10 +19,10 @@ export OPENAI_API_KEY=your_api_key
 Chunking strategies integrate with readers to process documents:
 
 ```python
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.knowledge.chunking.semantic import SemanticChunking
 
-reader = PDFUrlReader(
+reader = PDFReader(
     chunking_strategy=SemanticChunking()
 )
 knowledge.add_content(url="document.pdf", reader=reader)
@@ -32,7 +33,7 @@ agent = Agent(
 )
 
 agent.print_response(
-    "What are the key concepts covered in this document?", 
+    "What are the key concepts covered in this document?",
     markdown=True
 )
 ```

--- a/cookbook/knowledge/chunking/agentic_chunking.py
+++ b/cookbook/knowledge/chunking/agentic_chunking.py
@@ -1,7 +1,7 @@
 from agno.agent import Agent
 from agno.knowledge.chunking.agentic import AgenticChunking
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
@@ -12,7 +12,7 @@ knowledge = Knowledge(
 
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         name="Agentic Chunking Reader",
         chunking_strategy=AgenticChunking(),
     ),

--- a/cookbook/knowledge/chunking/custom_strategy_example.py
+++ b/cookbook/knowledge/chunking/custom_strategy_example.py
@@ -4,7 +4,7 @@ from agno.agent import Agent
 from agno.knowledge.chunking.strategy import ChunkingStrategy
 from agno.knowledge.document.base import Document
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 
@@ -84,7 +84,7 @@ knowledge = Knowledge(
 # - Any custom pattern that fits your content
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         name="Custom Strategy Reader",
         chunking_strategy=CustomSeparatorChunking(separator="---"),
     ),

--- a/cookbook/knowledge/chunking/document_chunking.py
+++ b/cookbook/knowledge/chunking/document_chunking.py
@@ -1,7 +1,7 @@
 from agno.agent import Agent
 from agno.knowledge.chunking.document import DocumentChunking
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
@@ -12,7 +12,7 @@ knowledge = Knowledge(
 
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         name="Document Chunking Reader",
         chunking_strategy=DocumentChunking(),
     ),

--- a/cookbook/knowledge/chunking/fixed_size_chunking.py
+++ b/cookbook/knowledge/chunking/fixed_size_chunking.py
@@ -1,7 +1,7 @@
 from agno.agent import Agent
 from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
@@ -12,7 +12,7 @@ knowledge = Knowledge(
 
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         name="Fixed Size Chunking Reader",
         chunking_strategy=FixedSizeChunking(),
     ),

--- a/cookbook/knowledge/chunking/recursive_chunking.py
+++ b/cookbook/knowledge/chunking/recursive_chunking.py
@@ -1,7 +1,7 @@
 from agno.agent import Agent
 from agno.knowledge.chunking.recursive import RecursiveChunking
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
@@ -12,7 +12,7 @@ knowledge = Knowledge(
 
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         name="Recursive Chunking Reader",
         chunking_strategy=RecursiveChunking(),
     ),

--- a/cookbook/knowledge/chunking/semantic_chunking.py
+++ b/cookbook/knowledge/chunking/semantic_chunking.py
@@ -1,7 +1,7 @@
 from agno.agent import Agent
 from agno.knowledge.chunking.semantic import SemanticChunking
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
@@ -11,7 +11,7 @@ knowledge = Knowledge(
 )
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         name="Semantic Chunking Reader",
         chunking_strategy=SemanticChunking(similarity_threshold=0.5),
     ),

--- a/cookbook/knowledge/embedders/aws_bedrock_embedder.py
+++ b/cookbook/knowledge/embedders/aws_bedrock_embedder.py
@@ -1,6 +1,6 @@
 from agno.knowledge.embedder.aws_bedrock import AwsBedrockEmbedder
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.reader.pdf_reader import PDFUrlReader
+from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.vectordb.pgvector import PgVector
 
 embeddings = AwsBedrockEmbedder().get_embedding(
@@ -21,7 +21,7 @@ knowledge = Knowledge(
 
 knowledge.add_content(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf",
-    reader=PDFUrlReader(
+    reader=PDFReader(
         chunk_size=2048
     ),  # Required because cohere has a fixed size of 2048
 )

--- a/libs/agno/agno/knowledge/chunking/semantic.py
+++ b/libs/agno/agno/knowledge/chunking/semantic.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+import inspect
 
 from agno.knowledge.chunking.strategy import ChunkingStrategy
 from agno.knowledge.document.base import Document
@@ -26,11 +27,37 @@ class SemanticChunking(ChunkingStrategy):
                     "Please install it using `pip install chonkie` to use SemanticChunking."
                 )
 
-            self.chunker = SemanticChunker(
-                embedding_model=self.embedder.id,  # type: ignore
-                chunk_size=self.chunk_size,
-                threshold=self.similarity_threshold,
-            )
+            # Build arguments dynamically based on chonkie's supported signature
+            params = {
+                "chunk_size": self.chunk_size,
+                "threshold": self.similarity_threshold,
+            }
+
+            try:
+                sig = inspect.signature(SemanticChunker)
+                param_names = set(sig.parameters.keys())
+
+                # Prefer passing a callable to avoid Chonkie initializing its own client
+                if "embedding_fn" in param_names:
+                    params["embedding_fn"] = self.embedder.get_embedding  # type: ignore[attr-defined]
+                    # If chonkie allows specifying dimensions, provide them
+                    if "embedding_dimensions" in param_names and getattr(self.embedder, "dimensions", None):
+                        params["embedding_dimensions"] = self.embedder.dimensions  # type: ignore[attr-defined]
+                elif "embedder" in param_names:
+                    # Some versions may accept an embedder object directly
+                    params["embedder"] = self.embedder
+                else:
+                    # Fallback to model id for older versions
+                    params["embedding_model"] = getattr(self.embedder, "id", None) or "text-embedding-3-small"
+
+                self.chunker = SemanticChunker(**params)
+            except Exception:
+                # As a final fallback, use the original behavior
+                self.chunker = SemanticChunker(
+                    embedding_model=getattr(self.embedder, "id", None) or "text-embedding-3-small",
+                    chunk_size=self.chunk_size,
+                    threshold=self.similarity_threshold,
+                )
 
     def chunk(self, document: Document) -> List[Document]:
         """Split document into semantic chunks using chonkie"""

--- a/libs/agno/tests/integration/knowledge/test_semantic_chunking_integration.py
+++ b/libs/agno/tests/integration/knowledge/test_semantic_chunking_integration.py
@@ -1,0 +1,67 @@
+from types import ModuleType, SimpleNamespace
+import sys
+
+from agno.knowledge.chunking.strategy import ChunkingStrategyFactory, ChunkingStrategyType
+from agno.knowledge.document.base import Document
+
+
+class DummyEmbedder:
+    def __init__(self, id: str = "azure-embedding-deployment", dimensions: int = 64):
+        self.id = id
+        self.dimensions = dimensions
+
+    def get_embedding(self, text: str):
+        # Return a deterministic fixed-size vector for integration flow
+        return [0.1] * self.dimensions
+
+
+def install_fake_chonkie(klass):
+    mod = ModuleType("chonkie")
+    setattr(mod, "SemanticChunker", klass)
+    sys.modules["chonkie"] = mod
+
+
+def remove_fake_chonkie():
+    sys.modules.pop("chonkie", None)
+
+
+def test_semantic_chunking_factory_integration_with_embedding_fn():
+    class FakeSemanticChunker:
+        def __init__(self, *, embedding_fn, chunk_size, threshold, embedding_dimensions=None):
+            # Basic sanity: callable and dims propagated
+            assert callable(embedding_fn)
+            self.embedding_fn = embedding_fn
+            self.chunk_size = chunk_size
+            self.threshold = threshold
+            self.embedding_dimensions = embedding_dimensions
+
+        def chunk(self, text: str):
+            # No real splitting; return one chunk to validate flow
+            return [SimpleNamespace(text=text)]
+
+    try:
+        install_fake_chonkie(FakeSemanticChunker)
+
+        embedder = DummyEmbedder(id="azure-deploy", dimensions=1536)
+        chunker = ChunkingStrategyFactory.create_strategy(
+            ChunkingStrategyType.SEMANTIC_CHUNKER,
+            embedder=embedder,
+            chunk_size=200,
+            similarity_threshold=0.6,
+        )
+
+        docs = chunker.chunk(Document(content="Hello integration world"))
+
+        assert isinstance(docs, list)
+        assert len(docs) == 1
+        assert docs[0].content == "Hello integration world"
+
+        # Access underlying chonkie instance to ensure arg propagation
+        inner = getattr(chunker, "chunker", None)
+        assert inner is not None
+        assert getattr(inner, "embedding_dimensions", None) == 1536
+        assert getattr(inner, "chunk_size", None) == 200
+    finally:
+        remove_fake_chonkie()
+
+

--- a/libs/agno/tests/unit/knowledge/chunking/test_semantic_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_semantic_chunking.py
@@ -1,0 +1,115 @@
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+from agno.knowledge.chunking.semantic import SemanticChunking
+from agno.knowledge.document.base import Document
+
+
+class DummyEmbedder:
+    def __init__(self, id: str = "azure-embedding-deployment", dimensions: int = 1024):
+        self.id = id
+        self.dimensions = dimensions
+
+    def get_embedding(self, text: str):
+        return [0.0] * self.dimensions
+
+
+def install_fake_chonkie(klass):
+    mod = ModuleType("chonkie")
+    setattr(mod, "SemanticChunker", klass)
+    sys.modules["chonkie"] = mod
+    return mod
+
+
+def remove_fake_chonkie():
+    sys.modules.pop("chonkie", None)
+
+
+def test_semantic_chunking_uses_embedding_fn_when_supported():
+    class FakeSemanticChunker:
+        def __init__(self, *, embedding_fn, chunk_size, threshold, embedding_dimensions=None):
+            self.embedding_fn = embedding_fn
+            self.chunk_size = chunk_size
+            self.threshold = threshold
+            self.embedding_dimensions = embedding_dimensions
+
+        def chunk(self, text: str):
+            return [SimpleNamespace(text=text)]
+
+    try:
+        install_fake_chonkie(FakeSemanticChunker)
+
+        embedder = DummyEmbedder(id="azure-deploy", dimensions=1536)
+        sc = SemanticChunking(embedder=embedder, chunk_size=123, similarity_threshold=0.7)
+
+        # Trigger initialization
+        _ = sc.chunk(Document(content="Hello world"))
+
+        fake = sc.chunker
+        assert fake is not None
+        # Compare bound method components rather than identity of bound method objects
+        assert getattr(fake.embedding_fn, "__self__", None) is embedder
+        assert getattr(fake.embedding_fn, "__func__", None) is getattr(embedder.get_embedding, "__func__", None)
+        assert fake.embedding_dimensions == 1536
+        assert fake.chunk_size == 123
+        assert abs(fake.threshold - 0.7) < 1e-9
+    finally:
+        remove_fake_chonkie()
+
+
+def test_semantic_chunking_uses_embedder_object_when_supported():
+    class FakeSemanticChunker:
+        def __init__(self, *, embedder, chunk_size, threshold):
+            self.embedder = embedder
+            self.chunk_size = chunk_size
+            self.threshold = threshold
+
+        def chunk(self, text: str):
+            return [SimpleNamespace(text=text)]
+
+    try:
+        install_fake_chonkie(FakeSemanticChunker)
+
+        embedder = DummyEmbedder(id="azure-deploy", dimensions=1536)
+        sc = SemanticChunking(embedder=embedder, chunk_size=256, similarity_threshold=0.4)
+
+        _ = sc.chunk(Document(content="Hello world"))
+
+        fake = sc.chunker
+        assert fake is not None
+        assert fake.embedder is embedder
+        assert fake.chunk_size == 256
+        assert abs(fake.threshold - 0.4) < 1e-9
+    finally:
+        remove_fake_chonkie()
+
+
+def test_semantic_chunking_falls_back_to_embedding_model_for_older_versions():
+    class FakeSemanticChunker:
+        def __init__(self, *, embedding_model, chunk_size, threshold):
+            self.embedding_model = embedding_model
+            self.chunk_size = chunk_size
+            self.threshold = threshold
+
+        def chunk(self, text: str):
+            return [SimpleNamespace(text=text)]
+
+    try:
+        install_fake_chonkie(FakeSemanticChunker)
+
+        embedder = DummyEmbedder(id="azure-deploy", dimensions=1536)
+        sc = SemanticChunking(embedder=embedder, chunk_size=512, similarity_threshold=0.8)
+
+        _ = sc.chunk(Document(content="Hello world"))
+
+        fake = sc.chunker
+        assert fake is not None
+        assert fake.embedding_model == "azure-deploy"
+        assert fake.chunk_size == 512
+        assert abs(fake.threshold - 0.8) < 1e-9
+    finally:
+        remove_fake_chonkie()
+
+


### PR DESCRIPTION
## Summary

Fix SemanticChunking to use the provided embedder (or embedding fn) with Chonkie instead of a model id, so Azure embedders work without OPENAI_API_KEY warnings. Issue was that we'd always fallback to openAI embedding model since we were just passing the embedder id to chonkie - but AzureOpenAIEmbeddings doesn't have a resolvable model string. We needed to be able to pass an actual embedder instance, which Chonkie supports

Also updates cookbooks to fix imports and I tested that all chunker cookbooks are running as expected.

Issue posted by user:
https://github.com/agno-agi/agno/issues/4219

Docs for Chonkie which I relied on for this:
https://docs.chonkie.ai/python-sdk/embeddings/azure-embeddings
https://docs.chonkie.ai/python-sdk/chunkers/semantic-chunker

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
