### PR TITLE
feat: improve AgentOS registering of dbs and mcp tools

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -12,6 +12,7 @@ from rich.panel import Panel
 from starlette.requests import Request
 
 from agno.agent.agent import Agent
+from agno.db.base import BaseDb
 from agno.os.config import (
     AgentOSConfig,
     DatabaseConfig,
@@ -36,7 +37,11 @@ from agno.os.routers.memory import get_memory_router
 from agno.os.routers.metrics import get_metrics_router
 from agno.os.routers.session import get_session_router
 from agno.os.settings import AgnoAPISettings
-from agno.os.utils import update_cors_middleware
+from agno.os.utils import (
+    collect_mcp_tools_from_team,
+    collect_mcp_tools_from_workflow,
+    update_cors_middleware,
+)
 from agno.team.team import Team
 from agno.utils.log import logger
 from agno.utils.string import generate_id, generate_id_from_name
@@ -140,7 +145,8 @@ class AgentOS:
                         # Checking if the tool is a MCPTools or MultiMCPTools instance
                         type_name = type(tool).__name__
                         if type_name in ("MCPTools", "MultiMCPTools"):
-                            self.mcp_tools.append(tool)
+                            if tool not in self.mcp_tools:
+                                self.mcp_tools.append(tool)
 
                 agent.initialize_agent()
 
@@ -149,13 +155,8 @@ class AgentOS:
 
         if self.teams:
             for team in self.teams:
-                # Track all MCP tools to later handle their connection
-                if team.tools:
-                    for tool in team.tools:
-                        # Checking if the tool is a MCPTools or MultiMCPTools instance
-                        type_name = type(tool).__name__
-                        if type_name in ("MCPTools", "MultiMCPTools"):
-                            self.mcp_tools.append(tool)
+                # Track all MCP tools recursively
+                collect_mcp_tools_from_team(team, self.mcp_tools)
 
                 team.initialize_team()
 
@@ -171,7 +172,8 @@ class AgentOS:
 
         if self.workflows:
             for workflow in self.workflows:
-                # TODO: track MCP tools in workflow members
+                # Track MCP tools recursively in workflow members
+                collect_mcp_tools_from_workflow(workflow, self.mcp_tools)
                 if not workflow.id:
                     workflow.id = generate_id_from_name(workflow.name)
 
@@ -420,34 +422,77 @@ class AgentOS:
 
         for agent in self.agents or []:
             if agent.db:
-                dbs[agent.db.id] = agent.db
+                self._register_db_with_validation(dbs, agent.db)
             if agent.knowledge and agent.knowledge.contents_db:
-                knowledge_dbs[agent.knowledge.contents_db.id] = agent.knowledge.contents_db
+                self._register_db_with_validation(knowledge_dbs, agent.knowledge.contents_db)
                 # Also add to general dbs if it's used for both purposes
                 if agent.knowledge.contents_db.id not in dbs:
-                    dbs[agent.knowledge.contents_db.id] = agent.knowledge.contents_db
+                    self._register_db_with_validation(dbs, agent.knowledge.contents_db)
 
         for team in self.teams or []:
             if team.db:
-                dbs[team.db.id] = team.db
+                self._register_db_with_validation(dbs, team.db)
             if team.knowledge and team.knowledge.contents_db:
-                knowledge_dbs[team.knowledge.contents_db.id] = team.knowledge.contents_db
+                self._register_db_with_validation(knowledge_dbs, team.knowledge.contents_db)
                 # Also add to general dbs if it's used for both purposes
                 if team.knowledge.contents_db.id not in dbs:
-                    dbs[team.knowledge.contents_db.id] = team.knowledge.contents_db
+                    self._register_db_with_validation(dbs, team.knowledge.contents_db)
 
         for workflow in self.workflows or []:
             if workflow.db:
-                dbs[workflow.db.id] = workflow.db
+                self._register_db_with_validation(dbs, workflow.db)
 
         for interface in self.interfaces or []:
             if interface.agent and interface.agent.db:
-                dbs[interface.agent.db.id] = interface.agent.db
+                self._register_db_with_validation(dbs, interface.agent.db)
             elif interface.team and interface.team.db:
-                dbs[interface.team.db.id] = interface.team.db
+                self._register_db_with_validation(dbs, interface.team.db)
 
         self.dbs = dbs
         self.knowledge_dbs = knowledge_dbs
+
+    def _register_db_with_validation(self, registered_dbs: Dict[str, Any], db: BaseDb) -> None:
+        """Register a database in the contextual OS after validating it is not conflicting with registered databases"""
+        if db.id in registered_dbs:
+            existing_db = registered_dbs[db.id]
+            if not self._are_db_instances_compatible(existing_db, db):
+                raise ValueError(
+                    f"Database ID conflict detected: Two different database instances have the same ID '{db.id}'. "
+                    f"Database instances with the same ID must point to the same database with identical configuration."
+                )
+        registered_dbs[db.id] = db
+
+    def _are_db_instances_compatible(self, db1: BaseDb, db2: BaseDb) -> bool:
+        """
+        Return True if the two given database objects are compatible
+        Two database objects are compatible if they point to the same database with identical configuration.
+        """
+        # If they're the same object reference, they're compatible
+        if db1 is db2:
+            return True
+
+        if type(db1) is not type(db2):
+            return False
+
+        if hasattr(db1, "db_url") and hasattr(db2, "db_url"):
+            if db1.db_url != db2.db_url:  # type: ignore
+                return False
+
+        if hasattr(db1, "db_file") and hasattr(db2, "db_file"):
+            if db1.db_file != db2.db_file:  # type: ignore
+                return False
+
+        # If table names are different, they're not compatible
+        if (
+            db1.session_table_name != db2.session_table_name
+            or db1.memory_table_name != db2.memory_table_name
+            or db1.metrics_table_name != db2.metrics_table_name
+            or db1.eval_table_name != db2.eval_table_name
+            or db1.knowledge_table_name != db2.knowledge_table_name
+        ):
+            return False
+
+        return True
 
     def _auto_discover_knowledge_instances(self) -> None:
         """Auto-discover the knowledge instances used by all contextual agents, teams and workflows."""

--- a/libs/agno/tests/integration/os/test_conflicting_dbs.py
+++ b/libs/agno/tests/integration/os/test_conflicting_dbs.py
@@ -1,0 +1,80 @@
+import pytest
+
+from agno.agent import Agent
+from agno.db.postgres.postgres import PostgresDb
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.os import AgentOS
+
+
+def test_equal_db_instances_with_same_configuration_are_compatible():
+    """Test that different db instances with the same id are not compatible"""
+    # Two db instances with the same id and configuration
+    db1 = PostgresDb(db_url="postgresql://localhost:5432/test", id="test")
+    db2 = PostgresDb(db_url="postgresql://localhost:5432/test", id="test")
+    assert db1 != db2
+    assert db1.id == db2.id
+
+    agent1 = Agent(db=db1)
+    agent2 = Agent(db=db2)
+    agent_os = AgentOS(agents=[agent1, agent2])
+
+    # Asserting the app gets created without raising
+    app = agent_os.get_app()
+    assert app is not None
+
+
+def test_db_instances_with_different_url_are_not_compatible():
+    """Test that different db instances with the same id and different url are not compatible"""
+    # Two db instances with the same id and different url
+    db1 = PostgresDb(db_url="postgresql://localhost:5432/test", id="test")
+    db2 = PostgresDb(db_url="postgresql://localhost:5433/test", id="test")
+    assert db1.id == db2.id
+    assert db1.db_url != db2.db_url
+
+    agent1 = Agent(db=db1)
+    agent2 = Agent(db=db2)
+    agent_os = AgentOS(agents=[agent1, agent2])
+
+    # Asserting an error is raised when trying to create the app containing incompatible databases
+    with pytest.raises(ValueError) as e:
+        agent_os.get_app()
+
+    assert "Database ID conflict detected" in str(e.value)
+
+
+def test_db_instances_with_different_db_files_are_not_compatible():
+    """Test that different db instances with the same id and different db files are not compatible"""
+    # Two db instances with the same id and different db files
+    db1 = SqliteDb(db_file="tmp/test.db", id="test")
+    db2 = SqliteDb(db_file="tmp/test2.db", id="test")
+    assert db1.id == db2.id
+    assert db1.db_file != db2.db_file
+
+    agent1 = Agent(db=db1)
+    agent2 = Agent(db=db2)
+    agent_os = AgentOS(agents=[agent1, agent2])
+
+    # Asserting an error is raised when trying to create the app containing incompatible databases
+    with pytest.raises(ValueError) as e:
+        agent_os.get_app()
+
+    assert "Database ID conflict detected" in str(e.value)
+
+
+def test_db_instances_with_different_table_names_are_not_compatible():
+    """Test that different db instances with the same id and different table names are not compatible"""
+    # Two db instances with the same id and different table names
+    db1 = PostgresDb(db_url="postgresql://localhost:5432/test", id="test", session_table="sessions")
+    db2 = PostgresDb(db_url="postgresql://localhost:5433/test", id="test", session_table="sessions2")
+    assert db1.id == db2.id
+    assert db1.session_table_name != db2.session_table_name
+
+    agent1 = Agent(db=db1)
+    agent2 = Agent(db=db2)
+    agent_os = AgentOS(agents=[agent1, agent2])
+
+    # Asserting an error is raised when trying to create the app containing incompatible databases
+    with pytest.raises(ValueError) as e:
+        agent_os.get_app()
+
+    assert "Database ID conflict detected" in str(e.value)

--- a/libs/agno/tests/integration/os/test_register_mcp_tools.py
+++ b/libs/agno/tests/integration/os/test_register_mcp_tools.py
@@ -1,0 +1,158 @@
+from agno.agent import Agent
+from agno.os import AgentOS
+from agno.team.team import Team
+from agno.tools.mcp import MCPTools
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+
+
+def test_agent_mcp_tools_are_registered():
+    """Test that agent MCP tools are registered"""
+    mcp_tools = MCPTools("npm fake-command")
+    agent = Agent(tools=[mcp_tools])
+    assert agent.tools is not None
+    assert agent.tools[0] is mcp_tools
+
+    # Asserting the MCP tools were registered
+    agent_os = AgentOS(agents=[agent])
+    assert agent_os.mcp_tools is not None
+    assert agent_os.mcp_tools[0] is mcp_tools
+
+
+def test_multiple_agent_mcp_tools_are_registered():
+    """Test that agent MCP tools are registered"""
+    mcp_tools1 = MCPTools("npm fake-command")
+    mcp_tools2 = MCPTools("npm fake-command2")
+    agent = Agent(tools=[mcp_tools1, mcp_tools2])
+    assert agent.tools is not None
+    assert len(agent.tools) == 2
+
+    agent_os = AgentOS(agents=[agent])
+
+    # Asserting all MCP tools were found and registered
+    assert agent_os.mcp_tools is not None
+    assert len(agent_os.mcp_tools) == 2
+    assert mcp_tools1 in agent_os.mcp_tools
+    assert mcp_tools2 in agent_os.mcp_tools
+
+
+def test_team_mcp_tools_are_registered():
+    """Test that team MCP tools are registered"""
+    mcp_tools = MCPTools("npm fake-command")
+    team = Team(tools=[mcp_tools], members=[])
+    assert team.tools is not None
+    assert team.tools[0] is mcp_tools
+
+    # Asserting the MCP tools were registered
+    agent_os = AgentOS(teams=[team])
+    assert agent_os.mcp_tools is not None
+    assert agent_os.mcp_tools[0] is mcp_tools
+
+
+def test_multiple_team_mcp_tools_are_registered():
+    """Test that team MCP tools are registered"""
+    mcp_tools = MCPTools("npm fake-command")
+    mcp_tools2 = MCPTools("npm fake-command2")
+    team = Team(tools=[mcp_tools, mcp_tools2], members=[])
+    assert team.tools is not None
+    assert len(team.tools) == 2
+
+    # Asserting the MCP tools were registered
+    agent_os = AgentOS(teams=[team])
+    assert agent_os.mcp_tools is not None
+    assert len(agent_os.mcp_tools) == 2
+    assert mcp_tools in agent_os.mcp_tools
+    assert mcp_tools2 in agent_os.mcp_tools
+
+
+def test_nested_team_mcp_tools_are_registered():
+    """Test that team MCP tools are registered"""
+    mcp_tools = MCPTools("npm fake-command")
+    agent = Agent(tools=[mcp_tools])
+    assert agent.tools is not None
+    assert agent.tools[0] is mcp_tools
+
+    mcp_tools2 = MCPTools("npm fake-command")
+    nested_team = Team(tools=[mcp_tools2], members=[agent])
+    assert nested_team.tools is not None
+    assert nested_team.tools[0] is mcp_tools2
+
+    mcp_tools3 = MCPTools("npm fake-command2")
+    team = Team(tools=[mcp_tools3], members=[nested_team])
+    assert team.tools is not None
+    assert team.tools[0] is mcp_tools3
+
+    # Asserting the MCP tools were registered
+    agent_os = AgentOS(teams=[team])
+    assert agent_os.mcp_tools is not None
+    assert len(agent_os.mcp_tools) == 3
+    assert mcp_tools in agent_os.mcp_tools
+    assert mcp_tools2 in agent_os.mcp_tools
+    assert mcp_tools3 in agent_os.mcp_tools
+
+
+def test_workflow_with_agent_step_mcp_tools_are_registered():
+    """Test that workflow MCP tools are registered from agent steps"""
+    mcp_tools = MCPTools("npm fake-command")
+    agent = Agent(tools=[mcp_tools])
+    step = Step(agent=agent)
+    workflow = Workflow(steps=[step])
+
+    # Asserting the MCP tools were registered
+    agent_os = AgentOS(workflows=[workflow])
+    assert agent_os.mcp_tools is not None
+    assert agent_os.mcp_tools[0] is mcp_tools
+
+
+def test_workflow_with_team_step_mcp_tools_are_registered():
+    """Test that workflow MCP tools are registered from team steps"""
+    mcp_tools = MCPTools("npm fake-command")
+    team = Team(tools=[mcp_tools], members=[])
+    step = Step(team=team)
+    workflow = Workflow(steps=[step])
+
+    # Asserting the MCP tools were registered
+    agent_os = AgentOS(workflows=[workflow])
+    assert agent_os.mcp_tools is not None
+    assert agent_os.mcp_tools[0] is mcp_tools
+
+
+def test_workflow_with_nested_structures_mcp_tools_are_registered():
+    """Test that workflow MCP tools are registered from complex nested structures"""
+    agent_mcp_tools = MCPTools("npm fake-command")
+    agent = Agent(tools=[agent_mcp_tools])
+
+    team_mcp_tools = MCPTools("npm fake-command2")
+    team = Team(tools=[team_mcp_tools], members=[])
+
+    agent_step = Step(agent=agent)
+    team_step = Step(team=team)
+    workflow = Workflow(steps=[agent_step, team_step])
+
+    # Asserting all MCP tools were registered
+    agent_os = AgentOS(workflows=[workflow])
+    assert agent_os.mcp_tools is not None
+    assert len(agent_os.mcp_tools) == 2
+    assert agent_mcp_tools in agent_os.mcp_tools
+    assert team_mcp_tools in agent_os.mcp_tools
+
+
+def test_mcp_tools_are_not_registered_multiple_times():
+    """Test that MCP tools are not registered multiple times when present in multiple places"""
+    agent_mcp_tools = MCPTools("npm fake-command")
+    agent = Agent(tools=[agent_mcp_tools])
+    agent2 = Agent(tools=[agent_mcp_tools])
+
+    team_mcp_tools = MCPTools("npm fake-command2")
+    team = Team(tools=[team_mcp_tools], members=[agent, agent2])
+
+    agent_step = Step(agent=agent)
+    team_step = Step(team=team)
+    workflow = Workflow(steps=[agent_step, team_step])
+
+    # Asserting all MCP tools were registered
+    agent_os = AgentOS(workflows=[workflow], agents=[agent, agent2], teams=[team])
+    assert agent_os.mcp_tools is not None
+    assert len(agent_os.mcp_tools) == 2
+    assert agent_mcp_tools in agent_os.mcp_tools
+    assert team_mcp_tools in agent_os.mcp_tools


### PR DESCRIPTION
- Update the logic to find and register MCP tools when setting up an AgentOS instance, so it works for cases with nested teams, workflows etc
- Update the logic to find and register DBs, to reject incompatible db instances with same ids - as this would break API usage
