### PR TITLE
[Fix] Rename tools named `search` to relevant ones

### DIFF
--- a/cookbook/demo/agents/basic.py
+++ b/cookbook/demo/agents/basic.py
@@ -52,7 +52,7 @@ finance_agent = Agent(
     model=Claude(id="claude-sonnet-4-20250514"),
     tools=[
         ReasoningTools(add_instructions=True),
-        YFinanceTools(enable_all=True),
+        YFinanceTools(),
     ],
     instructions="Always use tables to display data.",
     db=db,

--- a/cookbook/evals/accuracy/accuracy_9_11_bigger_or_9_99.py
+++ b/cookbook/evals/accuracy/accuracy_9_11_bigger_or_9_99.py
@@ -10,7 +10,7 @@ evaluation = AccuracyEval(
     model=OpenAIChat(id="o4-mini"),
     agent=Agent(
         model=OpenAIChat(id="gpt-4o"),
-        tools=[CalculatorTools(enable_all=True)],
+        tools=[CalculatorTools()],
         instructions="You must use the calculator tools for comparisons.",
     ),
     input="9.11 and 9.9 -- which is bigger?",

--- a/cookbook/evals/accuracy/accuracy_async.py
+++ b/cookbook/evals/accuracy/accuracy_async.py
@@ -12,7 +12,7 @@ evaluation = AccuracyEval(
     model=OpenAIChat(id="o4-mini"),
     agent=Agent(
         model=OpenAIChat(id="gpt-4o"),
-        tools=[CalculatorTools(enable_all=True)],
+        tools=[CalculatorTools()],
     ),
     input="What is 10*5 then to the power of 2? do it step by step",
     expected_output="2500",

--- a/cookbook/evals/accuracy/db_logging.py
+++ b/cookbook/evals/accuracy/db_logging.py
@@ -19,7 +19,7 @@ evaluation = AccuracyEval(
     model=OpenAIChat(id="o4-mini"),
     agent=Agent(
         model=OpenAIChat(id="gpt-4o"),
-        tools=[CalculatorTools(enable_all=True)],
+        tools=[CalculatorTools()],
     ),
     input="What is 10*5 then to the power of 2? do it step by step",
     expected_output="2500",

--- a/cookbook/examples/agents/competitor_analysis_agent.py
+++ b/cookbook/examples/agents/competitor_analysis_agent.py
@@ -33,9 +33,9 @@ competitor_analysis_agent = Agent(
     model=OpenAIChat(id="gpt-4.1"),
     tools=[
         FirecrawlTools(
-            search=True,
-            crawl=True,
-            mapping=True,
+            enable_search=True,
+            enable_crawl=True,
+            enable_mapping=True,
             formats=["markdown", "links", "html"],
             search_params={
                 "limit": 2,
@@ -200,4 +200,5 @@ competitor_analysis_agent.print_response(
     """,
     stream=True,
     show_full_reasoning=True,
+    debug_mode=True,
 )

--- a/cookbook/examples/agents/deep_research_agent_exa.py
+++ b/cookbook/examples/agents/deep_research_agent_exa.py
@@ -12,7 +12,7 @@ from agno.tools.exa import ExaTools
 
 agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
-    tools=[ExaTools(research=True, research_model="exa-research-pro")],
+    tools=[ExaTools(enable_research=True, research_model="exa-research-pro")],
     instructions=dedent("""
         You are an expert research analyst with access to advanced research tools.
         

--- a/cookbook/examples/agents/finance_agent_with_memory.py
+++ b/cookbook/examples/agents/finance_agent_with_memory.py
@@ -27,7 +27,7 @@ finance_agent_with_memory = Agent(
     name="Finance Agent with Memory",
     id="financial_agent_with_memory",
     model=OpenAIChat(id="gpt-4.1"),
-    tools=[YFinanceTools(enable_all=True), DuckDuckGoTools()],
+    tools=[YFinanceTools(), DuckDuckGoTools()],
     # Let the Agent create and manage user memories
     enable_agentic_memory=True,
     # Uncomment to always create memories from the input

--- a/cookbook/examples/agents/startup_analyst_agent.py
+++ b/cookbook/examples/agents/startup_analyst_agent.py
@@ -17,7 +17,7 @@ from agno.tools.scrapegraph import ScrapeGraphTools
 startup_analyst = Agent(
     name="Startup Analyst",
     model=OpenAIChat(id="gpt-4o"),
-    tools=[ScrapeGraphTools(markdownify=True, crawl=True, searchscraper=True)],
+    tools=[ScrapeGraphTools(enable_markdownify=True, enable_crawl=True, enable_searchscraper=True)],
     instructions=dedent("""
         You are an elite startup analyst providing comprehensive due diligence for investment decisions.
         

--- a/cookbook/examples/agents/thinking_finance_agent.py
+++ b/cookbook/examples/agents/thinking_finance_agent.py
@@ -24,7 +24,7 @@ from agno.tools.yfinance import YFinanceTools
 
 finance_agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
-    tools=[ReasoningTools(add_instructions=True), YFinanceTools(enable_all=True)],
+    tools=[ReasoningTools(add_instructions=True), YFinanceTools()],
     instructions=dedent("""\
         You are a seasoned Wall Street analyst with deep expertise in market analysis! 📊
 

--- a/cookbook/examples/agents/web_extraction_agent.py
+++ b/cookbook/examples/agents/web_extraction_agent.py
@@ -40,7 +40,7 @@ class PageInformation(BaseModel):
 
 agent = Agent(
     model=OpenAIChat(id="gpt-4.1"),
-    tools=[FirecrawlTools(scrape=True, crawl=True)],
+    tools=[FirecrawlTools(enable_scrape=True, enable_crawl=True)],
     instructions=dedent("""
         You are an expert web researcher and content extractor. Extract comprehensive, structured information
         from the provided webpage. Focus on:

--- a/cookbook/models/anthropic/financial_analyst_thinking.py
+++ b/cookbook/models/anthropic/financial_analyst_thinking.py
@@ -19,7 +19,7 @@ agent = Agent(
         default_headers={"anthropic-beta": "interleaved-thinking-2025-05-14"},
     ),
     tools=[
-        CalculatorTools(enable_all=True),
+        CalculatorTools(),
         YFinanceTools(),
     ],
     instructions=[

--- a/cookbook/models/dashscope/knowledge_tools.py
+++ b/cookbook/models/dashscope/knowledge_tools.py
@@ -1,0 +1,48 @@
+"""
+Here is a tool with reasoning capabilities to allow agents to search and analyze information from a knowledge base.
+
+1. Run: `pip install openai agno lancedb tantivy sqlalchemy` to install the dependencies
+2. Export your OPENAI_API_KEY
+3. Run: `cookbook/models/dashscope/knowledge_tools.py` to run the agent
+"""
+
+from agno.agent import Agent
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.dashscope import DashScope
+from agno.tools.knowledge import KnowledgeTools
+from agno.vectordb.lancedb import LanceDb, SearchType
+
+# Create a knowledge containing information from a URL
+agno_docs = Knowledge(
+    # Use LanceDB as the vector database and store embeddings in the `agno_docs` table
+    vector_db=LanceDb(
+        uri="tmp/lancedb",
+        table_name="agno_docs",
+        search_type=SearchType.hybrid,
+        embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+    ),
+)
+# Add content to the knowledge
+agno_docs.add_content(url="https://docs.agno.com/llms-full.txt")
+
+knowledge_tools = KnowledgeTools(
+    knowledge=agno_docs,
+    enable_think=True,
+    enable_search=True,
+    enable_analyze=True,
+    add_few_shot=True,
+)
+
+agent = Agent(
+    model=DashScope(id="qwen-plus"),
+    tools=[knowledge_tools],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "How do I build a team of agents in agno?",
+        markdown=True,
+        stream=True,
+    )

--- a/cookbook/models/openai/chat/reasoning_o3_mini.py
+++ b/cookbook/models/openai/chat/reasoning_o3_mini.py
@@ -4,7 +4,7 @@ from agno.tools.yfinance import YFinanceTools
 
 agent = Agent(
     model=OpenAIChat(id="o3-mini", reasoning_effort="high"),
-    tools=[YFinanceTools(enable_all=True)],
+    tools=[YFinanceTools()],
     markdown=True,
 )
 

--- a/cookbook/reasoning/models/openai/o3_mini_with_tools.py
+++ b/cookbook/reasoning/models/openai/o3_mini_with_tools.py
@@ -4,7 +4,7 @@ from agno.tools.duckduckgo import DuckDuckGoTools
 
 agent = Agent(
     model=OpenAIChat(id="o3-mini"),
-    tools=[DuckDuckGoTools(search=True)],
+    tools=[DuckDuckGoTools(enable_search=True)],
     instructions="Use tables to display data.",
     markdown=True,
 )

--- a/cookbook/reasoning/models/openai/reasoning_effort.py
+++ b/cookbook/reasoning/models/openai/reasoning_effort.py
@@ -4,7 +4,7 @@ from agno.tools.duckduckgo import DuckDuckGoTools
 
 agent = Agent(
     model=OpenAIChat(id="o3-mini", reasoning_effort="high"),
-    tools=[DuckDuckGoTools(search=True)],
+    tools=[DuckDuckGoTools(enable_search=True)],
     instructions="Use tables to display data.",
     markdown=True,
 )

--- a/cookbook/reasoning/teams/finance_team_chain_of_thought.py
+++ b/cookbook/reasoning/teams/finance_team_chain_of_thought.py
@@ -19,7 +19,7 @@ finance_agent = Agent(
     name="Finance Agent",
     role="Handle financial data requests",
     model=OpenAIChat(id="gpt-4o-mini"),
-    tools=[DuckDuckGoTools(search=True)],
+    tools=[DuckDuckGoTools(enable_search=True)],
     instructions=[
         "You are a financial data specialist. Provide concise and accurate data.",
         "Use tables to display stock prices, fundamentals (P/E, Market Cap), and recommendations.",

--- a/cookbook/reasoning/teams/knowledge_tool_team.py
+++ b/cookbook/reasoning/teams/knowledge_tool_team.py
@@ -38,7 +38,7 @@ finance_agent = Agent(
     name="Finance Agent",
     role="Handle financial data requests",
     model=OpenAIChat(id="gpt-4o-mini"),
-    tools=[DuckDuckGoTools(search=True)],
+    tools=[DuckDuckGoTools(enable_search=True)],
     add_datetime_to_context=True,
 )
 

--- a/cookbook/reasoning/teams/reasoning_finance_team.py
+++ b/cookbook/reasoning/teams/reasoning_finance_team.py
@@ -20,7 +20,7 @@ finance_agent = Agent(
     name="Finance Agent",
     role="Handle financial data requests",
     model=OpenAIChat(id="gpt-4o-mini"),
-    tools=[DuckDuckGoTools(search=True)],
+    tools=[DuckDuckGoTools(enable_search=True)],
     instructions=[
         "You are a financial data specialist. Provide concise and accurate data.",
         "Use tables to display stock prices, fundamentals (P/E, Market Cap), and recommendations.",

--- a/cookbook/tools/multiple_tools.py
+++ b/cookbook/tools/multiple_tools.py
@@ -7,7 +7,7 @@ from agno.tools.yfinance import YFinanceTools
 
 agent = Agent(
     model=OpenAIChat(id="gpt-4o"),
-    tools=[DuckDuckGoTools(), YFinanceTools(enable_all=True)],
+    tools=[DuckDuckGoTools(), YFinanceTools()],
     instructions=["Use tables to display data"],
     markdown=True,
 )

--- a/cookbook/tools/other/include_exclude_tools.py
+++ b/cookbook/tools/other/include_exclude_tools.py
@@ -9,7 +9,6 @@ agent = Agent(
     model=OpenAIChat(id="gpt-4o-mini"),
     tools=[
         CalculatorTools(
-            enable_all=True,
             exclude_tools=["exponentiate", "factorial", "is_prime", "square_root"],
         ),
         DuckDuckGoTools(include_tools=["duckduckgo_search"]),

--- a/libs/agno/agno/tools/firecrawl.py
+++ b/libs/agno/agno/tools/firecrawl.py
@@ -3,7 +3,7 @@ from os import getenv
 from typing import Any, Dict, List, Optional
 
 from agno.tools import Toolkit
-from agno.utils.log import logger
+from agno.utils.log import log_debug, log_error
 
 try:
     from firecrawl import FirecrawlApp  # type: ignore[attr-defined]
@@ -57,7 +57,7 @@ class FirecrawlTools(Toolkit):
     ):
         self.api_key: Optional[str] = api_key or getenv("FIRECRAWL_API_KEY")
         if not self.api_key:
-            logger.error("FIRECRAWL_API_KEY not set. Please set the FIRECRAWL_API_KEY environment variable.")
+            log_error("FIRECRAWL_API_KEY not set. Please set the FIRECRAWL_API_KEY environment variable.")
 
         self.formats: Optional[List[str]] = formats
         self.limit: int = limit
@@ -73,7 +73,7 @@ class FirecrawlTools(Toolkit):
         if all or enable_mapping:
             tools.append(self.map_website)
         if all or enable_search:
-            tools.append(self.search)
+            tools.append(self.search_web)
 
         super().__init__(name="firecrawl_tools", tools=tools, **kwargs)
 
@@ -121,7 +121,7 @@ class FirecrawlTools(Toolkit):
         map_result = self.app.map(url)
         return json.dumps(map_result.model_dump(), cls=CustomJSONEncoder)
 
-    def search(self, query: str, limit: Optional[int] = None):
+    def search_web(self, query: str, limit: Optional[int] = None):
         """Use this function to search for the web using Firecrawl.
 
         Args:
@@ -137,6 +137,7 @@ class FirecrawlTools(Toolkit):
             params.update(self.search_params)
 
         search_result = self.app.search(query, **params)
+        log_debug(search_result)
         if search_result.success:
             return json.dumps(search_result.data, cls=CustomJSONEncoder)
         else:

--- a/libs/agno/agno/tools/knowledge.py
+++ b/libs/agno/agno/tools/knowledge.py
@@ -39,21 +39,21 @@ class KnowledgeTools(Toolkit):
         # The knowledge to search
         self.knowledge: Knowledge = knowledge
 
-        tools: List[Any] = []
-        if enable_think or all:
-            tools.append(self.think)
-        if enable_search or all:
-            tools.append(self.search)
-        if enable_analyze or all:
-            tools.append(self.analyze)
-
         super().__init__(
             name="knowledge_tools",
             instructions=self.instructions,
             add_instructions=add_instructions,
-            tools=tools,
+            auto_register=False,  # We'll register manually with custom names
             **kwargs,
         )
+
+        # Register tools with custom names
+        if enable_think or all:
+            self.register(self.think, name="think")
+        if enable_search or all:
+            self.register(self.search, name="search_knowledge")
+        if enable_analyze or all:
+            self.register(self.analyze, name="analyze_knowledge")
 
     def think(self, session_state: Dict[str, Any], thought: str) -> str:
         """Use this tool as a scratchpad to reason about the question, refine your approach, brainstorm search terms, or revise your plan.

--- a/libs/agno/agno/tools/knowledge.py
+++ b/libs/agno/agno/tools/knowledge.py
@@ -39,21 +39,21 @@ class KnowledgeTools(Toolkit):
         # The knowledge to search
         self.knowledge: Knowledge = knowledge
 
+        tools: List[Any] = []
+        if enable_think or all:
+            tools.append(self.think)
+        if enable_search or all:
+            tools.append(self.search_knowledge)
+        if enable_analyze or all:
+            tools.append(self.analyze)
+
         super().__init__(
             name="knowledge_tools",
+            tools=tools,
             instructions=self.instructions,
             add_instructions=add_instructions,
-            auto_register=False,  # We'll register manually with custom names
             **kwargs,
         )
-
-        # Register tools with custom names
-        if enable_think or all:
-            self.register(self.think, name="think")
-        if enable_search or all:
-            self.register(self.search, name="search_knowledge")
-        if enable_analyze or all:
-            self.register(self.analyze, name="analyze_knowledge")
 
     def think(self, session_state: Dict[str, Any], thought: str) -> str:
         """Use this tool as a scratchpad to reason about the question, refine your approach, brainstorm search terms, or revise your plan.
@@ -89,7 +89,7 @@ class KnowledgeTools(Toolkit):
             log_error(f"Error recording thought: {e}")
             return f"Error recording thought: {e}"
 
-    def search(self, session_state: Dict[str, Any], query: str) -> str:
+    def search_knowledge(self, session_state: Dict[str, Any], query: str) -> str:
         """Use this tool to search the knowledge base for relevant information.
         After thinking through the question, use this tool as many times as needed to search for relevant information.
 

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -21,7 +21,7 @@ class Searxng(Toolkit):
         self.fixed_max_results = fixed_max_results
 
         tools: List[Any] = [
-            self.search,
+            self.search_web,
             self.image_search,
             self.it_search,
             self.map_search,
@@ -33,7 +33,7 @@ class Searxng(Toolkit):
 
         super().__init__(name="searxng", tools=tools, **kwargs)
 
-    def search(self, query: str, max_results: int = 5) -> str:
+    def search_web(self, query: str, max_results: int = 5) -> str:
         """Use this function to search the web.
 
         Args:

--- a/libs/agno/agno/tools/serper.py
+++ b/libs/agno/agno/tools/serper.py
@@ -44,7 +44,7 @@ class SerperTools(Toolkit):
 
         tools: List[Any] = []
         if all or enable_search:
-            tools.append(self.search)
+            tools.append(self.search_web)
         if all or enable_search_news:
             tools.append(self.search_news)
         if all or enable_search_scholar:
@@ -97,7 +97,7 @@ class SerperTools(Toolkit):
             log_error(f"Serper API error: {str(e)}")
             return {"success": False, "error": str(e)}
 
-    def search(
+    def search_web(
         self,
         query: str,
         num_results: Optional[int] = None,

--- a/libs/agno/agno/tools/spider.py
+++ b/libs/agno/agno/tools/spider.py
@@ -42,7 +42,7 @@ class SpiderTools(Toolkit):
 
         tools: List[Any] = []
         if enable_search or all:
-            tools.append(self.search)
+            tools.append(self.search_web)
         if enable_scrape or all:
             tools.append(self.scrape)
         if enable_crawl or all:
@@ -50,7 +50,7 @@ class SpiderTools(Toolkit):
 
         super().__init__(name="spider", tools=tools, **kwargs)
 
-    def search(self, query: str, max_results: int = 5) -> str:
+    def search_web(self, query: str, max_results: int = 5) -> str:
         """Use this function to search the web.
         Args:
             query (str): The query to search the web with.

--- a/libs/agno/tests/unit/telemetry/test_workflow_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_workflow_telemetry.py
@@ -5,10 +5,13 @@ import pytest
 from agno.workflow.step import Step
 from agno.workflow.workflow import Workflow
 
+
 def dummy_step(step_input):
     """Simple dummy step for testing"""
     from agno.workflow.types import StepOutput
+
     return StepOutput(content="Test step executed")
+
 
 def test_workflow_telemetry():
     """Test that telemetry logging is called during sync workflow run."""

--- a/libs/agno/tests/unit/tools/test_firecrawl.py
+++ b/libs/agno/tests/unit/tools/test_firecrawl.py
@@ -177,7 +177,7 @@ def test_search(firecrawl_tools, mock_firecrawl):
     mock_firecrawl.search.return_value = mock_response
 
     # Call the method
-    result = firecrawl_tools.search("test query")
+    result = firecrawl_tools.search_web("test query")
     result_data = json.loads(result)
 
     # Verify results
@@ -196,7 +196,7 @@ def test_search_with_error(firecrawl_tools, mock_firecrawl):
     mock_firecrawl.search.return_value = mock_response
 
     # Call the method
-    result = firecrawl_tools.search("test query")
+    result = firecrawl_tools.search_web("test query")
 
     # Verify results
     assert result == "Error searching with the Firecrawl tool: Search failed"
@@ -215,7 +215,7 @@ def test_search_with_custom_params(firecrawl_tools, mock_firecrawl):
     firecrawl_tools.search_params = {"language": "en", "region": "us"}
 
     # Call the method
-    result = firecrawl_tools.search("test query")
+    result = firecrawl_tools.search_web("test query")
     result_data = json.loads(result)
 
     # Verify results

--- a/libs/agno/tests/unit/tools/test_knowledge_tools.py
+++ b/libs/agno/tests/unit/tools/test_knowledge_tools.py
@@ -1,0 +1,213 @@
+"""Unit tests for KnowledgeTools class."""
+
+import json
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from agno.knowledge.knowledge import Knowledge
+from agno.tools.knowledge import KnowledgeTools
+
+
+@pytest.fixture
+def mock_knowledge():
+    """Create a mock Knowledge instance for testing."""
+    mock_kb = Mock(spec=Knowledge)
+    mock_kb.search = Mock()
+    return mock_kb
+
+
+@pytest.fixture
+def knowledge_tools(mock_knowledge):
+    """Create KnowledgeTools instance with mocked Knowledge."""
+    return KnowledgeTools(
+        knowledge=mock_knowledge,
+        enable_think=True,
+        enable_search=True,
+        enable_analyze=True,
+    )
+
+
+def test_knowledge_tools_initialization():
+    """Test KnowledgeTools initialization with different settings."""
+    mock_knowledge = Mock(spec=Knowledge)
+
+    # Test with all features enabled
+    tools = KnowledgeTools(
+        knowledge=mock_knowledge,
+        enable_think=True,
+        enable_search=True,
+        enable_analyze=True,
+    )
+
+    assert tools.knowledge == mock_knowledge
+    # Check that tools are registered with correct names
+    tool_names = list(tools.functions.keys())
+    assert "think" in tool_names
+    assert "search_knowledge" in tool_names
+    assert "analyze" in tool_names
+
+
+def test_knowledge_tools_selective_features():
+    """Test KnowledgeTools with selective feature enabling."""
+    mock_knowledge = Mock(spec=Knowledge)
+
+    # Test with only search enabled
+    tools = KnowledgeTools(
+        knowledge=mock_knowledge,
+        enable_think=False,
+        enable_search=True,
+        enable_analyze=False,
+    )
+
+    tool_names = list(tools.functions.keys())
+    assert "think" not in tool_names
+    assert "search_knowledge" in tool_names
+    assert "analyze" not in tool_names
+
+
+def test_search_knowledge_method(knowledge_tools, mock_knowledge):
+    """Test the search_knowledge method functionality."""
+    # Mock the knowledge.search return value
+    mock_doc = Mock()
+    mock_doc.to_dict.return_value = {"content": "Test content", "metadata": {"source": "test.txt"}}
+    mock_knowledge.search.return_value = [mock_doc]
+
+    # Test successful search
+    session_state = {}
+    result = knowledge_tools.search_knowledge(session_state, "test query")
+
+    # Verify knowledge.search was called correctly
+    mock_knowledge.search.assert_called_once_with(query="test query")
+
+    # Verify result is JSON string containing document data
+    result_data = json.loads(result)
+    assert len(result_data) == 1
+    assert result_data[0]["content"] == "Test content"
+    assert result_data[0]["metadata"]["source"] == "test.txt"
+
+
+def test_search_knowledge_no_results(knowledge_tools, mock_knowledge):
+    """Test search_knowledge when no documents are found."""
+    mock_knowledge.search.return_value = []
+
+    session_state = {}
+    result = knowledge_tools.search_knowledge(session_state, "test query")
+
+    assert result == "No documents found"
+
+
+def test_search_knowledge_error_handling(knowledge_tools, mock_knowledge):
+    """Test search_knowledge error handling."""
+    mock_knowledge.search.side_effect = Exception("Search failed")
+
+    session_state = {}
+    result = knowledge_tools.search_knowledge(session_state, "test query")
+
+    assert "Error searching knowledge base: Search failed" in result
+
+
+def test_think_method(knowledge_tools):
+    """Test the think method functionality."""
+    session_state = {}
+    thought = "This is a test thought about analyzing the problem."
+
+    result = knowledge_tools.think(session_state, thought)
+
+    # Should return the formatted thought
+    assert "This is a test thought about analyzing the problem." in result
+    assert len(result) > len(thought)  # Should be formatted/expanded
+
+
+def test_analyze_method(knowledge_tools):
+    """Test the analyze method functionality."""
+    session_state = {}
+    analysis = "This analysis shows that the data indicates a trend."
+
+    result = knowledge_tools.analyze(session_state, analysis)
+
+    # Should return the formatted analysis
+    assert "This analysis shows that the data indicates a trend." in result
+    assert len(result) > len(analysis)  # Should be formatted/expanded
+
+
+def test_tool_registration_names():
+    """Test that tools are registered with correct names for API compatibility."""
+    mock_knowledge = Mock(spec=Knowledge)
+
+    tools = KnowledgeTools(
+        knowledge=mock_knowledge,
+        enable_think=True,
+        enable_search=True,
+        enable_analyze=True,
+    )
+
+    # Verify the renamed search tool is registered as "search_knowledge"
+    tool_names = list(tools.functions.keys())
+    assert "search_knowledge" in tool_names
+    assert "search" not in tool_names  # Old name should not exist
+
+    # Verify other tools have expected names
+    assert "think" in tool_names
+    assert "analyze" in tool_names
+
+
+def test_all_parameter():
+    """Test the 'all' parameter enables all tools."""
+    mock_knowledge = Mock(spec=Knowledge)
+
+    tools = KnowledgeTools(
+        knowledge=mock_knowledge,
+        all=True,  # Should enable all tools regardless of individual flags
+        enable_think=False,
+        enable_search=False,
+        enable_analyze=False,
+    )
+
+    tool_names = list(tools.functions.keys())
+    assert "think" in tool_names
+    assert "search_knowledge" in tool_names
+    assert "analyze" in tool_names
+
+
+def test_custom_instructions():
+    """Test KnowledgeTools with custom instructions."""
+    mock_knowledge = Mock(spec=Knowledge)
+    custom_instructions = "Use this knowledge base to answer questions accurately."
+
+    tools = KnowledgeTools(
+        knowledge=mock_knowledge,
+        instructions=custom_instructions,
+        add_instructions=True,
+    )
+
+    assert custom_instructions in tools.instructions
+
+
+def test_few_shot_examples():
+    """Test KnowledgeTools with few-shot examples enabled."""
+    mock_knowledge = Mock(spec=Knowledge)
+
+    tools = KnowledgeTools(
+        knowledge=mock_knowledge,
+        add_few_shot=True,
+    )
+
+    # Should include few-shot examples in instructions
+    assert "Think" in tools.instructions
+    assert "Search" in tools.instructions
+    assert "Analyze" in tools.instructions
+
+
+def test_method_existence():
+    """Test that renamed methods exist and old ones don't."""
+    mock_knowledge = Mock(spec=Knowledge)
+    tools = KnowledgeTools(knowledge=mock_knowledge)
+
+    # New method should exist
+    assert hasattr(tools, "search_knowledge")
+    assert callable(getattr(tools, "search_knowledge"))
+
+    # Other methods should exist
+    assert hasattr(tools, "think")
+    assert hasattr(tools, "analyze")

--- a/libs/agno/tests/unit/tools/test_searxng.py
+++ b/libs/agno/tests/unit/tools/test_searxng.py
@@ -41,7 +41,7 @@ def test_searxng_search(searxng_instance):
         mock_response.json.return_value = mock_response_payload
         mock_get.return_value = mock_response
 
-        result = searxng_instance.search("test query", max_results=2)
+        result = searxng_instance.search_web("test query", max_results=2)
 
         # Parse the JSON result since the method returns JSON string
         result_data = json.loads(result)
@@ -63,7 +63,7 @@ def test_searxng_search_with_engines(searxng_with_engines):
         mock_response.json.return_value = mock_response_payload
         mock_get.return_value = mock_response
 
-        searxng_with_engines.search("test query")
+        searxng_with_engines.search_web("test query")
 
         expected_url = "http://localhost:53153/search?format=json&q=test%20query&engines=google,bing"
         mock_get.assert_called_once_with(expected_url)
@@ -80,7 +80,7 @@ def test_searxng_search_with_fixed_max_results(searxng_with_fixed_results):
         mock_response.json.return_value = mock_response_payload
         mock_get.return_value = mock_response
 
-        result = searxng_with_fixed_results.search("test query", max_results=10)
+        result = searxng_with_fixed_results.search_web("test query", max_results=10)
         result_data = json.loads(result)
 
         # Should respect fixed_max_results (3) instead of max_results (10)
@@ -128,7 +128,7 @@ def test_searxng_search_error_handling(searxng_instance):
     with patch("httpx.get") as mock_get:
         mock_get.side_effect = Exception("Network error")
 
-        result = searxng_instance.search("test query")
+        result = searxng_instance.search_web("test query")
 
         assert "Error fetching results from searxng: Network error" in result
 
@@ -142,7 +142,7 @@ def test_searxng_query_encoding(searxng_instance):
         mock_response.json.return_value = mock_response_payload
         mock_get.return_value = mock_response
 
-        searxng_instance.search("test query with spaces & symbols")
+        searxng_instance.search_web("test query with spaces & symbols")
 
         expected_url = "http://localhost:53153/search?format=json&q=test%20query%20with%20spaces%20%26%20symbols"
         mock_get.assert_called_once_with(expected_url)

--- a/libs/agno/tests/unit/tools/test_serper.py
+++ b/libs/agno/tests/unit/tools/test_serper.py
@@ -106,7 +106,7 @@ def test_init_with_custom_params():
 def test_search_no_api_key():
     """Calling search without any API key returns an error message."""
     tools = SerperTools(api_key=None)
-    result = tools.search("anything")
+    result = tools.search_web("anything")
     result_json = json.loads(result)
     assert "error" in result_json
     assert "Please provide a Serper API key" in result_json["error"]
@@ -114,7 +114,7 @@ def test_search_no_api_key():
 
 def test_search_empty_query(api_tools):
     """Calling search with an empty query returns an error message."""
-    result = api_tools.search("")
+    result = api_tools.search_web("")
     result_json = json.loads(result)
     assert "error" in result_json
     assert "Please provide a query to search for" in result_json["error"]
@@ -123,7 +123,7 @@ def test_search_empty_query(api_tools):
 def test_search_success(api_tools, mock_search_response):
     """A successful search should return the raw response.text and call requests.request correctly."""
     with patch("requests.request", return_value=mock_search_response) as mock_req:
-        result = api_tools.search("pytest testing")
+        result = api_tools.search_web("pytest testing")
         assert result == mock_search_response.text
 
         mock_req.assert_called_once_with(
@@ -137,7 +137,7 @@ def test_search_success(api_tools, mock_search_response):
 def test_search_with_custom_num_results(api_tools, mock_search_response):
     """Overriding the num_results parameter should be respected in the request payload."""
     with patch("requests.request", return_value=mock_search_response) as mock_req:
-        result = api_tools.search("pytest testing", num_results=20)
+        result = api_tools.search_web("pytest testing", num_results=20)
         assert result == mock_search_response.text
 
         expected_payload = {
@@ -158,7 +158,7 @@ def test_search_with_custom_num_results(api_tools, mock_search_response):
 def test_search_exception(api_tools):
     """If requests.request raises, search should catch and return an error string."""
     with patch("requests.request", side_effect=Exception("Network failure")):
-        result = api_tools.search("failure test")
+        result = api_tools.search_web("failure test")
         result_json = json.loads(result)
         assert "error" in result_json
         assert "Network failure" in result_json["error"]
@@ -353,7 +353,7 @@ def test_http_error_handling(api_tools):
     mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
 
     with patch("requests.request", return_value=mock_response):
-        result = api_tools.search("test query")
+        result = api_tools.search_web("test query")
         result_json = json.loads(result)
         assert "error" in result_json
         assert "404 Not Found" in result_json["error"]


### PR DESCRIPTION
## Summary

Rename all tools named `search` to relevant ones. Also fixes #3752 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)