### PR TITLE
[fix] fix user tool in format_message AWS Claude

### DIFF
--- a/libs/agno/agno/utils/models/aws_claude.py
+++ b/libs/agno/agno/utils/models/aws_claude.py
@@ -166,5 +166,14 @@ def format_messages(messages: List[Message]) -> Tuple[List[Dict[str, str]], str]
                             type="tool_use",
                         )
                     )
+        elif message.role == "tool":
+            content = []
+            content.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": message.tool_call_id,
+                    "content": str(message.content),
+                }
+            )
         chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
     return chat_messages, " ".join(system_messages)


### PR DESCRIPTION
## Summary

Similar to [PR](https://github.com/agno-agi/agno/pull/4709) AWS Claude format messages skips "tool" message role affecting run_continue with tools.

[(Link to issue)](https://github.com/agno-agi/agno/issues/4791)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
