### PR TITLE
[feat] gemini and gcs audio file uri support

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -18,7 +18,12 @@ from agno.models.message import Citations, Message, UrlCitation
 from agno.models.metrics import Metrics
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
-from agno.utils.gemini import format_function_definitions, format_image_for_message, prepare_response_schema
+from agno.utils.gemini import (
+    format_function_definitions,
+    format_image_for_message,
+    is_gemini_or_gcs_file_uri,
+    prepare_response_schema,
+)
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 
 try:
@@ -642,6 +647,11 @@ class Gemini(Model):
 
         # Case 2: Audio is an url
         elif audio.url is not None:
+            # Check if the URL is a Gemini or GCS file URI
+            if is_gemini_or_gcs_file_uri(audio.url):
+                mime_type = audio.mime_type or (f"audio/{audio.format}" if audio.format else "audio/mp3")
+                return Part.from_uri(file_uri=audio.url, mime_type=mime_type)
+
             audio_bytes = audio.get_content_bytes()  # type: ignore
             if audio_bytes is not None:
                 mime_type = f"audio/{audio.format}" if audio.format else "audio/mp3"

--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 
@@ -424,3 +425,14 @@ def format_function_definitions(tools_list: List[Dict[str, Any]]) -> Optional[To
         return Tool(function_declarations=function_declarations)
     else:
         return None
+
+
+GEMINI_FILE_URI_PATTERN = re.compile(r"^https://generativelanguage\.googleapis\.com/v1beta/files/[a-zA-Z0-9]+")
+GCS_FILE_URI_PATTERN = re.compile(r"^gs://")
+
+
+def is_gemini_or_gcs_file_uri(uri: str | None) -> bool:
+    """Check if the URI is a Gemini file URI or a GCS file URI."""
+    if not uri:
+        return False
+    return bool(GEMINI_FILE_URI_PATTERN.match(uri)) or bool(GCS_FILE_URI_PATTERN.match(uri))

--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -427,7 +427,7 @@ def format_function_definitions(tools_list: List[Dict[str, Any]]) -> Optional[To
         return None
 
 
-GEMINI_FILE_URI_PATTERN = re.compile(r"^https://generativelanguage\.googleapis\.com/v1beta/files/[a-zA-Z0-9]+")
+GEMINI_FILE_URI_PATTERN = re.compile(r"^https://generativelanguage\.googleapis\.com/v1beta/files/[a-zA-Z0-9-]+")
 GCS_FILE_URI_PATTERN = re.compile(r"^gs://")
 
 


### PR DESCRIPTION
## Summary

Add support for reusing Gemini uploaded files and GCS files in audio processing. When audio URL is a Gemini file URI (`https://generativelanguage.googleapis.com/v1beta/files/xxx`) or GCS URI (`gs://xxx`), the model now directly uses `Part.from_uri()` instead of downloading the file content. This allows reusing previously uploaded files and avoids redundant downloads on each request.

Also fixes the audio `mime_type` priority issue: now respects user-provided `mime_type` over `format` field.

**Changes:**
- Add `is_gemini_or_gcs_file_uri()` function to detect Gemini/GCS URIs
- Support hyphens in Gemini file IDs (e.g., `files/abc-123-def`)
- Fix `mime_type` priority: `mime_type` > `format` > default `"audio/mp3"`

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

**Why this matters:**
- Previously, audio URLs were always downloaded even if they were already uploaded to Gemini or stored in GCS
- With this change, Gemini/GCS URIs are passed directly to the API via `Part.from_uri()`, enabling file reuse
- This significantly reduces latency and bandwidth for repeated requests using the same audio files

**Files modified:**
| File | Changes |
|------|---------|
| `libs/agno/agno/utils/gemini.py` | Add `is_gemini_or_gcs_file_uri()` function with support for hyphens in file IDs |
| `libs/agno/agno/models/google/gemini.py` | Add Gemini/GCS URI detection in `_format_audio_for_message()`, fix `mime_type` priority |

