### PR TITLE
fix: remove unused fields from Knowledge and Eval Schema from DynamoDB

### DIFF
--- a/libs/agno/agno/db/dynamo/schemas.py
+++ b/libs/agno/agno/db/dynamo/schemas.py
@@ -123,7 +123,6 @@ EVAL_TABLE_SCHEMA = {
     "AttributeDefinitions": [
         {"AttributeName": "run_id", "AttributeType": "S"},
         {"AttributeName": "eval_type", "AttributeType": "S"},
-        {"AttributeName": "eval_input", "AttributeType": "S"},
         {"AttributeName": "agent_id", "AttributeType": "S"},
         {"AttributeName": "team_id", "AttributeType": "S"},
         {"AttributeName": "workflow_id", "AttributeType": "S"},
@@ -176,18 +175,9 @@ KNOWLEDGE_TABLE_SCHEMA = {
     "KeySchema": [{"AttributeName": "id", "KeyType": "HASH"}],
     "AttributeDefinitions": [
         {"AttributeName": "id", "AttributeType": "S"},
-        {"AttributeName": "name", "AttributeType": "S"},
-        {"AttributeName": "description", "AttributeType": "S"},
-        {"AttributeName": "metadata", "AttributeType": "S"},
         {"AttributeName": "type", "AttributeType": "S"},
-        {"AttributeName": "size", "AttributeType": "N"},
-        {"AttributeName": "linked_to", "AttributeType": "S"},
-        {"AttributeName": "access_count", "AttributeType": "N"},
         {"AttributeName": "status", "AttributeType": "S"},
-        {"AttributeName": "status_message", "AttributeType": "S"},
         {"AttributeName": "created_at", "AttributeType": "N"},
-        {"AttributeName": "updated_at", "AttributeType": "N"},
-        {"AttributeName": "external_id", "AttributeType": "S"},
     ],
     "GlobalSecondaryIndexes": [
         {


### PR DESCRIPTION
## Summary

Describe key changes, mention related issues or motivation for the changes.
Issue number: #4769
The main issue is that DynamoDB only allows defining attributes that act as keys e.g. KeySchema or any GSI KeySchema. However, current Knowledge and Eval Schemas tried to define more than that. I deleted unused attributes.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
