### PR TITLE
fix: include full system prompt in Anthropic model traces

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1639,22 +1639,29 @@ def get_messages_for_parser_model_stream(
 
 
 def get_messages_for_output_model(agent: Agent, messages: List[Message]) -> List[Message]:
-    """Get the messages for the output model."""
+    """Get the messages for the output model.
+
+    Returns a new list so the original run messages (and their system prompt)
+    are never mutated — this keeps traces/observability accurate.
+    """
+    from copy import deepcopy
+
+    output_messages = [deepcopy(m) for m in messages]
 
     if agent.output_model_prompt is not None:
         system_message_exists = False
-        for message in messages:
+        for message in output_messages:
             if message.role == "system":
                 system_message_exists = True
                 message.content = agent.output_model_prompt
                 break
         if not system_message_exists:
-            messages.insert(0, Message(role="system", content=agent.output_model_prompt))
+            output_messages.insert(0, Message(role="system", content=agent.output_model_prompt))
 
     # Remove the last assistant message from the messages list
-    messages.pop(-1)
+    output_messages.pop(-1)
 
-    return messages
+    return output_messages
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -555,7 +555,8 @@ class Claude(Model):
                 )
                 request_kwargs["system"] = [{"text": system_message, "type": "text", "cache_control": cache_control}]
             else:
-                request_kwargs["system"] = [{"text": system_message, "type": "text"}]
+                # Use plain string so trace/observability tools can read the full prompt
+                request_kwargs["system"] = system_message
 
         # Add code execution tool if skills are enabled
         if self.skills:


### PR DESCRIPTION
## Summary

Fixes #6540

The system prompt was being truncated in traces/observability tools (OpenLIT, Langfuse, etc.) when using Anthropic Claude models. Two root causes:

**1. In-place mutation of run messages (`agent/_messages.py`)**

`get_messages_for_output_model` was mutating the original `messages` list directly — overwriting the system message content with `output_model_prompt` and popping the last message. Since `run_response.messages` references the same list, the full system prompt was lost by the time traces captured it.

Fix: deep-copy the messages list before modifying it, so the originals stay intact.

**2. Unnecessary list wrapping (`models/anthropic/claude.py`)**

When prompt caching is disabled, the system message was still being wrapped in `[{"text": ..., "type": "text"}]` format. Trace/observability tools that instrument the Anthropic client typically expect a plain string for the `system` parameter. The list format caused them to either truncate or skip the content.

Fix: pass the system message as a plain string when caching is not enabled. The Anthropic API accepts both formats.

---

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A