### PR TITLE
fix: keep custom tool events out of llm output

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1518,6 +1518,7 @@ class Model(ABC):
                         or isinstance(item, tuple(get_args(WorkflowRunOutputEvent)))
                     ):
                         # We only capture content events for output accumulation
+                        # NOTE: CustomEvent instances are yielded below but intentionally never touch function_call_output.
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
                                 function_call_output += item.content.model_dump_json()
@@ -1527,9 +1528,6 @@ class Model(ABC):
 
                             if function_call.function.show_result and item.content is not None:
                                 yield ModelResponse(content=item.content)
-
-                        if isinstance(item, CustomEvent):
-                            function_call_output += str(item)
 
                         # For WorkflowCompletedEvent, extract content for final output
                         from agno.run.workflow import WorkflowCompletedEvent
@@ -1924,6 +1922,7 @@ class Model(ABC):
                         + tuple(get_args(WorkflowRunOutputEvent)),
                     ):
                         # We only capture content events
+                        # Custom events are telemetry-only; they get forwarded without changing function_call_output.
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
                                 function_call_output += item.content.model_dump_json()
@@ -1934,9 +1933,6 @@ class Model(ABC):
                             if function_call.function.show_result and item.content is not None:
                                 await event_queue.put(ModelResponse(content=item.content))
                                 continue
-
-                        if isinstance(item, CustomEvent):
-                            function_call_output += str(item)
 
                             # For WorkflowCompletedEvent, extract content for final output
                             from agno.run.workflow import WorkflowCompletedEvent

--- a/libs/agno/tests/unit/models/test_model_function_call_events.py
+++ b/libs/agno/tests/unit/models/test_model_function_call_events.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Iterator, List
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.run.agent import CustomEvent
+from agno.tools.decorator import tool
+from agno.tools.function import FunctionCall
+
+
+class DummyModel(Model):
+    """Minimal concrete Model to exercise run_function_call in isolation."""
+
+    def __init__(self):
+        super().__init__(id="dummy-model")
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:  # pragma: no cover - not used in these tests
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:  # pragma: no cover - not used in these tests
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:  # pragma: no cover
+        raise NotImplementedError
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:  # pragma: no cover
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:  # pragma: no cover
+        raise NotImplementedError
+
+
+def test_custom_events_do_not_pollute_function_outputs():
+    @dataclass
+    class ProcessingStatusEvent(CustomEvent):
+        status: str = ""
+
+    @tool()
+    def get_document(doc_id: str):
+        yield ProcessingStatusEvent(status="searching")
+        yield "<doc>document content</doc>"
+
+    model = DummyModel()
+    function_call = FunctionCall(function=get_document, arguments={"doc_id": "123"}, call_id="call_1")
+    function_call_results: List[Any] = []
+
+    responses = list(
+        model.run_function_call(function_call=function_call, function_call_results=function_call_results)
+    )
+
+    telemetry_events = [evt for evt in responses if isinstance(evt, ProcessingStatusEvent)]
+    assert telemetry_events, "Telemetry CustomEvent should bubble through run_function_call"
+    assert len(function_call_results) == 1
+
+    tool_message = function_call_results[0]
+    assert tool_message.tool_call_error is False
+    assert tool_message.content == "<doc>document content</doc>"
+    assert "ProcessingStatusEvent" not in tool_message.content
+


### PR DESCRIPTION
### Summary

Keep generator-tool `CustomEvent` telemetry out of the LLM-facing tool output. `run_function_call` (sync + async paths) now only aggregates `RunContentEvent` (and workflow completion) content while still yielding CustomEvents downstream for UI/telemetry. Added a regression test (`tests/unit/models/test_model_function_call_events.py`) to lock in the clean separation.

fix: #5483 

- Motivation: resolves the reported bug where progress/status events polluted tool call responses (#<issue> if known).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests added/updated (`python -m pytest tests/unit/models/test_model_function_call_events.py`)