### PR TITLE
fix: session upsert for InMemoryDB

### DIFF
--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -284,7 +284,12 @@ class InMemoryDb(BaseDb):
             if not deserialize:
                 return session_dict
 
-            return session
+            if session_dict["session_type"] == SessionType.AGENT:
+                return AgentSession.from_dict(session_dict)
+            elif session_dict["session_type"] == SessionType.TEAM:
+                return TeamSession.from_dict(session_dict)
+            else:
+                return WorkflowSession.from_dict(session_dict)
 
         except Exception as e:
             log_error(f"Exception upserting session: {e}")
@@ -501,6 +506,7 @@ class InMemoryDb(BaseDb):
 
             if not deserialize:
                 return memory_dict
+
             return UserMemory.from_dict(memory_dict)
 
         except Exception as e:


### PR DESCRIPTION
We were wrongly returning an outdated session in the `upsert_session` method of `InMemoryDb`

Fixes https://github.com/agno-agi/agno/issues/4844