### PR TITLE
[fix] Support reasoning attribute in OpenAI-compatible API responses

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -769,8 +769,17 @@ class OpenAIChat(Model):
             except Exception as e:
                 log_warning(f"Error processing audio: {e}")
 
+        # Extract reasoning_content attribute (for models like o1, o3)
         if hasattr(response_message, "reasoning_content") and response_message.reasoning_content is not None:  # type: ignore
             model_response.reasoning_content = response_message.reasoning_content  # type: ignore
+        # Extract reasoning attribute (for Gemini via OpenRouter and other providers)
+        elif hasattr(response_message, "reasoning") and response_message.reasoning is not None:  # type: ignore
+            reasoning = response_message.reasoning  # type: ignore
+            # Handle both string and object types
+            if isinstance(reasoning, str):
+                model_response.reasoning_content = reasoning
+            elif hasattr(reasoning, "content"):
+                model_response.reasoning_content = reasoning.content  # type: ignore
 
         if response.usage is not None:
             model_response.response_usage = self._get_metrics(response.usage)
@@ -801,8 +810,17 @@ class OpenAIChat(Model):
                 if choice_delta.tool_calls is not None:
                     model_response.tool_calls = choice_delta.tool_calls  # type: ignore
 
+                # Extract reasoning_content attribute (for models like o1, o3)
                 if hasattr(choice_delta, "reasoning_content") and choice_delta.reasoning_content is not None:
                     model_response.reasoning_content = choice_delta.reasoning_content
+                # Extract reasoning attribute (for Gemini via OpenRouter and other providers)
+                elif hasattr(choice_delta, "reasoning") and choice_delta.reasoning is not None:  # type: ignore
+                    reasoning = choice_delta.reasoning  # type: ignore
+                    # Handle both string and object types
+                    if isinstance(reasoning, str):
+                        model_response.reasoning_content = reasoning
+                    elif hasattr(reasoning, "content"):
+                        model_response.reasoning_content = reasoning.content  # type: ignore
 
                 # Add audio if present
                 if hasattr(choice_delta, "audio") and choice_delta.audio is not None:


### PR DESCRIPTION
## Description
This PR fixes the missing `reasoning_content` when using Gemini models (e.g., `google/gemini-2.5-flash`) through OpenRouter integration.

## Problem
When using Gemini models via OpenRouter, the `reasoning_content` in Agno responses was `None` despite `reasoning_tokens` being consumed, indicating that reasoning was running but the content wasn't being extracted.

## Solution
Updated `OpenAIChat._parse_provider_response()` and `_parse_provider_response_delta()` methods to extract the `reasoning` attribute from response messages, in addition to the existing `reasoning_content` attribute. The fix handles:
- Direct string reasoning content (OpenRouter/Gemini format)
- Reasoning objects with `.content` attribute
- Traditional `reasoning_content` attribute (OpenAI o1/o3)
- Both streaming and non-streaming responses

fixes #5329