### PR TITLE
Fix: structured output and stream

### DIFF
--- a/cookbook/models/openai/responses/structured_output_with_tools.py
+++ b/cookbook/models/openai/responses/structured_output_with_tools.py
@@ -1,0 +1,33 @@
+from typing import List
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from pydantic import BaseModel, Field
+
+
+class MovieScript(BaseModel):
+    setting: str = Field(
+        ..., description="Provide a nice setting for a blockbuster movie."
+    )
+    ending: str = Field(
+        ...,
+        description="Ending of the movie. If not available, provide a happy ending.",
+    )
+    genre: str = Field(
+        ...,
+        description="Genre of the movie. If not available, select action, thriller or romantic comedy.",
+    )
+    name: str = Field(..., description="Give a name to this movie")
+    characters: List[str] = Field(..., description="Name of characters for this movie.")
+    storyline: str = Field(
+        ..., description="3 sentence storyline for the movie. Make it exciting!"
+    )
+
+
+structured_output_agent = Agent(
+    model=OpenAIResponses(id="gpt-4o"),
+    description="You write movie scripts.",
+    output_schema=MovieScript,
+)
+
+structured_output_agent.print_response("New York")

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -790,7 +790,11 @@ class OpenAIResponses(Model):
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
 
     def format_function_call_results(
-        self, messages: List[Message], function_call_results: List[Message], tool_call_ids: List[str]
+        self,
+        messages: List[Message],
+        function_call_results: List[Message],
+        tool_call_ids: Optional[List[str]] = None,
+        **kwargs,
     ) -> None:
         """
         Handle the results of function calls.
@@ -798,11 +802,13 @@ class OpenAIResponses(Model):
         Args:
             messages (List[Message]): The list of conversation messages.
             function_call_results (List[Message]): The results of the function calls.
-            tool_ids (List[str]): The tool ids.
+            tool_call_ids (Optional[List[str]]): The tool call ids.
+            **kwargs: Additional keyword arguments for compatibility with base class.
         """
         if len(function_call_results) > 0:
             for _fc_message_index, _fc_message in enumerate(function_call_results):
-                _fc_message.tool_call_id = tool_call_ids[_fc_message_index]
+                if tool_call_ids and _fc_message_index < len(tool_call_ids):
+                    _fc_message.tool_call_id = tool_call_ids[_fc_message_index]
                 messages.append(_fc_message)
 
     def process_response_stream(

--- a/libs/agno/tests/unit/telemetry/test_workflow_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_workflow_telemetry.py
@@ -5,10 +5,13 @@ import pytest
 from agno.workflow.step import Step
 from agno.workflow.workflow import Workflow
 
+
 def dummy_step(step_input):
     """Simple dummy step for testing"""
     from agno.workflow.types import StepOutput
+
     return StepOutput(content="Test step executed")
+
 
 def test_workflow_telemetry():
     """Test that telemetry logging is called during sync workflow run."""


### PR DESCRIPTION
## Summary

A fix for structured output + tool calling causing issue on streaming.

Responses model  is always called in `base.py` with `tool_call_ids` but for `structured output ` we don't pass the 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
