### PR TITLE
feat: add Summarizer Agent to cookbook/demo

### DIFF
--- a/cookbook/demo/CLAUDE.md
+++ b/cookbook/demo/CLAUDE.md
@@ -19,6 +19,7 @@ Instructions for Claude Code when testing and maintaining the Demo cookbook.
 ```bash
 python cookbook/demo/agents/pal_agent.py
 python cookbook/demo/agents/research_agent.py "Your query here"
+python cookbook/demo/agents/summarizer_agent.py "Summarize: ..."
 ```
 
 **Test results file:**
@@ -42,6 +43,7 @@ cookbook/demo/
 │   ├── knowledge_agent.py         # General RAG agent
 │   ├── mcp_agent.py               # General MCP agent
 │   ├── devil_advocate_agent.py    # Critical review (used in teams)
+│   ├── summarizer_agent.py        # Condenses long-form content into summaries
 │   └── db.py                      # Database configuration
 ├── teams/
 │   ├── investment_team.py         # Finance + Research + Report Writer
@@ -89,6 +91,7 @@ cookbook/demo/
 | `report_writer_agent` | Professional report generation |
 | `knowledge_agent` | General RAG agent |
 | `mcp_agent` | General MCP integration |
+| `summarizer_agent` | Condenses long-form content into structured summaries |
 
 ### Team-Only Agents
 

--- a/cookbook/demo/agents/summarizer_agent.py
+++ b/cookbook/demo/agents/summarizer_agent.py
@@ -1,0 +1,140 @@
+"""
+Summarizer Agent - Condenses long-form content into structured summaries.
+
+This agent specializes in:
+- Summarizing documents, articles, and transcripts
+- Extracting key points and action items
+- Producing concise executive summaries
+- Supporting multiple summary formats (bullet, paragraph, structured)
+
+Example queries:
+- "Summarize this article: [paste text or URL]"
+- "Give me key takeaways from this meeting transcript"
+- "Extract the main arguments and conclusion from this document"
+- "Create a one-paragraph executive summary of the following"
+"""
+
+import sys
+from textwrap import dedent
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.parallel import ParallelTools
+from agno.tools.reasoning import ReasoningTools
+from db import demo_db
+
+# ============================================================================
+# Description & Instructions
+# ============================================================================
+description = dedent("""\
+    You are the Summarizer Agent - an expert at distilling long-form content
+    into clear, structured summaries that preserve key information and action items.
+    """)
+
+instructions = dedent("""\
+    You are a professional summarizer. Your job is to take long-form content and
+    produce accurate, well-structured summaries.
+
+    SUMMARIZATION PROCESS:
+
+    1. **Analyze the Input**
+       - Identify the type of content (article, transcript, report, etc.)
+       - Determine the main purpose and audience
+       - Note any explicit or implied structure
+
+    2. **Extract Key Information**
+       - Main thesis or central claim
+       - Supporting arguments or evidence
+       - Key facts, figures, and dates
+       - Conclusions and recommendations
+       - Action items or next steps (if present)
+
+    3. **Choose Output Format**
+       - **Executive summary**: One paragraph, high-level overview
+       - **Bullet summary**: Key points as concise bullets
+       - **Structured summary**: Sections matching original (e.g., Background, Findings, Conclusion)
+       - **TL;DR**: Ultra-brief (1-3 sentences) when appropriate
+
+    4. **Quality Standards**
+       - Preserve accurate meaning; do not distort or add interpretation
+       - Omit filler and redundancy
+       - Keep technical terms when they matter; explain only if requested
+       - Note uncertainty or gaps if the source is ambiguous
+
+    5. **When Content Is Provided via URL or "Summarize this"**
+       - Use search/extract tools to obtain the content when needed
+       - If the user pastes text, work directly from it
+       - If asked to summarize a URL, fetch and then summarize
+
+    OUTPUT FORMAT (adapt to request):
+
+    ## Summary: [Topic or Title]
+
+    ### Key Points
+    - [Point 1]
+    - [Point 2]
+    - [Point 3]
+
+    ### Conclusion / Main Takeaway
+    [One or two sentences]
+
+    ### Action Items (if any)
+    - [Item 1]
+    - [Item 2]
+
+    Keep tone neutral and factual. No emojis.
+    """)
+
+# ============================================================================
+# Create the Agent
+# ============================================================================
+summarizer_agent = Agent(
+    name="Summarizer Agent",
+    role="Condense long-form content into structured, actionable summaries",
+    model=OpenAIResponses(id="gpt-5.2"),
+    tools=[
+        ReasoningTools(add_instructions=True),
+        ParallelTools(enable_search=True, enable_extract=True),
+    ],
+    description=description,
+    instructions=instructions,
+    add_history_to_context=True,
+    add_datetime_to_context=True,
+    enable_agentic_memory=True,
+    markdown=True,
+    db=demo_db,
+)
+
+# ============================================================================
+# Demo Tests
+# ============================================================================
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Summarizer Agent")
+    print("   Condenses long-form content into structured summaries")
+    print("=" * 60)
+
+    if len(sys.argv) > 1:
+        # Run with command line argument
+        message = " ".join(sys.argv[1:])
+        summarizer_agent.print_response(message, stream=True)
+    else:
+        # Run demo tests
+        sample_text = (
+            "Agno is an open-source framework for building AI agents. "
+            "It supports single agents, teams, and workflows. Key features include "
+            "tools, knowledge/RAG, memory, and structured output. Use PostgreSQL "
+            "in production and SQLite for development. Start with one agent and "
+            "scale up only when needed."
+        )
+        print("\n--- Demo 1: Inline Text Summary ---")
+        summarizer_agent.print_response(
+            f"Summarize this in 3 bullet points:\n\n{sample_text}",
+            stream=True,
+        )
+
+        print("\n--- Demo 2: Executive Summary Style ---")
+        summarizer_agent.print_response(
+            "Give a one-paragraph executive summary of what Agno is and who it's for.",
+            stream=True,
+        )

--- a/cookbook/demo/run.py
+++ b/cookbook/demo/run.py
@@ -9,6 +9,7 @@ from agents.mcp_agent import mcp_agent
 from agents.pal_agent import pal_agent
 from agents.report_writer_agent import report_writer_agent
 from agents.research_agent import research_agent
+from agents.summarizer_agent import summarizer_agent
 from agents.web_intelligence_agent import web_intelligence_agent
 from agno.os import AgentOS
 from db import demo_db
@@ -36,6 +37,7 @@ agent_os = AgentOS(
         report_writer_agent,
         knowledge_agent,
         mcp_agent,
+        summarizer_agent,
     ],
     teams=[
         investment_team,


### PR DESCRIPTION
## Summary

Adds a new **Summarizer Agent** to `cookbook/demo` that condenses long-form content (articles, transcripts, documents) into structured summaries. The agent uses ReasoningTools and ParallelTools (search + extract), follows demo conventions (GPT-5.2, demo_db, agentic memory, markdown), and is registered in AgentOS and documented in CLAUDE.md.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — run in environment where ruff is available (e.g. `source .venv/bin/activate` first)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- **New file:** `cookbook/demo/agents/summarizer_agent.py` — Summarizer Agent with description, instructions, demo block (`if __name__ == "__main__"`), and CLI/query support.
- **Updated:** `cookbook/demo/run.py` — Import and register `summarizer_agent` in the AgentOS agents list.
- **Updated:** `cookbook/demo/CLAUDE.md` — Folder structure, “Run any agent” snippet, and Knowledge & Intelligence Agents table.

Run the agent:
```bash
python cookbook/demo/agents/summarizer_agent.py
python cookbook/demo/agents/summarizer_agent.py "Summarize: ..."
```
