### PR TITLE
feat: run memory, culture as background tasks

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -289,6 +289,10 @@ class Agent:
     post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None
     # If True, run hooks as FastAPI background tasks (non-blocking). Set by AgentOS.
     _run_hooks_in_background: Optional[bool] = None
+    # If True, run memory creation in background task
+    _run_memory_in_background: Optional[bool] = None
+    # If True, run cultural knowledge creation in background task
+    _run_culture_in_background: Optional[bool] = None
 
     # --- Agent Reasoning ---
     # Enable reasoning by working through the problem step by step.
@@ -1059,12 +1063,14 @@ class Agent:
                         run_messages=run_messages,
                         user_id=user_id,
                         existing_future=memory_future,
+                        background_tasks=background_tasks,
                     )
 
                     # Start cultural knowledge creation in background thread
                     cultural_knowledge_future = self._start_cultural_knowledge_future(
                         run_messages=run_messages,
                         existing_future=cultural_knowledge_future,
+                        background_tasks=background_tasks,
                     )
 
                     raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -1344,12 +1350,14 @@ class Agent:
                         run_messages=run_messages,
                         user_id=user_id,
                         existing_future=memory_future,
+                        background_tasks=background_tasks,
                     )
 
                     # Start cultural knowledge creation in background thread
                     cultural_knowledge_future = self._start_cultural_knowledge_future(
                         run_messages=run_messages,
                         existing_future=cultural_knowledge_future,
+                        background_tasks=background_tasks,
                     )
 
                     # Start the Run by yielding a RunStarted event
@@ -2018,12 +2026,14 @@ class Agent:
                         run_messages=run_messages,
                         user_id=user_id,
                         existing_task=memory_task,
+                        background_tasks=background_tasks,
                     )
 
                     # Start cultural knowledge creation as a background task (runs concurrently with the main execution)
                     cultural_knowledge_task = await self._astart_cultural_knowledge_task(
                         run_messages=run_messages,
                         existing_task=cultural_knowledge_task,
+                        background_tasks=background_tasks,
                     )
 
                     # Check for cancellation before model call
@@ -2367,12 +2377,14 @@ class Agent:
                         run_messages=run_messages,
                         user_id=user_id,
                         existing_task=memory_task,
+                        background_tasks=background_tasks,
                     )
 
                     # Start cultural knowledge creation as a background task (runs concurrently with the main execution)
                     cultural_knowledge_task = await self._astart_cultural_knowledge_task(
                         run_messages=run_messages,
                         existing_task=cultural_knowledge_task,
+                        background_tasks=background_tasks,
                     )
 
                     # 8. Reason about the task if reasoning is enabled
@@ -6075,6 +6087,7 @@ class Agent:
         run_messages: RunMessages,
         user_id: Optional[str],
         existing_task: Optional[Task[None]],
+        background_tasks: Optional[Any] = None,
     ) -> Optional[Task[None]]:
         """Cancel any existing memory task and start a new one if conditions are met.
 
@@ -6094,6 +6107,11 @@ class Agent:
             except CancelledError:
                 pass
 
+        # Run the memory creation as a background task if enabled
+        if self._run_memory_in_background is True and background_tasks is not None:
+            background_tasks.add_task(self._make_memories, run_messages=run_messages, user_id=user_id)
+            return
+
         # Create new task if conditions are met
         if (
             run_messages.user_message is not None
@@ -6110,6 +6128,7 @@ class Agent:
         self,
         run_messages: RunMessages,
         existing_task: Optional[Task[None]],
+        background_tasks: Optional[Any] = None,
     ) -> Optional[Task[None]]:
         """Cancel any existing cultural knowledge task and start a new one if conditions are met.
 
@@ -6128,6 +6147,11 @@ class Agent:
             except CancelledError:
                 pass
 
+        # Run the cultural knowledge creation as a background task if enabled
+        if self._run_culture_in_background is True and background_tasks is not None:
+            background_tasks.add_task(self._acreate_cultural_knowledge, run_messages=run_messages)
+            return
+
         # Create new task if conditions are met
         if (
             run_messages.user_message is not None
@@ -6144,6 +6168,7 @@ class Agent:
         run_messages: RunMessages,
         user_id: Optional[str],
         existing_future: Optional[Future] = None,
+        background_tasks: Optional[Any] = None,
     ) -> Optional[Future]:
         """Cancel any existing memory future and start a new one if conditions are met.
 
@@ -6159,6 +6184,11 @@ class Agent:
         # Note: cancel() only works if the future hasn't started yet
         if existing_future is not None and not existing_future.done():
             existing_future.cancel()
+
+        # Run the memory creation as a background task if enabled
+        if self._run_memory_in_background is True and background_tasks is not None:
+            background_tasks.add_task(self._make_memories, run_messages=run_messages, user_id=user_id)
+            return
 
         # Create new future if conditions are met
         if (
@@ -6176,6 +6206,7 @@ class Agent:
         self,
         run_messages: RunMessages,
         existing_future: Optional[Future] = None,
+        background_tasks: Optional[Any] = None,
     ) -> Optional[Future]:
         """Cancel any existing cultural knowledge future and start a new one if conditions are met.
 
@@ -6190,6 +6221,11 @@ class Agent:
         # Note: cancel() only works if the future hasn't started yet
         if existing_future is not None and not existing_future.done():
             existing_future.cancel()
+
+        # Run the cultural knowledge creation as a background task if enabled
+        if self._run_culture_in_background is True and background_tasks is not None:
+            background_tasks.add_task(self._make_cultural_knowledge, run_messages=run_messages)
+            return
 
         # Create new future if conditions are met
         if (

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -249,9 +249,9 @@ class AgentOS:
         configuration = AgentOSConfig.from_path(config_file_path)
 
         # TODO: handle all configuration setup
-        self.fastapi_config = configuration.fastapi_config
-        self.databases_config = configuration.databases_config
-        self.background_tasks_config = configuration.background_tasks_config
+        self.fastapi_config = configuration.fastapi_config or FastAPIConfig()
+        self.databases_config = configuration.databases_config or DatabasesConfig()
+        self.background_tasks_config = configuration.background_tasks_config or BackgroundTasksConfig()
         self.interfaces = configuration.interfaces
         self.a2a_interface = configuration.a2a_interface
         self.enable_mcp_server = configuration.enable_mcp_server
@@ -445,8 +445,10 @@ class AgentOS:
             # Required for the built-in routes to work
             agent.store_events = True
 
-            # Propagate run_hooks_in_background setting from AgentOS to agents
-            agent._run_hooks_in_background = self.run_hooks_in_background
+            # Propagate background tasks configuration to the Agent
+            agent._run_hooks_in_background = self.background_tasks_config.run_hooks_in_background
+            agent._run_memory_in_background = self.background_tasks_config.run_memory_in_background
+            agent._run_culture_in_background = self.background_tasks_config.run_culture_in_background
 
     def _initialize_teams(self) -> None:
         """Initialize and configure all teams for AgentOS usage."""
@@ -477,7 +479,9 @@ class AgentOS:
             team.store_events = True
 
             # Propagate run_hooks_in_background setting to team and all nested members
-            team.propagate_run_hooks_in_background(self.run_hooks_in_background)
+            team.propagate_run_hooks_in_background(self.background_tasks_config.run_hooks_in_background)
+            team.propagate_run_memory_in_background(self.background_tasks_config.run_memory_in_background)
+            team.propagate_run_culture_in_background(self.background_tasks_config.run_culture_in_background)
 
     def _initialize_workflows(self) -> None:
         """Initialize and configure all workflows for AgentOS usage."""

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -21,7 +21,11 @@ class AuthorizationConfig(BaseModel):
 
 
 class BackgroundTasksConfig(BaseModel):
+    """Configuration defining what to run as background tasks"""
+
+    run_culture_in_background: bool = False
     run_hooks_in_background: bool = False
+    run_memory_in_background: bool = False
 
 
 class DatabasesConfig(BaseModel):


### PR DESCRIPTION
WIP: what else can be background? we are at least missing memory actions

- Update BackgroundTasksConfig with flags to run memory, culture actions as background tasks
- Logic to propagate this from AgentOS to all agents, teams


