### PR TITLE
fix: header provider unused on connect

### DIFF
--- a/cookbook/06_agent_os/dbs/agentos_default_db.py
+++ b/cookbook/06_agent_os/dbs/agentos_default_db.py
@@ -45,7 +45,7 @@ agno_agent = Agent(
 agent_os = AgentOS(
     id="agentos-demo",
     agents=[agno_agent],
-    db=db, # This is the default database for AgentOS, the agno_agent will use this
+    db=db,  # This is the default database for AgentOS, the agno_agent will use this
 )
 app = agent_os.get_app()
 

--- a/cookbook/demo/run.py
+++ b/cookbook/demo/run.py
@@ -11,12 +11,11 @@ from agents.report_writer_agent import report_writer_agent
 from agents.research_agent import research_agent
 from agents.web_intelligence_agent import web_intelligence_agent
 from agno.os import AgentOS
+from db import demo_db
 from teams.due_diligence_team import due_diligence_team
 from teams.investment_team import investment_team
 from workflows.deep_research_workflow import deep_research_workflow
 from workflows.startup_analyst_workflow import startup_analyst_workflow
-
-from db import demo_db
 
 # ============================================================================
 # AgentOS Config

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -459,6 +459,8 @@ class MCPTools(Toolkit):
             streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
             if "url" not in streamable_http_params:
                 streamable_http_params["url"] = self.url
+            if "headers" not in streamable_http_params and self.header_provider is not None:
+                streamable_http_params["headers"] = self._call_header_provider()
             self._context = streamablehttp_client(**streamable_http_params)  # type: ignore
             params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
             if isinstance(params_timeout, timedelta):

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -471,6 +471,8 @@ class MultiMCPTools(Toolkit):
 
                 # Handle Streamable HTTP connections
                 elif isinstance(server_params, StreamableHTTPClientParams):
+                    if "headers" not in server_params and self.header_provider is not None:
+                        server_params["headers"] = self._call_header_provider()
                     client_connection = await self._async_exit_stack.enter_async_context(
                         streamablehttp_client(**asdict(server_params))
                     )

--- a/libs/agno/tests/unit/knowledge/test_knowledge_metadata_propagation.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_metadata_propagation.py
@@ -142,7 +142,12 @@ def test_prepare_documents_for_insert_with_metadata():
     result = knowledge._prepare_documents_for_insert(documents, "content-id-1", metadata=metadata)
 
     # Verify metadata was merged
-    assert result[0].meta_data == {"existing": "value1", "document_id": "123", "knowledge_base_id": "456", "filename": "test.txt"}
+    assert result[0].meta_data == {
+        "existing": "value1",
+        "document_id": "123",
+        "knowledge_base_id": "456",
+        "filename": "test.txt",
+    }
     assert result[1].meta_data == {"document_id": "123", "knowledge_base_id": "456", "filename": "test.txt"}
     assert result[2].meta_data == {"document_id": "123", "knowledge_base_id": "456", "filename": "test.txt"}
 
@@ -293,7 +298,9 @@ def test_load_from_path_without_metadata(temp_text_file, mock_vector_db):
     )
     content.content_hash = knowledge._build_content_hash(content)
 
-    with patch.object(knowledge, "_read", return_value=[Document(name="test", content="Test content", meta_data={"original": "data"})]):
+    with patch.object(
+        knowledge, "_read", return_value=[Document(name="test", content="Test content", meta_data={"original": "data"})]
+    ):
         knowledge._load_from_path(content, upsert=False, skip_if_exists=False)
 
     # Verify documents were inserted with original metadata preserved
@@ -318,7 +325,13 @@ def test_metadata_merges_with_existing_document_metadata(temp_text_file, mock_ve
     with patch.object(
         knowledge,
         "_read",
-        return_value=[Document(name="test", content="Test content", meta_data={"existing_field": "existing_value", "shared_field": "doc_value"})],
+        return_value=[
+            Document(
+                name="test",
+                content="Test content",
+                meta_data={"existing_field": "existing_value", "shared_field": "doc_value"},
+            )
+        ],
     ):
         knowledge._load_from_path(content, upsert=False, skip_if_exists=False)
 

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -699,8 +699,7 @@ def test_delete_by_metadata_complex(mock_pgvector):
 
 
 def test_get_document_record_merges_filters_into_metadata(mock_pgvector, mock_embedder):
-    """Test that _get_document_record correctly merges filters into meta_data.
-    """
+    """Test that _get_document_record correctly merges filters into meta_data."""
     doc = Document(
         id="test-id",
         content="Test document content",


### PR DESCRIPTION
## Summary

The `header_provider` was unused during the connect operation, which rendered it useless for authentication with `refresh_connection=True` since that setting implies a connect taking place for every toolcall, but the header wouldn't update on each toolcall falling back to the header provided in `server_params` which is static.

I made it be called in the connect method so that these 2 settings can work together.
The rest of the changes in the commit were made automatically by running the requested formatter.

## Type of change

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ x] Code complies with style guidelines
- [x ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

