### PR TITLE
feat(session): add session exporter (dict/json/markdown) + demo & tests

### DIFF
--- a/HACKTOBERFEST.md
+++ b/HACKTOBERFEST.md
@@ -1,0 +1,122 @@
+Hacktoberfest contribution: truncate_middle utility
+
+What I added
+- New utility: `agno.utils.string.truncate_middle(input_string, max_length)` — truncates long strings with an ellipsis in the middle while preserving start/end segments.
+- Unit tests added in: `libs/agno/tests/unit/utils/test_string.py` (several small tests covering behavior).
+
+Files changed
+- libs/agno/agno/utils/string.py  (added `truncate_middle`)
+- libs/agno/tests/unit/utils/test_string.py  (added tests)
+
+- libs/agno/agno/session/exporter.py (added `export_session_to_dict`, `export_session_to_json`, `export_session_to_markdown`)
+- libs/agno/tests/unit/session/test_exporter.py (added tests)
+
+Why this is a good first contribution
+- Small, self-contained change with unit tests
+- Low risk: pure-Python helper function, no external dependencies
+
+How to run the tests locally (Windows PowerShell)
+1. Create and activate a virtual environment:
+
+```powershell
+py -3 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+2. Install dev dependencies (recommended):
+
+```powershell
+pip install -e libs/agno[dev]
+pip install pytest
+```
+
+3. Run the new tests only:
+
+```powershell
+py -3 -m pytest libs/agno/tests/unit/utils/test_string.py -k truncate_middle -q
+```
+
+Notes about CI/test-run issues
+- When I attempted to run pytest in the current environment, pytest loaded an installed pytest plugin named `langsmith` which caused import-time errors (Pydantic v1/v2 forward-ref issue). To avoid this, run the tests in a clean virtualenv (see steps above) or uninstall the conflicting plugin from your environment: `pip uninstall langsmith`.
+
+What you can do next
+- Run the tests locally using the commands above.
+- Create a branch, commit the changes if you'd like to iterate, and open a PR to `main` with the contribution label for Hacktoberfest.
+
+Session exporter usage (example):
+
+```python
+from agno.session.agent import AgentSession
+from agno.session.exporter import export_session_to_json, export_session_to_markdown
+
+# assume `session` is an AgentSession object retrieved from storage
+json_str = export_session_to_json(session)
+md = export_session_to_markdown(session)
+
+# write to files
+export_session_to_json(session, path="/tmp/session_s1.json")
+export_session_to_markdown(session, path="/tmp/session_s1.md")
+```
+
+If you want, I can:
+- Open a local branch and prepare a commit message for you to push (I can generate the git commands), or
+- Add a small README note inside `libs/agno` describing the helper API.
+
+Happy Hacktoberfest! 🎉
+
+Demo run (actual output)
+
+Run the demo script to see the JSON and Markdown exports printed and written to `tmp_export/`:
+
+```powershell
+py -3 demo/session_export_demo.py
+```
+
+Observed output (trimmed for clarity):
+
+--- JSON Export (pretty) ---
+{
+	"session_id": "s1",
+	"agent_id": "agent1",
+	"team_id": null,
+	"user_id": "user1",
+	"workflow_id": null,
+	"session_data": {
+		"key": "value"
+	},
+	"runs": [
+		{
+			"run_id": "r1",
+			"agent_id": "agent1",
+			"session_id": "s1",
+			"content": "response text",
+			"content_type": "str",
+			"created_at": 1760345278,
+			"status": "RUNNING",
+			"messages": [
+				{"content": "hello", "role": "user"},
+				{"content": "world", "role": "assistant"}
+			]
+		}
+	],
+	"summary": {"summary": "short summary"}
+}
+
+Wrote JSON to: C:\\Users\\Asus\\agno\\tmp_export\\session_s1.json
+
+--- Markdown Export ---
+# Session s1
+- Agent: `agent1`
+- User: `user1`
+
+## Summary
+
+short summary
+
+## Runs
+
+### Run 1 — r1 — RunStatus.running
+**user**: hello
+**assistant**: world
+
+Wrote Markdown to: C:\\Users\\Asus\\agno\\tmp_export\\session_s1.md

--- a/demo/session_export_demo.py
+++ b/demo/session_export_demo.py
@@ -1,0 +1,47 @@
+"""Small demo script that creates a sample AgentSession and prints JSON and Markdown exports."""
+from pathlib import Path
+import json
+
+from agno.session.agent import AgentSession
+from agno.run.agent import RunOutput
+from agno.session.summary import SessionSummary
+from agno.models.message import Message
+from agno.session.exporter import export_session_to_json, export_session_to_markdown
+
+
+def make_simple_session():
+    s = AgentSession(session_id="s1", agent_id="agent1", user_id="user1", session_data={"key": "value"})
+    r = RunOutput(run_id="r1", session_id="s1", agent_id="agent1", content="response text")
+    r.messages = [Message(role="user", content="hello"), Message(role="assistant", content="world")]
+    s.runs = [r]
+    s.summary = SessionSummary(summary="short summary")
+    return s
+
+
+def main():
+    session = make_simple_session()
+
+    json_out = export_session_to_json(session, pretty=True)
+    md_out = export_session_to_markdown(session)
+
+    out_dir = Path("." )/ "tmp_export"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    json_path = out_dir / "session_s1.json"
+    md_path = out_dir / "session_s1.md"
+
+    json_path.write_text(json_out, encoding="utf-8")
+    md_path.write_text(md_out, encoding="utf-8")
+
+    print("--- JSON Export (pretty) ---")
+    print(json_out)
+    print()
+    print(f"Wrote JSON to: {json_path.resolve()}")
+    print()
+    print("--- Markdown Export ---")
+    print(md_out)
+    print()
+    print(f"Wrote Markdown to: {md_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/agno/agno/session/exporter.py
+++ b/libs/agno/agno/session/exporter.py
@@ -1,0 +1,151 @@
+"""Session exporter helpers
+
+Provides functions to export AgentSession/TeamSession objects to JSON, dict and
+human-readable Markdown formats. This is intentionally small and conservative:
+- it uses existing `.to_dict()` helpers where available
+- it avoids inlining binary attachments (only metadata/filenames are exported)
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+from agno.session.agent import AgentSession
+from agno.utils.log import log_debug, log_warning
+
+
+def export_session_to_dict(session: AgentSession, include_messages: bool = True) -> Dict[str, Any]:
+    """Return a serializable dict representation of the session.
+
+    This function tries to reuse existing `.to_dict()` implementations (for runs,
+    summaries, etc.) and prunes or converts non-serializable values.
+    """
+    if session is None:
+        return {}
+
+    # Start with AgentSession.to_dict() which already handles many conversions
+    try:
+        session_dict = session.to_dict()
+    except Exception as e:
+        log_warning(f"Failed converting session to dict using to_dict(): {e}")
+        # Fallback: manual shallow mapping
+        session_dict = {
+            "session_id": getattr(session, "session_id", None),
+            "agent_id": getattr(session, "agent_id", None),
+            "team_id": getattr(session, "team_id", None),
+            "user_id": getattr(session, "user_id", None),
+            "agent_data": getattr(session, "agent_data", None),
+            "session_data": getattr(session, "session_data", None),
+            "metadata": getattr(session, "metadata", None),
+            "created_at": getattr(session, "created_at", None),
+            "updated_at": getattr(session, "updated_at", None),
+        }
+
+    # Optionally remove messages content for very large sessions
+    if not include_messages and session_dict.get("runs"):
+        pruned_runs = []
+        for run in session_dict.get("runs", []):
+            run_copy = {k: v for k, v in run.items() if k != "messages"}
+            pruned_runs.append(run_copy)
+        session_dict["runs"] = pruned_runs
+
+    # Ensure all nested objects are JSON serializable (best effort)
+    try:
+        json.dumps(session_dict)
+    except TypeError:
+        # Convert any objects by stringifying them (safe fallback)
+        def _make_serializable(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {k: _make_serializable(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [_make_serializable(v) for v in value]
+            try:
+                json.dumps(value)
+                return value
+            except TypeError:
+                return str(value)
+
+        session_dict = _make_serializable(session_dict)
+
+    return session_dict
+
+
+def export_session_to_json(session: AgentSession, path: Optional[str] = None, pretty: bool = True) -> str:
+    """Return JSON string for the session; optionally write to `path` and return the path."""
+    session_dict = export_session_to_dict(session)
+    indent = 2 if pretty else None
+    json_str = json.dumps(session_dict, indent=indent, ensure_ascii=False)
+    if path:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(json_str)
+        log_debug(f"Wrote session export to {path}")
+        return path
+    return json_str
+
+
+def export_session_to_markdown(session: AgentSession, path: Optional[str] = None, include_runs: bool = True) -> str:
+    """Return a human-readable Markdown representation of the session.
+
+    The Markdown includes basic metadata, an optional summary, and runs with
+    messages. Attachments are represented by their metadata only.
+    """
+    if session is None:
+        return ""
+
+    lines = []
+    lines.append(f"# Session {session.session_id}")
+    if session.agent_id:
+        lines.append(f"- Agent: `{session.agent_id}`")
+    if session.user_id:
+        lines.append(f"- User: `{session.user_id}`")
+    if session.team_id:
+        lines.append(f"- Team: `{session.team_id}`")
+    if session.created_at:
+        lines.append(f"- Created at: {session.created_at}")
+    if session.updated_at:
+        lines.append(f"- Updated at: {session.updated_at}")
+
+    # Summary
+    if session.summary is not None:
+        lines.append("\n## Summary\n")
+        if hasattr(session.summary, "summary"):
+            lines.append(session.summary.summary)
+        else:
+            lines.append(str(session.summary))
+
+    # Runs
+    if include_runs and session.runs:
+        lines.append("\n## Runs\n")
+        for idx, run in enumerate(session.runs or [], start=1):
+            run_id = getattr(run, "run_id", None)
+            status = getattr(run, "status", None)
+            lines.append(f"### Run {idx} — {run_id} — {status}")
+
+            # messages: use available to_dict on messages
+            messages = getattr(run, "messages", None)
+            if messages:
+                for m in messages:
+                    role = getattr(m, "role", "")
+                    content = getattr(m, "content", "")
+                    # Show tool outputs concisely
+                    lines.append(f"**{role}**: {content}")
+            # Tool calls
+            tool_calls = []
+            if messages:
+                for m in messages:
+                    if getattr(m, "tool_calls", None):
+                        for tc in m.tool_calls:
+                            tool_calls.append(tc)
+            if tool_calls:
+                lines.append("\n**Tool calls:**")
+                for tc in tool_calls:
+                    lines.append(f"- {tc}")
+
+    md = "\n".join(lines)
+    if path:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(md)
+        log_debug(f"Wrote session markdown to {path}")
+        return path
+
+    return md

--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -229,3 +229,44 @@ def generate_id_from_name(name: Optional[str] = None) -> str:
         return name.lower().replace(" ", "-").replace("_", "-")
     else:
         return str(uuid4())
+
+
+def truncate_middle(input_string: str, max_length: int) -> str:
+    """
+    Truncate a string with an ellipsis in the middle if it exceeds max_length.
+
+    Behaviour:
+    - If the input string length is less than or equal to max_length, return it unchanged.
+    - If max_length is less than 4, return the input truncated to max_length (no ellipsis).
+    - When truncation is needed, preserve the start and end of the string and place '...' between them.
+
+    Examples:
+        truncate_middle('abcdefghijkl', 8) -> 'abc...kl'
+        truncate_middle('short', 10) -> 'short'
+
+    Args:
+        input_string: The string to truncate.
+        max_length: Maximum allowed length for the result string.
+
+    Returns:
+        The possibly-truncated string.
+    """
+    if max_length <= 0:
+        return ""
+
+    if len(input_string) <= max_length:
+        return input_string
+
+    # If we don't have room for an ellipsis, just cut to max_length
+    if max_length < 4:
+        return input_string[:max_length]
+
+    # Reserve 3 characters for '...'
+    keep = max_length - 3
+    # Split the keep between head and tail
+    head_len = (keep + 1) // 2
+    tail_len = keep // 2
+
+    head = input_string[:head_len]
+    tail = input_string[-tail_len:] if tail_len > 0 else ""
+    return f"{head}...{tail}"

--- a/libs/agno/tests/unit/session/test_exporter.py
+++ b/libs/agno/tests/unit/session/test_exporter.py
@@ -1,0 +1,40 @@
+import json
+
+from agno.session.agent import AgentSession
+from agno.run.agent import RunOutput
+from agno.session.summary import SessionSummary
+from agno.session.exporter import export_session_to_dict, export_session_to_json, export_session_to_markdown
+
+
+def _make_simple_session():
+    s = AgentSession(session_id="s1", agent_id="agent1", user_id="user1", session_data={"key": "value"})
+    r = RunOutput(run_id="r1", session_id="s1", agent_id="agent1", content="response text")
+    # Add a minimal message-like object
+    from agno.models.message import Message
+
+    r.messages = [Message(role="user", content="hello"), Message(role="assistant", content="world")]
+    s.runs = [r]
+    s.summary = SessionSummary(summary="short summary")
+    return s
+
+
+def test_export_dict_contains_expected_fields():
+    s = _make_simple_session()
+    d = export_session_to_dict(s)
+    assert d["session_id"] == "s1"
+    assert d["agent_id"] == "agent1"
+    assert "runs" in d and isinstance(d["runs"], list)
+    assert d["summary"]["summary"] == "short summary"
+
+
+def test_export_json_and_markdown():
+    s = _make_simple_session()
+    js = export_session_to_json(s, pretty=False)
+    # should be valid json
+    parsed = json.loads(js)
+    assert parsed["session_id"] == "s1"
+
+    md = export_session_to_markdown(s)
+    assert "# Session s1" in md
+    assert "short summary" in md
+    assert "hello" in md and "world" in md

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -346,3 +346,31 @@ def test_parse_json_with_python_code_in_value():
         == "def factorial(n):     # Calculate factorial of n     if n <= 1:         return 1     return n * factorial(n - 1)"
     )
     assert result.description == "A recursive factorial function with comments and multiplication"
+
+
+def test_truncate_middle_no_truncation():
+    assert url_safe_string("keep-me") == "keep-me"
+
+
+def test_truncate_middle_truncates():
+    from agno.utils.string import truncate_middle
+
+    s = "abcdefghijklmnopqrstuvwxyz"
+    # max_length 8 -> keep 5 chars around ellipsis -> head 3 tail 2
+    assert truncate_middle(s, 8) == "abc...yz"
+
+
+def test_truncate_middle_small_max():
+    from agno.utils.string import truncate_middle
+
+    s = "abcdef"
+    # max_length 2 -> no ellipsis used
+    assert truncate_middle(s, 2) == "ab"
+
+
+def test_truncate_middle_edge_case():
+    from agno.utils.string import truncate_middle
+
+    s = "abcd"
+    # max_length equals len(s)
+    assert truncate_middle(s, 4) == "abcd"

--- a/tmp_export/session_s1.json
+++ b/tmp_export/session_s1.json
@@ -1,0 +1,44 @@
+{
+  "session_id": "s1",
+  "agent_id": "agent1",
+  "team_id": null,
+  "user_id": "user1",
+  "workflow_id": null,
+  "session_data": {
+    "key": "value"
+  },
+  "metadata": null,
+  "agent_data": null,
+  "runs": [
+    {
+      "run_id": "r1",
+      "agent_id": "agent1",
+      "session_id": "s1",
+      "content": "response text",
+      "content_type": "str",
+      "created_at": 1760345278,
+      "status": "RUNNING",
+      "messages": [
+        {
+          "content": "hello",
+          "from_history": false,
+          "stop_after_tool_call": false,
+          "role": "user",
+          "created_at": 1760345278
+        },
+        {
+          "content": "world",
+          "from_history": false,
+          "stop_after_tool_call": false,
+          "role": "assistant",
+          "created_at": 1760345278
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "summary": "short summary"
+  },
+  "created_at": null,
+  "updated_at": null
+}

--- a/tmp_export/session_s1.md
+++ b/tmp_export/session_s1.md
@@ -1,0 +1,13 @@
+# Session s1
+- Agent: `agent1`
+- User: `user1`
+
+## Summary
+
+short summary
+
+## Runs
+
+### Run 1 — r1 — RunStatus.running
+**user**: hello
+**assistant**: world


### PR DESCRIPTION
This PR adds a session exporter utility and a small demo to show how to export an
AgentSession as JSON and Markdown. It also includes unit tests for the exporter and
the earlier small `truncate_middle` string helper.

Files changed (high level)
- `libs/agno/agno/session/exporter.py` — new module with:
  - `export_session_to_dict(session, include_messages=True)`
  - `export_session_to_json(session, path=None, pretty=True)`
  - `export_session_to_markdown(session, path=None, include_runs=True)`
- `libs/agno/tests/unit/session/test_exporter.py` — unit tests for the exporter
- `demo/session_export_demo.py` — small runnable script that prints JSON/Markdown
- `HACKTOBERFEST.md` — updated with demo run instructions and captured output
- `libs/agno/agno/utils/string.py` and tests — `truncate_middle` helper (small utils change)