### PR TITLE
fix(db): add cache check to _get_table() to prevent connection explosion

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -123,6 +123,17 @@ class AsyncMySQLDb(AsyncBaseDb):
             expire_on_commit=False,
         )
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
 
@@ -282,6 +293,8 @@ class AsyncMySQLDb(AsyncBaseDb):
 
     async def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Table:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = await self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -290,6 +303,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = await self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -298,6 +313,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = await self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -306,6 +323,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = await self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -314,6 +333,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = await self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -322,6 +343,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = await self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -330,6 +353,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = await self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -338,6 +363,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = await self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -349,6 +376,8 @@ class AsyncMySQLDb(AsyncBaseDb):
             # Ensure traces table exists first (spans has FK to traces)
             if create_table_if_not_found:
                 await self._get_table(table_type="traces", create_table_if_not_found=True)
+            if self.spans_table is not None:
+                return self.spans_table
             self.spans_table = await self._get_or_create_table(
                 table_name=self.span_table_name,
                 table_type="spans",

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -121,6 +121,17 @@ class MySQLDb(BaseDb):
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+
     def close(self) -> None:
         """Close database connections and dispose of the connection pool.
 
@@ -273,6 +284,8 @@ class MySQLDb(BaseDb):
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -281,6 +294,8 @@ class MySQLDb(BaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -289,6 +304,8 @@ class MySQLDb(BaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -297,6 +314,8 @@ class MySQLDb(BaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -305,6 +324,8 @@ class MySQLDb(BaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -313,6 +334,8 @@ class MySQLDb(BaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -321,6 +344,8 @@ class MySQLDb(BaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -329,6 +354,8 @@ class MySQLDb(BaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -341,6 +368,8 @@ class MySQLDb(BaseDb):
             if create_table_if_not_found:
                 self._get_table(table_type="traces", create_table_if_not_found=True)
 
+            if self.spans_table is not None:
+                return self.spans_table
             self.spans_table = self._get_or_create_table(
                 table_name=self.span_table_name,
                 table_type="spans",

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -136,6 +136,18 @@ class AsyncPostgresDb(AsyncBaseDb):
             expire_on_commit=False,
         )
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+        self.learnings_table: Optional[Table] = None
+
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
 
@@ -285,6 +297,8 @@ class AsyncPostgresDb(AsyncBaseDb):
 
     async def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Table:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = await self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -293,6 +307,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = await self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -301,6 +317,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = await self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -309,6 +327,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = await self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -317,6 +337,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = await self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -325,6 +347,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = await self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -333,6 +357,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = await self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -341,6 +367,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = await self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -352,6 +380,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             # Ensure traces table exists first (spans has FK to traces)
             if create_table_if_not_found:
                 await self._get_table(table_type="traces", create_table_if_not_found=True)
+            if self.spans_table is not None:
+                return self.spans_table
             self.spans_table = await self._get_or_create_table(
                 table_name=self.span_table_name,
                 table_type="spans",
@@ -360,6 +390,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.spans_table
 
         if table_type == "learnings":
+            if self.learnings_table is not None:
+                return self.learnings_table
             self.learnings_table = await self._get_or_create_table(
                 table_name=self.learnings_table_name,
                 table_type="learnings",

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -153,6 +153,21 @@ class PostgresDb(BaseDb):
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine, expire_on_commit=False))
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+        self.component_table: Optional[Table] = None
+        self.component_configs_table: Optional[Table] = None
+        self.component_links_table: Optional[Table] = None
+        self.learnings_table: Optional[Table] = None
+
     # -- Serialization methods --
     def to_dict(self):
         base = super().to_dict()
@@ -420,6 +435,8 @@ class PostgresDb(BaseDb):
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -428,6 +445,8 @@ class PostgresDb(BaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -436,6 +455,8 @@ class PostgresDb(BaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -444,6 +465,8 @@ class PostgresDb(BaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -452,6 +475,8 @@ class PostgresDb(BaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -460,6 +485,8 @@ class PostgresDb(BaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -468,6 +495,8 @@ class PostgresDb(BaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -476,6 +505,8 @@ class PostgresDb(BaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -488,6 +519,8 @@ class PostgresDb(BaseDb):
             if create_table_if_not_found:
                 self._get_table(table_type="traces", create_table_if_not_found=True)
 
+            if self.spans_table is not None:
+                return self.spans_table
             self.spans_table = self._get_or_create_table(
                 table_name=self.span_table_name,
                 table_type="spans",
@@ -496,6 +529,8 @@ class PostgresDb(BaseDb):
             return self.spans_table
 
         if table_type == "components":
+            if self.component_table is not None:
+                return self.component_table
             self.component_table = self._get_or_create_table(
                 table_name=self.components_table_name,
                 table_type="components",
@@ -504,6 +539,8 @@ class PostgresDb(BaseDb):
             return self.component_table
 
         if table_type == "component_configs":
+            if self.component_configs_table is not None:
+                return self.component_configs_table
             self.component_configs_table = self._get_or_create_table(
                 table_name=self.component_configs_table_name,
                 table_type="component_configs",
@@ -512,6 +549,8 @@ class PostgresDb(BaseDb):
             return self.component_configs_table
 
         if table_type == "component_links":
+            if self.component_links_table is not None:
+                return self.component_links_table
             self.component_links_table = self._get_or_create_table(
                 table_name=self.component_links_table_name,
                 table_type="component_links",
@@ -519,6 +558,8 @@ class PostgresDb(BaseDb):
             )
             return self.component_links_table
         if table_type == "learnings":
+            if self.learnings_table is not None:
+                return self.learnings_table
             self.learnings_table = self._get_or_create_table(
                 table_name=self.learnings_table_name,
                 table_type="learnings",

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -125,6 +125,17 @@ class SingleStoreDb(BaseDb):
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+
     # -- DB methods --
     def table_exists(self, table_name: str) -> bool:
         """Check if a table with the given name exists in the SingleStore database.
@@ -329,6 +340,8 @@ class SingleStoreDb(BaseDb):
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -337,6 +350,8 @@ class SingleStoreDb(BaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -345,6 +360,8 @@ class SingleStoreDb(BaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -353,6 +370,8 @@ class SingleStoreDb(BaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -361,6 +380,8 @@ class SingleStoreDb(BaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -369,6 +390,8 @@ class SingleStoreDb(BaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -377,6 +400,8 @@ class SingleStoreDb(BaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -385,6 +410,8 @@ class SingleStoreDb(BaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -393,6 +420,8 @@ class SingleStoreDb(BaseDb):
             return self.traces_table
 
         if table_type == "spans":
+            if self.spans_table is not None:
+                return self.spans_table
             # Ensure traces table exists first (for foreign key)
             if create_table_if_not_found:
                 self._get_table(table_type="traces", create_table_if_not_found=True)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -127,6 +127,18 @@ class AsyncSqliteDb(AsyncBaseDb):
         # Initialize database session factory
         self.async_session_factory = async_sessionmaker(bind=self.db_engine, expire_on_commit=False)
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+        self.learnings_table: Optional[Table] = None
+
     async def close(self) -> None:
         """Close database connections and dispose of the connection pool.
 
@@ -263,6 +275,8 @@ class AsyncSqliteDb(AsyncBaseDb):
 
     async def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = await self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type=table_type,
@@ -271,6 +285,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.session_table
 
         elif table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = await self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -279,6 +295,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.memory_table
 
         elif table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = await self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -287,6 +305,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.metrics_table
 
         elif table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = await self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -295,6 +315,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.eval_table
 
         elif table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = await self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -303,6 +325,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.knowledge_table
 
         elif table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = await self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -311,6 +335,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.culture_table
 
         elif table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = await self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -319,6 +345,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.versions_table
 
         elif table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = await self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -327,6 +355,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.traces_table
 
         elif table_type == "spans":
+            if self.spans_table is not None:
+                return self.spans_table
             # Ensure traces table exists first (spans has FK to traces)
             if create_table_if_not_found:
                 await self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -338,6 +368,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             return self.spans_table
 
         elif table_type == "learnings":
+            if self.learnings_table is not None:
+                return self.learnings_table
             self.learnings_table = await self._get_or_create_table(
                 table_name=self.learnings_table_name,
                 table_type="learnings",

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -137,6 +137,21 @@ class SqliteDb(BaseDb):
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
 
+        # Initialize table attributes for type checking
+        self.session_table: Optional[Table] = None
+        self.memory_table: Optional[Table] = None
+        self.metrics_table: Optional[Table] = None
+        self.eval_table: Optional[Table] = None
+        self.knowledge_table: Optional[Table] = None
+        self.traces_table: Optional[Table] = None
+        self.spans_table: Optional[Table] = None
+        self.culture_table: Optional[Table] = None
+        self.versions_table: Optional[Table] = None
+        self.components_table: Optional[Table] = None
+        self.component_configs_table: Optional[Table] = None
+        self.component_links_table: Optional[Table] = None
+        self.learnings_table: Optional[Table] = None
+
     # -- Serialization methods --
     def to_dict(self) -> Dict[str, Any]:
         base = super().to_dict()
@@ -403,6 +418,8 @@ class SqliteDb(BaseDb):
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type=table_type,
@@ -411,6 +428,8 @@ class SqliteDb(BaseDb):
             return self.session_table
 
         elif table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -419,6 +438,8 @@ class SqliteDb(BaseDb):
             return self.memory_table
 
         elif table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -427,6 +448,8 @@ class SqliteDb(BaseDb):
             return self.metrics_table
 
         elif table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -436,6 +459,8 @@ class SqliteDb(BaseDb):
             return self.eval_table
 
         elif table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -444,6 +469,8 @@ class SqliteDb(BaseDb):
             return self.knowledge_table
 
         elif table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -456,6 +483,8 @@ class SqliteDb(BaseDb):
             if create_table_if_not_found:
                 self._get_table(table_type="traces", create_table_if_not_found=True)
 
+            if self.spans_table is not None:
+                return self.spans_table
             self.spans_table = self._get_or_create_table(
                 table_name=self.span_table_name,
                 table_type="spans",
@@ -464,6 +493,8 @@ class SqliteDb(BaseDb):
             return self.spans_table
 
         elif table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -472,6 +503,8 @@ class SqliteDb(BaseDb):
             return self.culture_table
 
         elif table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -480,6 +513,8 @@ class SqliteDb(BaseDb):
             return self.versions_table
 
         elif table_type == "components":
+            if self.components_table is not None:
+                return self.components_table
             self.components_table = self._get_or_create_table(
                 table_name=self.components_table_name,
                 table_type="components",
@@ -492,6 +527,8 @@ class SqliteDb(BaseDb):
             if create_table_if_not_found:
                 self._get_table(table_type="components", create_table_if_not_found=True)
 
+            if self.component_configs_table is not None:
+                return self.component_configs_table
             self.component_configs_table = self._get_or_create_table(
                 table_name=self.component_configs_table_name,
                 table_type="component_configs",
@@ -505,6 +542,8 @@ class SqliteDb(BaseDb):
                 self._get_table(table_type="components", create_table_if_not_found=True)
                 self._get_table(table_type="component_configs", create_table_if_not_found=True)
 
+            if self.component_links_table is not None:
+                return self.component_links_table
             self.component_links_table = self._get_or_create_table(
                 table_name=self.component_links_table_name,
                 table_type="component_links",
@@ -512,6 +551,8 @@ class SqliteDb(BaseDb):
             )
             return self.component_links_table
         elif table_type == "learnings":
+            if self.learnings_table is not None:
+                return self.learnings_table
             self.learnings_table = self._get_or_create_table(
                 table_name=self.learnings_table_name,
                 table_type="learnings",


### PR DESCRIPTION
## Summary

Fixed connection explosion bug in `_get_table()` method by adding cache checks 
before calling `_get_or_create_table()`. This prevents redundant database 
connections when tables are already loaded.

Fixes #6257

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)
