### PR TITLE
fix: add cache check to PostgresDb._get_table() to prevent connection explosion

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -309,6 +309,8 @@ class AsyncPostgresDb(AsyncBaseDb):
 
     async def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Table:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = await self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -317,6 +319,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = await self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -325,6 +329,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = await self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -333,6 +339,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = await self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -341,6 +349,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = await self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -349,6 +359,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = await self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -357,6 +369,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = await self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -365,6 +379,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = await self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -373,6 +389,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.traces_table
 
         if table_type == "spans":
+            if self.spans_table is not None:
+                return self.spans_table
             # Ensure traces table exists first (spans has FK to traces)
             if create_table_if_not_found:
                 await self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -384,6 +402,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.spans_table
 
         if table_type == "learnings":
+            if self.learnings_table is not None:
+                return self.learnings_table
             self.learnings_table = await self._get_or_create_table(
                 table_name=self.learnings_table_name,
                 table_type="learnings",
@@ -392,6 +412,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.learnings_table
 
         if table_type == "schedules":
+            if self.schedules_table is not None:
+                return self.schedules_table
             self.schedules_table = await self._get_or_create_table(
                 table_name=self.schedules_table_name,
                 table_type="schedules",
@@ -400,6 +422,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.schedules_table
 
         if table_type == "schedule_runs":
+            if self.schedule_runs_table is not None:
+                return self.schedule_runs_table
             self.schedule_runs_table = await self._get_or_create_table(
                 table_name=self.schedule_runs_table_name,
                 table_type="schedule_runs",
@@ -408,6 +432,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             return self.schedule_runs_table
 
         if table_type == "approvals":
+            if self.approvals_table is not None:
+                return self.approvals_table
             self.approvals_table = await self._get_or_create_table(
                 table_name=self.approvals_table_name,
                 table_type="approvals",

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -450,6 +450,8 @@ class PostgresDb(BaseDb):
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
+            if self.session_table is not None:
+                return self.session_table
             self.session_table = self._get_or_create_table(
                 table_name=self.session_table_name,
                 table_type="sessions",
@@ -458,6 +460,8 @@ class PostgresDb(BaseDb):
             return self.session_table
 
         if table_type == "memories":
+            if self.memory_table is not None:
+                return self.memory_table
             self.memory_table = self._get_or_create_table(
                 table_name=self.memory_table_name,
                 table_type="memories",
@@ -466,6 +470,8 @@ class PostgresDb(BaseDb):
             return self.memory_table
 
         if table_type == "metrics":
+            if self.metrics_table is not None:
+                return self.metrics_table
             self.metrics_table = self._get_or_create_table(
                 table_name=self.metrics_table_name,
                 table_type="metrics",
@@ -474,6 +480,8 @@ class PostgresDb(BaseDb):
             return self.metrics_table
 
         if table_type == "evals":
+            if self.eval_table is not None:
+                return self.eval_table
             self.eval_table = self._get_or_create_table(
                 table_name=self.eval_table_name,
                 table_type="evals",
@@ -482,6 +490,8 @@ class PostgresDb(BaseDb):
             return self.eval_table
 
         if table_type == "knowledge":
+            if self.knowledge_table is not None:
+                return self.knowledge_table
             self.knowledge_table = self._get_or_create_table(
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
@@ -490,6 +500,8 @@ class PostgresDb(BaseDb):
             return self.knowledge_table
 
         if table_type == "culture":
+            if self.culture_table is not None:
+                return self.culture_table
             self.culture_table = self._get_or_create_table(
                 table_name=self.culture_table_name,
                 table_type="culture",
@@ -498,6 +510,8 @@ class PostgresDb(BaseDb):
             return self.culture_table
 
         if table_type == "versions":
+            if self.versions_table is not None:
+                return self.versions_table
             self.versions_table = self._get_or_create_table(
                 table_name=self.versions_table_name,
                 table_type="versions",
@@ -506,6 +520,8 @@ class PostgresDb(BaseDb):
             return self.versions_table
 
         if table_type == "traces":
+            if self.traces_table is not None:
+                return self.traces_table
             self.traces_table = self._get_or_create_table(
                 table_name=self.trace_table_name,
                 table_type="traces",
@@ -514,6 +530,8 @@ class PostgresDb(BaseDb):
             return self.traces_table
 
         if table_type == "spans":
+            if self.spans_table is not None:
+                return self.spans_table
             # Ensure traces table exists first (spans has FK to traces)
             if create_table_if_not_found:
                 self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -526,6 +544,8 @@ class PostgresDb(BaseDb):
             return self.spans_table
 
         if table_type == "components":
+            if self.component_table is not None:
+                return self.component_table
             self.component_table = self._get_or_create_table(
                 table_name=self.components_table_name,
                 table_type="components",
@@ -534,6 +554,8 @@ class PostgresDb(BaseDb):
             return self.component_table
 
         if table_type == "component_configs":
+            if self.component_configs_table is not None:
+                return self.component_configs_table
             self.component_configs_table = self._get_or_create_table(
                 table_name=self.component_configs_table_name,
                 table_type="component_configs",
@@ -542,13 +564,18 @@ class PostgresDb(BaseDb):
             return self.component_configs_table
 
         if table_type == "component_links":
+            if self.component_links_table is not None:
+                return self.component_links_table
             self.component_links_table = self._get_or_create_table(
                 table_name=self.component_links_table_name,
                 table_type="component_links",
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.component_links_table
+
         if table_type == "learnings":
+            if self.learnings_table is not None:
+                return self.learnings_table
             self.learnings_table = self._get_or_create_table(
                 table_name=self.learnings_table_name,
                 table_type="learnings",
@@ -557,6 +584,8 @@ class PostgresDb(BaseDb):
             return self.learnings_table
 
         if table_type == "schedules":
+            if self.schedules_table is not None:
+                return self.schedules_table
             self.schedules_table = self._get_or_create_table(
                 table_name=self.schedules_table_name,
                 table_type="schedules",
@@ -565,6 +594,8 @@ class PostgresDb(BaseDb):
             return self.schedules_table
 
         if table_type == "schedule_runs":
+            if self.schedule_runs_table is not None:
+                return self.schedule_runs_table
             self.schedule_runs_table = self._get_or_create_table(
                 table_name=self.schedule_runs_table_name,
                 table_type="schedule_runs",
@@ -573,6 +604,8 @@ class PostgresDb(BaseDb):
             return self.schedule_runs_table
 
         if table_type == "approvals":
+            if self.approvals_table is not None:
+                return self.approvals_table
             self.approvals_table = self._get_or_create_table(
                 table_name=self.approvals_table_name,
                 table_type="approvals",


### PR DESCRIPTION
## Summary

`_get_table()` in both `PostgresDb` and `AsyncPostgresDb` always called `_get_or_create_table()` even when the table was already loaded and cached in instance attributes (e.g. `self.session_table`, `self.memory_table`). Each `_get_or_create_table()` call creates a new database connection to check if the table exists, causing 900+ connections with remote databases like Neon PostgreSQL.

This fix adds an early return at the beginning of each `if table_type == "..."` block: if the cached table attribute is not `None`, return it immediately without opening a new connection.

Fixes #6257

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

### Files changed

- `libs/agno/agno/db/postgres/postgres.py` -- sync `_get_table()`: added cache checks for all 16 table types (sessions, memories, metrics, evals, knowledge, culture, versions, traces, spans, components, component_configs, component_links, learnings, schedules, schedule_runs, approvals)
- `libs/agno/agno/db/postgres/async_postgres.py` -- async `_get_table()`: added cache checks for all 13 table types (sessions, memories, metrics, evals, knowledge, culture, versions, traces, spans, learnings, schedules, schedule_runs, approvals)

### Pattern applied

```python
# Before (every call opens a DB connection):
if table_type == "sessions":
    self.session_table = self._get_or_create_table(...)
    return self.session_table

# After (returns cached table if available):
if table_type == "sessions":
    if self.session_table is not None:
        return self.session_table
    self.session_table = self._get_or_create_table(...)
    return self.session_table
```