### PR TITLE
feat: handle session_state as kwarg in the OS run endpoints

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -72,6 +72,15 @@ async def _get_request_kwargs(request: Request, endpoint_func: Callable) -> Dict
     sig = inspect.signature(endpoint_func)
     known_fields = set(sig.parameters.keys())
     kwargs = {key: value for key, value in form_data.items() if key not in known_fields}
+
+    if session_state := kwargs.get("session_state"):
+        try:
+            session_state_dict = json.loads(session_state)  # type: ignore
+            kwargs["session_state"] = session_state_dict
+        except json.JSONDecodeError:
+            kwargs.pop("session_state")
+            log_warning(f"Invalid session state couldn't be loaded: {session_state}")
+
     return kwargs
 
 


### PR DESCRIPTION
Add some parsing logic to correctly handle receiving `session_state` as kwarg in the OS run endpoints
