### PR TITLE
feat: add bulk writing logic to all db implementations

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -81,6 +81,13 @@ class BaseDb(ABC):
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         raise NotImplementedError
 
+    @abstractmethod
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """Bulk upsert multiple sessions for improved performance on large datasets."""
+        raise NotImplementedError
+
     # --- Memory ---
 
     @abstractmethod
@@ -133,6 +140,13 @@ class BaseDb(ABC):
     def upsert_user_memory(
         self, memory: UserMemory, deserialize: Optional[bool] = True
     ) -> Optional[Union[UserMemory, Dict[str, Any]]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """Bulk upsert multiple memories for improved performance on large datasets."""
         raise NotImplementedError
 
     # --- Metrics ---

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -31,7 +31,7 @@ from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
-from agno.utils.log import log_debug, log_error
+from agno.utils.log import log_debug, log_error, log_info
 from agno.utils.string import generate_id
 
 try:
@@ -522,6 +522,43 @@ class DynamoDb(BaseDb):
             log_error(f"Failed to upsert session {session.session_id}: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"DynamoDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     # --- User Memory ---
 
     def delete_user_memory(self, memory_id: str) -> None:
@@ -868,6 +905,43 @@ class DynamoDb(BaseDb):
         except Exception as e:
             log_error(f"Failed to upsert user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"DynamoDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -556,6 +556,43 @@ class FirestoreDb(BaseDb):
             log_error(f"Exception upserting session: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"FirestoreDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     # -- Memory methods --
 
     def delete_user_memory(self, memory_id: str):
@@ -860,6 +897,42 @@ class FirestoreDb(BaseDb):
         except Exception as e:
             log_error(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"FirestoreDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -410,6 +410,43 @@ class GcsJsonDb(BaseDb):
             log_warning(f"Exception upserting session: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"GcsJsonDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     def _matches_session_key(self, existing_session: Dict[str, Any], session: Session) -> bool:
         """Check if existing session matches the key for the session type."""
         if isinstance(session, AgentSession):
@@ -609,6 +646,42 @@ class GcsJsonDb(BaseDb):
         except Exception as e:
             log_error(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"GcsJsonDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -299,6 +299,40 @@ class InMemoryDb(BaseDb):
             return existing_session.get("workflow_id") == session.workflow_id
         return False
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(f"In-memory database: processing {len(sessions)} sessions with individual upsert operations")
+
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     # -- Memory methods --
     def delete_user_memory(self, memory_id: str):
         try:
@@ -469,6 +503,41 @@ class InMemoryDb(BaseDb):
         except Exception as e:
             log_warning(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(f"In-memory database: processing {len(memories)} memories with individual upsert operations")
+            # For in-memory database, individual upserts are actually efficient
+            # since we're just manipulating Python lists and dictionaries
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories.

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -396,6 +396,43 @@ class JsonDb(BaseDb):
             log_error(f"Exception upserting session: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"JsonDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     def _matches_session_key(self, existing_session: Dict[str, Any], session: Session) -> bool:
         """Check if existing session matches the key for the session type."""
         if isinstance(session, AgentSession):
@@ -597,6 +634,42 @@ class JsonDb(BaseDb):
         except Exception as e:
             log_warning(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"JsonDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/migrations/v1_to_v2.py
+++ b/libs/agno/agno/db/migrations/v1_to_v2.py
@@ -380,17 +380,17 @@ def migrate_table_in_batches(
         else:
             raise ValueError(f"Invalid table type: {v1_table_type}")
 
-        # Insert the batch into the new table
+        # Insert the batch into the new table using bulk operations
         if v1_table_type in ["agent_sessions", "team_sessions", "workflow_sessions"]:
-            # TODO: bulk
-            for session in sessions:
-                db.upsert_session(session)
-            total_migrated += len(sessions)
+            if sessions:
+                db.bulk_upsert_sessions(sessions)
+                total_migrated += len(sessions)
+                log_info(f"Bulk upserted {len(sessions)} sessions in batch {batch_count}")
         elif v1_table_type == "memories":
-            # TODO: bulk
-            for memory in memories:
-                db.upsert_user_memory(memory)
-            total_migrated += len(memories)
+            if memories:
+                db.bulk_upsert_memories(memories)
+                total_migrated += len(memories)
+                log_info(f"Bulk upserted {len(memories)} memories in batch {batch_count}")
 
         log_info(f"Completed batch {batch_count}: migrated {batch_size_actual} records")
 

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -587,6 +587,132 @@ class MongoDb(BaseDb):
             log_error(f"Exception upserting session: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            collection = self._get_collection(table_type="sessions", create_collection_if_not_found=True)
+            if collection is None:
+                log_info("Sessions collection not available, falling back to individual upserts")
+                return [
+                    result
+                    for session in sessions
+                    if session is not None
+                    for result in [self.upsert_session(session, deserialize=deserialize)]
+                    if result is not None
+                ]
+
+            from pymongo import ReplaceOne
+
+            operations = []
+            results = []
+
+            for session in sessions:
+                if session is None:
+                    continue
+
+                serialized_session_dict = serialize_session_json_fields(session.to_dict())
+
+                if isinstance(session, AgentSession):
+                    record = {
+                        "session_id": serialized_session_dict.get("session_id"),
+                        "session_type": SessionType.AGENT.value,
+                        "agent_id": serialized_session_dict.get("agent_id"),
+                        "user_id": serialized_session_dict.get("user_id"),
+                        "runs": serialized_session_dict.get("runs"),
+                        "agent_data": serialized_session_dict.get("agent_data"),
+                        "session_data": serialized_session_dict.get("session_data"),
+                        "summary": serialized_session_dict.get("summary"),
+                        "metadata": serialized_session_dict.get("metadata"),
+                        "created_at": serialized_session_dict.get("created_at"),
+                        "updated_at": int(time.time()),
+                    }
+                elif isinstance(session, TeamSession):
+                    record = {
+                        "session_id": serialized_session_dict.get("session_id"),
+                        "session_type": SessionType.TEAM.value,
+                        "team_id": serialized_session_dict.get("team_id"),
+                        "user_id": serialized_session_dict.get("user_id"),
+                        "runs": serialized_session_dict.get("runs"),
+                        "team_data": serialized_session_dict.get("team_data"),
+                        "session_data": serialized_session_dict.get("session_data"),
+                        "summary": serialized_session_dict.get("summary"),
+                        "metadata": serialized_session_dict.get("metadata"),
+                        "created_at": serialized_session_dict.get("created_at"),
+                        "updated_at": int(time.time()),
+                    }
+                elif isinstance(session, WorkflowSession):
+                    record = {
+                        "session_id": serialized_session_dict.get("session_id"),
+                        "session_type": SessionType.WORKFLOW.value,
+                        "workflow_id": serialized_session_dict.get("workflow_id"),
+                        "user_id": serialized_session_dict.get("user_id"),
+                        "runs": serialized_session_dict.get("runs"),
+                        "workflow_data": serialized_session_dict.get("workflow_data"),
+                        "session_data": serialized_session_dict.get("session_data"),
+                        "summary": serialized_session_dict.get("summary"),
+                        "metadata": serialized_session_dict.get("metadata"),
+                        "created_at": serialized_session_dict.get("created_at"),
+                        "updated_at": int(time.time()),
+                    }
+                else:
+                    continue
+
+                operations.append(
+                    ReplaceOne(filter={"session_id": record["session_id"]}, replacement=record, upsert=True)
+                )
+
+            if operations:
+                # Execute bulk write
+                collection.bulk_write(operations)
+
+                # Fetch the results
+                session_ids = [session.session_id for session in sessions if session and session.session_id]
+                cursor = collection.find({"session_id": {"$in": session_ids}})
+
+                for doc in cursor:
+                    session_dict = deserialize_session_json_fields(doc)
+                    if deserialize:
+                        session_type = doc.get("session_type")
+                        if session_type == SessionType.AGENT.value:
+                            results.append(AgentSession.from_dict(session_dict))
+                        elif session_type == SessionType.TEAM.value:
+                            results.append(TeamSession.from_dict(session_dict))
+                        elif session_type == SessionType.WORKFLOW.value:
+                            results.append(WorkflowSession.from_dict(session_dict))
+                    else:
+                        results.append(session_dict)
+
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert, falling back to individual upserts: {e}")
+
+            # Fallback to individual upserts
+            return [
+                result
+                for session in sessions
+                if session is not None
+                for result in [self.upsert_session(session, deserialize=deserialize)]
+                if result is not None
+            ]
+
     # -- Memory methods --
 
     def delete_user_memory(self, memory_id: str):
@@ -883,6 +1009,91 @@ class MongoDb(BaseDb):
         except Exception as e:
             log_error(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            collection = self._get_collection(table_type="memories", create_collection_if_not_found=True)
+            if collection is None:
+                log_info("Memories collection not available, falling back to individual upserts")
+                return [
+                    result
+                    for memory in memories
+                    if memory is not None
+                    for result in [self.upsert_user_memory(memory, deserialize=deserialize)]
+                    if result is not None
+                ]
+
+            from pymongo import ReplaceOne
+
+            operations = []
+            results = []
+
+            for memory in memories:
+                if memory is None:
+                    continue
+
+                if memory.memory_id is None:
+                    memory.memory_id = str(uuid4())
+
+                record = {
+                    "user_id": memory.user_id,
+                    "agent_id": memory.agent_id,
+                    "team_id": memory.team_id,
+                    "memory_id": memory.memory_id,
+                    "memory": memory.memory,
+                    "topics": memory.topics,
+                    "updated_at": int(time.time()),
+                }
+
+                operations.append(ReplaceOne(filter={"memory_id": memory.memory_id}, replacement=record, upsert=True))
+
+            if operations:
+                # Execute bulk write
+                collection.bulk_write(operations)
+
+                # Fetch the results
+                memory_ids = [memory.memory_id for memory in memories if memory and memory.memory_id]
+                cursor = collection.find({"memory_id": {"$in": memory_ids}})
+
+                for doc in cursor:
+                    if deserialize:
+                        # Remove MongoDB's _id field before creating UserMemory object
+                        doc_filtered = {k: v for k, v in doc.items() if k != "_id"}
+                        results.append(UserMemory.from_dict(doc_filtered))
+                    else:
+                        results.append(doc)
+
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert, falling back to individual upserts: {e}")
+
+            # Fallback to individual upserts
+            return [
+                result
+                for memory in memories
+                if memory is not None
+                for result in [self.upsert_user_memory(memory, deserialize=deserialize)]
+                if result is not None
+            ]
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -705,6 +705,208 @@ class MySQLDb(BaseDb):
             log_error(f"Exception upserting into sessions table: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            table = self._get_table(table_type="sessions", create_table_if_not_found=True)
+            if table is None:
+                log_info("Sessions table not available, falling back to individual upserts")
+                return [
+                    result
+                    for session in sessions
+                    if session is not None
+                    for result in [self.upsert_session(session, deserialize=deserialize)]
+                    if result is not None
+                ]
+
+            # Group sessions by type for batch processing
+            agent_sessions = []
+            team_sessions = []
+            workflow_sessions = []
+
+            for session in sessions:
+                if isinstance(session, AgentSession):
+                    agent_sessions.append(session)
+                elif isinstance(session, TeamSession):
+                    team_sessions.append(session)
+                elif isinstance(session, WorkflowSession):
+                    workflow_sessions.append(session)
+
+            results = []
+
+            # Process each session type in bulk
+            with self.Session() as sess, sess.begin():
+                # Bulk upsert agent sessions
+                if agent_sessions:
+                    agent_data = []
+                    for session in agent_sessions:
+                        session_dict = session.to_dict()
+                        agent_data.append(
+                            {
+                                "session_id": session_dict.get("session_id"),
+                                "session_type": SessionType.AGENT.value,
+                                "agent_id": session_dict.get("agent_id"),
+                                "user_id": session_dict.get("user_id"),
+                                "runs": session_dict.get("runs"),
+                                "agent_data": session_dict.get("agent_data"),
+                                "session_data": session_dict.get("session_data"),
+                                "summary": session_dict.get("summary"),
+                                "metadata": session_dict.get("metadata"),
+                                "created_at": session_dict.get("created_at"),
+                                "updated_at": session_dict.get("created_at"),
+                            }
+                        )
+
+                    if agent_data:
+                        stmt = mysql.insert(table)
+                        stmt = stmt.on_duplicate_key_update(
+                            agent_id=stmt.inserted.agent_id,
+                            user_id=stmt.inserted.user_id,
+                            agent_data=stmt.inserted.agent_data,
+                            session_data=stmt.inserted.session_data,
+                            summary=stmt.inserted.summary,
+                            metadata=stmt.inserted.metadata,
+                            runs=stmt.inserted.runs,
+                            updated_at=int(time.time()),
+                        )
+                        sess.execute(stmt, agent_data)
+
+                        # Fetch the results for agent sessions
+                        agent_ids = [session.session_id for session in agent_sessions]
+                        select_stmt = select(table).where(table.c.session_id.in_(agent_ids))
+                        result = sess.execute(select_stmt).fetchall()
+
+                        for row in result:
+                            session_dict = dict(row._mapping)
+                            if deserialize:
+                                results.append(AgentSession.from_dict(session_dict))
+                            else:
+                                results.append(session_dict)
+
+                # Bulk upsert team sessions
+                if team_sessions:
+                    team_data = []
+                    for session in team_sessions:
+                        session_dict = session.to_dict()
+                        team_data.append(
+                            {
+                                "session_id": session_dict.get("session_id"),
+                                "session_type": SessionType.TEAM.value,
+                                "team_id": session_dict.get("team_id"),
+                                "user_id": session_dict.get("user_id"),
+                                "runs": session_dict.get("runs"),
+                                "team_data": session_dict.get("team_data"),
+                                "session_data": session_dict.get("session_data"),
+                                "summary": session_dict.get("summary"),
+                                "metadata": session_dict.get("metadata"),
+                                "created_at": session_dict.get("created_at"),
+                                "updated_at": session_dict.get("created_at"),
+                            }
+                        )
+
+                    if team_data:
+                        stmt = mysql.insert(table)
+                        stmt = stmt.on_duplicate_key_update(
+                            team_id=stmt.inserted.team_id,
+                            user_id=stmt.inserted.user_id,
+                            team_data=stmt.inserted.team_data,
+                            session_data=stmt.inserted.session_data,
+                            summary=stmt.inserted.summary,
+                            metadata=stmt.inserted.metadata,
+                            runs=stmt.inserted.runs,
+                            updated_at=int(time.time()),
+                        )
+                        sess.execute(stmt, team_data)
+
+                        # Fetch the results for team sessions
+                        team_ids = [session.session_id for session in team_sessions]
+                        select_stmt = select(table).where(table.c.session_id.in_(team_ids))
+                        result = sess.execute(select_stmt).fetchall()
+
+                        for row in result:
+                            session_dict = dict(row._mapping)
+                            if deserialize:
+                                results.append(TeamSession.from_dict(session_dict))
+                            else:
+                                results.append(session_dict)
+
+                # Bulk upsert workflow sessions
+                if workflow_sessions:
+                    workflow_data = []
+                    for session in workflow_sessions:
+                        session_dict = session.to_dict()
+                        workflow_data.append(
+                            {
+                                "session_id": session_dict.get("session_id"),
+                                "session_type": SessionType.WORKFLOW.value,
+                                "workflow_id": session_dict.get("workflow_id"),
+                                "user_id": session_dict.get("user_id"),
+                                "runs": session_dict.get("runs"),
+                                "workflow_data": session_dict.get("workflow_data"),
+                                "session_data": session_dict.get("session_data"),
+                                "summary": session_dict.get("summary"),
+                                "metadata": session_dict.get("metadata"),
+                                "created_at": session_dict.get("created_at"),
+                                "updated_at": session_dict.get("created_at"),
+                            }
+                        )
+
+                    if workflow_data:
+                        stmt = mysql.insert(table)
+                        stmt = stmt.on_duplicate_key_update(
+                            workflow_id=stmt.inserted.workflow_id,
+                            user_id=stmt.inserted.user_id,
+                            workflow_data=stmt.inserted.workflow_data,
+                            session_data=stmt.inserted.session_data,
+                            summary=stmt.inserted.summary,
+                            metadata=stmt.inserted.metadata,
+                            runs=stmt.inserted.runs,
+                            updated_at=int(time.time()),
+                        )
+                        sess.execute(stmt, workflow_data)
+
+                        # Fetch the results for workflow sessions
+                        workflow_ids = [session.session_id for session in workflow_sessions]
+                        select_stmt = select(table).where(table.c.session_id.in_(workflow_ids))
+                        result = sess.execute(select_stmt).fetchall()
+
+                        for row in result:
+                            session_dict = dict(row._mapping)
+                            if deserialize:
+                                results.append(WorkflowSession.from_dict(session_dict))
+                            else:
+                                results.append(session_dict)
+
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert, falling back to individual upserts: {e}")
+            # Fallback to individual upserts
+            return [
+                result
+                for session in sessions
+                if session is not None
+                for result in [self.upsert_session(session, deserialize=deserialize)]
+                if result is not None
+            ]
+
     # -- Memory methods --
     def delete_user_memory(self, memory_id: str):
         """Delete a user memory from the database.
@@ -1054,6 +1256,96 @@ class MySQLDb(BaseDb):
         except Exception as e:
             log_error(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            table = self._get_table(table_type="memories", create_table_if_not_found=True)
+            if table is None:
+                log_info("Memories table not available, falling back to individual upserts")
+                return [
+                    result
+                    for memory in memories
+                    if memory is not None
+                    for result in [self.upsert_user_memory(memory, deserialize=deserialize)]
+                    if result is not None
+                ]
+
+            # Prepare bulk data
+            bulk_data = []
+            for memory in memories:
+                if memory.memory_id is None:
+                    memory.memory_id = str(uuid4())
+
+                bulk_data.append(
+                    {
+                        "memory_id": memory.memory_id,
+                        "memory": memory.memory,
+                        "input": memory.input,
+                        "user_id": memory.user_id,
+                        "agent_id": memory.agent_id,
+                        "team_id": memory.team_id,
+                        "topics": memory.topics,
+                        "updated_at": int(time.time()),
+                    }
+                )
+
+            results = []
+
+            with self.Session() as sess, sess.begin():
+                # Bulk upsert memories using MySQL ON DUPLICATE KEY UPDATE
+                stmt = mysql.insert(table)
+                stmt = stmt.on_duplicate_key_update(
+                    memory=stmt.inserted.memory,
+                    topics=stmt.inserted.topics,
+                    input=stmt.inserted.input,
+                    agent_id=stmt.inserted.agent_id,
+                    team_id=stmt.inserted.team_id,
+                    updated_at=int(time.time()),
+                )
+                sess.execute(stmt, bulk_data)
+
+                # Fetch results
+                memory_ids = [memory.memory_id for memory in memories if memory.memory_id]
+                select_stmt = select(table).where(table.c.memory_id.in_(memory_ids))
+                result = sess.execute(select_stmt).fetchall()
+
+                for row in result:
+                    memory_dict = dict(row._mapping)
+                    if deserialize:
+                        results.append(UserMemory.from_dict(memory_dict))
+                    else:
+                        results.append(memory_dict)
+
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert, falling back to individual upserts: {e}")
+            # Fallback to individual upserts
+            return [
+                result
+                for memory in memories
+                if memory is not None
+                for result in [self.upsert_user_memory(memory, deserialize=deserialize)]
+                if result is not None
+            ]
 
     # -- Metrics methods --
     def _get_all_sessions_for_metrics_calculation(

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -702,6 +702,163 @@ class PostgresDb(BaseDb):
             log_error(f"Exception upserting into sessions table: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk insert or update multiple sessions.
+
+        Args:
+            sessions (List[Session]): The list of session data to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        try:
+            if not sessions:
+                return []
+
+            table = self._get_table(table_type="sessions", create_table_if_not_found=True)
+            if table is None:
+                return []
+
+            # Group sessions by type for better handling
+            agent_sessions = [s for s in sessions if isinstance(s, AgentSession)]
+            team_sessions = [s for s in sessions if isinstance(s, TeamSession)]
+            workflow_sessions = [s for s in sessions if isinstance(s, WorkflowSession)]
+
+            results = []
+
+            # Bulk upsert agent sessions
+            if agent_sessions:
+                session_records = []
+                for session in agent_sessions:
+                    session_dict = session.to_dict()
+                    session_records.append(
+                        {
+                            "session_id": session_dict.get("session_id"),
+                            "session_type": SessionType.AGENT.value,
+                            "agent_id": session_dict.get("agent_id"),
+                            "user_id": session_dict.get("user_id"),
+                            "agent_data": session_dict.get("agent_data"),
+                            "session_data": session_dict.get("session_data"),
+                            "summary": session_dict.get("summary"),
+                            "metadata": session_dict.get("metadata"),
+                            "runs": session_dict.get("runs"),
+                            "created_at": session_dict.get("created_at"),
+                            "updated_at": int(time.time()),
+                        }
+                    )
+
+                with self.Session() as sess, sess.begin():
+                    stmt = postgresql.insert(table)
+                    update_columns = {
+                        col.name: stmt.excluded[col.name]
+                        for col in table.columns
+                        if col.name not in ["id", "session_id", "created_at"]
+                    }
+                    stmt = stmt.on_conflict_do_update(index_elements=["session_id"], set_=update_columns).returning(
+                        table
+                    )
+
+                    result = sess.execute(stmt, session_records)
+                    for row in result.fetchall():
+                        session_dict = dict(row._mapping)
+                        if deserialize:
+                            results.append(AgentSession.from_dict(session_dict))
+                        else:
+                            results.append(session_dict)
+
+            # Bulk upsert team sessions
+            if team_sessions:
+                session_records = []
+                for session in team_sessions:
+                    session_dict = session.to_dict()
+                    session_records.append(
+                        {
+                            "session_id": session_dict.get("session_id"),
+                            "session_type": SessionType.TEAM.value,
+                            "team_id": session_dict.get("team_id"),
+                            "user_id": session_dict.get("user_id"),
+                            "team_data": session_dict.get("team_data"),
+                            "session_data": session_dict.get("session_data"),
+                            "summary": session_dict.get("summary"),
+                            "metadata": session_dict.get("metadata"),
+                            "runs": session_dict.get("runs"),
+                            "created_at": session_dict.get("created_at"),
+                            "updated_at": int(time.time()),
+                        }
+                    )
+
+                with self.Session() as sess, sess.begin():
+                    stmt = postgresql.insert(table)
+                    update_columns = {
+                        col.name: stmt.excluded[col.name]
+                        for col in table.columns
+                        if col.name not in ["id", "session_id", "created_at"]
+                    }
+                    stmt = stmt.on_conflict_do_update(index_elements=["session_id"], set_=update_columns).returning(
+                        table
+                    )
+
+                    result = sess.execute(stmt, session_records)
+                    for row in result.fetchall():
+                        session_dict = dict(row._mapping)
+                        if deserialize:
+                            results.append(TeamSession.from_dict(session_dict))
+                        else:
+                            results.append(session_dict)
+
+            # Bulk upsert workflow sessions
+            if workflow_sessions:
+                session_records = []
+                for session in workflow_sessions:
+                    session_dict = session.to_dict()
+                    session_records.append(
+                        {
+                            "session_id": session_dict.get("session_id"),
+                            "session_type": SessionType.WORKFLOW.value,
+                            "workflow_id": session_dict.get("workflow_id"),
+                            "user_id": session_dict.get("user_id"),
+                            "workflow_data": session_dict.get("workflow_data"),
+                            "session_data": session_dict.get("session_data"),
+                            "summary": session_dict.get("summary"),
+                            "metadata": session_dict.get("metadata"),
+                            "runs": session_dict.get("runs"),
+                            "created_at": session_dict.get("created_at"),
+                            "updated_at": int(time.time()),
+                        }
+                    )
+
+                with self.Session() as sess, sess.begin():
+                    stmt = postgresql.insert(table)
+                    update_columns = {
+                        col.name: stmt.excluded[col.name]
+                        for col in table.columns
+                        if col.name not in ["id", "session_id", "created_at"]
+                    }
+                    stmt = stmt.on_conflict_do_update(index_elements=["session_id"], set_=update_columns).returning(
+                        table
+                    )
+
+                    result = sess.execute(stmt, session_records)
+                    for row in result.fetchall():
+                        session_dict = dict(row._mapping)
+                        if deserialize:
+                            results.append(WorkflowSession.from_dict(session_dict))
+                        else:
+                            results.append(session_dict)
+
+            return results
+
+        except Exception as e:
+            log_error(f"Exception bulk upserting sessions: {e}")
+            return []
+
     # -- Memory methods --
     def delete_user_memory(self, memory_id: str):
         """Delete a user memory from the database.
@@ -1044,6 +1201,75 @@ class PostgresDb(BaseDb):
         except Exception as e:
             log_error(f"Exception upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk insert or update multiple memories in the database for improved performance.
+
+        Args:
+            memories (List[UserMemory]): The list of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        try:
+            if not memories:
+                return []
+
+            table = self._get_table(table_type="memories", create_table_if_not_found=True)
+            if table is None:
+                return []
+
+            # Prepare memory records for bulk insert
+            memory_records = []
+            current_time = int(time.time())
+
+            for memory in memories:
+                if memory.memory_id is None:
+                    memory.memory_id = str(uuid4())
+
+                memory_records.append(
+                    {
+                        "memory_id": memory.memory_id,
+                        "memory": memory.memory,
+                        "input": memory.input,
+                        "user_id": memory.user_id,
+                        "agent_id": memory.agent_id,
+                        "team_id": memory.team_id,
+                        "topics": memory.topics,
+                        "updated_at": current_time,
+                    }
+                )
+
+            results = []
+            with self.Session() as sess, sess.begin():
+                stmt = postgresql.insert(table)
+                update_columns = {
+                    col.name: stmt.excluded[col.name]
+                    for col in table.columns
+                    if col.name not in ["memory_id"]  # Don't update primary key
+                }
+                stmt = stmt.on_conflict_do_update(index_elements=["memory_id"], set_=update_columns).returning(table)
+
+                result = sess.execute(stmt, memory_records)
+                for row in result.fetchall():
+                    memory_dict = dict(row._mapping)
+                    if deserialize:
+                        results.append(UserMemory.from_dict(memory_dict))
+                    else:
+                        results.append(memory_dict)
+
+            return results
+
+        except Exception as e:
+            log_error(f"Exception bulk upserting memories: {e}")
+            return []
 
     # -- Metrics methods --
     def _get_all_sessions_for_metrics_calculation(

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -587,6 +587,43 @@ class RedisDb(BaseDb):
             log_error(f"Error upserting session: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"RedisDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     # -- Memory methods --
 
     def delete_user_memory(self, memory_id: str):
@@ -843,6 +880,43 @@ class RedisDb(BaseDb):
         except Exception as e:
             log_error(f"Error upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"RedisDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -795,6 +795,43 @@ class SingleStoreDb(BaseDb):
             log_error(f"Error upserting into sessions table: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"SingleStoreDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     # -- Memory methods --
     def delete_user_memory(self, memory_id: str):
         """Delete a user memory from the database.
@@ -1127,6 +1164,43 @@ class SingleStoreDb(BaseDb):
         except Exception as e:
             log_error(f"Error upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"SingleStoreDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -687,6 +687,43 @@ class SqliteDb(BaseDb):
             log_warning(f"Exception upserting into table: {e}")
             return None
 
+    def bulk_upsert_sessions(
+        self, sessions: List[Session], deserialize: Optional[bool] = True
+    ) -> List[Union[Session, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple sessions for improved performance on large datasets.
+
+        Args:
+            sessions (List[Session]): List of sessions to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the sessions. Defaults to True.
+
+        Returns:
+            List[Union[Session, Dict[str, Any]]]: List of upserted sessions.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not sessions:
+            return []
+
+        try:
+            log_info(
+                f"SQLiteDb doesn't support efficient bulk operations, falling back to individual upserts for {len(sessions)} sessions"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for session in sessions:
+                if session is not None:
+                    result = self.upsert_session(session, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk session upsert: {e}")
+            return []
+
     # -- Memory methods --
 
     def delete_user_memory(self, memory_id: str):
@@ -1012,6 +1049,43 @@ class SqliteDb(BaseDb):
         except Exception as e:
             log_error(f"Error upserting user memory: {e}")
             return None
+
+    def bulk_upsert_memories(
+        self, memories: List[UserMemory], deserialize: Optional[bool] = True
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """
+        Bulk upsert multiple user memories for improved performance on large datasets.
+
+        Args:
+            memories (List[UserMemory]): List of memories to upsert.
+            deserialize (Optional[bool]): Whether to deserialize the memories. Defaults to True.
+
+        Returns:
+            List[Union[UserMemory, Dict[str, Any]]]: List of upserted memories.
+
+        Raises:
+            Exception: If an error occurs during bulk upsert.
+        """
+        if not memories:
+            return []
+
+        try:
+            log_info(
+                f"SQLiteDb doesn't support efficient bulk operations, falling back to individual upserts for {len(memories)} memories"
+            )
+
+            # Fall back to individual upserts
+            results = []
+            for memory in memories:
+                if memory is not None:
+                    result = self.upsert_user_memory(memory, deserialize=deserialize)
+                    if result is not None:
+                        results.append(result)
+            return results
+
+        except Exception as e:
+            log_error(f"Exception during bulk memory upsert: {e}")
+            return []
 
     def clear_memories(self) -> None:
         """Delete all memories from the database.

--- a/libs/agno/tests/integration/db/postgres/test_memory.py
+++ b/libs/agno/tests/integration/db/postgres/test_memory.py
@@ -241,3 +241,120 @@ def test_comprehensive_user_memory_fields(postgres_db_real: PostgresDb):
     assert retrieved.input == comprehensive_memory.input
     assert retrieved.agent_id == comprehensive_memory.agent_id
     assert retrieved.team_id == comprehensive_memory.team_id
+
+
+def test_bulk_upsert_memories(postgres_db_real: PostgresDb):
+    """Test bulk_upsert_memories for inserting new memories"""
+
+    # Create memories
+    memories = []
+    for i in range(5):
+        memory = UserMemory(
+            memory_id=f"bulk_memory_{i}",
+            memory=f"Bulk test memory {i} with user preferences and information",
+            topics=[f"topic_{i}", "bulk_test"],
+            user_id=f"user_{i}",
+            input=f"Input that generated memory {i}",
+            agent_id=f"agent_{i}",
+            updated_at=datetime.now(),
+        )
+        memories.append(memory)
+
+    # Bulk upsert memories
+    results = postgres_db_real.bulk_upsert_memories(memories)
+
+    # Verify results
+    assert len(results) == 5
+    for i, result in enumerate(results):
+        assert isinstance(result, UserMemory)
+        assert result.memory_id == f"bulk_memory_{i}"
+        assert result.user_id == f"user_{i}"
+        assert result.agent_id == f"agent_{i}"
+        assert result.topics is not None
+        assert f"topic_{i}" in result.topics
+        assert "bulk_test" in result.topics
+
+
+def test_bulk_upsert_memories_update(postgres_db_real: PostgresDb):
+    """Test bulk_upsert_memories for updating existing memories"""
+
+    # Create memories
+    initial_memories = []
+    for i in range(3):
+        memory = UserMemory(
+            memory_id=f"update_memory_{i}",
+            memory=f"Original memory {i}",
+            topics=["original"],
+            user_id=f"user_{i}",
+            input=f"Original input {i}",
+            updated_at=datetime.now(),
+        )
+        initial_memories.append(memory)
+    postgres_db_real.bulk_upsert_memories(initial_memories)
+
+    # Update memories
+    updated_memories = []
+    for i in range(3):
+        memory = UserMemory(
+            memory_id=f"update_memory_{i}",  # Same ID for update
+            memory=f"Updated memory {i} with more information",
+            topics=["updated", "enhanced"],
+            user_id=f"user_{i}",
+            input=f"Updated input {i}",
+            feedback="positive",
+            agent_id=f"new_agent_{i}",
+            updated_at=datetime.now(),
+        )
+        updated_memories.append(memory)
+    results = postgres_db_real.bulk_upsert_memories(updated_memories)
+    assert len(results) == 3
+
+    # Verify updates
+    for i, result in enumerate(results):
+        assert isinstance(result, UserMemory)
+        assert result.memory_id == f"update_memory_{i}"
+        assert "Updated memory" in result.memory
+        assert result.topics == ["updated", "enhanced"]
+        assert result.agent_id == f"new_agent_{i}"
+
+
+def test_bulk_upsert_memories_performance(postgres_db_real: PostgresDb):
+    """Ensure the bulk upsert method is considerably faster than individual upserts"""
+    import time as time_module
+
+    # Create memories
+    memories = []
+    for i in range(30):
+        memory = UserMemory(
+            memory_id=f"perf_memory_{i}",
+            memory=f"Performance test memory {i} with detailed information",
+            topics=["performance", "test"],
+            user_id="perf_user",
+            agent_id=f"perf_agent_{i}",
+            updated_at=datetime.now(),
+        )
+        memories.append(memory)
+
+    # Test individual upsert
+    start_time = time_module.time()
+    for memory in memories:
+        postgres_db_real.upsert_user_memory(memory)
+    individual_time = time_module.time() - start_time
+
+    # Clean up for bulk upsert
+    memory_ids = [m.memory_id for m in memories if m.memory_id]
+    postgres_db_real.delete_user_memories(memory_ids)
+
+    # Test bulk upsert
+    start_time = time_module.time()
+    postgres_db_real.bulk_upsert_memories(memories)
+    bulk_time = time_module.time() - start_time
+
+    # Verify all memories were created
+    all_memories = postgres_db_real.get_user_memories(user_id="perf_user")
+    assert len(all_memories) == 30
+
+    # Bulk should be at least 2x faster
+    assert bulk_time < individual_time / 2, (
+        f"Bulk upsert is not fast enough: {bulk_time:.3f}s vs {individual_time:.3f}s"
+    )

--- a/libs/agno/tests/integration/db/postgres/test_session.py
+++ b/libs/agno/tests/integration/db/postgres/test_session.py
@@ -82,18 +82,19 @@ def sample_team_session() -> TeamSession:
 def test_session_table_constraint_exists(postgres_db_real: PostgresDb):
     """Ensure the session table has the expected unique constraint on session_id"""
     with postgres_db_real.Session() as session:
-        # Dummy call to ensure schema and table creation
-        postgres_db_real.get_sessions(session_type=SessionType.AGENT)
+        # Ensure table is created by calling _get_table with create_table_if_not_found=True
+        table = postgres_db_real._get_table(table_type="sessions", create_table_if_not_found=True)
+        assert table is not None, "Session table should be created"
 
         result = session.execute(
             text(
                 "SELECT constraint_name FROM information_schema.table_constraints "
                 "WHERE table_schema = :schema AND table_name = :table AND constraint_type = 'UNIQUE'"
             ),
-            {"schema": postgres_db_real.db_schema, "table": "test_sessions"},
+            {"schema": postgres_db_real.db_schema, "table": postgres_db_real.session_table_name},
         )
         constraint_names = [row[0] for row in result.fetchall()]
-        expected_constraint = "test_sessions_uq_session_id"
+        expected_constraint = f"{postgres_db_real.session_table_name}_uq_session_id"
         assert expected_constraint in constraint_names, (
             f"Session table missing unique constraint {expected_constraint}. Found: {constraint_names}"
         )
@@ -693,3 +694,185 @@ def test_upsert_session_handles_all_team_session_fields(postgres_db_real: Postgr
     assert result.runs is not None
     assert len(result.runs) == 1
     assert result.runs[0].run_id == team_run.run_id
+
+
+def test_bulk_upsert_sessions(postgres_db_real: PostgresDb):
+    """Test bulk_upsert_sessions with mixed session types (Agent, Team, Workflow)"""
+    from agno.run.workflow import WorkflowRunOutput
+    from agno.session.workflow import WorkflowSession
+
+    # Create sessions
+    agent_run = RunOutput(
+        run_id="bulk_agent_run_1",
+        agent_id="bulk_agent_1",
+        user_id="bulk_user_1",
+        status=RunStatus.completed,
+        messages=[],
+    )
+    agent_session = AgentSession(
+        session_id="bulk_agent_session_1",
+        agent_id="bulk_agent_1",
+        user_id="bulk_user_1",
+        agent_data={"name": "Bulk Agent 1"},
+        session_data={"type": "bulk_test"},
+        runs=[agent_run],
+        created_at=int(time.time()),
+    )
+
+    team_run = TeamRunOutput(
+        run_id="bulk_team_run_1",
+        team_id="bulk_team_1",
+        status=RunStatus.completed,
+        messages=[],
+        created_at=int(time.time()),
+    )
+    team_session = TeamSession(
+        session_id="bulk_team_session_1",
+        team_id="bulk_team_1",
+        user_id="bulk_user_1",
+        team_data={"name": "Bulk Team 1"},
+        session_data={"type": "bulk_test"},
+        runs=[team_run],
+        created_at=int(time.time()),
+    )
+
+    workflow_run = WorkflowRunOutput(
+        run_id="bulk_workflow_run_1",
+        workflow_id="bulk_workflow_1",
+        status=RunStatus.completed,
+        created_at=int(time.time()),
+    )
+    workflow_session = WorkflowSession(
+        session_id="bulk_workflow_session_1",
+        workflow_id="bulk_workflow_1",
+        user_id="bulk_user_1",
+        workflow_data={"name": "Bulk Workflow 1"},
+        session_data={"type": "bulk_test"},
+        runs=[workflow_run],
+        created_at=int(time.time()),
+    )
+
+    # Bulk upsert all sessions
+    sessions = [agent_session, team_session, workflow_session]
+    results = postgres_db_real.bulk_upsert_sessions(sessions)
+
+    # Verify results
+    assert len(results) == 3
+
+    # Find and verify per session type
+    agent_result = next(r for r in results if isinstance(r, AgentSession))
+    team_result = next(r for r in results if isinstance(r, TeamSession))
+    workflow_result = next(r for r in results if isinstance(r, WorkflowSession))
+
+    # Verify agent session
+    assert agent_result.session_id == agent_session.session_id
+    assert agent_result.agent_id == agent_session.agent_id
+    assert agent_result.agent_data == agent_session.agent_data
+
+    # Verify team session
+    assert team_result.session_id == team_session.session_id
+    assert team_result.team_id == team_session.team_id
+    assert team_result.team_data == team_session.team_data
+
+    # Verify workflow session
+    assert workflow_result.session_id == workflow_session.session_id
+    assert workflow_result.workflow_id == workflow_session.workflow_id
+    assert workflow_result.workflow_data == workflow_session.workflow_data
+
+
+def test_bulk_upsert_sessions_update(postgres_db_real: PostgresDb):
+    """Test bulk_upsert_sessions correctly updates existing sessions"""
+
+    # Insert sessions
+    session1 = AgentSession(
+        session_id="bulk_update_1",
+        agent_id="agent_1",
+        user_id="user_1",
+        agent_data={"name": "Original Agent 1"},
+        session_data={"version": 1},
+        created_at=int(time.time()),
+    )
+    session2 = AgentSession(
+        session_id="bulk_update_2",
+        agent_id="agent_2",
+        user_id="user_1",
+        agent_data={"name": "Original Agent 2"},
+        session_data={"version": 1},
+        created_at=int(time.time()),
+    )
+    postgres_db_real.bulk_upsert_sessions([session1, session2])
+
+    # Update sessions
+    updated_session1 = AgentSession(
+        session_id="bulk_update_1",
+        agent_id="agent_1",
+        user_id="user_1",
+        agent_data={"name": "Updated Agent 1", "updated": True},
+        session_data={"version": 2, "updated": True},
+        created_at=session1.created_at,  # Keep original created_at
+    )
+    updated_session2 = AgentSession(
+        session_id="bulk_update_2",
+        agent_id="agent_2",
+        user_id="user_1",
+        agent_data={"name": "Updated Agent 2", "updated": True},
+        session_data={"version": 2, "updated": True},
+        created_at=session2.created_at,  # Keep original created_at
+    )
+    results = postgres_db_real.bulk_upsert_sessions([updated_session1, updated_session2])
+    assert len(results) == 2
+
+    # Verify sessions were updated
+    for result in results:
+        assert isinstance(result, AgentSession)
+        assert result.agent_data is not None and result.agent_data["updated"] is True
+        assert result.session_data is not None and result.session_data["version"] == 2
+        assert result.session_data is not None and result.session_data["updated"] is True
+
+        # created_at should be preserved
+        if result.session_id == "bulk_update_1":
+            assert result.created_at == session1.created_at
+        else:
+            assert result.created_at == session2.created_at
+
+
+def test_bulk_upsert_sessions_performance(postgres_db_real: PostgresDb):
+    """Ensure the bulk upsert method is considerably faster than individual upserts"""
+    import time as time_module
+
+    # Create sessions
+    sessions = []
+    for i in range(50):
+        session = AgentSession(
+            session_id=f"perf_test_{i}",
+            agent_id=f"agent_{i}",
+            user_id="perf_user",
+            agent_data={"name": f"Performance Agent {i}"},
+            session_data={"index": i},
+            created_at=int(time.time()),
+        )
+        sessions.append(session)
+
+    # Test individual upsert
+    start_time = time_module.time()
+    for session in sessions:
+        postgres_db_real.upsert_session(session)
+    individual_time = time_module.time() - start_time
+
+    # Clean up for bulk test
+    session_ids = [s.session_id for s in sessions]
+    postgres_db_real.delete_sessions(session_ids)
+
+    # Test bulk upsert
+    start_time = time_module.time()
+    postgres_db_real.bulk_upsert_sessions(sessions)
+    bulk_time = time_module.time() - start_time
+
+    # Verify all sessions were created
+    all_sessions = postgres_db_real.get_sessions(session_type=SessionType.AGENT, user_id="perf_user")
+    assert len(all_sessions) == 50
+
+    # Asserting bulk upsert is at least 2x faster
+    assert bulk_time < individual_time / 2, (
+        f"Bulk upsert is not fast enough: {bulk_time:.3f}s vs {individual_time:.3f}s"
+    )


### PR DESCRIPTION
- Add `bulk_upsert_sessions` and `bulk_upsert_memories` to all database implementations
- For databases that don't allow direct bulk writing, we log and fallback on iterating the individual write method
- Update the migration script to use the bulk write methods