### PR TITLE
feat: add pin_message, get_chat, get_file to TelegramTools

### DIFF
--- a/cookbook/91_tools/telegram_tools.py
+++ b/cookbook/91_tools/telegram_tools.py
@@ -3,38 +3,45 @@ Telegram Tools - Bot Communication and Messaging
 
 This example demonstrates how to use TelegramTools for Telegram bot operations.
 Shows enable_ flag patterns for selective function access.
-TelegramTools is a small tool (<6 functions) so it uses enable_ flags.
 
 Prerequisites:
 - Create a new bot with BotFather on Telegram: https://core.telegram.org/bots/features#creating-a-new-bot
 - Get the token from BotFather
 - Send a message to the bot
 - Get the chat_id by going to: https://api.telegram.org/bot<your-bot-token>/getUpdates
+- Set TELEGRAM_TOKEN and TELEGRAM_CHAT_ID environment variables
 """
 
+import os
+
 from agno.agent import Agent
+from agno.models.google import Gemini
 from agno.tools.telegram import TelegramTools
 
 # ---------------------------------------------------------------------------
 # Create Agent
 # ---------------------------------------------------------------------------
 
+# Use environment variables for credentials
+telegram_token = os.getenv("TELEGRAM_TOKEN", "<enter-your-bot-token>")
+chat_id = os.getenv("TELEGRAM_CHAT_ID", "<enter-your-chat-id>")
 
-telegram_token = "<enter-your-bot-token>"
-chat_id = "<enter-your-chat-id>"
-
-# Example 1: All functions enabled (default behavior)
+# Example 1: All functions enabled
 agent = Agent(
     name="telegram-full",
+    model=Gemini(id="gemini-2.5-flash"),
     tools=[
-        TelegramTools(token=telegram_token, chat_id=chat_id)
-    ],  # All functions enabled
+        TelegramTools(
+            token=telegram_token,
+            chat_id=chat_id,
+            all=True,  # Enable all tools including pin_message, get_chat, get_file
+        )
+    ],
     description="You are a comprehensive Telegram bot assistant with all messaging capabilities.",
     instructions=[
         "Help users with all Telegram bot operations",
         "Send messages, handle media, and manage bot interactions",
         "Provide clear feedback on bot operations",
-        "Follow Telegram bot best practices",
     ],
     markdown=True,
 )
@@ -42,6 +49,7 @@ agent = Agent(
 # Example 2: Agent that reacts to messages with emoji
 reaction_agent = Agent(
     name="telegram-reactor",
+    model=Gemini(id="gemini-2.5-flash"),
     tools=[
         TelegramTools(
             token=telegram_token,
@@ -52,12 +60,28 @@ reaction_agent = Agent(
     description="You are a Telegram assistant that acknowledges messages with emoji reactions.",
     instructions=[
         "When processing a user request, react to their message with an appropriate emoji",
-        "Use these reactions based on context:",
-        "  - Positive/success: react with a thumbs up",
-        "  - Question/thinking: react with eyes",
-        "  - Error/problem: react with a warning sign",
-        "  - Completed task: react with a checkmark",
-        "Always react BEFORE sending your response message",
+        "Use thumbs up for success, eyes for thinking, warning for errors",
+    ],
+    markdown=True,
+)
+
+# Example 3: Agent with file download capabilities
+download_agent = Agent(
+    name="telegram-downloader",
+    model=Gemini(id="gemini-2.5-flash"),
+    tools=[
+        TelegramTools(
+            token=telegram_token,
+            chat_id=chat_id,
+            enable_get_file=True,
+            save_downloads=True,
+            output_directory="/tmp/telegram_downloads",
+        )
+    ],
+    description="You are a Telegram assistant that downloads files from chat.",
+    instructions=[
+        "Download files when given a file_id",
+        "Report the local path where files are saved",
     ],
     markdown=True,
 )
@@ -66,4 +90,14 @@ reaction_agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    agent.print_response("Send a message to the bot")
+    # Test 1: Send a message
+    print("Test 1: Send message")
+    agent.print_response("Send a message saying 'Hello from cookbook test'")
+
+    # Test 2: Get chat info (new tool)
+    print("\nTest 2: Get chat info")
+    agent.print_response("Get information about this chat")
+
+    # Test 3: Send and pin a message (new tool)
+    print("\nTest 3: Pin message")
+    agent.print_response("Send 'Cookbook test pinned' and pin it")

--- a/cookbook/91_tools/telegram_tools.py
+++ b/cookbook/91_tools/telegram_tools.py
@@ -1,87 +1,64 @@
 """
-Telegram Tools - Bot Communication and Messaging
+Telegram Tools
+==============
 
-This example demonstrates how to use TelegramTools for Telegram bot operations.
-Shows enable_ flag patterns for selective function access.
+Environment variables:
+    TELEGRAM_TOKEN      Bot token from @BotFather
+    TELEGRAM_CHAT_ID    Chat ID to send messages to
 
-Prerequisites:
-- Create a new bot with BotFather on Telegram: https://core.telegram.org/bots/features#creating-a-new-bot
-- Get the token from BotFather
-- Send a message to the bot
-- Get the chat_id by going to: https://api.telegram.org/bot<your-bot-token>/getUpdates
-- Set TELEGRAM_TOKEN and TELEGRAM_CHAT_ID environment variables
+Get chat_id: https://api.telegram.org/bot<token>/getUpdates
 """
 
-import os
-
 from agno.agent import Agent
-from agno.models.google import Gemini
 from agno.tools.telegram import TelegramTools
 
 # ---------------------------------------------------------------------------
 # Create Agent
 # ---------------------------------------------------------------------------
 
-# Use environment variables for credentials
-telegram_token = os.getenv("TELEGRAM_TOKEN", "<enter-your-bot-token>")
-chat_id = os.getenv("TELEGRAM_CHAT_ID", "<enter-your-chat-id>")
-
-# Example 1: All functions enabled
-agent = Agent(
-    name="telegram-full",
-    model=Gemini(id="gemini-2.5-flash"),
+# Example 1: Enable all Telegram tools
+agent_all = Agent(
     tools=[
         TelegramTools(
-            token=telegram_token,
-            chat_id=chat_id,
             all=True,  # Enable all tools including pin_message, get_chat, get_file
         )
     ],
-    description="You are a comprehensive Telegram bot assistant with all messaging capabilities.",
-    instructions=[
-        "Help users with all Telegram bot operations",
-        "Send messages, handle media, and manage bot interactions",
-        "Provide clear feedback on bot operations",
-    ],
     markdown=True,
 )
 
-# Example 2: Agent that reacts to messages with emoji
-reaction_agent = Agent(
-    name="telegram-reactor",
-    model=Gemini(id="gemini-2.5-flash"),
+# Example 2: Messaging only (default)
+agent_messaging = Agent(
     tools=[
         TelegramTools(
-            token=telegram_token,
-            chat_id=chat_id,
-            enable_react_with_emoji=True,
+            enable_send_message=True,
+            enable_edit_message=True,
+            enable_delete_message=True,
         )
     ],
-    description="You are a Telegram assistant that acknowledges messages with emoji reactions.",
-    instructions=[
-        "When processing a user request, react to their message with an appropriate emoji",
-        "Use thumbs up for success, eyes for thinking, warning for errors",
-    ],
     markdown=True,
 )
 
-# Example 3: Agent with file download capabilities
-download_agent = Agent(
-    name="telegram-downloader",
-    model=Gemini(id="gemini-2.5-flash"),
+# Example 3: With file downloads saved to disk
+agent_downloads = Agent(
     tools=[
         TelegramTools(
-            token=telegram_token,
-            chat_id=chat_id,
+            enable_send_message=True,
             enable_get_file=True,
             save_downloads=True,
             output_directory="/tmp/telegram_downloads",
         )
     ],
-    description="You are a Telegram assistant that downloads files from chat.",
-    instructions=[
-        "Download files when given a file_id",
-        "Report the local path where files are saved",
+    markdown=True,
+)
+
+# Example 4: Reactions and pinning
+agent_reactions = Agent(
+    tools=[
+        TelegramTools(
+            enable_send_message=True,
+            enable_react_with_emoji=True,
+            enable_pin_message=True,
+        )
     ],
     markdown=True,
 )
@@ -90,14 +67,22 @@ download_agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    # Test 1: Send a message
-    print("Test 1: Send message")
-    agent.print_response("Send a message saying 'Hello from cookbook test'")
+    agent_all.print_response(
+        "Send 'Hello from Agno!' to the chat",
+        stream=True,
+    )
 
-    # Test 2: Get chat info (new tool)
-    print("\nTest 2: Get chat info")
-    agent.print_response("Get information about this chat")
+    # agent_messaging.print_response(
+    #     "Send 'Testing edit' then edit it to say 'Message edited!'",
+    #     stream=True,
+    # )
 
-    # Test 3: Send and pin a message (new tool)
-    print("\nTest 3: Pin message")
-    agent.print_response("Send 'Cookbook test pinned' and pin it")
+    # agent_downloads.print_response(
+    #     "Send a test message to the chat",
+    #     stream=True,
+    # )
+
+    # agent_reactions.print_response(
+    #     "Send 'Test pinned message' and pin it",
+    #     stream=True,
+    # )

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -29,6 +29,9 @@ class TelegramTools(Toolkit):
         enable_edit_message: Enable edit_message tool. Defaults to False.
         enable_delete_message: Enable delete_message tool. Defaults to False.
         enable_react_with_emoji: Enable react_with_emoji tool. Defaults to False.
+        enable_pin_message: Enable pin_message tool. Defaults to False.
+        enable_get_chat: Enable get_chat tool. Defaults to False.
+        enable_get_file: Enable get_file tool. Defaults to False.
         all: Enable all tools. Overrides individual flags when True.
     """
 
@@ -46,6 +49,9 @@ class TelegramTools(Toolkit):
         enable_edit_message: bool = False,
         enable_delete_message: bool = False,
         enable_react_with_emoji: bool = False,
+        enable_pin_message: bool = False,
+        enable_get_chat: bool = False,
+        enable_get_file: bool = False,
         all: bool = False,
         **kwargs: Any,
     ):
@@ -77,6 +83,12 @@ class TelegramTools(Toolkit):
             tools.append(self.delete_message)
         if enable_react_with_emoji or all:
             tools.append(self.react_with_emoji)
+        if enable_pin_message or all:
+            tools.append(self.pin_message)
+        if enable_get_chat or all:
+            tools.append(self.get_chat)
+        if enable_get_file or all:
+            tools.append(self.get_file)
 
         super().__init__(name="telegram", tools=tools, **kwargs)
 
@@ -249,5 +261,76 @@ class TelegramTools(Toolkit):
                 reaction=[ReactionTypeEmoji(emoji=emoji)],
             )
             return json.dumps({"status": "success", "message_id": message_id, "emoji": emoji})
+        except ApiTelegramException as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def pin_message(self, message_id: int, disable_notification: bool = False) -> str:
+        """Pin a message in a Telegram chat.
+
+        Args:
+            message_id: The ID of the message to pin.
+            disable_notification: If True, no notification is sent to chat members.
+
+        Returns:
+            JSON string with status.
+        """
+        try:
+            self.bot.pin_chat_message(self._chat_id, message_id, disable_notification=disable_notification)
+            return json.dumps({"status": "success", "pinned": True})
+        except ApiTelegramException as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def get_chat(self) -> str:
+        """Get information about the current chat.
+
+        Returns:
+            JSON string with chat details (id, type, title, description, etc.).
+        """
+        try:
+            chat = self.bot.get_chat(self._chat_id)
+            return json.dumps(
+                {
+                    "status": "success",
+                    "chat": {
+                        "id": chat.id,
+                        "type": chat.type,
+                        "title": getattr(chat, "title", None),
+                        "username": getattr(chat, "username", None),
+                        "first_name": getattr(chat, "first_name", None),
+                        "last_name": getattr(chat, "last_name", None),
+                        "description": getattr(chat, "description", None),
+                    },
+                }
+            )
+        except ApiTelegramException as e:
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def get_file(self, file_id: str) -> str:
+        """Download a file by its file_id and return as base64.
+
+        Use this for standalone file operations when not using the AgentOS interface.
+        The interface automatically downloads incoming files, but this tool is useful
+        for batch processing, organizing files, or accessing files from message history.
+
+        Args:
+            file_id: The file_id from a Telegram message (photo, document, etc.).
+
+        Returns:
+            JSON string with file metadata and base64-encoded content.
+        """
+        import base64
+
+        try:
+            file_info = self.bot.get_file(file_id)
+            file_content = self.bot.download_file(file_info.file_path)
+            return json.dumps(
+                {
+                    "status": "success",
+                    "file_id": file_info.file_id,
+                    "file_path": file_info.file_path,
+                    "file_size": file_info.file_size,
+                    "content_base64": base64.b64encode(file_content).decode("utf-8"),
+                }
+            )
         except ApiTelegramException as e:
             return json.dumps({"status": "error", "message": str(e)})

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -67,7 +67,6 @@ class TelegramTools(Toolkit):
         self.chat_id = chat_id or getenv("TELEGRAM_CHAT_ID")
         self.bot = TeleBot(self.token)
 
-        # output_directory implies save_downloads=True
         self.save_downloads = save_downloads or (output_directory is not None)
         if self.save_downloads:
             self.output_directory: Optional[Path] = (
@@ -125,9 +124,9 @@ class TelegramTools(Toolkit):
         log_debug(f"Sending telegram message: {message}")
         try:
             result = self.bot.send_message(self._chat_id, message)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def send_photo(self, photo: bytes, caption: Optional[str] = None) -> str:
         """Send a photo to the chat.
@@ -138,9 +137,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_photo(self._chat_id, photo, caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def send_document(self, document: bytes, filename: str, caption: Optional[str] = None) -> str:
         """Send a document to the chat.
@@ -152,9 +151,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_document(self._chat_id, (filename, document), caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def send_video(self, video: bytes, caption: Optional[str] = None) -> str:
         """Send a video to the chat.
@@ -165,9 +164,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_video(self._chat_id, video, caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def send_audio(self, audio: bytes, caption: Optional[str] = None, title: Optional[str] = None) -> str:
         """Send an audio file to the chat.
@@ -179,9 +178,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_audio(self._chat_id, audio, caption=caption, title=title)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def send_animation(self, animation: bytes, caption: Optional[str] = None) -> str:
         """Send an animation (GIF) to the chat.
@@ -192,9 +191,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_animation(self._chat_id, animation, caption=caption)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def send_sticker(self, sticker: bytes) -> str:
         """Send a sticker to the chat.
@@ -204,9 +203,9 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.send_sticker(self._chat_id, sticker)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            return json.dumps({"message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def edit_message(self, text: str, message_id: int) -> str:
         """Edit a previously sent message.
@@ -217,11 +216,10 @@ class TelegramTools(Toolkit):
         """
         try:
             result = self.bot.edit_message_text(text, chat_id=self._chat_id, message_id=message_id)
-            # edit_message_text returns Message on success, bool on inline message
             msg_id = result.message_id if hasattr(result, "message_id") else message_id
-            return json.dumps({"status": "success", "message_id": msg_id})
+            return json.dumps({"message_id": msg_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def delete_message(self, message_id: int) -> str:
         """Delete a message from the chat.
@@ -231,9 +229,9 @@ class TelegramTools(Toolkit):
         """
         try:
             self.bot.delete_message(self._chat_id, message_id)
-            return json.dumps({"status": "success", "deleted": True})
+            return json.dumps({"deleted": True})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def react_with_emoji(self, message_id: int, emoji: str) -> str:
         """React to a message with an emoji.
@@ -248,9 +246,9 @@ class TelegramTools(Toolkit):
                 message_id=message_id,
                 reaction=[ReactionTypeEmoji(emoji=emoji)],
             )
-            return json.dumps({"status": "success", "message_id": message_id, "emoji": emoji})
+            return json.dumps({"message_id": message_id, "emoji": emoji})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def pin_message(self, message_id: int, disable_notification: bool = False) -> str:
         """Pin a message in the chat.
@@ -261,9 +259,9 @@ class TelegramTools(Toolkit):
         """
         try:
             self.bot.pin_chat_message(self._chat_id, message_id, disable_notification=disable_notification)
-            return json.dumps({"status": "success", "pinned": True})
+            return json.dumps({"pinned": True, "message_id": message_id})
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def get_chat(self) -> str:
         """Get information about the current chat."""
@@ -271,7 +269,6 @@ class TelegramTools(Toolkit):
             chat = self.bot.get_chat(self._chat_id)
             return json.dumps(
                 {
-                    "status": "success",
                     "id": chat.id,
                     "type": chat.type,
                     "title": getattr(chat, "title", None),
@@ -282,7 +279,7 @@ class TelegramTools(Toolkit):
                 }
             )
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def get_file(self, file_id: str) -> str:
         """Download a file by its file_id. Returns path if save_downloads=True, else base64.
@@ -295,11 +292,10 @@ class TelegramTools(Toolkit):
         try:
             file_info = self.bot.get_file(file_id)
             if not file_info.file_path:
-                return json.dumps({"status": "error", "message": "File path not available"})
+                return json.dumps({"error": "File path not available"})
             file_content = self.bot.download_file(file_info.file_path)
 
             result: dict[str, Any] = {
-                "status": "success",
                 "file_id": file_info.file_id,
                 "file_path": file_info.file_path,
                 "file_size": file_info.file_size,
@@ -314,4 +310,4 @@ class TelegramTools(Toolkit):
 
             return json.dumps(result)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -1,5 +1,6 @@
 import json
 from os import getenv
+from pathlib import Path
 from typing import Any, List, Optional
 
 from agno.tools import Toolkit
@@ -19,6 +20,8 @@ class TelegramTools(Toolkit):
     Args:
         chat_id: Default chat ID. Falls back to TELEGRAM_CHAT_ID env var.
         token: Bot token. Falls back to TELEGRAM_TOKEN env var.
+        output_directory: Directory for saving downloaded files. Only used when save_downloads=True.
+        save_downloads: Save downloaded files to disk instead of returning base64.
         enable_send_message: Enable send_message tool. Defaults to True.
         enable_send_photo: Enable send_photo tool. Defaults to False.
         enable_send_document: Enable send_document tool. Defaults to False.
@@ -39,6 +42,8 @@ class TelegramTools(Toolkit):
         self,
         chat_id: Optional[str] = None,
         token: Optional[str] = None,
+        output_directory: Optional[str] = None,
+        save_downloads: bool = False,
         enable_send_message: bool = True,
         enable_send_photo: bool = False,
         enable_send_document: bool = False,
@@ -61,6 +66,17 @@ class TelegramTools(Toolkit):
 
         self.chat_id = chat_id or getenv("TELEGRAM_CHAT_ID")
         self.bot = TeleBot(self.token)
+
+        # output_directory implies save_downloads=True
+        self.save_downloads = save_downloads or (output_directory is not None)
+        if self.save_downloads:
+            self.output_directory: Optional[Path] = (
+                Path(output_directory).resolve() if output_directory else Path.cwd().resolve()
+            )
+            self.output_directory.mkdir(parents=True, exist_ok=True)
+            log_debug(f"Downloaded files will be saved to: {self.output_directory}")
+        else:
+            self.output_directory = None
 
         tools: List[Any] = []
         if enable_send_message or all:
@@ -101,13 +117,10 @@ class TelegramTools(Toolkit):
         return self.chat_id
 
     def send_message(self, message: str) -> str:
-        """Send a text message to a Telegram chat.
+        """Send a text message to the chat.
 
         Args:
             message: The message text to send.
-
-        Returns:
-            JSON string with status and message_id.
         """
         log_debug(f"Sending telegram message: {message}")
         try:
@@ -117,14 +130,11 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def send_photo(self, photo: bytes, caption: Optional[str] = None) -> str:
-        """Send a photo to a Telegram chat.
+        """Send a photo to the chat.
 
         Args:
             photo: The photo as bytes.
-            caption: Optional caption for the photo.
-
-        Returns:
-            JSON string with status and message_id.
+            caption: Optional caption.
         """
         try:
             result = self.bot.send_photo(self._chat_id, photo, caption=caption)
@@ -133,15 +143,12 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def send_document(self, document: bytes, filename: str, caption: Optional[str] = None) -> str:
-        """Send a document to a Telegram chat.
+        """Send a document to the chat.
 
         Args:
             document: The document as bytes.
             filename: The filename for the document.
-            caption: Optional caption for the document.
-
-        Returns:
-            JSON string with status and message_id.
+            caption: Optional caption.
         """
         try:
             result = self.bot.send_document(self._chat_id, (filename, document), caption=caption)
@@ -150,14 +157,11 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def send_video(self, video: bytes, caption: Optional[str] = None) -> str:
-        """Send a video to a Telegram chat.
+        """Send a video to the chat.
 
         Args:
             video: The video as bytes.
-            caption: Optional caption for the video.
-
-        Returns:
-            JSON string with status and message_id.
+            caption: Optional caption.
         """
         try:
             result = self.bot.send_video(self._chat_id, video, caption=caption)
@@ -166,15 +170,12 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def send_audio(self, audio: bytes, caption: Optional[str] = None, title: Optional[str] = None) -> str:
-        """Send an audio file to a Telegram chat.
+        """Send an audio file to the chat.
 
         Args:
             audio: The audio as bytes.
-            caption: Optional caption for the audio.
+            caption: Optional caption.
             title: Optional title for the audio track.
-
-        Returns:
-            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_audio(self._chat_id, audio, caption=caption, title=title)
@@ -183,14 +184,11 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def send_animation(self, animation: bytes, caption: Optional[str] = None) -> str:
-        """Send an animation (GIF) to a Telegram chat.
+        """Send an animation (GIF) to the chat.
 
         Args:
             animation: The animation as bytes.
-            caption: Optional caption for the animation.
-
-        Returns:
-            JSON string with status and message_id.
+            caption: Optional caption.
         """
         try:
             result = self.bot.send_animation(self._chat_id, animation, caption=caption)
@@ -199,13 +197,10 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def send_sticker(self, sticker: bytes) -> str:
-        """Send a sticker to a Telegram chat.
+        """Send a sticker to the chat.
 
         Args:
             sticker: The sticker as bytes.
-
-        Returns:
-            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_sticker(self._chat_id, sticker)
@@ -214,29 +209,25 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def edit_message(self, text: str, message_id: int) -> str:
-        """Edit a previously sent message in a Telegram chat.
+        """Edit a previously sent message.
 
         Args:
             text: The new message text.
             message_id: The ID of the message to edit.
-
-        Returns:
-            JSON string with status and message_id.
         """
         try:
             result = self.bot.edit_message_text(text, chat_id=self._chat_id, message_id=message_id)
-            return json.dumps({"status": "success", "message_id": result.message_id})
+            # edit_message_text returns Message on success, bool on inline message
+            msg_id = result.message_id if hasattr(result, "message_id") else message_id
+            return json.dumps({"status": "success", "message_id": msg_id})
         except ApiTelegramException as e:
             return json.dumps({"status": "error", "message": str(e)})
 
     def delete_message(self, message_id: int) -> str:
-        """Delete a message from a Telegram chat.
+        """Delete a message from the chat.
 
         Args:
             message_id: The ID of the message to delete.
-
-        Returns:
-            JSON string with status and deleted flag.
         """
         try:
             self.bot.delete_message(self._chat_id, message_id)
@@ -250,9 +241,6 @@ class TelegramTools(Toolkit):
         Args:
             message_id: The ID of the message to react to.
             emoji: The emoji to react with.
-
-        Returns:
-            JSON string with status.
         """
         try:
             self.bot.set_message_reaction(
@@ -265,14 +253,11 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def pin_message(self, message_id: int, disable_notification: bool = False) -> str:
-        """Pin a message in a Telegram chat.
+        """Pin a message in the chat.
 
         Args:
             message_id: The ID of the message to pin.
             disable_notification: If True, no notification is sent to chat members.
-
-        Returns:
-            JSON string with status.
         """
         try:
             self.bot.pin_chat_message(self._chat_id, message_id, disable_notification=disable_notification)
@@ -281,11 +266,7 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def get_chat(self) -> str:
-        """Get information about the current chat.
-
-        Returns:
-            JSON string with chat details (id, type, title, description, etc.).
-        """
+        """Get information about the current chat (id, type, title, description)."""
         try:
             chat = self.bot.get_chat(self._chat_id)
             return json.dumps(
@@ -306,31 +287,34 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def get_file(self, file_id: str) -> str:
-        """Download a file by its file_id and return as base64.
-
-        Use this for standalone file operations when not using the AgentOS interface.
-        The interface automatically downloads incoming files, but this tool is useful
-        for batch processing, organizing files, or accessing files from message history.
+        """Download a file by its file_id. Returns path if save_downloads=True, else base64.
 
         Args:
             file_id: The file_id from a Telegram message (photo, document, etc.).
-
-        Returns:
-            JSON string with file metadata and base64-encoded content.
         """
         import base64
 
         try:
             file_info = self.bot.get_file(file_id)
+            if not file_info.file_path:
+                return json.dumps({"status": "error", "message": "File path not available"})
             file_content = self.bot.download_file(file_info.file_path)
-            return json.dumps(
-                {
-                    "status": "success",
-                    "file_id": file_info.file_id,
-                    "file_path": file_info.file_path,
-                    "file_size": file_info.file_size,
-                    "content_base64": base64.b64encode(file_content).decode("utf-8"),
-                }
-            )
+
+            result: dict[str, Any] = {
+                "status": "success",
+                "file_id": file_info.file_id,
+                "file_path": file_info.file_path,
+                "file_size": file_info.file_size,
+            }
+
+            if self.save_downloads and self.output_directory:
+                filename = Path(file_info.file_path).name
+                local_path = self.output_directory / filename
+                local_path.write_bytes(file_content)
+                result["local_path"] = str(local_path)
+            else:
+                result["content_base64"] = base64.b64encode(file_content).decode("utf-8")
+
+            return json.dumps(result)
         except ApiTelegramException as e:
             return json.dumps({"status": "error", "message": str(e)})

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -116,122 +116,149 @@ class TelegramTools(Toolkit):
         return self.chat_id
 
     def send_message(self, message: str) -> str:
-        """Send a text message to the chat.
+        """Send a text message to a Telegram chat.
 
         Args:
             message: The message text to send.
+
+        Returns:
+            JSON string with status and message_id.
         """
         log_debug(f"Sending telegram message: {message}")
         try:
             result = self.bot.send_message(self._chat_id, message)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def send_photo(self, photo: bytes, caption: Optional[str] = None) -> str:
-        """Send a photo to the chat.
+        """Send a photo to a Telegram chat.
 
         Args:
             photo: The photo as bytes.
-            caption: Optional caption.
+            caption: Optional caption for the photo.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_photo(self._chat_id, photo, caption=caption)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def send_document(self, document: bytes, filename: str, caption: Optional[str] = None) -> str:
-        """Send a document to the chat.
+        """Send a document to a Telegram chat.
 
         Args:
             document: The document as bytes.
             filename: The filename for the document.
-            caption: Optional caption.
+            caption: Optional caption for the document.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_document(self._chat_id, (filename, document), caption=caption)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def send_video(self, video: bytes, caption: Optional[str] = None) -> str:
-        """Send a video to the chat.
+        """Send a video to a Telegram chat.
 
         Args:
             video: The video as bytes.
-            caption: Optional caption.
+            caption: Optional caption for the video.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_video(self._chat_id, video, caption=caption)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def send_audio(self, audio: bytes, caption: Optional[str] = None, title: Optional[str] = None) -> str:
-        """Send an audio file to the chat.
+        """Send an audio file to a Telegram chat.
 
         Args:
             audio: The audio as bytes.
-            caption: Optional caption.
+            caption: Optional caption for the audio.
             title: Optional title for the audio track.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_audio(self._chat_id, audio, caption=caption, title=title)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def send_animation(self, animation: bytes, caption: Optional[str] = None) -> str:
-        """Send an animation (GIF) to the chat.
+        """Send an animation (GIF) to a Telegram chat.
 
         Args:
             animation: The animation as bytes.
-            caption: Optional caption.
+            caption: Optional caption for the animation.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_animation(self._chat_id, animation, caption=caption)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def send_sticker(self, sticker: bytes) -> str:
-        """Send a sticker to the chat.
+        """Send a sticker to a Telegram chat.
 
         Args:
             sticker: The sticker as bytes.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.send_sticker(self._chat_id, sticker)
-            return json.dumps({"message_id": result.message_id})
+            return json.dumps({"status": "success", "message_id": result.message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def edit_message(self, text: str, message_id: int) -> str:
-        """Edit a previously sent message.
+        """Edit a previously sent message in a Telegram chat.
 
         Args:
             text: The new message text.
             message_id: The ID of the message to edit.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             result = self.bot.edit_message_text(text, chat_id=self._chat_id, message_id=message_id)
             msg_id = result.message_id if hasattr(result, "message_id") else message_id
-            return json.dumps({"message_id": msg_id})
+            return json.dumps({"status": "success", "message_id": msg_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def delete_message(self, message_id: int) -> str:
-        """Delete a message from the chat.
+        """Delete a message from a Telegram chat.
 
         Args:
             message_id: The ID of the message to delete.
+
+        Returns:
+            JSON string with status and deleted flag.
         """
         try:
             self.bot.delete_message(self._chat_id, message_id)
-            return json.dumps({"deleted": True})
+            return json.dumps({"status": "success", "deleted": True})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def react_with_emoji(self, message_id: int, emoji: str) -> str:
         """React to a message with an emoji.
@@ -239,6 +266,9 @@ class TelegramTools(Toolkit):
         Args:
             message_id: The ID of the message to react to.
             emoji: The emoji to react with.
+
+        Returns:
+            JSON string with status.
         """
         try:
             self.bot.set_message_reaction(
@@ -246,9 +276,9 @@ class TelegramTools(Toolkit):
                 message_id=message_id,
                 reaction=[ReactionTypeEmoji(emoji=emoji)],
             )
-            return json.dumps({"message_id": message_id, "emoji": emoji})
+            return json.dumps({"status": "success", "message_id": message_id, "emoji": emoji})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def pin_message(self, message_id: int, disable_notification: bool = False) -> str:
         """Pin a message in the chat.
@@ -256,19 +286,27 @@ class TelegramTools(Toolkit):
         Args:
             message_id: The ID of the message to pin.
             disable_notification: If True, no notification is sent to chat members.
+
+        Returns:
+            JSON string with status and message_id.
         """
         try:
             self.bot.pin_chat_message(self._chat_id, message_id, disable_notification=disable_notification)
-            return json.dumps({"pinned": True, "message_id": message_id})
+            return json.dumps({"status": "success", "pinned": True, "message_id": message_id})
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def get_chat(self) -> str:
-        """Get information about the current chat."""
+        """Get information about the current chat.
+
+        Returns:
+            JSON string with status and chat info.
+        """
         try:
             chat = self.bot.get_chat(self._chat_id)
             return json.dumps(
                 {
+                    "status": "success",
                     "id": chat.id,
                     "type": chat.type,
                     "title": getattr(chat, "title", None),
@@ -279,23 +317,27 @@ class TelegramTools(Toolkit):
                 }
             )
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def get_file(self, file_id: str) -> str:
         """Download a file by its file_id. Returns path if save_downloads=True, else base64.
 
         Args:
             file_id: The file_id from a Telegram message (photo, document, etc.).
+
+        Returns:
+            JSON string with status and file info (local_path or content_base64).
         """
         import base64
 
         try:
             file_info = self.bot.get_file(file_id)
             if not file_info.file_path:
-                return json.dumps({"error": "File path not available"})
+                return json.dumps({"status": "error", "message": "File path not available"})
             file_content = self.bot.download_file(file_info.file_path)
 
             result: dict[str, Any] = {
+                "status": "success",
                 "file_id": file_info.file_id,
                 "file_path": file_info.file_path,
                 "file_size": file_info.file_size,
@@ -310,4 +352,4 @@ class TelegramTools(Toolkit):
 
             return json.dumps(result)
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -269,9 +269,20 @@ class TelegramTools(Toolkit):
         """Get information about the current chat."""
         try:
             chat = self.bot.get_chat(self._chat_id)
-            return json.dumps(chat.__dict__)
+            return json.dumps(
+                {
+                    "status": "success",
+                    "id": chat.id,
+                    "type": chat.type,
+                    "title": getattr(chat, "title", None),
+                    "username": getattr(chat, "username", None),
+                    "first_name": getattr(chat, "first_name", None),
+                    "last_name": getattr(chat, "last_name", None),
+                    "description": getattr(chat, "description", None),
+                }
+            )
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})
 
     def get_file(self, file_id: str) -> str:
         """Download a file by its file_id. Returns path if save_downloads=True, else base64.
@@ -284,10 +295,15 @@ class TelegramTools(Toolkit):
         try:
             file_info = self.bot.get_file(file_id)
             if not file_info.file_path:
-                return json.dumps({"error": "File path not available"})
+                return json.dumps({"status": "error", "message": "File path not available"})
             file_content = self.bot.download_file(file_info.file_path)
 
-            result = dict(file_info.__dict__)
+            result: dict[str, Any] = {
+                "status": "success",
+                "file_id": file_info.file_id,
+                "file_path": file_info.file_path,
+                "file_size": file_info.file_size,
+            }
             if self.save_downloads and self.output_directory:
                 filename = Path(file_info.file_path).name
                 local_path = self.output_directory / filename
@@ -298,4 +314,4 @@ class TelegramTools(Toolkit):
 
             return json.dumps(result)
         except ApiTelegramException as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"status": "error", "message": str(e)})

--- a/libs/agno/agno/tools/telegram.py
+++ b/libs/agno/agno/tools/telegram.py
@@ -266,25 +266,12 @@ class TelegramTools(Toolkit):
             return json.dumps({"status": "error", "message": str(e)})
 
     def get_chat(self) -> str:
-        """Get information about the current chat (id, type, title, description)."""
+        """Get information about the current chat."""
         try:
             chat = self.bot.get_chat(self._chat_id)
-            return json.dumps(
-                {
-                    "status": "success",
-                    "chat": {
-                        "id": chat.id,
-                        "type": chat.type,
-                        "title": getattr(chat, "title", None),
-                        "username": getattr(chat, "username", None),
-                        "first_name": getattr(chat, "first_name", None),
-                        "last_name": getattr(chat, "last_name", None),
-                        "description": getattr(chat, "description", None),
-                    },
-                }
-            )
+            return json.dumps(chat.__dict__)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})
 
     def get_file(self, file_id: str) -> str:
         """Download a file by its file_id. Returns path if save_downloads=True, else base64.
@@ -297,16 +284,10 @@ class TelegramTools(Toolkit):
         try:
             file_info = self.bot.get_file(file_id)
             if not file_info.file_path:
-                return json.dumps({"status": "error", "message": "File path not available"})
+                return json.dumps({"error": "File path not available"})
             file_content = self.bot.download_file(file_info.file_path)
 
-            result: dict[str, Any] = {
-                "status": "success",
-                "file_id": file_info.file_id,
-                "file_path": file_info.file_path,
-                "file_size": file_info.file_size,
-            }
-
+            result = dict(file_info.__dict__)
             if self.save_downloads and self.output_directory:
                 filename = Path(file_info.file_path).name
                 local_path = self.output_directory / filename
@@ -317,4 +298,4 @@ class TelegramTools(Toolkit):
 
             return json.dumps(result)
         except ApiTelegramException as e:
-            return json.dumps({"status": "error", "message": str(e)})
+            return json.dumps({"error": str(e)})

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -557,7 +557,7 @@ class TestGetChat:
 
 
 class TestGetFile:
-    def test_success(self, monkeypatch):
+    def test_success_base64(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
         from agno.tools.telegram import TelegramTools
 
@@ -577,6 +577,37 @@ class TestGetFile:
         assert parsed["file_id"] == "ABC123"
         assert parsed["file_path"] == "photos/file_0.jpg"
         assert "content_base64" in parsed
+        assert "local_path" not in parsed
+
+    def test_save_downloads_to_disk(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(
+            chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path)
+        )
+        mock_file = MagicMock()
+        mock_file.file_id = "ABC123"
+        mock_file.file_path = "photos/file_0.jpg"
+        mock_file.file_size = 12345
+        tools.bot.get_file = MagicMock(return_value=mock_file)
+        tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
+
+        result = tools.get_file(file_id="ABC123")
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+        assert "local_path" in parsed
+        assert "content_base64" not in parsed
+        assert (tmp_path / "file_0.jpg").exists()
+        assert (tmp_path / "file_0.jpg").read_bytes() == b"fake-image-bytes"
+
+    def test_output_directory_implies_save_downloads(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_get_file=True, output_directory=str(tmp_path))
+        assert tools.save_downloads is True
+        assert tools.output_directory == tmp_path.resolve()
 
     def test_api_error(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -223,7 +223,7 @@ class TestSendMessage:
         result = tools.send_message("Hello")
         tools.bot.send_message.assert_called_once_with("12345", "Hello")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 101
 
     def test_api_error(self, monkeypatch):
@@ -235,8 +235,8 @@ class TestSendMessage:
 
         result = tools.send_message("Hello")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestSendPhoto:
@@ -252,7 +252,7 @@ class TestSendPhoto:
         result = tools.send_photo(b"image-bytes", caption="A photo")
         tools.bot.send_photo.assert_called_once_with("12345", b"image-bytes", caption="A photo")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 103
 
 
@@ -269,7 +269,7 @@ class TestSendDocument:
         result = tools.send_document(b"doc-bytes", "report.pdf")
         tools.bot.send_document.assert_called_once_with("12345", ("report.pdf", b"doc-bytes"), caption=None)
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 105
 
 
@@ -286,7 +286,7 @@ class TestSendVideo:
         result = tools.send_video(b"video-bytes", caption="A video")
         tools.bot.send_video.assert_called_once_with("12345", b"video-bytes", caption="A video")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 107
 
     def test_api_error(self, monkeypatch):
@@ -298,8 +298,8 @@ class TestSendVideo:
 
         result = tools.send_video(b"video-bytes")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestSendAudio:
@@ -315,7 +315,7 @@ class TestSendAudio:
         result = tools.send_audio(b"audio-bytes", caption="A song", title="Song Title")
         tools.bot.send_audio.assert_called_once_with("12345", b"audio-bytes", caption="A song", title="Song Title")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 109
 
     def test_api_error(self, monkeypatch):
@@ -327,8 +327,8 @@ class TestSendAudio:
 
         result = tools.send_audio(b"audio-bytes")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestSendAnimation:
@@ -344,7 +344,7 @@ class TestSendAnimation:
         result = tools.send_animation(b"gif-bytes", caption="A GIF")
         tools.bot.send_animation.assert_called_once_with("12345", b"gif-bytes", caption="A GIF")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 111
 
     def test_api_error(self, monkeypatch):
@@ -356,8 +356,8 @@ class TestSendAnimation:
 
         result = tools.send_animation(b"gif-bytes")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestSendSticker:
@@ -373,7 +373,7 @@ class TestSendSticker:
         result = tools.send_sticker(b"sticker-bytes")
         tools.bot.send_sticker.assert_called_once_with("12345", b"sticker-bytes")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 113
 
     def test_api_error(self, monkeypatch):
@@ -385,8 +385,8 @@ class TestSendSticker:
 
         result = tools.send_sticker(b"sticker-bytes")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestEditMessage:
@@ -402,7 +402,7 @@ class TestEditMessage:
         result = tools.edit_message("Updated text", message_id=42)
         tools.bot.edit_message_text.assert_called_once_with("Updated text", chat_id="12345", message_id=42)
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 42
 
     def test_api_error(self, monkeypatch):
@@ -416,8 +416,8 @@ class TestEditMessage:
 
         result = tools.edit_message("Updated text", message_id=42)
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestDeleteMessage:
@@ -431,7 +431,7 @@ class TestDeleteMessage:
         result = tools.delete_message(message_id=42)
         tools.bot.delete_message.assert_called_once_with("12345", 42)
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["deleted"] is True
 
     def test_api_error(self, monkeypatch):
@@ -443,8 +443,8 @@ class TestDeleteMessage:
 
         result = tools.delete_message(message_id=42)
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestReactWithEmoji:
@@ -461,7 +461,7 @@ class TestReactWithEmoji:
         assert call_kwargs.kwargs["chat_id"] == "12345"
         assert call_kwargs.kwargs["message_id"] == 42
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["message_id"] == 42
         assert parsed["emoji"] == "👍"
 
@@ -476,8 +476,8 @@ class TestReactWithEmoji:
 
         result = tools.react_with_emoji(message_id=42, emoji="👍")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
-        assert "Bad Request" in parsed["message"]
+        assert "error" in parsed
+        assert "Bad Request" in parsed["error"]
 
 
 class TestPinMessage:
@@ -491,7 +491,7 @@ class TestPinMessage:
         result = tools.pin_message(message_id=42)
         tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=False)
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["pinned"] is True
 
     def test_silent(self, monkeypatch):
@@ -504,7 +504,7 @@ class TestPinMessage:
         result = tools.pin_message(message_id=42, disable_notification=True)
         tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=True)
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
 
     def test_api_error(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
@@ -517,7 +517,7 @@ class TestPinMessage:
 
         result = tools.pin_message(message_id=42)
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
+        assert "error" in parsed
 
 
 class TestGetChat:
@@ -539,7 +539,7 @@ class TestGetChat:
         result = tools.get_chat()
         tools.bot.get_chat.assert_called_once_with("12345")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["id"] == 12345
         assert parsed["type"] == "group"
         assert parsed["title"] == "Test Group"
@@ -553,7 +553,7 @@ class TestGetChat:
 
         result = tools.get_chat()
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
+        assert "error" in parsed
 
 
 class TestGetFile:
@@ -573,7 +573,7 @@ class TestGetFile:
         tools.bot.get_file.assert_called_once_with("ABC123")
         tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert parsed["file_id"] == "ABC123"
         assert parsed["file_path"] == "photos/file_0.jpg"
         assert "content_base64" in parsed
@@ -595,7 +595,7 @@ class TestGetFile:
 
         result = tools.get_file(file_id="ABC123")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
+        assert "error" not in parsed
         assert "local_path" in parsed
         assert "content_base64" not in parsed
         assert (tmp_path / "file_0.jpg").exists()
@@ -618,4 +618,4 @@ class TestGetFile:
 
         result = tools.get_file(file_id="invalid")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
+        assert "error" in parsed

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -223,7 +223,7 @@ class TestSendMessage:
         result = tools.send_message("Hello")
         tools.bot.send_message.assert_called_once_with("12345", "Hello")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 101
 
     def test_api_error(self, monkeypatch):
@@ -235,8 +235,8 @@ class TestSendMessage:
 
         result = tools.send_message("Hello")
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestSendPhoto:
@@ -252,7 +252,7 @@ class TestSendPhoto:
         result = tools.send_photo(b"image-bytes", caption="A photo")
         tools.bot.send_photo.assert_called_once_with("12345", b"image-bytes", caption="A photo")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 103
 
 
@@ -269,7 +269,7 @@ class TestSendDocument:
         result = tools.send_document(b"doc-bytes", "report.pdf")
         tools.bot.send_document.assert_called_once_with("12345", ("report.pdf", b"doc-bytes"), caption=None)
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 105
 
 
@@ -286,7 +286,7 @@ class TestSendVideo:
         result = tools.send_video(b"video-bytes", caption="A video")
         tools.bot.send_video.assert_called_once_with("12345", b"video-bytes", caption="A video")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 107
 
     def test_api_error(self, monkeypatch):
@@ -298,8 +298,8 @@ class TestSendVideo:
 
         result = tools.send_video(b"video-bytes")
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestSendAudio:
@@ -315,7 +315,7 @@ class TestSendAudio:
         result = tools.send_audio(b"audio-bytes", caption="A song", title="Song Title")
         tools.bot.send_audio.assert_called_once_with("12345", b"audio-bytes", caption="A song", title="Song Title")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 109
 
     def test_api_error(self, monkeypatch):
@@ -327,8 +327,8 @@ class TestSendAudio:
 
         result = tools.send_audio(b"audio-bytes")
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestSendAnimation:
@@ -344,7 +344,7 @@ class TestSendAnimation:
         result = tools.send_animation(b"gif-bytes", caption="A GIF")
         tools.bot.send_animation.assert_called_once_with("12345", b"gif-bytes", caption="A GIF")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 111
 
     def test_api_error(self, monkeypatch):
@@ -356,8 +356,8 @@ class TestSendAnimation:
 
         result = tools.send_animation(b"gif-bytes")
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestSendSticker:
@@ -373,7 +373,7 @@ class TestSendSticker:
         result = tools.send_sticker(b"sticker-bytes")
         tools.bot.send_sticker.assert_called_once_with("12345", b"sticker-bytes")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 113
 
     def test_api_error(self, monkeypatch):
@@ -385,8 +385,8 @@ class TestSendSticker:
 
         result = tools.send_sticker(b"sticker-bytes")
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestEditMessage:
@@ -402,7 +402,7 @@ class TestEditMessage:
         result = tools.edit_message("Updated text", message_id=42)
         tools.bot.edit_message_text.assert_called_once_with("Updated text", chat_id="12345", message_id=42)
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 42
 
     def test_api_error(self, monkeypatch):
@@ -416,8 +416,8 @@ class TestEditMessage:
 
         result = tools.edit_message("Updated text", message_id=42)
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestDeleteMessage:
@@ -431,7 +431,7 @@ class TestDeleteMessage:
         result = tools.delete_message(message_id=42)
         tools.bot.delete_message.assert_called_once_with("12345", 42)
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["deleted"] is True
 
     def test_api_error(self, monkeypatch):
@@ -443,8 +443,8 @@ class TestDeleteMessage:
 
         result = tools.delete_message(message_id=42)
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestReactWithEmoji:
@@ -461,7 +461,7 @@ class TestReactWithEmoji:
         assert call_kwargs.kwargs["chat_id"] == "12345"
         assert call_kwargs.kwargs["message_id"] == 42
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["message_id"] == 42
         assert parsed["emoji"] == "👍"
 
@@ -476,8 +476,8 @@ class TestReactWithEmoji:
 
         result = tools.react_with_emoji(message_id=42, emoji="👍")
         parsed = json.loads(result)
-        assert "error" in parsed
-        assert "Bad Request" in parsed["error"]
+        assert parsed["status"] == "error"
+        assert "Bad Request" in parsed["message"]
 
 
 class TestPinMessage:
@@ -491,7 +491,7 @@ class TestPinMessage:
         result = tools.pin_message(message_id=42)
         tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=False)
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["pinned"] is True
 
     def test_silent(self, monkeypatch):
@@ -504,7 +504,7 @@ class TestPinMessage:
         result = tools.pin_message(message_id=42, disable_notification=True)
         tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=True)
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
 
     def test_api_error(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
@@ -517,7 +517,7 @@ class TestPinMessage:
 
         result = tools.pin_message(message_id=42)
         parsed = json.loads(result)
-        assert "error" in parsed
+        assert parsed["status"] == "error"
 
 
 class TestGetChat:
@@ -539,7 +539,7 @@ class TestGetChat:
         result = tools.get_chat()
         tools.bot.get_chat.assert_called_once_with("12345")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["id"] == 12345
         assert parsed["type"] == "group"
         assert parsed["title"] == "Test Group"
@@ -553,7 +553,7 @@ class TestGetChat:
 
         result = tools.get_chat()
         parsed = json.loads(result)
-        assert "error" in parsed
+        assert parsed["status"] == "error"
 
 
 class TestGetFile:
@@ -573,7 +573,7 @@ class TestGetFile:
         tools.bot.get_file.assert_called_once_with("ABC123")
         tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert parsed["file_id"] == "ABC123"
         assert parsed["file_path"] == "photos/file_0.jpg"
         assert "content_base64" in parsed
@@ -595,7 +595,7 @@ class TestGetFile:
 
         result = tools.get_file(file_id="ABC123")
         parsed = json.loads(result)
-        assert "error" not in parsed
+        assert parsed["status"] == "success"
         assert "local_path" in parsed
         assert "content_base64" not in parsed
         assert (tmp_path / "file_0.jpg").exists()
@@ -618,4 +618,4 @@ class TestGetFile:
 
         result = tools.get_file(file_id="invalid")
         parsed = json.loads(result)
-        assert "error" in parsed
+        assert parsed["status"] == "error"

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -527,18 +527,19 @@ class TestGetChat:
 
         tools = TelegramTools(chat_id="12345", enable_get_chat=True)
         mock_chat = MagicMock()
-        mock_chat.__dict__ = {
-            "id": 12345,
-            "type": "group",
-            "title": "Test Group",
-            "username": None,
-            "description": "A test group",
-        }
+        mock_chat.id = 12345
+        mock_chat.type = "group"
+        mock_chat.title = "Test Group"
+        mock_chat.username = None
+        mock_chat.first_name = None
+        mock_chat.last_name = None
+        mock_chat.description = "A test group"
         tools.bot.get_chat = MagicMock(return_value=mock_chat)
 
         result = tools.get_chat()
         tools.bot.get_chat.assert_called_once_with("12345")
         parsed = json.loads(result)
+        assert parsed["status"] == "success"
         assert parsed["id"] == 12345
         assert parsed["type"] == "group"
         assert parsed["title"] == "Test Group"
@@ -552,7 +553,7 @@ class TestGetChat:
 
         result = tools.get_chat()
         parsed = json.loads(result)
-        assert "error" in parsed
+        assert parsed["status"] == "error"
 
 
 class TestGetFile:
@@ -562,8 +563,9 @@ class TestGetFile:
 
         tools = TelegramTools(chat_id="12345", enable_get_file=True)
         mock_file = MagicMock()
+        mock_file.file_id = "ABC123"
         mock_file.file_path = "photos/file_0.jpg"
-        mock_file.__dict__ = {"file_id": "ABC123", "file_path": "photos/file_0.jpg", "file_size": 12345}
+        mock_file.file_size = 12345
         tools.bot.get_file = MagicMock(return_value=mock_file)
         tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
 
@@ -571,6 +573,7 @@ class TestGetFile:
         tools.bot.get_file.assert_called_once_with("ABC123")
         tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
         parsed = json.loads(result)
+        assert parsed["status"] == "success"
         assert parsed["file_id"] == "ABC123"
         assert parsed["file_path"] == "photos/file_0.jpg"
         assert "content_base64" in parsed
@@ -584,13 +587,15 @@ class TestGetFile:
             chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path)
         )
         mock_file = MagicMock()
+        mock_file.file_id = "ABC123"
         mock_file.file_path = "photos/file_0.jpg"
-        mock_file.__dict__ = {"file_id": "ABC123", "file_path": "photos/file_0.jpg", "file_size": 12345}
+        mock_file.file_size = 12345
         tools.bot.get_file = MagicMock(return_value=mock_file)
         tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
 
         result = tools.get_file(file_id="ABC123")
         parsed = json.loads(result)
+        assert parsed["status"] == "success"
         assert "local_path" in parsed
         assert "content_base64" not in parsed
         assert (tmp_path / "file_0.jpg").exists()
@@ -613,4 +618,4 @@ class TestGetFile:
 
         result = tools.get_file(file_id="invalid")
         parsed = json.loads(result)
-        assert "error" in parsed
+        assert parsed["status"] == "error"

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -152,6 +152,9 @@ class TestTelegramToolsInit:
             "edit_message",
             "delete_message",
             "react_with_emoji",
+            "pin_message",
+            "get_chat",
+            "get_file",
         )
         for name in expected:
             assert name in tools.functions
@@ -475,3 +478,113 @@ class TestReactWithEmoji:
         parsed = json.loads(result)
         assert parsed["status"] == "error"
         assert "Bad Request" in parsed["message"]
+
+
+class TestPinMessage:
+    def test_success(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_pin_message=True)
+        tools.bot.pin_chat_message = MagicMock(return_value=True)
+
+        result = tools.pin_message(message_id=42)
+        tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=False)
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+        assert parsed["pinned"] is True
+
+    def test_silent(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_pin_message=True)
+        tools.bot.pin_chat_message = MagicMock(return_value=True)
+
+        result = tools.pin_message(message_id=42, disable_notification=True)
+        tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=True)
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+
+    def test_api_error(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_pin_message=True)
+        tools.bot.pin_chat_message = MagicMock(
+            side_effect=_FakeApiTelegramException("pinChatMessage", "Bad Request", 400)
+        )
+
+        result = tools.pin_message(message_id=42)
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"
+
+
+class TestGetChat:
+    def test_success(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_get_chat=True)
+        mock_chat = MagicMock()
+        mock_chat.id = 12345
+        mock_chat.type = "group"
+        mock_chat.title = "Test Group"
+        mock_chat.username = None
+        mock_chat.first_name = None
+        mock_chat.last_name = None
+        mock_chat.description = "A test group"
+        tools.bot.get_chat = MagicMock(return_value=mock_chat)
+
+        result = tools.get_chat()
+        tools.bot.get_chat.assert_called_once_with("12345")
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+        assert parsed["chat"]["id"] == 12345
+        assert parsed["chat"]["type"] == "group"
+        assert parsed["chat"]["title"] == "Test Group"
+
+    def test_api_error(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_get_chat=True)
+        tools.bot.get_chat = MagicMock(side_effect=_FakeApiTelegramException("getChat", "Chat not found", 400))
+
+        result = tools.get_chat()
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"
+
+
+class TestGetFile:
+    def test_success(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_get_file=True)
+        mock_file = MagicMock()
+        mock_file.file_id = "ABC123"
+        mock_file.file_path = "photos/file_0.jpg"
+        mock_file.file_size = 12345
+        tools.bot.get_file = MagicMock(return_value=mock_file)
+        tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
+
+        result = tools.get_file(file_id="ABC123")
+        tools.bot.get_file.assert_called_once_with("ABC123")
+        tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
+        parsed = json.loads(result)
+        assert parsed["status"] == "success"
+        assert parsed["file_id"] == "ABC123"
+        assert parsed["file_path"] == "photos/file_0.jpg"
+        assert "content_base64" in parsed
+
+    def test_api_error(self, monkeypatch):
+        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+        from agno.tools.telegram import TelegramTools
+
+        tools = TelegramTools(chat_id="12345", enable_get_file=True)
+        tools.bot.get_file = MagicMock(side_effect=_FakeApiTelegramException("getFile", "File not found", 400))
+
+        result = tools.get_file(file_id="invalid")
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -527,22 +527,21 @@ class TestGetChat:
 
         tools = TelegramTools(chat_id="12345", enable_get_chat=True)
         mock_chat = MagicMock()
-        mock_chat.id = 12345
-        mock_chat.type = "group"
-        mock_chat.title = "Test Group"
-        mock_chat.username = None
-        mock_chat.first_name = None
-        mock_chat.last_name = None
-        mock_chat.description = "A test group"
+        mock_chat.__dict__ = {
+            "id": 12345,
+            "type": "group",
+            "title": "Test Group",
+            "username": None,
+            "description": "A test group",
+        }
         tools.bot.get_chat = MagicMock(return_value=mock_chat)
 
         result = tools.get_chat()
         tools.bot.get_chat.assert_called_once_with("12345")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
-        assert parsed["chat"]["id"] == 12345
-        assert parsed["chat"]["type"] == "group"
-        assert parsed["chat"]["title"] == "Test Group"
+        assert parsed["id"] == 12345
+        assert parsed["type"] == "group"
+        assert parsed["title"] == "Test Group"
 
     def test_api_error(self, monkeypatch):
         monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
@@ -553,7 +552,7 @@ class TestGetChat:
 
         result = tools.get_chat()
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
+        assert "error" in parsed
 
 
 class TestGetFile:
@@ -563,9 +562,8 @@ class TestGetFile:
 
         tools = TelegramTools(chat_id="12345", enable_get_file=True)
         mock_file = MagicMock()
-        mock_file.file_id = "ABC123"
         mock_file.file_path = "photos/file_0.jpg"
-        mock_file.file_size = 12345
+        mock_file.__dict__ = {"file_id": "ABC123", "file_path": "photos/file_0.jpg", "file_size": 12345}
         tools.bot.get_file = MagicMock(return_value=mock_file)
         tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
 
@@ -573,7 +571,6 @@ class TestGetFile:
         tools.bot.get_file.assert_called_once_with("ABC123")
         tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
         assert parsed["file_id"] == "ABC123"
         assert parsed["file_path"] == "photos/file_0.jpg"
         assert "content_base64" in parsed
@@ -587,15 +584,13 @@ class TestGetFile:
             chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path)
         )
         mock_file = MagicMock()
-        mock_file.file_id = "ABC123"
         mock_file.file_path = "photos/file_0.jpg"
-        mock_file.file_size = 12345
+        mock_file.__dict__ = {"file_id": "ABC123", "file_path": "photos/file_0.jpg", "file_size": 12345}
         tools.bot.get_file = MagicMock(return_value=mock_file)
         tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
 
         result = tools.get_file(file_id="ABC123")
         parsed = json.loads(result)
-        assert parsed["status"] == "success"
         assert "local_path" in parsed
         assert "content_base64" not in parsed
         assert (tmp_path / "file_0.jpg").exists()
@@ -618,4 +613,4 @@ class TestGetFile:
 
         result = tools.get_file(file_id="invalid")
         parsed = json.loads(result)
-        assert parsed["status"] == "error"
+        assert "error" in parsed

--- a/libs/agno/tests/unit/tools/test_telegram.py
+++ b/libs/agno/tests/unit/tools/test_telegram.py
@@ -480,142 +480,154 @@ class TestReactWithEmoji:
         assert "Bad Request" in parsed["message"]
 
 
-class TestPinMessage:
-    def test_success(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
-
-        tools = TelegramTools(chat_id="12345", enable_pin_message=True)
-        tools.bot.pin_chat_message = MagicMock(return_value=True)
-
-        result = tools.pin_message(message_id=42)
-        tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=False)
-        parsed = json.loads(result)
-        assert parsed["status"] == "success"
-        assert parsed["pinned"] is True
-
-    def test_silent(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
-
-        tools = TelegramTools(chat_id="12345", enable_pin_message=True)
-        tools.bot.pin_chat_message = MagicMock(return_value=True)
-
-        result = tools.pin_message(message_id=42, disable_notification=True)
-        tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=True)
-        parsed = json.loads(result)
-        assert parsed["status"] == "success"
-
-    def test_api_error(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
-
-        tools = TelegramTools(chat_id="12345", enable_pin_message=True)
-        tools.bot.pin_chat_message = MagicMock(
-            side_effect=_FakeApiTelegramException("pinChatMessage", "Bad Request", 400)
-        )
-
-        result = tools.pin_message(message_id=42)
-        parsed = json.loads(result)
-        assert parsed["status"] == "error"
+# === pin_message ===
 
 
-class TestGetChat:
-    def test_success(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
+def test_pin_message_success(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
 
-        tools = TelegramTools(chat_id="12345", enable_get_chat=True)
-        mock_chat = MagicMock()
-        mock_chat.id = 12345
-        mock_chat.type = "group"
-        mock_chat.title = "Test Group"
-        mock_chat.username = None
-        mock_chat.first_name = None
-        mock_chat.last_name = None
-        mock_chat.description = "A test group"
-        tools.bot.get_chat = MagicMock(return_value=mock_chat)
+    tools = TelegramTools(chat_id="12345", enable_pin_message=True)
+    tools.bot.pin_chat_message = MagicMock(return_value=True)
 
-        result = tools.get_chat()
-        tools.bot.get_chat.assert_called_once_with("12345")
-        parsed = json.loads(result)
-        assert parsed["status"] == "success"
-        assert parsed["id"] == 12345
-        assert parsed["type"] == "group"
-        assert parsed["title"] == "Test Group"
-
-    def test_api_error(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
-
-        tools = TelegramTools(chat_id="12345", enable_get_chat=True)
-        tools.bot.get_chat = MagicMock(side_effect=_FakeApiTelegramException("getChat", "Chat not found", 400))
-
-        result = tools.get_chat()
-        parsed = json.loads(result)
-        assert parsed["status"] == "error"
+    result = tools.pin_message(message_id=42)
+    tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=False)
+    parsed = json.loads(result)
+    assert parsed["status"] == "success"
+    assert parsed["pinned"] is True
 
 
-class TestGetFile:
-    def test_success_base64(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
+def test_pin_message_silent(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
 
-        tools = TelegramTools(chat_id="12345", enable_get_file=True)
-        mock_file = MagicMock()
-        mock_file.file_id = "ABC123"
-        mock_file.file_path = "photos/file_0.jpg"
-        mock_file.file_size = 12345
-        tools.bot.get_file = MagicMock(return_value=mock_file)
-        tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
+    tools = TelegramTools(chat_id="12345", enable_pin_message=True)
+    tools.bot.pin_chat_message = MagicMock(return_value=True)
 
-        result = tools.get_file(file_id="ABC123")
-        tools.bot.get_file.assert_called_once_with("ABC123")
-        tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
-        parsed = json.loads(result)
-        assert parsed["status"] == "success"
-        assert parsed["file_id"] == "ABC123"
-        assert parsed["file_path"] == "photos/file_0.jpg"
-        assert "content_base64" in parsed
-        assert "local_path" not in parsed
+    result = tools.pin_message(message_id=42, disable_notification=True)
+    tools.bot.pin_chat_message.assert_called_once_with("12345", 42, disable_notification=True)
+    parsed = json.loads(result)
+    assert parsed["status"] == "success"
 
-    def test_save_downloads_to_disk(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
 
-        tools = TelegramTools(
-            chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path)
-        )
-        mock_file = MagicMock()
-        mock_file.file_id = "ABC123"
-        mock_file.file_path = "photos/file_0.jpg"
-        mock_file.file_size = 12345
-        tools.bot.get_file = MagicMock(return_value=mock_file)
-        tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
+def test_pin_message_api_error(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
 
-        result = tools.get_file(file_id="ABC123")
-        parsed = json.loads(result)
-        assert parsed["status"] == "success"
-        assert "local_path" in parsed
-        assert "content_base64" not in parsed
-        assert (tmp_path / "file_0.jpg").exists()
-        assert (tmp_path / "file_0.jpg").read_bytes() == b"fake-image-bytes"
+    tools = TelegramTools(chat_id="12345", enable_pin_message=True)
+    tools.bot.pin_chat_message = MagicMock(
+        side_effect=_FakeApiTelegramException("pinChatMessage", "Bad Request", 400)
+    )
 
-    def test_output_directory_implies_save_downloads(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
+    result = tools.pin_message(message_id=42)
+    parsed = json.loads(result)
+    assert parsed["status"] == "error"
 
-        tools = TelegramTools(chat_id="12345", enable_get_file=True, output_directory=str(tmp_path))
-        assert tools.save_downloads is True
-        assert tools.output_directory == tmp_path.resolve()
 
-    def test_api_error(self, monkeypatch):
-        monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
-        from agno.tools.telegram import TelegramTools
+# === get_chat ===
 
-        tools = TelegramTools(chat_id="12345", enable_get_file=True)
-        tools.bot.get_file = MagicMock(side_effect=_FakeApiTelegramException("getFile", "File not found", 400))
 
-        result = tools.get_file(file_id="invalid")
-        parsed = json.loads(result)
-        assert parsed["status"] == "error"
+def test_get_chat_success(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
+
+    tools = TelegramTools(chat_id="12345", enable_get_chat=True)
+    mock_chat = MagicMock()
+    mock_chat.id = 12345
+    mock_chat.type = "group"
+    mock_chat.title = "Test Group"
+    mock_chat.username = None
+    mock_chat.first_name = None
+    mock_chat.last_name = None
+    mock_chat.description = "A test group"
+    tools.bot.get_chat = MagicMock(return_value=mock_chat)
+
+    result = tools.get_chat()
+    tools.bot.get_chat.assert_called_once_with("12345")
+    parsed = json.loads(result)
+    assert parsed["status"] == "success"
+    assert parsed["id"] == 12345
+    assert parsed["type"] == "group"
+    assert parsed["title"] == "Test Group"
+
+
+def test_get_chat_api_error(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
+
+    tools = TelegramTools(chat_id="12345", enable_get_chat=True)
+    tools.bot.get_chat = MagicMock(side_effect=_FakeApiTelegramException("getChat", "Chat not found", 400))
+
+    result = tools.get_chat()
+    parsed = json.loads(result)
+    assert parsed["status"] == "error"
+
+
+# === get_file ===
+
+
+def test_get_file_success_base64(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
+
+    tools = TelegramTools(chat_id="12345", enable_get_file=True)
+    mock_file = MagicMock()
+    mock_file.file_id = "ABC123"
+    mock_file.file_path = "photos/file_0.jpg"
+    mock_file.file_size = 12345
+    tools.bot.get_file = MagicMock(return_value=mock_file)
+    tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
+
+    result = tools.get_file(file_id="ABC123")
+    tools.bot.get_file.assert_called_once_with("ABC123")
+    tools.bot.download_file.assert_called_once_with("photos/file_0.jpg")
+    parsed = json.loads(result)
+    assert parsed["status"] == "success"
+    assert parsed["file_id"] == "ABC123"
+    assert parsed["file_path"] == "photos/file_0.jpg"
+    assert "content_base64" in parsed
+    assert "local_path" not in parsed
+
+
+def test_get_file_save_downloads_to_disk(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
+
+    tools = TelegramTools(
+        chat_id="12345", enable_get_file=True, save_downloads=True, output_directory=str(tmp_path)
+    )
+    mock_file = MagicMock()
+    mock_file.file_id = "ABC123"
+    mock_file.file_path = "photos/file_0.jpg"
+    mock_file.file_size = 12345
+    tools.bot.get_file = MagicMock(return_value=mock_file)
+    tools.bot.download_file = MagicMock(return_value=b"fake-image-bytes")
+
+    result = tools.get_file(file_id="ABC123")
+    parsed = json.loads(result)
+    assert parsed["status"] == "success"
+    assert "local_path" in parsed
+    assert "content_base64" not in parsed
+    assert (tmp_path / "file_0.jpg").exists()
+    assert (tmp_path / "file_0.jpg").read_bytes() == b"fake-image-bytes"
+
+
+def test_get_file_output_directory_implies_save_downloads(monkeypatch, tmp_path):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
+
+    tools = TelegramTools(chat_id="12345", enable_get_file=True, output_directory=str(tmp_path))
+    assert tools.save_downloads is True
+    assert tools.output_directory == tmp_path.resolve()
+
+
+def test_get_file_api_error(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_TOKEN", "fake-token")
+    from agno.tools.telegram import TelegramTools
+
+    tools = TelegramTools(chat_id="12345", enable_get_file=True)
+    tools.bot.get_file = MagicMock(side_effect=_FakeApiTelegramException("getFile", "File not found", 400))
+
+    result = tools.get_file(file_id="invalid")
+    parsed = json.loads(result)
+    assert parsed["status"] == "error"


### PR DESCRIPTION
## Summary

Adds 3 new tools and file download options to `TelegramTools`, aligned with Slack toolkit patterns.

**New tools:**
| Tool | Purpose |
|------|---------|
| `pin_message` | Pin a message in chat (with `disable_notification` option) |
| `get_chat` | Get chat info (id, type, title, username, description) |
| `get_file` | Download file by file_id, returns base64 or saves to disk |

**New constructor options:**
- `save_downloads`: Save downloaded files to disk instead of returning base64
- `output_directory`: Directory for saved files (implies `save_downloads=True`)

**Pattern alignment:**
- Success: returns data directly (`{"message_id": 123}`, `{"file_id": ..., "file_path": ...}`)
- Error: `{"error": "..."}`
- Matches Slack toolkit pattern for consistency across the codebase

## Test Results

All tools verified against live Telegram API:

| Tool | Status | Notes |
|------|--------|-------|
| `send_message` | PASS | Messages visible in Telegram Web |
| `send_document` | PASS | Files uploaded correctly |
| `edit_message` | PASS | Message text updated |
| `react_with_emoji` | PASS | Reaction visible on message |
| `delete_message` | PASS | Message removed |
| `pin_message` | PASS | Pinned message header + notifications |
| `get_chat` | PASS | Returns chat info (id, type, title, etc.) |
| `get_file` (base64) | PASS | Downloaded and decoded file content |
| `get_file` (save_downloads) | PASS | Saved to disk, content verified |

## Changes

- `libs/agno/agno/tools/telegram.py` - 3 new tools, save_downloads/output_directory options, Slack-style returns
- `libs/agno/tests/unit/tools/test_telegram.py` - 47 tests (all passing)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added docstrings to all public methods
- [x] New and existing unit tests pass locally with my changes
- [x] Tested against live Telegram API
- [x] Verified in Telegram Web UI