### PR TITLE
[fix] deep_copy() TypeError for agents inside teams/workflows

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -10172,29 +10172,49 @@ class Team:
         """
         from dataclasses import fields
 
-        # Extract the fields to set for the new Team
+        from agno.utils.deep_copy import get_init_params
+
+        init_params = get_init_params(self.__class__)
+
         fields_for_new_team: Dict[str, Any] = {}
+        non_init_fields: Dict[str, Any] = {}
 
         for f in fields(self):
-            # Skip private fields (not part of __init__ signature)
             if f.name.startswith("_"):
                 continue
 
             field_value = getattr(self, f.name)
+            is_init = f.name in init_params
+
             if field_value is not None:
                 try:
-                    fields_for_new_team[f.name] = self._deep_copy_field(f.name, field_value)
+                    copied = self._deep_copy_field(f.name, field_value)
                 except Exception as e:
                     log_warning(f"Failed to deep copy field '{f.name}': {e}. Using original value.")
-                    fields_for_new_team[f.name] = field_value
+                    copied = field_value
+            elif is_init:
+                # Preserve explicit None for init fields (avoids inheriting non-None defaults)
+                copied = None
+            else:
+                # Non-init fields default to None on new instances, no need to copy
+                continue
 
-        # Update fields if provided
+            if is_init:
+                fields_for_new_team[f.name] = copied
+            else:
+                non_init_fields[f.name] = copied
+
         if update:
-            fields_for_new_team.update(update)
+            for key, value in update.items():
+                if key in init_params:
+                    fields_for_new_team[key] = value
+                else:
+                    non_init_fields[key] = value
 
-        # Create a new Team
         try:
             new_team = self.__class__(**fields_for_new_team)
+            for field_name, field_value in non_init_fields.items():
+                setattr(new_team, field_name, field_value)
             log_debug(f"Created new {self.__class__.__name__}")
             return new_team
         except Exception as e:

--- a/libs/agno/agno/utils/deep_copy.py
+++ b/libs/agno/agno/utils/deep_copy.py
@@ -1,0 +1,21 @@
+"""Utilities for deep_copy() in Agent, Team, and Workflow.
+
+These classes use @dataclass(init=False) with custom __init__ methods that don't
+accept all dataclass fields (e.g. team_id, workflow_id are set at runtime).
+deep_copy() must only pass init-accepted fields to the constructor, then restore
+non-init fields via setattr.
+"""
+
+import inspect
+from functools import lru_cache
+from typing import FrozenSet, Type
+
+
+@lru_cache(maxsize=None)
+def get_init_params(cls: Type) -> FrozenSet[str]:
+    """Return the set of parameter names accepted by cls.__init__ (excluding 'self').
+
+    Results are cached per class since __init__ signatures don't change at runtime.
+    """
+    sig = inspect.signature(cls.__init__)
+    return frozenset(name for name in sig.parameters if name != "self")

--- a/libs/agno/tests/unit/agent/test_basic.py
+++ b/libs/agno/tests/unit/agent/test_basic.py
@@ -54,3 +54,41 @@ def test_deep_copy():
     # Test deep_copy with update
     updated = original.deep_copy(update={"name": "updated-agent"})
     assert updated.name == "updated-agent"
+
+
+def test_deep_copy_with_non_init_fields():
+    """Test that deep_copy() works when non-init fields (team_id, workflow_id) are set.
+
+    These fields are dataclass fields but NOT parameters of __init__, so passing
+    them to the constructor raises TypeError. deep_copy() should handle this by
+    restoring them via setattr after construction.
+    """
+    agent = Agent(name="test-agent")
+    agent.team_id = "team-123"
+    agent.workflow_id = "workflow-456"
+
+    # This should not raise TypeError about unexpected keyword arguments
+    copied = agent.deep_copy()
+
+    assert copied is not agent
+    assert copied.name == "test-agent"
+    assert copied.team_id == "team-123"
+    assert copied.workflow_id == "workflow-456"
+
+
+def test_deep_copy_update_with_non_init_fields():
+    """Test that deep_copy(update=...) works for non-init fields."""
+    agent = Agent(name="test-agent")
+    agent.team_id = "team-123"
+
+    # Update a non-init field via the update dict
+    copied = agent.deep_copy(update={"team_id": "new-team-id"})
+
+    assert copied.team_id == "new-team-id"
+    assert copied.name == "test-agent"
+
+    # Update both init and non-init fields
+    copied2 = agent.deep_copy(update={"name": "new-name", "workflow_id": "wf-789"})
+    assert copied2.name == "new-name"
+    assert copied2.workflow_id == "wf-789"
+    assert copied2.team_id == "team-123"


### PR DESCRIPTION
## Summary

`deep_copy()` on Agent, Team, and Workflow crashes with `TypeError` when runtime-assigned dataclass fields (`team_id`, `workflow_id`, `parent_team_id`, `websocket_handler`) have values set. This breaks AgentOS per-request isolation for any agent that's part of a Team or Workflow.

**Root cause:** These classes use `@dataclass(init=False)` with custom `__init__` methods that don't accept all dataclass fields. The previous `deep_copy()` passed all fields to the constructor, which rejects the ones it doesn't recognize.

**Fix:** Introspect the `__init__` signature to partition fields into init-accepted vs non-init. Only pass init-accepted fields to the constructor, then restore non-init fields via `setattr`.

**Reproducer:**
```python
agent = Agent(name="test")
agent.team_id = "team-123"  # Set by Team._initialize_member() at runtime
agent.deep_copy()  # TypeError: Agent.__init__() got an unexpected keyword argument 'team_id'
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- New utility `libs/agno/agno/utils/deep_copy.py` with `get_init_params()` — uses `inspect.signature` + `lru_cache` since `@dataclass(init=False)` makes field metadata unreliable for determining what `__init__` accepts.
- Also fixes a pre-existing issue where init fields explicitly set to `None` would inherit non-None defaults instead of preserving `None`.
- 8 new tests covering `team_id`, `workflow_id`, `parent_team_id`, `websocket_handler`, nested teams, and update dicts with non-init fields.