### PR TITLE
feat: add ExcelTools for creating and manipulating Excel files

### DIFF
--- a/cookbook/91_tools/excel_tools.py
+++ b/cookbook/91_tools/excel_tools.py
@@ -1,0 +1,100 @@
+"""Excel Tools - Create and Manipulate Excel Files
+
+This example demonstrates how to use ExcelTools for Excel file operations.
+ExcelTools enables AI agents to create workbooks, write data, add formulas,
+and work with multiple sheets.
+
+Setup:
+    pip install openpyxl
+
+Usage:
+    python excel_tools.py
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.tools.excel import ExcelTools
+
+# Create a working directory for Excel files
+work_dir = Path(__file__).parent / "excel_output"
+work_dir.mkdir(exist_ok=True)
+
+# Example 1: Basic usage with default tools
+# create_workbook, write_data, read_data, add_sheet, list_sheets are enabled
+agent = Agent(
+    tools=[ExcelTools(base_dir=work_dir)],
+    description="You are an Excel assistant that helps create and manage spreadsheets.",
+    instructions=[
+        "Create Excel files with well-organized data",
+        "Use meaningful sheet names",
+        "Structure data with headers in the first row",
+    ],
+    markdown=True,
+)
+
+# Example 2: Enable all tools including formulas and formatting
+agent_full = Agent(
+    tools=[ExcelTools(base_dir=work_dir, all=True)],
+    description="You are a full-featured Excel assistant with formatting capabilities.",
+    instructions=[
+        "Create professional Excel reports with formatting",
+        "Use formulas for calculations",
+        "Apply bold headers and appropriate formatting",
+    ],
+    markdown=True,
+)
+
+# Example 3: Read-only agent for data analysis
+agent_readonly = Agent(
+    tools=[
+        ExcelTools(
+            base_dir=work_dir,
+            enable_create_workbook=False,
+            enable_write_data=False,
+            enable_read_data=True,
+            enable_add_sheet=False,
+            enable_list_sheets=True,
+        )
+    ],
+    description="You are an Excel reader that analyzes existing spreadsheets.",
+    instructions=[
+        "Read and analyze data from Excel files",
+        "Summarize the contents of spreadsheets",
+        "Cannot create or modify files",
+    ],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # Create a sample spreadsheet
+    print("=" * 60)
+    print("Example 1: Creating a sales report")
+    print("=" * 60)
+    agent.print_response(
+        "Create an Excel file called 'sales_report.xlsx' with a sheet named 'Q1 Sales'. "
+        "Add headers: Product, Units Sold, Price, Revenue. "
+        "Then add 3 rows of sample product data.",
+        stream=True,
+    )
+
+    # Read data back
+    print("\n" + "=" * 60)
+    print("Example 2: Reading the created file")
+    print("=" * 60)
+    agent.print_response(
+        "Read and summarize the data in sales_report.xlsx",
+        stream=True,
+    )
+
+    # Create formatted report with formulas
+    print("\n" + "=" * 60)
+    print("Example 3: Creating formatted report with formulas")
+    print("=" * 60)
+    agent_full.print_response(
+        "Create a budget.xlsx file with columns: Category, Planned, Actual. "
+        "Add rows for Rent (1000, 1000), Utilities (200, 180), Food (500, 550). "
+        "Add a formula in a Total row to sum each column. "
+        "Make the headers bold.",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/excel.py
+++ b/libs/agno/agno/tools/excel.py
@@ -116,9 +116,7 @@ class ExcelTools(Toolkit):
 
             return openpyxl
         except ImportError as e:
-            raise ImportError(
-                "`openpyxl` not installed. Please install it via `pip install openpyxl`."
-            ) from e
+            raise ImportError("`openpyxl` not installed. Please install it via `pip install openpyxl`.") from e
 
     def create_workbook(
         self,
@@ -143,17 +141,11 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to create file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to create file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if file_path.exists() and not overwrite:
-                return json.dumps(
-                    {
-                        "error": f"File '{file_name}' already exists. Set overwrite=True to replace."
-                    }
-                )
+                return json.dumps({"error": f"File '{file_name}' already exists. Set overwrite=True to replace."})
 
             log_info(f"Creating Excel workbook: {file_path}")
 
@@ -216,17 +208,11 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
-                return json.dumps(
-                    {
-                        "error": f"File '{file_name}' not found. Create it first with create_workbook."
-                    }
-                )
+                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
 
             log_info(f"Writing data to: {file_path}")
 
@@ -234,11 +220,7 @@ class ExcelTools(Toolkit):
 
             if sheet_name:
                 if sheet_name not in workbook.sheetnames:
-                    return json.dumps(
-                        {
-                            "error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"
-                        }
-                    )
+                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
                 sheet = workbook[sheet_name]
             else:
                 sheet = workbook.active
@@ -251,9 +233,7 @@ class ExcelTools(Toolkit):
             rows_written = 0
             for row_idx, row_data in enumerate(data):
                 for col_idx, value in enumerate(row_data):
-                    sheet.cell(
-                        row=start_row + row_idx, column=start_col + col_idx, value=value
-                    )
+                    sheet.cell(row=start_row + row_idx, column=start_col + col_idx, value=value)
                 rows_written += 1
 
             workbook.save(str(file_path))
@@ -303,9 +283,7 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -318,11 +296,7 @@ class ExcelTools(Toolkit):
             if sheet_name:
                 if sheet_name not in workbook.sheetnames:
                     workbook.close()
-                    return json.dumps(
-                        {
-                            "error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"
-                        }
-                    )
+                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
                 sheet = workbook[sheet_name]
             else:
                 sheet = workbook.active
@@ -395,17 +369,11 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
-                return json.dumps(
-                    {
-                        "error": f"File '{file_name}' not found. Create it first with create_workbook."
-                    }
-                )
+                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
 
             log_info(f"Adding sheet '{sheet_name}' to: {file_path}")
 
@@ -456,9 +424,7 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -502,9 +468,7 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -554,9 +518,7 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -634,9 +596,7 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(
-                    f"Attempted to access file outside base directory: {file_name}"
-                )
+                log_error(f"Attempted to access file outside base directory: {file_name}")
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -669,9 +629,7 @@ class ExcelTools(Toolkit):
             # Build fill style
             fill = None
             if bg_color:
-                fill = PatternFill(
-                    start_color=bg_color, end_color=bg_color, fill_type="solid"
-                )
+                fill = PatternFill(start_color=bg_color, end_color=bg_color, fill_type="solid")
 
             # Apply formatting to range
             cells_formatted = 0

--- a/libs/agno/agno/tools/excel.py
+++ b/libs/agno/agno/tools/excel.py
@@ -47,6 +47,7 @@ class ExcelTools(Toolkit):
         enable_read_data: bool = True,
         enable_add_sheet: bool = True,
         enable_list_sheets: bool = True,
+        enable_get_file_path: bool = True,
         enable_add_formula: bool = False,
         enable_format_cells: bool = False,
         all: bool = False,
@@ -62,6 +63,7 @@ class ExcelTools(Toolkit):
             enable_read_data: Enable the read_data tool. Default: True.
             enable_add_sheet: Enable the add_sheet tool. Default: True.
             enable_list_sheets: Enable the list_sheets tool. Default: True.
+            enable_get_file_path: Enable the get_file_path tool. Default: True.
             enable_add_formula: Enable the add_formula tool. Default: False.
             enable_format_cells: Enable the format_cells tool. Default: False.
             all: Enable all tools. Default: False.
@@ -80,6 +82,8 @@ class ExcelTools(Toolkit):
             tools.append(self.add_sheet)
         if all or enable_list_sheets:
             tools.append(self.list_sheets)
+        if all or enable_get_file_path:
+            tools.append(self.get_file_path)
         if all or enable_add_formula:
             tools.append(self.add_formula)
         if all or enable_format_cells:
@@ -112,7 +116,9 @@ class ExcelTools(Toolkit):
 
             return openpyxl
         except ImportError as e:
-            raise ImportError("`openpyxl` not installed. Please install it via `pip install openpyxl`.") from e
+            raise ImportError(
+                "`openpyxl` not installed. Please install it via `pip install openpyxl`."
+            ) from e
 
     def create_workbook(
         self,
@@ -137,11 +143,17 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to create file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to create file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if file_path.exists() and not overwrite:
-                return json.dumps({"error": f"File '{file_name}' already exists. Set overwrite=True to replace."})
+                return json.dumps(
+                    {
+                        "error": f"File '{file_name}' already exists. Set overwrite=True to replace."
+                    }
+                )
 
             log_info(f"Creating Excel workbook: {file_path}")
 
@@ -204,11 +216,17 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
-                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
+                return json.dumps(
+                    {
+                        "error": f"File '{file_name}' not found. Create it first with create_workbook."
+                    }
+                )
 
             log_info(f"Writing data to: {file_path}")
 
@@ -216,7 +234,11 @@ class ExcelTools(Toolkit):
 
             if sheet_name:
                 if sheet_name not in workbook.sheetnames:
-                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
+                    return json.dumps(
+                        {
+                            "error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"
+                        }
+                    )
                 sheet = workbook[sheet_name]
             else:
                 sheet = workbook.active
@@ -229,7 +251,9 @@ class ExcelTools(Toolkit):
             rows_written = 0
             for row_idx, row_data in enumerate(data):
                 for col_idx, value in enumerate(row_data):
-                    sheet.cell(row=start_row + row_idx, column=start_col + col_idx, value=value)
+                    sheet.cell(
+                        row=start_row + row_idx, column=start_col + col_idx, value=value
+                    )
                 rows_written += 1
 
             workbook.save(str(file_path))
@@ -279,7 +303,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -292,7 +318,11 @@ class ExcelTools(Toolkit):
             if sheet_name:
                 if sheet_name not in workbook.sheetnames:
                     workbook.close()
-                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
+                    return json.dumps(
+                        {
+                            "error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"
+                        }
+                    )
                 sheet = workbook[sheet_name]
             else:
                 sheet = workbook.active
@@ -365,11 +395,17 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
-                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
+                return json.dumps(
+                    {
+                        "error": f"File '{file_name}' not found. Create it first with create_workbook."
+                    }
+                )
 
             log_info(f"Adding sheet '{sheet_name}' to: {file_path}")
 
@@ -420,7 +456,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -447,6 +485,50 @@ class ExcelTools(Toolkit):
             log_error(f"Error listing sheets: {e}")
             return json.dumps({"error": f"Error listing sheets: {e}"})
 
+    def get_file_path(self, file_name: str) -> str:
+        """Get the full absolute path to an Excel file.
+
+        Use this to retrieve the file location for downloading or accessing
+        the Excel file outside of the agent.
+
+        Args:
+            file_name: Name of the Excel file.
+
+        Returns:
+            JSON string with the full file path and file info.
+        """
+        try:
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found."})
+
+            # Get file size
+            file_size = file_path.stat().st_size
+
+            log_debug(f"Retrieved path for: {file_path}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "path": str(file_path),
+                    "size_bytes": file_size,
+                    "exists": True,
+                }
+            )
+
+        except Exception as e:
+            log_error(f"Error getting file path: {e}")
+            return json.dumps({"error": f"Error getting file path: {e}"})
+
     def add_formula(
         self,
         file_name: str,
@@ -472,7 +554,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -550,7 +634,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -583,7 +669,9 @@ class ExcelTools(Toolkit):
             # Build fill style
             fill = None
             if bg_color:
-                fill = PatternFill(start_color=bg_color, end_color=bg_color, fill_type="solid")
+                fill = PatternFill(
+                    start_color=bg_color, end_color=bg_color, fill_type="solid"
+                )
 
             # Apply formatting to range
             cells_formatted = 0

--- a/libs/agno/agno/tools/excel.py
+++ b/libs/agno/agno/tools/excel.py
@@ -1,0 +1,631 @@
+"""Excel Tools for creating and manipulating Excel files.
+
+This toolkit provides AI agents with the ability to create, read, and modify
+Excel workbooks (.xlsx format) using the openpyxl library.
+
+Install dependencies: pip install openpyxl
+"""
+
+import json
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error, log_info
+
+
+class ExcelTools(Toolkit):
+    """A toolkit for creating and manipulating Excel files.
+
+    This toolkit enables AI agents to:
+    - Create new Excel workbooks
+    - Write data to cells and ranges
+    - Read data from sheets
+    - Add and manage sheets
+    - Add formulas to cells
+    - Apply cell formatting
+
+    Example:
+        ```python
+        from agno.agent import Agent
+        from agno.models.openai import OpenAIChat
+        from agno.tools.excel import ExcelTools
+
+        agent = Agent(
+            model=OpenAIChat(id="gpt-4o"),
+            tools=[ExcelTools()],
+        )
+        agent.print_response("Create an Excel file with sales data")
+        ```
+    """
+
+    def __init__(
+        self,
+        base_dir: Optional[Path] = None,
+        enable_create_workbook: bool = True,
+        enable_write_data: bool = True,
+        enable_read_data: bool = True,
+        enable_add_sheet: bool = True,
+        enable_list_sheets: bool = True,
+        enable_add_formula: bool = False,
+        enable_format_cells: bool = False,
+        all: bool = False,
+        **kwargs: Any,
+    ):
+        """Initialize the Excel toolkit.
+
+        Args:
+            base_dir: Base directory for Excel file operations. If not provided,
+                uses the current working directory.
+            enable_create_workbook: Enable the create_workbook tool. Default: True.
+            enable_write_data: Enable the write_data tool. Default: True.
+            enable_read_data: Enable the read_data tool. Default: True.
+            enable_add_sheet: Enable the add_sheet tool. Default: True.
+            enable_list_sheets: Enable the list_sheets tool. Default: True.
+            enable_add_formula: Enable the add_formula tool. Default: False.
+            enable_format_cells: Enable the format_cells tool. Default: False.
+            all: Enable all tools. Default: False.
+            **kwargs: Additional arguments passed to the Toolkit base class.
+        """
+        self.base_dir: Path = (base_dir or Path.cwd()).resolve()
+
+        tools: List[Any] = []
+        if all or enable_create_workbook:
+            tools.append(self.create_workbook)
+        if all or enable_write_data:
+            tools.append(self.write_data)
+        if all or enable_read_data:
+            tools.append(self.read_data)
+        if all or enable_add_sheet:
+            tools.append(self.add_sheet)
+        if all or enable_list_sheets:
+            tools.append(self.list_sheets)
+        if all or enable_add_formula:
+            tools.append(self.add_formula)
+        if all or enable_format_cells:
+            tools.append(self.format_cells)
+
+        super().__init__(name="excel_tools", tools=tools, **kwargs)
+
+    def _check_path(self, file_name: str) -> Tuple[bool, Path]:
+        """Check if the file path is within the base directory.
+
+        Args:
+            file_name: The file name or relative path to check.
+
+        Returns:
+            Tuple of (is_safe, resolved_path). If not safe, returns base_dir as path.
+        """
+        # Delegate to parent Toolkit class method
+        return super()._check_path(file_name, self.base_dir)
+
+    def _ensure_xlsx_extension(self, file_name: str) -> str:
+        """Ensure the file has .xlsx extension."""
+        if not file_name.endswith(".xlsx"):
+            return f"{file_name}.xlsx"
+        return file_name
+
+    def _get_openpyxl(self):
+        """Import and return openpyxl, raising ImportError if not installed."""
+        try:
+            import openpyxl
+
+            return openpyxl
+        except ImportError as e:
+            raise ImportError("`openpyxl` not installed. Please install it via `pip install openpyxl`.") from e
+
+    def create_workbook(
+        self,
+        file_name: str,
+        sheet_name: Optional[str] = None,
+        overwrite: bool = False,
+    ) -> str:
+        """Create a new Excel workbook.
+
+        Args:
+            file_name: Name of the Excel file to create (will add .xlsx if missing).
+            sheet_name: Optional name for the first sheet. Defaults to 'Sheet'.
+            overwrite: If True, overwrite existing file. Default: False.
+
+        Returns:
+            JSON string with the result including file path and sheet name.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to create file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if file_path.exists() and not overwrite:
+                return json.dumps({"error": f"File '{file_name}' already exists. Set overwrite=True to replace."})
+
+            log_info(f"Creating Excel workbook: {file_path}")
+
+            # Create new workbook
+            workbook = openpyxl.Workbook()
+            sheet = workbook.active
+
+            if sheet_name:
+                sheet.title = sheet_name
+
+            # Ensure parent directory exists
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+
+            workbook.save(str(file_path))
+            workbook.close()
+
+            log_debug(f"Created workbook: {file_path}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "sheet": sheet.title,
+                    "message": f"Created Excel workbook '{file_name}' with sheet '{sheet.title}'",
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error creating workbook: {e}")
+            return json.dumps({"error": f"Error creating workbook: {e}"})
+
+    def write_data(
+        self,
+        file_name: str,
+        data: List[List[Any]],
+        sheet_name: Optional[str] = None,
+        start_cell: str = "A1",
+    ) -> str:
+        """Write data to an Excel sheet.
+
+        Args:
+            file_name: Name of the Excel file.
+            data: 2D list of data to write (rows and columns).
+            sheet_name: Name of the sheet to write to. Uses active sheet if not specified.
+            start_cell: Starting cell for data (e.g., "A1", "B2"). Default: "A1".
+
+        Returns:
+            JSON string with the result including rows and columns written.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+            from openpyxl.utils.cell import (
+                column_index_from_string,
+                coordinate_from_string,
+            )
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to access file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
+
+            log_info(f"Writing data to: {file_path}")
+
+            workbook = openpyxl.load_workbook(str(file_path))
+
+            if sheet_name:
+                if sheet_name not in workbook.sheetnames:
+                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
+                sheet = workbook[sheet_name]
+            else:
+                sheet = workbook.active
+
+            # Parse start cell
+            col_letter, start_row = coordinate_from_string(start_cell)
+            start_col = column_index_from_string(col_letter)
+
+            # Write data
+            rows_written = 0
+            for row_idx, row_data in enumerate(data):
+                for col_idx, value in enumerate(row_data):
+                    sheet.cell(row=start_row + row_idx, column=start_col + col_idx, value=value)
+                rows_written += 1
+
+            workbook.save(str(file_path))
+            workbook.close()
+
+            log_debug(f"Wrote {rows_written} rows to {sheet.title}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "sheet": sheet.title,
+                    "rows_written": rows_written,
+                    "columns_written": len(data[0]) if data else 0,
+                    "start_cell": start_cell,
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error writing data: {e}")
+            return json.dumps({"error": f"Error writing data: {e}"})
+
+    def read_data(
+        self,
+        file_name: str,
+        sheet_name: Optional[str] = None,
+        start_cell: str = "A1",
+        end_cell: Optional[str] = None,
+    ) -> str:
+        """Read data from an Excel sheet.
+
+        Args:
+            file_name: Name of the Excel file.
+            sheet_name: Name of the sheet to read from. Uses active sheet if not specified.
+            start_cell: Starting cell to read from (e.g., "A1"). Default: "A1".
+            end_cell: Optional ending cell. If not specified, reads all data from start.
+
+        Returns:
+            JSON string with the data as a 2D list.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to access file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found."})
+
+            log_info(f"Reading data from: {file_path}")
+
+            workbook = openpyxl.load_workbook(str(file_path), data_only=True)
+
+            if sheet_name:
+                if sheet_name not in workbook.sheetnames:
+                    workbook.close()
+                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
+                sheet = workbook[sheet_name]
+            else:
+                sheet = workbook.active
+
+            # Define range
+            if end_cell:
+                cell_range = f"{start_cell}:{end_cell}"
+            else:
+                # Get the max row and column from the sheet
+                max_row = sheet.max_row or 1
+                max_col = sheet.max_column or 1
+                from openpyxl.utils import get_column_letter
+
+                end_col_letter = get_column_letter(max_col)
+                cell_range = f"{start_cell}:{end_col_letter}{max_row}"
+
+            # Read data
+            data = []
+            for row in sheet[cell_range]:
+                row_data = []
+                for cell in row:
+                    value = cell.value
+                    # Convert datetime objects to string for JSON serialization
+                    if hasattr(value, "isoformat"):
+                        value = value.isoformat()
+                    row_data.append(value)
+                data.append(row_data)
+
+            workbook.close()
+
+            log_debug(f"Read {len(data)} rows from {sheet.title}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "sheet": sheet.title,
+                    "data": data,
+                    "rows": len(data),
+                    "columns": len(data[0]) if data else 0,
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error reading data: {e}")
+            return json.dumps({"error": f"Error reading data: {e}"})
+
+    def add_sheet(
+        self,
+        file_name: str,
+        sheet_name: str,
+        position: Optional[int] = None,
+    ) -> str:
+        """Add a new sheet to an existing workbook.
+
+        Args:
+            file_name: Name of the Excel file.
+            sheet_name: Name for the new sheet.
+            position: Optional position for the sheet (0-indexed). Adds at end if not specified.
+
+        Returns:
+            JSON string with the result including all sheet names.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to access file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
+
+            log_info(f"Adding sheet '{sheet_name}' to: {file_path}")
+
+            workbook = openpyxl.load_workbook(str(file_path))
+
+            if sheet_name in workbook.sheetnames:
+                return json.dumps({"error": f"Sheet '{sheet_name}' already exists."})
+
+            if position is not None:
+                workbook.create_sheet(title=sheet_name, index=position)
+            else:
+                workbook.create_sheet(title=sheet_name)
+
+            workbook.save(str(file_path))
+            sheets = workbook.sheetnames
+            workbook.close()
+
+            log_debug(f"Added sheet '{sheet_name}' to {file_name}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "new_sheet": sheet_name,
+                    "all_sheets": sheets,
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error adding sheet: {e}")
+            return json.dumps({"error": f"Error adding sheet: {e}"})
+
+    def list_sheets(self, file_name: str) -> str:
+        """List all sheets in a workbook.
+
+        Args:
+            file_name: Name of the Excel file.
+
+        Returns:
+            JSON string with the list of sheet names.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to access file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found."})
+
+            log_debug(f"Listing sheets in: {file_path}")
+
+            workbook = openpyxl.load_workbook(str(file_path), read_only=True)
+            sheets = workbook.sheetnames
+            workbook.close()
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "sheets": sheets,
+                    "count": len(sheets),
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error listing sheets: {e}")
+            return json.dumps({"error": f"Error listing sheets: {e}"})
+
+    def add_formula(
+        self,
+        file_name: str,
+        cell: str,
+        formula: str,
+        sheet_name: Optional[str] = None,
+    ) -> str:
+        """Add a formula to a cell.
+
+        Args:
+            file_name: Name of the Excel file.
+            cell: Cell reference (e.g., "C1", "D5").
+            formula: Excel formula (e.g., "=SUM(A1:B1)", "=A1*B1").
+            sheet_name: Name of the sheet. Uses active sheet if not specified.
+
+        Returns:
+            JSON string with the result.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to access file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found."})
+
+            # Ensure formula starts with =
+            if not formula.startswith("="):
+                formula = f"={formula}"
+
+            log_info(f"Adding formula to {cell} in: {file_path}")
+
+            workbook = openpyxl.load_workbook(str(file_path))
+
+            if sheet_name:
+                if sheet_name not in workbook.sheetnames:
+                    return json.dumps({"error": f"Sheet '{sheet_name}' not found."})
+                sheet = workbook[sheet_name]
+            else:
+                sheet = workbook.active
+
+            sheet[cell] = formula
+
+            workbook.save(str(file_path))
+            workbook.close()
+
+            log_debug(f"Added formula '{formula}' to {cell}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "sheet": sheet.title,
+                    "cell": cell,
+                    "formula": formula,
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error adding formula: {e}")
+            return json.dumps({"error": f"Error adding formula: {e}"})
+
+    def format_cells(
+        self,
+        file_name: str,
+        cell_range: str,
+        sheet_name: Optional[str] = None,
+        bold: Optional[bool] = None,
+        italic: Optional[bool] = None,
+        font_size: Optional[int] = None,
+        font_color: Optional[str] = None,
+        bg_color: Optional[str] = None,
+    ) -> str:
+        """Apply formatting to cells.
+
+        Args:
+            file_name: Name of the Excel file.
+            cell_range: Cell or range to format (e.g., "A1", "A1:C5").
+            sheet_name: Name of the sheet. Uses active sheet if not specified.
+            bold: Set bold formatting.
+            italic: Set italic formatting.
+            font_size: Font size in points.
+            font_color: Font color as hex (e.g., "FF0000" for red).
+            bg_color: Background color as hex (e.g., "FFFF00" for yellow).
+
+        Returns:
+            JSON string with the result.
+        """
+        try:
+            openpyxl = self._get_openpyxl()
+            from openpyxl.styles import Font, PatternFill
+
+            file_name = self._ensure_xlsx_extension(file_name)
+            safe, file_path = self._check_path(file_name)
+
+            if not safe:
+                log_error(f"Attempted to access file outside base directory: {file_name}")
+                return json.dumps({"error": "Invalid file path"})
+
+            if not file_path.exists():
+                return json.dumps({"error": f"File '{file_name}' not found."})
+
+            log_info(f"Formatting cells {cell_range} in: {file_path}")
+
+            workbook = openpyxl.load_workbook(str(file_path))
+
+            if sheet_name:
+                if sheet_name not in workbook.sheetnames:
+                    return json.dumps({"error": f"Sheet '{sheet_name}' not found."})
+                sheet = workbook[sheet_name]
+            else:
+                sheet = workbook.active
+
+            # Build font style
+            font_kwargs = {}
+            if bold is not None:
+                font_kwargs["bold"] = bold
+            if italic is not None:
+                font_kwargs["italic"] = italic
+            if font_size is not None:
+                font_kwargs["size"] = font_size
+            if font_color is not None:
+                font_kwargs["color"] = font_color
+
+            font = Font(**font_kwargs) if font_kwargs else None
+
+            # Build fill style
+            fill = None
+            if bg_color:
+                fill = PatternFill(start_color=bg_color, end_color=bg_color, fill_type="solid")
+
+            # Apply formatting to range
+            cells_formatted = 0
+            cell_selection = sheet[cell_range]
+
+            # Handle single cell case (returns Cell directly, not tuple)
+            from openpyxl.cell import Cell
+
+            if isinstance(cell_selection, Cell):
+                if font:
+                    cell_selection.font = font
+                if fill:
+                    cell_selection.fill = fill
+                cells_formatted = 1
+            else:
+                for row in cell_selection:
+                    if not hasattr(row, "__iter__"):
+                        row = [row]
+                    for cell in row:
+                        if font:
+                            cell.font = font
+                        if fill:
+                            cell.fill = fill
+                        cells_formatted += 1
+
+            workbook.save(str(file_path))
+            workbook.close()
+
+            log_debug(f"Formatted {cells_formatted} cells in {cell_range}")
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "file": file_name,
+                    "sheet": sheet.title,
+                    "range": cell_range,
+                    "cells_formatted": cells_formatted,
+                }
+            )
+
+        except ImportError as e:
+            return json.dumps({"error": str(e)})
+        except Exception as e:
+            log_error(f"Error formatting cells: {e}")
+            return json.dumps({"error": f"Error formatting cells: {e}"})

--- a/libs/agno/agno/tools/excel.py
+++ b/libs/agno/agno/tools/excel.py
@@ -116,7 +116,9 @@ class ExcelTools(Toolkit):
 
             return openpyxl
         except ImportError as e:
-            raise ImportError("`openpyxl` not installed. Please install it via `pip install openpyxl`.") from e
+            raise ImportError(
+                "`openpyxl` not installed. Please install it via `pip install openpyxl`."
+            ) from e
 
     def create_workbook(
         self,
@@ -141,11 +143,17 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to create file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to create file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if file_path.exists() and not overwrite:
-                return json.dumps({"error": f"File '{file_name}' already exists. Set overwrite=True to replace."})
+                return json.dumps(
+                    {
+                        "error": f"File '{file_name}' already exists. Set overwrite=True to replace."
+                    }
+                )
 
             log_info(f"Creating Excel workbook: {file_path}")
 
@@ -208,11 +216,17 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
-                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
+                return json.dumps(
+                    {
+                        "error": f"File '{file_name}' not found. Create it first with create_workbook."
+                    }
+                )
 
             log_info(f"Writing data to: {file_path}")
 
@@ -220,7 +234,11 @@ class ExcelTools(Toolkit):
 
             if sheet_name:
                 if sheet_name not in workbook.sheetnames:
-                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
+                    return json.dumps(
+                        {
+                            "error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"
+                        }
+                    )
                 sheet = workbook[sheet_name]
             else:
                 sheet = workbook.active
@@ -233,7 +251,9 @@ class ExcelTools(Toolkit):
             rows_written = 0
             for row_idx, row_data in enumerate(data):
                 for col_idx, value in enumerate(row_data):
-                    sheet.cell(row=start_row + row_idx, column=start_col + col_idx, value=value)
+                    sheet.cell(
+                        row=start_row + row_idx, column=start_col + col_idx, value=value
+                    )
                 rows_written += 1
 
             workbook.save(str(file_path))
@@ -283,7 +303,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -296,7 +318,11 @@ class ExcelTools(Toolkit):
             if sheet_name:
                 if sheet_name not in workbook.sheetnames:
                     workbook.close()
-                    return json.dumps({"error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"})
+                    return json.dumps(
+                        {
+                            "error": f"Sheet '{sheet_name}' not found. Available: {workbook.sheetnames}"
+                        }
+                    )
                 sheet = workbook[sheet_name]
             else:
                 sheet = workbook.active
@@ -369,11 +395,17 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
-                return json.dumps({"error": f"File '{file_name}' not found. Create it first with create_workbook."})
+                return json.dumps(
+                    {
+                        "error": f"File '{file_name}' not found. Create it first with create_workbook."
+                    }
+                )
 
             log_info(f"Adding sheet '{sheet_name}' to: {file_path}")
 
@@ -424,7 +456,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -468,7 +502,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -518,7 +554,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -596,7 +634,9 @@ class ExcelTools(Toolkit):
             safe, file_path = self._check_path(file_name)
 
             if not safe:
-                log_error(f"Attempted to access file outside base directory: {file_name}")
+                log_error(
+                    f"Attempted to access file outside base directory: {file_name}"
+                )
                 return json.dumps({"error": "Invalid file path"})
 
             if not file_path.exists():
@@ -614,7 +654,7 @@ class ExcelTools(Toolkit):
                 sheet = workbook.active
 
             # Build font style
-            font_kwargs = {}
+            font_kwargs: dict[str, Any] = {}
             if bold is not None:
                 font_kwargs["bold"] = bold
             if italic is not None:
@@ -629,7 +669,9 @@ class ExcelTools(Toolkit):
             # Build fill style
             fill = None
             if bg_color:
-                fill = PatternFill(start_color=bg_color, end_color=bg_color, fill_type="solid")
+                fill = PatternFill(
+                    start_color=bg_color, end_color=bg_color, fill_type="solid"
+                )
 
             # Apply formatting to range
             cells_formatted = 0

--- a/libs/agno/tests/unit/tools/test_excel.py
+++ b/libs/agno/tests/unit/tools/test_excel.py
@@ -42,6 +42,7 @@ class TestExcelToolsInit:
         assert "read_data" in function_names
         assert "add_sheet" in function_names
         assert "list_sheets" in function_names
+        assert "get_file_path" in function_names
         # Disabled by default
         assert "add_formula" not in function_names
         assert "format_cells" not in function_names
@@ -56,6 +57,7 @@ class TestExcelToolsInit:
         assert "read_data" in function_names
         assert "add_sheet" in function_names
         assert "list_sheets" in function_names
+        assert "get_file_path" in function_names
         assert "add_formula" in function_names
         assert "format_cells" in function_names
 
@@ -298,6 +300,48 @@ class TestListSheets:
         assert "not found" in result_data["error"]
 
 
+class TestGetFilePath:
+    """Tests for get_file_path method."""
+
+    def test_get_file_path_success(self, excel_tools, temp_dir):
+        """Test successful file path retrieval."""
+        excel_tools.create_workbook("test.xlsx")
+
+        result = excel_tools.get_file_path("test.xlsx")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["file"] == "test.xlsx"
+        assert str(temp_dir) in result_data["path"]
+        assert result_data["exists"] is True
+        assert result_data["size_bytes"] > 0
+
+    def test_get_file_path_adds_extension(self, excel_tools, temp_dir):
+        """Test that .xlsx extension is added if missing."""
+        excel_tools.create_workbook("test")
+
+        result = excel_tools.get_file_path("test")
+        result_data = json.loads(result)
+
+        assert result_data["file"] == "test.xlsx"
+        assert result_data["success"] is True
+
+    def test_get_file_path_file_not_found(self, excel_tools):
+        """Test getting path for non-existent file."""
+        result = excel_tools.get_file_path("missing.xlsx")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+    def test_get_file_path_escape_blocked(self, excel_tools):
+        """Test that path escape is blocked."""
+        result = excel_tools.get_file_path("../../escape.xlsx")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+
+
 class TestAddFormula:
     """Tests for add_formula method."""
 
@@ -350,7 +394,9 @@ class TestFormatCells:
         excel_tools_all.create_workbook("test.xlsx")
         excel_tools_all.write_data("test.xlsx", [["A", "B"], ["C", "D"]])
 
-        result = excel_tools_all.format_cells("test.xlsx", "A1:B2", bold=True, font_size=14)
+        result = excel_tools_all.format_cells(
+            "test.xlsx", "A1:B2", bold=True, font_size=14
+        )
         result_data = json.loads(result)
 
         assert result_data["success"] is True

--- a/libs/agno/tests/unit/tools/test_excel.py
+++ b/libs/agno/tests/unit/tools/test_excel.py
@@ -1,0 +1,407 @@
+"""Unit tests for ExcelTools class."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from agno.tools.excel import ExcelTools
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for tests."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield Path(tmp_dir)
+
+
+@pytest.fixture
+def excel_tools(temp_dir):
+    """Create ExcelTools instance with temporary base directory."""
+    return ExcelTools(base_dir=temp_dir)
+
+
+@pytest.fixture
+def excel_tools_all(temp_dir):
+    """Create ExcelTools instance with all tools enabled."""
+    return ExcelTools(base_dir=temp_dir, all=True)
+
+
+class TestExcelToolsInit:
+    """Tests for ExcelTools initialization."""
+
+    def test_init_with_default_tools(self, temp_dir):
+        """Test initialization with default tools."""
+        tools = ExcelTools(base_dir=temp_dir)
+        function_names = [func.name for func in tools.functions.values()]
+
+        assert "create_workbook" in function_names
+        assert "write_data" in function_names
+        assert "read_data" in function_names
+        assert "add_sheet" in function_names
+        assert "list_sheets" in function_names
+        # Disabled by default
+        assert "add_formula" not in function_names
+        assert "format_cells" not in function_names
+
+    def test_init_with_all_tools(self, temp_dir):
+        """Test initialization with all tools enabled."""
+        tools = ExcelTools(base_dir=temp_dir, all=True)
+        function_names = [func.name for func in tools.functions.values()]
+
+        assert "create_workbook" in function_names
+        assert "write_data" in function_names
+        assert "read_data" in function_names
+        assert "add_sheet" in function_names
+        assert "list_sheets" in function_names
+        assert "add_formula" in function_names
+        assert "format_cells" in function_names
+
+    def test_init_with_selective_tools(self, temp_dir):
+        """Test initialization with only selected tools."""
+        tools = ExcelTools(
+            base_dir=temp_dir,
+            enable_create_workbook=True,
+            enable_write_data=False,
+            enable_read_data=True,
+            enable_add_sheet=False,
+            enable_list_sheets=True,
+        )
+        function_names = [func.name for func in tools.functions.values()]
+
+        assert "create_workbook" in function_names
+        assert "write_data" not in function_names
+        assert "read_data" in function_names
+        assert "add_sheet" not in function_names
+        assert "list_sheets" in function_names
+
+    def test_init_default_base_dir(self):
+        """Test initialization uses current directory as default."""
+        tools = ExcelTools()
+        assert tools.base_dir == Path.cwd().resolve()
+
+
+class TestCreateWorkbook:
+    """Tests for create_workbook method."""
+
+    def test_create_workbook_success(self, excel_tools, temp_dir):
+        """Test successful workbook creation."""
+        result = excel_tools.create_workbook("test.xlsx")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["file"] == "test.xlsx"
+        assert (temp_dir / "test.xlsx").exists()
+
+    def test_create_workbook_adds_extension(self, excel_tools, temp_dir):
+        """Test that .xlsx extension is added if missing."""
+        result = excel_tools.create_workbook("test")
+        result_data = json.loads(result)
+
+        assert result_data["file"] == "test.xlsx"
+        assert (temp_dir / "test.xlsx").exists()
+
+    def test_create_workbook_with_sheet_name(self, excel_tools, temp_dir):
+        """Test workbook creation with custom sheet name."""
+        result = excel_tools.create_workbook("test.xlsx", sheet_name="MySheet")
+        result_data = json.loads(result)
+
+        assert result_data["sheet"] == "MySheet"
+
+    def test_create_workbook_no_overwrite(self, excel_tools, temp_dir):
+        """Test that existing file is not overwritten by default."""
+        excel_tools.create_workbook("test.xlsx")
+        result = excel_tools.create_workbook("test.xlsx")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "already exists" in result_data["error"]
+
+    def test_create_workbook_with_overwrite(self, excel_tools, temp_dir):
+        """Test that existing file can be overwritten."""
+        excel_tools.create_workbook("test.xlsx")
+        result = excel_tools.create_workbook("test.xlsx", overwrite=True)
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+
+    def test_create_workbook_path_escape(self, excel_tools):
+        """Test that path escape attempts are blocked."""
+        result = excel_tools.create_workbook("../escape.xlsx")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+
+
+class TestWriteData:
+    """Tests for write_data method."""
+
+    def test_write_data_success(self, excel_tools, temp_dir):
+        """Test successful data writing."""
+        excel_tools.create_workbook("test.xlsx")
+
+        data = [["Name", "Age"], ["Alice", 30], ["Bob", 25]]
+        result = excel_tools.write_data("test.xlsx", data)
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["rows_written"] == 3
+        assert result_data["columns_written"] == 2
+
+    def test_write_data_to_specific_sheet(self, excel_tools, temp_dir):
+        """Test writing data to a specific sheet."""
+        excel_tools.create_workbook("test.xlsx")
+        excel_tools.add_sheet("test.xlsx", "Data")
+
+        data = [["Value"], [100]]
+        result = excel_tools.write_data("test.xlsx", data, sheet_name="Data")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["sheet"] == "Data"
+
+    def test_write_data_with_start_cell(self, excel_tools, temp_dir):
+        """Test writing data starting from a specific cell."""
+        excel_tools.create_workbook("test.xlsx")
+
+        data = [["X", "Y"]]
+        result = excel_tools.write_data("test.xlsx", data, start_cell="C3")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["start_cell"] == "C3"
+
+    def test_write_data_file_not_found(self, excel_tools):
+        """Test writing to non-existent file."""
+        result = excel_tools.write_data("missing.xlsx", [["data"]])
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+    def test_write_data_sheet_not_found(self, excel_tools, temp_dir):
+        """Test writing to non-existent sheet."""
+        excel_tools.create_workbook("test.xlsx")
+
+        result = excel_tools.write_data("test.xlsx", [["data"]], sheet_name="Missing")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+
+class TestReadData:
+    """Tests for read_data method."""
+
+    def test_read_data_success(self, excel_tools, temp_dir):
+        """Test successful data reading."""
+        excel_tools.create_workbook("test.xlsx")
+        excel_tools.write_data("test.xlsx", [["A", "B"], [1, 2]])
+
+        result = excel_tools.read_data("test.xlsx")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["data"] == [["A", "B"], [1, 2]]
+        assert result_data["rows"] == 2
+
+    def test_read_data_from_specific_sheet(self, excel_tools, temp_dir):
+        """Test reading data from a specific sheet."""
+        excel_tools.create_workbook("test.xlsx")
+        excel_tools.add_sheet("test.xlsx", "Data")
+        excel_tools.write_data("test.xlsx", [["Test"]], sheet_name="Data")
+
+        result = excel_tools.read_data("test.xlsx", sheet_name="Data")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["sheet"] == "Data"
+
+    def test_read_data_file_not_found(self, excel_tools):
+        """Test reading from non-existent file."""
+        result = excel_tools.read_data("missing.xlsx")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+
+class TestAddSheet:
+    """Tests for add_sheet method."""
+
+    def test_add_sheet_success(self, excel_tools, temp_dir):
+        """Test successful sheet addition."""
+        excel_tools.create_workbook("test.xlsx")
+
+        result = excel_tools.add_sheet("test.xlsx", "NewSheet")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["new_sheet"] == "NewSheet"
+        assert "NewSheet" in result_data["all_sheets"]
+
+    def test_add_sheet_at_position(self, excel_tools, temp_dir):
+        """Test adding sheet at specific position."""
+        excel_tools.create_workbook("test.xlsx")
+        excel_tools.add_sheet("test.xlsx", "Second")
+
+        result = excel_tools.add_sheet("test.xlsx", "First", position=0)
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["all_sheets"][0] == "First"
+
+    def test_add_sheet_duplicate_name(self, excel_tools, temp_dir):
+        """Test adding sheet with duplicate name."""
+        excel_tools.create_workbook("test.xlsx", sheet_name="MySheet")
+
+        result = excel_tools.add_sheet("test.xlsx", "MySheet")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "already exists" in result_data["error"]
+
+    def test_add_sheet_file_not_found(self, excel_tools):
+        """Test adding sheet to non-existent file."""
+        result = excel_tools.add_sheet("missing.xlsx", "Sheet")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+
+class TestListSheets:
+    """Tests for list_sheets method."""
+
+    def test_list_sheets_success(self, excel_tools, temp_dir):
+        """Test successful sheet listing."""
+        excel_tools.create_workbook("test.xlsx")
+        excel_tools.add_sheet("test.xlsx", "Sheet2")
+        excel_tools.add_sheet("test.xlsx", "Sheet3")
+
+        result = excel_tools.list_sheets("test.xlsx")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["count"] == 3
+        assert "Sheet2" in result_data["sheets"]
+        assert "Sheet3" in result_data["sheets"]
+
+    def test_list_sheets_file_not_found(self, excel_tools):
+        """Test listing sheets from non-existent file."""
+        result = excel_tools.list_sheets("missing.xlsx")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+
+class TestAddFormula:
+    """Tests for add_formula method."""
+
+    def test_add_formula_success(self, excel_tools_all, temp_dir):
+        """Test successful formula addition."""
+        excel_tools_all.create_workbook("test.xlsx")
+        excel_tools_all.write_data("test.xlsx", [[10, 20]])
+
+        result = excel_tools_all.add_formula("test.xlsx", "C1", "=SUM(A1:B1)")
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["cell"] == "C1"
+        assert result_data["formula"] == "=SUM(A1:B1)"
+
+    def test_add_formula_without_equals(self, excel_tools_all, temp_dir):
+        """Test that formula without = gets it added."""
+        excel_tools_all.create_workbook("test.xlsx")
+
+        result = excel_tools_all.add_formula("test.xlsx", "A1", "SUM(B1:C1)")
+        result_data = json.loads(result)
+
+        assert result_data["formula"] == "=SUM(B1:C1)"
+
+    def test_add_formula_file_not_found(self, excel_tools_all):
+        """Test adding formula to non-existent file."""
+        result = excel_tools_all.add_formula("missing.xlsx", "A1", "=1+1")
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+
+class TestFormatCells:
+    """Tests for format_cells method."""
+
+    def test_format_cells_bold(self, excel_tools_all, temp_dir):
+        """Test applying bold formatting."""
+        excel_tools_all.create_workbook("test.xlsx")
+        excel_tools_all.write_data("test.xlsx", [["Header"]])
+
+        result = excel_tools_all.format_cells("test.xlsx", "A1", bold=True)
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["cells_formatted"] == 1
+
+    def test_format_cells_range(self, excel_tools_all, temp_dir):
+        """Test formatting a range of cells."""
+        excel_tools_all.create_workbook("test.xlsx")
+        excel_tools_all.write_data("test.xlsx", [["A", "B"], ["C", "D"]])
+
+        result = excel_tools_all.format_cells("test.xlsx", "A1:B2", bold=True, font_size=14)
+        result_data = json.loads(result)
+
+        assert result_data["success"] is True
+        assert result_data["cells_formatted"] == 4
+
+    def test_format_cells_file_not_found(self, excel_tools_all):
+        """Test formatting in non-existent file."""
+        result = excel_tools_all.format_cells("missing.xlsx", "A1", bold=True)
+        result_data = json.loads(result)
+
+        assert "error" in result_data
+        assert "not found" in result_data["error"]
+
+
+class TestPathSecurity:
+    """Tests for path security."""
+
+    def test_path_escape_blocked_create(self, excel_tools):
+        """Test path escape is blocked for create."""
+        result = excel_tools.create_workbook("../../escape.xlsx")
+        result_data = json.loads(result)
+        assert "error" in result_data
+
+    def test_path_escape_blocked_read(self, excel_tools):
+        """Test path escape is blocked for read."""
+        result = excel_tools.read_data("../../escape.xlsx")
+        result_data = json.loads(result)
+        assert "error" in result_data
+
+    def test_path_escape_blocked_write(self, excel_tools):
+        """Test path escape is blocked for write."""
+        result = excel_tools.write_data("../../escape.xlsx", [["data"]])
+        result_data = json.loads(result)
+        assert "error" in result_data
+
+
+class TestOpenpyxlNotInstalled:
+    """Tests for handling missing openpyxl."""
+
+    def test_openpyxl_not_installed(self, temp_dir):
+        """Test error message when openpyxl is not installed."""
+        tools = ExcelTools(base_dir=temp_dir)
+
+        with patch.dict("sys.modules", {"openpyxl": None}):
+            with patch.object(
+                tools,
+                "_get_openpyxl",
+                side_effect=ImportError("openpyxl not installed"),
+            ):
+                result = tools.create_workbook("test.xlsx")
+                result_data = json.loads(result)
+
+                assert "error" in result_data
+                assert "openpyxl" in result_data["error"].lower()

--- a/libs/agno/tests/unit/tools/test_excel.py
+++ b/libs/agno/tests/unit/tools/test_excel.py
@@ -7,6 +7,9 @@ from unittest.mock import patch
 
 import pytest
 
+# Skip all tests if openpyxl is not installed
+pytest.importorskip("openpyxl")
+
 from agno.tools.excel import ExcelTools
 
 
@@ -394,9 +397,7 @@ class TestFormatCells:
         excel_tools_all.create_workbook("test.xlsx")
         excel_tools_all.write_data("test.xlsx", [["A", "B"], ["C", "D"]])
 
-        result = excel_tools_all.format_cells(
-            "test.xlsx", "A1:B2", bold=True, font_size=14
-        )
+        result = excel_tools_all.format_cells("test.xlsx", "A1:B2", bold=True, font_size=14)
         result_data = json.loads(result)
 
         assert result_data["success"] is True


### PR DESCRIPTION
- Add ExcelTools toolkit with 7 tools: create_workbook, write_data, read_data, add_sheet, list_sheets, add_formula, format_cells
- Uses openpyxl library for Excel operations
- Includes base directory security to prevent path traversal
- Default tools enabled: create_workbook, write_data, read_data, add_sheet, list_sheets
- Advanced tools disabled by default: add_formula, format_cells
- Add comprehensive unit tests (34 tests)
- Add cookbook example in cookbook/91_tools/excel_tools.py
