### PR TITLE
fix: resolve circular import between Vectordb and knowledge modules

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from io import BytesIO
 from os.path import basename
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast, overload
 
 from httpx import AsyncClient
 
@@ -21,7 +21,9 @@ from agno.knowledge.remote_content.remote_content import GCSContent, RemoteConte
 from agno.utils.http import async_fetch_with_retry
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
-from agno.vectordb import VectorDb
+
+if TYPE_CHECKING:
+    from agno.vectordb import VectorDb
 
 ContentDict = Dict[str, Union[str, Dict[str, str]]]
 
@@ -39,7 +41,7 @@ class Knowledge:
 
     name: Optional[str] = None
     description: Optional[str] = None
-    vector_db: Optional[VectorDb] = None
+    vector_db: Optional["VectorDb"] = None
     contents_db: Optional[BaseDb] = None
     max_results: int = 10
     readers: Optional[Dict[str, Reader]] = None


### PR DESCRIPTION
## Summary
Fixed the circular import error in agno.vectordb by:

  1. Problem: Circular dependency chain:
     agno.vectordb → agno.vectordb.base → agno.knowledge.document → agno.knowledge → agno.knowledge.knowledge → agno.vectordb (circular!)
  2. Solution: Moved VectorDb import behind if TYPE_CHECKING: guard

(If applicable, issue number: #4681)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
