### PR TITLE
fix: run_input not being populated in session runs endpoint if workflow raises error

### DIFF
--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -60,6 +60,14 @@ def get_run_input(run_dict: Dict[str, Any], is_workflow_run: bool = False) -> st
             for message in step_executor_runs[0].get("messages", []):
                 if message.get("role") == "user":
                     return message.get("content", "")
+        
+        # Check the input field directly as final fallback
+        if run_dict.get("input") is not None:
+            input_value = run_dict.get("input")
+            if isinstance(input_value, str):
+                return input_value
+            else:
+                return str(input_value)
 
     if run_dict.get("messages") is not None:
         for message in run_dict["messages"]:


### PR DESCRIPTION
## Summary

fixes: https://github.com/agno-agi/agno/issues/4726

The `/sessions/<session_id>/runs` endpoint does not return `run_input` in case of error as it references it from `step_executor_runs` and its empty if the workflow hasn't run yet, so in this case we fallback to directly get it from `input`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
