### PR TITLE
fix: Remove mastra mcp from example and move to sqlite

### DIFF
--- a/cookbook/agent_os/mcp/enable_mcp_example.py
+++ b/cookbook/agent_os/mcp/enable_mcp_example.py
@@ -5,13 +5,13 @@ After starting this AgentOS app, you can test the MCP server with the test_clien
 """
 
 from agno.agent import Agent
-from agno.db.postgres import PostgresDb
+from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.os import AgentOS
 from agno.tools.duckduckgo import DuckDuckGoTools
 
 # Setup the database
-db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+db = SqliteDb(db_file="tmp/agentos.db")
 
 # Setup basic agents, teams and workflows
 web_research_agent = Agent(

--- a/cookbook/agent_os/mcp/enable_mcp_example.py
+++ b/cookbook/agent_os/mcp/enable_mcp_example.py
@@ -13,7 +13,7 @@ from agno.tools.duckduckgo import DuckDuckGoTools
 # Setup the database
 db = SqliteDb(db_file="tmp/agentos.db")
 
-# Setup basic agents, teams and workflows
+# Setup basic research agent
 web_research_agent = Agent(
     id="web-research-agent",
     name="Web Research Agent",

--- a/cookbook/agent_os/mcp/mcp_tools_advanced_example.py
+++ b/cookbook/agent_os/mcp/mcp_tools_advanced_example.py
@@ -5,25 +5,33 @@ AgentOS handles the lifespan of the MCPTools internally.
 """
 
 from agno.agent import Agent
-from agno.db.postgres import PostgresDb
+from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.os import AgentOS
 from agno.tools.mcp import MCPTools  # noqa: F401
+from os import getenv
 
 # Setup the database
-db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
-
-mastra_mcp_tools = MCPTools(
-    command="npx -y @mastra/mcp-docs-server", timeout_seconds=60
-)
+db = SqliteDb(db_file="tmp/agentos.db")
 
 agno_mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp")
 
+# Example: Brave Search MCP server
+brave_mcp_tools = MCPTools(
+    command="npx -y @modelcontextprotocol/server-brave-search",
+    env={
+        "BRAVE_API_KEY": getenv("BRAVE_API_KEY"),
+    },
+    timeout_seconds=60,
+)
+
 # You can also use MultiMCPTools to connect to multiple MCP servers at once:
 #
+# from agno.tools.mcp import MultiMCPTools
 # mcp_tools = MultiMCPTools(
-#     commands=["npx -y @mastra/mcp-docs-server"],
+#     commands=["npx -y @modelcontextprotocol/server-brave-search"],
 #     urls=["https://docs.agno.com/mcp"],
+#     env={"BRAVE_API_KEY": getenv("BRAVE_API_KEY")},
 # )
 
 # Setup basic agents, teams and workflows
@@ -32,10 +40,7 @@ ai_framework_agent = Agent(
     name="Agno Support Agent",
     model=Claude(id="claude-sonnet-4-0"),
     db=db,
-    tools=[
-        mastra_mcp_tools,
-        agno_mcp_tools,
-    ],
+    tools=[brave_mcp_tools, agno_mcp_tools],
     add_history_to_context=True,
     num_history_runs=3,
     markdown=True,

--- a/cookbook/agent_os/mcp/mcp_tools_advanced_example.py
+++ b/cookbook/agent_os/mcp/mcp_tools_advanced_example.py
@@ -34,7 +34,7 @@ brave_mcp_tools = MCPTools(
 #     env={"BRAVE_API_KEY": getenv("BRAVE_API_KEY")},
 # )
 
-# Setup basic agents, teams and workflows
+# Setup ai framework agent
 ai_framework_agent = Agent(
     id="agno-support-agent",
     name="Agno Support Agent",

--- a/cookbook/agent_os/mcp/mcp_tools_example.py
+++ b/cookbook/agent_os/mcp/mcp_tools_example.py
@@ -5,13 +5,13 @@ AgentOS handles the lifespan of the MCPTools internally.
 """
 
 from agno.agent import Agent
-from agno.db.postgres import PostgresDb
+from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.os import AgentOS
 from agno.tools.mcp import MCPTools
 
 # Setup the database
-db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+db = SqliteDb(db_file="tmp/agentos.db")
 
 mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp")
 

--- a/cookbook/agent_os/mcp/mcp_tools_example.py
+++ b/cookbook/agent_os/mcp/mcp_tools_example.py
@@ -15,7 +15,7 @@ db = SqliteDb(db_file="tmp/agentos.db")
 
 mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp")
 
-# Setup basic agents, teams and workflows
+# Setup basic agent
 agno_support_agent = Agent(
     id="agno-support-agent",
     name="Agno Support Agent",

--- a/cookbook/agent_os/mcp/mcp_tools_existing_lifespan.py
+++ b/cookbook/agent_os/mcp/mcp_tools_existing_lifespan.py
@@ -9,14 +9,14 @@ In addition you can pass your own lifespan to AgentOS.
 from contextlib import asynccontextmanager
 
 from agno.agent import Agent
-from agno.db.postgres import PostgresDb
+from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
 from agno.os import AgentOS
 from agno.tools.mcp import MCPTools
 from agno.utils.log import log_info
 
-# Setup the database
-db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+# Setup the database (SQLite for quick local setup)
+db = SqliteDb(db_file="tmp/agentos.db")
 
 mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp")
 
@@ -58,4 +58,4 @@ if __name__ == "__main__":
 
     """
     # Don't use reload=True here, this can cause issues with the lifespan
-    agent_os.serve(app="mcp_tools_example_existing_lifespan:app")
+    agent_os.serve(app="mcp_tools_existing_lifespan:app")

--- a/cookbook/agent_os/mcp/mcp_tools_existing_lifespan.py
+++ b/cookbook/agent_os/mcp/mcp_tools_existing_lifespan.py
@@ -15,12 +15,12 @@ from agno.os import AgentOS
 from agno.tools.mcp import MCPTools
 from agno.utils.log import log_info
 
-# Setup the database (SQLite for quick local setup)
+# Setup the database
 db = SqliteDb(db_file="tmp/agentos.db")
 
 mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp")
 
-# Setup basic agents, teams and workflows
+# Setup basic support agent
 agno_support_agent = Agent(
     id="agno-support-agent",
     name="Agno Support Agent",


### PR DESCRIPTION
## Summary

Ensures agentos mcp examples use sqlite and removed mastra mcp in example in favour of brave search mcp

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
