### PR TITLE
fix: json serialize issue in websocket

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -117,19 +117,8 @@ class BaseRunOutputEvent:
 
     def to_json(self, separators=(", ", ": "), indent: Optional[int] = 2) -> str:
         import json
-        from datetime import date, datetime, time
-        from enum import Enum
 
-        def json_serializer(obj):
-            # Datetime like
-            if isinstance(obj, (datetime, date, time)):
-                return obj.isoformat()
-            # Enums
-            if isinstance(obj, Enum):
-                v = obj.value
-                return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
-            # Fallback to string
-            return str(obj)
+        from agno.utils.serialize import json_serializer
 
         try:
             _dict = self.to_dict()

--- a/libs/agno/agno/utils/serialize.py
+++ b/libs/agno/agno/utils/serialize.py
@@ -1,0 +1,32 @@
+"""JSON serialization utilities for handling datetime and enum objects."""
+
+from datetime import date, datetime, time
+from enum import Enum
+from typing import Any
+
+
+def json_serializer(obj: Any) -> Any:
+    """Custom JSON serializer for objects not serializable by default json module.
+
+    Handles:
+    - datetime, date, time objects -> ISO format strings
+    - Enum objects -> their values (or names if values are not JSON-serializable)
+    - All other objects -> string representation
+
+    Args:
+        obj: Object to serialize
+
+    Returns:
+        JSON-serializable representation of the object
+    """
+    # Datetime like
+    if isinstance(obj, (datetime, date, time)):
+        return obj.isoformat()
+
+    # Enums
+    if isinstance(obj, Enum):
+        v = obj.value
+        return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
+
+    # Fallback to string
+    return str(obj)

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
+import json
+from datetime import date, datetime, time
 
 from fastapi import WebSocket
 from pydantic import BaseModel
@@ -443,9 +445,18 @@ class WebSocketHandler:
             else:
                 data = {"type": "message", "content": str(event)}
 
-            import json
+            def json_serializer(obj):
+                # Datetime like
+                if isinstance(obj, (datetime, date, time)):
+                    return obj.isoformat()
+                # Enums
+                if isinstance(obj, Enum):
+                    v = obj.value
+                    return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
+                # Fallback to string
+                return str(obj)
 
-            await self.websocket.send_text(self.format_sse_event(json.dumps(data)))
+            await self.websocket.send_text(self.format_sse_event(json.dumps(data, default=json_serializer)))
 
         except Exception as e:
             log_warning(f"Failed to handle WebSocket event: {e}")
@@ -466,9 +477,18 @@ class WebSocketHandler:
             return
 
         try:
-            import json
+            def json_serializer(obj):
+                # Datetime like
+                if isinstance(obj, (datetime, date, time)):
+                    return obj.isoformat()
+                # Enums
+                if isinstance(obj, Enum):
+                    v = obj.value
+                    return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
+                # Fallback to string
+                return str(obj)
 
-            await self.websocket.send_text(self.format_sse_event(json.dumps(data)))
+            await self.websocket.send_text(self.format_sse_event(json.dumps(data, default=json_serializer)))
         except Exception as e:
             log_warning(f"Failed to send WebSocket dict: {e}")
 

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -1,8 +1,7 @@
+import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
-import json
-from datetime import date, datetime, time
 
 from fastapi import WebSocket
 from pydantic import BaseModel
@@ -10,6 +9,7 @@ from pydantic import BaseModel
 from agno.media import Audio, File, Image, Video
 from agno.models.metrics import Metrics
 from agno.utils.log import log_warning
+from agno.utils.serialize import json_serializer
 
 
 @dataclass
@@ -445,17 +445,6 @@ class WebSocketHandler:
             else:
                 data = {"type": "message", "content": str(event)}
 
-            def json_serializer(obj):
-                # Datetime like
-                if isinstance(obj, (datetime, date, time)):
-                    return obj.isoformat()
-                # Enums
-                if isinstance(obj, Enum):
-                    v = obj.value
-                    return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
-                # Fallback to string
-                return str(obj)
-
             await self.websocket.send_text(self.format_sse_event(json.dumps(data, default=json_serializer)))
 
         except Exception as e:
@@ -477,17 +466,6 @@ class WebSocketHandler:
             return
 
         try:
-            def json_serializer(obj):
-                # Datetime like
-                if isinstance(obj, (datetime, date, time)):
-                    return obj.isoformat()
-                # Enums
-                if isinstance(obj, Enum):
-                    v = obj.value
-                    return v if isinstance(v, (str, int, float, bool, type(None))) else obj.name
-                # Fallback to string
-                return str(obj)
-
             await self.websocket.send_text(self.format_sse_event(json.dumps(data, default=json_serializer)))
         except Exception as e:
             log_warning(f"Failed to send WebSocket dict: {e}")


### PR DESCRIPTION
## Summary

Issue: `WebSocketHandler.handle_event()` and `handle_dict()` methods in `types.py` failed to serialize datetime/date objects when sending workflow events via WebSocket, causing "Object of type datetime is not JSON serializable" errors.

Before:
<img width="719" height="127" alt="image" src="https://github.com/user-attachments/assets/eb07a00d-ac73-4fe6-8421-16e8588d4b30" />

After:
<img width="720" height="706" alt="image" src="https://github.com/user-attachments/assets/efe04c39-e972-494d-be12-a27942bbf7f8" />

<img width="1938" height="232" alt="image" src="https://github.com/user-attachments/assets/40caebe3-9d06-444f-bf90-a9218a896008" />

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
