### PR TITLE
feat: extend reasoning detection to all OpenAI-compatible providers

### DIFF
--- a/cookbook/10_reasoning/models/deepinfra/README.md
+++ b/cookbook/10_reasoning/models/deepinfra/README.md
@@ -1,0 +1,21 @@
+# DeepInfra Reasoning Models
+
+Demonstrates reasoning capabilities with DeepInfra's hosted models.
+
+## Available Reasoning Models
+
+- `Qwen/QwQ-32B` - QwQ 32B reasoning model
+- `deepseek-ai/DeepSeek-R1-Turbo` - DeepSeek R1 Turbo
+- `Qwen/Qwen3-32B` - Qwen3 32B with thinking mode
+
+## Setup
+
+```bash
+export DEEPINFRA_API_KEY=your_api_key
+```
+
+## Run
+
+```bash
+python reasoning_agent.py
+```

--- a/cookbook/10_reasoning/models/deepinfra/reasoning_agent.py
+++ b/cookbook/10_reasoning/models/deepinfra/reasoning_agent.py
@@ -1,0 +1,18 @@
+from agno.agent import Agent
+from agno.models.deepinfra import DeepInfra
+
+task = (
+    "Three missionaries and three cannibals need to cross a river. "
+    "They have a boat that can carry up to two people at a time. "
+    "If, at any time, the cannibals outnumber the missionaries on either side of the river, the cannibals will eat the missionaries. "
+    "How can all six people get across the river safely? Provide a step-by-step solution and show the state after each crossing."
+)
+
+agent = Agent(
+    model=DeepInfra(id="Qwen/QwQ-32B"),
+    reasoning=True,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(task, stream=True, show_full_reasoning=True)

--- a/cookbook/10_reasoning/models/fireworks/README.md
+++ b/cookbook/10_reasoning/models/fireworks/README.md
@@ -1,0 +1,21 @@
+# Fireworks AI Reasoning Models
+
+Demonstrates reasoning capabilities with Fireworks AI's hosted models.
+
+## Available Reasoning Models
+
+- `accounts/fireworks/models/qwen3-30b-a3b` - Qwen3 30B reasoning model
+- `accounts/fireworks/models/deepseek-r1` - DeepSeek R1 reasoning model
+- `accounts/fireworks/models/deepseek-v4-pro` - DeepSeek V4 Pro
+
+## Setup
+
+```bash
+export FIREWORKS_API_KEY=your_api_key
+```
+
+## Run
+
+```bash
+python reasoning_agent.py
+```

--- a/cookbook/10_reasoning/models/fireworks/reasoning_agent.py
+++ b/cookbook/10_reasoning/models/fireworks/reasoning_agent.py
@@ -1,0 +1,18 @@
+from agno.agent import Agent
+from agno.models.fireworks import Fireworks
+
+task = (
+    "Three missionaries and three cannibals need to cross a river. "
+    "They have a boat that can carry up to two people at a time. "
+    "If, at any time, the cannibals outnumber the missionaries on either side of the river, the cannibals will eat the missionaries. "
+    "How can all six people get across the river safely? Provide a step-by-step solution and show the state after each crossing."
+)
+
+agent = Agent(
+    model=Fireworks(id="accounts/fireworks/models/qwen3-30b-a3b"),
+    reasoning=True,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(task, stream=True, show_full_reasoning=True)

--- a/cookbook/10_reasoning/models/openrouter/README.md
+++ b/cookbook/10_reasoning/models/openrouter/README.md
@@ -1,0 +1,21 @@
+# OpenRouter Reasoning Models
+
+Demonstrates reasoning capabilities with OpenRouter's model routing.
+
+## Available Reasoning Models
+
+- `deepseek/deepseek-r1` - DeepSeek R1 reasoning model
+- `deepseek/deepseek-r1-distill-qwen-32b` - DeepSeek R1 distilled
+- `deepseek/deepseek-r1-distill-llama-70b` - DeepSeek R1 distilled (Llama)
+
+## Setup
+
+```bash
+export OPENROUTER_API_KEY=your_api_key
+```
+
+## Run
+
+```bash
+python reasoning_agent.py
+```

--- a/cookbook/10_reasoning/models/openrouter/reasoning_agent.py
+++ b/cookbook/10_reasoning/models/openrouter/reasoning_agent.py
@@ -1,0 +1,18 @@
+from agno.agent import Agent
+from agno.models.openrouter import OpenRouter
+
+task = (
+    "Three missionaries and three cannibals need to cross a river. "
+    "They have a boat that can carry up to two people at a time. "
+    "If, at any time, the cannibals outnumber the missionaries on either side of the river, the cannibals will eat the missionaries. "
+    "How can all six people get across the river safely? Provide a step-by-step solution and show the state after each crossing."
+)
+
+agent = Agent(
+    model=OpenRouter(id="deepseek/deepseek-r1-distill-qwen-32b"),
+    reasoning=True,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(task, stream=True, show_full_reasoning=True)

--- a/cookbook/10_reasoning/models/together/README.md
+++ b/cookbook/10_reasoning/models/together/README.md
@@ -1,0 +1,21 @@
+# Together AI Reasoning Models
+
+Demonstrates reasoning capabilities with Together AI's hosted models.
+
+## Available Reasoning Models
+
+- `Qwen/QwQ-32B` - QwQ reasoning model
+- `deepseek-ai/DeepSeek-R1` - DeepSeek R1 reasoning model
+- `deepseek-ai/DeepSeek-R1-Distill-Qwen-14B` - Distilled variant
+
+## Setup
+
+```bash
+export TOGETHER_API_KEY=your_api_key
+```
+
+## Run
+
+```bash
+python reasoning_agent.py
+```

--- a/cookbook/10_reasoning/models/together/reasoning_agent.py
+++ b/cookbook/10_reasoning/models/together/reasoning_agent.py
@@ -1,0 +1,18 @@
+from agno.agent import Agent
+from agno.models.together import Together
+
+task = (
+    "Three missionaries and three cannibals need to cross a river. "
+    "They have a boat that can carry up to two people at a time. "
+    "If, at any time, the cannibals outnumber the missionaries on either side of the river, the cannibals will eat the missionaries. "
+    "How can all six people get across the river safely? Provide a step-by-step solution and show the state after each crossing."
+)
+
+agent = Agent(
+    model=Together(id="Qwen/QwQ-32B"),
+    reasoning=True,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(task, stream=True, show_full_reasoning=True)

--- a/cookbook/10_reasoning/models/vllm/README.md
+++ b/cookbook/10_reasoning/models/vllm/README.md
@@ -1,0 +1,26 @@
+# VLLM Reasoning Models
+
+Cookbooks for using reasoning models served via vLLM.
+
+## Prerequisites
+
+1. A vLLM server running a reasoning-capable model:
+   ```bash
+   vllm serve Qwen/QwQ-32B --enable-reasoning --reasoning-parser deepseek_r1
+   ```
+
+2. Environment variables:
+   ```bash
+   export VLLM_API_KEY=your-key
+   export VLLM_BASE_URL=http://localhost:8000/v1/
+   ```
+
+## Supported Reasoning Models
+
+Models are detected as native reasoning models when:
+- `enable_thinking=True` is set on the VLLM model (recommended), OR
+- The model ID contains a known reasoning pattern: `qwq`, `qwen3`, `deepseek-r1`, `openthinker`
+
+## Cookbooks
+
+- `reasoning_agent.py` - Basic reasoning agent with vLLM

--- a/cookbook/10_reasoning/models/vllm/reasoning_agent.py
+++ b/cookbook/10_reasoning/models/vllm/reasoning_agent.py
@@ -1,0 +1,20 @@
+from agno.agent import Agent
+from agno.models.vllm import VLLM
+
+task = (
+    "Three missionaries and three cannibals need to cross a river. "
+    "They have a boat that can carry up to two people at a time. "
+    "If, at any time, the cannibals outnumber the missionaries on either side of the river, the cannibals will eat the missionaries. "
+    "How can all six people get across the river safely? Provide a step-by-step solution and show the state after each crossing."
+)
+
+agent = Agent(
+    model=VLLM(
+        id="Qwen/QwQ-32B",
+        enable_thinking=True,
+    ),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response(task, stream=True, show_full_reasoning=True)

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1486,16 +1486,6 @@ def handle_model_response_chunk(
                     if think_tag_state is not None and reasoning_state is not None:
                         tag_result = process_think_tag_chunk(model_response_event.content, think_tag_state)
 
-                        # Emit ReasoningStartedEvent when entering <think> block
-                        if tag_result.entered_think and stream_events and not reasoning_state["reasoning_started"]:
-                            yield handle_event(  # type: ignore
-                                create_reasoning_started_event(from_run_response=run_response),
-                                run_response,
-                                events_to_skip=agent.events_to_skip,  # type: ignore
-                                store_events=agent.store_events,
-                            )
-                            reasoning_state["reasoning_started"] = True
-
                         # Accumulate clean content (outside <think> tags)
                         if tag_result.clean_content:
                             model_response.content = (model_response.content or "") + tag_result.clean_content
@@ -1517,18 +1507,8 @@ def handle_model_response_chunk(
 
                     run_response.content_type = "str"
 
-            # Process reasoning content
+            # Process reasoning content (native reasoning_content field)
             if model_response_event.reasoning_content is not None:
-                # Emit ReasoningStartedEvent on first reasoning chunk
-                if stream_events and reasoning_state is not None and not reasoning_state["reasoning_started"]:
-                    yield handle_event(  # type: ignore
-                        create_reasoning_started_event(from_run_response=run_response),
-                        run_response,
-                        events_to_skip=agent.events_to_skip,  # type: ignore
-                        store_events=agent.store_events,
-                    )
-                    reasoning_state["reasoning_started"] = True
-
                 model_response.reasoning_content = (
                     model_response.reasoning_content or ""
                 ) + model_response_event.reasoning_content
@@ -1541,6 +1521,35 @@ def handle_model_response_chunk(
                     model_response.reasoning_content += model_response_event.redacted_reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
 
+            # Emit ReasoningContentDeltaEvent for ALL reasoning sources when streaming
+            # This includes: parsed <think> tags, native reasoning_content, redacted_reasoning_content
+            reasoning_delta = (
+                chunk_reasoning_to_emit
+                or model_response_event.reasoning_content
+                or model_response_event.redacted_reasoning_content
+            )
+            if stream_events and reasoning_state is not None and reasoning_delta:
+                # Emit ReasoningStartedEvent on first reasoning chunk
+                if not reasoning_state["reasoning_started"]:
+                    yield handle_event(  # type: ignore
+                        create_reasoning_started_event(from_run_response=run_response),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
+                    reasoning_state["reasoning_started"] = True
+
+                # Emit ReasoningContentDeltaEvent for each reasoning chunk
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data
@@ -1549,7 +1558,7 @@ def handle_model_response_chunk(
             if model_response_event.citations is not None:
                 run_response.citations = model_response_event.citations
 
-            # Only yield if we have content to show
+            # Emit RunContentEvent for content (NOT reasoning when streaming)
             if content_type != "str":
                 yield handle_event(  # type: ignore
                     create_run_output_content_event(
@@ -1563,20 +1572,28 @@ def handle_model_response_chunk(
                 )
             elif (
                 chunk_content_to_emit is not None
-                or chunk_reasoning_to_emit is not None
-                or model_response_event.reasoning_content is not None
-                or model_response_event.redacted_reasoning_content is not None
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
+                # Include reasoning on RunContentEvent ONLY when NOT streaming events
+                or (
+                    not stream_events
+                    and (
+                        model_response_event.reasoning_content is not None
+                        or model_response_event.redacted_reasoning_content is not None
+                    )
+                )
             ):
-                # Use parsed content (clean_content/reasoning_content) when available
-                # Falls back to raw model_response_event fields for native reasoning models
                 yield handle_event(  # type: ignore
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=chunk_content_to_emit,
-                        reasoning_content=chunk_reasoning_to_emit or model_response_event.reasoning_content,
-                        redacted_reasoning_content=model_response_event.redacted_reasoning_content,
+                        # Only include reasoning on RunContentEvent when NOT streaming events
+                        reasoning_content=(chunk_reasoning_to_emit or model_response_event.reasoning_content)
+                        if not stream_events
+                        else None,
+                        redacted_reasoning_content=model_response_event.redacted_reasoning_content
+                        if not stream_events
+                        else None,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,
                     ),

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -63,7 +63,6 @@ from agno.utils.reasoning import (
     add_reasoning_metrics_to_metadata,
     add_reasoning_step_to_metadata,
     append_to_reasoning_content,
-    extract_thinking_content,
     flush_think_tag_state,
     process_think_tag_chunk,
     update_run_output_with_reasoning,
@@ -1190,14 +1189,14 @@ def handle_model_response_stream(
 
         # Emit final content event if there was buffered content
         if flush_result.clean_content or flush_result.reasoning_content:
-            yield handle_event(
+            yield handle_event(  # type: ignore
                 create_run_output_content_event(
                     from_run_response=run_response,
                     content=flush_result.clean_content,
                     reasoning_content=flush_result.reasoning_content,
                 ),
                 run_response,
-                events_to_skip=agent.events_to_skip,
+                events_to_skip=agent.events_to_skip,  # type: ignore
                 store_events=agent.store_events,
             )
 
@@ -1378,14 +1377,14 @@ async def ahandle_model_response_stream(
 
         # Emit final content event if there was buffered content
         if flush_result.clean_content or flush_result.reasoning_content:
-            yield handle_event(
+            yield handle_event(  # type: ignore
                 create_run_output_content_event(
                     from_run_response=run_response,
                     content=flush_result.clean_content,
                     reasoning_content=flush_result.reasoning_content,
                 ),
                 run_response,
-                events_to_skip=agent.events_to_skip,
+                events_to_skip=agent.events_to_skip,  # type: ignore
                 store_events=agent.store_events,
             )
 
@@ -1483,16 +1482,16 @@ def handle_model_response_chunk(
                     run_response.content_type = content_type
                 else:
                     # Parse <think>/<thinking> tags in-flight during streaming
-                    think_tag_state = reasoning_state.get("think_tag_state")
-                    if think_tag_state is not None:
+                    think_tag_state = reasoning_state.get("think_tag_state") if reasoning_state else None
+                    if think_tag_state is not None and reasoning_state is not None:
                         tag_result = process_think_tag_chunk(model_response_event.content, think_tag_state)
 
                         # Emit ReasoningStartedEvent when entering <think> block
                         if tag_result.entered_think and stream_events and not reasoning_state["reasoning_started"]:
-                            yield handle_event(
+                            yield handle_event(  # type: ignore
                                 create_reasoning_started_event(from_run_response=run_response),
                                 run_response,
-                                events_to_skip=agent.events_to_skip,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
                                 store_events=agent.store_events,
                             )
                             reasoning_state["reasoning_started"] = True
@@ -1521,11 +1520,11 @@ def handle_model_response_chunk(
             # Process reasoning content
             if model_response_event.reasoning_content is not None:
                 # Emit ReasoningStartedEvent on first reasoning chunk
-                if stream_events and not reasoning_state["reasoning_started"]:
-                    yield handle_event(
+                if stream_events and reasoning_state is not None and not reasoning_state["reasoning_started"]:
+                    yield handle_event(  # type: ignore
                         create_reasoning_started_event(from_run_response=run_response),
                         run_response,
-                        events_to_skip=agent.events_to_skip,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
                         store_events=agent.store_events,
                     )
                     reasoning_state["reasoning_started"] = True

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -59,9 +59,13 @@ from agno.utils.events import (
 from agno.utils.log import log_debug, log_warning
 from agno.utils.merge_dict import merge_dictionaries
 from agno.utils.reasoning import (
+    ThinkTagStreamState,
     add_reasoning_metrics_to_metadata,
     add_reasoning_step_to_metadata,
     append_to_reasoning_content,
+    extract_thinking_content,
+    flush_think_tag_state,
+    process_think_tag_chunk,
     update_run_output_with_reasoning,
 )
 from agno.utils.string import parse_response_dict_str, parse_response_model_str
@@ -1058,9 +1062,10 @@ def handle_model_response_stream(
 ) -> Iterator[RunOutputEvent]:
     agent.model = cast(Model, agent.model)
 
-    reasoning_state = {
+    reasoning_state: Dict[str, Any] = {
         "reasoning_started": False,
         "reasoning_time_taken": 0.0,
+        "think_tag_state": ThinkTagStreamState(),
     }
     model_response = ModelResponse(content="")
 
@@ -1172,6 +1177,30 @@ def handle_model_response_stream(
             run_context=run_context,
         )
 
+    # Flush any remaining buffered content from <think> tag parsing
+    think_tag_state = reasoning_state.get("think_tag_state")
+    if think_tag_state is not None:
+        flush_result = flush_think_tag_state(think_tag_state)
+        if flush_result.clean_content:
+            model_response.content = (model_response.content or "") + flush_result.clean_content
+            run_response.content = model_response.content
+        if flush_result.reasoning_content:
+            model_response.reasoning_content = (model_response.reasoning_content or "") + flush_result.reasoning_content
+            run_response.reasoning_content = model_response.reasoning_content
+
+        # Emit final content event if there was buffered content
+        if flush_result.clean_content or flush_result.reasoning_content:
+            yield handle_event(
+                create_run_output_content_event(
+                    from_run_response=run_response,
+                    content=flush_result.clean_content,
+                    reasoning_content=flush_result.reasoning_content,
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,
+                store_events=agent.store_events,
+            )
+
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput
     messages_for_run_response = [m for m in run_messages.messages if m.add_to_agent_memory]
@@ -1218,9 +1247,10 @@ async def ahandle_model_response_stream(
 ) -> AsyncIterator[RunOutputEvent]:
     agent.model = cast(Model, agent.model)
 
-    reasoning_state = {
+    reasoning_state: Dict[str, Any] = {
         "reasoning_started": False,
         "reasoning_time_taken": 0.0,
+        "think_tag_state": ThinkTagStreamState(),
     }
     model_response = ModelResponse(content="")
 
@@ -1335,6 +1365,30 @@ async def ahandle_model_response_stream(
         ):
             yield event
 
+    # Flush any remaining buffered content from <think> tag parsing
+    think_tag_state = reasoning_state.get("think_tag_state")
+    if think_tag_state is not None:
+        flush_result = flush_think_tag_state(think_tag_state)
+        if flush_result.clean_content:
+            model_response.content = (model_response.content or "") + flush_result.clean_content
+            run_response.content = model_response.content
+        if flush_result.reasoning_content:
+            model_response.reasoning_content = (model_response.reasoning_content or "") + flush_result.reasoning_content
+            run_response.reasoning_content = model_response.reasoning_content
+
+        # Emit final content event if there was buffered content
+        if flush_result.clean_content or flush_result.reasoning_content:
+            yield handle_event(
+                create_run_output_content_event(
+                    from_run_response=run_response,
+                    content=flush_result.clean_content,
+                    reasoning_content=flush_result.reasoning_content,
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,
+                store_events=agent.store_events,
+            )
+
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput
     messages_for_run_response = [m for m in run_messages.messages if m.add_to_agent_memory]
@@ -1413,6 +1467,10 @@ def handle_model_response_chunk(
             content_type = "str"
 
             # Process content and thinking
+            # Variables to track what to emit this chunk
+            chunk_content_to_emit: Optional[str] = None
+            chunk_reasoning_to_emit: Optional[str] = None
+
             if model_response_event.content is not None:
                 if parse_structured_output:
                     model_response.content = model_response_event.content
@@ -1424,12 +1482,54 @@ def handle_model_response_chunk(
                     run_response.content = model_response.content
                     run_response.content_type = content_type
                 else:
-                    model_response.content = (model_response.content or "") + model_response_event.content
-                    run_response.content = model_response.content
+                    # Parse <think>/<thinking> tags in-flight during streaming
+                    think_tag_state = reasoning_state.get("think_tag_state")
+                    if think_tag_state is not None:
+                        tag_result = process_think_tag_chunk(model_response_event.content, think_tag_state)
+
+                        # Emit ReasoningStartedEvent when entering <think> block
+                        if tag_result.entered_think and stream_events and not reasoning_state["reasoning_started"]:
+                            yield handle_event(
+                                create_reasoning_started_event(from_run_response=run_response),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,
+                                store_events=agent.store_events,
+                            )
+                            reasoning_state["reasoning_started"] = True
+
+                        # Accumulate clean content (outside <think> tags)
+                        if tag_result.clean_content:
+                            model_response.content = (model_response.content or "") + tag_result.clean_content
+                            run_response.content = model_response.content
+                            chunk_content_to_emit = tag_result.clean_content
+
+                        # Accumulate reasoning content (inside <think> tags)
+                        if tag_result.reasoning_content:
+                            model_response.reasoning_content = (
+                                model_response.reasoning_content or ""
+                            ) + tag_result.reasoning_content
+                            run_response.reasoning_content = model_response.reasoning_content
+                            chunk_reasoning_to_emit = tag_result.reasoning_content
+                    else:
+                        # No think tag state - pass through raw content
+                        model_response.content = (model_response.content or "") + model_response_event.content
+                        run_response.content = model_response.content
+                        chunk_content_to_emit = model_response_event.content
+
                     run_response.content_type = "str"
 
             # Process reasoning content
             if model_response_event.reasoning_content is not None:
+                # Emit ReasoningStartedEvent on first reasoning chunk
+                if stream_events and not reasoning_state["reasoning_started"]:
+                    yield handle_event(
+                        create_reasoning_started_event(from_run_response=run_response),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,
+                        store_events=agent.store_events,
+                    )
+                    reasoning_state["reasoning_started"] = True
+
                 model_response.reasoning_content = (
                     model_response.reasoning_content or ""
                 ) + model_response_event.reasoning_content
@@ -1463,17 +1563,20 @@ def handle_model_response_chunk(
                     store_events=agent.store_events,
                 )
             elif (
-                model_response_event.content is not None
+                chunk_content_to_emit is not None
+                or chunk_reasoning_to_emit is not None
                 or model_response_event.reasoning_content is not None
                 or model_response_event.redacted_reasoning_content is not None
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
             ):
+                # Use parsed content (clean_content/reasoning_content) when available
+                # Falls back to raw model_response_event fields for native reasoning models
                 yield handle_event(  # type: ignore
                     create_run_output_content_event(
                         from_run_response=run_response,
-                        content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
+                        content=chunk_content_to_emit,
+                        reasoning_content=chunk_reasoning_to_emit or model_response_event.reasoning_content,
                         redacted_reasoning_content=model_response_event.redacted_reasoning_content,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,

--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -14,6 +14,7 @@ from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.openai import images_to_message
+from agno.utils.reasoning import extract_thinking_content
 
 try:
     from groq import APIError, APIResponseValidationError, APIStatusError
@@ -506,6 +507,18 @@ class Groq(Model):
         if response_message.content is not None:
             model_response.content = response_message.content
 
+        # Add reasoning content (gpt-oss models return reasoning in a separate field)
+        if hasattr(response_message, "reasoning") and response_message.reasoning is not None:
+            model_response.reasoning_content = response_message.reasoning
+        # Fallback: extract thinking content between <think> or <thinking> tags if present
+        elif model_response.content and (
+            "</think>" in model_response.content or "</thinking>" in model_response.content
+        ):
+            reasoning_content, clean_content = extract_thinking_content(model_response.content)
+            if reasoning_content:
+                model_response.reasoning_content = reasoning_content
+                model_response.content = clean_content
+
         # Add tool calls
         if response_message.tool_calls is not None and len(response_message.tool_calls) > 0:
             try:
@@ -538,6 +551,10 @@ class Groq(Model):
                 # Add content
                 if choice_delta.content is not None:
                     model_response.content = choice_delta.content
+
+                # Add reasoning content (gpt-oss models return reasoning in a separate field)
+                if hasattr(choice_delta, "reasoning") and choice_delta.reasoning is not None:
+                    model_response.reasoning_content = choice_delta.reasoning
 
                 # Add tool calls
                 if choice_delta.tool_calls is not None:

--- a/libs/agno/agno/models/ollama/chat.py
+++ b/libs/agno/agno/models/ollama/chat.py
@@ -363,8 +363,13 @@ class Ollama(Model):
         if response_message.get("content") is not None:
             model_response.content = response_message.get("content")
 
-        # Extract thinking content between <think> tags if present
-        if model_response.content and model_response.content.find("<think>") != -1:
+        # Extract thinking content from separate field (gpt-oss, thinking models)
+        if response_message.get("thinking") is not None:
+            model_response.reasoning_content = response_message.get("thinking")
+        # Fallback: extract thinking content between <think> or <thinking> tags if present
+        elif model_response.content and (
+            "</think>" in model_response.content or "</thinking>" in model_response.content
+        ):
             reasoning_content, clean_content = extract_thinking_content(model_response.content)
 
             if reasoning_content:
@@ -414,6 +419,11 @@ class Ollama(Model):
             content_delta = response_message.get("content")
             if content_delta is not None and content_delta != "":
                 model_response.content = content_delta
+
+            # Extract thinking content from separate field (gpt-oss, thinking models)
+            thinking_delta = response_message.get("thinking")
+            if thinking_delta is not None and thinking_delta != "":
+                model_response.reasoning_content = thinking_delta
 
             tool_calls = response_message.get("tool_calls")
             if tool_calls is not None:

--- a/libs/agno/agno/reasoning/azure_ai_foundry.py
+++ b/libs/agno/agno/reasoning/azure_ai_foundry.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, AsyncIterator, Iterator, List, Optional, Tuple
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.utils.log import log_warning
+from agno.utils.reasoning import extract_thinking_content
 
 if TYPE_CHECKING:
     from agno.metrics import RunMetrics
@@ -36,17 +37,13 @@ def get_ai_foundry_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    # We use the normal content as no reasoning content is returned
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
-        content = reasoning_agent_response.content
-        if "<think>" in content and "</think>" in content:
-            start_idx = content.find("<think>") + len("<think>")
-            end_idx = content.find("</think>")
-            reasoning_content = content[start_idx:end_idx].strip()
-        else:
-            reasoning_content = content
+    # 1. Prefer already-extracted reasoning_content
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to extracting from content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content:
+        extracted, _ = extract_thinking_content(reasoning_agent_response.content)
+        reasoning_content = extracted or reasoning_agent_response.content
 
     return Message(
         role="assistant", content=f"<thinking>\n{reasoning_content}\n</thinking>", reasoning_content=reasoning_content
@@ -70,16 +67,13 @@ async def aget_ai_foundry_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
-        content = reasoning_agent_response.content
-        if "<think>" in content and "</think>" in content:
-            start_idx = content.find("<think>") + len("<think>")
-            end_idx = content.find("</think>")
-            reasoning_content = content[start_idx:end_idx].strip()
-        else:
-            reasoning_content = content
+    # 1. Prefer already-extracted reasoning_content
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to extracting from content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content:
+        extracted, _ = extract_thinking_content(reasoning_agent_response.content)
+        reasoning_content = extracted or reasoning_agent_response.content
 
     return Message(
         role="assistant", content=f"<thinking>\n{reasoning_content}\n</thinking>", reasoning_content=reasoning_content

--- a/libs/agno/agno/reasoning/groq.py
+++ b/libs/agno/agno/reasoning/groq.py
@@ -5,17 +5,20 @@ from typing import TYPE_CHECKING, AsyncIterator, Iterator, List, Optional, Tuple
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.utils.log import log_warning
+from agno.utils.reasoning import extract_thinking_content
 
 if TYPE_CHECKING:
     from agno.metrics import RunMetrics
 
 
 def is_groq_reasoning_model(reasoning_model: Model) -> bool:
+    model_id_lower = reasoning_model.id.lower()
     return reasoning_model.__class__.__name__ == "Groq" and (
-        "deepseek" in reasoning_model.id.lower()
-        or "openai/gpt-oss-20b" in reasoning_model.id.lower()
-        or "openai/gpt-oss-120b" in reasoning_model.id.lower()
-        or "qwen/qwen3-32b" in reasoning_model.id.lower()
+        "deepseek-r1" in model_id_lower
+        or "qwq" in model_id_lower
+        or "qwen3" in model_id_lower
+        or "openthinker" in model_id_lower
+        or "gpt-oss" in model_id_lower
     )
 
 
@@ -41,16 +44,13 @@ def get_groq_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
-        content = reasoning_agent_response.content
-        if "<think>" in content and "</think>" in content:
-            start_idx = content.find("<think>") + len("<think>")
-            end_idx = content.find("</think>")
-            reasoning_content = content[start_idx:end_idx].strip()
-        else:
-            reasoning_content = content
+    # 1. Prefer already-extracted reasoning_content (Groq adapter extracts native field)
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to extracting from content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content:
+        extracted, _ = extract_thinking_content(reasoning_agent_response.content)
+        reasoning_content = extracted or reasoning_agent_response.content
 
     return Message(
         role="assistant", content=f"<thinking>\n{reasoning_content}\n</thinking>", reasoning_content=reasoning_content
@@ -79,16 +79,13 @@ async def aget_groq_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
-        content = reasoning_agent_response.content
-        if "<think>" in content and "</think>" in content:
-            start_idx = content.find("<think>") + len("<think>")
-            end_idx = content.find("</think>")
-            reasoning_content = content[start_idx:end_idx].strip()
-        else:
-            reasoning_content = content
+    # 1. Prefer already-extracted reasoning_content (Groq adapter extracts native field)
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to extracting from content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content:
+        extracted, _ = extract_thinking_content(reasoning_agent_response.content)
+        reasoning_content = extracted or reasoning_agent_response.content
 
     return Message(
         role="assistant", content=f"<thinking>\n{reasoning_content}\n</thinking>", reasoning_content=reasoning_content

--- a/libs/agno/agno/reasoning/manager.py
+++ b/libs/agno/agno/reasoning/manager.py
@@ -135,6 +135,7 @@ class ReasoningManager:
             return "deepseek"
         if is_anthropic_reasoning_model(model):
             return "anthropic"
+        # OpenAI check handles: native OpenAI (o1/o3/o4), OpenAILike providers (Together, Fireworks, etc.), VLLM
         if is_openai_reasoning_model(model):
             return "openai"
         if is_groq_reasoning_model(model):

--- a/libs/agno/agno/reasoning/ollama.py
+++ b/libs/agno/agno/reasoning/ollama.py
@@ -5,17 +5,19 @@ from typing import TYPE_CHECKING, AsyncIterator, Iterator, List, Optional, Tuple
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.utils.log import log_warning
+from agno.utils.reasoning import extract_thinking_content
 
 if TYPE_CHECKING:
     from agno.metrics import RunMetrics
 
 
 def is_ollama_reasoning_model(reasoning_model: Model) -> bool:
+    model_id_lower = reasoning_model.id.lower()
     return reasoning_model.__class__.__name__ == "Ollama" and (
-        "qwq" in reasoning_model.id
-        or "deepseek-r1" in reasoning_model.id
-        or "qwen2.5-coder" in reasoning_model.id
-        or "openthinker" in reasoning_model.id
+        "qwq" in model_id_lower
+        or "qwen3" in model_id_lower
+        or "deepseek-r1" in model_id_lower
+        or "openthinker" in model_id_lower
     )
 
 
@@ -36,17 +38,13 @@ def get_ollama_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    # We use the normal content as no reasoning content is returned
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
-        content = reasoning_agent_response.content
-        if "<think>" in content and "</think>" in content:
-            start_idx = content.find("<think>") + len("<think>")
-            end_idx = content.find("</think>")
-            reasoning_content = content[start_idx:end_idx].strip()
-        else:
-            reasoning_content = content
+    # 1. Prefer already-extracted reasoning_content (Ollama adapter extracts thinking field)
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to extracting from content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content:
+        extracted, _ = extract_thinking_content(reasoning_agent_response.content)
+        reasoning_content = extracted or reasoning_agent_response.content
 
     return Message(
         role="assistant", content=f"<thinking>\n{reasoning_content}\n</thinking>", reasoning_content=reasoning_content
@@ -70,16 +68,13 @@ async def aget_ollama_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
-        content = reasoning_agent_response.content
-        if "<think>" in content and "</think>" in content:
-            start_idx = content.find("<think>") + len("<think>")
-            end_idx = content.find("</think>")
-            reasoning_content = content[start_idx:end_idx].strip()
-        else:
-            reasoning_content = content
+    # 1. Prefer already-extracted reasoning_content (Ollama adapter extracts thinking field)
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to extracting from content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content:
+        extracted, _ = extract_thinking_content(reasoning_agent_response.content)
+        reasoning_content = extracted or reasoning_agent_response.content
 
     return Message(
         role="assistant", content=f"<thinking>\n{reasoning_content}\n</thinking>", reasoning_content=reasoning_content

--- a/libs/agno/agno/reasoning/openai.py
+++ b/libs/agno/agno/reasoning/openai.py
@@ -12,27 +12,37 @@ if TYPE_CHECKING:
 
 
 def is_openai_reasoning_model(reasoning_model: Model) -> bool:
-    return (
-        (
-            reasoning_model.__class__.__name__ == "OpenAIChat"
-            or reasoning_model.__class__.__name__ == "OpenAIResponses"
-            or reasoning_model.__class__.__name__ == "AzureOpenAI"
-        )
-        and (
-            ("o4" in reasoning_model.id)
-            or ("o3" in reasoning_model.id)
-            or ("o1" in reasoning_model.id)
-            or ("5.1" in reasoning_model.id)
-            or ("5.2" in reasoning_model.id)
-        )
-    ) or (
-        isinstance(reasoning_model, OpenAILike)
-        and (
-            "deepseek-r1" in reasoning_model.id.lower()
-            or "minimax-m2" in reasoning_model.id.lower()
-            or "minimax-m3" in reasoning_model.id.lower()
-        )
+    model_id_lower = reasoning_model.id.lower()
+
+    # Native OpenAI reasoning models (o1, o3, o4, 5.1, 5.2)
+    is_native_openai = (
+        reasoning_model.__class__.__name__ == "OpenAIChat"
+        or reasoning_model.__class__.__name__ == "OpenAIResponses"
+        or reasoning_model.__class__.__name__ == "AzureOpenAI"
+    ) and (
+        ("o4" in reasoning_model.id)
+        or ("o3" in reasoning_model.id)
+        or ("o1" in reasoning_model.id)
+        or ("5.1" in reasoning_model.id)
+        or ("5.2" in reasoning_model.id)
     )
+
+    # OpenAILike providers (Together, Fireworks, OpenRouter, DeepInfra, VLLM, etc.)
+    # Also covers self-hosted OpenAI-compatible servers (OpenAIChat with custom base_url)
+    is_openai_compatible = isinstance(reasoning_model, OpenAILike) or (
+        reasoning_model.__class__.__name__ == "OpenAIChat" and getattr(reasoning_model, "base_url", None) is not None
+    )
+    is_openai_like_reasoning = is_openai_compatible and (
+        getattr(reasoning_model, "enable_thinking", None) is True
+        or "qwq" in model_id_lower
+        or "qwen3" in model_id_lower
+        or "deepseek-r1" in model_id_lower
+        or "openthinker" in model_id_lower
+        or "minimax-m2" in model_id_lower
+        or "minimax-m3" in model_id_lower
+    )
+
+    return is_native_openai or is_openai_like_reasoning
 
 
 def get_openai_reasoning(
@@ -57,10 +67,11 @@ def get_openai_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    # We use the normal content as no reasoning content is returned
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
+    # 1. Prefer already-extracted reasoning_content (OpenAIChat parses <think> tags)
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to parsing content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content is not None:
         content = reasoning_agent_response.content
         if "<think>" in content and "</think>" in content:
             start_idx = content.find("<think>") + len("<think>")
@@ -96,9 +107,11 @@ async def aget_openai_reasoning(
 
         accumulate_eval_metrics(reasoning_agent_response.metrics, run_metrics, prefix="reasoning")
 
-    reasoning_content: str = ""
-    if reasoning_agent_response.content is not None:
-        # Extract content between <think> tags if present
+    # 1. Prefer already-extracted reasoning_content (OpenAIChat parses <think> tags)
+    reasoning_content = getattr(reasoning_agent_response, "reasoning_content", None) or ""
+
+    # 2. Fall back to parsing content if reasoning_content is empty
+    if not reasoning_content and reasoning_agent_response.content is not None:
         content = reasoning_agent_response.content
         if "<think>" in content and "</think>" in content:
             start_idx = content.find("<think>") + len("<think>")

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -63,6 +63,7 @@ from agno.utils.reasoning import (
     add_reasoning_metrics_to_metadata,
     add_reasoning_step_to_metadata,
     append_to_reasoning_content,
+    extract_thinking_content,
     update_run_output_with_reasoning,
 )
 from agno.utils.string import parse_response_dict_str, parse_response_model_str
@@ -1127,6 +1128,14 @@ def _handle_model_response_stream(
             run_context=run_context,
         )
 
+    # Extract <think> or <thinking> tags from accumulated streaming content
+    if full_model_response.content and isinstance(full_model_response.content, str):
+        reasoning_content, clean_content = extract_thinking_content(full_model_response.content)
+        if reasoning_content:
+            full_model_response.content = clean_content
+            if not full_model_response.reasoning_content:
+                full_model_response.reasoning_content = reasoning_content
+
     # 3. Update TeamRunOutput
     if full_model_response.content is not None:
         run_response.content = full_model_response.content
@@ -1288,6 +1297,14 @@ async def _ahandle_model_response_stream(
             run_context=run_context,
         ):
             yield event
+
+    # Extract <think> or <thinking> tags from accumulated streaming content
+    if full_model_response.content and isinstance(full_model_response.content, str):
+        reasoning_content, clean_content = extract_thinking_content(full_model_response.content)
+        if reasoning_content:
+            full_model_response.content = clean_content
+            if not full_model_response.reasoning_content:
+                full_model_response.reasoning_content = reasoning_content
 
     # Update TeamRunOutput
     if full_model_response.content is not None:

--- a/libs/agno/agno/utils/reasoning.py
+++ b/libs/agno/agno/utils/reasoning.py
@@ -1,5 +1,5 @@
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from agno.metrics import MessageMetrics

--- a/libs/agno/agno/utils/reasoning.py
+++ b/libs/agno/agno/utils/reasoning.py
@@ -1,3 +1,5 @@
+import re
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 
 from agno.metrics import MessageMetrics
@@ -9,23 +11,155 @@ if TYPE_CHECKING:
     from agno.team.team import TeamRunOutput
 
 
+@dataclass
+class ThinkTagStreamState:
+    """State for streaming <think> tag parsing."""
+
+    in_think_block: bool = False
+    tag_type: Optional[str] = None  # "think" or "thinking"
+    tag_buffer: str = ""  # Buffer for partial tag detection
+    accumulated_reasoning: str = ""
+    accumulated_content: str = ""
+
+
+@dataclass
+class ThinkTagStreamResult:
+    """Result of processing a streaming chunk for <think> tags."""
+
+    reasoning_content: Optional[str] = None  # Reasoning to emit this chunk
+    clean_content: Optional[str] = None  # Clean content to emit this chunk
+    entered_think: bool = False  # True if we just entered a <think> block
+    exited_think: bool = False  # True if we just exited a </think> block
+
+
+def process_think_tag_chunk(chunk: str, state: ThinkTagStreamState) -> ThinkTagStreamResult:
+    """Process a streaming chunk, parsing <think>/<thinking> tags in-flight.
+
+    This enables real-time separation of reasoning and content during streaming,
+    rather than waiting for the complete response.
+    """
+    result = ThinkTagStreamResult()
+
+    # Add chunk to buffer for tag detection
+    state.tag_buffer += chunk
+    buffer = state.tag_buffer
+
+    while buffer:
+        if state.in_think_block:
+            # Look for closing tag
+            close_tag = f"</{state.tag_type}>"
+            close_idx = buffer.find(close_tag)
+
+            if close_idx != -1:
+                # Found closing tag - emit reasoning up to it
+                reasoning_chunk = buffer[:close_idx]
+                if reasoning_chunk:
+                    result.reasoning_content = (result.reasoning_content or "") + reasoning_chunk
+                    state.accumulated_reasoning += reasoning_chunk
+
+                # Exit think block
+                state.in_think_block = False
+                result.exited_think = True
+                buffer = buffer[close_idx + len(close_tag) :]
+                state.tag_type = None
+            elif len(buffer) >= 12:
+                # No closing tag yet but buffer is long enough to safely emit
+                # Keep last 11 chars (len("</thinking>") - 1) in buffer for partial tag detection
+                safe_len = len(buffer) - 11
+                if safe_len > 0:
+                    reasoning_chunk = buffer[:safe_len]
+                    result.reasoning_content = (result.reasoning_content or "") + reasoning_chunk
+                    state.accumulated_reasoning += reasoning_chunk
+                    buffer = buffer[safe_len:]
+                break
+            else:
+                # Buffer too short, wait for more data
+                break
+        else:
+            # Look for opening tag
+            think_idx = buffer.find("<think>")
+            thinking_idx = buffer.find("<thinking>")
+
+            # Find earliest opening tag
+            open_idx = -1
+            tag_len = 0
+            if think_idx != -1 and (thinking_idx == -1 or think_idx < thinking_idx):
+                open_idx = think_idx
+                tag_len = 7  # len("<think>")
+                state.tag_type = "think"
+            elif thinking_idx != -1:
+                open_idx = thinking_idx
+                tag_len = 10  # len("<thinking>")
+                state.tag_type = "thinking"
+
+            if open_idx != -1:
+                # Found opening tag - emit content before it
+                content_chunk = buffer[:open_idx]
+                if content_chunk:
+                    result.clean_content = (result.clean_content or "") + content_chunk
+                    state.accumulated_content += content_chunk
+
+                # Enter think block
+                state.in_think_block = True
+                result.entered_think = True
+                buffer = buffer[open_idx + tag_len :]
+            elif len(buffer) >= 11:
+                # No opening tag yet but buffer is long enough to safely emit
+                # Keep last 10 chars (len("<thinking>") - 1) in buffer for partial tag detection
+                safe_len = len(buffer) - 10
+                if safe_len > 0:
+                    content_chunk = buffer[:safe_len]
+                    result.clean_content = (result.clean_content or "") + content_chunk
+                    state.accumulated_content += content_chunk
+                    buffer = buffer[safe_len:]
+                break
+            else:
+                # Buffer too short, wait for more data
+                break
+
+    state.tag_buffer = buffer
+    return result
+
+
+def flush_think_tag_state(state: ThinkTagStreamState) -> ThinkTagStreamResult:
+    """Flush any remaining buffered content at end of stream."""
+    result = ThinkTagStreamResult()
+
+    if state.tag_buffer:
+        if state.in_think_block:
+            result.reasoning_content = state.tag_buffer
+            state.accumulated_reasoning += state.tag_buffer
+        else:
+            result.clean_content = state.tag_buffer
+            state.accumulated_content += state.tag_buffer
+        state.tag_buffer = ""
+
+    return result
+
+
 def extract_thinking_content(content: str) -> Tuple[Optional[str], str]:
-    """Extract thinking content from response text between <think> tags."""
-    if not content or "</think>" not in content:
+    """Extract thinking content from response text between <think> or <thinking> tags.
+
+    Handles multiple blocks that accumulate across tool-call iterations.
+    """
+    if not content:
         return None, content
 
-    # Find the end of thinking content
-    end_idx = content.find("</think>")
-
-    # Look for opening <think> tag, if not found, assume thinking starts at beginning
-    start_idx = content.find("<think>")
-    if start_idx == -1:
-        reasoning_content = content[:end_idx].strip()
+    # Determine which tag format is present
+    if "</think>" in content:
+        pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+    elif "</thinking>" in content:
+        pattern = re.compile(r"<thinking>(.*?)</thinking>", re.DOTALL)
     else:
-        start_idx = start_idx + len("<think>")
-        reasoning_content = content[start_idx:end_idx].strip()
+        return None, content
 
-    output_content = content[end_idx + len("</think>") :].strip()
+    # Extract all thinking blocks
+    matches = pattern.findall(content)
+    if not matches:
+        return None, content
+
+    reasoning_content = "\n".join(m.strip() for m in matches if m.strip())
+    output_content = pattern.sub("", content).strip()
 
     return reasoning_content, output_content
 

--- a/libs/agno/tests/unit/models/groq_model/test_groq_reasoning.py
+++ b/libs/agno/tests/unit/models/groq_model/test_groq_reasoning.py
@@ -1,0 +1,153 @@
+from unittest.mock import MagicMock
+
+
+class TestGroqReasoningExtraction:
+    """Test that Groq model extracts reasoning from gpt-oss models."""
+
+    def test_parse_provider_response_extracts_reasoning(self):
+        """Test that _parse_provider_response extracts reasoning field from gpt-oss."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="openai/gpt-oss-20b", api_key="test-key")
+
+        mock_message = MagicMock()
+        mock_message.role = "assistant"
+        mock_message.content = "2 + 2 = 4"
+        mock_message.reasoning = "The user asks for 2+2. Simple addition. Answer is 4."
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+
+        result = model._parse_provider_response(mock_response)
+
+        assert result.content == "2 + 2 = 4"
+        assert result.reasoning_content == "The user asks for 2+2. Simple addition. Answer is 4."
+
+    def test_parse_provider_response_no_reasoning(self):
+        """Test that _parse_provider_response works when no reasoning field is present."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="llama-3.3-70b-versatile", api_key="test-key")
+
+        mock_message = MagicMock()
+        mock_message.role = "assistant"
+        mock_message.content = "Hello!"
+        mock_message.tool_calls = None
+        del mock_message.reasoning
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+
+        result = model._parse_provider_response(mock_response)
+
+        assert result.content == "Hello!"
+        assert result.reasoning_content is None
+
+    def test_parse_provider_response_delta_extracts_reasoning(self):
+        """Test that _parse_provider_response_delta extracts reasoning from streaming chunks."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="openai/gpt-oss-20b", api_key="test-key")
+
+        mock_delta = MagicMock()
+        mock_delta.content = "The answer"
+        mock_delta.reasoning = "Thinking..."
+        mock_delta.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.delta = mock_delta
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.x_groq = None
+
+        result = model._parse_provider_response_delta(mock_response)
+
+        assert result.content == "The answer"
+        assert result.reasoning_content == "Thinking..."
+
+    def test_parse_provider_response_delta_no_reasoning(self):
+        """Test that _parse_provider_response_delta works when no reasoning field is present."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="llama-3.3-70b-versatile", api_key="test-key")
+
+        mock_delta = MagicMock()
+        mock_delta.content = "Hello"
+        mock_delta.tool_calls = None
+        del mock_delta.reasoning
+
+        mock_choice = MagicMock()
+        mock_choice.delta = mock_delta
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.x_groq = None
+
+        result = model._parse_provider_response_delta(mock_response)
+
+        assert result.content == "Hello"
+        assert result.reasoning_content is None
+
+    def test_parse_provider_response_extracts_think_tags_fallback(self):
+        """Test that _parse_provider_response extracts <think> tags when reasoning field is None.
+
+        This is the case for qwen3 models on Groq which emit <think> tags in content
+        instead of using the native reasoning field.
+        """
+        from agno.models.groq import Groq
+
+        model = Groq(id="qwen/qwen3-32b", api_key="test-key")
+
+        mock_message = MagicMock()
+        mock_message.role = "assistant"
+        mock_message.content = "<think>Let me work through this step by step.</think>The answer is 42."
+        mock_message.reasoning = None
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+
+        result = model._parse_provider_response(mock_response)
+
+        assert result.content == "The answer is 42."
+        assert result.reasoning_content == "Let me work through this step by step."
+        assert "<think>" not in result.content
+
+    def test_parse_provider_response_extracts_thinking_tags_fallback(self):
+        """Test that _parse_provider_response extracts <thinking> tags when reasoning field is None."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="qwen/qwen3-32b", api_key="test-key")
+
+        mock_message = MagicMock()
+        mock_message.role = "assistant"
+        mock_message.content = "<thinking>Analyzing the problem.</thinking>Here is my answer."
+        mock_message.reasoning = None
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+
+        result = model._parse_provider_response(mock_response)
+
+        assert result.content == "Here is my answer."
+        assert result.reasoning_content == "Analyzing the problem."
+        assert "<thinking>" not in result.content

--- a/libs/agno/tests/unit/reasoning/test_reasoning_checkers.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_checkers.py
@@ -250,6 +250,150 @@ def test_openai_like_without_deepseek_r1():
     assert is_openai_reasoning_model(model) is False
 
 
+def test_openai_like_with_qwq():
+    """Test OpenAILike model with qwq in ID returns True (Together, Fireworks, etc.)."""
+    from agno.models.openai.like import OpenAILike
+
+    model = OpenAILike(
+        id="Qwen/QwQ-32B",
+        name="Together",
+    )
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_openai_like_with_qwen3():
+    """Test OpenAILike model with qwen3 in ID returns True."""
+    from agno.models.openai.like import OpenAILike
+
+    model = OpenAILike(
+        id="Qwen/Qwen3-8B",
+        name="OpenRouter",
+    )
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_openai_like_with_openthinker():
+    """Test OpenAILike model with openthinker in ID returns True."""
+    from agno.models.openai.like import OpenAILike
+
+    model = OpenAILike(
+        id="openthinker-7b",
+        name="DeepInfra",
+    )
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_openai_chat_self_hosted_with_reasoning_model():
+    """Test OpenAIChat with custom base_url and reasoning model returns True."""
+    model = MockModel(
+        class_name="OpenAIChat",
+        model_id="Qwen/QwQ-32B",
+        base_url="http://localhost:8080/v1",
+    )
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_openai_chat_self_hosted_without_reasoning_model():
+    """Test OpenAIChat with custom base_url but non-reasoning model returns False."""
+    model = MockModel(
+        class_name="OpenAIChat",
+        model_id="Llama-3.1-8B",
+        base_url="http://localhost:8080/v1",
+    )
+    assert is_openai_reasoning_model(model) is False
+
+
+def test_vllm_matched_by_openai_checker():
+    """VLLM extends OpenAILike, so it's handled by the OpenAI reasoning checker."""
+    from agno.models.vllm import VLLM
+
+    model = VLLM(id="Qwen/Qwen3-8B", enable_thinking=True)
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_vllm_without_enable_thinking_non_reasoning_model():
+    """VLLM without enable_thinking and non-reasoning model ID returns False."""
+    from agno.models.vllm import VLLM
+
+    model = VLLM(id="meta-llama/Llama-3.1-70B")
+    assert is_openai_reasoning_model(model) is False
+
+
+def test_vllm_with_qwq_model_id():
+    """VLLM with qwq in model ID is auto-detected as reasoning."""
+    from agno.models.vllm import VLLM
+
+    model = VLLM(id="Qwen/QwQ-32B")
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_vllm_with_deepseek_r1_model_id():
+    """VLLM with deepseek-r1 in model ID is auto-detected as reasoning."""
+    from agno.models.vllm import VLLM
+
+    model = VLLM(id="deepseek-ai/deepseek-r1-distill-qwen-32b")
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_vllm_with_openthinker_model_id():
+    """VLLM with openthinker in model ID is auto-detected as reasoning."""
+    from agno.models.vllm import VLLM
+
+    model = VLLM(id="openthinker-7b")
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_vllm_enable_thinking_false():
+    """VLLM with enable_thinking=False and non-reasoning ID returns False."""
+    from agno.models.vllm import VLLM
+
+    model = VLLM(id="Llama-3.1-8B", enable_thinking=False)
+    assert is_openai_reasoning_model(model) is False
+
+
+def test_dashscope_with_enable_thinking():
+    """DashScope extends OpenAILike, detected when enable_thinking=True."""
+    from agno.models.dashscope import DashScope
+
+    model = DashScope(id="qwen-plus", enable_thinking=True)
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_dashscope_without_enable_thinking():
+    """DashScope without enable_thinking returns False for non-reasoning model IDs."""
+    from agno.models.dashscope import DashScope
+
+    model = DashScope(id="qwen-plus")
+    assert is_openai_reasoning_model(model) is False
+
+
+def test_dashscope_with_qwen3_model():
+    """DashScope with qwen3 in model ID is auto-detected as reasoning."""
+    from agno.models.dashscope import DashScope
+
+    model = DashScope(id="qwen3-72b")
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_dashscope_with_qwq_model():
+    """DashScope with qwq model ID is auto-detected as reasoning."""
+    from agno.models.dashscope import DashScope
+
+    model = DashScope(id="qwq-32b-preview")
+    assert is_openai_reasoning_model(model) is True
+
+
+def test_openai_like_with_minimax_m3():
+    """Test OpenAILike model with minimax-m3 in ID returns True."""
+    from agno.models.openai.like import OpenAILike
+
+    model = OpenAILike(
+        id="minimax-m3-01-128k",
+        name="MiniMax",
+    )
+    assert is_openai_reasoning_model(model) is True
+
+
 # ============================================================================
 # Anthropic Reasoning Model Tests
 # ============================================================================
@@ -615,13 +759,17 @@ def test_ollama_with_deepseek_r1():
     assert is_ollama_reasoning_model(model) is True
 
 
-def test_ollama_with_qwen2_5_coder():
-    """Test Ollama model with qwen2.5-coder in ID returns True."""
+def test_ollama_with_qwen2_5_coder_is_not_reasoning():
+    """Test Ollama model with qwen2.5-coder in ID returns False.
+
+    qwen2.5-coder is a code-focused model without <think> tag support.
+    Only Qwen3 and QwQ models have thinking capability.
+    """
     model = MockModel(
         class_name="Ollama",
         model_id="qwen2.5-coder:32b",
     )
-    assert is_ollama_reasoning_model(model) is True
+    assert is_ollama_reasoning_model(model) is False
 
 
 def test_ollama_with_openthinker():

--- a/libs/agno/tests/unit/team/test_thinking_content.py
+++ b/libs/agno/tests/unit/team/test_thinking_content.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for team streaming content handling with thinking mode enabled.
+
+Tests cover:
+- Think tag extraction from accumulated streaming content in team _response.py
+- Correct behavior when reasoning_content already exists (native reasoning preserved)
+- No-op behavior for non-thinking model content
+- Proper content/reasoning_content propagation from full_model_response to run_response
+"""
+
+from agno.models.response import ModelResponse
+from agno.run.team import TeamRunOutput
+from agno.utils.reasoning import extract_thinking_content
+
+# =============================================================================
+# Tests for team streaming think tag extraction
+# =============================================================================
+
+
+class TestTeamStreamingThinkTagExtraction:
+    """Test think tag extraction logic applied in team _handle_model_response_stream.
+
+    This mirrors the extraction block added at team/_response.py lines ~1035-1048 (sync)
+    and ~1204-1214 (async). The logic operates on full_model_response before its values
+    are copied into run_response.
+    """
+
+    def _apply_extraction(self, full_model_response: ModelResponse) -> None:
+        """Reproduce the exact extraction logic from team/_response.py."""
+        if (
+            full_model_response.content
+            and isinstance(full_model_response.content, str)
+            and "</think>" in full_model_response.content
+        ):
+            reasoning_content, clean_content = extract_thinking_content(full_model_response.content)
+            if reasoning_content:
+                full_model_response.content = clean_content
+                if not full_model_response.reasoning_content:
+                    full_model_response.reasoning_content = reasoning_content
+
+    def _propagate_to_run_response(self, full_model_response: ModelResponse, run_response: TeamRunOutput) -> None:
+        """Reproduce the propagation logic from team/_response.py lines ~1050-1060."""
+        if full_model_response.content is not None:
+            run_response.content = full_model_response.content
+        if full_model_response.reasoning_content is not None:
+            run_response.reasoning_content = full_model_response.reasoning_content
+
+    def test_think_tags_extracted_and_propagated(self):
+        """Content with <think> tags should be cleaned; reasoning propagated to run_response."""
+        full_model_response = ModelResponse(content="<think>Step-by-step reasoning here</think>Final answer.")
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert full_model_response.content == "Final answer."
+        assert full_model_response.reasoning_content == "Step-by-step reasoning here"
+        assert run_response.content == "Final answer."
+        assert run_response.reasoning_content == "Step-by-step reasoning here"
+
+    def test_no_think_tags_content_unchanged(self):
+        """Content without <think> tags should pass through unmodified."""
+        full_model_response = ModelResponse(content="Plain answer with no thinking.")
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert run_response.content == "Plain answer with no thinking."
+        assert run_response.reasoning_content is None
+
+    def test_existing_reasoning_content_preserved(self):
+        """Native reasoning_content (from model API field) should not be overwritten by tag extraction."""
+        full_model_response = ModelResponse(
+            content="<think>tag-based reasoning</think>output",
+            reasoning_content="native reasoning from API",
+        )
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert full_model_response.content == "output"
+        # Native reasoning preserved
+        assert full_model_response.reasoning_content == "native reasoning from API"
+        assert run_response.reasoning_content == "native reasoning from API"
+
+    def test_think_tags_with_empty_output(self):
+        """When all content is inside <think> tags, content becomes empty string."""
+        full_model_response = ModelResponse(content="<think>All reasoning, no output</think>")
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert run_response.content == ""
+        assert run_response.reasoning_content == "All reasoning, no output"
+
+    def test_none_content_skipped(self):
+        """None content should not be processed at all."""
+        full_model_response = ModelResponse(content=None)
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        # content is None, so propagation condition `content is not None` is False
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert run_response.content is None
+        assert run_response.reasoning_content is None
+
+    def test_multiline_think_content(self):
+        """Multiline reasoning inside <think> tags should be extracted correctly."""
+        full_model_response = ModelResponse(
+            content="<think>\nLine 1: analyze\nLine 2: decide\n</think>\nThe result is X."
+        )
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert "Line 1: analyze" in run_response.reasoning_content
+        assert "Line 2: decide" in run_response.reasoning_content
+        assert run_response.content == "The result is X."
+
+    def test_non_string_content_skipped(self):
+        """Non-string content (e.g., dict for structured output) should not be processed."""
+        full_model_response = ModelResponse(content={"key": "value"})
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert run_response.content == {"key": "value"}
+        assert run_response.reasoning_content is None
+
+    def test_guard_condition_skip_for_no_close_tag(self):
+        """Content with <think> but no </think> should not be processed."""
+        full_model_response = ModelResponse(content="<think>incomplete thinking without close tag")
+        run_response = TeamRunOutput()
+
+        self._apply_extraction(full_model_response)
+        self._propagate_to_run_response(full_model_response, run_response)
+
+        assert run_response.content == "<think>incomplete thinking without close tag"
+        assert run_response.reasoning_content is None

--- a/libs/agno/tests/unit/utils/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/utils/test_reasoning_streaming.py
@@ -1,7 +1,5 @@
 """Tests for streaming <think> tag parsing."""
 
-
-
 from agno.utils.reasoning import (
     ThinkTagStreamState,
     flush_think_tag_state,

--- a/libs/agno/tests/unit/utils/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/utils/test_reasoning_streaming.py
@@ -1,0 +1,108 @@
+"""Tests for streaming <think> tag parsing."""
+
+
+
+from agno.utils.reasoning import (
+    ThinkTagStreamState,
+    flush_think_tag_state,
+    process_think_tag_chunk,
+)
+
+
+class TestThinkTagStreaming:
+    """Tests for in-flight <think> tag parsing during streaming."""
+
+    def test_basic_think_tag_extraction(self):
+        """Test basic extraction of <think> content."""
+        state = ThinkTagStreamState()
+
+        # Simulate streaming: '<think>reasoning</think>answer'
+        result1 = process_think_tag_chunk("<think>", state)
+        assert result1.entered_think is True
+        assert result1.reasoning_content is None
+        assert result1.clean_content is None
+
+        result2 = process_think_tag_chunk("reasoning", state)
+        # Content is buffered until we're sure it's not a closing tag
+
+        result3 = process_think_tag_chunk("</think>", state)
+        assert result3.exited_think is True
+        assert "reasoning" in (result2.reasoning_content or "") + (result3.reasoning_content or "")
+
+        _result4 = process_think_tag_chunk("answer", state)
+        # Content after </think> goes to clean_content
+
+        _flush = flush_think_tag_state(state)
+
+        # Verify accumulated content
+        assert state.accumulated_reasoning == "reasoning"
+        assert "answer" in state.accumulated_content
+
+    def test_partial_tag_handling(self):
+        """Test handling of tags split across chunks."""
+        state = ThinkTagStreamState()
+
+        # Tag split: '<thi' + 'nk>'
+        result1 = process_think_tag_chunk("<thi", state)
+        assert result1.entered_think is False  # Not yet detected
+
+        result2 = process_think_tag_chunk("nk>hello", state)
+        assert result2.entered_think is True  # Now detected
+
+        # Verify state
+        assert state.in_think_block is True
+
+    def test_thinking_tag_variant(self):
+        """Test <thinking> tag variant works too."""
+        state = ThinkTagStreamState()
+
+        process_think_tag_chunk("<thinking>", state)
+        assert state.in_think_block is True
+        assert state.tag_type == "thinking"
+
+        process_think_tag_chunk("deep thoughts", state)
+        process_think_tag_chunk("</thinking>", state)
+
+        assert state.in_think_block is False
+        assert "deep thoughts" in state.accumulated_reasoning
+
+    def test_content_only_no_think_tags(self):
+        """Test content without <think> tags passes through."""
+        state = ThinkTagStreamState()
+
+        _result1 = process_think_tag_chunk("Hello ", state)
+        _result2 = process_think_tag_chunk("world!", state)
+        _flush = flush_think_tag_state(state)
+
+        # All content should be in accumulated_content
+        assert "Hello" in state.accumulated_content
+        assert "world" in state.accumulated_content
+        assert state.accumulated_reasoning == ""
+
+    def test_multiple_think_blocks(self):
+        """Test multiple <think> blocks in one stream."""
+        state = ThinkTagStreamState()
+
+        process_think_tag_chunk("<think>first</think>", state)
+        process_think_tag_chunk("middle", state)
+        process_think_tag_chunk("<think>second</think>", state)
+        process_think_tag_chunk("end", state)
+        flush_think_tag_state(state)
+
+        assert "first" in state.accumulated_reasoning
+        assert "second" in state.accumulated_reasoning
+        assert "middle" in state.accumulated_content
+        assert "end" in state.accumulated_content
+
+    def test_flush_remaining_buffer(self):
+        """Test flushing handles remaining buffered content."""
+        state = ThinkTagStreamState()
+
+        # Partial content that might be a tag
+        process_think_tag_chunk("Hello <thi", state)
+
+        # Flush should emit buffered content
+        flush_result = flush_think_tag_state(state)
+
+        # Since we never completed the tag, it should be in content
+        assert "Hello" in state.accumulated_content or "Hello" in (flush_result.clean_content or "")

--- a/libs/agno/tests/unit/workflow/test_thinking_content.py
+++ b/libs/agno/tests/unit/workflow/test_thinking_content.py
@@ -1,0 +1,462 @@
+"""
+Unit tests for workflow step content handling with thinking mode enabled.
+
+Tests cover:
+- Thinking content extraction from streamed responses with <think> tags
+- Proper content preservation when thinking mode is enabled
+- _prepare_message correctly passes content between workflow steps
+"""
+
+from unittest.mock import MagicMock
+
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+from agno.utils.reasoning import extract_thinking_content
+from agno.workflow.step import Step
+from agno.workflow.types import StepOutput
+
+# =============================================================================
+# Tests for extract_thinking_content
+# =============================================================================
+
+
+class TestExtractThinkingContent:
+    """Test the extract_thinking_content utility used in streaming post-processing."""
+
+    def test_content_with_think_tags(self):
+        content = "<think>I need to analyze this</think>The answer is 42."
+        reasoning, output = extract_thinking_content(content)
+        assert reasoning == "I need to analyze this"
+        assert output == "The answer is 42."
+
+    def test_content_without_think_tags(self):
+        content = "The answer is 42."
+        reasoning, output = extract_thinking_content(content)
+        assert reasoning is None
+        assert output == "The answer is 42."
+
+    def test_empty_output_after_think(self):
+        content = "<think>All reasoning, no output</think>"
+        reasoning, output = extract_thinking_content(content)
+        assert reasoning == "All reasoning, no output"
+        assert output == ""
+
+    def test_empty_content(self):
+        reasoning, output = extract_thinking_content("")
+        assert reasoning is None
+        assert output == ""
+
+    def test_multiline_think_content(self):
+        content = "<think>\nStep 1: analyze\nStep 2: decide\n</think>\nFinal answer here."
+        reasoning, output = extract_thinking_content(content)
+        assert "Step 1: analyze" in reasoning
+        assert output == "Final answer here."
+
+    def test_multiple_think_blocks(self):
+        """Multiple <think> blocks from tool-call iterations should all be extracted."""
+        content = "<think>\nstep1 reasoning\n</think>\n<think>\nstep2 reasoning\n</think>\nFinal answer."
+        reasoning, output = extract_thinking_content(content)
+        assert "step1 reasoning" in reasoning
+        assert "step2 reasoning" in reasoning
+        assert "<think>" not in output
+        assert output == "Final answer."
+
+    def test_multiple_think_blocks_with_tool_results(self):
+        """Simulates accumulated content from a model that thinks before and after tool calls."""
+        content = (
+            "<think>\nI need to call tools\n</think>\n"
+            "<think>\nTool returned data, formatting answer\n</think>\n"
+            "The weather is sunny and population is 5 million."
+        )
+        reasoning, output = extract_thinking_content(content)
+        assert "I need to call tools" in reasoning
+        assert "Tool returned data" in reasoning
+        assert "<think>" not in output
+        assert "weather is sunny" in output
+
+    def test_thinking_tags_variant(self):
+        """Some providers use <thinking> instead of <think> tags."""
+        content = "<thinking>Analyzing the problem</thinking>The solution is X."
+        reasoning, output = extract_thinking_content(content)
+        assert reasoning == "Analyzing the problem"
+        assert output == "The solution is X."
+        assert "<thinking>" not in output
+
+    def test_multiple_thinking_blocks(self):
+        """Multiple <thinking> blocks should all be extracted."""
+        content = "<thinking>First thought</thinking><thinking>Second thought</thinking>Final answer."
+        reasoning, output = extract_thinking_content(content)
+        assert "First thought" in reasoning
+        assert "Second thought" in reasoning
+        assert output == "Final answer."
+
+    def test_mixed_tags_prefers_think(self):
+        """When both </think> and </thinking> are present, <think> takes precedence."""
+        content = "<think>Think content</think><thinking>Thinking content</thinking>Answer."
+        reasoning, output = extract_thinking_content(content)
+        # Current implementation: </think> is checked first, so <think> is extracted
+        assert "Think content" in reasoning
+        # <thinking> block remains in output (known limitation)
+        assert "<thinking>" in output
+
+
+# =============================================================================
+# Tests for _process_step_output with thinking mode
+# =============================================================================
+
+
+class TestProcessStepOutputWithThinking:
+    """Test that _process_step_output correctly preserves content from responses with thinking."""
+
+    def test_step_output_preserves_content_from_run_output(self):
+        """When RunOutput has content (after thinking extraction), StepOutput should preserve it."""
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="test_step", agent=agent)
+
+        run_output = RunOutput(
+            content="This is the actual output after thinking extraction.",
+            reasoning_content="I thought about this carefully.",
+        )
+
+        step_output = step._process_step_output(run_output)
+        assert step_output.content == "This is the actual output after thinking extraction."
+
+    def test_step_output_with_none_content(self):
+        """When RunOutput has None content, StepOutput should have None content."""
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="test_step", agent=agent)
+
+        run_output = RunOutput(
+            content=None,
+            reasoning_content="Only reasoning, no content.",
+        )
+
+        step_output = step._process_step_output(run_output)
+        assert step_output.content is None
+
+    def test_step_output_with_empty_string_content(self):
+        """When RunOutput has empty string content, StepOutput should have empty string."""
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="test_step", agent=agent)
+
+        run_output = RunOutput(content="")
+        step_output = step._process_step_output(run_output)
+        assert step_output.content == ""
+
+
+# =============================================================================
+# Tests for _prepare_message with thinking mode outputs
+# =============================================================================
+
+
+class TestPrepareMessageWithThinking:
+    """Test that _prepare_message correctly handles previous step outputs from thinking models."""
+
+    def test_prepare_message_uses_clean_content(self):
+        """When previous step has clean content (after thinking extraction), it should be used."""
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="step2", agent=agent)
+
+        previous_outputs = {
+            "step1": StepOutput(
+                step_name="step1",
+                content="Clean output from step 1.",
+            )
+        }
+
+        result = step._prepare_message("original input", previous_outputs)
+        assert result == "Clean output from step 1."
+
+    def test_prepare_message_falls_back_on_empty_content(self):
+        """When previous step has empty content, original message should be used."""
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="step2", agent=agent)
+
+        previous_outputs = {
+            "step1": StepOutput(
+                step_name="step1",
+                content="",
+            )
+        }
+
+        result = step._prepare_message("original input", previous_outputs)
+        # Empty string is falsy, so original message is returned
+        assert result == "original input"
+
+    def test_prepare_message_falls_back_on_none_content(self):
+        """When previous step has None content, original message should be used."""
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="step2", agent=agent)
+
+        previous_outputs = {
+            "step1": StepOutput(
+                step_name="step1",
+                content=None,
+            )
+        }
+
+        result = step._prepare_message("original input", previous_outputs)
+        assert result == "original input"
+
+    def test_prepare_message_with_think_tags_in_content(self):
+        """Content with <think> tags should still be passed if non-empty after tags.
+
+        Note: This tests the case where streaming didn't extract think tags (pre-fix).
+        After the fix, the streaming path extracts think tags before content reaches here.
+        """
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        step = Step(name="step2", agent=agent)
+
+        # If somehow think tags are still in content, the content is non-empty and truthy
+        previous_outputs = {
+            "step1": StepOutput(
+                step_name="step1",
+                content="<think>reasoning</think>Actual output",
+            )
+        }
+
+        result = step._prepare_message("original input", previous_outputs)
+        assert result == "<think>reasoning</think>Actual output"
+
+
+# =============================================================================
+# Tests for streaming think tag extraction in handle_model_response_stream
+# =============================================================================
+
+
+class TestStreamingThinkTagExtraction:
+    """Test that <think> tags are extracted from accumulated streaming content.
+
+    This tests the fix applied in handle_model_response_stream and ahandle_model_response_stream
+    that extracts <think> tags from run_response.content after streaming is complete.
+    """
+
+    def test_think_tags_extracted_from_run_response(self):
+        """Simulate what handle_model_response_stream does after streaming with think tags."""
+        run_response = RunOutput()
+        model_response = ModelResponse(content="")
+
+        # Simulate accumulated streaming content with think tags
+        accumulated = "<think>Let me think step by step...</think>The final answer is 42."
+        run_response.content = accumulated
+        model_response.content = accumulated
+
+        # This is the logic from handle_model_response_stream
+        if run_response.content and isinstance(run_response.content, str) and "</think>" in run_response.content:
+            from agno.utils.reasoning import extract_thinking_content
+
+            reasoning_content, clean_content = extract_thinking_content(run_response.content)
+            if reasoning_content:
+                if not run_response.reasoning_content:
+                    run_response.reasoning_content = reasoning_content
+                run_response.content = clean_content
+                model_response.content = clean_content
+                if not model_response.reasoning_content:
+                    model_response.reasoning_content = reasoning_content
+
+        assert run_response.content == "The final answer is 42."
+        assert run_response.reasoning_content == "Let me think step by step..."
+        assert model_response.content == "The final answer is 42."
+        assert model_response.reasoning_content == "Let me think step by step..."
+
+    def test_no_extraction_when_no_think_tags(self):
+        """No extraction should happen when content has no think tags."""
+        run_response = RunOutput()
+        model_response = ModelResponse(content="")
+
+        run_response.content = "Plain content without thinking."
+        model_response.content = "Plain content without thinking."
+
+        if run_response.content and isinstance(run_response.content, str) and "</think>" in run_response.content:
+            from agno.utils.reasoning import extract_thinking_content
+
+            reasoning_content, clean_content = extract_thinking_content(run_response.content)
+            if reasoning_content:
+                run_response.content = clean_content
+
+        assert run_response.content == "Plain content without thinking."
+
+    def test_existing_reasoning_content_not_overwritten(self):
+        """If reasoning_content already exists (from native field), don't overwrite it."""
+        run_response = RunOutput()
+        model_response = ModelResponse(content="")
+
+        run_response.content = "<think>tag-based reasoning</think>output"
+        run_response.reasoning_content = "native reasoning content"
+        model_response.content = run_response.content
+        model_response.reasoning_content = "native reasoning content"
+
+        if run_response.content and isinstance(run_response.content, str) and "</think>" in run_response.content:
+            from agno.utils.reasoning import extract_thinking_content
+
+            reasoning_content, clean_content = extract_thinking_content(run_response.content)
+            if reasoning_content:
+                if not run_response.reasoning_content:
+                    run_response.reasoning_content = reasoning_content
+                run_response.content = clean_content
+                model_response.content = clean_content
+                if not model_response.reasoning_content:
+                    model_response.reasoning_content = reasoning_content
+
+        # Content should be cleaned
+        assert run_response.content == "output"
+        # Existing reasoning_content should be preserved (not overwritten)
+        assert run_response.reasoning_content == "native reasoning content"
+
+    def test_think_tags_with_empty_output(self):
+        """When think tags contain everything and output is empty, content becomes empty string."""
+        run_response = RunOutput()
+        model_response = ModelResponse(content="")
+
+        run_response.content = "<think>Only thinking, no output</think>"
+        model_response.content = run_response.content
+
+        if run_response.content and isinstance(run_response.content, str) and "</think>" in run_response.content:
+            from agno.utils.reasoning import extract_thinking_content
+
+            reasoning_content, clean_content = extract_thinking_content(run_response.content)
+            if reasoning_content:
+                if not run_response.reasoning_content:
+                    run_response.reasoning_content = reasoning_content
+                run_response.content = clean_content
+                model_response.content = clean_content
+                if not model_response.reasoning_content:
+                    model_response.reasoning_content = reasoning_content
+
+        assert run_response.content == ""
+        assert run_response.reasoning_content == "Only thinking, no output"
+
+    def test_none_content_not_processed(self):
+        """None content should not be processed."""
+        run_response = RunOutput()
+        run_response.content = None
+
+        # The condition should prevent processing
+        if run_response.content and isinstance(run_response.content, str) and "</think>" in run_response.content:
+            pass  # Should not reach here
+
+        assert run_response.content is None
+
+    def test_thinking_tags_extracted_from_run_response(self):
+        """Some providers use <thinking> tags instead of <think>."""
+        run_response = RunOutput()
+        model_response = ModelResponse(content="")
+
+        # Simulate content with <thinking> tags
+        accumulated = "<thinking>Analyzing step by step</thinking>The answer is correct."
+        run_response.content = accumulated
+        model_response.content = accumulated
+
+        # Updated logic checks for both tag variants
+        if (
+            run_response.content
+            and isinstance(run_response.content, str)
+            and ("</think>" in run_response.content or "</thinking>" in run_response.content)
+        ):
+            from agno.utils.reasoning import extract_thinking_content
+
+            reasoning_content, clean_content = extract_thinking_content(run_response.content)
+            if reasoning_content:
+                if not run_response.reasoning_content:
+                    run_response.reasoning_content = reasoning_content
+                run_response.content = clean_content
+                model_response.content = clean_content
+
+        assert run_response.content == "The answer is correct."
+        assert run_response.reasoning_content == "Analyzing step by step"
+
+    def test_extraction_handles_plain_content(self):
+        """Plain content without tags should pass through unchanged."""
+        from agno.utils.reasoning import extract_thinking_content
+
+        content = "plain answer without any tags"
+        reasoning, output = extract_thinking_content(content)
+
+        assert reasoning is None
+        assert output == content
+
+
+# =============================================================================
+# Integration-style test for workflow step content flow with thinking
+# =============================================================================
+
+
+class TestWorkflowStepContentFlowWithThinking:
+    """Test end-to-end content flow through workflow steps when thinking mode is enabled."""
+
+    def test_step_output_content_after_think_extraction(self):
+        """
+        Simulate the full flow:
+        1. Model streams response with <think> tags
+        2. After streaming, think tags are extracted from run_response.content
+        3. StepOutput is created from the cleaned RunOutput
+        4. Next step receives clean content via _prepare_message
+        """
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        # Step 1: Create RunOutput as if streaming completed and think tags were extracted
+        run_output_step1 = RunOutput(
+            content="Analysis result from step 1.",
+            reasoning_content="I analyzed the input carefully.",
+        )
+
+        # Process into StepOutput
+        step1 = Step(name="analysis_step", agent=agent)
+        step_output_step1 = step1._process_step_output(run_output_step1)
+        assert step_output_step1.content == "Analysis result from step 1."
+
+        # Step 2: _prepare_message should use step 1's clean content
+        step2 = Step(name="synthesis_step", agent=agent)
+        previous_outputs = {"analysis_step": step_output_step1}
+        message_for_step2 = step2._prepare_message("original user input", previous_outputs)
+        assert message_for_step2 == "Analysis result from step 1."
+
+    def test_step_output_content_before_fix_with_think_tags(self):
+        """
+        Before the fix, streaming would accumulate <think> tags in content.
+        The _prepare_message would still pass the content (with tags) to the next step.
+        After the fix, the tags are extracted and only clean content is passed.
+        """
+        agent = MagicMock()
+        agent.id = "test-agent"
+        agent.name = "Test Agent"
+
+        # Simulate RunOutput AFTER the fix (think tags extracted)
+        run_output = RunOutput(
+            content="Clean output after extraction.",
+            reasoning_content="The extracted thinking content.",
+        )
+
+        step1 = Step(name="step1", agent=agent)
+        step_output = step1._process_step_output(run_output)
+
+        step2 = Step(name="step2", agent=agent)
+        previous_outputs = {"step1": step_output}
+        result = step2._prepare_message("original", previous_outputs)
+
+        # After fix, second step gets clean content
+        assert result == "Clean output after extraction."
+        assert "<think>" not in result


### PR DESCRIPTION
Fixes #6254, fixes #5297, addresses #7602

## Summary

Extends reasoning model detection to all OpenAI-compatible providers and consolidates thinking tag extraction across the codebase.

### Providers Now Supported

| Provider | Detection Method |
|----------|-----------------|
| **OpenAI** | Native (o1, o3, o4, 5.1, 5.2) |
| **Azure OpenAI** | Same as OpenAI |
| **Groq** | `deepseek-r1`, `qwq`, `qwen3`, `gpt-oss`, `openthinker` |
| **Ollama** | `qwq`, `qwen3`, `deepseek-r1`, `openthinker` |
| **DashScope** | `enable_thinking=True`, `qwen3`, `qwq` |
| **DeepSeek** | Native v4 models |
| **VLLM** | `enable_thinking=True` or keyword match |
| **Together/Fireworks/OpenRouter/DeepInfra** | OpenAILike with keyword match |

### Tag Formats Supported

- `<think>...</think>` ✅
- `<thinking>...</thinking>` ✅
- Native `reasoning` field (Groq gpt-oss) ✅
- Native `thinking` field (Ollama) ✅
- Native `reasoning_content` field (OpenAI, DeepSeek) ✅

## Changes

### 1. Multi-block regex extraction (`utils/reasoning.py`)

Models produce multiple `<think>` blocks across tool-call iterations. Changed from `find()` to regex `findall()` to extract ALL blocks:

```python
# Before: Only extracted first block
end_idx = content.find("</think>")
reasoning_content = content[start_idx:end_idx]

# After: Extracts all blocks, handles both tag formats
pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL)
matches = pattern.findall(content)
reasoning_content = "\n".join(m.strip() for m in matches)
```

### 2. Unified streaming guards (`agent/_response.py`, `team/_response.py`)

All 4 streaming paths (sync/async × agent/team) now check for both tag variants:

```python
if ("</think>" in content or "</thinking>" in content):
    reasoning_content, clean_content = extract_thinking_content(content)
```

### 3. Ollama adapter fix (fixes #5297)

The guard only checked `<think>`, missing `<thinking>` tags entirely:

```python
# Before: Missed <thinking> tags
elif content.find("<think>") != -1:

# After: Checks both
elif ("</think>" in content or "</thinking>" in content):
```

### 4. DashScope support documented (#7602)

DashScope already works because it extends `OpenAILike` and has `enable_thinking` parameter. Added 4 unit tests documenting this support.

### 5. Removed qwen2.5-coder from detection

Web search confirmed qwen2.5-coder is NOT a reasoning model — it's a code completion model without thinking capabilities.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Test plan

- [x] 137 unit tests pass (reasoning checkers + streaming extraction)
- [x] E2E tested with OpenRouter qwen3-32b (multi-turn with tools) ✓
- [x] E2E tested curly braces in `<thinking>` tags (issue #5297) ✓
- [x] format.sh and validate.sh pass

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added for new functionality