### PR TITLE
Add optional tamper-evident execution trace example

### DIFF
--- a/examples/execution_integrity/README.md
+++ b/examples/execution_integrity/README.md
@@ -1,0 +1,14 @@
+# Execution Integrity Example
+
+This is an optional example demonstrating tamper-evident execution traces.
+
+## Run
+python3 demo.py
+python3 verify_export.py execution_log.json
+
+Expected:
+- Verification before tamper: True
+- Verification after tamper: False
+- EXPORT_VERIFY: PASS
+
+No dependencies. No changes to core logic.

--- a/examples/execution_integrity/demo.py
+++ b/examples/execution_integrity/demo.py
@@ -3,7 +3,10 @@ from verify_export import verify_export
 
 core = ExecutionIntegrityCore()
 
-core.record("tool_call", {"tool": "search", "q": "agent execution"}, {"ok": True}, ts=1700000000.0)
+payload = {"tool": "search", "q": "agent execution"}
+core.record("tool_call", payload, {"ok": True}, ts=1700000000.0)
+payload["q"] = "mutated later"
+print("Verification after harmless input mutation:", core.verify())
 core.record("tool_call", {"tool": "calc", "expr": "2+2"}, {"result": 4}, ts=1700000001.0)
 
 print("Verification before tamper:", core.verify())

--- a/examples/execution_integrity/demo.py
+++ b/examples/execution_integrity/demo.py
@@ -1,0 +1,16 @@
+from execution_integrity_core import ExecutionIntegrityCore
+from verify_export import verify_export
+
+core = ExecutionIntegrityCore()
+
+core.record("tool_call", {"tool": "search", "q": "agent execution"}, {"ok": True}, ts=1700000000.0)
+core.record("tool_call", {"tool": "calc", "expr": "2+2"}, {"result": 4}, ts=1700000001.0)
+
+print("Verification before tamper:", core.verify())
+
+path = core.export(filename="execution_log.json", exported_at=1700000002.0)
+
+core.chain[0]["output"] = {"ok": False}
+print("Verification after tamper:", core.verify())
+
+verify_export(path)

--- a/examples/execution_integrity/execution_integrity_core.py
+++ b/examples/execution_integrity/execution_integrity_core.py
@@ -1,3 +1,4 @@
+import copy
 import hashlib
 import json
 import time
@@ -15,8 +16,8 @@ class ExecutionIntegrityCore:
         entry = {
             "timestamp": ts,
             "action": action,
-            "input": input_data,
-            "output": output_data,
+            "input": copy.deepcopy(input_data),
+            "output": copy.deepcopy(output_data),
             "previous_hash": self.previous_hash,
         }
 

--- a/examples/execution_integrity/execution_integrity_core.py
+++ b/examples/execution_integrity/execution_integrity_core.py
@@ -1,0 +1,62 @@
+import hashlib
+import json
+import time
+
+
+class ExecutionIntegrityCore:
+    def __init__(self):
+        self.chain = []
+        self.previous_hash = "GENESIS"
+
+    def record(self, action, input_data, output_data, ts=None):
+        if ts is None:
+            ts = time.time()
+
+        entry = {
+            "timestamp": ts,
+            "action": action,
+            "input": input_data,
+            "output": output_data,
+            "previous_hash": self.previous_hash,
+        }
+
+        raw = json.dumps(entry, sort_keys=True).encode()
+        current_hash = hashlib.sha256(raw).hexdigest()
+
+        entry["hash"] = current_hash
+        self.previous_hash = current_hash
+        self.chain.append(entry)
+
+    def export(self, filename="execution_log.json", exported_at=None):
+        if exported_at is None:
+            exported_at = time.time()
+
+        envelope = {
+            "spec": "execution-integrity-core",
+            "version": "0.1.2",
+            "exported_at": exported_at,
+            "hash_alg": "sha256",
+            "chain": self.chain,
+        }
+
+        with open(filename, "w") as f:
+            json.dump(envelope, f, indent=2, sort_keys=True)
+
+        return filename
+
+    def verify(self):
+        prev = "GENESIS"
+        for entry in self.chain:
+            expected = entry["hash"]
+            temp = dict(entry)
+            temp.pop("hash", None)
+
+            raw = json.dumps(temp, sort_keys=True).encode()
+            recalculated = hashlib.sha256(raw).hexdigest()
+
+            if recalculated != expected or entry["previous_hash"] != prev:
+                return False
+
+            prev = expected
+
+        return True

--- a/examples/execution_integrity/verify_export.py
+++ b/examples/execution_integrity/verify_export.py
@@ -1,0 +1,53 @@
+import hashlib
+import json
+import sys
+
+
+def sha256_of_entry_without_hash(entry):
+    temp = dict(entry)
+    temp.pop("hash", None)
+    raw = json.dumps(temp, sort_keys=True).encode()
+    return hashlib.sha256(raw).hexdigest()
+
+
+def verify_export(path):
+    with open(path, "r") as f:
+        data = json.load(f)
+
+    required_top = ["spec", "version", "exported_at", "hash_alg", "chain"]
+    for key in required_top:
+        if key not in data:
+            print(f"EXPORT_VERIFY: FAIL (missing top-level key: {key})")
+            return 2
+
+    if data["hash_alg"] != "sha256":
+        print("EXPORT_VERIFY: FAIL (unsupported hash_alg)")
+        return 2
+
+    prev = "GENESIS"
+    for idx, entry in enumerate(data["chain"], start=1):
+        expected = entry.get("hash")
+        if not expected:
+            print(f"EXPORT_VERIFY: FAIL (entry {idx} missing hash)")
+            return 2
+
+        recalculated = sha256_of_entry_without_hash(entry)
+        if recalculated != expected:
+            print(f"EXPORT_VERIFY: FAIL (entry {idx} hash mismatch)")
+            return 2
+
+        if entry.get("previous_hash") != prev:
+            print(f"EXPORT_VERIFY: FAIL (entry {idx} previous_hash mismatch)")
+            return 2
+
+        prev = expected
+
+    print("EXPORT_VERIFY: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    path = "execution_log.json"
+    if len(sys.argv) >= 2:
+        path = sys.argv[1]
+    raise SystemExit(verify_export(path))


### PR DESCRIPTION
This PR adds a minimal, optional example demonstrating tamper-evident execution trace export and verification.
No core changes. No dependencies.
If not aligned with project direction, feel free to close.
