### PR TITLE
Simplify tests using a matrix and astral-sh/ruff-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,103 +14,39 @@ on:
       - "v2.0"
 
 jobs:
-  style-check-agno:
+  style-check:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9"]
+        working-directory: ["libs/agno", "libs/agno_infra", "cookbook"]
 
     defaults:
       run:
-        working-directory: libs/agno
+        working-directory: ${{ matrix.working-directory }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+      - name: Lint Python code
+        uses: astral-sh/ruff-action@v3
+      - name: Format Python code
+        run: ruff format --check --diff
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        if: matrix.working-directory != 'cookbook'
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - name: Install dependencies
+        if: matrix.working-directory != 'cookbook'
         run: |
           python -m pip install --upgrade \
             pip setuptools wheel \
             ruff mypy pytest types-pyyaml
           pip install --no-deps -r requirements.txt
-      - name: Ruff format
-        run: |
-          ruff format .
-      - name: Ruff check
-        run: |
-          ruff check .
       - name: Mypy
-        run: |
-          mypy .
-
-  style-check-cookbook:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-
-    defaults:
-      run:
-        working-directory: cookbook
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade \
-            pip setuptools wheel \
-            ruff mypy pytest
-          pip install --no-deps -r ../libs/agno/requirements.txt
-      - name: Ruff format
-        run: |
-          ruff format .
-      - name: Ruff check
-        run: |
-          ruff check .
-      # - name: Mypy
-      #   run: |
-      #     mypy .
-
-
-  style-check-agno-infra:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
-
-    defaults:
-      run:
-        working-directory: libs/agno_infra
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade \
-            pip setuptools wheel \
-            ruff mypy pytest
-          pip install -r requirements.txt
-      - name: Ruff format
-        run: |
-          ruff format .
-      - name: Ruff check
-        run: |
-          ruff check .
-      - name: Mypy
+        if: matrix.working-directory != 'cookbook'
         run: |
           mypy .
 


### PR DESCRIPTION
Consolidate three style check jobs into one with a matrix of `working-directory`.  Ruff does not need Python to run because it is written in Rust.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
