### PR TITLE
fix: agentos datetime serialization

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -117,6 +117,19 @@ class BaseRunOutputEvent:
 
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
         import json
+        from datetime import datetime, date, time
+        from enum import Enum
+
+        def json_serializer(obj):
+            # Datetime like 
+            if isinstance(obj, (datetime, date, time)):
+                return obj.isoformat()
+            # Enums
+            if isinstance(obj, Enum):
+                v = obj.value
+                return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
+            # Fallback to string
+            return str(obj)
 
         try:
             _dict = self.to_dict()
@@ -125,9 +138,9 @@ class BaseRunOutputEvent:
             raise
 
         if indent is None:
-            return json.dumps(_dict, separators=separators)
+            return json.dumps(_dict, separators=separators, default=json_serializer, ensure_ascii=False)
         else:
-            return json.dumps(_dict, indent=indent, separators=separators)
+            return json.dumps(_dict, indent=indent, separators=separators, default=json_serializer, ensure_ascii=False)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]):

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -117,11 +117,11 @@ class BaseRunOutputEvent:
 
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
         import json
-        from datetime import datetime, date, time
+        from datetime import date, datetime, time
         from enum import Enum
 
         def json_serializer(obj):
-            # Datetime like 
+            # Datetime like
             if isinstance(obj, (datetime, date, time)):
                 return obj.isoformat()
             # Enums

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from enum import Enum
+
+from agno.run.base import BaseRunOutputEvent
+
+
+class RunEnum(Enum):
+    NY = "New York"
+    LA = "Los Angeles"
+    SF = "San Francisco"
+    CHI = "Chicago"
+
+@dataclass
+class SampleRunEvent(BaseRunOutputEvent):
+    date: datetime
+    location: RunEnum
+    name: str
+    age: int
+
+def test_run_events():
+    now = datetime(2025, 1, 1, 12, 0, 0)
+
+    event = SampleRunEvent(
+        date=now,
+        location=RunEnum.NY,
+        name="John Doe",
+        age=30,
+    )
+
+    # to_dict returns native Python types
+    d = event.to_dict()
+    assert d["date"] == now
+    assert d["location"] == RunEnum.NY
+    assert d["name"] == "John Doe"
+    assert d["age"] == 30
+
+    # to_json should contain serialized values; compare as dict
+    expected_json_dict = {
+        "date": now.isoformat(),
+        "location": RunEnum.NY.value,
+        "name": "John Doe",
+        "age": 30,
+    }
+    assert json.loads(event.to_json(indent=None)) == expected_json_dict


### PR DESCRIPTION
## Summary

Fixes a bug on Agent OS when output schema includes a non serializable type 

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
