### PR TITLE
fix: improve functionality of send_media_to_model flag

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -762,6 +762,7 @@ class Agent:
             tool_call_limit=self.tool_call_limit,
             response_format=response_format,
             run_response=run_response,
+            send_media_to_model=self.send_media_to_model,
         )
 
         # Check for cancellation after model call
@@ -1359,6 +1360,7 @@ class Agent:
             tool_choice=self.tool_choice,
             tool_call_limit=self.tool_call_limit,
             response_format=response_format,
+            send_media_to_model=self.send_media_to_model,
         )
 
         # Check for cancellation after model call
@@ -3174,6 +3176,7 @@ class Agent:
             tool_call_limit=self.tool_call_limit,
             stream_model_response=stream_model_response,
             run_response=run_response,
+            send_media_to_model=self.send_media_to_model,
         ):
             yield from self._handle_model_response_chunk(
                 session=session,
@@ -3250,6 +3253,7 @@ class Agent:
             tool_call_limit=self.tool_call_limit,
             stream_model_response=stream_model_response,
             run_response=run_response,
+            send_media_to_model=self.send_media_to_model,
         )  # type: ignore
 
         async for model_response_event in model_response_stream:  # type: ignore

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -196,6 +196,7 @@ class Model(ABC):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_call_limit: Optional[int] = None,
         run_response: Optional[RunOutput] = None,
+        send_media_to_model: bool = True,
     ) -> ModelResponse:
         """
         Generate a response from the model.
@@ -301,7 +302,7 @@ class Model(ABC):
 
                 if any(msg.images or msg.videos or msg.audio or msg.files for msg in function_call_results):
                     # Handle function call media
-                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results)
+                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results, send_media_to_model=send_media_to_model)
 
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True)
@@ -339,6 +340,7 @@ class Model(ABC):
         functions: Optional[Dict[str, Function]] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_call_limit: Optional[int] = None,
+        send_media_to_model: bool = True,
     ) -> ModelResponse:
         """
         Generate an asynchronous response from the model.
@@ -441,7 +443,7 @@ class Model(ABC):
 
                 if any(msg.images or msg.videos or msg.audio or msg.files for msg in function_call_results):
                     # Handle function call media
-                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results)
+                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results, send_media_to_model=send_media_to_model)
 
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True)
@@ -689,6 +691,7 @@ class Model(ABC):
         tool_call_limit: Optional[int] = None,
         stream_model_response: bool = True,
         run_response: Optional[RunOutput] = None,
+        send_media_to_model: bool = True,
     ) -> Iterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate a streaming response from the model.
@@ -778,7 +781,7 @@ class Model(ABC):
 
                 # Handle function call media
                 if any(msg.images or msg.videos or msg.audio for msg in function_call_results):
-                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results)
+                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results, send_media_to_model=send_media_to_model)
 
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True)
@@ -848,6 +851,7 @@ class Model(ABC):
         tool_call_limit: Optional[int] = None,
         stream_model_response: bool = True,
         run_response: Optional[RunOutput] = None,
+        send_media_to_model: bool = True,
     ) -> AsyncIterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate an asynchronous streaming response from the model.
@@ -937,7 +941,7 @@ class Model(ABC):
 
                 # Handle function call media
                 if any(msg.images or msg.videos or msg.audio for msg in function_call_results):
-                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results)
+                    self._handle_function_call_media(messages=messages, function_call_results=function_call_results, send_media_to_model=send_media_to_model)
 
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True)
@@ -1708,7 +1712,7 @@ class Model(ABC):
         if len(function_call_results) > 0:
             messages.extend(function_call_results)
 
-    def _handle_function_call_media(self, messages: List[Message], function_call_results: List[Message]) -> None:
+    def _handle_function_call_media(self, messages: List[Message], function_call_results: List[Message], send_media_to_model: bool = True) -> None:
         """
         Handle media artifacts from function calls by adding follow-up user messages for generated media if needed.
         """
@@ -1739,9 +1743,10 @@ class Model(ABC):
                 all_files.extend(result_message.files)
                 result_message.files = None
 
-        # If we have media artifacts, add a follow-up "user" message instead of a "tool"
-        # message with the media artifacts which throws error for some models
-        if all_images or all_videos or all_audio or all_files:
+        # Only add media message if we should send media to model
+        if send_media_to_model and (all_images or all_videos or all_audio or all_files):
+            # If we have media artifacts, add a follow-up "user" message instead of a "tool"
+            # message with the media artifacts which throws error for some models
             media_message = Message(
                 role="user",
                 content="Take note of the following content",

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -829,6 +829,7 @@ class Team:
             functions=self._functions_for_model,
             tool_choice=self.tool_choice,
             tool_call_limit=self.tool_call_limit,
+            send_media_to_model=self.send_media_to_model,
         )
 
         # Check for cancellation after model call
@@ -1415,6 +1416,7 @@ class Team:
             tool_choice=self.tool_choice,
             tool_call_limit=self.tool_call_limit,
             response_format=response_format,
+            send_media_to_model=self.send_media_to_model,
         )  # type: ignore
 
         # Check for cancellation after model call
@@ -2061,6 +2063,7 @@ class Team:
             tool_choice=self.tool_choice,
             tool_call_limit=self.tool_call_limit,
             stream_model_response=stream_model_response,
+            send_media_to_model=self.send_media_to_model,
         ):
             yield from self._handle_model_response_chunk(
                 session=session,
@@ -2141,6 +2144,7 @@ class Team:
             tool_choice=self.tool_choice,
             tool_call_limit=self.tool_call_limit,
             stream_model_response=stream_model_response,
+            send_media_to_model=self.send_media_to_model,
         )  # type: ignore
         async for model_response_event in model_stream:
             for event in self._handle_model_response_chunk(


### PR DESCRIPTION
## Summary

fixes: https://github.com/agno-agi/agno/issues/4670

we currently use the `send_media_to_model` flag for the case where the input image to agent is to be accessed by a tool and should not be available to the model.

In this usecase if we use a tool to generate an image (custom or dalle) and using a non multimodal model, so in this case case we append the tool generated media now as a user message to model, we can also use the same `send_media_to_model` to decide to not send to model, otherwise the non multimodal model throws error.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
