### PR TITLE
feat: Support configurable DashScope region through DASHSCOPE_REGION

### DIFF
--- a/cookbook/models/dashscope/README.md
+++ b/cookbook/models/dashscope/README.md
@@ -15,6 +15,21 @@ Get your API key from: https://modelstudio.console.alibabacloud.com/?tab=model#/
 export DASHSCOPE_API_KEY=***
 ```
 
+🆕 Region Configuration (optional)
+
+You can now specify the DashScope region via environment variable DASHSCOPE_REGION:
+• intl → use the Singapore endpoint (default)
+• cn → use the Beijing (China Mainland) endpoint
+
+```shell
+# Example: use China Mainland region
+export DASHSCOPE_REGION=cn
+``` 
+
+This automatically sets:
+• https://dashscope.aliyuncs.com/compatible-mode/v1 for cn
+• https://dashscope-intl.aliyuncs.com/compatible-mode/v1 for intl
+
 ### 3. Install libraries
 
 ```shell

--- a/libs/agno/agno/models/dashscope/dashscope.py
+++ b/libs/agno/agno/models/dashscope/dashscope.py
@@ -19,8 +19,7 @@ class DashScope(OpenAILike):
         provider (str): The provider name. Defaults to "Qwen".
         api_key (Optional[str]): The DashScope API key.
         region (str): The DashScope region, either "cn" or "intl". Defaults to "intl".
-        base_url (str): The base URL. Defaults to international endpoint.
-        base_url (str): The base URL. Defaults to "https://dashscope-intl.aliyuncs.com/compatible-mode/v1".
+        base_url (str): The base URL, determined dynamically based on the region ("cn" or "intl").
         enable_thinking (bool): Enable thinking process (DashScope native parameter). Defaults to False.
         include_thoughts (Optional[bool]): Include thinking process in response (alternative parameter). Defaults to None.
     """
@@ -44,12 +43,19 @@ class DashScope(OpenAILike):
     supports_json_schema_outputs: bool = True
 
     def __post_init__(self):
-        """Initialize base_url based on region."""
+        """Initialize base_url based on region and validate region."""
+        valid_regions = {"cn", "intl"}
+        if self.region not in valid_regions:
+            raise ModelProviderError(
+                message=f"Invalid region '{self.region}'. Supported regions are 'cn' and 'intl'.",
+                model_name=self.name,
+                model_id=self.id,
+            )
         if self.region == "cn":
             self.base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
-        else:
+        elif self.region == "intl":
             self.base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
-
+            
     def _get_client_params(self) -> Dict[str, Any]:
         if not self.api_key:
             self.api_key = getenv("DASHSCOPE_API_KEY")

--- a/libs/agno/agno/models/dashscope/dashscope.py
+++ b/libs/agno/agno/models/dashscope/dashscope.py
@@ -18,6 +18,8 @@ class DashScope(OpenAILike):
         name (str): The model name. Defaults to "Qwen".
         provider (str): The provider name. Defaults to "Qwen".
         api_key (Optional[str]): The DashScope API key.
+        region (str): The DashScope region, either "cn" or "intl". Defaults to "intl".
+        base_url (str): The base URL. Defaults to international endpoint.
         base_url (str): The base URL. Defaults to "https://dashscope-intl.aliyuncs.com/compatible-mode/v1".
         enable_thinking (bool): Enable thinking process (DashScope native parameter). Defaults to False.
         include_thoughts (Optional[bool]): Include thinking process in response (alternative parameter). Defaults to None.
@@ -28,7 +30,9 @@ class DashScope(OpenAILike):
     provider: str = "Dashscope"
 
     api_key: Optional[str] = getenv("DASHSCOPE_API_KEY") or getenv("QWEN_API_KEY")
-    base_url: str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+
+    region: str = getenv("DASHSCOPE_REGION", "intl").lower()
+    base_url: Optional[str] = None
 
     # Thinking parameters
     enable_thinking: bool = False
@@ -38,6 +42,13 @@ class DashScope(OpenAILike):
     # DashScope supports structured outputs
     supports_native_structured_outputs: bool = True
     supports_json_schema_outputs: bool = True
+
+    def __post_init__(self):
+        """Initialize base_url based on region."""
+        if self.region == "cn":
+            self.base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        else:
+            self.base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 
     def _get_client_params(self) -> Dict[str, Any]:
         if not self.api_key:


### PR DESCRIPTION
## Summary

Added support for configurable DashScope region through DASHSCOPE_REGION environment variable. This allows users to specify their preferred region for DashScope API calls.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)
---