### PR TITLE
feat: workflow agent refactor

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -23,6 +23,8 @@ class RunContext:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
     output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None
+    # This allows correlating workflow events to the workflow agent's run
+    workflow_agent_run_id: Optional[str] = None
 
 
 @dataclass

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -74,6 +74,8 @@ class BaseWorkflowRunOutputEvent(BaseRunOutputEvent):
     run_id: Optional[str] = None
     step_id: Optional[str] = None
     parent_step_id: Optional[str] = None
+    # This allows the FE to correlate workflow events to the workflow agent's run
+    workflow_agent_run_id: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         _dict = {k: v for k, v in asdict(self).items() if v is not None}
@@ -517,6 +519,10 @@ class WorkflowRunOutput:
     # Workflow agent run - stores the full agent RunOutput when workflow agent is used
     # The agent's parent_run_id will point to this workflow run's run_id to establish the relationship
     workflow_agent_run: Optional[RunOutput] = None
+
+    # The workflow agent's run_id (when workflow is executed via workflow agent)
+    # This allows the FE to correlate workflow events to the workflow agent's run
+    workflow_agent_run_id: Optional[str] = None
 
     # Store events from workflow execution
     events: Optional[List[WorkflowRunOutputEvent]] = None

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -520,7 +520,6 @@ class WorkflowRunOutput:
     # The agent's parent_run_id will point to this workflow run's run_id to establish the relationship
     workflow_agent_run: Optional[RunOutput] = None
 
-    # The workflow agent's run_id (when workflow is executed via workflow agent)
     # This allows the FE to correlate workflow events to the workflow agent's run
     workflow_agent_run_id: Optional[str] = None
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1108,6 +1108,9 @@ class Workflow:
         if hasattr(event, "step_index") and step_index is not None:
             if event.step_index is None:
                 event.step_index = step_index
+        # Set workflow_agent_run_id if available (for workflow agent correlation)
+        if hasattr(event, "workflow_agent_run_id") and workflow_run_response.workflow_agent_run_id:
+            event.workflow_agent_run_id = workflow_run_response.workflow_agent_run_id
 
         return event
 
@@ -1490,11 +1493,16 @@ class Workflow:
 
         workflow_run_response.status = RunStatus.running
 
+        # Copy workflow_agent_run_id from run_context to workflow_run_response for event enrichment
+        if run_context.workflow_agent_run_id:
+            workflow_run_response.workflow_agent_run_id = run_context.workflow_agent_run_id
+
         workflow_started_event = WorkflowStartedEvent(
             run_id=workflow_run_response.run_id or "",
             workflow_name=workflow_run_response.workflow_name,
             workflow_id=workflow_run_response.workflow_id,
             session_id=workflow_run_response.session_id,
+            workflow_agent_run_id=run_context.workflow_agent_run_id,
         )
         yield self._handle_event(workflow_started_event, workflow_run_response)
 
@@ -1771,6 +1779,7 @@ class Workflow:
             session_id=workflow_run_response.session_id,
             step_results=workflow_run_response.step_results,  # type: ignore
             metadata=workflow_run_response.metadata,
+            workflow_agent_run_id=run_context.workflow_agent_run_id,
         )
         yield self._handle_event(workflow_completed_event, workflow_run_response)
 
@@ -2081,11 +2090,16 @@ class Workflow:
 
         workflow_run_response.status = RunStatus.running
 
+        # Copy workflow_agent_run_id from run_context to workflow_run_response for event enrichment
+        if run_context.workflow_agent_run_id:
+            workflow_run_response.workflow_agent_run_id = run_context.workflow_agent_run_id
+
         workflow_started_event = WorkflowStartedEvent(
             run_id=workflow_run_response.run_id or "",
             workflow_name=workflow_run_response.workflow_name,
             workflow_id=workflow_run_response.workflow_id,
             session_id=workflow_run_response.session_id,
+            workflow_agent_run_id=run_context.workflow_agent_run_id,
         )
         yield self._handle_event(workflow_started_event, workflow_run_response, websocket_handler=websocket_handler)
 
@@ -2377,6 +2391,7 @@ class Workflow:
             session_id=workflow_run_response.session_id,
             step_results=workflow_run_response.step_results,  # type: ignore[arg-type]
             metadata=workflow_run_response.metadata,
+            workflow_agent_run_id=run_context.workflow_agent_run_id,
         )
         yield self._handle_event(workflow_completed_event, workflow_run_response, websocket_handler=websocket_handler)
 
@@ -2839,6 +2854,8 @@ class Workflow:
         )
         yield agent_started_event
 
+        from agno.run.agent import RunStartedEvent as AgentRunStartedEvent
+
         # Run the agent in streaming mode and yield all events
         for event in self.agent.run(  # type: ignore[union-attr]
             input=agent_input,
@@ -2849,6 +2866,12 @@ class Workflow:
             dependencies=run_context.dependencies,  # Pass context dynamically per-run
             session_state=run_context.session_state,  # Pass session state dynamically per-run
         ):  # type: ignore
+            # Capture the workflow agent's run_id from the FIRST RunStartedEvent only
+            # (subsequent RunStartedEvents are from step agents, not the workflow agent)
+            if isinstance(event, AgentRunStartedEvent) and event.run_id and not run_context.workflow_agent_run_id:
+                run_context.workflow_agent_run_id = event.run_id
+                log_debug(f"Captured workflow agent run_id: {event.run_id}")
+
             if isinstance(event, tuple(get_args(WorkflowRunOutputEvent))):
                 yield event  # type: ignore[misc]
 
@@ -3228,6 +3251,8 @@ class Workflow:
         self._broadcast_to_websocket(agent_started_event, websocket_handler)
         yield agent_started_event
 
+        from agno.run.agent import RunStartedEvent as AgentRunStartedEvent
+
         # Run the agent in streaming mode and yield all events
         async for event in self.agent.arun(  # type: ignore[union-attr]
             input=agent_input,
@@ -3238,6 +3263,12 @@ class Workflow:
             dependencies=run_context.dependencies,  # Pass context dynamically per-run
             session_state=run_context.session_state,  # Pass session state dynamically per-run
         ):  # type: ignore
+            # Capture the workflow agent's run_id from the FIRST RunStartedEvent only
+            # (subsequent RunStartedEvents are from step agents, not the workflow agent)
+            if isinstance(event, AgentRunStartedEvent) and event.run_id and not run_context.workflow_agent_run_id:
+                run_context.workflow_agent_run_id = event.run_id
+                log_debug(f"Captured workflow agent run_id: {event.run_id}")
+
             if isinstance(event, tuple(get_args(WorkflowRunOutputEvent))):
                 yield event  # type: ignore[misc]
 


### PR DESCRIPTION
## Summary

we store `workflow_agent_run` but we need to have a relation between that and the workflow events to correctly identify.
So now we push through that workflow agent's run id to the workflow events for FE to know better and handle it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Closes: SDK- 253

Add any important context (deployment instructions, screenshots, security considerations, etc.)
