### PR TITLE
feat: add enrichment_model for LLM-generated document descriptions

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -36,6 +36,7 @@ class Knowledge:
     enable_catalog: bool = False
     enable_backup_tools: bool = False
     backup_dir: Optional[str] = None
+    enrichment_model: Optional[Any] = None
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
@@ -66,6 +67,7 @@ class Knowledge:
             knowledge_name=self.name,
             isolate_vector_search=self.isolate_vector_search,
             managed_backend=self._managed_backend,
+            enrichment_model=self.enrichment_model,
         )
         self._remote_loader = RemoteLoader(
             pipeline=self._pipeline,

--- a/libs/agno/agno/knowledge/pipeline/ingestion.py
+++ b/libs/agno/agno/knowledge/pipeline/ingestion.py
@@ -44,6 +44,7 @@ class IngestionPipeline:
     isolate_vector_search: bool = False
     managed_backend: Optional[Any] = None
     backup_store: Optional[Any] = None
+    enrichment_model: Optional[Any] = None
 
     # ==========================================
     # MAIN ENTRY POINTS
@@ -902,6 +903,8 @@ class IngestionPipeline:
                 return
 
         content.status = ContentStatus.COMPLETED
+        if not content.description and self.enrichment_model is not None:
+            content.description = self._generate_description(content, read_documents)
         self.content_store.update(content, vector_db=self.vector_db)  # type: ignore[union-attr]
         self._backup_documents(content, read_documents)
 
@@ -941,6 +944,8 @@ class IngestionPipeline:
                 return
 
         content.status = ContentStatus.COMPLETED
+        if not content.description and self.enrichment_model is not None:
+            content.description = await self._agenerate_description(content, read_documents)
         await self.content_store.aupdate(content, vector_db=self.vector_db)  # type: ignore[union-attr]
         await self._abackup_documents(content, read_documents)
 
@@ -1127,6 +1132,52 @@ class IngestionPipeline:
                 )
         except Exception as e:
             log_warning(f"Could not backup content {content.id}: {e}")
+
+    # ==========================================
+    # ENRICHMENT (LLM description generation)
+    # ==========================================
+
+    _ENRICHMENT_SYSTEM_PROMPT = (
+        "You are a document cataloging assistant. "
+        "Given document content, write a single sentence description "
+        "suitable for a document catalog. Be concise: 10-25 words, no quotes, no formatting."
+    )
+
+    def _generate_description(self, content: Content, read_documents: List[Document]) -> str:
+        """Generate a short description for the content using the enrichment model."""
+        try:
+            from agno.models.message import Message
+
+            sample_text = "\n\n".join(d.content for d in read_documents if d.content)[:2000]
+            name = content.name or "document"
+            messages = [
+                Message(role="system", content=self._ENRICHMENT_SYSTEM_PROMPT),
+                Message(role="user", content=f"Document name: {name}\n\nContent sample:\n{sample_text}"),
+            ]
+            response = self.enrichment_model.response(messages=messages)
+            description = (response.content or "").strip()
+            return description[:200]
+        except Exception as e:
+            log_warning(f"Could not generate description for {content.id}: {e}")
+            return ""
+
+    async def _agenerate_description(self, content: Content, read_documents: List[Document]) -> str:
+        """Async variant of _generate_description."""
+        try:
+            from agno.models.message import Message
+
+            sample_text = "\n\n".join(d.content for d in read_documents if d.content)[:2000]
+            name = content.name or "document"
+            messages = [
+                Message(role="system", content=self._ENRICHMENT_SYSTEM_PROMPT),
+                Message(role="user", content=f"Document name: {name}\n\nContent sample:\n{sample_text}"),
+            ]
+            response = await self.enrichment_model.aresponse(messages=messages)
+            description = (response.content or "").strip()
+            return description[:200]
+        except Exception as e:
+            log_warning(f"Could not generate description for {content.id}: {e}")
+            return ""
 
     # ==========================================
     # MANAGED BACKEND INGESTION

--- a/libs/agno/tests/unit/knowledge/test_enrichment_model.py
+++ b/libs/agno/tests/unit/knowledge/test_enrichment_model.py
@@ -1,0 +1,177 @@
+"""Tests for enrichment_model description generation."""
+
+from dataclasses import dataclass
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.knowledge.content import Content, ContentStatus
+from agno.knowledge.document import Document
+from agno.knowledge.pipeline.ingestion import IngestionPipeline
+
+
+@dataclass
+class MockModelResponse:
+    content: Optional[str] = None
+
+
+class MockModel:
+    """Mock model that returns a fixed description."""
+
+    def __init__(self, description: str = "A test document about important topics"):
+        self._description = description
+
+    def response(self, messages=None, **kwargs):
+        return MockModelResponse(content=self._description)
+
+    async def aresponse(self, messages=None, **kwargs):
+        return MockModelResponse(content=self._description)
+
+
+class MockFailingModel:
+    """Mock model that raises an exception."""
+
+    def response(self, messages=None, **kwargs):
+        raise RuntimeError("Model unavailable")
+
+    async def aresponse(self, messages=None, **kwargs):
+        raise RuntimeError("Model unavailable")
+
+
+@pytest.fixture
+def pipeline():
+    return IngestionPipeline(
+        vector_db=MagicMock(),
+        content_store=MagicMock(),
+        reader_registry=MagicMock(),
+    )
+
+
+@pytest.fixture
+def documents():
+    return [
+        Document(content="This is a report about quarterly financials."),
+        Document(content="Revenue grew by 15% year over year."),
+    ]
+
+
+@pytest.fixture
+def content():
+    return Content(
+        id="test-id",
+        name="Q4 Report",
+        description=None,
+        status=ContentStatus.PROCESSING,
+    )
+
+
+class TestGenerateDescription:
+    def test_generates_description(self, pipeline, documents, content):
+        pipeline.enrichment_model = MockModel("Quarterly financial report with revenue analysis")
+        result = pipeline._generate_description(content, documents)
+        assert result == "Quarterly financial report with revenue analysis"
+
+    def test_truncates_long_description(self, pipeline, documents, content):
+        long_desc = "x" * 300
+        pipeline.enrichment_model = MockModel(long_desc)
+        result = pipeline._generate_description(content, documents)
+        assert len(result) == 200
+
+    def test_returns_empty_on_failure(self, pipeline, documents, content):
+        pipeline.enrichment_model = MockFailingModel()
+        result = pipeline._generate_description(content, documents)
+        assert result == ""
+
+    def test_uses_document_name_in_prompt(self, pipeline, content):
+        pipeline.enrichment_model = MockModel("test")
+        docs = [Document(content="sample text")]
+        with patch.object(pipeline.enrichment_model, "response", wraps=pipeline.enrichment_model.response) as mock_resp:
+            pipeline._generate_description(content, docs)
+            call_args = mock_resp.call_args
+            messages = call_args[1].get("messages") or call_args[0][0]
+            user_msg = next(m for m in messages if m.role == "user")
+            assert "Q4 Report" in user_msg.content
+
+    @pytest.mark.asyncio
+    async def test_async_generates_description(self, pipeline, documents, content):
+        pipeline.enrichment_model = MockModel("Async description result")
+        result = await pipeline._agenerate_description(content, documents)
+        assert result == "Async description result"
+
+    @pytest.mark.asyncio
+    async def test_async_returns_empty_on_failure(self, pipeline, documents, content):
+        pipeline.enrichment_model = MockFailingModel()
+        result = await pipeline._agenerate_description(content, documents)
+        assert result == ""
+
+
+class TestEnrichmentInHandleVectorDbInsert:
+    """Test that enrichment is called at the right time in handle_vector_db_insert."""
+
+    def test_enrichment_called_when_no_description(self, pipeline, documents):
+        content = Content(id="test-id", name="test", description=None, status=ContentStatus.PROCESSING)
+        pipeline.enrichment_model = MockModel("Generated description")
+
+        mock_vdb = MagicMock()
+        mock_vdb.upsert_available.return_value = True
+        pipeline.vector_db = mock_vdb
+
+        mock_store = MagicMock()
+        pipeline.content_store = mock_store
+
+        pipeline.handle_vector_db_insert(content, documents, upsert=True)
+
+        assert content.description == "Generated description"
+        assert content.status == ContentStatus.COMPLETED
+
+    def test_enrichment_skipped_when_description_exists(self, pipeline, documents):
+        content = Content(
+            id="test-id", name="test", description="User-provided description", status=ContentStatus.PROCESSING
+        )
+        pipeline.enrichment_model = MockModel("Should not be used")
+
+        mock_vdb = MagicMock()
+        mock_vdb.upsert_available.return_value = True
+        pipeline.vector_db = mock_vdb
+
+        mock_store = MagicMock()
+        pipeline.content_store = mock_store
+
+        pipeline.handle_vector_db_insert(content, documents, upsert=True)
+
+        assert content.description == "User-provided description"
+
+    def test_enrichment_skipped_when_no_model(self, pipeline, documents):
+        content = Content(id="test-id", name="test", description=None, status=ContentStatus.PROCESSING)
+        pipeline.enrichment_model = None
+
+        mock_vdb = MagicMock()
+        mock_vdb.upsert_available.return_value = True
+        pipeline.vector_db = mock_vdb
+
+        mock_store = MagicMock()
+        pipeline.content_store = mock_store
+
+        pipeline.handle_vector_db_insert(content, documents, upsert=True)
+
+        assert content.description is None
+
+    @pytest.mark.asyncio
+    async def test_async_enrichment_called_when_no_description(self, pipeline, documents):
+        content = Content(id="test-id", name="test", description=None, status=ContentStatus.PROCESSING)
+        pipeline.enrichment_model = MockModel("Async generated")
+
+        mock_vdb = MagicMock()
+        mock_vdb.upsert_available.return_value = True
+        mock_vdb.async_upsert = AsyncMock()
+        pipeline.vector_db = mock_vdb
+
+        mock_store = MagicMock()
+        mock_store.aupdate = AsyncMock()
+        pipeline.content_store = mock_store
+
+        await pipeline.ahandle_vector_db_insert(content, documents, upsert=True)
+
+        assert content.description == "Async generated"
+        assert content.status == ContentStatus.COMPLETED


### PR DESCRIPTION
## Summary

Adds an optional `enrichment_model` field to `Knowledge` that auto-generates short document descriptions during ingestion using an LLM. Descriptions flow through `ContentStore` -> `KnowledgeCatalog` -> agent system prompt, enabling agents to know what each document is about before searching.

### How it works

- `enrichment_model: Optional[Model]` field on `Knowledge`, passed to `IngestionPipeline`
- After successful vector DB insertion, if `content.description` is empty and model is set, calls `model.response()` with a catalog-style prompt
- Generates concise 10-25 word descriptions, truncated to 200 chars
- Never overwrites user-supplied descriptions
- Graceful failure: logs warning, leaves description empty, never blocks ingestion

### Usage

```python
from agno.models.openai import OpenAIChat

knowledge = Knowledge(
    vector_db=qdrant,
    enrichment_model=OpenAIChat(id="gpt-4o-mini"),
    enable_catalog=True,
)
knowledge.insert(path="data/report.pdf")
# description auto-generated and visible in catalog
```

### Files modified

- `libs/agno/agno/knowledge/pipeline/ingestion.py` — `enrichment_model` field, `_generate_description()` / `_agenerate_description()`, call sites in `handle_vector_db_insert`
- `libs/agno/agno/knowledge/knowledge.py` — `enrichment_model` field, wired to pipeline

### New files

- `libs/agno/tests/unit/knowledge/test_enrichment_model.py` — 10 tests

Depends on Phase 4 (#6727).

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

All 10 new tests pass. Uses the same `model.response(messages)` pattern as `SummarizeStrategy` and `SessionSummaryManager`.