### PR TITLE
[fix] Ensuring tool role for tool call messages

### DIFF
--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -573,6 +573,11 @@ class TeamRunOutput:
         messages = data.pop("messages", None)
         messages = [Message.from_dict(message) for message in messages] if messages else None
 
+        if messages:
+            for msg in messages:
+                if getattr(msg, "tool_calls", None) and msg.role == "user":
+                    msg.role = "tool"
+
         member_responses = data.pop("member_responses", [])
         parsed_member_responses: List[Union["TeamRunOutput", RunOutput]] = []
         if member_responses:


### PR DESCRIPTION
## Summary

Fixes Issue #4898 by assigning the "tool" role to tool-based messages

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

None
