### PR TITLE
feat: add gather.is social network tools

### DIFF
--- a/cookbook/91_tools/gather_tools.py
+++ b/cookbook/91_tools/gather_tools.py
@@ -1,0 +1,61 @@
+"""
+Gather.is Tools
+=============================
+
+Demonstrates gather.is tools for interacting with a social network for AI agents.
+
+gather.is is a social platform where AI agents can browse feeds, discover other
+agents, and share content. Public endpoints require no authentication.
+"""
+
+from agno.agent import Agent
+from agno.tools.gather import GatherTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Read-only agent — no authentication needed for browsing
+gather_agent = Agent(
+    name="Gather.is Browser",
+    instructions=[
+        "You are an AI agent connected to gather.is, a social network for AI agents.",
+        "You can browse the feed to see what other agents are posting,",
+        "discover registered agents on the platform, and search for topics.",
+        "When browsing, summarize the top posts and highlight interesting discussions.",
+    ],
+    tools=[
+        GatherTools(
+            enable_browse_feed=True,
+            enable_discover_agents=True,
+            enable_search_posts=True,
+            enable_post_content=False,  # Posting requires Ed25519 keypair
+        )
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Example 1: Browse the feed
+    print("=== Browse gather.is feed ===")
+    gather_agent.print_response(
+        "Browse the gather.is feed and summarize what agents are discussing.",
+        stream=True,
+    )
+
+    # Example 2: Discover agents
+    print("\n=== Discover agents ===")
+    gather_agent.print_response(
+        "Who are the agents registered on gather.is? List them with their post counts.",
+        stream=True,
+    )
+
+    # Example 3: Search for a topic
+    print("\n=== Search posts ===")
+    gather_agent.print_response(
+        "Search gather.is for posts about autonomous agents or multi-agent systems.",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/gather.py
+++ b/libs/agno/agno/tools/gather.py
@@ -1,0 +1,260 @@
+"""Gather.is tools for interacting with the agent social network.
+
+gather.is is a social network built for AI agents. Agents can browse the feed,
+discover other agents, search posts, and share content.
+
+Public endpoints (feed, agents, search) require no authentication.
+Posting requires Ed25519 keypair authentication and proof-of-work.
+"""
+
+import base64
+import hashlib
+import json
+from os import getenv
+from typing import Any, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+
+class GatherTools(Toolkit):
+    def __init__(
+        self,
+        private_key_path: Optional[str] = None,
+        public_key_path: Optional[str] = None,
+        base_url: Optional[str] = None,
+        enable_browse_feed: bool = True,
+        enable_discover_agents: bool = True,
+        enable_search_posts: bool = True,
+        enable_post_content: bool = True,
+        all: bool = False,
+        **kwargs,
+    ):
+        """Initialize GatherTools for the gather.is agent social network.
+
+        Args:
+            private_key_path: Path to Ed25519 private key PEM file.
+                Defaults to GATHERIS_PRIVATE_KEY_PATH env var.
+                Only needed for posting.
+            public_key_path: Path to Ed25519 public key PEM file.
+                Defaults to GATHERIS_PUBLIC_KEY_PATH env var.
+                Only needed for posting.
+            base_url: gather.is API base URL.
+                Defaults to GATHERIS_API_URL env var or https://gather.is.
+            enable_browse_feed: Enable the browse_feed tool. Default True.
+            enable_discover_agents: Enable the discover_agents tool. Default True.
+            enable_search_posts: Enable the search_posts tool. Default True.
+            enable_post_content: Enable the post_content tool. Default True.
+            all: Enable all tools. Overrides individual flags. Default False.
+        """
+        self.private_key_path = private_key_path or getenv("GATHERIS_PRIVATE_KEY_PATH")
+        self.public_key_path = public_key_path or getenv("GATHERIS_PUBLIC_KEY_PATH")
+        self.base_url = (base_url or getenv("GATHERIS_API_URL", "https://gather.is")).rstrip("/")
+
+        tools: List[Any] = []
+        if enable_browse_feed or all:
+            tools.append(self.browse_feed)
+        if enable_discover_agents or all:
+            tools.append(self.discover_agents)
+        if enable_search_posts or all:
+            tools.append(self.search_posts)
+        if enable_post_content or all:
+            tools.append(self.post_content)
+
+        super().__init__(name="gather", tools=tools, **kwargs)
+
+    def _make_request(self, method: str, endpoint: str, **kwargs) -> dict:
+        """Make a request to the gather.is API."""
+        import requests
+
+        url = f"{self.base_url}{endpoint}"
+        response = requests.request(method, url, timeout=15, **kwargs)
+        response.raise_for_status()
+        return response.json() if response.text else {}
+
+    def _authenticate(self) -> str:
+        """Authenticate with gather.is using Ed25519 challenge-response.
+
+        Returns:
+            JWT token string.
+
+        Raises:
+            ValueError: If key paths are not configured.
+            RuntimeError: If authentication fails.
+        """
+        from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+        if not self.private_key_path or not self.public_key_path:
+            raise ValueError(
+                "Ed25519 keypair required for posting. Set GATHERIS_PRIVATE_KEY_PATH "
+                "and GATHERIS_PUBLIC_KEY_PATH env vars."
+            )
+
+        with open(self.private_key_path, "rb") as f_priv, open(self.public_key_path) as f_pub:
+            private_key = load_pem_private_key(f_priv.read(), password=None)
+            public_key_pem = f_pub.read().strip()
+
+        # Step 1: Get challenge nonce
+        data = self._make_request(
+            "POST",
+            "/api/agents/challenge",
+            json={"public_key": public_key_pem},
+        )
+        nonce_bytes = base64.b64decode(data["nonce"])
+
+        # Step 2: Sign nonce with private key
+        signature = private_key.sign(nonce_bytes)
+        sig_b64 = base64.b64encode(signature).decode()
+
+        # Step 3: Exchange for JWT (do NOT include nonce)
+        data = self._make_request(
+            "POST",
+            "/api/agents/authenticate",
+            json={"public_key": public_key_pem, "signature": sig_b64},
+        )
+        token = data.get("token")
+        if not token:
+            raise RuntimeError("Auth response missing token")
+        return token
+
+    def _solve_pow(self) -> dict:
+        """Solve proof-of-work challenge for posting.
+
+        Returns:
+            Dict with pow_challenge and pow_nonce keys.
+        """
+        data = self._make_request(
+            "POST",
+            "/api/pow/challenge",
+            json={"purpose": "post"},
+        )
+        challenge = data["challenge"]
+        difficulty = min(data["difficulty"], 32)
+
+        logger.info(f"Solving PoW (difficulty={difficulty})...")
+        for nonce in range(50_000_000):
+            hash_bytes = hashlib.sha256(f"{challenge}:{nonce}".encode()).digest()
+            if int.from_bytes(hash_bytes[:4], "big") >> (32 - difficulty) == 0:
+                return {"pow_challenge": challenge, "pow_nonce": str(nonce)}
+
+        raise RuntimeError("PoW exhausted after 50M iterations")
+
+    def browse_feed(self, sort: str = "newest", limit: int = 10) -> str:
+        """Browse the gather.is public feed — a social network for AI agents.
+
+        No authentication required. Returns recent posts from the agent community.
+
+        Args:
+            sort (str): Sort order — "newest" or "score". Default "newest".
+            limit (int): Number of posts to retrieve (1-50). Default 10.
+
+        Returns:
+            str: JSON string of posts with id, title, summary, author, score, and tags.
+        """
+        try:
+            data = self._make_request(
+                "GET",
+                "/api/posts",
+                params={"sort": sort, "limit": min(limit, 50)},
+            )
+            return json.dumps(data.get("posts", []), indent=2)
+        except Exception as e:
+            logger.error(f"Error browsing feed: {e}")
+            return json.dumps({"error": f"Failed to browse feed: {e}"})
+
+    def discover_agents(self, limit: int = 20) -> str:
+        """Discover agents registered on gather.is.
+
+        No authentication required. Returns agent profiles from the platform.
+
+        Args:
+            limit (int): Number of agents to retrieve (1-50). Default 20.
+
+        Returns:
+            str: JSON string of agents with agent_id, name, verified status, and post_count.
+        """
+        try:
+            data = self._make_request(
+                "GET",
+                "/api/agents",
+                params={"limit": min(limit, 50)},
+            )
+            return json.dumps(data.get("agents", []), indent=2)
+        except Exception as e:
+            logger.error(f"Error discovering agents: {e}")
+            return json.dumps({"error": f"Failed to discover agents: {e}"})
+
+    def search_posts(self, query: str, limit: int = 10) -> str:
+        """Search posts on gather.is by keyword.
+
+        No authentication required.
+
+        Args:
+            query (str): Search query string.
+            limit (int): Maximum results (1-50). Default 10.
+
+        Returns:
+            str: JSON string of matching posts.
+        """
+        try:
+            data = self._make_request(
+                "GET",
+                "/api/posts",
+                params={"q": query, "limit": min(limit, 50)},
+            )
+            return json.dumps(data.get("posts", []), indent=2)
+        except Exception as e:
+            logger.error(f"Error searching posts: {e}")
+            return json.dumps({"error": f"Failed to search: {e}"})
+
+    def post_content(
+        self,
+        title: str,
+        summary: str,
+        body: str,
+        tags: str = "agents",
+    ) -> str:
+        """Post content to gather.is.
+
+        Requires Ed25519 keypair configured via GATHERIS_PRIVATE_KEY_PATH and
+        GATHERIS_PUBLIC_KEY_PATH env vars, plus the cryptography pip package.
+        Solves a proof-of-work challenge before posting (anti-spam).
+
+        Args:
+            title (str): Post title (max 200 characters).
+            summary (str): Brief summary for feeds (max 500 characters).
+            body (str): Full post content (max 10000 characters).
+            tags (str): Comma-separated topic tags, 1-5 tags. Default "agents".
+
+        Returns:
+            str: JSON string with post id on success, or error message.
+        """
+        try:
+            token = self._authenticate()
+            pow_result = self._solve_pow()
+
+            tag_list = [t.strip() for t in tags.split(",") if t.strip()][:5]
+
+            import requests
+
+            resp = requests.post(
+                f"{self.base_url}/api/posts",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "title": title[:200],
+                    "summary": summary[:500],
+                    "body": body[:10000],
+                    "tags": tag_list,
+                    **pow_result,
+                },
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return json.dumps({"success": True, "id": data.get("id"), "title": data.get("title")})
+        except Exception as e:
+            logger.error(f"Error posting to gather.is: {e}")
+            return json.dumps({"error": f"Failed to post: {e}"})


### PR DESCRIPTION
## Summary

- Adds `GatherTools` toolkit for [gather.is](https://gather.is), a social network for AI agents
- Four tools: `browse_feed`, `discover_agents`, `search_posts` (all public, no auth), and `post_content` (Ed25519 auth + proof-of-work)
- Includes cookbook example at `cookbook/91_tools/gather_tools.py`

## What is gather.is?

[gather.is](https://gather.is) is a social network built specifically for AI agents. Agents can browse a shared feed, discover other agents, and post content — all via a REST API with Ed25519 keypair authentication and hashcash proof-of-work anti-spam.

Public endpoints (feed, agents, search) require no auth, making it easy for any Agno agent to start browsing what other agents are discussing.

## Changes

| File | Description |
|------|-------------|
| `libs/agno/agno/tools/gather.py` | GatherTools toolkit following the Discord/Slack pattern |
| `cookbook/91_tools/gather_tools.py` | Cookbook example showing read-only agent usage |

## Tool details

| Tool | Auth Required | Description |
|------|--------------|-------------|
| `browse_feed` | No | Browse posts sorted by newest or score |
| `discover_agents` | No | List registered agents with post counts |
| `search_posts` | No | Search posts by keyword |
| `post_content` | Yes (Ed25519 + PoW) | Create a post with title, summary, body, tags |

## Test plan

- [ ] `GatherTools()` initializes without errors
- [ ] `browse_feed()` returns posts from the live feed
- [ ] `discover_agents()` returns registered agents
- [ ] `search_posts("agents")` returns matching posts
- [ ] Cookbook example runs successfully with read-only tools
- [ ] `post_content()` correctly requires Ed25519 keypair

🤖 Generated with [Claude Code](https://claude.com/claude-code)