### PR TITLE
fix: Don't overwrite tool call ids each time - this is a patch for now as the issue is annoying

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1041,12 +1041,14 @@ class Model(ABC):
         if model_response_delta.extra is not None:
             if stream_data.extra is None:
                 stream_data.extra = {}
-            if "tool_call_ids" in model_response_delta.extra:
-                if not stream_data.extra.get("tool_call_ids"):
-                    stream_data.extra["tool_call_ids"] = []
-                stream_data.extra["tool_call_ids"].extend(model_response_delta.extra["tool_call_ids"])
-
-            stream_data.extra.update({k: v for k, v in model_response_delta.extra.items() if k != "tool_call_ids"})
+            for key in model_response_delta.extra:
+                if isinstance(model_response_delta.extra[key], list):
+                    if not stream_data.extra.get(key):
+                        stream_data.extra[key] = []
+                    stream_data.extra[key].extend(model_response_delta.extra[key])
+                else:
+                    stream_data.extra[key] = model_response_delta.extra[key]
+                    
         if should_yield:
             yield model_response_delta
 

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1046,9 +1046,7 @@ class Model(ABC):
                     stream_data.extra["tool_call_ids"] = []
                 stream_data.extra["tool_call_ids"].extend(model_response_delta.extra["tool_call_ids"])
 
-            stream_data.extra.update(
-                stream_data.extra.update({k: v for k, v in model_response_delta.extra.items() if k != "tool_call_ids"})
-            )
+            stream_data.extra.update({k: v for k, v in model_response_delta.extra.items() if k != "tool_call_ids"})
         if should_yield:
             yield model_response_delta
 

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1041,8 +1041,14 @@ class Model(ABC):
         if model_response_delta.extra is not None:
             if stream_data.extra is None:
                 stream_data.extra = {}
-            stream_data.extra.update(model_response_delta.extra)
+            if "tool_call_ids" in model_response_delta.extra:
+                if not stream_data.extra.get("tool_call_ids"):
+                    stream_data.extra["tool_call_ids"] = []
+                stream_data.extra["tool_call_ids"].extend(model_response_delta.extra["tool_calls"])
 
+            stream_data.extra.update(
+                stream_data.extra.update({k: v for k, v in model_response_delta.extra.items() if k != "tool_call_ids"})
+            )
         if should_yield:
             yield model_response_delta
 

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1044,7 +1044,7 @@ class Model(ABC):
             if "tool_call_ids" in model_response_delta.extra:
                 if not stream_data.extra.get("tool_call_ids"):
                     stream_data.extra["tool_call_ids"] = []
-                stream_data.extra["tool_call_ids"].extend(model_response_delta.extra["tool_calls"])
+                stream_data.extra["tool_call_ids"].extend(model_response_delta.extra["tool_call_ids"])
 
             stream_data.extra.update(
                 stream_data.extra.update({k: v for k, v in model_response_delta.extra.items() if k != "tool_call_ids"})

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1048,7 +1048,7 @@ class Model(ABC):
                     stream_data.extra[key].extend(model_response_delta.extra[key])
                 else:
                     stream_data.extra[key] = model_response_delta.extra[key]
-                    
+
         if should_yield:
             yield model_response_delta
 


### PR DESCRIPTION
## Summary

This is a patch
We are overwriting tool call ids, probably an issue with parallelization specifically - anyway this ensures we don't.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
