### PR TITLE
feat: claims props for AGUI interface

### DIFF
--- a/cookbook/agent_os/workflow/customer_research_workflow_parallel.py
+++ b/cookbook/agent_os/workflow/customer_research_workflow_parallel.py
@@ -1,81 +1,145 @@
+import json
+from datetime import datetime
+from typing import Any, AsyncIterator, Dict, List, Union
 
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
+from agno.run.workflow import WorkflowRunOutputEvent
 from agno.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.googlesearch import GoogleSearchTools
 from agno.tools.hackernews import HackerNewsTools
+from agno.workflow.parallel import Parallel
 from agno.workflow.step import Step, StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-from agno.workflow.parallel import Parallel
-from typing import Dict, Any, AsyncIterator, Union, List
-import json
-from agno.run.workflow import WorkflowRunOutputEvent
-from datetime import datetime
 from pydantic import BaseModel, Field
 
 
 # Define structured output models for each research phase
 class CustomerProfileResearch(BaseModel):
     """Structured customer profile research findings"""
-    
+
     research_topic: str = Field(description="The customer research topic")
-    target_demographics: List[str] = Field(description="Key demographic segments identified", min_items=2)
-    customer_personas: List[str] = Field(description="Defined customer personas", min_items=2)
-    pain_points: List[str] = Field(description="Major customer pain points discovered", min_items=3)
-    motivations: List[str] = Field(description="Customer motivations and drivers", min_items=3)
-    customer_journey: List[str] = Field(description="Key touchpoints in customer journey", min_items=3)
-    behavioral_patterns: List[str] = Field(description="Customer behavioral insights", min_items=2)
+    target_demographics: List[str] = Field(
+        description="Key demographic segments identified", min_items=2
+    )
+    customer_personas: List[str] = Field(
+        description="Defined customer personas", min_items=2
+    )
+    pain_points: List[str] = Field(
+        description="Major customer pain points discovered", min_items=3
+    )
+    motivations: List[str] = Field(
+        description="Customer motivations and drivers", min_items=3
+    )
+    customer_journey: List[str] = Field(
+        description="Key touchpoints in customer journey", min_items=3
+    )
+    behavioral_patterns: List[str] = Field(
+        description="Customer behavioral insights", min_items=2
+    )
     segmentation_insights: str = Field(description="Customer segmentation summary")
-    confidence_score: float = Field(description="Confidence in findings (0.0-1.0)", ge=0.0, le=1.0)
+    confidence_score: float = Field(
+        description="Confidence in findings (0.0-1.0)", ge=0.0, le=1.0
+    )
 
 
 class BusinessGoalsResearch(BaseModel):
     """Structured business goals research findings"""
-    
+
     research_topic: str = Field(description="The business goals research topic")
-    primary_objectives: List[str] = Field(description="Main business objectives identified", min_items=3)
-    key_metrics: List[str] = Field(description="Important KPIs and success metrics", min_items=3)
-    industry_trends: List[str] = Field(description="Relevant industry trends", min_items=3)
-    competitive_landscape: List[str] = Field(description="Competitive analysis insights", min_items=2)
-    growth_opportunities: List[str] = Field(description="Identified growth opportunities", min_items=2)
-    strategic_challenges: List[str] = Field(description="Key challenges to address", min_items=2)
+    primary_objectives: List[str] = Field(
+        description="Main business objectives identified", min_items=3
+    )
+    key_metrics: List[str] = Field(
+        description="Important KPIs and success metrics", min_items=3
+    )
+    industry_trends: List[str] = Field(
+        description="Relevant industry trends", min_items=3
+    )
+    competitive_landscape: List[str] = Field(
+        description="Competitive analysis insights", min_items=2
+    )
+    growth_opportunities: List[str] = Field(
+        description="Identified growth opportunities", min_items=2
+    )
+    strategic_challenges: List[str] = Field(
+        description="Key challenges to address", min_items=2
+    )
     market_positioning: str = Field(description="Market positioning analysis")
-    success_factors: List[str] = Field(description="Critical success factors", min_items=2)
-    confidence_score: float = Field(description="Confidence in findings (0.0-1.0)", ge=0.0, le=1.0)
+    success_factors: List[str] = Field(
+        description="Critical success factors", min_items=2
+    )
+    confidence_score: float = Field(
+        description="Confidence in findings (0.0-1.0)", ge=0.0, le=1.0
+    )
 
 
 class WebIntelligenceResearch(BaseModel):
     """Structured web intelligence research findings"""
-    
+
     research_topic: str = Field(description="The web intelligence research topic")
-    digital_presence: List[str] = Field(description="Digital presence insights", min_items=2)
-    social_media_patterns: List[str] = Field(description="Social media engagement patterns", min_items=2)
+    digital_presence: List[str] = Field(
+        description="Digital presence insights", min_items=2
+    )
+    social_media_patterns: List[str] = Field(
+        description="Social media engagement patterns", min_items=2
+    )
     web_behavior: List[str] = Field(description="Web behavior analysis", min_items=2)
-    digital_touchpoints: List[str] = Field(description="Key digital touchpoints", min_items=3)
-    online_positioning: List[str] = Field(description="Online brand positioning insights", min_items=2)
-    digital_marketing: List[str] = Field(description="Digital marketing strategies observed", min_items=2)
-    engagement_metrics: str = Field(description="Engagement and interaction patterns summary")
-    technology_stack: List[str] = Field(description="Technology platforms and tools identified", min_items=2)
-    confidence_score: float = Field(description="Confidence in findings (0.0-1.0)", ge=0.0, le=1.0)
+    digital_touchpoints: List[str] = Field(
+        description="Key digital touchpoints", min_items=3
+    )
+    online_positioning: List[str] = Field(
+        description="Online brand positioning insights", min_items=2
+    )
+    digital_marketing: List[str] = Field(
+        description="Digital marketing strategies observed", min_items=2
+    )
+    engagement_metrics: str = Field(
+        description="Engagement and interaction patterns summary"
+    )
+    technology_stack: List[str] = Field(
+        description="Technology platforms and tools identified", min_items=2
+    )
+    confidence_score: float = Field(
+        description="Confidence in findings (0.0-1.0)", ge=0.0, le=1.0
+    )
 
 
 class ConsolidatedResearch(BaseModel):
     """Consolidated research findings from all phases"""
-    
+
     research_query: str = Field(description="Original research query")
-    key_insights: List[str] = Field(description="Top consolidated insights", min_items=5)
-    customer_profile_summary: str = Field(description="Executive summary of customer profile")
-    business_goals_summary: str = Field(description="Executive summary of business goals")
-    web_intelligence_summary: str = Field(description="Executive summary of web intelligence")
-    strategic_opportunities: List[str] = Field(description="Strategic opportunities identified", min_items=3)
-    critical_findings: List[str] = Field(description="Most critical findings across all research", min_items=4)
-    patterns_correlations: List[str] = Field(description="Patterns and correlations found", min_items=2)
-    recommendations: List[str] = Field(description="High-level recommendations", min_items=3)
-    research_confidence: float = Field(description="Overall research confidence (0.0-1.0)", ge=0.0, le=1.0)
+    key_insights: List[str] = Field(
+        description="Top consolidated insights", min_items=5
+    )
+    customer_profile_summary: str = Field(
+        description="Executive summary of customer profile"
+    )
+    business_goals_summary: str = Field(
+        description="Executive summary of business goals"
+    )
+    web_intelligence_summary: str = Field(
+        description="Executive summary of web intelligence"
+    )
+    strategic_opportunities: List[str] = Field(
+        description="Strategic opportunities identified", min_items=3
+    )
+    critical_findings: List[str] = Field(
+        description="Most critical findings across all research", min_items=4
+    )
+    patterns_correlations: List[str] = Field(
+        description="Patterns and correlations found", min_items=2
+    )
+    recommendations: List[str] = Field(
+        description="High-level recommendations", min_items=3
+    )
+    research_confidence: float = Field(
+        description="Overall research confidence (0.0-1.0)", ge=0.0, le=1.0
+    )
 
 
 # Define specialized research agents
@@ -91,13 +155,13 @@ customer_profile_agent = Agent(
         "Analyze customer journey touchpoints and behavioral insights",
         "Provide structured findings according to the CustomerProfileResearch model",
         "Include confidence scores and detailed segmentation insights",
-        "Use tools extensively to gather data-driven insights"
+        "Use tools extensively to gather data-driven insights",
     ],
     db=InMemoryDb(),
 )
 
 business_goals_agent = Agent(
-    name="Business Goals Researcher", 
+    name="Business Goals Researcher",
     model=OpenAIChat(id="gpt-4o"),
     tools=[GoogleSearchTools(), HackerNewsTools()],
     output_schema=BusinessGoalsResearch,
@@ -109,14 +173,14 @@ business_goals_agent = Agent(
         "Focus on understanding what customers want to achieve and critical success factors",
         "Provide structured findings according to the BusinessGoalsResearch model",
         "Include confidence scores and comprehensive market positioning analysis",
-        "Use tools to gather current industry data and competitive intelligence"
+        "Use tools to gather current industry data and competitive intelligence",
     ],
     db=InMemoryDb(),
 )
 
 web_intelligence_agent = Agent(
     name="Web Intelligence Researcher",
-    model=OpenAIChat(id="gpt-4o"), 
+    model=OpenAIChat(id="gpt-4o"),
     tools=[GoogleSearchTools(), DuckDuckGoTools(), HackerNewsTools()],
     output_schema=WebIntelligenceResearch,
     instructions=[
@@ -127,7 +191,7 @@ web_intelligence_agent = Agent(
         "Provide insights on customer's digital marketing approaches and engagement metrics",
         "Structure your findings according to the WebIntelligenceResearch model",
         "Include confidence scores and comprehensive engagement analysis",
-        "Use tools to gather current digital presence and online behavior data"
+        "Use tools to gather current digital presence and online behavior data",
     ],
     db=InMemoryDb(),
 )
@@ -145,7 +209,7 @@ research_consolidation_team = Team(
         "Analyze critical findings and provide executive summaries for each research phase",
         "Structure your consolidated findings according to the ConsolidatedResearch model",
         "Include overall research confidence and strategic recommendations",
-        "Focus on creating cohesive insights that integrate all research phases"
+        "Focus on creating cohesive insights that integrate all research phases",
     ],
     db=InMemoryDb(),
 )
@@ -162,18 +226,20 @@ task_recommender_agent = Agent(
         "Identify quick wins, resource requirements, and risk mitigation strategies",
         "Develop both high and medium priority task categories with long-term strategic initiatives",
         "Structure your recommendations according to the TaskRecommendations model",
-        "Include feasibility assessment and comprehensive implementation guidance"
+        "Include feasibility assessment and comprehensive implementation guidance",
     ],
     db=InMemoryDb(),
 )
 
 
-def set_session_state_step(step_input: StepInput, session_state: Dict[str, Any]) -> StepOutput:
+def set_session_state_step(
+    step_input: StepInput, session_state: Dict[str, Any]
+) -> StepOutput:
     """
     Initialize session state for customer research workflow
     """
     customer_query = step_input.input
-    
+
     # Initialize comprehensive session state structure
     if "customer_research" not in session_state:
         session_state["customer_research"] = {
@@ -182,67 +248,71 @@ def set_session_state_step(step_input: StepInput, session_state: Dict[str, Any])
             "research_phases": {
                 "profile": {"status": "pending", "findings": []},
                 "business_goals": {"status": "pending", "findings": []},
-                "web_intelligence": {"status": "pending", "findings": []}
+                "web_intelligence": {"status": "pending", "findings": []},
             },
             "consolidated_insights": [],
             "recommendations": [],
             "research_metadata": {
                 "started_at": datetime.now().isoformat(),
                 "total_research_steps": 0,
-                "completed_steps": 0
-            }
+                "completed_steps": 0,
+            },
         }
-    
+
     # Set workflow configuration
     session_state["workflow_config"] = {
         "research_depth": "comprehensive",
         "focus_areas": ["customer_profile", "business_goals", "web_intelligence"],
         "output_format": "detailed_report",
-        "created_by": "customer_research_team"
+        "created_by": "customer_research_team",
     }
-    
+
     # Set research preferences
     session_state["research_preferences"] = {
         "analysis_style": "data_driven",
         "recommendation_type": "actionable_tasks",
-        "reporting_level": "executive_summary"
+        "reporting_level": "executive_summary",
     }
-    
+
     session_state["customer_research"]["research_metadata"]["total_research_steps"] += 1
-    
+
     return StepOutput(
         content=f"""
         ## Customer Research Session Initialized
         
         **Research Query:** {customer_query}
-        **Workflow ID:** {session_state['customer_research']['workflow_id']}
-        **Research Phases:** {len(session_state['customer_research']['research_phases'])} phases planned
+        **Workflow ID:** {session_state["customer_research"]["workflow_id"]}
+        **Research Phases:** {len(session_state["customer_research"]["research_phases"])} phases planned
         
         **Session Configuration:**
-        - Research Depth: {session_state['workflow_config']['research_depth']}
-        - Focus Areas: {', '.join(session_state['workflow_config']['focus_areas'])}
-        - Analysis Style: {session_state['research_preferences']['analysis_style']}
+        - Research Depth: {session_state["workflow_config"]["research_depth"]}
+        - Focus Areas: {", ".join(session_state["workflow_config"]["focus_areas"])}
+        - Analysis Style: {session_state["research_preferences"]["analysis_style"]}
         
         Session state has been initialized and is ready for comprehensive customer research.
         """.strip()
     )
 
 
-async def customer_profile_research_step(step_input: StepInput, session_state: Dict[str, Any]) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
+async def customer_profile_research_step(
+    step_input: StepInput, session_state: Dict[str, Any]
+) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
     """
     Conduct customer profile research with session state tracking
     """
     customer_query = step_input.input
     previous_content = step_input.previous_step_content
-    
+
     # Update session state
-    session_state["customer_research"]["research_phases"]["profile"]["status"] = "in_progress"
-    
+    session_state["customer_research"]["research_phases"]["profile"]["status"] = (
+        "in_progress"
+    )
+
     research_prompt = f"""
     CUSTOMER PROFILE RESEARCH REQUEST:
     
     Research Query: {customer_query}
-    Session Context: {session_state['customer_research']['workflow_id']}
+    Session Context: {session_state["customer_research"]["workflow_id"]}
     Previous Context: {previous_content[:300] if previous_content else "Initial research"}
     
     RESEARCH OBJECTIVES:
@@ -254,57 +324,65 @@ async def customer_profile_research_step(step_input: StepInput, session_state: D
     
     Provide comprehensive customer profile insights with specific data points and actionable findings.
     """
-    
+
     try:
-        research_result_iterator = customer_profile_agent.arun(research_prompt, stream=True, stream_intermediate_steps=True)
+        research_result_iterator = customer_profile_agent.arun(
+            research_prompt, stream=True, stream_intermediate_steps=True
+        )
 
         async for event in research_result_iterator:
             yield event
-        
+
         # Get the actual response after streaming
         research_result = customer_profile_agent.get_last_run_output()
-        
+
         # Store findings in session state with structured data
         findings = {
             "research_type": "customer_profile",
             "timestamp": datetime.now().isoformat(),
             "structured_data": research_result.content,
-            "success": True
+            "success": True,
         }
-        
-        session_state["customer_research"]["research_phases"]["profile"]["findings"].append(findings)
-        session_state["customer_research"]["research_phases"]["profile"]["status"] = "completed"
+
+        session_state["customer_research"]["research_phases"]["profile"][
+            "findings"
+        ].append(findings)
+        session_state["customer_research"]["research_phases"]["profile"]["status"] = (
+            "completed"
+        )
         session_state["customer_research"]["research_metadata"]["completed_steps"] += 1
-        
+
         # Return the structured Pydantic data directly
-        yield StepOutput(
-            content=research_result.content,
-            success=True
-        )
-        
+        yield StepOutput(content=research_result.content, success=True)
+
     except Exception as e:
-        session_state["customer_research"]["research_phases"]["profile"]["status"] = "failed"
+        session_state["customer_research"]["research_phases"]["profile"]["status"] = (
+            "failed"
+        )
         yield StepOutput(
-            content=f"Customer profile research failed: {str(e)}",
-            success=False
+            content=f"Customer profile research failed: {str(e)}", success=False
         )
 
 
-async def customer_biz_goals_research_step(step_input: StepInput, session_state: Dict[str, Any]) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
+async def customer_biz_goals_research_step(
+    step_input: StepInput, session_state: Dict[str, Any]
+) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
     """
     Conduct business goals research with session state tracking
     """
     customer_query = step_input.input
-    
+
     # Update session state
-    session_state["customer_research"]["research_phases"]["business_goals"]["status"] = "in_progress"
-    
+    session_state["customer_research"]["research_phases"]["business_goals"][
+        "status"
+    ] = "in_progress"
+
     research_prompt = f"""
     CUSTOMER BUSINESS GOALS RESEARCH REQUEST:
     
     Research Query: {customer_query}
-    Session Context: {session_state['customer_research']['workflow_id']}
-    Research Depth: {session_state['workflow_config']['research_depth']}
+    Session Context: {session_state["customer_research"]["workflow_id"]}
+    Research Depth: {session_state["workflow_config"]["research_depth"]}
     
     RESEARCH OBJECTIVES:
     1. Identify customer's primary business objectives and KPIs
@@ -315,57 +393,65 @@ async def customer_biz_goals_research_step(step_input: StepInput, session_state:
     
     Provide detailed business goals analysis with strategic insights and market context.
     """
-    
+
     try:
-        research_result_iterator = business_goals_agent.arun(research_prompt, stream=True, stream_intermediate_steps=True)
+        research_result_iterator = business_goals_agent.arun(
+            research_prompt, stream=True, stream_intermediate_steps=True
+        )
 
         async for event in research_result_iterator:
             yield event
-        
+
         # Get the actual response after streaming
         research_result = business_goals_agent.get_last_run_output()
-        
+
         # Store findings in session state with structured data
         findings = {
             "research_type": "business_goals",
             "timestamp": datetime.now().isoformat(),
             "structured_data": research_result.content,
-            "success": True
+            "success": True,
         }
-        
-        session_state["customer_research"]["research_phases"]["business_goals"]["findings"].append(findings)
-        session_state["customer_research"]["research_phases"]["business_goals"]["status"] = "completed"
+
+        session_state["customer_research"]["research_phases"]["business_goals"][
+            "findings"
+        ].append(findings)
+        session_state["customer_research"]["research_phases"]["business_goals"][
+            "status"
+        ] = "completed"
         session_state["customer_research"]["research_metadata"]["completed_steps"] += 1
-        
+
         # Return the structured Pydantic data directly
-        yield StepOutput(
-            content=research_result.content,
-            success=True
-        )
-        
+        yield StepOutput(content=research_result.content, success=True)
+
     except Exception as e:
-        session_state["customer_research"]["research_phases"]["business_goals"]["status"] = "failed"
+        session_state["customer_research"]["research_phases"]["business_goals"][
+            "status"
+        ] = "failed"
         yield StepOutput(
-            content=f"Business goals research failed: {str(e)}",
-            success=False
+            content=f"Business goals research failed: {str(e)}", success=False
         )
 
 
-async def web_intelligence_research_step(step_input: StepInput, session_state: Dict[str, Any]) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
+async def web_intelligence_research_step(
+    step_input: StepInput, session_state: Dict[str, Any]
+) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
     """
     Conduct web intelligence research with session state tracking
     """
     customer_query = step_input.input
-    
+
     # Update session state
-    session_state["customer_research"]["research_phases"]["web_intelligence"]["status"] = "in_progress"
-    
+    session_state["customer_research"]["research_phases"]["web_intelligence"][
+        "status"
+    ] = "in_progress"
+
     research_prompt = f"""
     WEB INTELLIGENCE RESEARCH REQUEST:
     
     Research Query: {customer_query}
-    Session Context: {session_state['customer_research']['workflow_id']}
-    Analysis Style: {session_state['research_preferences']['analysis_style']}
+    Session Context: {session_state["customer_research"]["workflow_id"]}
+    Analysis Style: {session_state["research_preferences"]["analysis_style"]}
     
     RESEARCH OBJECTIVES:
     1. Analyze customer's digital presence and online footprint
@@ -376,51 +462,57 @@ async def web_intelligence_research_step(step_input: StepInput, session_state: D
     
     Provide comprehensive web intelligence with digital insights and online behavior analysis.
     """
-    
+
     try:
-        research_result_iterator = web_intelligence_agent.arun(research_prompt, stream=True, stream_intermediate_steps=True)
+        research_result_iterator = web_intelligence_agent.arun(
+            research_prompt, stream=True, stream_intermediate_steps=True
+        )
 
         async for event in research_result_iterator:
             yield event
-        
+
         # Get the actual response after streaming
         research_result = web_intelligence_agent.get_last_run_output()
-        
+
         # Store findings in session state with structured data
         findings = {
             "research_type": "web_intelligence",
             "timestamp": datetime.now().isoformat(),
             "structured_data": research_result.content,
-            "success": True
+            "success": True,
         }
-        
-        session_state["customer_research"]["research_phases"]["web_intelligence"]["findings"].append(findings)
-        session_state["customer_research"]["research_phases"]["web_intelligence"]["status"] = "completed"
+
+        session_state["customer_research"]["research_phases"]["web_intelligence"][
+            "findings"
+        ].append(findings)
+        session_state["customer_research"]["research_phases"]["web_intelligence"][
+            "status"
+        ] = "completed"
         session_state["customer_research"]["research_metadata"]["completed_steps"] += 1
-        
+
         # Return the structured Pydantic data directly
-        yield StepOutput(
-            content=research_result.content,
-            success=True
-        )
-        
+        yield StepOutput(content=research_result.content, success=True)
+
     except Exception as e:
-        session_state["customer_research"]["research_phases"]["web_intelligence"]["status"] = "failed"
+        session_state["customer_research"]["research_phases"]["web_intelligence"][
+            "status"
+        ] = "failed"
         yield StepOutput(
-            content=f"Web intelligence research failed: {str(e)}",
-            success=False
+            content=f"Web intelligence research failed: {str(e)}", success=False
         )
 
 
-async def customer_report_consolidation_step(step_input: StepInput, session_state: Dict[str, Any]) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
+async def customer_report_consolidation_step(
+    step_input: StepInput, session_state: Dict[str, Any]
+) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
     """
     Consolidate all research findings into comprehensive customer report
     """
     customer_query = step_input.input
-    
+
     # Gather all research findings from session state
     research_data = session_state["customer_research"]
-    
+
     # Compile research findings with structured data
     all_findings = []
     structured_summaries = {}
@@ -428,40 +520,44 @@ async def customer_report_consolidation_step(step_input: StepInput, session_stat
         for finding in phase_data["findings"]:
             if "structured_data" in finding:
                 # Include structured data summary
-                all_findings.append({
-                    "phase": phase_name,
-                    "structured_data": finding["structured_data"],
-                    "research_topic": finding.get("research_topic", "N/A"),
-                    "confidence_score": finding.get("confidence_score", 0.0),
-                    "timestamp": finding["timestamp"]
-                })
+                all_findings.append(
+                    {
+                        "phase": phase_name,
+                        "structured_data": finding["structured_data"],
+                        "research_topic": finding.get("research_topic", "N/A"),
+                        "confidence_score": finding.get("confidence_score", 0.0),
+                        "timestamp": finding["timestamp"],
+                    }
+                )
                 structured_summaries[phase_name] = finding["structured_data"]
             else:
                 # Fallback for non-structured data
-                all_findings.append({
-                    "phase": phase_name,
-                    "content": str(finding.get("content", ""))[:500],
-                    "timestamp": finding["timestamp"]
-                })
-    
+                all_findings.append(
+                    {
+                        "phase": phase_name,
+                        "content": str(finding.get("content", ""))[:500],
+                        "timestamp": finding["timestamp"],
+                    }
+                )
+
     consolidation_prompt = f"""
     COMPREHENSIVE CUSTOMER RESEARCH CONSOLIDATION (STRUCTURED DATA):
     
     Original Query: {customer_query}
-    Session ID: {research_data['workflow_id']}
-    Total Research Phases: {len(research_data['research_phases'])}
-    Completed Steps: {research_data['research_metadata']['completed_steps']}
+    Session ID: {research_data["workflow_id"]}
+    Total Research Phases: {len(research_data["research_phases"])}
+    Completed Steps: {research_data["research_metadata"]["completed_steps"]}
     
     STRUCTURED RESEARCH FINDINGS TO CONSOLIDATE:
     
     Customer Profile Research:
-    {json.dumps(structured_summaries.get('profile', {}), indent=2) if 'profile' in structured_summaries else 'No structured data available'}
+    {json.dumps(structured_summaries.get("profile", {}), indent=2) if "profile" in structured_summaries else "No structured data available"}
     
     Business Goals Research:
-    {json.dumps(structured_summaries.get('business_goals', {}), indent=2) if 'business_goals' in structured_summaries else 'No structured data available'}
+    {json.dumps(structured_summaries.get("business_goals", {}), indent=2) if "business_goals" in structured_summaries else "No structured data available"}
     
     Web Intelligence Research:
-    {json.dumps(structured_summaries.get('web_intelligence', {}), indent=2) if 'web_intelligence' in structured_summaries else 'No structured data available'}
+    {json.dumps(structured_summaries.get("web_intelligence", {}), indent=2) if "web_intelligence" in structured_summaries else "No structured data available"}
     
     CONSOLIDATION OBJECTIVES:
     1. Synthesize all structured research findings into cohesive customer insights
@@ -473,71 +569,79 @@ async def customer_report_consolidation_step(step_input: StepInput, session_stat
     
     Create a detailed, consolidated customer research report that integrates all structured findings.
     """
-    
+
     try:
-        consolidation_result_iterator = research_consolidation_team.arun(consolidation_prompt, stream=True, stream_intermediate_steps=True)
+        consolidation_result_iterator = research_consolidation_team.arun(
+            consolidation_prompt, stream=True, stream_intermediate_steps=True
+        )
 
         async for event in consolidation_result_iterator:
             yield event
-        
+
         # Get the actual response after streaming
         consolidation_result = research_consolidation_team.get_last_run_output()
-        
+
         # Store consolidated insights in session state
         consolidated_insight = {
             "consolidation_timestamp": datetime.now().isoformat(),
             "structured_data": consolidation_result.content,
             "research_phases_included": list(research_data["research_phases"].keys()),
-            "total_findings_consolidated": len(all_findings)
+            "total_findings_consolidated": len(all_findings),
         }
-        
-        session_state["customer_research"]["consolidated_insights"].append(consolidated_insight)
-        
-        # Return the structured Pydantic data directly
-        yield StepOutput(
-            content=consolidation_result.content,
-            success=True
+
+        session_state["customer_research"]["consolidated_insights"].append(
+            consolidated_insight
         )
-        
+
+        # Return the structured Pydantic data directly
+        yield StepOutput(content=consolidation_result.content, success=True)
+
     except Exception as e:
         yield StepOutput(
-            content=f"Research consolidation failed: {str(e)}",
-            success=False
+            content=f"Research consolidation failed: {str(e)}", success=False
         )
 
 
-async def task_recommender_step(step_input: StepInput, session_state: Dict[str, Any]) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
+async def task_recommender_step(
+    step_input: StepInput, session_state: Dict[str, Any]
+) -> AsyncIterator[Union[WorkflowRunOutputEvent, StepOutput]]:
     """
     Generate actionable task recommendations based on consolidated research
     """
     customer_query = step_input.input
-    
+
     research_data = session_state["customer_research"]
     workflow_config = session_state["workflow_config"]
     research_prefs = session_state["research_preferences"]
-    
+
     # Get latest consolidated insights
-    latest_insights = research_data["consolidated_insights"][-1] if research_data["consolidated_insights"] else {}
-    consolidated_structured_data = latest_insights.get("structured_data", {}) if latest_insights else {}
-    
+    latest_insights = (
+        research_data["consolidated_insights"][-1]
+        if research_data["consolidated_insights"]
+        else {}
+    )
+    consolidated_structured_data = (
+        latest_insights.get("structured_data", {}) if latest_insights else {}
+    )
+
     recommendation_prompt = f"""
     STRATEGIC TASK RECOMMENDATIONS REQUEST (BASED ON STRUCTURED DATA):
     
     Research Query: {customer_query}
-    Session Context: {research_data['workflow_id']}
+    Session Context: {research_data["workflow_id"]}
     
     CONSOLIDATED RESEARCH INSIGHTS (STRUCTURED):
     {json.dumps(consolidated_structured_data, indent=2) if consolidated_structured_data else "No structured consolidated research available"}
     
     WORKFLOW CONFIGURATION:
-    - Research Depth: {workflow_config['research_depth']}
-    - Focus Areas: {', '.join(workflow_config['focus_areas'])}
-    - Recommendation Type: {research_prefs['recommendation_type']}
-    - Reporting Level: {research_prefs['reporting_level']}
+    - Research Depth: {workflow_config["research_depth"]}
+    - Focus Areas: {", ".join(workflow_config["focus_areas"])}
+    - Recommendation Type: {research_prefs["recommendation_type"]}
+    - Reporting Level: {research_prefs["reporting_level"]}
     
     SESSION RESEARCH SUMMARY:
-    - Total Research Phases: {len(research_data['research_phases'])}
-    - Completed Analysis Steps: {research_data['research_metadata']['completed_steps']}
+    - Total Research Phases: {len(research_data["research_phases"])}
+    - Completed Analysis Steps: {research_data["research_metadata"]["completed_steps"]}
     - Research Duration: Session-based analysis
     
     RECOMMENDATION OBJECTIVES:
@@ -549,40 +653,44 @@ async def task_recommender_step(step_input: StepInput, session_state: Dict[str, 
     
     Create comprehensive task recommendations with clear action items and strategic priorities.
     """
-    
+
     try:
-        recommendation_result_iterator = task_recommender_agent.arun(recommendation_prompt, stream=True, stream_intermediate_steps=True)
+        recommendation_result_iterator = task_recommender_agent.arun(
+            recommendation_prompt, stream=True, stream_intermediate_steps=True
+        )
 
         async for event in recommendation_result_iterator:
             yield event
-        
+
         # Get the actual response after streaming
         recommendation_result = task_recommender_agent.get_last_run_output()
-        
+
         # Store recommendations in session state
         recommendation_data = {
             "recommendation_timestamp": datetime.now().isoformat(),
             "structured_data": recommendation_result.content,
             "based_on_insights": len(research_data["consolidated_insights"]),
-            "recommendation_type": research_prefs["recommendation_type"]
+            "recommendation_type": research_prefs["recommendation_type"],
         }
-        
-        session_state["customer_research"]["recommendations"].append(recommendation_data)
-        
-        # Final session state update
-        session_state["customer_research"]["research_metadata"]["completed_at"] = datetime.now().isoformat()
-        session_state["customer_research"]["research_metadata"]["final_status"] = "completed_successfully"
-        
-        # Return the structured Pydantic data directly
-        yield StepOutput(
-            content=recommendation_result.content,
-            success=True
+
+        session_state["customer_research"]["recommendations"].append(
+            recommendation_data
         )
-        
+
+        # Final session state update
+        session_state["customer_research"]["research_metadata"]["completed_at"] = (
+            datetime.now().isoformat()
+        )
+        session_state["customer_research"]["research_metadata"]["final_status"] = (
+            "completed_successfully"
+        )
+
+        # Return the structured Pydantic data directly
+        yield StepOutput(content=recommendation_result.content, success=True)
+
     except Exception as e:
         yield StepOutput(
-            content=f"Task recommendation generation failed: {str(e)}",
-            success=False
+            content=f"Task recommendation generation failed: {str(e)}", success=False
         )
 
 
@@ -598,7 +706,7 @@ customer_profile_research_step_obj = Step(
 )
 
 customer_biz_goals_research_step_obj = Step(
-    name="Customer Business Goals Research", 
+    name="Customer Business Goals Research",
     executor=customer_biz_goals_research_step,
 )
 
@@ -629,9 +737,9 @@ customer_research_workflow = Workflow(
         set_session_state_step_obj,
         Parallel(
             customer_profile_research_step_obj,
-            customer_biz_goals_research_step_obj, 
+            customer_biz_goals_research_step_obj,
             web_intelligence_research_step_obj,
-            name="Parallel Research Phase"
+            name="Parallel Research Phase",
         ),
         customer_report_consolidation_step_obj,
         task_recommender_step_obj,
@@ -651,10 +759,10 @@ if __name__ == "__main__":
 # async def main():
 #     print("🔍 Starting Comprehensive Customer Research Workflow...")
 #     print("=" * 70)
-    
+
 #     # Example customer research query
 #     research_query = "Analyze SaaS startup customers in the healthcare technology space, focusing on mid-market companies (50-500 employees) looking for patient management solutions"
-    
+
 #     # Run the workflow
 #     result = await customer_research_workflow.aprint_response(
 #         input=research_query,
@@ -662,7 +770,7 @@ if __name__ == "__main__":
 #         stream=True,
 #         stream_intermediate_steps=True,
 #     )
-    
+
 #     print("\n" + "=" * 70)
 #     print("✅ Customer Research Workflow Completed Successfully!")
 

--- a/cookbook/integrations/observability/opik_via_openinference.py
+++ b/cookbook/integrations/observability/opik_via_openinference.py
@@ -4,11 +4,11 @@ Instrument your Agno agents with OpenTelemetry and stream traces to Opik for ric
 1. Install dependencies:
    pip install -U opik agno openai opentelemetry-sdk opentelemetry-exporter-otlp openinference-instrumentation-agno
 2. Point the OTLP exporter at the Opik collector:
-   - Opik Cloud:  
-     export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel  
+   - Opik Cloud:
+     export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
      export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<workspace>,projectName=<project>'
-   - Self-hosted:  
-     export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:5173/api/v1/private/otel  
+   - Self-hosted:
+     export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:5173/api/v1/private/otel
      export OTEL_EXPORTER_OTLP_HEADERS='projectName=<project>'
 """
 
@@ -43,4 +43,6 @@ agent = Agent(
 
 if __name__ == "__main__":
     # The span hierarchy (agent → model → tool) will appear in Opik for every request
-    agent.print_response("What is the current price of Apple and how did it move today?")
+    agent.print_response(
+        "What is the current price of Apple and how did it move today?"
+    )

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -21,6 +21,8 @@ class AGUI(BaseInterface):
         team: Optional[Team] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
+        user_id_claim: Optional[str] = None,
+        dependencies_claims: Optional[List[str]] = None,
     ):
         """
         Initialize the AGUI interface.
@@ -30,11 +32,15 @@ class AGUI(BaseInterface):
             team: The team to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
+            user_id_claim: Claim to extract user ID from AGUI forwardedProps (defaults to "user_id")
+            dependencies_claims: List of claims to extract from AGUI forwardedProps
         """
         self.agent = agent
         self.team = team
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
+        self.user_id_claim = user_id_claim or "user_id"
+        self.dependencies_claims = dependencies_claims or []
 
         if not (self.agent or self.team):
             raise ValueError("AGUI requires an agent or a team")
@@ -42,6 +48,12 @@ class AGUI(BaseInterface):
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(
+            router=self.router,
+            agent=self.agent,
+            team=self.team,
+            user_id_claim=self.user_id_claim,
+            dependencies_claims=self.dependencies_claims,
+        )  # type: ignore
 
         return self.router

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -2023,9 +2023,7 @@ class Team:
         try:
             # Start the Run by yielding a RunStarted event
             if stream_intermediate_steps:
-                yield self._handle_event(
-                    create_team_run_started_event(from_run_response=run_response), run_response
-                )
+                yield self._handle_event(create_team_run_started_event(from_run_response=run_response), run_response)
 
             # 3. Reason about the task(s) if reasoning is enabled
             async for item in self._ahandle_reasoning_stream(run_response=run_response, run_messages=run_messages):

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -357,7 +357,7 @@ class Step:
         """Enrich event with step and workflow context information"""
         if workflow_run_response is None:
             return event
-            
+
         if hasattr(event, "step_id"):
             event.step_id = self.step_id
         if hasattr(event, "step_name") and self.name is not None:


### PR DESCRIPTION
## Summary

I've followed the logic behind the JWT middleware where the user defines the claims to grab and use as user_id and/or dependencies from the `forwardedProps` field in the AGUI runner.

I'm not sure about the dependencies part, as they are read by the agent run but have no effect on the agent context. Could anybody review this? If it all sounds good to you, this could be expanded to other use-cases as agent-state and so on.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

```python
agent_os = AgentOS(
    agents=[agent],
    interfaces=[AGUI(agent=agent)],
    user_id_claim="user_id",
    dependencies_claims=["email", "name"]
)
```
