### PR TITLE
[Fix] Dashscope doesn't accept `search` tool

### DIFF
--- a/libs/agno/agno/tools/knowledge.py
+++ b/libs/agno/agno/tools/knowledge.py
@@ -39,21 +39,21 @@ class KnowledgeTools(Toolkit):
         # The knowledge to search
         self.knowledge: Knowledge = knowledge
 
-        tools: List[Any] = []
-        if enable_think or all:
-            tools.append(self.think)
-        if enable_search or all:
-            tools.append(self.search)
-        if enable_analyze or all:
-            tools.append(self.analyze)
-
         super().__init__(
             name="knowledge_tools",
             instructions=self.instructions,
             add_instructions=add_instructions,
-            tools=tools,
+            auto_register=False,  # We'll register manually with custom names
             **kwargs,
         )
+
+        # Register tools with custom names
+        if enable_think or all:
+            self.register(self.think, name="think")
+        if enable_search or all:
+            self.register(self.search, name="search_knowledge")
+        if enable_analyze or all:
+            self.register(self.analyze, name="analyze_knowledge")
 
     def think(self, session_state: Dict[str, Any], thought: str) -> str:
         """Use this tool as a scratchpad to reason about the question, refine your approach, brainstorm search terms, or revise your plan.


### PR DESCRIPTION
## Summary

Dashscope models do not accept `search` named tools. For knowledge we can rename the tool 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)