### PR TITLE
fix: early stop in workflow to return correct last output

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -954,9 +954,7 @@ class Workflow:
 
                     # Update the workflow-level previous_step_outputs dictionary
                     previous_step_outputs[step_name] = step_output
-                    if step_output.stop:
-                        logger.info(f"Early termination requested by step {step_name}")
-                        break
+                    collected_step_outputs.append(step_output)
 
                     # Update shared media for next step
                     shared_images.extend(step_output.images or [])
@@ -968,7 +966,9 @@ class Workflow:
                     output_audio.extend(step_output.audio or [])
                     output_files.extend(step_output.files or [])
 
-                    collected_step_outputs.append(step_output)
+                    if step_output.stop:
+                        logger.info(f"Early termination requested by step {step_name}")
+                        break
 
                 # Update the workflow_run_response with completion data
                 if collected_step_outputs:
@@ -1390,9 +1390,7 @@ class Workflow:
 
                     # Update the workflow-level previous_step_outputs dictionary
                     previous_step_outputs[step_name] = step_output
-                    if step_output.stop:
-                        logger.info(f"Early termination requested by step {step_name}")
-                        break
+                    collected_step_outputs.append(step_output)
 
                     # Update shared media for next step
                     shared_images.extend(step_output.images or [])
@@ -1404,7 +1402,10 @@ class Workflow:
                     output_audio.extend(step_output.audio or [])
                     output_files.extend(step_output.files or [])
 
-                    collected_step_outputs.append(step_output)
+                    if step_output.stop:
+                        logger.info(f"Early termination requested by step {step_name}")
+                        break
+
 
                 # Update the workflow_run_response with completion data
                 if collected_step_outputs:


### PR DESCRIPTION
## Summary

fixes: https://github.com/agno-agi/agno/issues/4742

early stop functionality in workflow was not updating the last output properly for non stream cases

Before: 
<img width="475" height="47" alt="image" src="https://github.com/user-attachments/assets/303ac1a4-0897-4f09-b2b5-5d1864877399" />

After: 
<img width="534" height="54" alt="image" src="https://github.com/user-attachments/assets/33bf7b44-9328-46ae-953f-ab02a63282ff" />

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
