### PR TITLE
Fix: Dictionary Key Order Causing Redundant Cache Files

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -473,6 +473,7 @@ class Function(BaseModel):
 
     def _get_cache_key(self, entrypoint_args: Dict[str, Any], call_args: Optional[Dict[str, Any]] = None) -> str:
         """Generate a cache key based on function name and arguments."""
+        import json
         from hashlib import md5
 
         copy_entrypoint_args = entrypoint_args.copy()
@@ -493,7 +494,8 @@ class Function(BaseModel):
             del copy_entrypoint_args["files"]
         if "dependencies" in copy_entrypoint_args:
             del copy_entrypoint_args["dependencies"]
-        args_str = str(copy_entrypoint_args)
+        # Use json.dumps with sort_keys=True to ensure consistent ordering regardless of dict key order
+        args_str = json.dumps(copy_entrypoint_args, sort_keys=True, default=str)
 
         kwargs_str = str(sorted((call_args or {}).items()))
         key_str = f"{self.name}:{args_str}:{kwargs_str}"

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -234,7 +234,25 @@ def test_function_cache_key_generation():
 
     cache_key = func._get_cache_key(entrypoint_args, call_args)
     assert isinstance(cache_key, str)
-    assert cache_key == "12cfb4e42ec8561012d976e2dca0e0c1"
+    # Hash updated to use json.dumps with sort_keys=True for consistent ordering
+    assert cache_key == "d76d42a06e815b6402e24486f1f61805"
+
+
+def test_function_cache_key_dict_order_independence():
+    """Test that cache keys are identical regardless of dictionary key order."""
+    func = Function(name="test_func", cache_results=True, cache_dir="/tmp")
+
+    # Same data, different key orders
+    args1 = {"param1": "value1", "param2": 42, "param3": "value3"}
+    args2 = {"param3": "value3", "param1": "value1", "param2": 42}
+    args3 = {"param2": 42, "param3": "value3", "param1": "value1"}
+
+    cache_key1 = func._get_cache_key(args1)
+    cache_key2 = func._get_cache_key(args2)
+    cache_key3 = func._get_cache_key(args3)
+
+    # Should generate identical cache keys
+    assert cache_key1 == cache_key2 == cache_key3
 
 
 def test_function_cache_file_path():


### PR DESCRIPTION
## Summary
fixes #4822
 The current caching in `agno/tools/function.py` used `str()` to serialize dictionary arguments for cache key generation. Since str() preserves dictionary key order, identical data with different key orders produced different cache keys.
 
 Replaced str() with json.dumps(sort_keys=True) to ensure serialization regardless of dictionary key order

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
