### PR TITLE
fix: preserve custom routes from base_app during AgentOS resync()

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -242,6 +242,10 @@ class AgentOS:
         self.mcp_tools: List[Any] = []
         self._mcp_app: Optional[Any] = None
 
+        # Track routes managed by AgentOS for proper cleanup during resync
+        # Stores tuples of (path, frozenset of methods) to identify routes
+        self._managed_route_paths: set[tuple[str, frozenset[str]]] = set()
+
         self._initialize_agents()
         self._initialize_teams()
         self._initialize_workflows()
@@ -322,14 +326,19 @@ class AgentOS:
         if self.registry is not None:
             updated_routers.append(get_registry_router(registry=self.registry))
 
-        # Clear all previously existing routes
-        app.router.routes = [
-            route
-            for route in app.router.routes
-            if hasattr(route, "path")
-            and route.path in ["/docs", "/redoc", "/openapi.json", "/docs/oauth2-redirect"]
-            or route.path.startswith("/mcp")  # type: ignore
-        ]
+        # Clear only AgentOS-managed routes, preserving user-defined custom routes
+        # This ensures that custom routes from base_app are not deleted during resync
+        def _is_agentos_managed_route(route) -> bool:
+            """Check if a route was added by AgentOS."""
+            if not hasattr(route, "path") or not hasattr(route, "methods"):
+                return False
+            route_key = (route.path, frozenset(route.methods))
+            return route_key in self._managed_route_paths
+
+        app.router.routes = [route for route in app.router.routes if not _is_agentos_managed_route(route)]
+
+        # Clear the managed routes set before re-adding routes
+        self._managed_route_paths.clear()
 
         # Add the built-in routes
         self._add_built_in_routes(app=app)
@@ -811,6 +820,11 @@ class AgentOS:
         else:
             # No conflicts, add router normally
             fastapi_app.include_router(router)
+
+        # Track all routes from this router as managed by AgentOS
+        for route in router.routes:
+            if hasattr(route, "path") and hasattr(route, "methods"):
+                self._managed_route_paths.add((route.path, frozenset(route.methods)))
 
     def _get_telemetry_data(self) -> Dict[str, Any]:
         """Get the telemetry data for the OS"""

--- a/libs/agno/tests/integration/os/test_resync.py
+++ b/libs/agno/tests/integration/os/test_resync.py
@@ -738,22 +738,32 @@ class TestResyncPreservesCustomRoutes:
 
         with TestClient(app) as client:
             # Verify all custom routes work before resync
-            assert client.get("/status").status_code == 200
-            assert client.get("/custom/endpoint").status_code == 200
-            assert client.post("/custom/data").status_code == 200
-            assert client.put("/custom/update").status_code == 200
-            assert client.delete("/custom/delete").status_code == 200
+            status_response = client.get("/status")
+            assert status_response.status_code == 200
+            custom_endpoint_response = client.get("/custom/endpoint")
+            assert custom_endpoint_response.status_code == 200
+            post_data_response = client.post("/custom/data")
+            assert post_data_response.status_code == 200
+            update_data_response = client.put("/custom/update")
+            assert update_data_response.status_code == 200
+            delete_data_response = client.delete("/custom/delete")
+            assert delete_data_response.status_code == 200
 
             # Add new agent and resync
             agent_os.agents.append(second_agent)
             agent_os.resync(app=app)
 
             # Verify all custom routes still work after resync
-            assert client.get("/status").status_code == 200, "GET /status was deleted"
-            assert client.get("/custom/endpoint").status_code == 200, "GET /custom/endpoint was deleted"
-            assert client.post("/custom/data").status_code == 200, "POST /custom/data was deleted"
-            assert client.put("/custom/update").status_code == 200, "PUT /custom/update was deleted"
-            assert client.delete("/custom/delete").status_code == 200, "DELETE /custom/delete was deleted"
+            status_response = client.get("/status")
+            assert status_response.status_code == 200, "GET /status was deleted"
+            custom_endpoint_response = client.get("/custom/endpoint")
+            assert custom_endpoint_response.status_code == 200, "GET /custom/endpoint was deleted"
+            post_data_response = client.post("/custom/data")
+            assert post_data_response.status_code == 200, "POST /custom/data was deleted"
+            update_data_response = client.put("/custom/update")
+            assert update_data_response.status_code == 200, "PUT /custom/update was deleted"
+            delete_data_response = client.delete("/custom/delete")
+            assert delete_data_response.status_code == 200, "DELETE /custom/delete was deleted"
 
     def test_resync_preserves_custom_routes_after_multiple_resyncs(self, test_agent: Agent):
         """Test that custom routes are preserved after multiple resync calls."""


### PR DESCRIPTION
## Summary

 When using AgentOS with a custom FastAPI app via `base_app`, calling `resync()` after modifying the agents list would delete all user-defined routes. This happened  because `_reprovision_routers()` cleared all routes except documentation endpoints (`/docs`, `/redoc`, etc.) and `/mcp` routes.
 
   - Added `_managed_route_paths` attribute to track routes registered by AgentOS                                                                                         
  - Modified `_add_router()` to record each route added as `(path, methods)` tuples                                                                                      
  - Modified `_reprovision_routers()` to only remove routes in `_managed_route_paths` instead of using a whitelist approach                                                    
                                                                                                                                                                         
  Fixes #5860   


(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
