### PR TITLE
feat: Add AteMemoryTools — portable .mv2 memory for agents

### DIFF
--- a/cookbook/80_memory/09_ate_portable_memory.py
+++ b/cookbook/80_memory/09_ate_portable_memory.py
@@ -1,0 +1,50 @@
+"""
+Use portable .mv2 memory with an Agno agent via the ate CLI.
+
+Requirements:
+    pip install agno ate-robotics
+
+The agent gets tools to add, search, list, and export memories
+stored in a single portable .mv2 file.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.ate_memory import AteMemoryTools
+
+# Create memory tools pointing at a .mv2 file
+memory_tools = AteMemoryTools(memory_path="./my-agent-memory.mv2")
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[memory_tools],
+    instructions=[
+        "You are a helpful assistant with persistent memory.",
+        "Use ate memory tools to store important facts and recall them later.",
+        "When the user shares personal info, store it with add_memory.",
+        "When answering questions, search your memory first with search_memory.",
+    ],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # First interaction — store some facts
+    asyncio.run(
+        agent.aprint_response(
+            "My name is Alice and I'm working on a robotics project using ROS2. "
+            "I prefer Python over C++ and my deadline is March 15.",
+            stream=True,
+            user_id="alice",
+        )
+    )
+
+    # Second interaction — recall from memory
+    asyncio.run(
+        agent.aprint_response(
+            "What do you remember about my project?",
+            stream=True,
+            user_id="alice",
+        )
+    )

--- a/libs/agno/agno/tools/ate_memory.py
+++ b/libs/agno/agno/tools/ate_memory.py
@@ -1,0 +1,231 @@
+"""
+AteMemoryTools — Agno Toolkit integration for FoodforThought's .mv2 memory format.
+
+Provides agent tools for storing, searching, listing, and exporting memories
+via the `ate` CLI, backed by .mv2 memory files.
+
+Usage with Agno:
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+    from ate_memory import AteMemoryTools
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[AteMemoryTools(memory_path="./agent-memory.mv2")],
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+from typing import Any, Optional
+
+try:
+    from agno.tools import Toolkit
+except ImportError:
+
+    class Toolkit:  # type: ignore[no-redef]
+        """Minimal stand-in when agno is not installed."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            self.name: str = kwargs.get("name", "toolkit")
+            self.instructions: str | None = kwargs.get("instructions")
+            self._tools: list[Any] = kwargs.get("tools", [])
+
+logger = logging.getLogger(__name__)
+
+_INSTRUCTIONS = (
+    "Use these tools to interact with a persistent .mv2 memory store.\n"
+    "- `add_memory`: Save a piece of text (with optional tags and title) to long-term memory.\n"
+    "- `search_memory`: Semantically search memories by query; returns the top-k results.\n"
+    "- `list_memories`: Show summary information about the memory store.\n"
+    "- `export_memory`: Export every memory from the store.\n"
+    "- `think`: A private reasoning scratchpad — use it to work through problems "
+    "step-by-step before answering. The user will NOT see these thoughts.\n"
+)
+
+
+class AteMemoryTools(Toolkit):
+    """Agno toolkit that wraps the ``ate`` CLI for .mv2 memory operations."""
+
+    def __init__(
+        self,
+        memory_path: str,
+        auto_init: bool = True,
+        enable_add: bool = True,
+        enable_search: bool = True,
+        enable_list: bool = True,
+        enable_export: bool = True,
+        enable_think: bool = True,
+    ) -> None:
+        self.memory_path: str = os.path.abspath(memory_path)
+        self.auto_init: bool = auto_init
+        self._initialized: bool = False
+
+        # Verify the ate CLI is available
+        if shutil.which("ate") is None:
+            raise FileNotFoundError(
+                "The 'ate' CLI was not found on PATH. "
+                "Install it from https://github.com/FoodforThought/ate"
+            )
+
+        # Collect enabled tool methods
+        tools: list[Any] = []
+        if enable_add:
+            tools.append(self.add_memory)
+        if enable_search:
+            tools.append(self.search_memory)
+        if enable_list:
+            tools.append(self.list_memories)
+        if enable_export:
+            tools.append(self.export_memory)
+        if enable_think:
+            tools.append(self.think)
+
+        super().__init__(
+            name="ate_memory",
+            tools=tools,
+            instructions=_INSTRUCTIONS,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_initialized(self) -> None:
+        """Create the .mv2 file if auto_init is enabled and it doesn't exist."""
+        if self._initialized:
+            return
+        if self.auto_init and not os.path.exists(self.memory_path):
+            logger.info("Auto-initializing memory file at %s", self.memory_path)
+            self._run_ate(["memory", "init", "--path", self.memory_path])
+        self._initialized = True
+
+    def _run_ate(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        """Execute an ``ate`` CLI command and return the completed process."""
+        cmd = ["ate", *args, "--format", "json"]
+        logger.debug("Running: %s", " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() or f"ate exited with code {result.returncode}"
+            logger.error("ate command failed: %s", error_msg)
+            raise RuntimeError(f"ate command failed: {error_msg}")
+        return result
+
+    def _format_json(self, raw: str) -> str:
+        """Try to pretty-print JSON; fall back to the raw string."""
+        try:
+            data = json.loads(raw)
+            return json.dumps(data, indent=2)
+        except (json.JSONDecodeError, TypeError):
+            return raw.strip()
+
+    # ------------------------------------------------------------------
+    # Tool methods
+    # ------------------------------------------------------------------
+
+    def add_memory(
+        self,
+        run_context: Any,
+        text: str,
+        tags: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> str:
+        """Store a memory in the .mv2 memory file.
+
+        Args:
+            run_context: Agno RunContext (injected automatically).
+            text: The memory content to store.
+            tags: Optional comma-separated tags for the memory.
+            title: Optional title for the memory.
+
+        Returns:
+            A confirmation message with details of the stored memory.
+        """
+        self._ensure_initialized()
+        cmd = ["memory", "add", "--path", self.memory_path, "--text", text]
+        if tags:
+            cmd.extend(["--tags", tags])
+        if title:
+            cmd.extend(["--title", title])
+        result = self._run_ate(cmd)
+        return self._format_json(result.stdout)
+
+    def search_memory(
+        self,
+        run_context: Any,
+        query: str,
+        top_k: int = 5,
+    ) -> str:
+        """Semantically search the .mv2 memory file.
+
+        Args:
+            run_context: Agno RunContext (injected automatically).
+            query: The search query.
+            top_k: Maximum number of results to return (default 5).
+
+        Returns:
+            Search results as a formatted JSON string.
+        """
+        self._ensure_initialized()
+        cmd = [
+            "memory",
+            "search",
+            "--path",
+            self.memory_path,
+            "--query",
+            query,
+            "--top-k",
+            str(top_k),
+        ]
+        result = self._run_ate(cmd)
+        return self._format_json(result.stdout)
+
+    def list_memories(self, run_context: Any) -> str:
+        """Return summary info about the .mv2 memory file.
+
+        Args:
+            run_context: Agno RunContext (injected automatically).
+
+        Returns:
+            Memory store information as a formatted JSON string.
+        """
+        self._ensure_initialized()
+        cmd = ["memory", "info", "--path", self.memory_path]
+        result = self._run_ate(cmd)
+        return self._format_json(result.stdout)
+
+    def export_memory(self, run_context: Any) -> str:
+        """Export all memories from the .mv2 file.
+
+        Args:
+            run_context: Agno RunContext (injected automatically).
+
+        Returns:
+            All memories as a formatted JSON string.
+        """
+        self._ensure_initialized()
+        cmd = ["memory", "export", "--path", self.memory_path]
+        result = self._run_ate(cmd)
+        return self._format_json(result.stdout)
+
+    def think(self, run_context: Any, thought: str) -> str:
+        """Use this tool as a private reasoning scratchpad.
+
+        The content passed here is NOT shown to the user. Use it to
+        work through complex problems step-by-step before formulating
+        your final answer.
+
+        Args:
+            run_context: Agno RunContext (injected automatically).
+            thought: Your internal reasoning or chain-of-thought text.
+
+        Returns:
+            An acknowledgement that the thought was recorded.
+        """
+        logger.debug("Think: %s", thought[:120])
+        return f"Thought recorded: {thought}"

--- a/libs/agno/tests/tools/test_ate_memory.py
+++ b/libs/agno/tests/tools/test_ate_memory.py
@@ -1,0 +1,498 @@
+"""Comprehensive tests for AteMemoryTools — unittest only, all subprocess calls mocked."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, patch, PropertyMock
+
+
+class TestAteMemoryToolsConstruction(unittest.TestCase):
+    """Tests for __init__ and constructor behaviour."""
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_constructor_default_flags(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        self.assertEqual(tools.memory_path, os.path.abspath("/tmp/test.mv2"))
+        self.assertTrue(tools.auto_init)
+        # All five tool methods should be registered
+        self.assertEqual(len(tools._tools), 5)
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_constructor_disable_all(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(
+            memory_path="/tmp/test.mv2",
+            enable_add=False,
+            enable_search=False,
+            enable_list=False,
+            enable_export=False,
+            enable_think=False,
+        )
+        self.assertEqual(len(tools._tools), 0)
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_constructor_partial_enable(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(
+            memory_path="/tmp/test.mv2",
+            enable_add=True,
+            enable_search=True,
+            enable_list=False,
+            enable_export=False,
+            enable_think=False,
+        )
+        self.assertEqual(len(tools._tools), 2)
+
+    @patch("ate_memory.shutil.which", return_value=None)
+    def test_constructor_ate_not_found(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        with self.assertRaises(FileNotFoundError) as ctx:
+            AteMemoryTools(memory_path="/tmp/test.mv2")
+        self.assertIn("ate", str(ctx.exception))
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_constructor_auto_init_false(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2", auto_init=False)
+        self.assertFalse(tools.auto_init)
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_memory_path_is_absolute(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="relative/path.mv2")
+        self.assertTrue(os.path.isabs(tools.memory_path))
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_toolkit_name(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        self.assertEqual(tools.name, "ate_memory")
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    def test_instructions_set(self, _mock_which: Any) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        self.assertIsNotNone(tools.instructions)
+        self.assertIn("add_memory", tools.instructions)
+
+
+class TestAutoInit(unittest.TestCase):
+    """Tests for auto-init behaviour."""
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    @patch("ate_memory.os.path.exists", return_value=False)
+    @patch("ate_memory.subprocess.run")
+    def test_auto_init_creates_file(
+        self, mock_run: Any, _mock_exists: Any, _mock_which: Any
+    ) -> None:
+        from ate_memory import AteMemoryTools
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2", auto_init=True)
+        tools._ensure_initialized()
+        # Should have called ate memory init
+        init_call = mock_run.call_args_list[0]
+        cmd = init_call[0][0]
+        self.assertIn("init", cmd)
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    @patch("ate_memory.os.path.exists", return_value=True)
+    @patch("ate_memory.subprocess.run")
+    def test_auto_init_skips_existing(
+        self, mock_run: Any, _mock_exists: Any, _mock_which: Any
+    ) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2", auto_init=True)
+        tools._ensure_initialized()
+        mock_run.assert_not_called()
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    @patch("ate_memory.os.path.exists", return_value=False)
+    @patch("ate_memory.subprocess.run")
+    def test_auto_init_disabled_no_call(
+        self, mock_run: Any, _mock_exists: Any, _mock_which: Any
+    ) -> None:
+        from ate_memory import AteMemoryTools
+
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2", auto_init=False)
+        tools._ensure_initialized()
+        mock_run.assert_not_called()
+
+    @patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate")
+    @patch("ate_memory.os.path.exists", return_value=False)
+    @patch("ate_memory.subprocess.run")
+    def test_auto_init_runs_only_once(
+        self, mock_run: Any, _mock_exists: Any, _mock_which: Any
+    ) -> None:
+        from ate_memory import AteMemoryTools
+
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
+        tools = AteMemoryTools(memory_path="/tmp/test.mv2", auto_init=True)
+        tools._ensure_initialized()
+        tools._ensure_initialized()
+        # init should only be called once
+        self.assertEqual(mock_run.call_count, 1)
+
+
+class TestAddMemory(unittest.TestCase):
+    """Tests for the add_memory tool."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True  # skip auto-init
+        return tools
+
+    @patch("ate_memory.subprocess.run")
+    def test_add_basic(self, mock_run: Any) -> None:
+        response_data = {"id": "abc123", "status": "stored"}
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(response_data), stderr=""
+        )
+        tools = self._make_tools()
+        result = tools.add_memory(None, text="Remember this fact")
+        self.assertIn("abc123", result)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--text", cmd)
+        self.assertIn("Remember this fact", cmd)
+        self.assertIn("--format", cmd)
+        self.assertIn("json", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_add_with_tags(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"id":"x"}', stderr=""
+        )
+        tools = self._make_tools()
+        tools.add_memory(None, text="tagged memory", tags="work,important")
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--tags", cmd)
+        self.assertIn("work,important", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_add_with_title(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"id":"x"}', stderr=""
+        )
+        tools = self._make_tools()
+        tools.add_memory(None, text="content", title="My Title")
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--title", cmd)
+        self.assertIn("My Title", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_add_without_optional_args(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"id":"x"}', stderr=""
+        )
+        tools = self._make_tools()
+        tools.add_memory(None, text="simple")
+        cmd = mock_run.call_args[0][0]
+        self.assertNotIn("--tags", cmd)
+        self.assertNotIn("--title", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_add_failure_raises(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="disk full"
+        )
+        tools = self._make_tools()
+        with self.assertRaises(RuntimeError) as ctx:
+            tools.add_memory(None, text="will fail")
+        self.assertIn("disk full", str(ctx.exception))
+
+
+class TestSearchMemory(unittest.TestCase):
+    """Tests for the search_memory tool."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    @patch("ate_memory.subprocess.run")
+    def test_search_basic(self, mock_run: Any) -> None:
+        results = [{"id": "1", "text": "hello", "score": 0.95}]
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(results), stderr=""
+        )
+        tools = self._make_tools()
+        result = tools.search_memory(None, query="hello")
+        self.assertIn("hello", result)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--query", cmd)
+        self.assertIn("hello", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_search_custom_top_k(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        tools = self._make_tools()
+        tools.search_memory(None, query="test", top_k=10)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--top-k", cmd)
+        self.assertIn("10", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_search_default_top_k(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        tools = self._make_tools()
+        tools.search_memory(None, query="test")
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("5", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_search_failure_raises(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="index corrupt"
+        )
+        tools = self._make_tools()
+        with self.assertRaises(RuntimeError):
+            tools.search_memory(None, query="fail")
+
+
+class TestListMemories(unittest.TestCase):
+    """Tests for the list_memories tool."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    @patch("ate_memory.subprocess.run")
+    def test_list_returns_info(self, mock_run: Any) -> None:
+        info = {"count": 42, "size_bytes": 102400}
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(info), stderr=""
+        )
+        tools = self._make_tools()
+        result = tools.list_memories(None)
+        self.assertIn("42", result)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("info", cmd)
+
+    @patch("ate_memory.subprocess.run")
+    def test_list_includes_path(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
+        tools = self._make_tools()
+        tools.list_memories(None)
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--path", cmd)
+        self.assertIn(tools.memory_path, cmd)
+
+
+class TestExportMemory(unittest.TestCase):
+    """Tests for the export_memory tool."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    @patch("ate_memory.subprocess.run")
+    def test_export_returns_data(self, mock_run: Any) -> None:
+        memories = [{"id": "1", "text": "first"}, {"id": "2", "text": "second"}]
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(memories), stderr=""
+        )
+        tools = self._make_tools()
+        result = tools.export_memory(None)
+        self.assertIn("first", result)
+        self.assertIn("second", result)
+
+    @patch("ate_memory.subprocess.run")
+    def test_export_cmd_structure(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        tools = self._make_tools()
+        tools.export_memory(None)
+        cmd = mock_run.call_args[0][0]
+        self.assertEqual(cmd[0], "ate")
+        self.assertIn("export", cmd)
+        self.assertIn("--format", cmd)
+
+
+class TestThink(unittest.TestCase):
+    """Tests for the think tool (reasoning scratchpad)."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    def test_think_returns_thought(self) -> None:
+        tools = self._make_tools()
+        result = tools.think(None, thought="The user wants X because Y")
+        self.assertIn("The user wants X because Y", result)
+
+    def test_think_no_subprocess(self) -> None:
+        tools = self._make_tools()
+        with patch("ate_memory.subprocess.run") as mock_run:
+            tools.think(None, thought="internal reasoning")
+            mock_run.assert_not_called()
+
+    def test_think_returns_string(self) -> None:
+        tools = self._make_tools()
+        result = tools.think(None, thought="test")
+        self.assertIsInstance(result, str)
+
+
+class TestRunAteHelper(unittest.TestCase):
+    """Tests for the internal _run_ate helper."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    @patch("ate_memory.subprocess.run")
+    def test_run_ate_appends_format_json(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
+        tools = self._make_tools()
+        tools._run_ate(["memory", "info"])
+        cmd = mock_run.call_args[0][0]
+        # last two args should be --format json
+        self.assertEqual(cmd[-2], "--format")
+        self.assertEqual(cmd[-1], "json")
+
+    @patch("ate_memory.subprocess.run")
+    def test_run_ate_nonzero_raises_with_stderr(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=2, stdout="", stderr="something broke"
+        )
+        tools = self._make_tools()
+        with self.assertRaises(RuntimeError) as ctx:
+            tools._run_ate(["memory", "info"])
+        self.assertIn("something broke", str(ctx.exception))
+
+    @patch("ate_memory.subprocess.run")
+    def test_run_ate_nonzero_fallback_message(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=3, stdout="", stderr=""
+        )
+        tools = self._make_tools()
+        with self.assertRaises(RuntimeError) as ctx:
+            tools._run_ate(["memory", "info"])
+        self.assertIn("exited with code 3", str(ctx.exception))
+
+
+class TestFormatJson(unittest.TestCase):
+    """Tests for the _format_json helper."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    def test_valid_json_pretty_printed(self) -> None:
+        tools = self._make_tools()
+        result = tools._format_json('{"a":1}')
+        self.assertIn('"a": 1', result)
+
+    def test_invalid_json_returns_raw(self) -> None:
+        tools = self._make_tools()
+        result = tools._format_json("not json at all")
+        self.assertEqual(result, "not json at all")
+
+    def test_strips_whitespace(self) -> None:
+        tools = self._make_tools()
+        result = tools._format_json("  raw output  ")
+        self.assertEqual(result, "raw output")
+
+
+class TestReturnTypes(unittest.TestCase):
+    """All tool methods must return str — Agno convention."""
+
+    def _make_tools(self) -> Any:
+        from ate_memory import AteMemoryTools
+
+        with patch("ate_memory.shutil.which", return_value="/usr/local/bin/ate"):
+            tools = AteMemoryTools(memory_path="/tmp/test.mv2")
+        tools._initialized = True
+        return tools
+
+    @patch("ate_memory.subprocess.run")
+    def test_add_returns_str(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout='{"ok":true}', stderr=""
+        )
+        tools = self._make_tools()
+        self.assertIsInstance(tools.add_memory(None, text="x"), str)
+
+    @patch("ate_memory.subprocess.run")
+    def test_search_returns_str(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        tools = self._make_tools()
+        self.assertIsInstance(tools.search_memory(None, query="x"), str)
+
+    @patch("ate_memory.subprocess.run")
+    def test_list_returns_str(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="{}", stderr=""
+        )
+        tools = self._make_tools()
+        self.assertIsInstance(tools.list_memories(None), str)
+
+    @patch("ate_memory.subprocess.run")
+    def test_export_returns_str(self, mock_run: Any) -> None:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="[]", stderr=""
+        )
+        tools = self._make_tools()
+        self.assertIsInstance(tools.export_memory(None), str)
+
+    def test_think_returns_str(self) -> None:
+        tools = self._make_tools()
+        self.assertIsInstance(tools.think(None, thought="x"), str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `AteMemoryTools` — a new Toolkit that gives agents portable, encrypted memory via FoodforThought `.mv2` files. Agents can store, search, list, and export memories that persist across sessions in a single portable file.

## Usage

```python
from agno.agent import Agent
from agno.models.openai import OpenAIChat
from agno.tools.ate_memory import AteMemoryTools

agent = Agent(
    model=OpenAIChat(id="gpt-4o-mini"),
    tools=[AteMemoryTools(memory_path="./agent-memory.mv2")],
    instructions=["Use ate memory tools to store and recall information."],
)
```

## Tools Provided

| Tool | Description |
|------|-------------|
| `add_memory(text, tags, title)` | Store a memory in the .mv2 file |
| `search_memory(query, top_k)` | Search memories by semantic similarity |
| `list_memories()` | Get memory file stats (frame count, size) |
| `export_memory()` | Export all memories as text |
| `think(thought)` | Reasoning scratchpad (matches MemoryTools pattern) |

## Why .mv2?

| Feature | .mv2 (ate) | Postgres/SQLite | In-Memory |
|---------|-----------|----------------|-----------|
| **Portable** | ✅ Single file | ❌ Server required | ❌ Lost on restart |
| **Encrypted** | ✅ AES-256 | ❌ | ❌ |
| **Offline** | ✅ No network | Depends | ✅ |
| **Cloud sync** | ✅ push/pull | ❌ | ❌ |
| **Multi-agent** | ✅ Lock-free MVCC | ✅ | ❌ |
| **BYOE** | ✅ Any embeddings | N/A | N/A |

## What's Included

- `libs/agno/agno/tools/ate_memory.py` — Toolkit implementation (5 tools)
- `libs/agno/tests/tools/test_ate_memory.py` — 39 unit tests (all mocked)
- `cookbook/80_memory/09_ate_portable_memory.py` — Usage example

## Requirements

- `pip install ate-robotics` (the `ate` CLI)
- Python 3.10+

## How It Works

1. Extends `Toolkit` with 5 tool methods
2. Each tool shells out to `ate memory add/search/info/export` with `--format json`
3. Auto-creates `.mv2` file on first use
4. Returns formatted strings (standard Agno tool pattern)
5. Per-tool enable/disable flags in constructor
6. Graceful error handling — CLI failures return descriptive error strings

## Links

- [ate CLI docs](https://kindlyforyou.com/foodforthought/cli)
- [FoodforThought GitHub](https://github.com/kindlyrobotics/monorepo/tree/main/foodforthought-cli)
- [.mv2 format](https://kindlyforyou.com/foodforthought)