### PR TITLE
fix: [v1] output model messages formatting 

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections import ChainMap, defaultdict, deque
 from dataclasses import asdict, dataclass
+from copy import deepcopy
 from os import getenv
 from textwrap import dedent
 from typing import (
@@ -5105,22 +5106,54 @@ class Agent:
         ]
 
     def get_messages_for_output_model(self, messages: List[Message]) -> List[Message]:
-        """Get the messages for the output model."""
+        """Get the messages for the output model, converting formats between different providers."""
+        output_messages = []
+
+        for message in messages:
+            new_message = deepcopy(message)
+
+            if isinstance(message.content, list):
+                filtered_content = []
+                tool_results = []
+
+                for content_item in message.content:
+                    if isinstance(content_item, dict) and content_item.get("type") == "tool_result":
+                        # Collect tool results to convert to separate messages from Claude
+                        tool_message = Message(
+                            role="tool",
+                            content=str(content_item.get("content", "")),
+                            tool_call_id=content_item.get("tool_use_id")
+                        )
+                        tool_results.append(tool_message)
+                    else:
+                        if not (isinstance(content_item, dict) and content_item.get("type") == "tool_use"):
+                            filtered_content.append(content_item)
+
+                new_message.content = filtered_content if filtered_content else ""
+
+                if new_message.content or message.role != "user":
+                    output_messages.append(new_message)
+
+                output_messages.extend(tool_results)
+
+            else:
+                output_messages.append(new_message)
 
         if self.output_model_prompt is not None:
             system_message_exists = False
-            for message in messages:
+            for message in output_messages:
                 if message.role == "system":
                     system_message_exists = True
                     message.content = self.output_model_prompt
                     break
             if not system_message_exists:
-                messages.insert(0, Message(role="system", content=self.output_model_prompt))
+                output_messages.insert(0, Message(role="system", content=self.output_model_prompt))
 
-        # Remove the last assistant message from the messages list
-        messages.pop(-1)
+        # Remove the last assistant message
+        if output_messages and output_messages[-1].role == "assistant":
+            output_messages.pop(-1)
 
-        return messages
+        return output_messages
 
     def get_session_summary(self, session_id: Optional[str] = None, user_id: Optional[str] = None):
         """Get the session summary for the given session ID and user ID."""


### PR DESCRIPTION
## Summary

for a configuration where we set main model as claude and output model as openai we see following error-

```
Invalid value: 'tool_result'. Supported values are: 'text', 'image_url', 'input_audio', 'refusal', 'audio', and 'file'.

Stacktrace:
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.13/site-packages/agno/models/openai/chat.py", line 521, in ainvoke_stream
    async_stream = await self.get_async_client().chat.completions.create(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
    )
    ^
  File "/app/.heroku/python/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py", line 2589, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
    ...<48 lines>...
    )
    ^
  File "/app/.heroku/python/lib/python3.13/site-packages/openai/_base_client.py", line 1794, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.heroku/python/lib/python3.13/site-packages/openai/_base_client.py", line 1594, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid value: 'tool_result'. Supported values are: 'text', 'image_url', 'input_audio', 'refusal', 'audio', and 'file'.", 'type': 'invalid_request_error', 'param': 'messages[3].content[0].type', 'code': 'invalid_value'}}
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
