### PR TITLE
[refactor] Add JSON dict fallback for structured output parsing

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 import warnings
 from asyncio import CancelledError, Task, create_task
@@ -177,7 +178,7 @@ from agno.utils.response import (
     get_paused_content,
 )
 from agno.utils.safe_formatter import SafeFormatter
-from agno.utils.string import generate_id_from_name, parse_response_dict_str, parse_response_model_str
+from agno.utils.string import generate_id_from_name, parse_response_model_str
 from agno.utils.timer import Timer
 
 
@@ -5058,34 +5059,30 @@ class Agent:
         output_schema = run_context.output_schema if run_context else None
 
         # Convert the response to the structured format if needed
-        if output_schema is not None:
-            # If the output schema is a dict, do not convert it into a BaseModel
-            if isinstance(output_schema, dict):
-                if isinstance(run_response.content, str):
-                    parsed_dict = parse_response_dict_str(run_response.content)
-                    if parsed_dict is not None:
-                        run_response.content = parsed_dict
-                        if isinstance(run_response, RunOutput):
-                            run_response.content_type = "dict"
-                    else:
-                        log_warning("Failed to parse JSON response against the provided output schema.")
-            # If the output schema is a Pydantic model and parse_response is True, parse it into a BaseModel
-            elif not isinstance(run_response.content, output_schema):
-                if isinstance(run_response.content, str) and self.parse_response:
-                    try:
-                        structured_output = parse_response_model_str(run_response.content, output_schema)
+        if output_schema is not None and not isinstance(run_response.content, output_schema):
+            if isinstance(run_response.content, str) and self.parse_response:
+                try:
+                    # Try to parse into Pydantic BaseModel
+                    structured_output = parse_response_model_str(run_response.content, output_schema)
 
-                        # Update RunOutput
-                        if structured_output is not None:
-                            run_response.content = structured_output
-                            if isinstance(run_response, RunOutput):
-                                run_response.content_type = output_schema.__name__
-                        else:
-                            log_warning("Failed to convert response to output_schema")
-                    except Exception as e:
-                        log_warning(f"Failed to convert response to output model: {e}")
-                else:
-                    log_warning("Something went wrong. Run response content is not a string")
+                    # Update RunOutput
+                    if structured_output is not None:
+                        run_response.content = structured_output
+                        if isinstance(run_response, RunOutput):
+                            run_response.content_type = output_schema.__name__
+                    else:
+                        # Failed to parse as BaseModel, try to parse as JSON dict
+                        log_warning("Failed to convert response to output_schema, attempting JSON dict fallback")
+                        try:
+                            run_response.content = json.loads(run_response.content)
+                            log_debug("Successfully parsed response as JSON dict (fallback)")
+                        except (json.JSONDecodeError, TypeError) as json_error:
+                            # Failed to parse as JSON, keep original string
+                            log_warning(f"Failed to parse response as JSON dict: {json_error}. Keeping as string.")
+                except Exception as e:
+                    log_warning(f"Failed to convert response to output model: {e}")
+            else:
+                log_warning("Something went wrong. Run response content is not a string")
 
     def _handle_external_execution_update(self, run_messages: RunMessages, tool: ToolExecution):
         self.model = cast(Model, self.model)


### PR DESCRIPTION
Improves the _convert_response_to_structured_format method in Agent class by:

- Simplifying conditional logic flow

- Adding JSON dict fallback when BaseModel parsing fails

- Improving error logging with more specific messages

- Removing unused parse_response_dict_str import

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
