### PR TITLE
[feat] Add create_filters_index to PgVector

### DIFF
--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -1198,23 +1198,24 @@ class PgVector(VectorDb):
 
     def create_filters_index(
         self,
+        fields: List[str],
         force_recreate: bool = False,
-        fields: Optional[List[str]] = None,
     ) -> None:
         """
         Create BTREE indexes on specific fields within the "filters" JSONB column.
 
         For each field, creates a BTREE index on `filters->>'{field}'`
         Skips fields that already have an index unless force_recreate is True.
-        Does nothing if no fields are provided.
 
         Args:
+            fields (List[str]): JSONB field names to index (e.g. ["user_id", "category"]).
             force_recreate (bool): If True, drop and recreate existing indexes.
-            fields (Optional[List[str]]): JSONB field names to index (e.g. ["user_id", "category"]).
+
+        Raises:
+            ValueError: If fields is empty.
         """
         if not fields:
-            log_warning("No fields specified, skipping filters index creation.")
-            return
+            raise ValueError("At least one field must be specified for filters index creation.")
 
         for field in fields:
             index_name = f"{self.table_name}_filters_{field}_index"

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -1213,6 +1213,7 @@ class PgVector(VectorDb):
 
         Raises:
             ValueError: If fields is empty.
+            Exception: If index creation fails.
         """
         if not fields:
             raise ValueError("At least one field must be specified for filters index creation.")

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -794,14 +794,12 @@ def test_insert_merges_filters_into_metadata(mock_pgvector, mock_embedder):
 
 
 def test_create_filters_index_no_fields(mock_pgvector):
-    """Test create_filters_index does nothing when no fields are provided."""
-    with patch.object(mock_pgvector, "_index_exists") as mock_index_exists:
+    """Test create_filters_index raises ValueError when no fields are provided."""
+    with pytest.raises(TypeError):
         mock_pgvector.create_filters_index()
-        mock_index_exists.assert_not_called()
 
-    with patch.object(mock_pgvector, "_index_exists") as mock_index_exists:
+    with pytest.raises(ValueError, match="At least one field must be specified"):
         mock_pgvector.create_filters_index(fields=[])
-        mock_index_exists.assert_not_called()
 
 
 def test_create_filters_index_single_field(mock_pgvector):


### PR DESCRIPTION
## Summary
- Add public `create_filters_index()` method to PgVector for creating BTREE indexes on specific fields in the `filters` JSONB column.
- Improves query performance for filtered vector searches as it's indexed.
- No "index all" option; callers must explicitly specify which fields to index to avoid unexpected storage/write overhead.

## Usage
```python
vector_db = PgVector(table_name="docs", db_url=db_url)
vector_db.create_filters_index(fields=["user_id", "category"])
```

## Test plan
-  No-op when fields is None or empty
- Creates BTREE index for single field
- Creates indexes for multiple fields
- Skips existing indexes
- Drops and recreates with force_recreate=True
- Propagates database errors
- All existing tests still passing
