### PR TITLE
Update ollama chat.py

### DIFF
--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -296,14 +296,17 @@ class Ollama(Model):
             run_response.metrics.set_time_to_first_token()
 
         assistant_message.metrics.start_timer()
-
+        isThinking = False
         for chunk in self.get_client().chat(
             model=self.id,
             messages=[self._format_message(m) for m in messages],  # type: ignore
             stream=True,
             **self.get_request_params(tools=tools),
         ):
-            yield self._parse_provider_response_delta(chunk)
+            message = chunk.get('message', {}).get('content', '')
+            if message == '<think>' or message == '</think>':
+                isThinking = message == '<think>'            
+            yield self._parse_provider_response_delta(chunk, isThinking)
 
         assistant_message.metrics.stop_timer()
 
@@ -323,14 +326,17 @@ class Ollama(Model):
             run_response.metrics.set_time_to_first_token()
 
         assistant_message.metrics.start_timer()
-
+        isThinking = False
         async for chunk in await self.get_async_client().chat(
             model=self.id.strip(),
             messages=[self._format_message(m) for m in messages],  # type: ignore
             stream=True,
             **self.get_request_params(tools=tools),
         ):
-            yield self._parse_provider_response_delta(chunk)
+            message = chunk.get('message', {}).get('content', '')
+            if message == '<think>' or message == '</think>':
+                isThinking = message == '<think>'
+            yield self._parse_provider_response_delta(chunk, isThinking)
 
         assistant_message.metrics.stop_timer()
 
@@ -397,8 +403,10 @@ class Ollama(Model):
 
         if response_message is not None:
             content_delta = response_message.get("content")
-            if content_delta is not None and content_delta != "":
+            if content_delta is not None  and not isThinking and content_delta != "</think>":
                 model_response.content = content_delta
+            elif isThinking and content_delta != "<think>":
+                model_response.reasoning_content = content_delta
 
             tool_calls = response_message.get("tool_calls")
             if tool_calls is not None:


### PR DESCRIPTION
Extract thinking content between 'think' tags if present in '_parse_provider_response_delta'

## Summary
In ollama stream response, the 'think' tag has not been processed.
Add a parameter 'isThinking' to _parse_provider_response_delta for extract reason content.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
