### PR TITLE
fix: get media on top level on GET runs

### DIFF
--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -15,6 +15,7 @@ from agno.os.utils import (
     get_run_input,
     get_session_name,
     get_workflow_input_schema_dict,
+    extract_media,
 )
 from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
@@ -841,6 +842,9 @@ class RunSchema(BaseModel):
     created_at: Optional[datetime]
     references: Optional[List[dict]]
     reasoning_messages: Optional[List[dict]]
+    images: Optional[List[dict]]
+    videos: Optional[List[dict]]
+    audio: Optional[List[dict]]
 
     @classmethod
     def from_dict(cls, run_dict: Dict[str, Any]) -> "RunSchema":
@@ -862,6 +866,9 @@ class RunSchema(BaseModel):
             events=[event for event in run_dict["events"]] if run_dict.get("events") else None,
             references=run_dict.get("references", []),
             reasoning_messages=run_dict.get("reasoning_messages", []),
+            images=extract_media(run_dict, "images"),
+            videos=extract_media(run_dict, "videos"),
+            audio=extract_media(run_dict, "audio"),
             created_at=datetime.fromtimestamp(run_dict.get("created_at", 0), tz=timezone.utc)
             if run_dict.get("created_at") is not None
             else None,
@@ -884,6 +891,9 @@ class TeamRunSchema(BaseModel):
     created_at: Optional[datetime]
     references: Optional[List[dict]]
     reasoning_messages: Optional[List[dict]]
+    images: Optional[List[dict]]
+    videos: Optional[List[dict]]
+    audio: Optional[List[dict]]
 
     @classmethod
     def from_dict(cls, run_dict: Dict[str, Any]) -> "TeamRunSchema":
@@ -907,6 +917,9 @@ class TeamRunSchema(BaseModel):
             else None,
             references=run_dict.get("references", []),
             reasoning_messages=run_dict.get("reasoning_messages", []),
+            images=extract_media(run_dict, "images"),
+            videos=extract_media(run_dict, "videos"),
+            audio=extract_media(run_dict, "audio"),
         )
 
 
@@ -926,6 +939,9 @@ class WorkflowRunSchema(BaseModel):
     reasoning_steps: Optional[List[dict]]
     references: Optional[List[dict]]
     reasoning_messages: Optional[List[dict]]
+    images: Optional[List[dict]]
+    videos: Optional[List[dict]]
+    audio: Optional[List[dict]]
 
     @classmethod
     def from_dict(cls, run_response: Dict[str, Any]) -> "WorkflowRunSchema":
@@ -946,6 +962,9 @@ class WorkflowRunSchema(BaseModel):
             reasoning_steps=run_response.get("reasoning_steps", []),
             references=run_response.get("references", []),
             reasoning_messages=run_response.get("reasoning_messages", []),
+            images=extract_media(run_response, "images"),
+            videos=extract_media(run_response, "videos"),
+            audio=extract_media(run_response, "audio"),
         )
 
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union, Literal
 
 from fastapi import FastAPI, HTTPException, UploadFile
 from fastapi.routing import APIRoute, APIRouter
@@ -114,6 +114,14 @@ def get_session_name(session: Dict[str, Any]) -> str:
                 if message["role"] == "user":
                     return message["content"]
     return ""
+
+
+def extract_media(run_dict: Dict[str, Any], media_type: Literal["images", "videos", "audio"] = "images"):
+    media=[]
+    for message in run_dict.get("messages", []):
+        if message.get(media_type):
+            media.extend(message.get(media_type, []))
+    return media
 
 
 def process_image(file: UploadFile) -> Image:


### PR DESCRIPTION
## Summary

Get media (images/audio/videos) on top level of an object inside of array instead of messages on GET runs

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
