### PR TITLE
fix: reduce telemetry timeout and run sync telemetry in background thread

### DIFF
--- a/libs/agno/agno/agent/_telemetry.py
+++ b/libs/agno/agno/agent/_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
@@ -44,18 +45,21 @@ def log_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = N
     if not agent.telemetry:
         return
 
-    from agno.api.agent import AgentRunCreate, create_agent_run
+    def _send() -> None:
+        from agno.api.agent import AgentRunCreate, create_agent_run
 
-    try:
-        create_agent_run(
-            run=AgentRunCreate(
-                session_id=session_id,
-                run_id=run_id,
-                data=get_telemetry_data(agent),
-            ),
-        )
-    except Exception as e:
-        log_debug(f"Could not create Agent run telemetry event: {e}")
+        try:
+            create_agent_run(
+                run=AgentRunCreate(
+                    session_id=session_id,
+                    run_id=run_id,
+                    data=get_telemetry_data(agent),
+                ),
+            )
+        except Exception as e:
+            log_debug(f"Could not create Agent run telemetry event: {e}")
+
+    threading.Thread(target=_send, daemon=True).start()
 
 
 async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = None) -> None:

--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -3,6 +3,7 @@ from typing import Dict
 from httpx import AsyncClient as HttpxAsyncClient
 from httpx import Client as HttpxClient
 from httpx import Response
+from httpx import Timeout
 
 from agno.api.settings import agno_api_settings
 
@@ -18,7 +19,7 @@ class Api:
         return HttpxClient(
             base_url=agno_api_settings.api_url,
             headers=self.headers,
-            timeout=60,
+            timeout=Timeout(5.0, connect=2.0),
             http2=True,
         )
 
@@ -26,7 +27,7 @@ class Api:
         return HttpxAsyncClient(
             base_url=agno_api_settings.api_url,
             headers=self.headers,
-            timeout=60,
+            timeout=Timeout(5.0, connect=2.0),
             http2=True,
         )
 


### PR DESCRIPTION
## Summary

When outbound traffic to `os-api.agno.com` is blocked (firewall, network issues, corporate proxy), the agent response is blocked for up to 60 seconds waiting for the telemetry HTTP request to time out. This makes the agent unusable in restricted network environments.

Two changes fix this:

1. **Reduce httpx timeout from 60s to 5s** in `libs/agno/agno/api/api.py` — uses `httpx.Timeout(5.0, connect=2.0)` so telemetry requests fail fast (2s connect, 5s overall) when the server is unreachable.
2. **Run sync telemetry in a background daemon thread** in `libs/agno/agno/agent/_telemetry.py` — the `log_agent_telemetry` function now dispatches the blocking `create_agent_run` call to a daemon thread so it never blocks the agent response path.

Closes #6236

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- The async variant `alog_agent_telemetry` is left unchanged since it already runs non-blocking via `await` in an async context.
- The daemon thread ensures the background telemetry call does not prevent process exit.
- The reduced timeout (5s overall, 2s connect) is still generous for a telemetry ping but prevents the 60s hang that made agents unusable behind firewalls.