### PR TITLE
feat: default Claude agents to Sonnet 4.5

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -59,7 +59,7 @@ class Claude(Model):
     For more information, see: https://docs.anthropic.com/en/api/messages
     """
 
-    id: str = "claude-3-5-sonnet-20241022"
+    id: str = "claude-sonnet-4-5-20250929"
     name: str = "Claude"
     provider: str = "Anthropic"
 

--- a/libs/agno/agno/utils/streamlit.py
+++ b/libs/agno/agno/utils/streamlit.py
@@ -452,7 +452,7 @@ MODELS = [
     "gpt-4o",
     "o3-mini",
     "gpt-5",
-    "claude-4-sonnet",
+    "claude-sonnet-4-5-20250929",
     "gemini-2.5-pro",
 ]
 

--- a/libs/agno/tests/integration/models/anthropic/test_multimodal.py
+++ b/libs/agno/tests/integration/models/anthropic/test_multimodal.py
@@ -4,7 +4,7 @@ from agno.models.anthropic import Claude
 
 
 def test_image_input():
-    agent = Agent(model=Claude(id="claude-3-5-sonnet-20241022"), markdown=True, telemetry=False)
+    agent = Agent(model=Claude(id="claude-sonnet-4-20250514"), markdown=True, telemetry=False)
 
     response = agent.run(
         "Tell me about this image.",
@@ -18,7 +18,7 @@ def test_image_input():
 
 def test_file_upload():
     agent = Agent(
-        model=Claude(id="claude-3-5-sonnet-20241022"),
+        model=Claude(id="claude-sonnet-4-20250514"),
         markdown=True,
     )
 

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -100,7 +100,7 @@ def test_prompt_caching_with_agent():
     print(f"System prompt length: {len(large_system_prompt)} characters")
 
     agent = Agent(
-        model=Claude(id="claude-3-5-sonnet-20241022", cache_system_prompt=True),
+        model=Claude(id="claude-sonnet-4-5-20250929", cache_system_prompt=True),
         system_message=large_system_prompt,
         telemetry=False,
     )


### PR DESCRIPTION
## Summary
Updates the default Anthropic Claude model from `claude-3-5-sonnet-20241022` to `claude-sonnet-4-5-20250929`.

## Changes
- Updated `Claude` class default model ID to `claude-sonnet-4-5-20250929` (line 62 in `claude.py`)
- Updated Streamlit helper to include the new model ID in the default list
- Fixed integration tests to use supported Claude 4 model IDs:
  - `test_multimodal.py`: Now uses `claude-sonnet-4-20250514` (Claude Sonnet 4)
  - `test_prompt_caching.py`: Now uses `claude-sonnet-4-5-20250929` (Claude Sonnet 4.5)

## Motivation
Claude Sonnet 4.5 is Anthropic's latest model released on September 29, 2025. According to [Anthropic's official documentation](https://docs.anthropic.com/en/docs/about-claude/models), it is "our best model for complex agents and coding, with the highest intelligence across most tasks."

Key improvements:
- Highest intelligence across most tasks
- Exceptional agent and coding capabilities
- 200K context window (1M beta available)
- Same pricing as Claude Sonnet 4 ($3/$15 per million tokens)

This PR ensures new Agno agents use the latest Claude model by default.

## Testing
- ✅ Verified model ID `claude-sonnet-4-5-20250929` exists in [Anthropic's API docs](https://docs.anthropic.com/en/docs/about-claude/models)
- ✅ Tested basic model instantiation successfully
- ⚠️ Integration tests require `ANTHROPIC_API_KEY` (structure verified, actual API calls not tested)

## Documentation
Model ID verified from official sources:
- **Claude API**: `claude-sonnet-4-5-20250929`
- **AWS Bedrock**: `anthropic.claude-sonnet-4-5-20250929-v1:0`
- **GCP Vertex AI**: `claude-sonnet-4-5@20250929`

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are focused and minimal (4 files, 5 insertions, 5 deletions)
- [x] Model ID verified against official Anthropic documentation
- [x] Integration test structure verified
- [x] Backward compatibility maintained (existing code with explicit model IDs unaffected)

## Notes
This is a simple default change - existing code using explicit model IDs will continue to work unchanged. Users can still use previous Claude models by specifying them explicitly:

```python
# Still works - explicitly using Claude Sonnet 4
agent = Agent(model=Claude(id="claude-sonnet-4-20250514"))

# Now uses Claude Sonnet 4.5 by default
agent = Agent(model=Claude())
```