### PR TITLE
feat: make all telemetry calls fire-and-forget

### DIFF
--- a/libs/agno/agno/agent/_telemetry.py
+++ b/libs/agno/agno/agent/_telemetry.py
@@ -37,44 +37,44 @@ def get_telemetry_data(agent: Agent) -> Dict[str, Any]:
 
 
 def log_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = None) -> None:
-    """Send a telemetry event to the API for a created Agent run."""
+    """Fire-and-forget telemetry event for a created Agent run."""
     from agno.agent import _init
 
     _init.set_telemetry(agent)
     if not agent.telemetry:
         return
 
+    from agno.api._executor import get_telemetry_executor
     from agno.api.agent import AgentRunCreate, create_agent_run
 
     try:
-        create_agent_run(
-            run=AgentRunCreate(
-                session_id=session_id,
-                run_id=run_id,
-                data=get_telemetry_data(agent),
-            ),
+        run = AgentRunCreate(
+            session_id=session_id,
+            run_id=run_id,
+            data=get_telemetry_data(agent),
         )
+        get_telemetry_executor().submit(create_agent_run, run)
     except Exception as e:
-        log_debug(f"Could not create Agent run telemetry event: {e}")
+        log_debug(f"Could not submit Agent run telemetry event: {e}")
 
 
 async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = None) -> None:
-    """Send a telemetry event to the API for a created Agent async run."""
+    """Fire-and-forget telemetry event for a created Agent async run."""
     from agno.agent import _init
 
     _init.set_telemetry(agent)
     if not agent.telemetry:
         return
 
-    from agno.api.agent import AgentRunCreate, acreate_agent_run
+    from agno.api._executor import get_telemetry_executor
+    from agno.api.agent import AgentRunCreate, create_agent_run
 
     try:
-        await acreate_agent_run(
-            run=AgentRunCreate(
-                session_id=session_id,
-                run_id=run_id,
-                data=get_telemetry_data(agent),
-            )
+        run = AgentRunCreate(
+            session_id=session_id,
+            run_id=run_id,
+            data=get_telemetry_data(agent),
         )
+        get_telemetry_executor().submit(create_agent_run, run)
     except Exception as e:
-        log_debug(f"Could not create Agent run telemetry event: {e}")
+        log_debug(f"Could not submit Agent run telemetry event: {e}")

--- a/libs/agno/agno/agent/_telemetry.py
+++ b/libs/agno/agno/agent/_telemetry.py
@@ -41,9 +41,11 @@ def log_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = N
     if not agent.telemetry:
         return
 
-    from agno.api.agent import AgentRunCreate, create_agent_run
-
+    # Everything telemetry needs, the import included, stays inside the try:
+    # a telemetry failure must never change the outcome of the run.
     try:
+        from agno.api.agent import AgentRunCreate, create_agent_run
+
         create_agent_run(
             run=AgentRunCreate(
                 session_id=session_id,
@@ -63,9 +65,9 @@ async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[s
     if not agent.telemetry:
         return
 
-    from agno.api.agent import AgentRunCreate, acreate_agent_run
-
     try:
+        from agno.api.agent import AgentRunCreate, acreate_agent_run
+
         await acreate_agent_run(
             run=AgentRunCreate(
                 session_id=session_id,

--- a/libs/agno/agno/api/_executor.py
+++ b/libs/agno/agno/api/_executor.py
@@ -1,0 +1,32 @@
+"""Shared background executor for fire-and-forget telemetry."""
+
+from __future__ import annotations
+
+import atexit
+from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
+
+_telemetry_executor: Optional[ThreadPoolExecutor] = None
+
+
+def get_telemetry_executor() -> ThreadPoolExecutor:
+    """Lazy-initialize a module-level daemon thread pool for telemetry.
+
+    Uses max_workers=2 since telemetry is low-volume (one event per run).
+    """
+    global _telemetry_executor
+    if _telemetry_executor is None:
+        _telemetry_executor = ThreadPoolExecutor(
+            max_workers=2,
+            thread_name_prefix="agno-telemetry",
+        )
+        atexit.register(_shutdown_telemetry_executor)
+    return _telemetry_executor
+
+
+def _shutdown_telemetry_executor() -> None:
+    """Best-effort shutdown: cancel pending futures, don't block."""
+    global _telemetry_executor
+    if _telemetry_executor is not None:
+        _telemetry_executor.shutdown(wait=False)
+        _telemetry_executor = None

--- a/libs/agno/agno/api/agent.py
+++ b/libs/agno/agno/api/agent.py
@@ -1,28 +1,13 @@
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.agent import AgentRunCreate
-from agno.utils.log import log_debug
 
 
 def create_agent_run(run: AgentRunCreate) -> None:
     """Telemetry recording for Agent runs"""
-    with api.Client() as api_client:
-        try:
-            api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Agent run: {e}")
+    api.post_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))
 
 
 async def acreate_agent_run(run: AgentRunCreate) -> None:
     """Telemetry recording for async Agent runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Agent run: {e}")
+    api.post_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/agent.py
+++ b/libs/agno/agno/api/agent.py
@@ -10,4 +10,4 @@ def create_agent_run(run: AgentRunCreate) -> None:
 
 async def acreate_agent_run(run: AgentRunCreate) -> None:
     """Telemetry recording for async Agent runs"""
-    api.post_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))
+    await api.apost_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -18,15 +18,15 @@ class Api:
         return HttpxClient(
             base_url=agno_api_settings.api_url,
             headers=self.headers,
-            timeout=60,
-            http2=True,
+            timeout=5,
+            http2=False,
         )
 
     def AsyncClient(self) -> HttpxAsyncClient:
         return HttpxAsyncClient(
             base_url=agno_api_settings.api_url,
             headers=self.headers,
-            timeout=60,
+            timeout=5,
             http2=True,
         )
 

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -14,6 +14,7 @@ from agno.utils.log import log_debug
 # Bounded so a dead or slow endpoint can never accumulate unbounded memory;
 # when it fills, new events are dropped (telemetry is best-effort).
 TELEMETRY_QUEUE_SIZE = 2000
+TELEMETRY_TIMEOUT = 5.0
 
 
 class Api:
@@ -57,7 +58,7 @@ class Api:
         )
 
     def post_in_background(self, route: str, payload: dict) -> None:
-        """Queue a fire-and-forget telemetry POST; never blocks, never raises."""
+        """Queue a telemetry POST without waiting on network I/O; never raises."""
         try:
             self._ensure_worker()
             self._queue.put_nowait((route, payload))
@@ -76,14 +77,16 @@ class Api:
         self.post_in_background(route, payload)
 
     def _ensure_worker(self) -> None:
-        if self._worker is not None and self._worker.is_alive() and self._pid == os.getpid():
+        current_pid = os.getpid()
+        if self._pid != current_pid:
+            # A child created without invoking Python's at-fork hooks can inherit
+            # a lock held by a vanished parent thread. Replace inherited state
+            # before acquiring that lock; the child is single-threaded here.
+            self._reset_after_fork()
+
+        if self._worker is not None and self._worker.is_alive():
             return
         with self._lock:
-            if self._pid != os.getpid():
-                # Forked child that bypassed Python's fork hooks (e.g. a C
-                # extension calling fork() directly): the worker thread and any
-                # open connection belong to the parent, so start fresh.
-                self._reset_after_fork()
             if self._worker is None or not self._worker.is_alive():
                 self._register_fork_reset()
                 self._worker = threading.Thread(target=self._drain, name="agno-telemetry", daemon=True)
@@ -127,15 +130,24 @@ class Api:
                 if invalid_response(response):
                     log_debug(f"Telemetry request to {route} returned status {response.status_code}")
             except Exception as e:
-                log_debug(f"Could not send telemetry event to {route}: {e}")
+                log_debug(f"Could not send telemetry event to {route}: {type(e).__name__}")
             finally:
                 self._queue.task_done()
 
     def _shared_client(self) -> HttpxClient:
         # Only ever touched from the worker thread, so no lock is needed.
         if self._client is None:
-            self._client = self.Client()
+            self._client = self._telemetry_client()
         return self._client
+
+    def _telemetry_client(self) -> HttpxClient:
+        """Create the worker's short-timeout, connection-reusing client."""
+        return HttpxClient(
+            base_url=agno_api_settings.api_url,
+            headers=self.headers,
+            timeout=TELEMETRY_TIMEOUT,
+            http2=True,
+        )
 
 
 api = Api()

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -64,6 +64,15 @@ class Api:
         except Exception as e:
             log_debug(f"Could not queue telemetry event for {route}: {e}")
 
+    async def apost_in_background(self, route: str, payload: dict) -> None:
+        """Async pair of ``post_in_background``.
+
+        The enqueue itself is non-blocking (a bounded ``put_nowait``), so this
+        delegates directly; it exists to keep the public sync/async interface
+        paired and safe to await from event-loop code.
+        """
+        self.post_in_background(route, payload)
+
     def _ensure_worker(self) -> None:
         if self._worker is not None and self._worker.is_alive() and self._pid == getpid():
             return

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -1,18 +1,42 @@
-from typing import Dict
+import threading
+from os import getpid
+from queue import Full, Queue
+from typing import Dict, Optional, Tuple
 
 from httpx import AsyncClient as HttpxAsyncClient
 from httpx import Client as HttpxClient
 from httpx import Response
 
 from agno.api.settings import agno_api_settings
+from agno.utils.log import log_debug
+
+# Bounded so a dead or slow endpoint can never accumulate unbounded memory;
+# when it fills, new events are dropped (telemetry is best-effort).
+TELEMETRY_QUEUE_SIZE = 2000
 
 
 class Api:
+    """Client for the Agno telemetry API.
+
+    Telemetry events go through ``post_in_background``: they are queued and
+    sent from a single daemon thread over one keep-alive connection, so the
+    caller never waits on telemetry I/O and consecutive events reuse the same
+    TCP/TLS session instead of paying a fresh handshake per event.
+
+    Delivery is best-effort: events still queued when the process exits are
+    dropped, matching telemetry's fire-and-forget contract.
+    """
+
     def __init__(self):
         self.headers: Dict[str, str] = {
             "user-agent": f"{agno_api_settings.app_name}/{agno_api_settings.app_version}",
             "Content-Type": "application/json",
         }
+        self._client: Optional[HttpxClient] = None
+        self._queue: "Queue[Tuple[str, dict]]" = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
+        self._worker: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._pid: int = getpid()
 
     def Client(self) -> HttpxClient:
         return HttpxClient(
@@ -29,6 +53,49 @@ class Api:
             timeout=60,
             http2=True,
         )
+
+    def post_in_background(self, route: str, payload: dict) -> None:
+        """Queue a fire-and-forget telemetry POST; never blocks, never raises."""
+        try:
+            self._ensure_worker()
+            self._queue.put_nowait((route, payload))
+        except Full:
+            log_debug(f"Telemetry queue full, dropping event for {route}")
+        except Exception as e:
+            log_debug(f"Could not queue telemetry event for {route}: {e}")
+
+    def _ensure_worker(self) -> None:
+        if self._worker is not None and self._worker.is_alive() and self._pid == getpid():
+            return
+        with self._lock:
+            if self._pid != getpid():
+                # We are in a forked child: the worker thread and any open
+                # connection belong to the parent, so start fresh.
+                self._pid = getpid()
+                self._worker = None
+                self._client = None
+                self._queue = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
+            if self._worker is None or not self._worker.is_alive():
+                self._worker = threading.Thread(target=self._drain, name="agno-telemetry", daemon=True)
+                self._worker.start()
+
+    def _drain(self) -> None:
+        while True:
+            route, payload = self._queue.get()
+            try:
+                response = self._shared_client().post(route, json=payload)
+                if invalid_response(response):
+                    log_debug(f"Telemetry request to {route} returned status {response.status_code}")
+            except Exception as e:
+                log_debug(f"Could not send telemetry event to {route}: {e}")
+            finally:
+                self._queue.task_done()
+
+    def _shared_client(self) -> HttpxClient:
+        # Only ever touched from the worker thread, so no lock is needed.
+        if self._client is None:
+            self._client = self.Client()
+        return self._client
 
 
 api = Api()

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -1,5 +1,6 @@
+import os
 import threading
-from os import getpid
+import weakref
 from queue import Full, Queue
 from typing import Dict, Optional, Tuple
 
@@ -36,7 +37,8 @@ class Api:
         self._queue: "Queue[Tuple[str, dict]]" = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
         self._worker: Optional[threading.Thread] = None
         self._lock = threading.Lock()
-        self._pid: int = getpid()
+        self._pid: int = os.getpid()
+        self._fork_reset_registered = False
 
     def Client(self) -> HttpxClient:
         return HttpxClient(
@@ -74,19 +76,48 @@ class Api:
         self.post_in_background(route, payload)
 
     def _ensure_worker(self) -> None:
-        if self._worker is not None and self._worker.is_alive() and self._pid == getpid():
+        if self._worker is not None and self._worker.is_alive() and self._pid == os.getpid():
             return
         with self._lock:
-            if self._pid != getpid():
-                # We are in a forked child: the worker thread and any open
-                # connection belong to the parent, so start fresh.
-                self._pid = getpid()
-                self._worker = None
-                self._client = None
-                self._queue = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
+            if self._pid != os.getpid():
+                # Forked child that bypassed Python's fork hooks (e.g. a C
+                # extension calling fork() directly): the worker thread and any
+                # open connection belong to the parent, so start fresh.
+                self._reset_after_fork()
             if self._worker is None or not self._worker.is_alive():
+                self._register_fork_reset()
                 self._worker = threading.Thread(target=self._drain, name="agno-telemetry", daemon=True)
                 self._worker.start()
+
+    def _register_fork_reset(self) -> None:
+        """Reinitialize dispatcher state in forked children, before any user code runs.
+
+        A lock (ours, or the queue's internal mutex) held by another thread at
+        fork time is inherited permanently locked by the child; resetting in an
+        ``after_in_child`` hook closes that window entirely. The pid check in
+        ``_ensure_worker`` remains as a fallback for forks that bypass the hooks.
+        """
+        if self._fork_reset_registered:
+            return
+        self._fork_reset_registered = True
+        if not hasattr(os, "register_at_fork"):  # Windows
+            return
+        ref = weakref.ref(self)
+
+        def _reset_in_child() -> None:
+            instance = ref()
+            if instance is not None:
+                instance._reset_after_fork()
+
+        os.register_at_fork(after_in_child=_reset_in_child)
+
+    def _reset_after_fork(self) -> None:
+        # Runs single-threaded in the child, so plain reassignment is safe.
+        self._lock = threading.Lock()
+        self._queue = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
+        self._worker = None
+        self._client = None
+        self._pid = os.getpid()
 
     def _drain(self) -> None:
         while True:

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -16,8 +16,10 @@ from agno.utils.log import log_debug
 # Bounded so a dead or slow endpoint can never accumulate unbounded memory;
 # when it fills, new events are dropped (telemetry is best-effort).
 TELEMETRY_QUEUE_SIZE = 2000
-TELEMETRY_TIMEOUT = 5.0
-TELEMETRY_SHUTDOWN_TIMEOUT = 2.0
+# Both are read once at import from AGNO_TELEMETRY_TIMEOUT and
+# AGNO_TELEMETRY_SHUTDOWN_TIMEOUT (see AgnoAPISettings); defaults 5s and 2s.
+TELEMETRY_TIMEOUT = agno_api_settings.telemetry_timeout
+TELEMETRY_SHUTDOWN_TIMEOUT = agno_api_settings.telemetry_shutdown_timeout
 
 _STOP = object()
 

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -56,7 +56,11 @@ class _TelemetryDispatcher:
     ``multiprocessing`` children leave through ``os._exit`` without running
     ``atexit``, so the same flush is also registered as a ``multiprocessing``
     exit finalizer in any process that starts a worker while ``multiprocessing``
-    is in use.
+    is in use. That covers children that exit normally (``Process.run``
+    returning or raising, ``Pool.close()`` + ``join()``,
+    ``ProcessPoolExecutor`` shutdown); ``Pool.terminate()`` (which the
+    ``with Pool()`` idiom calls) kills workers with a signal and nothing can
+    flush there.
     """
 
     def __init__(
@@ -80,8 +84,10 @@ class _TelemetryDispatcher:
         # Set once close() has finished its flush in this process; later calls
         # (atexit plus a multiprocessing finalizer) return without waiting again.
         self._closed = False
-        # PID in which the multiprocessing exit finalizer was registered.
+        # PID in which the multiprocessing exit finalizer was registered, and
+        # whether this process registered the multiprocessing after-fork hook.
         self._finalizer_pid: Optional[int] = None
+        self._after_fork_hook_registered = False
 
         if register_at_fork and hasattr(os, "register_at_fork"):
             ref = weakref.ref(self)
@@ -131,9 +137,15 @@ class _TelemetryDispatcher:
         event already in flight can outlive this call, but its worker remains a
         daemon and closes the shared client when the request returns. Once a
         close has finished in this process, later calls return immediately.
+
+        The deadline applies to every wait in here, the lifecycle locks
+        included: a concurrent ``post`` holds the state lock across
+        ``Thread.start()``, which can take a long time on a loaded machine, and
+        shutdown must not wait behind it past the window.
         """
         if flush_timeout is None:
             flush_timeout = TELEMETRY_SHUTDOWN_TIMEOUT
+        deadline = time.monotonic() + max(0.0, flush_timeout)
         # A hook-bypassing child may have inherited a held close lock. Reset
         # process state before acquiring any lifecycle lock from the parent.
         try:
@@ -146,19 +158,28 @@ class _TelemetryDispatcher:
             # behind another closer that is itself waiting for this request.
             current_worker = threading.current_thread()
             if self._worker is current_worker:
-                with self._lock:
+                if not self._acquire_before(self._lock, deadline):
+                    return
+                try:
                     self._accepting = False
                     queue = self._queue
-                self._enqueue_stop(queue, current_worker)
+                finally:
+                    self._lock.release()
+                self._enqueue_stop(queue, current_worker, deadline)
                 return
 
-            deadline = time.monotonic() + max(0.0, flush_timeout)
-            remaining = deadline - time.monotonic()
-            acquired = self._close_lock.acquire(timeout=remaining) if remaining > 0 else self._close_lock.acquire(False)
-            if not acquired:
+            if not self._acquire_before(self._close_lock, deadline):
                 return
             try:
-                with self._lock:
+                if self._closed:
+                    # The closer this call waited behind already finished.
+                    return
+                if not self._acquire_before(self._lock, deadline):
+                    # A post is mid worker start. Stop accepting and leave; the
+                    # daemon worker cannot hold process exit open.
+                    self._accepting = False
+                    return
+                try:
                     self._accepting = False
                     if self._queue.unfinished_tasks and (self._worker is None or not self._worker.is_alive()):
                         try:
@@ -169,6 +190,8 @@ class _TelemetryDispatcher:
                             pass
                     worker = self._worker
                     queue = self._queue
+                finally:
+                    self._lock.release()
 
                 if worker is None:
                     self._discard_pending(queue)
@@ -184,7 +207,7 @@ class _TelemetryDispatcher:
                 if queue.unfinished_tasks:
                     self._discard_pending(queue)
 
-                self._enqueue_stop(queue, worker)
+                self._enqueue_stop(queue, worker, deadline)
                 remaining = deadline - time.monotonic()
                 if remaining > 0:
                     worker.join(remaining)
@@ -193,6 +216,14 @@ class _TelemetryDispatcher:
                 self._close_lock.release()
         except Exception as e:
             log_debug(f"Could not close telemetry dispatcher: {type(e).__name__}")
+
+    @staticmethod
+    def _acquire_before(lock: threading.Lock, deadline: float) -> bool:
+        """Acquire ``lock`` without waiting past ``deadline``."""
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            return lock.acquire(timeout=remaining)
+        return lock.acquire(blocking=False)
 
     def _ensure_process_state(self) -> None:
         # Bind the old lock before checking the PID. Concurrent callers that
@@ -226,15 +257,18 @@ class _TelemetryDispatcher:
     def _register_multiprocessing_finalizer(self) -> None:
         """Flush at multiprocessing child exit, which never runs ``atexit``.
 
-        Children started by ``multiprocessing`` (fork and forkserver start
-        methods) leave through ``os._exit`` after running ``multiprocessing``'s
-        exit finalizers, so the ``atexit`` flush registered at import never
-        runs there and the daemon worker would be killed with the event still
-        queued. Registering ``close`` as a finalizer gives such children the
-        same bounded flush the parent gets. This has to happen after the worker
-        starts in the current process: ``BaseProcess._bootstrap`` clears the
-        finalizer registry in every child before user code runs, so an
-        import-time registration is lost. Processes that never imported
+        Children started by ``multiprocessing`` leave through ``os._exit`` after
+        running ``multiprocessing``'s exit finalizers, so the ``atexit`` flush
+        registered at import never runs there and the daemon worker would be
+        killed with the event still queued. Registering ``close`` as a
+        finalizer gives such children the same bounded flush the parent gets.
+        This has to happen after the worker starts in the current process:
+        fork and forkserver children clear the finalizer registry in
+        ``BaseProcess._bootstrap`` before user code runs (spawn children start
+        from a fresh interpreter), so an import-time registration is lost. A
+        forkserver child can also start its worker while the parent module is
+        being re-imported, before that clear; the after-fork hook registered
+        here re-registers in that case. Processes that never imported
         ``multiprocessing.util`` keep the ``atexit`` path alone.
         """
         if self._finalizer_pid == os.getpid():
@@ -251,10 +285,20 @@ class _TelemetryDispatcher:
 
         try:
             util.Finalize(None, _close_at_exit, exitpriority=0)
+            if not self._after_fork_hook_registered:
+                util.register_after_fork(self, _TelemetryDispatcher._reregister_after_multiprocessing_fork)
+                self._after_fork_hook_registered = True
         except Exception as e:
             log_debug(f"Could not register telemetry exit finalizer: {type(e).__name__}")
             return
         self._finalizer_pid = os.getpid()
+
+    def _reregister_after_multiprocessing_fork(self) -> None:
+        """Runs in a fork or forkserver child right after its finalizer registry was cleared."""
+        self._finalizer_pid = None
+        worker = self._worker
+        if worker is not None and worker.is_alive():
+            self._register_multiprocessing_finalizer()
 
     def _reset_after_fork(self, *, replace_fallback_lock: bool = True) -> None:
         # Defensive recovery for an unsupported post-telemetry fork: fresh
@@ -273,6 +317,8 @@ class _TelemetryDispatcher:
         self._stop_enqueued = False
         self._closed = False
         self._finalizer_pid = None
+        # The after-fork registry is inherited by fork children; registering
+        # again there is harmless because the finalizer is gated by PID.
         # Publish the new PID last so other callers cannot observe partially
         # initialized child state.
         self._pid = os.getpid()
@@ -326,8 +372,11 @@ class _TelemetryDispatcher:
                     # retired queue and cannot affect delivery.
                     self._stop_enqueued = False
 
-    def _enqueue_stop(self, queue: "Queue[object]", worker: threading.Thread) -> None:
-        with self._lock:
+    def _enqueue_stop(self, queue: "Queue[object]", worker: threading.Thread, deadline: float) -> None:
+        if not self._acquire_before(self._lock, deadline):
+            # Past the window: the worker stays a daemon and dies with the process.
+            return
+        try:
             if self._stop_enqueued or not worker.is_alive():
                 return
             try:
@@ -338,6 +387,8 @@ class _TelemetryDispatcher:
                 self._discard_pending(queue)
                 queue.put_nowait(_STOP)
             self._stop_enqueued = True
+        finally:
+            self._lock.release()
 
 
 _telemetry_dispatcher = _TelemetryDispatcher()
@@ -358,9 +409,10 @@ class Api:
     POSIX applications must create forked workers before posting telemetry or
     use a spawn-based process start method. Forking after this dispatcher starts
     its background thread is unsupported because live threads and HTTP/TLS
-    resources cannot be inherited safely. ``multiprocessing`` children get the
-    same bounded exit flush as the parent through a ``multiprocessing`` exit
-    finalizer, since they exit without running ``atexit``.
+    resources cannot be inherited safely. ``multiprocessing`` children that exit
+    normally get the same bounded exit flush as the parent through a
+    ``multiprocessing`` exit finalizer, since they exit without running
+    ``atexit``; workers killed by ``Pool.terminate()`` cannot flush.
     """
 
     def __init__(self, dispatcher: _TelemetryDispatcher = _telemetry_dispatcher) -> None:

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -1,8 +1,10 @@
+import atexit
 import os
 import threading
+import time
 import weakref
-from queue import Full, Queue
-from typing import Dict, Optional, Tuple
+from queue import Empty, Full, Queue
+from typing import Callable, Dict, Optional, Tuple, cast
 
 from httpx import AsyncClient as HttpxAsyncClient
 from httpx import Client as HttpxClient
@@ -15,31 +17,277 @@ from agno.utils.log import log_debug
 # when it fills, new events are dropped (telemetry is best-effort).
 TELEMETRY_QUEUE_SIZE = 2000
 TELEMETRY_TIMEOUT = 5.0
+TELEMETRY_SHUTDOWN_TIMEOUT = 2.0
+
+_STOP = object()
+
+
+def _telemetry_headers() -> Dict[str, str]:
+    return {
+        "user-agent": f"{agno_api_settings.app_name}/{agno_api_settings.app_version}",
+        "Content-Type": "application/json",
+    }
+
+
+def _create_telemetry_client() -> HttpxClient:
+    """Create the background worker's short-timeout HTTP client."""
+    return HttpxClient(
+        base_url=agno_api_settings.api_url,
+        headers=_telemetry_headers(),
+        timeout=TELEMETRY_TIMEOUT,
+        http2=True,
+    )
+
+
+class _TelemetryDispatcher:
+    """Process-wide, bounded dispatcher for best-effort telemetry events."""
+
+    def __init__(
+        self,
+        client_factory: Callable[[], HttpxClient] = _create_telemetry_client,
+        *,
+        register_at_fork: bool = True,
+    ) -> None:
+        self._client_factory = client_factory
+        self._queue: "Queue[object]" = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
+        self._worker: Optional[threading.Thread] = None
+        self._client: Optional[HttpxClient] = None
+        self._lock = threading.Lock()
+        # This lock is used only after a PID mismatch, so normal parent work
+        # cannot leave it held across a hook-bypassing fork.
+        self._fork_fallback_lock = threading.Lock()
+        self._close_lock = threading.Lock()
+        self._pid = os.getpid()
+        self._accepting = True
+        self._stop_enqueued = False
+
+        if register_at_fork and hasattr(os, "register_at_fork"):
+            ref = weakref.ref(self)
+
+            def _reset_in_child() -> None:
+                instance = ref()
+                if instance is not None:
+                    instance._reset_after_fork()
+
+            # Register before the lazy worker starts. AgentOS and preloaded apps
+            # can then fork while this module is imported but still single-threaded.
+            os.register_at_fork(after_in_child=_reset_in_child)
+
+    def post(self, route: str, payload: dict) -> None:
+        """Queue one event without waiting for network I/O; never raises."""
+        try:
+            self._ensure_process_state()
+            closed = False
+            with self._lock:
+                if not self._accepting:
+                    closed = True
+                else:
+                    # Enqueue first so a transient Thread.start() failure does
+                    # not discard the event; a later post or shutdown can retry
+                    # startup.
+                    try:
+                        self._queue.put_nowait((route, payload))
+                    except Full:
+                        # If an earlier Thread.start() failed and filled the
+                        # queue, retry the stranded worker before dropping this
+                        # new event.
+                        self._start_worker_locked()
+                        raise
+                    self._start_worker_locked()
+            if closed:
+                log_debug(f"Telemetry dispatcher closed, dropping event for {route}")
+        except Full:
+            log_debug(f"Telemetry queue full, dropping event for {route}")
+        except Exception as e:
+            log_debug(f"Could not queue telemetry event for {route}: {type(e).__name__}")
+
+    def close(self, flush_timeout: float = TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
+        """Request shutdown and wait at most ``flush_timeout`` seconds.
+
+        Pending events are given that bounded window to finish. An event already
+        in flight can outlive this call, but its worker remains a daemon and
+        closes the shared client when the request returns.
+        """
+        # A hook-bypassing child may have inherited a held close lock. Reset
+        # process state before acquiring any lifecycle lock from the parent.
+        try:
+            self._ensure_process_state()
+
+            # A client or transport callback can request shutdown from inside
+            # the worker. Bypass the close-serialization lock so it cannot wait
+            # behind another closer that is itself waiting for this request.
+            current_worker = threading.current_thread()
+            if self._worker is current_worker:
+                with self._lock:
+                    self._accepting = False
+                    queue = self._queue
+                self._enqueue_stop(queue, current_worker)
+                return
+
+            deadline = time.monotonic() + max(0.0, flush_timeout)
+            remaining = deadline - time.monotonic()
+            acquired = self._close_lock.acquire(timeout=remaining) if remaining > 0 else self._close_lock.acquire(False)
+            if not acquired:
+                return
+            try:
+                with self._lock:
+                    self._accepting = False
+                    if self._queue.unfinished_tasks and (self._worker is None or not self._worker.is_alive()):
+                        try:
+                            self._start_worker_locked()
+                        except Exception:
+                            # There is no worker that can flush the queued work.
+                            # The pending events are discarded below.
+                            pass
+                    worker = self._worker
+                    queue = self._queue
+
+                if worker is None:
+                    self._discard_pending(queue)
+                    return
+
+                while queue.unfinished_tasks and time.monotonic() < deadline:
+                    time.sleep(0.01)
+
+                # Once the deadline expires, discard work the worker has not
+                # taken yet. An in-flight request remains bounded by its own
+                # timeout and the daemon cannot delay interpreter termination.
+                if queue.unfinished_tasks:
+                    self._discard_pending(queue)
+
+                self._enqueue_stop(queue, worker)
+                remaining = deadline - time.monotonic()
+                if remaining > 0:
+                    worker.join(remaining)
+            finally:
+                self._close_lock.release()
+        except Exception as e:
+            log_debug(f"Could not close telemetry dispatcher: {type(e).__name__}")
+
+    def _ensure_process_state(self) -> None:
+        # Bind the old lock before checking the PID. Concurrent callers that
+        # observe the same stale PID must serialize on the same inherited lock,
+        # even though the winning reset installs a fresh lock for future forks.
+        reset_lock = self._fork_fallback_lock
+        current_pid = os.getpid()
+        if self._pid == current_pid:
+            return
+        with reset_lock:
+            current_pid = os.getpid()
+            if self._pid != current_pid:
+                # Keep every concurrent stale-PID caller on this same old lock
+                # until the new PID is published. The at-fork hook, which runs
+                # single-threaded, may instead install a fresh fallback lock.
+                self._reset_after_fork(replace_fallback_lock=False)
+
+    def _start_worker_locked(self) -> None:
+        if self._worker is not None and self._worker.is_alive():
+            return
+        queue = self._queue
+        worker = threading.Thread(target=self._drain, args=(queue,), name="agno-telemetry", daemon=True)
+        self._worker = worker
+        try:
+            worker.start()
+        except Exception:
+            self._worker = None
+            raise
+
+    def _reset_after_fork(self, *, replace_fallback_lock: bool = True) -> None:
+        # Runs in the single surviving child thread for normal Python forks.
+        # Do not close the inherited client here: httpx/OpenSSL locks are not
+        # safe to acquire in an at-fork callback.
+        self._queue = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
+        self._worker = None
+        self._client = None
+        self._lock = threading.Lock()
+        if replace_fallback_lock:
+            self._fork_fallback_lock = threading.Lock()
+        self._close_lock = threading.Lock()
+        self._accepting = True
+        self._stop_enqueued = False
+        # Publish the new PID last so other callers cannot observe partially
+        # initialized child state.
+        self._pid = os.getpid()
+
+    def _drain(self, queue: "Queue[object]") -> None:
+        client: Optional[HttpxClient] = None
+        try:
+            while True:
+                item = queue.get()
+                try:
+                    if item is _STOP:
+                        return
+                    route, payload = cast(Tuple[str, dict], item)
+                    try:
+                        if client is None:
+                            client = self._client_factory()
+                            self._client = client
+                        response = client.post(route, json=payload)
+                        if invalid_response(response):
+                            log_debug(f"Telemetry request to {route} returned status {response.status_code}")
+                    except Exception as e:
+                        log_debug(f"Could not send telemetry event to {route}: {type(e).__name__}")
+                finally:
+                    # Use the queue bound when this worker started. A process
+                    # reset must never pair get() from one queue with task_done()
+                    # on its replacement.
+                    queue.task_done()
+        finally:
+            if client is not None:
+                try:
+                    client.close()
+                except Exception as e:
+                    log_debug(f"Could not close telemetry client: {type(e).__name__}")
+            with self._lock:
+                if self._client is client:
+                    self._client = None
+                if self._worker is threading.current_thread():
+                    self._worker = None
+
+    def _discard_pending(self, queue: "Queue[object]") -> None:
+        while True:
+            try:
+                item = queue.get_nowait()
+            except Empty:
+                return
+            else:
+                queue.task_done()
+                if item is _STOP:
+                    self._stop_enqueued = False
+
+    def _enqueue_stop(self, queue: "Queue[object]", worker: threading.Thread) -> None:
+        with self._lock:
+            if self._stop_enqueued or not worker.is_alive():
+                return
+            try:
+                queue.put_nowait(_STOP)
+            except Full:
+                # close() has stopped producers and discarded pending events,
+                # so this is defensive against a concurrent worker dequeue.
+                self._discard_pending(queue)
+                queue.put_nowait(_STOP)
+            self._stop_enqueued = True
+
+
+_telemetry_dispatcher = _TelemetryDispatcher()
+atexit.register(_telemetry_dispatcher.close)
 
 
 class Api:
     """Client for the Agno telemetry API.
 
-    Telemetry events go through ``post_in_background``: they are queued and
-    sent from a single daemon thread over one keep-alive connection, so the
-    caller never waits on telemetry I/O and consecutive events reuse the same
-    TCP/TLS session instead of paying a fresh handshake per event.
+    Telemetry events go through ``post_in_background``: they are queued on one
+    process-wide dispatcher and sent from a daemon thread over a reusable HTTP
+    client, so callers never wait on telemetry I/O.
 
-    Delivery is best-effort: events still queued when the process exits are
-    dropped, matching telemetry's fire-and-forget contract.
+    Delivery is best-effort. Process shutdown gives queued events a bounded
+    chance to finish; events are dropped after that deadline or when the queue
+    is full.
     """
 
-    def __init__(self):
-        self.headers: Dict[str, str] = {
-            "user-agent": f"{agno_api_settings.app_name}/{agno_api_settings.app_version}",
-            "Content-Type": "application/json",
-        }
-        self._client: Optional[HttpxClient] = None
-        self._queue: "Queue[Tuple[str, dict]]" = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
-        self._worker: Optional[threading.Thread] = None
-        self._lock = threading.Lock()
-        self._pid: int = os.getpid()
-        self._fork_reset_registered = False
+    def __init__(self, dispatcher: _TelemetryDispatcher = _telemetry_dispatcher) -> None:
+        self.headers = _telemetry_headers()
+        self._dispatcher = dispatcher
 
     def Client(self) -> HttpxClient:
         return HttpxClient(
@@ -59,13 +307,7 @@ class Api:
 
     def post_in_background(self, route: str, payload: dict) -> None:
         """Queue a telemetry POST without waiting on network I/O; never raises."""
-        try:
-            self._ensure_worker()
-            self._queue.put_nowait((route, payload))
-        except Full:
-            log_debug(f"Telemetry queue full, dropping event for {route}")
-        except Exception as e:
-            log_debug(f"Could not queue telemetry event for {route}: {e}")
+        self._dispatcher.post(route, payload)
 
     async def apost_in_background(self, route: str, payload: dict) -> None:
         """Async pair of ``post_in_background``.
@@ -75,79 +317,6 @@ class Api:
         paired and safe to await from event-loop code.
         """
         self.post_in_background(route, payload)
-
-    def _ensure_worker(self) -> None:
-        current_pid = os.getpid()
-        if self._pid != current_pid:
-            # A child created without invoking Python's at-fork hooks can inherit
-            # a lock held by a vanished parent thread. Replace inherited state
-            # before acquiring that lock; the child is single-threaded here.
-            self._reset_after_fork()
-
-        if self._worker is not None and self._worker.is_alive():
-            return
-        with self._lock:
-            if self._worker is None or not self._worker.is_alive():
-                self._register_fork_reset()
-                self._worker = threading.Thread(target=self._drain, name="agno-telemetry", daemon=True)
-                self._worker.start()
-
-    def _register_fork_reset(self) -> None:
-        """Reinitialize dispatcher state in forked children, before any user code runs.
-
-        A lock (ours, or the queue's internal mutex) held by another thread at
-        fork time is inherited permanently locked by the child; resetting in an
-        ``after_in_child`` hook closes that window entirely. The pid check in
-        ``_ensure_worker`` remains as a fallback for forks that bypass the hooks.
-        """
-        if self._fork_reset_registered:
-            return
-        self._fork_reset_registered = True
-        if not hasattr(os, "register_at_fork"):  # Windows
-            return
-        ref = weakref.ref(self)
-
-        def _reset_in_child() -> None:
-            instance = ref()
-            if instance is not None:
-                instance._reset_after_fork()
-
-        os.register_at_fork(after_in_child=_reset_in_child)
-
-    def _reset_after_fork(self) -> None:
-        # Runs single-threaded in the child, so plain reassignment is safe.
-        self._lock = threading.Lock()
-        self._queue = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
-        self._worker = None
-        self._client = None
-        self._pid = os.getpid()
-
-    def _drain(self) -> None:
-        while True:
-            route, payload = self._queue.get()
-            try:
-                response = self._shared_client().post(route, json=payload)
-                if invalid_response(response):
-                    log_debug(f"Telemetry request to {route} returned status {response.status_code}")
-            except Exception as e:
-                log_debug(f"Could not send telemetry event to {route}: {type(e).__name__}")
-            finally:
-                self._queue.task_done()
-
-    def _shared_client(self) -> HttpxClient:
-        # Only ever touched from the worker thread, so no lock is needed.
-        if self._client is None:
-            self._client = self._telemetry_client()
-        return self._client
-
-    def _telemetry_client(self) -> HttpxClient:
-        """Create the worker's short-timeout, connection-reusing client."""
-        return HttpxClient(
-            base_url=agno_api_settings.api_url,
-            headers=self.headers,
-            timeout=TELEMETRY_TIMEOUT,
-            http2=True,
-        )
 
 
 api = Api()

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -1,5 +1,6 @@
 import atexit
 import os
+import sys
 import threading
 import time
 import weakref
@@ -18,6 +19,8 @@ from agno.utils.log import log_debug
 TELEMETRY_QUEUE_SIZE = 2000
 # Both are read once at import from AGNO_TELEMETRY_TIMEOUT and
 # AGNO_TELEMETRY_SHUTDOWN_TIMEOUT (see AgnoAPISettings); defaults 5s and 2s.
+# The client factory and close() read these module attributes when they run,
+# so a later assignment here is honored by the next client or close().
 TELEMETRY_TIMEOUT = agno_api_settings.telemetry_timeout
 TELEMETRY_SHUTDOWN_TIMEOUT = agno_api_settings.telemetry_shutdown_timeout
 
@@ -48,6 +51,12 @@ class _TelemetryDispatcher:
     or created with a spawn-based start method. A live dispatcher owns a thread
     and may own HTTP/TLS resources that cannot be inherited safely across
     ``fork()``.
+
+    Process exit flushes queued events for a bounded time through ``atexit``.
+    ``multiprocessing`` children leave through ``os._exit`` without running
+    ``atexit``, so the same flush is also registered as a ``multiprocessing``
+    exit finalizer in any process that starts a worker while ``multiprocessing``
+    is in use.
     """
 
     def __init__(
@@ -68,6 +77,11 @@ class _TelemetryDispatcher:
         self._pid = os.getpid()
         self._accepting = True
         self._stop_enqueued = False
+        # Set once close() has finished its flush in this process; later calls
+        # (atexit plus a multiprocessing finalizer) return without waiting again.
+        self._closed = False
+        # PID in which the multiprocessing exit finalizer was registered.
+        self._finalizer_pid: Optional[int] = None
 
         if register_at_fork and hasattr(os, "register_at_fork"):
             ref = weakref.ref(self)
@@ -109,17 +123,23 @@ class _TelemetryDispatcher:
         except Exception as e:
             log_debug(f"Could not queue telemetry event for {route}: {type(e).__name__}")
 
-    def close(self, flush_timeout: float = TELEMETRY_SHUTDOWN_TIMEOUT) -> None:
+    def close(self, flush_timeout: Optional[float] = None) -> None:
         """Request shutdown and wait at most ``flush_timeout`` seconds.
 
-        Pending events are given that bounded window to finish. An event already
-        in flight can outlive this call, but its worker remains a daemon and
-        closes the shared client when the request returns.
+        ``None`` means the module's ``TELEMETRY_SHUTDOWN_TIMEOUT`` as it is when
+        this runs. Pending events are given that bounded window to finish. An
+        event already in flight can outlive this call, but its worker remains a
+        daemon and closes the shared client when the request returns. Once a
+        close has finished in this process, later calls return immediately.
         """
+        if flush_timeout is None:
+            flush_timeout = TELEMETRY_SHUTDOWN_TIMEOUT
         # A hook-bypassing child may have inherited a held close lock. Reset
         # process state before acquiring any lifecycle lock from the parent.
         try:
             self._ensure_process_state()
+            if self._closed:
+                return
 
             # A client or transport callback can request shutdown from inside
             # the worker. Bypass the close-serialization lock so it cannot wait
@@ -152,6 +172,7 @@ class _TelemetryDispatcher:
 
                 if worker is None:
                     self._discard_pending(queue)
+                    self._closed = True
                     return
 
                 while queue.unfinished_tasks and time.monotonic() < deadline:
@@ -167,6 +188,7 @@ class _TelemetryDispatcher:
                 remaining = deadline - time.monotonic()
                 if remaining > 0:
                     worker.join(remaining)
+                self._closed = True
             finally:
                 self._close_lock.release()
         except Exception as e:
@@ -199,6 +221,40 @@ class _TelemetryDispatcher:
         except Exception:
             self._worker = None
             raise
+        self._register_multiprocessing_finalizer()
+
+    def _register_multiprocessing_finalizer(self) -> None:
+        """Flush at multiprocessing child exit, which never runs ``atexit``.
+
+        Children started by ``multiprocessing`` (fork and forkserver start
+        methods) leave through ``os._exit`` after running ``multiprocessing``'s
+        exit finalizers, so the ``atexit`` flush registered at import never
+        runs there and the daemon worker would be killed with the event still
+        queued. Registering ``close`` as a finalizer gives such children the
+        same bounded flush the parent gets. This has to happen after the worker
+        starts in the current process: ``BaseProcess._bootstrap`` clears the
+        finalizer registry in every child before user code runs, so an
+        import-time registration is lost. Processes that never imported
+        ``multiprocessing.util`` keep the ``atexit`` path alone.
+        """
+        if self._finalizer_pid == os.getpid():
+            return
+        util = sys.modules.get("multiprocessing.util")
+        if util is None:
+            return
+        ref = weakref.ref(self)
+
+        def _close_at_exit() -> None:
+            instance = ref()
+            if instance is not None:
+                instance.close()
+
+        try:
+            util.Finalize(None, _close_at_exit, exitpriority=0)
+        except Exception as e:
+            log_debug(f"Could not register telemetry exit finalizer: {type(e).__name__}")
+            return
+        self._finalizer_pid = os.getpid()
 
     def _reset_after_fork(self, *, replace_fallback_lock: bool = True) -> None:
         # Defensive recovery for an unsupported post-telemetry fork: fresh
@@ -215,6 +271,8 @@ class _TelemetryDispatcher:
         self._close_lock = threading.Lock()
         self._accepting = True
         self._stop_enqueued = False
+        self._closed = False
+        self._finalizer_pid = None
         # Publish the new PID last so other callers cannot observe partially
         # initialized child state.
         self._pid = os.getpid()
@@ -300,7 +358,9 @@ class Api:
     POSIX applications must create forked workers before posting telemetry or
     use a spawn-based process start method. Forking after this dispatcher starts
     its background thread is unsupported because live threads and HTTP/TLS
-    resources cannot be inherited safely.
+    resources cannot be inherited safely. ``multiprocessing`` children get the
+    same bounded exit flush as the parent through a ``multiprocessing`` exit
+    finalizer, since they exit without running ``atexit``.
     """
 
     def __init__(self, dispatcher: _TelemetryDispatcher = _telemetry_dispatcher) -> None:

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -40,7 +40,13 @@ def _create_telemetry_client() -> HttpxClient:
 
 
 class _TelemetryDispatcher:
-    """Process-wide, bounded dispatcher for best-effort telemetry events."""
+    """Process-wide, bounded dispatcher for best-effort telemetry events.
+
+    On POSIX, worker processes must be forked before the first event is posted,
+    or created with a spawn-based start method. A live dispatcher owns a thread
+    and may own HTTP/TLS resources that cannot be inherited safely across
+    ``fork()``.
+    """
 
     def __init__(
         self,
@@ -193,9 +199,11 @@ class _TelemetryDispatcher:
             raise
 
     def _reset_after_fork(self, *, replace_fallback_lock: bool = True) -> None:
-        # Runs in the single surviving child thread for normal Python forks.
-        # Do not close the inherited client here: httpx/OpenSSL locks are not
-        # safe to acquire in an at-fork callback.
+        # Defensive recovery for an unsupported post-telemetry fork: fresh
+        # dispatcher state lets the child deliver, but cannot reclaim resources
+        # retained by vanished parent threads. Do not close the inherited client
+        # here: httpx/OpenSSL locks are not safe in an at-fork callback. Supported
+        # applications fork before the first event or use a spawn-based method.
         self._queue = Queue(maxsize=TELEMETRY_QUEUE_SIZE)
         self._worker = None
         self._client = None
@@ -253,6 +261,9 @@ class _TelemetryDispatcher:
             else:
                 queue.task_done()
                 if item is _STOP:
+                    # This flag only avoids duplicate sentinels. A racing closer
+                    # may enqueue one extra after producers stop; it stays in the
+                    # retired queue and cannot affect delivery.
                     self._stop_enqueued = False
 
     def _enqueue_stop(self, queue: "Queue[object]", worker: threading.Thread) -> None:
@@ -283,6 +294,11 @@ class Api:
     Delivery is best-effort. Process shutdown gives queued events a bounded
     chance to finish; events are dropped after that deadline or when the queue
     is full.
+
+    POSIX applications must create forked workers before posting telemetry or
+    use a spawn-based process start method. Forking after this dispatcher starts
+    its background thread is unsupported because live threads and HTTP/TLS
+    resources cannot be inherited safely.
     """
 
     def __init__(self, dispatcher: _TelemetryDispatcher = _telemetry_dispatcher) -> None:

--- a/libs/agno/agno/api/evals.py
+++ b/libs/agno/agno/api/evals.py
@@ -20,3 +20,13 @@ async def async_create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
             await api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
         except Exception as e:
             log_debug(f"Could not create evaluation run: {e}")
+
+
+def fire_and_forget_eval_telemetry(eval_run: EvalRunCreate) -> None:
+    """Fire-and-forget eval telemetry. Works from both sync and async contexts."""
+    from agno.api._executor import get_telemetry_executor
+
+    try:
+        get_telemetry_executor().submit(create_eval_run_telemetry, eval_run)
+    except Exception as e:
+        log_debug(f"Could not submit eval telemetry event: {e}")

--- a/libs/agno/agno/api/evals.py
+++ b/libs/agno/agno/api/evals.py
@@ -1,22 +1,13 @@
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.evals import EvalRunCreate
-from agno.utils.log import log_debug
 
 
 def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
     """Telemetry recording for Eval runs"""
-    with api.Client() as api_client:
-        try:
-            api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
-        except Exception as e:
-            log_debug(f"Could not create evaluation run: {e}")
+    api.post_in_background(ApiRoutes.EVAL_RUN_CREATE, eval_run.model_dump(exclude_none=True))
 
 
 async def async_create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
     """Telemetry recording for async Eval runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
-        except Exception as e:
-            log_debug(f"Could not create evaluation run: {e}")
+    api.post_in_background(ApiRoutes.EVAL_RUN_CREATE, eval_run.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/evals.py
+++ b/libs/agno/agno/api/evals.py
@@ -10,4 +10,4 @@ def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
 
 async def async_create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
     """Telemetry recording for async Eval runs"""
-    api.post_in_background(ApiRoutes.EVAL_RUN_CREATE, eval_run.model_dump(exclude_none=True))
+    await api.apost_in_background(ApiRoutes.EVAL_RUN_CREATE, eval_run.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/os.py
+++ b/libs/agno/agno/api/os.py
@@ -1,17 +1,8 @@
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.os import OSLaunch
-from agno.utils.log import log_debug
 
 
 def log_os_telemetry(launch: OSLaunch) -> None:
     """Telemetry recording for OS launches"""
-    try:
-        with api.Client() as api_client:
-            response = api_client.post(
-                ApiRoutes.AGENT_OS_LAUNCH,
-                json=launch.model_dump(exclude_none=True),
-            )
-            response.raise_for_status()
-    except Exception as e:
-        log_debug(f"Could not register OS launch for telemetry: {type(e).__name__}")
+    api.post_in_background(ApiRoutes.AGENT_OS_LAUNCH, launch.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/schemas/utils.py
+++ b/libs/agno/agno/api/schemas/utils.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from functools import lru_cache
 
 
 class TelemetryRunEventType(str, Enum):
@@ -8,10 +9,13 @@ class TelemetryRunEventType(str, Enum):
     WORKFLOW = "workflow"
 
 
+@lru_cache(maxsize=1)
 def get_sdk_version() -> str:
     """Return the installed agno SDK version from package metadata.
 
-    Falls back to "unknown" if the package metadata isn't available.
+    Falls back to "unknown" if the package metadata isn't available. Cached:
+    every telemetry schema calls this as a field default on the caller's thread,
+    and the metadata lookup re-parses the package METADATA file each time.
     """
     from importlib.metadata import version as pkg_version
 

--- a/libs/agno/agno/api/settings.py
+++ b/libs/agno/agno/api/settings.py
@@ -18,7 +18,18 @@ class AgnoAPISettings(BaseSettings):
 
     api_url: str = "https://os-api.agno.com"
 
+    # Background telemetry delivery. Override with AGNO_TELEMETRY_TIMEOUT and
+    # AGNO_TELEMETRY_SHUTDOWN_TIMEOUT (seconds). The shutdown timeout bounds the
+    # at-exit flush of queued events; set it to 0 to skip that flush entirely.
+    telemetry_timeout: float = 5.0
+    telemetry_shutdown_timeout: float = 2.0
+
     model_config = SettingsConfigDict(env_prefix="AGNO_")
+
+    @field_validator("telemetry_timeout", "telemetry_shutdown_timeout")
+    def clamp_non_negative(cls, v: float) -> float:
+        """A negative timeout is meaningless; treat it as zero rather than failing import."""
+        return max(0.0, v)
 
     @field_validator("api_runtime", mode="before")
     def validate_runtime_env(cls, v):

--- a/libs/agno/agno/api/settings.py
+++ b/libs/agno/agno/api/settings.py
@@ -67,6 +67,18 @@ class AgnoAPISettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="AGNO_")
 
+    @field_validator("alpha_features", mode="before")
+    def coerce_alpha_features(cls, v: Any) -> bool:
+        """An unparsable AGNO_ALPHA_FEATURES must not fail the import either; anything but a true-ish value is off."""
+        if isinstance(v, bool):
+            return v
+        text = str(v).strip().lower() if v is not None else ""
+        if text in ("1", "true", "yes", "on"):
+            return True
+        if text not in ("", "0", "false", "no", "off"):
+            log_warning(f"Ignoring AGNO_ALPHA_FEATURES={v!r}: expected a boolean, using False")
+        return False
+
     @field_validator("telemetry_timeout", mode="before")
     def coerce_telemetry_timeout(cls, v: Any) -> float:
         return _coerce_timeout("AGNO_TELEMETRY_TIMEOUT", v, 5.0, zero_allowed=False)
@@ -80,7 +92,7 @@ class AgnoAPISettings(BaseSettings):
         """Validate api_runtime; an unknown value falls back to production rather than failing import."""
 
         valid_api_runtimes = ["dev", "stg", "prd"]
-        runtime = str(v).lower() if v is not None else ""
+        runtime = str(v).strip().lower() if v is not None else ""
         if runtime not in valid_api_runtimes:
             log_warning(f"Ignoring AGNO_API_RUNTIME={v!r}: expected one of {valid_api_runtimes}, using prd")
             return "prd"

--- a/libs/agno/agno/api/settings.py
+++ b/libs/agno/agno/api/settings.py
@@ -1,12 +1,50 @@
 from __future__ import annotations
 
+import math
 from importlib import metadata
+from typing import Any
 
 from pydantic import field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from agno.utils.log import log_error
+from agno.utils.log import log_error, log_warning
+
+# Telemetry timeouts above this are capped: larger values overflow the socket
+# and lock timeout APIs and would turn a misconfiguration into zero delivery.
+MAX_TELEMETRY_TIMEOUT_SECONDS = 3600.0
+
+
+def _coerce_timeout(name: str, value: Any, default: float, *, zero_allowed: bool) -> float:
+    """Turn a timeout setting into a usable float, never raising.
+
+    These settings are read when telemetry first runs, from inside agent, team,
+    workflow, eval and AgentOS code paths. A value that cannot be used must not
+    make those paths fail, so anything unusable falls back to the default with a
+    warning: non-numeric or empty values, nan, inf, and (unless zero is a
+    documented setting) zero or negative values. Finite values above the cap
+    are clamped.
+    """
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        log_warning(f"Ignoring {name}={value!r}: not a number, using {default}")
+        return default
+    if math.isnan(number) or math.isinf(number):
+        log_warning(f"Ignoring {name}={value!r}: must be finite, using {default}")
+        return default
+    if number < 0:
+        if zero_allowed:
+            return 0.0
+        log_warning(f"Ignoring {name}={value!r}: must be positive, using {default}")
+        return default
+    if number == 0 and not zero_allowed:
+        log_warning(f"Ignoring {name}=0: a zero request timeout fails every request, using {default}")
+        return default
+    if number > MAX_TELEMETRY_TIMEOUT_SECONDS:
+        log_warning(f"Capping {name}={value!r} at {MAX_TELEMETRY_TIMEOUT_SECONDS} seconds")
+        return MAX_TELEMETRY_TIMEOUT_SECONDS
+    return number
 
 
 class AgnoAPISettings(BaseSettings):
@@ -19,27 +57,35 @@ class AgnoAPISettings(BaseSettings):
     api_url: str = "https://os-api.agno.com"
 
     # Background telemetry delivery. Override with AGNO_TELEMETRY_TIMEOUT and
-    # AGNO_TELEMETRY_SHUTDOWN_TIMEOUT (seconds). The shutdown timeout bounds the
-    # at-exit flush of queued events; set it to 0 to skip that flush entirely.
+    # AGNO_TELEMETRY_SHUTDOWN_TIMEOUT (seconds). Both are read once, when
+    # telemetry first runs. The request timeout must be positive. The shutdown
+    # timeout bounds the at-exit flush of queued events; set it to 0 to skip
+    # that flush entirely. Unusable values fall back to these defaults with a
+    # warning instead of failing the import.
     telemetry_timeout: float = 5.0
     telemetry_shutdown_timeout: float = 2.0
 
     model_config = SettingsConfigDict(env_prefix="AGNO_")
 
-    @field_validator("telemetry_timeout", "telemetry_shutdown_timeout")
-    def clamp_non_negative(cls, v: float) -> float:
-        """A negative timeout is meaningless; treat it as zero rather than failing import."""
-        return max(0.0, v)
+    @field_validator("telemetry_timeout", mode="before")
+    def coerce_telemetry_timeout(cls, v: Any) -> float:
+        return _coerce_timeout("AGNO_TELEMETRY_TIMEOUT", v, 5.0, zero_allowed=False)
+
+    @field_validator("telemetry_shutdown_timeout", mode="before")
+    def coerce_telemetry_shutdown_timeout(cls, v: Any) -> float:
+        return _coerce_timeout("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", v, 2.0, zero_allowed=True)
 
     @field_validator("api_runtime", mode="before")
     def validate_runtime_env(cls, v):
-        """Validate api_runtime."""
+        """Validate api_runtime; an unknown value falls back to production rather than failing import."""
 
         valid_api_runtimes = ["dev", "stg", "prd"]
-        if v.lower() not in valid_api_runtimes:
-            raise ValueError(f"Invalid api_runtime: {v}")
+        runtime = str(v).lower() if v is not None else ""
+        if runtime not in valid_api_runtimes:
+            log_warning(f"Ignoring AGNO_API_RUNTIME={v!r}: expected one of {valid_api_runtimes}, using prd")
+            return "prd"
 
-        return v.lower()
+        return runtime
 
     @field_validator("api_url", mode="before")
     def update_api_url(cls, v, info: ValidationInfo):

--- a/libs/agno/agno/api/team.py
+++ b/libs/agno/agno/api/team.py
@@ -10,4 +10,4 @@ def create_team_run(run: TeamRunCreate) -> None:
 
 async def acreate_team_run(run: TeamRunCreate) -> None:
     """Telemetry recording for async Team runs"""
-    api.post_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))
+    await api.apost_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/team.py
+++ b/libs/agno/agno/api/team.py
@@ -1,30 +1,13 @@
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.team import TeamRunCreate
-from agno.utils.log import log_debug
 
 
 def create_team_run(run: TeamRunCreate) -> None:
     """Telemetry recording for Team runs"""
-    with api.Client() as api_client:
-        try:
-            response = api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-            response.raise_for_status()
-        except Exception as e:
-            log_debug(f"Could not create Team run: {e}")
+    api.post_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))
 
 
 async def acreate_team_run(run: TeamRunCreate) -> None:
     """Telemetry recording for async Team runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            response = await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-            response.raise_for_status()
-        except Exception as e:
-            log_debug(f"Could not create Team run: {e}")
+    api.post_in_background(ApiRoutes.RUN_CREATE, run.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/workflow.py
+++ b/libs/agno/agno/api/workflow.py
@@ -1,28 +1,13 @@
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.workflows import WorkflowRunCreate
-from agno.utils.log import log_debug
 
 
 def create_workflow_run(workflow: WorkflowRunCreate) -> None:
     """Telemetry recording for Workflow runs"""
-    with api.Client() as api_client:
-        try:
-            api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=workflow.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Workflow: {e}")
+    api.post_in_background(ApiRoutes.RUN_CREATE, workflow.model_dump(exclude_none=True))
 
 
 async def acreate_workflow_run(workflow: WorkflowRunCreate) -> None:
     """Telemetry recording for async Workflow runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=workflow.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Team: {e}")
+    api.post_in_background(ApiRoutes.RUN_CREATE, workflow.model_dump(exclude_none=True))

--- a/libs/agno/agno/api/workflow.py
+++ b/libs/agno/agno/api/workflow.py
@@ -10,4 +10,4 @@ def create_workflow_run(workflow: WorkflowRunCreate) -> None:
 
 async def acreate_workflow_run(workflow: WorkflowRunCreate) -> None:
     """Telemetry recording for async Workflow runs"""
-    api.post_in_background(ApiRoutes.RUN_CREATE, workflow.model_dump(exclude_none=True))
+    await api.apost_in_background(ApiRoutes.RUN_CREATE, workflow.model_dump(exclude_none=True))

--- a/libs/agno/agno/eval/accuracy.py
+++ b/libs/agno/agno/eval/accuracy.py
@@ -457,9 +457,9 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=self.eval_id,
                     eval_type=EvalType.ACCURACY,
@@ -602,9 +602,9 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            await async_create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(run_id=self.eval_id, eval_type=EvalType.ACCURACY),
             )
 
@@ -721,9 +721,9 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=self.eval_id,
                     eval_type=EvalType.ACCURACY,

--- a/libs/agno/agno/eval/accuracy.py
+++ b/libs/agno/agno/eval/accuracy.py
@@ -9,7 +9,14 @@ from pydantic import BaseModel, Field
 from agno.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas.evals import EvalType
-from agno.eval.utils import async_log_eval, log_eval_run, spinner_live, store_result_in_file
+from agno.eval.utils import (
+    async_log_eval,
+    async_log_eval_telemetry,
+    log_eval_run,
+    log_eval_telemetry,
+    spinner_live,
+    store_result_in_file,
+)
 from agno.exceptions import EvalError
 from agno.models.base import Model
 from agno.team.team import Team
@@ -485,15 +492,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
-
-            create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id,
-                    eval_type=EvalType.ACCURACY,
-                    data=self._get_telemetry_data(),
-                ),
-            )
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, data=self._get_telemetry_data())
 
         logger.debug(f"*********** Evaluation {self.eval_id} Finished ***********")
         return self.result
@@ -631,11 +630,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
-
-            await async_create_eval_run_telemetry(
-                eval_run=EvalRunCreate(run_id=self.eval_id, eval_type=EvalType.ACCURACY),
-            )
+            await async_log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY)
 
         logger.debug(f"*********** Evaluation {self.eval_id} Finished ***********")
         return self.result
@@ -750,15 +745,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
-
-            create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id,
-                    eval_type=EvalType.ACCURACY,
-                    data=self._get_telemetry_data(),
-                ),
-            )
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, data=self._get_telemetry_data())
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
         return self.result

--- a/libs/agno/agno/eval/accuracy.py
+++ b/libs/agno/agno/eval/accuracy.py
@@ -492,7 +492,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, data=self._get_telemetry_data())
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data)
 
         logger.debug(f"*********** Evaluation {self.eval_id} Finished ***********")
         return self.result
@@ -630,7 +630,9 @@ Remember: You must only compare the agent_output to the expected_output. The exp
             )
 
         if self.telemetry:
-            await async_log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY)
+            await async_log_eval_telemetry(
+                run_id=self.eval_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data
+            )
 
         logger.debug(f"*********** Evaluation {self.eval_id} Finished ***********")
         return self.result
@@ -745,7 +747,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, data=self._get_telemetry_data())
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.ACCURACY, get_data=self._get_telemetry_data)
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
         return self.result

--- a/libs/agno/agno/eval/agent_as_judge.py
+++ b/libs/agno/agno/eval/agent_as_judge.py
@@ -525,9 +525,9 @@ class AgentAsJudgeEval(BaseEval):
         self._log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
                 )
@@ -623,9 +623,9 @@ class AgentAsJudgeEval(BaseEval):
         await self._async_log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            await async_create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
                 )
@@ -694,9 +694,9 @@ class AgentAsJudgeEval(BaseEval):
         self._log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
                 )
@@ -764,9 +764,9 @@ class AgentAsJudgeEval(BaseEval):
         await self._async_log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            await async_create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
                 )

--- a/libs/agno/agno/eval/agent_as_judge.py
+++ b/libs/agno/agno/eval/agent_as_judge.py
@@ -10,7 +10,14 @@ from agno.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas.evals import EvalType
 from agno.eval.base import BaseEval
-from agno.eval.utils import async_log_eval, log_eval_run, spinner_live, store_result_in_file
+from agno.eval.utils import (
+    async_log_eval,
+    async_log_eval_telemetry,
+    log_eval_run,
+    log_eval_telemetry,
+    spinner_live,
+    store_result_in_file,
+)
 from agno.exceptions import EvalError
 from agno.models.base import Model
 from agno.run.agent import RunInput, RunOutput
@@ -562,13 +569,7 @@ class AgentAsJudgeEval(BaseEval):
         self._log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
-
-            create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
-                )
-            )
+            log_eval_telemetry(run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result))
 
         return result
 
@@ -666,12 +667,8 @@ class AgentAsJudgeEval(BaseEval):
         await self._async_log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
-
-            await async_create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
-                )
+            await async_log_eval_telemetry(
+                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
             )
 
         return result
@@ -739,13 +736,7 @@ class AgentAsJudgeEval(BaseEval):
         self._log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
-
-            create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
-                )
-            )
+            log_eval_telemetry(run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result))
 
         return result
 
@@ -812,12 +803,8 @@ class AgentAsJudgeEval(BaseEval):
         await self._async_log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
-
-            await async_create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
-                )
+            await async_log_eval_telemetry(
+                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
             )
 
         return result

--- a/libs/agno/agno/eval/agent_as_judge.py
+++ b/libs/agno/agno/eval/agent_as_judge.py
@@ -569,7 +569,9 @@ class AgentAsJudgeEval(BaseEval):
         self._log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            log_eval_telemetry(run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result))
+            log_eval_telemetry(
+                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, get_data=lambda: self._get_telemetry_data(result)
+            )
 
         return result
 
@@ -668,7 +670,7 @@ class AgentAsJudgeEval(BaseEval):
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
+                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, get_data=lambda: self._get_telemetry_data(result)
             )
 
         return result
@@ -736,7 +738,9 @@ class AgentAsJudgeEval(BaseEval):
         self._log_eval_to_db(run_id=run_id, result=result, model_id=model_id, model_provider=model_provider)
 
         if self.telemetry:
-            log_eval_telemetry(run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result))
+            log_eval_telemetry(
+                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, get_data=lambda: self._get_telemetry_data(result)
+            )
 
         return result
 
@@ -804,7 +808,7 @@ class AgentAsJudgeEval(BaseEval):
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, data=self._get_telemetry_data(result)
+                run_id=run_id, eval_type=EvalType.AGENT_AS_JUDGE, get_data=lambda: self._get_telemetry_data(result)
             )
 
         return result

--- a/libs/agno/agno/eval/performance.py
+++ b/libs/agno/agno/eval/performance.py
@@ -610,9 +610,9 @@ class PerformanceEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
                 ),
@@ -756,9 +756,9 @@ class PerformanceEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            await async_create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
                 ),

--- a/libs/agno/agno/eval/performance.py
+++ b/libs/agno/agno/eval/performance.py
@@ -8,7 +8,14 @@ from uuid import uuid4
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas.evals import EvalType
-from agno.eval.utils import async_log_eval, log_eval_run, spinner_live, store_result_in_file
+from agno.eval.utils import (
+    async_log_eval,
+    async_log_eval_telemetry,
+    log_eval_run,
+    log_eval_telemetry,
+    spinner_live,
+    store_result_in_file,
+)
 from agno.utils.log import log_debug, set_log_level_to_debug, set_log_level_to_info
 from agno.utils.timer import Timer
 
@@ -617,13 +624,7 @@ class PerformanceEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
-
-            create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
-                ),
-            )
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data())
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")
         return self.result
@@ -762,12 +763,8 @@ class PerformanceEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
-
-            await async_create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
-                ),
+            await async_log_eval_telemetry(
+                run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
             )
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")

--- a/libs/agno/agno/eval/performance.py
+++ b/libs/agno/agno/eval/performance.py
@@ -624,7 +624,7 @@ class PerformanceEval:
             )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data())
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, get_data=self._get_telemetry_data)
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")
         return self.result
@@ -764,7 +764,7 @@ class PerformanceEval:
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
+                run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, get_data=self._get_telemetry_data
             )
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")

--- a/libs/agno/agno/eval/reliability.py
+++ b/libs/agno/agno/eval/reliability.py
@@ -176,9 +176,9 @@ class ReliabilityEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=self.eval_id,
                     eval_type=EvalType.RELIABILITY,
@@ -292,9 +292,9 @@ class ReliabilityEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
+            from agno.api.evals import EvalRunCreate, fire_and_forget_eval_telemetry
 
-            await async_create_eval_run_telemetry(
+            fire_and_forget_eval_telemetry(
                 eval_run=EvalRunCreate(
                     run_id=self.eval_id,
                     eval_type=EvalType.RELIABILITY,

--- a/libs/agno/agno/eval/reliability.py
+++ b/libs/agno/agno/eval/reliability.py
@@ -341,7 +341,7 @@ class ReliabilityEval:
             )
 
         if self.telemetry:
-            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.RELIABILITY, data=self._get_telemetry_data())
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.RELIABILITY, get_data=self._get_telemetry_data)
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
         return self.result
@@ -416,7 +416,7 @@ class ReliabilityEval:
 
         if self.telemetry:
             await async_log_eval_telemetry(
-                run_id=self.eval_id, eval_type=EvalType.RELIABILITY, data=self._get_telemetry_data()
+                run_id=self.eval_id, eval_type=EvalType.RELIABILITY, get_data=self._get_telemetry_data
             )
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")

--- a/libs/agno/agno/eval/reliability.py
+++ b/libs/agno/agno/eval/reliability.py
@@ -12,7 +12,14 @@ if TYPE_CHECKING:
 
 from agno.agent import RunOutput
 from agno.db.schemas.evals import EvalType
-from agno.eval.utils import async_log_eval, log_eval_run, spinner_live, store_result_in_file
+from agno.eval.utils import (
+    async_log_eval,
+    async_log_eval_telemetry,
+    log_eval_run,
+    log_eval_telemetry,
+    spinner_live,
+    store_result_in_file,
+)
 from agno.utils.log import logger
 
 
@@ -334,15 +341,7 @@ class ReliabilityEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
-
-            create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id,
-                    eval_type=EvalType.RELIABILITY,
-                    data=self._get_telemetry_data(),
-                ),
-            )
+            log_eval_telemetry(run_id=self.eval_id, eval_type=EvalType.RELIABILITY, data=self._get_telemetry_data())
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")
         return self.result
@@ -416,14 +415,8 @@ class ReliabilityEval:
             )
 
         if self.telemetry:
-            from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
-
-            await async_create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id,
-                    eval_type=EvalType.RELIABILITY,
-                    data=self._get_telemetry_data(),
-                ),
+            await async_log_eval_telemetry(
+                run_id=self.eval_id, eval_type=EvalType.RELIABILITY, data=self._get_telemetry_data()
             )
 
         logger.debug(f"*********** Evaluation End: {run_id} ***********")

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -345,8 +345,8 @@ async def _run_case_body(
                 # The final run output arrives in-stream (yield_run_output=True). It is
                 # captured, not forwarded to on_run_event - on_case_end delivers it.
                 # Response AND evidence fields are committed immediately: the stream can
-                # stall after the final output (e.g. a hung telemetry call in transport
-                # cleanup) and a timeout then must not discard what the run produced.
+                # stall after the final output (e.g. a hung persistence or user cleanup
+                # call) and a timeout then must not discard what the run produced.
                 response = event
                 result.response = event
                 _extract_evidence(result, event)
@@ -410,8 +410,8 @@ async def _run_case_body(
                 model=case.judge_model or judge_model,
                 db=db,
                 show_spinner=False,
-                # The eval awaits its telemetry POST before returning; on a blackholed
-                # network that burns case-timeout budget after the verdict is computed.
+                # Preserve EvalSuite's existing policy: its internally-created evals
+                # do not emit hidden telemetry, and the suite has no telemetry option.
                 telemetry=False,
             ).arun(input=case.input, output=result.output or "")
         except Exception as exc:

--- a/libs/agno/agno/eval/utils.py
+++ b/libs/agno/agno/eval/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas.evals import EvalRunRecord, EvalType
-from agno.utils.log import log_warning
+from agno.utils.log import log_debug, log_warning
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -193,6 +193,30 @@ async def async_log_eval(
     except Exception as e:
         # A failed write means eval history silently stops persisting - warn, don't debug-log.
         log_warning(f"Could not log eval run: {e}")
+
+
+def log_eval_telemetry(*, run_id: str, eval_type: EvalType, data: Optional[dict] = None) -> None:
+    """Queue an eval telemetry event; never raises.
+
+    Everything telemetry needs, the import included, stays inside the try: a
+    telemetry failure must never change the outcome of an eval.
+    """
+    try:
+        from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
+
+        create_eval_run_telemetry(eval_run=EvalRunCreate(run_id=run_id, eval_type=eval_type, data=data))
+    except Exception as e:
+        log_debug(f"Could not create eval run telemetry event: {type(e).__name__}")
+
+
+async def async_log_eval_telemetry(*, run_id: str, eval_type: EvalType, data: Optional[dict] = None) -> None:
+    """Async pair of ``log_eval_telemetry``; never raises."""
+    try:
+        from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
+
+        await async_create_eval_run_telemetry(eval_run=EvalRunCreate(run_id=run_id, eval_type=eval_type, data=data))
+    except Exception as e:
+        log_debug(f"Could not create eval run telemetry event: {type(e).__name__}")
 
 
 def store_result_in_file(

--- a/libs/agno/agno/eval/utils.py
+++ b/libs/agno/agno/eval/utils.py
@@ -195,13 +195,17 @@ async def async_log_eval(
         log_warning(f"Could not log eval run: {e}")
 
 
-def log_eval_telemetry(*, run_id: str, eval_type: EvalType, data: Optional[dict] = None) -> None:
+def log_eval_telemetry(
+    *, run_id: str, eval_type: EvalType, get_data: Optional[Callable[[], Optional[dict]]] = None
+) -> None:
     """Queue an eval telemetry event; never raises.
 
-    Everything telemetry needs, the import included, stays inside the try: a
-    telemetry failure must never change the outcome of an eval.
+    Everything telemetry needs stays inside the try, the import and the
+    ``get_data`` call that builds the payload included: a telemetry failure
+    must never change the outcome of an eval that already completed.
     """
     try:
+        data = get_data() if get_data is not None else None
         from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
 
         create_eval_run_telemetry(eval_run=EvalRunCreate(run_id=run_id, eval_type=eval_type, data=data))
@@ -209,9 +213,12 @@ def log_eval_telemetry(*, run_id: str, eval_type: EvalType, data: Optional[dict]
         log_debug(f"Could not create eval run telemetry event: {type(e).__name__}")
 
 
-async def async_log_eval_telemetry(*, run_id: str, eval_type: EvalType, data: Optional[dict] = None) -> None:
+async def async_log_eval_telemetry(
+    *, run_id: str, eval_type: EvalType, get_data: Optional[Callable[[], Optional[dict]]] = None
+) -> None:
     """Async pair of ``log_eval_telemetry``; never raises."""
     try:
+        data = get_data() if get_data is not None else None
         from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
 
         await async_create_eval_run_telemetry(eval_run=EvalRunCreate(run_id=run_id, eval_type=eval_type, data=data))

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -303,9 +303,14 @@ class AgentOS:
             self._setup_tracing()
 
         if self.telemetry:
+            from agno.api._executor import get_telemetry_executor
             from agno.api.os import OSLaunch, log_os_telemetry
 
-            log_os_telemetry(launch=OSLaunch(os_id=self.id, data=self._get_telemetry_data()))
+            try:
+                launch = OSLaunch(os_id=self.id, data=self._get_telemetry_data())
+                get_telemetry_executor().submit(log_os_telemetry, launch=launch)
+            except Exception:
+                pass
 
     def _add_agent_os_to_lifespan_function(self, lifespan):
         """

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -115,6 +115,15 @@ async def http_client_lifespan(_):
     await aclose_default_clients()
 
 
+@asynccontextmanager
+async def agent_os_telemetry_lifespan(_, agent_os: "AgentOS"):
+    """Emit launch telemetry after the serving worker has started."""
+    from agno.api.os import OSLaunch, log_os_telemetry
+
+    log_os_telemetry(launch=OSLaunch(os_id=agent_os.id, data=agent_os._get_telemetry_data()))
+    yield
+
+
 async def _drain_cancel_persist_tasks(timeout: float = 30.0) -> None:
     """Await in-flight cancel-persist writes before databases close on shutdown."""
     from agno.agent._run import _background_tasks as agent_tasks
@@ -483,11 +492,6 @@ class AgentOS:
 
         if self.tracing:
             self._setup_tracing()
-
-        if self.telemetry:
-            from agno.api.os import OSLaunch, log_os_telemetry
-
-            log_os_telemetry(launch=OSLaunch(os_id=self.id, data=self._get_telemetry_data()))
 
     @property
     def mcp_server(self) -> bool:
@@ -1070,6 +1074,11 @@ class AgentOS:
             if self.queue is not None and self.queue.durable:
                 lifespans.append(partial(queue_lifespan, agent_os=self))
 
+            # Launch telemetry starts here, after any pre-fork application
+            # construction and after substantive worker startup lifespans.
+            if self.telemetry:
+                lifespans.append(partial(agent_os_telemetry_lifespan, agent_os=self))
+
             # The httpx client cleanup lifespan (should be last to close after other lifespans)
             lifespans.append(http_client_lifespan)
 
@@ -1113,6 +1122,11 @@ class AgentOS:
             # The durable job queue worker (after db so tables exist)
             if self.queue is not None and self.queue.durable:
                 lifespans.append(partial(queue_lifespan, agent_os=self))
+
+            # Launch telemetry starts here, after any pre-fork application
+            # construction and after substantive worker startup lifespans.
+            if self.telemetry:
+                lifespans.append(partial(agent_os_telemetry_lifespan, agent_os=self))
 
             # The httpx client cleanup lifespan (should be last to close after other lifespans)
             lifespans.append(http_client_lifespan)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -117,10 +117,17 @@ async def http_client_lifespan(_):
 
 @asynccontextmanager
 async def agent_os_telemetry_lifespan(_, agent_os: "AgentOS"):
-    """Emit launch telemetry after the serving worker has started."""
-    from agno.api.os import OSLaunch, log_os_telemetry
+    """Emit launch telemetry after the serving worker has started.
 
-    log_os_telemetry(launch=OSLaunch(os_id=agent_os.id, data=agent_os._get_telemetry_data()))
+    Best-effort: a telemetry failure (including a failed import of the
+    telemetry client) must not stop the server from starting.
+    """
+    try:
+        from agno.api.os import OSLaunch, log_os_telemetry
+
+        log_os_telemetry(launch=OSLaunch(os_id=agent_os.id, data=agent_os._get_telemetry_data()))
+    except Exception as e:
+        log_debug(f"Could not send AgentOS launch telemetry: {type(e).__name__}")
     yield
 
 

--- a/libs/agno/agno/team/_telemetry.py
+++ b/libs/agno/agno/team/_telemetry.py
@@ -39,7 +39,7 @@ def get_telemetry_data(team: "Team") -> Dict[str, Any]:
 
 
 def log_team_telemetry(team: "Team", session_id: str, run_id: Optional[str] = None) -> None:
-    """Send a telemetry event to the API for a created Team run"""
+    """Fire-and-forget telemetry event for a created Team run."""
 
     from agno.team._init import _set_telemetry
 
@@ -47,18 +47,18 @@ def log_team_telemetry(team: "Team", session_id: str, run_id: Optional[str] = No
     if not team.telemetry:
         return
 
+    from agno.api._executor import get_telemetry_executor
     from agno.api.team import TeamRunCreate, create_team_run
 
     try:
-        create_team_run(
-            run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team)),
-        )
+        run = TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team))
+        get_telemetry_executor().submit(create_team_run, run)
     except Exception as e:
-        log_debug(f"Could not create Team run telemetry event: {e}")
+        log_debug(f"Could not submit Team run telemetry event: {e}")
 
 
 async def alog_team_telemetry(team: "Team", session_id: str, run_id: Optional[str] = None) -> None:
-    """Send a telemetry event to the API for a created Team async run"""
+    """Fire-and-forget telemetry event for a created Team async run."""
 
     from agno.team._init import _set_telemetry
 
@@ -66,9 +66,11 @@ async def alog_team_telemetry(team: "Team", session_id: str, run_id: Optional[st
     if not team.telemetry:
         return
 
-    from agno.api.team import TeamRunCreate, acreate_team_run
+    from agno.api._executor import get_telemetry_executor
+    from agno.api.team import TeamRunCreate, create_team_run
 
     try:
-        await acreate_team_run(run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team)))
+        run = TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team))
+        get_telemetry_executor().submit(create_team_run, run)
     except Exception as e:
-        log_debug(f"Could not create Team run telemetry event: {e}")
+        log_debug(f"Could not submit Team run telemetry event: {e}")

--- a/libs/agno/agno/team/_telemetry.py
+++ b/libs/agno/agno/team/_telemetry.py
@@ -47,9 +47,11 @@ def log_team_telemetry(team: "Team", session_id: str, run_id: Optional[str] = No
     if not team.telemetry:
         return
 
-    from agno.api.team import TeamRunCreate, create_team_run
-
+    # Everything telemetry needs, the import included, stays inside the try:
+    # a telemetry failure must never change the outcome of the run.
     try:
+        from agno.api.team import TeamRunCreate, create_team_run
+
         create_team_run(
             run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team)),
         )
@@ -66,9 +68,9 @@ async def alog_team_telemetry(team: "Team", session_id: str, run_id: Optional[st
     if not team.telemetry:
         return
 
-    from agno.api.team import TeamRunCreate, acreate_team_run
-
     try:
+        from agno.api.team import TeamRunCreate, acreate_team_run
+
         await acreate_team_run(run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team)))
     except Exception as e:
         log_debug(f"Could not create Team run telemetry event: {e}")

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -4662,36 +4662,36 @@ class Workflow:
         }
 
     def _log_workflow_telemetry(self, session_id: str, run_id: Optional[str] = None) -> None:
-        """Send a telemetry event to the API for a created Workflow run"""
+        """Fire-and-forget telemetry event for a created Workflow run."""
 
         self._set_telemetry()
         if not self.telemetry:
             return
 
+        from agno.api._executor import get_telemetry_executor
         from agno.api.workflow import WorkflowRunCreate, create_workflow_run
 
         try:
-            create_workflow_run(
-                workflow=WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data()),
-            )
+            workflow = WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data())
+            get_telemetry_executor().submit(create_workflow_run, workflow)
         except Exception as e:
-            log_debug(f"Could not create Workflow run telemetry event: {e}")
+            log_debug(f"Could not submit Workflow run telemetry event: {e}")
 
     async def _alog_workflow_telemetry(self, session_id: str, run_id: Optional[str] = None) -> None:
-        """Send a telemetry event to the API for a created Workflow async run"""
+        """Fire-and-forget telemetry event for a created Workflow async run."""
 
         self._set_telemetry()
         if not self.telemetry:
             return
 
-        from agno.api.workflow import WorkflowRunCreate, acreate_workflow_run
+        from agno.api._executor import get_telemetry_executor
+        from agno.api.workflow import WorkflowRunCreate, create_workflow_run
 
         try:
-            await acreate_workflow_run(
-                workflow=WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data())
-            )
+            workflow = WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data())
+            get_telemetry_executor().submit(create_workflow_run, workflow)
         except Exception as e:
-            log_debug(f"Could not create Workflow run telemetry event: {e}")
+            log_debug(f"Could not submit Workflow run telemetry event: {e}")
 
     def cli_app(
         self,

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -10966,9 +10966,11 @@ class Workflow:
         if not self.telemetry:
             return
 
-        from agno.api.workflow import WorkflowRunCreate, create_workflow_run
-
+        # Everything telemetry needs, the import included, stays inside the try:
+        # a telemetry failure must never change the outcome of the run.
         try:
+            from agno.api.workflow import WorkflowRunCreate, create_workflow_run
+
             create_workflow_run(
                 workflow=WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data()),
             )
@@ -10982,9 +10984,9 @@ class Workflow:
         if not self.telemetry:
             return
 
-        from agno.api.workflow import WorkflowRunCreate, acreate_workflow_run
-
         try:
+            from agno.api.workflow import WorkflowRunCreate, acreate_workflow_run
+
             await acreate_workflow_run(
                 workflow=WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data())
             )

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -335,6 +335,8 @@ def test_unusable_telemetry_timeouts_fall_back_instead_of_failing(monkeypatch):
 
 
 def test_unknown_api_runtime_falls_back_to_prd(monkeypatch):
+    monkeypatch.delenv("AGNO_TELEMETRY_TIMEOUT", raising=False)
+    monkeypatch.delenv("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", raising=False)
     monkeypatch.setenv("AGNO_API_RUNTIME", "bogus")
 
     with patch("agno.api.settings.log_warning") as warn:
@@ -343,6 +345,24 @@ def test_unknown_api_runtime_falls_back_to_prd(monkeypatch):
     assert settings.api_runtime == "prd"
     assert settings.api_url == "https://os-api.agno.com"
     warn.assert_called_once()
+
+
+def test_alpha_features_and_runtime_tolerate_unusable_values(monkeypatch):
+    monkeypatch.delenv("AGNO_TELEMETRY_TIMEOUT", raising=False)
+    monkeypatch.delenv("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", raising=False)
+
+    with patch("agno.api.settings.log_warning") as warn:
+        monkeypatch.setenv("AGNO_ALPHA_FEATURES", "abc")
+        assert AgnoAPISettings().alpha_features is False
+        monkeypatch.setenv("AGNO_ALPHA_FEATURES", "yes")
+        assert AgnoAPISettings().alpha_features is True
+        monkeypatch.setenv("AGNO_ALPHA_FEATURES", "")
+        assert AgnoAPISettings().alpha_features is False
+        monkeypatch.delenv("AGNO_ALPHA_FEATURES")
+        monkeypatch.setenv("AGNO_API_RUNTIME", " Dev ")
+        assert AgnoAPISettings().api_url == "http://localhost:7070"
+
+    assert warn.call_count == 1
 
 
 def test_sdk_version_is_computed_once():
@@ -410,6 +430,70 @@ def test_close_is_a_no_op_once_the_flush_has_finished():
     assert time.monotonic() - start < 0.2
 
 
+def test_close_deadline_holds_while_a_post_is_stuck_in_thread_start(monkeypatch):
+    # post() holds the state lock across Thread.start(); on a loaded machine
+    # that can take a long time. close() must not wait behind it past its window.
+    original_start = threading.Thread.start
+
+    def slow_start(self):
+        if self.name == "agno-telemetry":
+            time.sleep(0.6)
+        return original_start(self)
+
+    monkeypatch.setattr(threading.Thread, "start", slow_start)
+
+    class Client:
+        def post(self, route, json):
+            class Response:
+                status_code = 200
+
+            return Response()
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(Client, register_at_fork=False)
+    poster = threading.Thread(target=dispatcher.post, args=("/telemetry/test", {"run_id": "run"}), daemon=True)
+    poster.start()
+    time.sleep(0.1)  # the poster now holds dispatcher._lock inside Thread.start()
+    assert dispatcher._lock.locked()
+
+    start = time.monotonic()
+    dispatcher.close(0.05)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 0.3, f"close() waited {elapsed:.2f}s behind a post stuck in Thread.start()"
+    assert not dispatcher._accepting
+    poster.join(2)
+    dispatcher.close(1.0)
+
+
+def test_eval_telemetry_helpers_never_raise_when_building_the_payload_fails():
+    from agno.eval.utils import async_log_eval_telemetry, log_eval_telemetry
+
+    def explode():
+        raise RuntimeError("telemetry data broken")
+
+    log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, get_data=explode)
+    asyncio.run(async_log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, get_data=explode))
+
+
+def test_eval_run_completes_when_its_telemetry_data_cannot_be_built(monkeypatch):
+    from agno.eval.performance import PerformanceEval
+
+    monkeypatch.delenv("AGNO_TELEMETRY", raising=False)
+    posted = []
+    monkeypatch.setattr(api, "post_in_background", lambda route, payload: posted.append(route))
+
+    evaluation = PerformanceEval(func=lambda: 1, num_iterations=1, warmup_runs=0, telemetry=True)
+    monkeypatch.setattr(evaluation, "_get_telemetry_data", lambda: (_ for _ in ()).throw(RuntimeError("broken")))
+
+    result = evaluation.run(print_summary=False, print_results=False)
+
+    assert result is not None and len(result.run_times) == 1
+    assert posted == []
+
+
 @pytest.mark.parametrize("module", ["agno.api.agent", "agno.api.team", "agno.api.workflow", "agno.api.evals"])
 def test_run_telemetry_helpers_never_raise_when_the_api_module_is_unimportable(monkeypatch, module):
     from agno.agent import Agent
@@ -437,8 +521,8 @@ def test_run_telemetry_helpers_never_raise_when_the_api_module_is_unimportable(m
         workflow._log_workflow_telemetry(session_id="s", run_id="r")
         asyncio.run(workflow._alog_workflow_telemetry(session_id="s", run_id="r"))
     else:
-        log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, data={})
-        asyncio.run(async_log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, data={}))
+        log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, get_data=dict)
+        asyncio.run(async_log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, get_data=dict))
 
 
 def test_changed_pid_is_reset_before_acquiring_inherited_lock(dispatcher_factory):
@@ -1047,7 +1131,7 @@ assert (TELEMETRY_TIMEOUT, TELEMETRY_SHUTDOWN_TIMEOUT) == (5.0, 2.0), (TELEMETRY
 
 class Client:
     def post(self, route, json):
-        os.write(1, b'D')
+        os.write(1, b'<delivered:' + json['run_id'].encode() + b'>')
         class Response:
             status_code = 200
         return Response()
@@ -1056,7 +1140,7 @@ class Client:
         pass
 
 api._dispatcher._client_factory = Client
-api.post_in_background('/telemetry/test', {'run_id': 'run'})
+api.post_in_background('/telemetry/test', {'run_id': 'run-7f3a'})
 """
     env = subprocess_env()
     env["AGNO_TELEMETRY_TIMEOUT"] = "abc"
@@ -1064,15 +1148,16 @@ api.post_in_background('/telemetry/test', {'run_id': 'run'})
 
     result = subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=env, capture_output=True)
 
-    assert b"D" in result.stdout
+    assert b"<delivered:run-7f3a>" in result.stdout
 
 
 MULTIPROCESSING_CHILD_SCRIPT = """
 import multiprocessing
+import multiprocessing.util  # imported before agno: an import-time registration in the parent would be possible
 import sys
 import time
 
-from agno.api.api import Api, _TelemetryDispatcher
+from agno.api.api import api
 
 
 def child(conn):
@@ -1094,8 +1179,12 @@ def child(conn):
         def close(self):
             pass
 
-    dispatcher = _TelemetryDispatcher(Client, register_at_fork=False)
-    Api(dispatcher).post_in_background("/telemetry/test", {"session_id": "child"})
+    # The process-wide dispatcher, as production code uses it. fork and
+    # forkserver children clear multiprocessing's finalizer registry before
+    # this runs, so only a registration made when the child's worker starts
+    # can flush it.
+    api._dispatcher._client_factory = Client
+    api.post_in_background("/telemetry/test", {"session_id": "child"})
     # Return at once. The worker has not sent anything yet; delivery depends on
     # the flush multiprocessing runs before it exits the child with os._exit.
 
@@ -1122,7 +1211,8 @@ if __name__ == "__main__":
 def test_multiprocessing_children_flush_queued_events_before_exit(tmp_path, method):
     # fork and forkserver children exit through os._exit without running atexit;
     # the dispatcher's multiprocessing finalizer gives them the same bounded
-    # flush. spawn children run atexit anyway; included to pin parity.
+    # flush. spawn children run the same finalizer from BaseProcess._bootstrap
+    # (and atexit on top); included to pin parity across start methods.
     script = tmp_path / "mp_child.py"
     script.write_text(MULTIPROCESSING_CHILD_SCRIPT)
 
@@ -1208,3 +1298,74 @@ finally:
 assert os.waitstatus_to_exitcode(status) == 0
 """
     subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=subprocess_env())
+
+
+IMPORT_TIME_POST_SCRIPT = """
+import multiprocessing
+import os
+import sys
+import time
+
+from agno.api.api import api
+
+RESULTS = os.environ["RESULTS_FILE"]
+
+
+class Client:
+    def __init__(self):
+        time.sleep(0.1)
+
+    def post(self, route, json):
+        with open(RESULTS, "a") as f:
+            f.write(json["session_id"] + "\\n")
+
+        class Response:
+            status_code = 200
+
+        return Response()
+
+    def close(self):
+        pass
+
+
+api._dispatcher._client_factory = Client
+# Posted at import, outside the __main__ guard: this runs in the parent and
+# again in every forkserver/spawn child while the main module is re-imported,
+# i.e. before multiprocessing clears the child's finalizer registry.
+where = "parent" if multiprocessing.current_process().name == "MainProcess" else "child"
+api.post_in_background("/telemetry/test", {"session_id": "import:" + where})
+
+
+def child():
+    api.post_in_background("/telemetry/test", {"session_id": "run:child"})
+
+
+if __name__ == "__main__":
+    context = multiprocessing.get_context(sys.argv[1])
+    process = context.Process(target=child)
+    process.start()
+    process.join(20)
+    print("EXIT", process.exitcode, flush=True)
+"""
+
+
+@pytest.mark.parametrize("method", multiprocessing.get_all_start_methods())
+def test_child_that_posts_while_its_main_module_is_imported_still_flushes(tmp_path, method):
+    # A forkserver child starts its worker during the re-import of the main
+    # module, before BaseProcess._bootstrap clears the finalizer registry; the
+    # after-fork hook has to register the flush again or the child loses both
+    # its import-time and run-time events.
+    script = tmp_path / "import_post.py"
+    script.write_text(IMPORT_TIME_POST_SCRIPT)
+    results = tmp_path / "results.txt"
+    env = subprocess_env()
+    env["RESULTS_FILE"] = str(results)
+
+    completed = subprocess.run(
+        [sys.executable, str(script), method], check=True, timeout=60, env=env, capture_output=True, text=True
+    )
+
+    assert "EXIT 0" in completed.stdout, (completed.stdout, completed.stderr[-800:])
+    delivered = set(results.read_text().split()) if results.exists() else set()
+    expected = {"import:parent", "run:child"} if method == "fork" else {"import:parent", "import:child", "run:child"}
+    assert delivered == expected, (delivered, completed.stderr[-800:])

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -1,15 +1,30 @@
 """Tests for the background telemetry dispatcher (Api.post_in_background)."""
 
 import os
+import subprocess
+import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
-from agno.api.agent import create_agent_run
-from agno.api.api import Api, api
+from agno.api.agent import acreate_agent_run, create_agent_run
+from agno.api.api import TELEMETRY_TIMEOUT, Api, api
+from agno.api.evals import async_create_eval_run_telemetry, create_eval_run_telemetry
+from agno.api.os import log_os_telemetry
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.agent import AgentRunCreate
+from agno.api.schemas.evals import EvalRunCreate
+from agno.api.schemas.os import OSLaunch
+from agno.api.schemas.team import TeamRunCreate
+from agno.api.schemas.workflows import WorkflowRunCreate
+from agno.api.team import acreate_team_run, create_team_run
+from agno.api.workflow import acreate_workflow_run, create_workflow_run
+from agno.db.schemas.evals import EvalType
 
 
 def wait_for_drain(instance: Api, timeout: float = 5.0) -> None:
@@ -29,7 +44,7 @@ def make_api_with_mock_transport(handler) -> tuple[Api, list[httpx.Client]]:
         constructed.append(client)
         return client
 
-    instance.Client = make_client  # type: ignore[method-assign]
+    instance._telemetry_client = make_client  # type: ignore[method-assign]
     return instance, constructed
 
 
@@ -52,6 +67,29 @@ def test_events_are_sent_over_a_single_reused_client():
     assert b"s1" in requests[0].content and b"s2" in requests[1].content
 
 
+def test_concurrent_first_use_starts_one_worker_and_delivers_every_event():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    instance, constructed = make_api_with_mock_transport(handler)
+
+    with ThreadPoolExecutor(max_workers=16) as callers:
+        futures = [
+            callers.submit(instance.post_in_background, ApiRoutes.RUN_CREATE, {"session_id": f"s{i}"})
+            for i in range(64)
+        ]
+        for future in futures:
+            future.result()
+    wait_for_drain(instance)
+
+    assert len(requests) == 64
+    assert len(constructed) == 1
+    assert instance._worker is not None and instance._worker.is_alive()
+
+
 def test_worker_survives_transport_errors_and_bad_statuses():
     calls = {"n": 0}
     delivered: list[httpx.Request] = []
@@ -59,7 +97,7 @@ def test_worker_survives_transport_errors_and_bad_statuses():
     def handler(request: httpx.Request) -> httpx.Response:
         calls["n"] += 1
         if calls["n"] == 1:
-            raise httpx.ConnectError("telemetry endpoint down")
+            raise httpx.ConnectError("https://secret-telemetry.example/internal")
         if calls["n"] == 2:
             return httpx.Response(500)
         delivered.append(request)
@@ -67,13 +105,17 @@ def test_worker_survives_transport_errors_and_bad_statuses():
 
     instance, _ = make_api_with_mock_transport(handler)
 
-    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "boom"})
-    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "rejected"})
-    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "ok"})
-    wait_for_drain(instance)
+    with patch("agno.api.api.log_debug") as log:
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "boom"})
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "rejected"})
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "ok"})
+        wait_for_drain(instance)
 
     assert calls["n"] == 3
     assert len(delivered) == 1 and b"ok" in delivered[0].content
+    messages = [str(call.args[0]) for call in log.call_args_list]
+    assert any("ConnectError" in message for message in messages)
+    assert all("secret-telemetry.example" not in message for message in messages)
 
 
 def test_post_in_background_never_blocks_or_raises_when_queue_is_full():
@@ -88,16 +130,61 @@ def test_post_in_background_never_blocks_or_raises_when_queue_is_full():
     assert instance._queue.qsize() == instance._queue.maxsize
 
 
-def test_create_agent_run_dispatches_in_background(monkeypatch):
-    enqueued = []
+@pytest.mark.parametrize(
+    ("helper", "payload", "route"),
+    [
+        (create_agent_run, AgentRunCreate(session_id="agent-session", run_id="agent-run"), ApiRoutes.RUN_CREATE),
+        (create_team_run, TeamRunCreate(session_id="team-session", run_id="team-run"), ApiRoutes.RUN_CREATE),
+        (
+            create_workflow_run,
+            WorkflowRunCreate(session_id="workflow-session", run_id="workflow-run"),
+            ApiRoutes.RUN_CREATE,
+        ),
+        (
+            create_eval_run_telemetry,
+            EvalRunCreate(run_id="eval-run", eval_type=EvalType.ACCURACY),
+            ApiRoutes.EVAL_RUN_CREATE,
+        ),
+        (log_os_telemetry, OSLaunch(os_id="test-os"), ApiRoutes.AGENT_OS_LAUNCH),
+    ],
+)
+def test_sync_telemetry_helpers_dispatch_in_background(monkeypatch, helper, payload, route):
+    enqueued: list[tuple[str, dict]] = []
     monkeypatch.setattr(api, "post_in_background", lambda route, payload: enqueued.append((route, payload)))
 
-    create_agent_run(AgentRunCreate(session_id="session-1", run_id="run-1"))
+    helper(payload)
 
     assert len(enqueued) == 1
-    route, payload = enqueued[0]
-    assert route == ApiRoutes.RUN_CREATE
-    assert payload["session_id"] == "session-1" and payload["run_id"] == "run-1"
+    actual_route, actual_payload = enqueued[0]
+    assert actual_route == route
+    assert actual_payload == payload.model_dump(exclude_none=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("helper", "payload", "route"),
+    [
+        (acreate_agent_run, AgentRunCreate(session_id="agent-session", run_id="agent-run"), ApiRoutes.RUN_CREATE),
+        (acreate_team_run, TeamRunCreate(session_id="team-session", run_id="team-run"), ApiRoutes.RUN_CREATE),
+        (
+            acreate_workflow_run,
+            WorkflowRunCreate(session_id="workflow-session", run_id="workflow-run"),
+            ApiRoutes.RUN_CREATE,
+        ),
+        (
+            async_create_eval_run_telemetry,
+            EvalRunCreate(run_id="eval-run", eval_type=EvalType.ACCURACY),
+            ApiRoutes.EVAL_RUN_CREATE,
+        ),
+    ],
+)
+async def test_async_telemetry_helpers_dispatch_in_background(monkeypatch, helper, payload, route):
+    enqueue = AsyncMock()
+    monkeypatch.setattr(api, "apost_in_background", enqueue)
+
+    await helper(payload)
+
+    enqueue.assert_awaited_once_with(route, payload.model_dump(exclude_none=True))
 
 
 def test_async_variant_is_paired_and_delegates():
@@ -117,20 +204,79 @@ def test_async_variant_is_paired_and_delegates():
     assert len(constructed) == 1
 
 
+def test_background_client_uses_short_telemetry_timeout():
+    instance = Api()
+
+    with patch("agno.api.api.HttpxClient") as client:
+        instance._telemetry_client()
+
+    assert client.call_args.kwargs["timeout"] == TELEMETRY_TIMEOUT
+
+
+def test_changed_pid_is_reset_before_acquiring_inherited_lock():
+    instance = Api()
+    inherited_lock = instance._lock
+    inherited_lock.acquire()
+    instance._pid = -1
+    completed = threading.Event()
+
+    def ensure_worker() -> None:
+        instance._ensure_worker()
+        completed.set()
+
+    thread = threading.Thread(target=ensure_worker, daemon=True)
+    thread.start()
+    try:
+        assert completed.wait(1), "pid fallback must not acquire a lock inherited from the parent"
+        assert instance._lock is not inherited_lock
+        assert instance._pid == os.getpid()
+    finally:
+        inherited_lock.release()
+
+
+def test_daemon_worker_does_not_delay_process_exit():
+    script = """
+import threading
+import time
+
+from agno.api.api import Api
+
+started = threading.Event()
+
+class BlockingClient:
+    def post(self, route, json):
+        started.set()
+        time.sleep(30)
+
+instance = Api()
+instance._telemetry_client = lambda: BlockingClient()
+instance.post_in_background('/telemetry/test', {'run_id': 'run'})
+assert started.wait(2)
+"""
+    env = os.environ.copy()
+    package_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=5, env=env)
+
+
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not available on this platform")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_forked_child_resets_dispatcher_state():
+    requests: list[httpx.Request] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
         return httpx.Response(200)
 
-    instance, _ = make_api_with_mock_transport(handler)
+    instance, constructed = make_api_with_mock_transport(handler)
     instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "parent"})
     wait_for_drain(instance)
     assert instance._worker is not None and instance._worker.is_alive()
 
     read_fd, write_fd = os.pipe()
     pid = os.fork()
-    if pid == 0:  # child: report whether the fork hook gave us fresh state
+    if pid == 0:  # child: prove reset state can deliver through a new worker/client
         try:
             fresh = (
                 instance._worker is None
@@ -138,12 +284,15 @@ def test_forked_child_resets_dispatcher_state():
                 and instance._queue.qsize() == 0
                 and instance._pid == os.getpid()
             )
-            os.write(write_fd, b"1" if fresh else b"0")
+            instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "child"})
+            wait_for_drain(instance)
+            delivered = len(requests) == 2 and b"child" in requests[-1].content and len(constructed) == 2
+            os.write(write_fd, b"1" if fresh and delivered else b"0")
         finally:
             os._exit(0)
     os.close(write_fd)
     try:
-        assert os.read(read_fd, 1) == b"1", "child must see reset dispatcher state"
+        assert os.read(read_fd, 1) == b"1", "child must reset dispatcher state and deliver through a fresh worker"
     finally:
         os.close(read_fd)
         os.waitpid(pid, 0)

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -96,3 +96,20 @@ def test_create_agent_run_dispatches_in_background(monkeypatch):
     route, payload = enqueued[0]
     assert route == ApiRoutes.RUN_CREATE
     assert payload["session_id"] == "session-1" and payload["run_id"] == "run-1"
+
+
+def test_async_variant_is_paired_and_delegates():
+    import asyncio
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    instance, constructed = make_api_with_mock_transport(handler)
+    asyncio.run(instance.apost_in_background(ApiRoutes.RUN_CREATE, {"session_id": "async-1"}))
+    wait_for_drain(instance)
+
+    assert len(requests) == 1 and b"async-1" in requests[0].content
+    assert len(constructed) == 1

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -1,0 +1,98 @@
+"""Tests for the background telemetry dispatcher (Api.post_in_background)."""
+
+import time
+
+import httpx
+
+from agno.api.agent import create_agent_run
+from agno.api.api import Api, api
+from agno.api.routes import ApiRoutes
+from agno.api.schemas.agent import AgentRunCreate
+
+
+def wait_for_drain(instance: Api, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while instance._queue.unfinished_tasks and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert not instance._queue.unfinished_tasks, "telemetry queue did not drain in time"
+
+
+def make_api_with_mock_transport(handler) -> tuple[Api, list[httpx.Client]]:
+    """An Api whose clients hit a mock transport, tracking each construction."""
+    instance = Api()
+    constructed: list[httpx.Client] = []
+
+    def make_client() -> httpx.Client:
+        client = httpx.Client(base_url="https://telemetry.test", transport=httpx.MockTransport(handler))
+        constructed.append(client)
+        return client
+
+    instance.Client = make_client  # type: ignore[method-assign]
+    return instance, constructed
+
+
+def test_events_are_sent_over_a_single_reused_client():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    instance, constructed = make_api_with_mock_transport(handler)
+
+    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "s1"})
+    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "s2"})
+    wait_for_drain(instance)
+
+    assert len(requests) == 2
+    assert len(constructed) == 1, "every event must reuse the one shared client"
+    assert requests[0].url.path == ApiRoutes.RUN_CREATE
+    assert b"s1" in requests[0].content and b"s2" in requests[1].content
+
+
+def test_worker_survives_transport_errors_and_bad_statuses():
+    calls = {"n": 0}
+    delivered: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("telemetry endpoint down")
+        if calls["n"] == 2:
+            return httpx.Response(500)
+        delivered.append(request)
+        return httpx.Response(200)
+
+    instance, _ = make_api_with_mock_transport(handler)
+
+    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "boom"})
+    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "rejected"})
+    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "ok"})
+    wait_for_drain(instance)
+
+    assert calls["n"] == 3
+    assert len(delivered) == 1 and b"ok" in delivered[0].content
+
+
+def test_post_in_background_never_blocks_or_raises_when_queue_is_full():
+    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - never reached
+        return httpx.Response(200)
+
+    instance, _ = make_api_with_mock_transport(handler)
+    # Fill the queue without a worker so puts beyond the bound must drop, not block
+    instance._ensure_worker = lambda: None  # type: ignore[method-assign]
+    for i in range(instance._queue.maxsize + 10):
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"i": i})
+    assert instance._queue.qsize() == instance._queue.maxsize
+
+
+def test_create_agent_run_dispatches_in_background(monkeypatch):
+    enqueued = []
+    monkeypatch.setattr(api, "post_in_background", lambda route, payload: enqueued.append((route, payload)))
+
+    create_agent_run(AgentRunCreate(session_id="session-1", run_id="run-1"))
+
+    assert len(enqueued) == 1
+    route, payload = enqueued[0]
+    assert route == ApiRoutes.RUN_CREATE
+    assert payload["session_id"] == "session-1" and payload["run_id"] == "run-1"

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -754,39 +754,78 @@ assert started.wait(2)
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not available on this platform")
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_forked_child_resets_dispatcher_state(dispatcher_factory):
-    requests: list[httpx.Request] = []
+def test_fork_before_first_event_resets_child_dispatcher_state():
+    # Run in a fresh interpreter so unrelated pytest/plugin threads cannot make
+    # Python's process-wide multi-threaded-fork warning look telemetry-related.
+    script = """
+import os
+import time
+import warnings
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        requests.append(request)
-        return httpx.Response(200)
+from agno.api.api import Api, _TelemetryDispatcher
 
-    dispatcher, constructed = dispatcher_factory(handler, register_at_fork=True)
-    instance = Api(dispatcher)
-    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "parent"})
-    wait_for_drain(dispatcher)
-    assert dispatcher._worker is not None and dispatcher._worker.is_alive()
+requests = []
+constructed = []
 
-    read_fd, write_fd = os.pipe()
+class Client:
+    def __init__(self):
+        constructed.append(self)
+
+    def post(self, route, json):
+        requests.append((route, json))
+
+        class Response:
+            status_code = 200
+
+        return Response()
+
+    def close(self):
+        pass
+
+dispatcher = _TelemetryDispatcher(Client, register_at_fork=True)
+instance = Api(dispatcher)
+assert dispatcher._worker is None
+assert dispatcher._client is None
+assert constructed == []
+
+read_fd, write_fd = os.pipe()
+with warnings.catch_warnings(record=True) as fork_warnings:
+    warnings.simplefilter("always", DeprecationWarning)
     pid = os.fork()
-    if pid == 0:  # child: prove reset state can deliver through a new worker/client
-        try:
-            fresh = (
-                dispatcher._worker is None
-                and dispatcher._client is None
-                and dispatcher._queue.qsize() == 0
-                and dispatcher._pid == os.getpid()
-            )
-            instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "child"})
-            wait_for_drain(dispatcher)
-            delivered = len(requests) == 2 and b"child" in requests[-1].content and len(constructed) == 2
-            os.write(write_fd, b"1" if fresh and delivered else b"0")
-        finally:
-            os._exit(0)
-    os.close(write_fd)
+
+if pid == 0:
     try:
-        assert os.read(read_fd, 1) == b"1", "child must reset dispatcher state and deliver through a fresh worker"
+        fresh = (
+            dispatcher._worker is None
+            and dispatcher._client is None
+            and dispatcher._queue.qsize() == 0
+            and dispatcher._pid == os.getpid()
+        )
+        instance.post_in_background("/telemetry/test", {"session_id": "child"})
+        deadline = time.monotonic() + 2
+        while dispatcher._queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+        delivered = requests == [("/telemetry/test", {"session_id": "child"})] and len(constructed) == 1
+        os.write(write_fd, b"1" if fresh and delivered else b"0")
     finally:
-        os.close(read_fd)
-        os.waitpid(pid, 0)
+        os._exit(0)
+
+os.close(write_fd)
+try:
+    assert os.read(read_fd, 1) == b"1"
+finally:
+    os.close(read_fd)
+    _, status = os.waitpid(pid, 0)
+
+assert os.waitstatus_to_exitcode(status) == 0
+assert not [
+    warning
+    for warning in fork_warnings
+    if issubclass(warning.category, DeprecationWarning) and "multi-threaded" in str(warning.message)
+]
+"""
+    env = os.environ.copy()
+    package_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=env)

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -1,7 +1,10 @@
 """Tests for the background telemetry dispatcher (Api.post_in_background)."""
 
+import asyncio
 import gc
+import importlib.metadata
 import json
+import multiprocessing
 import os
 import subprocess
 import sys
@@ -32,8 +35,9 @@ from agno.api.schemas.agent import AgentRunCreate
 from agno.api.schemas.evals import EvalRunCreate
 from agno.api.schemas.os import OSLaunch
 from agno.api.schemas.team import TeamRunCreate
+from agno.api.schemas.utils import get_sdk_version
 from agno.api.schemas.workflows import WorkflowRunCreate
-from agno.api.settings import AgnoAPISettings
+from agno.api.settings import MAX_TELEMETRY_TIMEOUT_SECONDS, AgnoAPISettings
 from agno.api.team import acreate_team_run, create_team_run
 from agno.api.workflow import acreate_workflow_run, create_workflow_run
 from agno.db.schemas.evals import EvalType
@@ -44,6 +48,21 @@ def wait_for_drain(dispatcher: _TelemetryDispatcher, timeout: float = 5.0) -> No
     while dispatcher._queue.unfinished_tasks and time.monotonic() < deadline:
         time.sleep(0.01)
     assert not dispatcher._queue.unfinished_tasks, "telemetry queue did not drain in time"
+
+
+def subprocess_env() -> dict:
+    """Environment for the subprocess-based tests.
+
+    The package root goes first on PYTHONPATH, and the telemetry timeout
+    variables are removed so a developer or CI shell that exports them cannot
+    change the windows these tests assert on.
+    """
+    env = os.environ.copy()
+    env.pop("AGNO_TELEMETRY_TIMEOUT", None)
+    env.pop("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", None)
+    package_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    return env
 
 
 @pytest.fixture
@@ -284,11 +303,142 @@ def test_telemetry_timeouts_are_env_tunable(monkeypatch):
     assert settings.telemetry_shutdown_timeout == 0.0
 
 
-def test_negative_telemetry_timeouts_clamp_to_zero():
-    settings = AgnoAPISettings(telemetry_timeout=-1, telemetry_shutdown_timeout=-0.5)
+def test_unusable_telemetry_timeouts_fall_back_instead_of_failing(monkeypatch):
+    # A zero or negative request timeout fails every request, so it falls back to
+    # the default; a negative shutdown timeout clamps to the documented 0 (skip
+    # the flush). Non-numeric, empty and non-finite values never break import.
+    with patch("agno.api.settings.log_warning") as warn:
+        settings = AgnoAPISettings(telemetry_timeout=-1, telemetry_shutdown_timeout=-0.5)
+        assert (settings.telemetry_timeout, settings.telemetry_shutdown_timeout) == (5.0, 0.0)
 
-    assert settings.telemetry_timeout == 0.0
-    assert settings.telemetry_shutdown_timeout == 0.0
+        assert AgnoAPISettings(telemetry_timeout=0).telemetry_timeout == 5.0
+        assert AgnoAPISettings(telemetry_timeout=float("nan")).telemetry_timeout == 5.0
+        assert AgnoAPISettings(telemetry_timeout=float("inf")).telemetry_timeout == 5.0
+        assert AgnoAPISettings(telemetry_shutdown_timeout=float("inf")).telemetry_shutdown_timeout == 2.0
+        assert AgnoAPISettings(telemetry_timeout=1e10).telemetry_timeout == MAX_TELEMETRY_TIMEOUT_SECONDS
+        assert (
+            AgnoAPISettings(telemetry_shutdown_timeout=1e10).telemetry_shutdown_timeout == MAX_TELEMETRY_TIMEOUT_SECONDS
+        )
+
+        monkeypatch.setenv("AGNO_TELEMETRY_TIMEOUT", "abc")
+        monkeypatch.setenv("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", "")
+        settings = AgnoAPISettings()
+        assert (settings.telemetry_timeout, settings.telemetry_shutdown_timeout) == (5.0, 2.0)
+
+        monkeypatch.setenv("AGNO_TELEMETRY_TIMEOUT", " 1.5 ")
+        monkeypatch.setenv("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", "0")
+        settings = AgnoAPISettings()
+        assert (settings.telemetry_timeout, settings.telemetry_shutdown_timeout) == (1.5, 0.0)
+
+    assert warn.call_count >= 7
+    assert all("AGNO_TELEMETRY" in str(call.args[0]) for call in warn.call_args_list)
+
+
+def test_unknown_api_runtime_falls_back_to_prd(monkeypatch):
+    monkeypatch.setenv("AGNO_API_RUNTIME", "bogus")
+
+    with patch("agno.api.settings.log_warning") as warn:
+        settings = AgnoAPISettings()
+
+    assert settings.api_runtime == "prd"
+    assert settings.api_url == "https://os-api.agno.com"
+    warn.assert_called_once()
+
+
+def test_sdk_version_is_computed_once():
+    get_sdk_version.cache_clear()
+    real_version = importlib.metadata.version
+    calls = []
+
+    def counting_version(name):
+        calls.append(name)
+        return real_version(name)
+
+    with patch("importlib.metadata.version", counting_version):
+        first = get_sdk_version()
+        second = get_sdk_version()
+        assert AgentRunCreate(session_id="s").sdk_version == first
+
+    assert first == second == real_version("agno")
+    assert calls == ["agno"]
+
+
+def test_close_default_flush_timeout_is_read_at_call_time(monkeypatch):
+    started = threading.Event()
+
+    class BlockingClient:
+        def post(self, route, json):
+            started.set()
+            time.sleep(5)
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(BlockingClient, register_at_fork=False)
+    dispatcher.post("/telemetry/test", {"run_id": "run"})
+    assert started.wait(2)
+
+    monkeypatch.setattr("agno.api.api.TELEMETRY_SHUTDOWN_TIMEOUT", 0.0)
+    start = time.monotonic()
+    dispatcher.close()
+
+    assert time.monotonic() - start < 0.5
+    assert not dispatcher._accepting
+
+
+def test_close_is_a_no_op_once_the_flush_has_finished():
+    started = threading.Event()
+
+    class BlockingClient:
+        def post(self, route, json):
+            started.set()
+            time.sleep(5)
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(BlockingClient, register_at_fork=False)
+    dispatcher.post("/telemetry/test", {"run_id": "run"})
+    assert started.wait(2)
+    dispatcher.close(0.2)
+    assert dispatcher._closed
+
+    # atexit and a multiprocessing finalizer can both call close(); the second
+    # must not wait another full window on the still-blocked worker.
+    start = time.monotonic()
+    dispatcher.close(5.0)
+    assert time.monotonic() - start < 0.2
+
+
+@pytest.mark.parametrize("module", ["agno.api.agent", "agno.api.team", "agno.api.workflow", "agno.api.evals"])
+def test_run_telemetry_helpers_never_raise_when_the_api_module_is_unimportable(monkeypatch, module):
+    from agno.agent import Agent
+    from agno.agent._telemetry import alog_agent_telemetry, log_agent_telemetry
+    from agno.eval.utils import async_log_eval_telemetry, log_eval_telemetry
+    from agno.team import Team
+    from agno.team._telemetry import alog_team_telemetry, log_team_telemetry
+    from agno.workflow import Workflow
+
+    monkeypatch.delenv("AGNO_TELEMETRY", raising=False)
+    # A None entry makes `from module import name` raise ImportError, the same
+    # failure a broken settings import produces on the first telemetry event.
+    monkeypatch.setitem(sys.modules, module, None)
+
+    if module == "agno.api.agent":
+        agent = Agent()
+        log_agent_telemetry(agent, session_id="s", run_id="r")
+        asyncio.run(alog_agent_telemetry(agent, session_id="s", run_id="r"))
+    elif module == "agno.api.team":
+        team = Team(members=[Agent()])
+        log_team_telemetry(team, session_id="s", run_id="r")
+        asyncio.run(alog_team_telemetry(team, session_id="s", run_id="r"))
+    elif module == "agno.api.workflow":
+        workflow = Workflow()
+        workflow._log_workflow_telemetry(session_id="s", run_id="r")
+        asyncio.run(workflow._alog_workflow_telemetry(session_id="s", run_id="r"))
+    else:
+        log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, data={})
+        asyncio.run(async_log_eval_telemetry(run_id="r", eval_type=EvalType.ACCURACY, data={}))
 
 
 def test_changed_pid_is_reset_before_acquiring_inherited_lock(dispatcher_factory):
@@ -712,9 +862,7 @@ assert len(constructed) == 1, constructed
 assert sum(t.name == 'agno-telemetry' and t.is_alive() for t in threading.enumerate()) == 1
 dispatcher.close(0.5)
 """
-    env = os.environ.copy()
-    package_root = str(Path(__file__).resolve().parents[3])
-    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    env = subprocess_env()
 
     subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=env)
 
@@ -740,9 +888,7 @@ class Client:
 api._dispatcher._client_factory = Client
 api.post_in_background('/telemetry/test', {'run_id': 'run'})
 """
-    env = os.environ.copy()
-    package_root = str(Path(__file__).resolve().parents[3])
-    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    env = subprocess_env()
 
     result = subprocess.run([sys.executable, "-c", script], check=True, timeout=5, env=env, capture_output=True)
 
@@ -770,9 +916,7 @@ api._dispatcher._client_factory = BlockingClient
 api.post_in_background('/telemetry/test', {'run_id': 'run'})
 assert started.wait(2)
 """
-    env = os.environ.copy()
-    package_root = str(Path(__file__).resolve().parents[3])
-    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    env = subprocess_env()
 
     start = time.monotonic()
     subprocess.run([sys.executable, "-c", script], check=True, timeout=6, env=env)
@@ -803,9 +947,7 @@ api._dispatcher._client_factory = BlockingClient
 api.post_in_background('/telemetry/test', {'run_id': 'run'})
 assert started.wait(2)
 """
-    env = os.environ.copy()
-    package_root = str(Path(__file__).resolve().parents[3])
-    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    env = subprocess_env()
     env["AGNO_TELEMETRY_SHUTDOWN_TIMEOUT"] = "0"
 
     start = time.monotonic()
@@ -886,8 +1028,183 @@ assert not [
     if issubclass(warning.category, DeprecationWarning) and "multi-threaded" in str(warning.message)
 ]
 """
-    env = os.environ.copy()
-    package_root = str(Path(__file__).resolve().parents[3])
-    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    env = subprocess_env()
 
     subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=env)
+
+
+def test_malformed_telemetry_env_is_ignored_end_to_end():
+    # An unparsable or empty value in a deployment's environment must leave the
+    # defaults in place and deliver; it used to fail the settings import, which
+    # surfaced as an error status on every run.
+    script = """
+import os
+import time
+
+from agno.api.api import TELEMETRY_SHUTDOWN_TIMEOUT, TELEMETRY_TIMEOUT, api
+
+assert (TELEMETRY_TIMEOUT, TELEMETRY_SHUTDOWN_TIMEOUT) == (5.0, 2.0), (TELEMETRY_TIMEOUT, TELEMETRY_SHUTDOWN_TIMEOUT)
+
+class Client:
+    def post(self, route, json):
+        os.write(1, b'D')
+        class Response:
+            status_code = 200
+        return Response()
+
+    def close(self):
+        pass
+
+api._dispatcher._client_factory = Client
+api.post_in_background('/telemetry/test', {'run_id': 'run'})
+"""
+    env = subprocess_env()
+    env["AGNO_TELEMETRY_TIMEOUT"] = "abc"
+    env["AGNO_TELEMETRY_SHUTDOWN_TIMEOUT"] = ""
+
+    result = subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=env, capture_output=True)
+
+    assert b"D" in result.stdout
+
+
+MULTIPROCESSING_CHILD_SCRIPT = """
+import multiprocessing
+import sys
+import time
+
+from agno.api.api import Api, _TelemetryDispatcher
+
+
+def child(conn):
+    class Client:
+        def __init__(self):
+            # The real client takes tens of milliseconds to build (TLS context);
+            # without that delay the worker can win the race against os._exit
+            # and the test would pass without any exit flush.
+            time.sleep(0.1)
+
+        def post(self, route, json):
+            conn.send(json["session_id"])
+
+            class Response:
+                status_code = 200
+
+            return Response()
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(Client, register_at_fork=False)
+    Api(dispatcher).post_in_background("/telemetry/test", {"session_id": "child"})
+    # Return at once. The worker has not sent anything yet; delivery depends on
+    # the flush multiprocessing runs before it exits the child with os._exit.
+
+
+if __name__ == "__main__":
+    method = sys.argv[1]
+    context = multiprocessing.get_context(method)
+    parent_conn, child_conn = context.Pipe(duplex=False)
+    process = context.Process(target=child, args=(child_conn,))
+    process.start()
+    child_conn.close()
+    process.join(20)
+    delivered = []
+    while parent_conn.poll(1.0):
+        try:
+            delivered.append(parent_conn.recv())
+        except EOFError:
+            break
+    print("EXIT", process.exitcode, "DELIVERED", delivered, flush=True)
+"""
+
+
+@pytest.mark.parametrize("method", multiprocessing.get_all_start_methods())
+def test_multiprocessing_children_flush_queued_events_before_exit(tmp_path, method):
+    # fork and forkserver children exit through os._exit without running atexit;
+    # the dispatcher's multiprocessing finalizer gives them the same bounded
+    # flush. spawn children run atexit anyway; included to pin parity.
+    script = tmp_path / "mp_child.py"
+    script.write_text(MULTIPROCESSING_CHILD_SCRIPT)
+
+    result = subprocess.run(
+        [sys.executable, str(script), method],
+        check=True,
+        timeout=60,
+        env=subprocess_env(),
+        capture_output=True,
+        text=True,
+    )
+
+    assert "EXIT 0 DELIVERED ['child']" in result.stdout, (result.stdout, result.stderr[-800:])
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not available on this platform")
+def test_fork_after_first_event_resets_child_dispatcher_state():
+    # Forking after the worker started is unsupported for the inherited client,
+    # but the at-fork reset must still give the child fresh state that delivers
+    # through a new worker. Fresh interpreter so pytest's threads stay out of it.
+    script = """
+import os
+import time
+import warnings
+
+from agno.api.api import Api, _TelemetryDispatcher
+
+requests = []
+constructed = []
+
+class Client:
+    def __init__(self):
+        constructed.append(self)
+
+    def post(self, route, json):
+        requests.append(json["session_id"])
+
+        class Response:
+            status_code = 200
+
+        return Response()
+
+    def close(self):
+        pass
+
+dispatcher = _TelemetryDispatcher(Client, register_at_fork=True)
+instance = Api(dispatcher)
+instance.post_in_background("/telemetry/test", {"session_id": "parent"})
+deadline = time.monotonic() + 2
+while dispatcher._queue.unfinished_tasks and time.monotonic() < deadline:
+    time.sleep(0.01)
+assert requests == ["parent"] and dispatcher._worker is not None and dispatcher._worker.is_alive()
+
+read_fd, write_fd = os.pipe()
+with warnings.catch_warnings():
+    # The parent is multi-threaded on purpose here; CPython's fork warning is expected.
+    warnings.simplefilter("ignore", DeprecationWarning)
+    pid = os.fork()
+
+if pid == 0:
+    try:
+        fresh = (
+            dispatcher._worker is None
+            and dispatcher._client is None
+            and dispatcher._queue.qsize() == 0
+            and dispatcher._pid == os.getpid()
+        )
+        instance.post_in_background("/telemetry/test", {"session_id": "child"})
+        deadline = time.monotonic() + 2
+        while dispatcher._queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+        delivered = requests == ["parent", "child"] and len(constructed) == 2
+        os.write(write_fd, b"1" if fresh and delivered else b"0")
+    finally:
+        os._exit(0)
+
+os.close(write_fd)
+try:
+    assert os.read(read_fd, 1) == b"1"
+finally:
+    os.close(read_fd)
+    _, status = os.waitpid(pid, 0)
+assert os.waitstatus_to_exitcode(status) == 0
+"""
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=subprocess_env())

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -33,6 +33,7 @@ from agno.api.schemas.evals import EvalRunCreate
 from agno.api.schemas.os import OSLaunch
 from agno.api.schemas.team import TeamRunCreate
 from agno.api.schemas.workflows import WorkflowRunCreate
+from agno.api.settings import AgnoAPISettings
 from agno.api.team import acreate_team_run, create_team_run
 from agno.api.workflow import acreate_workflow_run, create_workflow_run
 from agno.db.schemas.evals import EvalType
@@ -261,6 +262,33 @@ def test_background_client_uses_short_telemetry_timeout():
         _create_telemetry_client()
 
     assert client.call_args.kwargs["timeout"] == TELEMETRY_TIMEOUT
+
+
+def test_telemetry_timeouts_default_when_env_is_unset(monkeypatch):
+    monkeypatch.delenv("AGNO_TELEMETRY_TIMEOUT", raising=False)
+    monkeypatch.delenv("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", raising=False)
+
+    settings = AgnoAPISettings()
+
+    assert settings.telemetry_timeout == 5.0
+    assert settings.telemetry_shutdown_timeout == 2.0
+
+
+def test_telemetry_timeouts_are_env_tunable(monkeypatch):
+    monkeypatch.setenv("AGNO_TELEMETRY_TIMEOUT", "1.5")
+    monkeypatch.setenv("AGNO_TELEMETRY_SHUTDOWN_TIMEOUT", "0")
+
+    settings = AgnoAPISettings()
+
+    assert settings.telemetry_timeout == 1.5
+    assert settings.telemetry_shutdown_timeout == 0.0
+
+
+def test_negative_telemetry_timeouts_clamp_to_zero():
+    settings = AgnoAPISettings(telemetry_timeout=-1, telemetry_shutdown_timeout=-0.5)
+
+    assert settings.telemetry_timeout == 0.0
+    assert settings.telemetry_shutdown_timeout == 0.0
 
 
 def test_changed_pid_is_reset_before_acquiring_inherited_lock(dispatcher_factory):
@@ -751,6 +779,40 @@ assert started.wait(2)
     elapsed = time.monotonic() - start
 
     assert 1.5 <= elapsed < TELEMETRY_SHUTDOWN_TIMEOUT + 2
+
+
+def test_zero_shutdown_timeout_skips_atexit_flush():
+    script = """
+import threading
+import time
+
+from agno.api.api import TELEMETRY_SHUTDOWN_TIMEOUT, api
+
+assert TELEMETRY_SHUTDOWN_TIMEOUT == 0.0
+started = threading.Event()
+
+class BlockingClient:
+    def post(self, route, json):
+        started.set()
+        time.sleep(30)
+
+    def close(self):
+        pass
+
+api._dispatcher._client_factory = BlockingClient
+api.post_in_background('/telemetry/test', {'run_id': 'run'})
+assert started.wait(2)
+"""
+    env = os.environ.copy()
+    package_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+    env["AGNO_TELEMETRY_SHUTDOWN_TIMEOUT"] = "0"
+
+    start = time.monotonic()
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=6, env=env)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.5, "a zero shutdown timeout must not hold process exit for a blocked worker"
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not available on this platform")

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -1,19 +1,30 @@
 """Tests for the background telemetry dispatcher (Api.post_in_background)."""
 
+import gc
+import json
 import os
 import subprocess
 import sys
 import threading
 import time
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from queue import Queue
 from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
 from agno.api.agent import acreate_agent_run, create_agent_run
-from agno.api.api import TELEMETRY_TIMEOUT, Api, api
+from agno.api.api import (
+    TELEMETRY_SHUTDOWN_TIMEOUT,
+    TELEMETRY_TIMEOUT,
+    Api,
+    _create_telemetry_client,
+    _TelemetryDispatcher,
+    api,
+)
 from agno.api.evals import async_create_eval_run_telemetry, create_eval_run_telemetry
 from agno.api.os import log_os_telemetry
 from agno.api.routes import ApiRoutes
@@ -27,39 +38,49 @@ from agno.api.workflow import acreate_workflow_run, create_workflow_run
 from agno.db.schemas.evals import EvalType
 
 
-def wait_for_drain(instance: Api, timeout: float = 5.0) -> None:
+def wait_for_drain(dispatcher: _TelemetryDispatcher, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
-    while instance._queue.unfinished_tasks and time.monotonic() < deadline:
+    while dispatcher._queue.unfinished_tasks and time.monotonic() < deadline:
         time.sleep(0.01)
-    assert not instance._queue.unfinished_tasks, "telemetry queue did not drain in time"
+    assert not dispatcher._queue.unfinished_tasks, "telemetry queue did not drain in time"
 
 
-def make_api_with_mock_transport(handler) -> tuple[Api, list[httpx.Client]]:
-    """An Api whose clients hit a mock transport, tracking each construction."""
-    instance = Api()
-    constructed: list[httpx.Client] = []
+@pytest.fixture
+def dispatcher_factory():
+    """Build isolated dispatchers and always stop their workers after a test."""
+    dispatchers: list[_TelemetryDispatcher] = []
 
-    def make_client() -> httpx.Client:
-        client = httpx.Client(base_url="https://telemetry.test", transport=httpx.MockTransport(handler))
-        constructed.append(client)
-        return client
+    def make(handler, *, register_at_fork: bool = False) -> tuple[_TelemetryDispatcher, list[httpx.Client]]:
+        constructed: list[httpx.Client] = []
 
-    instance._telemetry_client = make_client  # type: ignore[method-assign]
-    return instance, constructed
+        def make_client() -> httpx.Client:
+            client = httpx.Client(base_url="https://telemetry.test", transport=httpx.MockTransport(handler))
+            constructed.append(client)
+            return client
+
+        dispatcher = _TelemetryDispatcher(make_client, register_at_fork=register_at_fork)
+        dispatchers.append(dispatcher)
+        return dispatcher, constructed
+
+    yield make
+
+    for dispatcher in reversed(dispatchers):
+        dispatcher.close(flush_timeout=0.5)
 
 
-def test_events_are_sent_over_a_single_reused_client():
+def test_events_are_sent_over_a_single_reused_client(dispatcher_factory):
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         return httpx.Response(200)
 
-    instance, constructed = make_api_with_mock_transport(handler)
+    dispatcher, constructed = dispatcher_factory(handler)
+    instance = Api(dispatcher)
 
     instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "s1"})
     instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "s2"})
-    wait_for_drain(instance)
+    wait_for_drain(dispatcher)
 
     assert len(requests) == 2
     assert len(constructed) == 1, "every event must reuse the one shared client"
@@ -67,14 +88,15 @@ def test_events_are_sent_over_a_single_reused_client():
     assert b"s1" in requests[0].content and b"s2" in requests[1].content
 
 
-def test_concurrent_first_use_starts_one_worker_and_delivers_every_event():
+def test_concurrent_first_use_starts_one_worker_and_delivers_every_event(dispatcher_factory):
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         return httpx.Response(200)
 
-    instance, constructed = make_api_with_mock_transport(handler)
+    dispatcher, constructed = dispatcher_factory(handler)
+    instance = Api(dispatcher)
 
     with ThreadPoolExecutor(max_workers=16) as callers:
         futures = [
@@ -83,14 +105,14 @@ def test_concurrent_first_use_starts_one_worker_and_delivers_every_event():
         ]
         for future in futures:
             future.result()
-    wait_for_drain(instance)
+    wait_for_drain(dispatcher)
 
     assert len(requests) == 64
     assert len(constructed) == 1
-    assert instance._worker is not None and instance._worker.is_alive()
+    assert dispatcher._worker is not None and dispatcher._worker.is_alive()
 
 
-def test_worker_survives_transport_errors_and_bad_statuses():
+def test_worker_survives_transport_errors_and_bad_statuses(dispatcher_factory):
     calls = {"n": 0}
     delivered: list[httpx.Request] = []
 
@@ -103,13 +125,14 @@ def test_worker_survives_transport_errors_and_bad_statuses():
         delivered.append(request)
         return httpx.Response(200)
 
-    instance, _ = make_api_with_mock_transport(handler)
+    dispatcher, _ = dispatcher_factory(handler)
+    instance = Api(dispatcher)
 
     with patch("agno.api.api.log_debug") as log:
         instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "boom"})
         instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "rejected"})
         instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "ok"})
-        wait_for_drain(instance)
+        wait_for_drain(dispatcher)
 
     assert calls["n"] == 3
     assert len(delivered) == 1 and b"ok" in delivered[0].content
@@ -119,15 +142,43 @@ def test_worker_survives_transport_errors_and_bad_statuses():
 
 
 def test_post_in_background_never_blocks_or_raises_when_queue_is_full():
-    def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - never reached
-        return httpx.Response(200)
+    started = threading.Event()
+    release = threading.Event()
+    delivered: list[int] = []
 
-    instance, _ = make_api_with_mock_transport(handler)
-    # Fill the queue without a worker so puts beyond the bound must drop, not block
-    instance._ensure_worker = lambda: None  # type: ignore[method-assign]
-    for i in range(instance._queue.maxsize + 10):
-        instance.post_in_background(ApiRoutes.RUN_CREATE, {"i": i})
-    assert instance._queue.qsize() == instance._queue.maxsize
+    class BlockingClient:
+        def post(self, route, json):
+            delivered.append(json["i"])
+            if json["i"] == 1:
+                started.set()
+                release.wait(2)
+
+            class Response:
+                status_code = 200
+
+            return Response()
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(lambda: BlockingClient(), register_at_fork=False)
+    dispatcher._queue = Queue(maxsize=1)
+    instance = Api(dispatcher)
+    try:
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"i": 1})
+        assert started.wait(1)
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"i": 2})
+
+        start = time.monotonic()
+        instance.post_in_background(ApiRoutes.RUN_CREATE, {"i": 3})
+        assert time.monotonic() - start < 0.1
+        assert dispatcher._queue.qsize() == 1
+    finally:
+        release.set()
+        wait_for_drain(dispatcher)
+        dispatcher.close(flush_timeout=0.5)
+
+    assert delivered == [1, 2]
 
 
 @pytest.mark.parametrize(
@@ -187,7 +238,7 @@ async def test_async_telemetry_helpers_dispatch_in_background(monkeypatch, helpe
     enqueue.assert_awaited_once_with(route, payload.model_dump(exclude_none=True))
 
 
-def test_async_variant_is_paired_and_delegates():
+def test_async_variant_is_paired_and_delegates(dispatcher_factory):
     import asyncio
 
     requests: list[httpx.Request] = []
@@ -196,50 +247,486 @@ def test_async_variant_is_paired_and_delegates():
         requests.append(request)
         return httpx.Response(200)
 
-    instance, constructed = make_api_with_mock_transport(handler)
+    dispatcher, constructed = dispatcher_factory(handler)
+    instance = Api(dispatcher)
     asyncio.run(instance.apost_in_background(ApiRoutes.RUN_CREATE, {"session_id": "async-1"}))
-    wait_for_drain(instance)
+    wait_for_drain(dispatcher)
 
     assert len(requests) == 1 and b"async-1" in requests[0].content
     assert len(constructed) == 1
 
 
 def test_background_client_uses_short_telemetry_timeout():
-    instance = Api()
-
     with patch("agno.api.api.HttpxClient") as client:
-        instance._telemetry_client()
+        _create_telemetry_client()
 
     assert client.call_args.kwargs["timeout"] == TELEMETRY_TIMEOUT
 
 
-def test_changed_pid_is_reset_before_acquiring_inherited_lock():
-    instance = Api()
-    inherited_lock = instance._lock
+def test_changed_pid_is_reset_before_acquiring_inherited_lock(dispatcher_factory):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    dispatcher, _ = dispatcher_factory(handler)
+    inherited_lock = dispatcher._lock
     inherited_lock.acquire()
-    instance._pid = -1
+    dispatcher._pid = -1
     completed = threading.Event()
 
-    def ensure_worker() -> None:
-        instance._ensure_worker()
+    def post() -> None:
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"run_id": "child"})
         completed.set()
 
-    thread = threading.Thread(target=ensure_worker, daemon=True)
+    thread = threading.Thread(target=post, daemon=True)
     thread.start()
     try:
         assert completed.wait(1), "pid fallback must not acquire a lock inherited from the parent"
-        assert instance._lock is not inherited_lock
-        assert instance._pid == os.getpid()
+        assert dispatcher._lock is not inherited_lock
+        assert dispatcher._pid == os.getpid()
+        wait_for_drain(dispatcher)
     finally:
         inherited_lock.release()
 
 
-def test_daemon_worker_does_not_delay_process_exit():
+def test_changed_pid_is_reset_before_acquiring_inherited_close_lock(dispatcher_factory):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    dispatcher, _ = dispatcher_factory(handler)
+    inherited_close_lock = dispatcher._close_lock
+    inherited_close_lock.acquire()
+    dispatcher._pid = -1
+    completed = threading.Event()
+
+    def close() -> None:
+        dispatcher.close(flush_timeout=0.1)
+        completed.set()
+
+    thread = threading.Thread(target=close, daemon=True)
+    thread.start()
+    try:
+        assert completed.wait(1), "pid fallback must run before acquiring a close lock inherited from the parent"
+        assert dispatcher._close_lock is not inherited_close_lock
+        assert dispatcher._pid == os.getpid()
+    finally:
+        inherited_close_lock.release()
+
+
+def test_api_wrappers_share_dispatcher_without_retaining_instances(dispatcher_factory):
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    dispatcher, constructed = dispatcher_factory(handler)
+    baseline_threads = set(threading.enumerate())
+    references: list[weakref.ReferenceType[Api]] = []
+
+    def dispatch_from_temporary_wrappers() -> None:
+        for i in range(25):
+            wrapper = Api(dispatcher)
+            references.append(weakref.ref(wrapper))
+            wrapper.post_in_background(ApiRoutes.RUN_CREATE, {"i": i})
+
+    dispatch_from_temporary_wrappers()
+    wait_for_drain(dispatcher)
+    gc.collect()
+
+    assert all(reference() is None for reference in references)
+    assert len(requests) == 25
+    assert len(constructed) == 1
+    worker = dispatcher._worker
+    assert worker is not None and worker.is_alive()
+    assert [thread for thread in threading.enumerate() if thread not in baseline_threads and thread.is_alive()] == [
+        worker
+    ]
+
+    dispatcher.close(flush_timeout=1)
+
+    assert not worker.is_alive()
+    assert dispatcher._worker is None
+    assert dispatcher._client is None
+    assert constructed[0].is_closed
+
+
+def test_default_api_wrappers_share_the_process_dispatcher():
+    assert Api()._dispatcher is api._dispatcher
+    assert Api()._dispatcher is Api()._dispatcher
+
+
+def test_close_is_idempotent_and_rejects_later_posts(dispatcher_factory):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    dispatcher, constructed = dispatcher_factory(handler)
+
+    dispatcher.close(flush_timeout=0.1)
+    dispatcher.close(flush_timeout=0.1)
+    dispatcher.post(ApiRoutes.RUN_CREATE, {"run_id": "too-late"})
+
+    assert dispatcher._worker is None
+    assert dispatcher._queue.unfinished_tasks == 0
+    assert constructed == []
+
+
+def test_worker_start_failure_is_retried_without_losing_queued_event(dispatcher_factory):
+    delivered: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        delivered.append(json.loads(request.content)["i"])
+        return httpx.Response(200)
+
+    dispatcher, _ = dispatcher_factory(handler)
+    original_start = threading.Thread.start
+    starts = 0
+
+    def fail_once(worker: threading.Thread) -> None:
+        nonlocal starts
+        if worker.name == "agno-telemetry":
+            starts += 1
+            if starts == 1:
+                raise RuntimeError("synthetic start failure")
+        original_start(worker)
+
+    with patch.object(threading.Thread, "start", fail_once):
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 1})
+        assert dispatcher._worker is None
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 2})
+        wait_for_drain(dispatcher)
+
+    assert delivered == [1, 2]
+    assert starts == 2
+
+
+def test_full_queue_retries_a_worker_stranded_by_start_failures(dispatcher_factory):
+    delivered: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        delivered.append(json.loads(request.content)["i"])
+        return httpx.Response(200)
+
+    dispatcher, _ = dispatcher_factory(handler)
+    dispatcher._queue = Queue(maxsize=2)
+    original_start = threading.Thread.start
+    starts = 0
+
+    def fail_twice(worker: threading.Thread) -> None:
+        nonlocal starts
+        if worker.name == "agno-telemetry":
+            starts += 1
+            if starts <= 2:
+                raise RuntimeError("synthetic start failure")
+        original_start(worker)
+
+    with patch.object(threading.Thread, "start", fail_twice):
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 1})
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 2})
+        assert dispatcher._queue.full()
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 3})
+        wait_for_drain(dispatcher)
+
+    assert delivered == [1, 2]
+    assert starts == 3
+
+
+def test_dead_worker_is_replaced_and_pending_events_are_delivered(dispatcher_factory):
+    delivered: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        delivered.append(json.loads(request.content)["i"])
+        return httpx.Response(200)
+
+    dispatcher, _ = dispatcher_factory(handler)
+    original_drain = dispatcher._drain
+    first_worker_exited = threading.Event()
+
+    def exit_once(queue: Queue[object]) -> None:
+        dispatcher._drain = original_drain
+        first_worker_exited.set()
+
+    dispatcher._drain = exit_once
+    dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 1})
+    assert first_worker_exited.wait(1)
+    assert dispatcher._worker is not None
+    dispatcher._worker.join(1)
+    assert not dispatcher._worker.is_alive()
+
+    dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 2})
+    wait_for_drain(dispatcher)
+
+    assert delivered == [1, 2]
+
+
+def test_close_discards_a_full_queue_within_its_deadline():
+    started = threading.Event()
+    release = threading.Event()
+    delivered: list[int] = []
+    closed = threading.Event()
+
+    class BlockingClient:
+        def post(self, route, json):
+            delivered.append(json["i"])
+            started.set()
+            release.wait(2)
+
+            class Response:
+                status_code = 200
+
+            return Response()
+
+        def close(self):
+            closed.set()
+
+    dispatcher = _TelemetryDispatcher(lambda: BlockingClient(), register_at_fork=False)
+    dispatcher._queue = Queue(maxsize=1)
+    try:
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 1})
+        assert started.wait(1)
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"i": 2})
+
+        start = time.monotonic()
+        dispatcher.close(flush_timeout=0.05)
+        assert time.monotonic() - start < 0.5
+        assert delivered == [1]
+
+        release.set()
+        worker = dispatcher._worker
+        assert worker is not None
+        worker.join(1)
+        assert not worker.is_alive()
+        assert dispatcher._queue.unfinished_tasks == 0
+        assert closed.is_set()
+    finally:
+        release.set()
+        dispatcher.close(flush_timeout=0.5)
+
+
+def test_post_racing_close_is_either_flushed_or_rejected(dispatcher_factory):
+    delivered: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        delivered.append(json.loads(request.content)["run_id"])
+        return httpx.Response(200)
+
+    dispatcher, _ = dispatcher_factory(handler)
+    original_put = dispatcher._queue.put_nowait
+    insertion_started = threading.Event()
+    allow_insertion = threading.Event()
+
+    def paused_put(item: object) -> None:
+        insertion_started.set()
+        assert allow_insertion.wait(1)
+        original_put(item)
+
+    with patch.object(dispatcher._queue, "put_nowait", paused_put):
+        poster = threading.Thread(
+            target=dispatcher.post,
+            args=(ApiRoutes.RUN_CREATE, {"run_id": "accepted"}),
+        )
+        poster.start()
+        assert insertion_started.wait(1)
+
+        closer = threading.Thread(target=dispatcher.close, kwargs={"flush_timeout": 1})
+        closer.start()
+        allow_insertion.set()
+        poster.join(1)
+        closer.join(2)
+
+    assert not poster.is_alive()
+    assert not closer.is_alive()
+    assert delivered == ["accepted"]
+
+    dispatcher.post(ApiRoutes.RUN_CREATE, {"run_id": "rejected"})
+    assert delivered == ["accepted"]
+
+
+def test_concurrent_close_call_respects_its_own_timeout():
+    started = threading.Event()
+    release = threading.Event()
+
+    class BlockingClient:
+        def post(self, route, json):
+            started.set()
+            release.wait(2)
+
+            class Response:
+                status_code = 200
+
+            return Response()
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(lambda: BlockingClient(), register_at_fork=False)
+    try:
+        dispatcher.post(ApiRoutes.RUN_CREATE, {"run_id": "blocked"})
+        assert started.wait(1)
+        long_close = threading.Thread(target=dispatcher.close, kwargs={"flush_timeout": 1})
+        long_close.start()
+        deadline = time.monotonic() + 1
+        while not dispatcher._close_lock.locked() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert dispatcher._close_lock.locked()
+
+        start = time.monotonic()
+        dispatcher.close(flush_timeout=0.05)
+        assert time.monotonic() - start < 0.5
+
+        release.set()
+        long_close.join(2)
+        assert not long_close.is_alive()
+    finally:
+        release.set()
+        dispatcher.close(flush_timeout=0.5)
+
+
+def test_worker_callback_can_close_without_waiting_on_itself():
+    request_started = threading.Event()
+    allow_callback_close = threading.Event()
+    close_elapsed: list[float] = []
+    dispatcher: _TelemetryDispatcher
+
+    class ClosingClient:
+        def post(self, route, json):
+            request_started.set()
+            assert allow_callback_close.wait(1)
+            start = time.monotonic()
+            dispatcher.close(flush_timeout=1)
+            close_elapsed.append(time.monotonic() - start)
+
+            class Response:
+                status_code = 200
+
+            return Response()
+
+        def close(self):
+            pass
+
+    dispatcher = _TelemetryDispatcher(lambda: ClosingClient(), register_at_fork=False)
+    dispatcher.post(ApiRoutes.RUN_CREATE, {"run_id": "self-close"})
+    assert request_started.wait(1)
+
+    external_close = threading.Thread(target=dispatcher.close, kwargs={"flush_timeout": 1})
+    external_close.start()
+    deadline = time.monotonic() + 1
+    while not dispatcher._close_lock.locked() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert dispatcher._close_lock.locked()
+    allow_callback_close.set()
+
+    deadline = time.monotonic() + 2
+    while dispatcher._worker is not None and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    external_close.join(1)
+    assert not external_close.is_alive()
+    assert close_elapsed and close_elapsed[0] < 0.5
+    assert dispatcher._queue.unfinished_tasks == 0
+
+
+def test_concurrent_pid_fallback_resets_once_and_starts_one_worker():
     script = """
 import threading
 import time
 
-from agno.api.api import Api
+from agno.api.api import _TelemetryDispatcher
+
+delivered = []
+constructed = []
+
+class Client:
+    def __init__(self):
+        constructed.append(self)
+
+    def post(self, route, json):
+        delivered.append(json['i'])
+        class Response:
+            status_code = 200
+        return Response()
+
+    def close(self):
+        pass
+
+dispatcher = _TelemetryDispatcher(Client, register_at_fork=False)
+dispatcher._pid = -1
+original_reset = dispatcher._reset_after_fork
+reset_count = [0]
+reset_count_lock = threading.Lock()
+
+def slow_reset(*, replace_fallback_lock=True):
+    with reset_count_lock:
+        reset_count[0] += 1
+    time.sleep(0.05)
+    original_reset(replace_fallback_lock=replace_fallback_lock)
+
+dispatcher._reset_after_fork = slow_reset
+barrier = threading.Barrier(16)
+
+def post(index):
+    barrier.wait()
+    dispatcher.post('/telemetry/test', {'i': index})
+
+threads = [threading.Thread(target=post, args=(index,)) for index in range(16)]
+for thread in threads:
+    thread.start()
+for thread in threads:
+    thread.join(2)
+assert all(not thread.is_alive() for thread in threads)
+
+deadline = time.monotonic() + 2
+while dispatcher._queue.unfinished_tasks and time.monotonic() < deadline:
+    time.sleep(0.01)
+
+assert reset_count[0] == 1, reset_count
+assert len(delivered) == 16, delivered
+assert len(constructed) == 1, constructed
+assert sum(t.name == 'agno-telemetry' and t.is_alive() for t in threading.enumerate()) == 1
+dispatcher.close(0.5)
+"""
+    env = os.environ.copy()
+    package_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=8, env=env)
+
+
+def test_atexit_flush_delivers_one_shot_event_and_closes_client():
+    script = """
+import os
+import time
+
+from agno.api.api import api
+
+class Client:
+    def post(self, route, json):
+        time.sleep(0.25)
+        os.write(1, b'D')
+        class Response:
+            status_code = 200
+        return Response()
+
+    def close(self):
+        os.write(1, b'C')
+
+api._dispatcher._client_factory = Client
+api.post_in_background('/telemetry/test', {'run_id': 'run'})
+"""
+    env = os.environ.copy()
+    package_root = str(Path(__file__).resolve().parents[3])
+    env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
+
+    result = subprocess.run([sys.executable, "-c", script], check=True, timeout=5, env=env, capture_output=True)
+
+    assert b"DC" in result.stdout
+
+
+def test_blocked_worker_respects_bounded_atexit_flush():
+    script = """
+import threading
+import time
+
+from agno.api.api import api
 
 started = threading.Event()
 
@@ -248,44 +735,51 @@ class BlockingClient:
         started.set()
         time.sleep(30)
 
-instance = Api()
-instance._telemetry_client = lambda: BlockingClient()
-instance.post_in_background('/telemetry/test', {'run_id': 'run'})
+    def close(self):
+        pass
+
+api._dispatcher._client_factory = BlockingClient
+api.post_in_background('/telemetry/test', {'run_id': 'run'})
 assert started.wait(2)
 """
     env = os.environ.copy()
     package_root = str(Path(__file__).resolve().parents[3])
     env["PYTHONPATH"] = os.pathsep.join(filter(None, (package_root, env.get("PYTHONPATH"))))
 
-    subprocess.run([sys.executable, "-c", script], check=True, timeout=5, env=env)
+    start = time.monotonic()
+    subprocess.run([sys.executable, "-c", script], check=True, timeout=6, env=env)
+    elapsed = time.monotonic() - start
+
+    assert 1.5 <= elapsed < TELEMETRY_SHUTDOWN_TIMEOUT + 2
 
 
 @pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not available on this platform")
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_forked_child_resets_dispatcher_state():
+def test_forked_child_resets_dispatcher_state(dispatcher_factory):
     requests: list[httpx.Request] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         return httpx.Response(200)
 
-    instance, constructed = make_api_with_mock_transport(handler)
+    dispatcher, constructed = dispatcher_factory(handler, register_at_fork=True)
+    instance = Api(dispatcher)
     instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "parent"})
-    wait_for_drain(instance)
-    assert instance._worker is not None and instance._worker.is_alive()
+    wait_for_drain(dispatcher)
+    assert dispatcher._worker is not None and dispatcher._worker.is_alive()
 
     read_fd, write_fd = os.pipe()
     pid = os.fork()
     if pid == 0:  # child: prove reset state can deliver through a new worker/client
         try:
             fresh = (
-                instance._worker is None
-                and instance._client is None
-                and instance._queue.qsize() == 0
-                and instance._pid == os.getpid()
+                dispatcher._worker is None
+                and dispatcher._client is None
+                and dispatcher._queue.qsize() == 0
+                and dispatcher._pid == os.getpid()
             )
             instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "child"})
-            wait_for_drain(instance)
+            wait_for_drain(dispatcher)
             delivered = len(requests) == 2 and b"child" in requests[-1].content and len(constructed) == 2
             os.write(write_fd, b"1" if fresh and delivered else b"0")
         finally:

--- a/libs/agno/tests/unit/api/test_telemetry_dispatch.py
+++ b/libs/agno/tests/unit/api/test_telemetry_dispatch.py
@@ -1,8 +1,10 @@
 """Tests for the background telemetry dispatcher (Api.post_in_background)."""
 
+import os
 import time
 
 import httpx
+import pytest
 
 from agno.api.agent import create_agent_run
 from agno.api.api import Api, api
@@ -113,3 +115,35 @@ def test_async_variant_is_paired_and_delegates():
 
     assert len(requests) == 1 and b"async-1" in requests[0].content
     assert len(constructed) == 1
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="fork is not available on this platform")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_forked_child_resets_dispatcher_state():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200)
+
+    instance, _ = make_api_with_mock_transport(handler)
+    instance.post_in_background(ApiRoutes.RUN_CREATE, {"session_id": "parent"})
+    wait_for_drain(instance)
+    assert instance._worker is not None and instance._worker.is_alive()
+
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:  # child: report whether the fork hook gave us fresh state
+        try:
+            fresh = (
+                instance._worker is None
+                and instance._client is None
+                and instance._queue.qsize() == 0
+                and instance._pid == os.getpid()
+            )
+            os.write(write_fd, b"1" if fresh else b"0")
+        finally:
+            os._exit(0)
+    os.close(write_fd)
+    try:
+        assert os.read(read_fd, 1) == b"1", "child must see reset dispatcher state"
+    finally:
+        os.close(read_fd)
+        os.waitpid(pid, 0)

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -775,8 +775,8 @@ def test_suite_disables_eval_spinners(monkeypatch):
 
 
 def test_suite_disables_eval_telemetry(monkeypatch):
-    # The evals await their telemetry POST before returning; on a blackholed
-    # network that burns case-timeout budget after the verdict is computed.
+    # Preserve the suite's existing behavior: internally-created evals do not
+    # emit hidden telemetry when the suite exposes no telemetry option.
     judge_instances, reliability_instances = _install_fake_evals(monkeypatch)
 
     run_cases([_make_case(expected_tool_calls=("search_web",))])

--- a/libs/agno/tests/unit/telemetry/test_eval_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_eval_telemetry.py
@@ -16,7 +16,7 @@ def test_accuracy_evals_telemetry():
     assert accuracy_eval.telemetry
 
     # Mock the API call that gets made when telemetry is enabled
-    with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
+    with patch("agno.api.evals.fire_and_forget_eval_telemetry") as mock_create:
         agent.model = MagicMock()
         accuracy_eval.run(print_summary=False, print_results=False)
 
@@ -39,7 +39,7 @@ def test_performance_evals_telemetry():
     assert performance_eval.telemetry
 
     # Mock the API call that gets made when telemetry is enabled
-    with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
+    with patch("agno.api.evals.fire_and_forget_eval_telemetry") as mock_create:
         performance_eval.run()
 
         # Verify API was called with correct parameters
@@ -67,7 +67,7 @@ def test_reliability_evals_telemetry():
     assert reliability_eval.telemetry
 
     # Mock the API call that gets made when telemetry is enabled
-    with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
+    with patch("agno.api.evals.fire_and_forget_eval_telemetry") as mock_create:
         reliability_eval.run(print_results=False)
 
         # Verify API was called with correct parameters
@@ -92,7 +92,7 @@ def test_agent_as_judge_numeric_telemetry():
     evaluator.model = MagicMock()
 
     # Mock the API call that gets made when telemetry is enabled
-    with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
+    with patch("agno.api.evals.fire_and_forget_eval_telemetry") as mock_create:
         eval.run(input="What is Python?", output="Python is a programming language.", print_results=False)
 
         # Verify API was called with correct parameters
@@ -115,7 +115,7 @@ def test_agent_as_judge_binary_telemetry():
     evaluator.model = MagicMock()
 
     # Mock the API call that gets made when telemetry is enabled
-    with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
+    with patch("agno.api.evals.fire_and_forget_eval_telemetry") as mock_create:
         eval.run(input="Tell me about privacy", output="Privacy is important.", print_results=False)
 
         # Verify API was called with correct parameters

--- a/libs/agno/tests/unit/telemetry/test_os_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_os_telemetry.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import asynccontextmanager
 from unittest.mock import patch
 
@@ -73,3 +74,13 @@ def test_os_telemetry_failure_does_not_stop_the_app_from_starting():
             assert client.get("/health").status_code == 200
 
         mock_log.assert_called_once()
+
+
+def test_os_telemetry_import_failure_does_not_stop_the_app_from_starting(monkeypatch):
+    # The lifespan imports the telemetry client lazily; an unimportable module
+    # (what a broken settings import looks like) must not abort startup.
+    monkeypatch.setitem(sys.modules, "agno.api.os", None)
+    app = AgentOS(id="test", agents=[Agent(telemetry=False)]).get_app()
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200

--- a/libs/agno/tests/unit/telemetry/test_os_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_os_telemetry.py
@@ -1,21 +1,63 @@
+from contextlib import asynccontextmanager
 from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from agno.agent.agent import Agent
 from agno.os import AgentOS
 
 
-def test_accuracy_evals_telemetry():
-    """Test that telemetry logging is called when initializing an AgentOS instance."""
-    agent = Agent()
+def test_os_telemetry_runs_once_in_generated_app_lifespan():
+    with patch("agno.api.os.log_os_telemetry") as mock_log:
+        agent_os = AgentOS(id="test", agents=[Agent(telemetry=False)])
 
-    # Mock the API call that gets made when telemetry is enabled
-    with patch("agno.api.os.log_os_telemetry") as mock_create:
-        os = AgentOS(id="test", agents=[agent])
+        assert agent_os.telemetry
+        mock_log.assert_not_called()
 
-        # Assert telemetry is active by default
-        assert os.telemetry
+        app = agent_os.get_app()
+        mock_log.assert_not_called()
 
-        # Verify API was called with correct parameters
-        mock_create.assert_called_once()
-        call_args = mock_create.call_args[1]["launch"]
-        assert call_args.os_id == "test"
+        with TestClient(app):
+            mock_log.assert_called_once()
+
+        mock_log.assert_called_once()
+        launch = mock_log.call_args.kwargs["launch"]
+        assert launch.os_id == "test"
+
+
+def test_os_telemetry_preserves_base_app_lifespan_and_runs_once():
+    lifespan_events = []
+
+    @asynccontextmanager
+    async def base_app_lifespan(_):
+        lifespan_events.append("startup")
+        yield
+        lifespan_events.append("shutdown")
+
+    base_app = FastAPI(lifespan=base_app_lifespan)
+
+    with patch("agno.api.os.log_os_telemetry") as mock_log:
+        agent_os = AgentOS(id="test", agents=[Agent(telemetry=False)], base_app=base_app)
+        mock_log.assert_not_called()
+
+        app = agent_os.get_app()
+        assert app is base_app
+        mock_log.assert_not_called()
+
+        with TestClient(app):
+            assert lifespan_events == ["startup"]
+            mock_log.assert_called_once()
+
+        assert lifespan_events == ["startup", "shutdown"]
+        mock_log.assert_called_once()
+
+
+def test_disabled_os_telemetry_stays_silent_during_app_lifespan():
+    with patch("agno.api.os.log_os_telemetry") as mock_log:
+        app = AgentOS(id="test", agents=[Agent(telemetry=False)], telemetry=False).get_app()
+
+        with TestClient(app):
+            pass
+
+        mock_log.assert_not_called()

--- a/libs/agno/tests/unit/telemetry/test_os_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_os_telemetry.py
@@ -61,3 +61,15 @@ def test_disabled_os_telemetry_stays_silent_during_app_lifespan():
             pass
 
         mock_log.assert_not_called()
+
+
+def test_os_telemetry_failure_does_not_stop_the_app_from_starting():
+    # The launch event is best-effort: a failing telemetry client (including a
+    # failed import of it) must not abort the ASGI lifespan.
+    with patch("agno.api.os.log_os_telemetry", side_effect=RuntimeError("telemetry down")) as mock_log:
+        app = AgentOS(id="test", agents=[Agent(telemetry=False)]).get_app()
+
+        with TestClient(app) as client:
+            assert client.get("/health").status_code == 200
+
+        mock_log.assert_called_once()


### PR DESCRIPTION
## Summary

Telemetry delivery previously performed HTTP work on Agent, Team, Workflow,
Eval, and AgentOS execution paths. A slow or unreachable telemetry endpoint
could therefore delay user-visible results by the network timeout.

This branch is rebased on `feat/v3.0` and moves telemetry behind one
process-wide, lifecycle-managed dispatcher:

- callers enqueue telemetry without waiting on network I/O;
- one daemon worker preserves ordering and reuses one keep-alive HTTP client;
- the bounded queue drops the newest event instead of accumulating unbounded work;
- a telemetry-only five-second request timeout bounds in-flight I/O;
- shutdown gives accepted events up to two seconds to flush, then stops without
  holding process exit open;
- a process that emitted telemetry may therefore spend up to two seconds in
  exit flushing, while a process that emitted nothing pays no dispatcher exit
  cost;
- both timeouts are configurable through `AgnoAPISettings`:
  `AGNO_TELEMETRY_TIMEOUT` (request timeout, default 5s) and
  `AGNO_TELEMETRY_SHUTDOWN_TIMEOUT` (exit flush window, default 2s; set to 0
  to skip the exit flush on hosts where the endpoint is unreachable). Both are
  read once, when telemetry first runs. A value that cannot be used
  (non-numeric, empty, nan, inf, a zero or negative request timeout) falls
  back to the default with a warning; a negative shutdown timeout clamps to 0;
  values above one hour are capped. An unknown `AGNO_API_RUNTIME` falls back
  to `prd` and an unparsable `AGNO_ALPHA_FEATURES` to off the same way. No
  value of any `AGNO_*` setting can fail the import that agent, team,
  workflow, eval and AgentOS paths perform on their first event;
- every run-path telemetry helper (agent, team, workflow, the eval classes,
  and the AgentOS launch lifespan) keeps the telemetry import and the
  payload construction inside its `try`, so a telemetry failure of any kind
  cannot change a run's status, make an eval raise, or stop AgentOS from
  starting;
- the shutdown deadline bounds every wait in `close()`, the lifecycle locks
  included: a concurrent `post` holds the state lock across `Thread.start()`,
  which is slow on a loaded machine, and shutdown no longer waits behind it
  past the window (`close(0.05)` with a post stuck in `Thread.start()`:
  0.05 s, was 0.4 s);
- `multiprocessing` children (fork and forkserver start methods exit through
  `os._exit` without running `atexit`) get the same bounded exit flush through
  a `multiprocessing` exit finalizer registered when a worker starts in a
  process that has `multiprocessing` in use, re-registered by an after-fork
  hook for a forkserver child that started its worker while its main module
  was being re-imported; a second `close()` after the flush has finished
  returns immediately, so `atexit` plus the finalizer never wait twice.
  Workers killed by `Pool.terminate()` (the `with Pool()` idiom) cannot
  flush;
- the SDK version the telemetry schemas stamp on every event is computed once
  instead of re-reading package metadata per event (~0.75 ms on the caller's
  thread, which was the whole remaining on-path cost);
- the worker owns and closes its client, while temporary `Api` wrappers remain
  collectible and do not create threads or at-fork registrations;
- spawn-based workers and POSIX workers forked before the first telemetry event
  are supported and start with independent dispatcher state;
- eager at-fork reset plus the serialized PID fallback rebuild child state after
  a PID change, but after telemetry has started this is defensive recovery only:
  inheriting a live worker and HTTP/TLS resources is unsupported;
- AgentOS launch telemetry starts from the ASGI lifespan, after pre-fork app
  construction, keeping both generated apps and supplied `base_app` instances
  within the supported fork-before-first-telemetry model;
- a launch event now represents a serving worker lifespan: multi-worker servers
  emit once per worker, reloads emit once per new lifespan, and an `AgentOS`
  instance that is constructed but never served emits nothing;
- sync and async telemetry helper signatures remain paired and unchanged.

Queue saturation, transport failures, shutdown, worker-start failure, worker
replacement, concurrent first use, concurrent close/post races, immediate
process exit, real fork-before-first-telemetry child delivery without
Python's multi-threaded-fork warning, fork-after-first-event child reset,
multiprocessing children across every available start method, unusable
setting values (in-process and end to end through a subprocess environment),
every run-path helper surviving an unimportable telemetry module, the
one-time SDK version lookup, and the call-time shutdown default are covered
by regressions.

## Delivery contract (what changes for operators)

Delivery is best-effort, and this is where it is not complete:

- A process that exits with more queued events than the worker can send in
  the shutdown window drops the rest. Against the production endpoint from a
  laptop the worker sends ~5.6 events/s over one reused HTTP/2 connection, so
  the 2 s default window carries roughly 10 events; a one-shot script that
  made 20 runs delivered 7–13 of them (the inline code delivered 20/20 but
  blocked the caller 20 x ~0.5 s to do it).
- A process that sustains more runs per second than the worker's throughput
  fills the 2,000-event queue and drops the newest events until it drains.
  Batching events per request is the planned follow-up and removes both
  limits.
- Forking after the first event remains unsupported for the inherited client;
  the at-fork reset still gives the child fresh state that delivers.
- `Pool.terminate()` / `with Pool() as pool:` kills workers with SIGTERM;
  events still queued in those workers are lost. `pool.close(); pool.join()`
  and `ProcessPoolExecutor` shutdown flush normally.

## Measured

A/B of this branch against its merge-base, mock model (the run loop executes
fully; nothing waits on an LLM), fresh process per cell, clean `AGNO_*`
environment, M4 Max:

| `agent.run()` median, telemetry on | merge-base | this branch |
|---|---:|---:|
| local endpoint, instant 200 | 10.1 ms (~8 ms is a fresh TLS context per event) | 0.09 ms |
| local endpoint, 200 ms | 218 ms | 0.1 ms |
| os-api.agno.com (laptop) | 525 ms | 0.1 ms |
| blackholed endpoint | 60,012 ms (60 s client timeout) | 0.1 ms |
| 8 concurrent threads, local endpoint | 370–460 ms | 0.1 ms |
| telemetry off (control) | 0.082 ms | 0.084 ms |

Import time (`from agno.agent import Agent` 206 vs 207 ms), `Agent()`
construction (2.83 µs both) and thread count are unchanged; no thread exists
until the first event. A one-shot script's wall time is unchanged on a healthy
endpoint (the POST moves from `run()` to exit) and bounded at 2 s instead of
60 s on a dead one.

There are no breaking Agent, Team, Workflow, Eval, or AgentOS API changes.
`Api.Client()` and `Api.AsyncClient()` retain their existing behavior. EvalSuite
continues to disable telemetry for its internally-created evals because the
Suite API does not expose a telemetry choice; only its obsolete blocking-I/O
comment was corrected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable; internal telemetry delivery only)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

PR #9632 overlaps the original dispatcher work. To retain #6458 as the requested
ownership path, its three dispatcher commits were transplanted with Samuel
Jupe's original authorship preserved. No changes were made to #9632. This PR
also covers bounded exit flushing, process-wide ownership, explicit shutdown,
spawn/fork-before-first-telemetry AgentOS startup, defensive concurrent PID
fallback, exception-detail redaction, and the additional lifecycle/race
regressions above.

This PR is not entirely AI-generated: the source dispatcher commits are by
@SamJupe, with AI-assisted rebase, hardening, testing, and review disclosed here.

Validation at `3ca66959d` (the three newest commits: cached SDK version;
unusable-setting fallback, imports inside the telemetry try blocks,
multiprocessing exit flush; bounded shutdown waits, payload construction
inside the eval fail-safe, forkserver re-registration) on
`feat/v3.0@e86fff58d`:

- `./scripts/format.sh`: PASS
- `./scripts/validate.sh`: ruff PASS; mypy reports the same pre-existing,
  environment-dependent error set on the parent commit with the local stubs
  (none in touched files) — hosted CI is the gate
- `tests/unit/api`, `tests/unit/telemetry`, `tests/unit/eval/test_suite.py`:
  159 passed (137 existing + 22 new)
- `tests/unit/{eval,os,agent,team,workflow,telemetry,api}` from the repo
  root: 4,771 passed, 16 skipped (optional dependencies), 1 known
  order-dependent flake that #9702 fixed on feat/v3.0 after this branch's
  base (passes alone)
- mutation checks on the new tests: removing the multiprocessing finalizer,
  registering it at construction instead of worker start, the second-close
  short-circuit, the import-inside-try, the setting coercion, the bounded
  state-lock wait in `close()`, and building eval payload data at the call
  site each fail the test written for it
- probes on the branch: `AGNO_TELEMETRY_TIMEOUT=abc` and `AGNO_API_RUNTIME=bogus`
  → `agent.run()` completes with a warning (was `RunStatus.error`), AgentOS
  lifespan starts and serves `/health` (was exit code 3); multiprocessing
  children deliver 1/1 for fork, forkserver and spawn (fork/forkserver were 0)

Earlier validation at `4a109392d` (dispatcher design, unchanged since):
`./scripts/validate.sh` PASS; dispatcher suite 31 tests, the supported
real-fork regression passing 30 standalone repetitions and 20 from a pytest
parent with an unrelated live thread; 550 repeated concurrency/fork cases plus
adversarial PID, shutdown, and 6,400-post race probes at parent `6922d630`;
broader AgentOS unit suite 2,460 passed, 22 skipped.

The telemetry/eval suite emits existing `AsyncMock` coroutine warnings. The
optional Chroma integration module also cannot collect locally because
`chromadb` is not installed. Neither is introduced by this PR; hosted validation
is the dependency-complete merge gate.