### PR TITLE
fix: custom function step workflows empty session name

### DIFF
--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -93,7 +93,14 @@ def get_session_name(session: Dict[str, Any]) -> str:
 
         # For teams, identify the first Team run and avoid using the first member's run
         if session.get("session_type") == "team":
-            run = runs[0] if not runs[0].get("agent_id") else runs[1]
+            run = None
+            for r in runs:
+                if not r.get("agent_id"):  
+                    run = r
+                    break
+            # Fallback to first run if no team run found
+            if run is None and runs:
+                run = runs[0]
 
         elif session.get("session_type") == "workflow":
             try:

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -106,7 +106,8 @@ def get_session_name(session: Dict[str, Any]) -> str:
                     workflow_input = workflow_run.get("input")
                     if isinstance(workflow_input, str):
                         return workflow_input
-                    
+                    elif isinstance(workflow_input, dict):
+                        return str(workflow_input)
                     # Fallback to workflow name
                     workflow_name = session.get("workflow_data", {}).get("name")
                     return f"New {workflow_name} Session" if workflow_name else ""

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -122,7 +122,10 @@ def get_session_name(session: Dict[str, Any]) -> str:
 
         # For agents, use the first run
         else:
-            run = runs[0]
+            run = runs[0] if runs else None
+
+        if run is None:
+            return ""
 
         if not isinstance(run, dict):
             run = run.to_dict()

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -106,9 +106,7 @@ def get_session_name(session: Dict[str, Any]) -> str:
                         import json
                         return json.dumps(workflow_input)
                     except (TypeError, ValueError):
-                        # Fallback to workflow name if json.dumps fails
-                        workflow_name = session.get("workflow_data", {}).get("name")
-                        return f"New {workflow_name} Session" if workflow_name else ""
+                        pass
 
                 workflow_name = session.get("workflow_data", {}).get("name")
                 return f"New {workflow_name} Session" if workflow_name else ""

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -95,6 +95,7 @@ def get_session_name(session: Dict[str, Any]) -> str:
         if session.get("session_type") == "team":
             run = None
             for r in runs:
+                # If agent_id is not present, it's a team run
                 if not r.get("agent_id"):  
                     run = r
                     break

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -99,19 +99,20 @@ def get_session_name(session: Dict[str, Any]) -> str:
         elif session.get("session_type") == "workflow":
             try:
                 workflow_run = runs[0]
-                step_executor_runs = workflow_run.get("step_executor_runs")
-                if step_executor_runs:
-                    run = step_executor_runs[0]
-                else:
-                    workflow_input = workflow_run.get("input")
-                    if isinstance(workflow_input, str):
-                        return workflow_input
-                    elif isinstance(workflow_input, dict):
+                workflow_input = workflow_run.get("input")
+                if isinstance(workflow_input, str):
+                    return workflow_input
+                elif isinstance(workflow_input, dict):
+                    try:
                         import json
                         return json.dumps(workflow_input)
-                    # Fallback to workflow name
-                    workflow_name = session.get("workflow_data", {}).get("name")
-                    return f"New {workflow_name} Session" if workflow_name else ""
+                    except:
+                        # Fallback to workflow name if json.dumps fails
+                        workflow_name = session.get("workflow_data", {}).get("name")
+                        return f"New {workflow_name} Session" if workflow_name else ""
+
+                workflow_name = session.get("workflow_data", {}).get("name")
+                return f"New {workflow_name} Session" if workflow_name else ""
             except (KeyError, IndexError, TypeError):
                 return ""
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -95,10 +95,21 @@ def get_session_name(session: Dict[str, Any]) -> str:
         if session.get("session_type") == "team":
             run = runs[0] if not runs[0].get("agent_id") else runs[1]
 
-        # For workflows, pass along the first step_executor_run
+        # For workflows, try agent/team steps first, then custom function steps
         elif session.get("session_type") == "workflow":
             try:
-                run = session["runs"][0]["step_executor_runs"][0]
+                workflow_run = runs[0]
+                step_executor_runs = workflow_run.get("step_executor_runs")
+                if step_executor_runs:
+                    run = step_executor_runs[0]
+                else:
+                    workflow_input = workflow_run.get("input")
+                    if isinstance(workflow_input, str):
+                        return workflow_input
+                    
+                    # Fallback to workflow name
+                    workflow_name = session.get("workflow_data", {}).get("name")
+                    return f"New {workflow_name} Session" if workflow_name else ""
             except (KeyError, IndexError, TypeError):
                 return ""
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -95,7 +95,6 @@ def get_session_name(session: Dict[str, Any]) -> str:
         if session.get("session_type") == "team":
             run = runs[0] if not runs[0].get("agent_id") else runs[1]
 
-        # For workflows, try agent/team steps first, then custom function steps
         elif session.get("session_type") == "workflow":
             try:
                 workflow_run = runs[0]
@@ -106,7 +105,7 @@ def get_session_name(session: Dict[str, Any]) -> str:
                     try:
                         import json
                         return json.dumps(workflow_input)
-                    except:
+                    except (TypeError, ValueError):
                         # Fallback to workflow name if json.dumps fails
                         workflow_name = session.get("workflow_data", {}).get("name")
                         return f"New {workflow_name} Session" if workflow_name else ""

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -107,7 +107,8 @@ def get_session_name(session: Dict[str, Any]) -> str:
                     if isinstance(workflow_input, str):
                         return workflow_input
                     elif isinstance(workflow_input, dict):
-                        return str(workflow_input)
+                        import json
+                        return json.dumps(workflow_input)
                     # Fallback to workflow name
                     workflow_name = session.get("workflow_data", {}).get("name")
                     return f"New {workflow_name} Session" if workflow_name else ""


### PR DESCRIPTION
## Summary

- `session_name` is coming empty in the api `sessions?type=workflow` when first step is a custom function for workflows where events are not yielded

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
