### PR TITLE
fix: handle reasoning_text.delta events in streaming

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1034,9 +1034,9 @@ class OpenAIResponses(Model):
         elif stream_event.type == "response.output_text.delta":
             model_response.content = stream_event.delta
 
-            # Treat the output_text deltas as reasoning content if the reasoning summary is not requested.
-            if self.reasoning is not None and self.reasoning_summary is None:
-                model_response.reasoning_content = stream_event.delta
+        # 3.5. Add reasoning content from reasoning_text events
+        elif stream_event.type == "response.reasoning_text.delta":
+            model_response.reasoning_content = stream_event.delta
 
         # 4. Add tool calls information
 


### PR DESCRIPTION
## Summary

Fixes incorrect handling of reasoning content in streaming responses when using OpenRouter. The current implementation uses fallback logic that incorrectly duplicates `output_text` as `reasoning_content`, causing models accessed via OpenRouter to show duplicate content in the reasoning field.

This PR adds a dedicated handler for `response.reasoning_text.delta` events and removes the problematic fallback logic, ensuring proper separation between regular output and reasoning content.

**Problem:**
- Models accessed via OpenRouter incorrectly populate `reasoning_content` with duplicated output text
- The fallback logic `if self.reasoning is not None and self.reasoning_summary is None` triggers false positives
- True reasoning models that send separate `response.reasoning_text.delta` events work correctly, but the fallback creates confusion for non-reasoning models

**Solution:**
- Remove fallback logic that duplicates `output_text` as `reasoning_content`
- Add dedicated `elif` handler for `response.reasoning_text.delta` events
- Let the API event stream determine whether reasoning content exists based on actual events received

**Testing Results:**
- Non-reasoning models via OpenRouter: Only content field populated, no reasoning duplication
- True reasoning models (e.g., minimax/minimax-m2.1): Separate reasoning and content fields working correctly
- Verified with raw API event inspection showing different event types for reasoning vs non-reasoning models

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

**Files Changed:**
- `libs/agno/agno/models/openai/responses.py` - Modified `_parse_provider_response_delta` method

**Impact:**
- Non-breaking change
- Fixes behavior for models accessed via OpenRouter
- Maintains correct behavior for native OpenAI reasoning models
- No changes to public API or method signatures

**Verification:**
Tested with raw OpenRouter API event inspection to confirm:
1. Non-reasoning models (via OpenRouter) only send `response.output_text.delta` events
2. True reasoning models send separate `response.reasoning_text.delta` events
3. The fix correctly handles both scenarios without false positives

**Models Tested:**
- Non-reasoning models via OpenRouter
- `minimax/minimax-m2.1` via OpenRouter (reasoning model)