### PR TITLE
fix: guard None points in Qdrant set_payload

### DIFF
--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -1074,9 +1074,10 @@ class Qdrant(VectorDb):
 
             # Execute all updates
             for operation in update_operations:
-                self.client.set_payload(
-                    collection_name=self.collection, payload=operation.payload, points=operation.points
-                )
+                if operation.points is not None:
+                    self.client.set_payload(
+                        collection_name=self.collection, payload=operation.payload, points=operation.points
+                    )
 
             log_debug(f"Updated metadata for {len(update_operations)} documents with content_id: {content_id}")
 


### PR DESCRIPTION
## Summary
- Add None guard on `operation.points` before passing to `QdrantClient.set_payload()` to fix mypy `arg-type` error
- `SetPayload.points` is typed as optional but `set_payload()` requires a non-None value

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>