### PR TITLE
feat: better handle of MCP lifecycle in the AgentOS

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -78,21 +78,21 @@ def get_mcp_server(
         agent = get_agent_by_id(agent_id, os.agents)
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
-        return agent.run(message)
+        return await agent.arun(message)
 
     @mcp.tool(name="run_team", description="Run a team", tags={"core"})  # type: ignore
     async def run_team(team_id: str, message: str) -> TeamRunOutput:
         team = get_team_by_id(team_id, os.teams)
         if team is None:
             raise Exception(f"Team {team_id} not found")
-        return team.run(message)
+        return await team.arun(message)
 
     @mcp.tool(name="run_workflow", description="Run a workflow", tags={"core"})  # type: ignore
     async def run_workflow(workflow_id: str, message: str) -> WorkflowRunOutput:
         workflow = get_workflow_by_id(workflow_id, os.workflows)
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
-        return workflow.run(message)
+        return await workflow.arun(message)
 
     # Session Management Tools
     @mcp.tool(name="get_sessions_for_agent", description="Get list of sessions for an agent", tags={"session"})  # type: ignore

--- a/libs/agno/tests/integration/os/test_custom_fastapi_app.py
+++ b/libs/agno/tests/integration/os/test_custom_fastapi_app.py
@@ -731,28 +731,14 @@ def test_custom_app_with_mcp_tools_lifespan(test_agent: Agent):
 
     # Setup MCP tools with mocked connect/close methods
     mcp_tools = MCPTools("npm fake-command")
-    original_connect = mcp_tools.connect
-    original_close = mcp_tools.close
 
     async def mock_connect():
         nonlocal mcp_connect_called
         mcp_connect_called = True
-        # Call original if it exists and is safe
-        if callable(original_connect):
-            try:
-                await original_connect()
-            except Exception:
-                pass  # Ignore connection errors in tests
 
     async def mock_close():
         nonlocal mcp_close_called
         mcp_close_called = True
-        # Call original if it exists and is safe
-        if callable(original_close):
-            try:
-                await original_close()
-            except Exception:
-                pass  # Ignore close errors in tests
 
     mcp_tools.connect = mock_connect
     mcp_tools.close = mock_close

--- a/libs/agno/tests/integration/os/test_custom_fastapi_app.py
+++ b/libs/agno/tests/integration/os/test_custom_fastapi_app.py
@@ -726,7 +726,7 @@ def test_custom_app_with_mcp_tools_lifespan(test_agent: Agent):
         yield
         base_app_shutdown_called = True
 
-    # sETUP custom FastAPI app with custom lifespan
+    # Setup custom FastAPI app with custom lifespan
     custom_app = FastAPI(title="Custom App", lifespan=base_app_lifespan)
 
     # Setup MCP tools with mocked connect/close methods


### PR DESCRIPTION
This updates how we handle MCP lifespans in the OS, fixing multiple problems:

- MCP tools work with AgentOS with a base_app
    - Fixes https://github.com/agno-agi/agno/issues/4942
- `enable_mcp_server` works with AgentOS with a base_app
- MCP tools work inside our AgentOS MCP server