### PR TITLE
fix: skip structured output conversion when stop_after_tool_call is triggered

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -554,7 +554,11 @@ def _run(
                     store_media_util(run_response, model_response)
 
                 # 9. Convert the response to the structured format if needed
-                convert_response_to_structured_format(agent, run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    convert_response_to_structured_format(agent, run_response, run_context=run_context)
 
                 # 10. Execute post-hooks after output is generated but before response is returned
                 if agent.post_hooks is not None:
@@ -1626,7 +1630,11 @@ async def _arun(
                     )
 
                 # 11. Convert the response to the structured format if needed
-                convert_response_to_structured_format(agent, run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    convert_response_to_structured_format(agent, run_response, run_context=run_context)
 
                 # 12. Store media if enabled
                 if agent.store_media:
@@ -2930,7 +2938,11 @@ def _continue_run(
                     )
 
                 # 4. Convert the response to the structured format if needed
-                convert_response_to_structured_format(agent, run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    convert_response_to_structured_format(agent, run_response, run_context=run_context)
 
                 # 5. Store media if enabled
                 if agent.store_media:
@@ -3669,7 +3681,11 @@ async def _acontinue_run(
                     )
 
                 # 10. Convert the response to the structured format if needed
-                convert_response_to_structured_format(agent, run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    convert_response_to_structured_format(agent, run_response, run_context=run_context)
 
                 # 11. Store media if enabled
                 if agent.store_media:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -373,7 +373,11 @@ def _run_tasks(
             store_media_util(run_response, model_response)
 
         # Convert response to structured format
-        _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+        # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+        if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+            log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+        else:
+            _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
         # Execute post-hooks
         if team.post_hooks is not None:
@@ -501,7 +505,6 @@ def _run_tasks_stream(
     from agno.team._managers import _start_learning_future, _start_memory_future
     from agno.team._messages import _get_run_messages
     from agno.team._response import (
-        _convert_response_to_structured_format,
         _handle_model_response_stream,
         generate_response_with_output_model_stream,
         handle_reasoning_stream,
@@ -769,9 +772,6 @@ def _run_tasks_stream(
                 log_warning(f"Reached max_iterations ({team.max_iterations}) without completing all tasks.")
 
         # === Post-loop ===
-
-        # Convert response to structured format
-        _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
         # Yield RunContentCompletedEvent
         if stream_events:
@@ -1142,7 +1142,11 @@ def _run(
                     store_media_util(run_response, model_response)
 
                 # 9. Convert response to structured format
-                _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
                 # 10. Execute post-hooks after output is generated but before response is returned
                 if team.post_hooks is not None:
@@ -2125,7 +2129,11 @@ async def _arun_tasks(
             store_media_util(run_response, model_response)
 
         # Convert response to structured format
-        _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+        # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+        if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+            log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+        else:
+            _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
         # Execute post-hooks
         if team.post_hooks is not None:
@@ -2260,7 +2268,6 @@ async def _arun_tasks_stream(
     from agno.team._messages import _aget_run_messages
     from agno.team._response import (
         _ahandle_model_response_stream,
-        _convert_response_to_structured_format,
         agenerate_response_with_output_model_stream,
         ahandle_reasoning_stream,
     )
@@ -2540,9 +2547,6 @@ async def _arun_tasks_stream(
                 log_warning(f"Reached max_iterations ({team.max_iterations}) without completing all tasks.")
 
         # === Post-loop ===
-
-        # Convert response to structured format
-        _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
         # Yield RunContentCompletedEvent
         if stream_events:
@@ -2953,7 +2957,11 @@ async def _arun(
                     store_media_util(run_response, model_response)
 
                 # 9. Convert response to structured format
-                _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
                 # 10. Execute post-hooks after output is generated but before response is returned
                 if team.post_hooks is not None:
@@ -4915,7 +4923,11 @@ def _continue_run(
                     )
 
                 # Convert to structured format
-                _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                    log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                else:
+                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
                 # Store media
                 if team.store_media:
@@ -5564,7 +5576,11 @@ async def _acontinue_run(
                             team, run_response=run_response, session=team_session, run_context=run_context
                         )
 
-                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                    # Skip conversion if stop_after_tool_call was triggered (response content will be empty)
+                    if any(tool_call.stop_after_tool_call for tool_call in run_response.tools or []):
+                        log_debug("Skipping structured output conversion: stop_after_tool_call was triggered")
+                    else:
+                        _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
 
                     if team.store_media:
                         store_media_util(run_response, model_response)


### PR DESCRIPTION
## Summary

Fixes an issue where using `stop_after_tool_call=True` on a tool combined with `output_schema` on an agent causes JSON parsing errors.

## Problem

When a tool with `stop_after_tool_call=True` executes:
1. The tool runs and returns a result
2. The execution loop stops (no further LLM call)
3. `response.content` is empty (no assistant response generated)
4. `convert_response_to_structured_format()` attempts to parse the empty string as JSON
5. Parsing fails with warnings like "Failed to parse cleaned JSON"

Skip the structured output conversion when `stop_after_tool_call` was triggered, since there's no LLM-generated content to convert because model call is cut off. Added debug logging to help users understand when this happens.

fixes: https://github.com/agno-agi/agno/issues/6298

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
