### PR TITLE
fix: add source type identifier to AGUI events for agent/team distinction

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -238,6 +238,32 @@ def _format_reasoning_step_delta(step: Optional[ReasoningStep], step_number: int
     return "\n".join(parts) + "\n\n" if parts else ""
 
 
+def _extract_source_metadata(chunk: Union[RunOutputEvent, TeamRunOutputEvent]) -> Dict[str, str]:
+    """Extract source metadata (type, id, name) from a chunk for AG-UI event enrichment."""
+    metadata: Dict[str, str] = {}
+    agent_id = getattr(chunk, "agent_id", "")
+    agent_name = getattr(chunk, "agent_name", "")
+    team_id = getattr(chunk, "team_id", "")
+    team_name = getattr(chunk, "team_name", "")
+
+    # Use camelCase keys to stay consistent with ag_ui's alias_generator
+    # (extra fields bypass alias_generator, so we apply the convention manually)
+    if team_id or team_name:
+        metadata["sourceType"] = "team"
+        if team_id:
+            metadata["sourceId"] = team_id
+        if team_name:
+            metadata["sourceName"] = team_name
+    elif agent_id or agent_name:
+        metadata["sourceType"] = "agent"
+        if agent_id:
+            metadata["sourceId"] = agent_id
+        if agent_name:
+            metadata["sourceName"] = agent_name
+
+    return metadata
+
+
 def _create_events_from_chunk(
     chunk: Union[RunOutputEvent, TeamRunOutputEvent],
     message_id: str,
@@ -257,6 +283,9 @@ def _create_events_from_chunk(
         Tuple of (events_to_emit, new_message_started_state, message_id)
     """
     events_to_emit: List[BaseEvent] = []
+
+    # Extract source metadata for enriching AG-UI events
+    source_metadata = _extract_source_metadata(chunk)
 
     # Extract content if the contextual event is a content event
     if chunk.event == RunEvent.run_content:
@@ -280,6 +309,7 @@ def _create_events_from_chunk(
                 type=EventType.TEXT_MESSAGE_START,
                 message_id=message_id,
                 role="assistant",
+                **source_metadata,
             )
             events_to_emit.append(start_event)
 

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -86,6 +86,9 @@ class EventBuffer:
     pending_tool_calls_parent_id: str = ""  # Parent message ID for pending tool calls
     reasoning_message_id: Optional[str] = None  # Active reasoning session ID, set by reasoning_started
     reasoning_step_count: int = 0  # Step counter for ReasoningTools (reset each session)
+    current_source_key: str = (
+        ""  # "<sourceType>:<sourceId>" of the active text message, for source-change boundary detection
+    )
 
     def __init__(self):
         self.active_tool_call_ids = set()
@@ -95,6 +98,19 @@ class EventBuffer:
         self.pending_tool_calls_parent_id = ""
         self.reasoning_message_id = None
         self.reasoning_step_count = 0
+        self.current_source_key = ""
+
+    def source_changed(self, new_source_key: str) -> bool:
+        """Return True if source key differs from the active one AND both are non-empty.
+
+        Used to insert TEXT_MESSAGE_END + new TEXT_MESSAGE_START boundaries when
+        a nested team's sub-team and member agent share a streaming text message
+        (issue #6141). Returns False when either key is empty so chunks without
+        source metadata don't trigger spurious boundaries.
+        """
+        if not new_source_key or not self.current_source_key:
+            return False
+        return new_source_key != self.current_source_key
 
     def start_tool_call(self, tool_call_id: str) -> None:
         """Start a new tool call."""
@@ -286,6 +302,12 @@ def _create_events_from_chunk(
 
     # Extract source metadata for enriching AG-UI events
     source_metadata = _extract_source_metadata(chunk)
+    # Build a source key only when we actually have a source type; otherwise leave it empty so
+    # anonymous chunks (no agent_id/team_id) don't trigger a spurious boundary against an
+    # established source key like "agent:a-1".
+    source_type = source_metadata.get("sourceType", "")
+    source_id = source_metadata.get("sourceId", "")
+    new_source_key = f"{source_type}:{source_id}" if source_type else ""
 
     # Extract content if the contextual event is a content event
     if chunk.event == RunEvent.run_content:
@@ -297,10 +319,29 @@ def _create_events_from_chunk(
 
     # Handle text responses
     if content is not None:
+        # Source-change boundary (issue #6141): when a different agent/team starts
+        # streaming mid-message, end the current message and start a fresh one with
+        # a new message_id, so consumers can attribute each chunk to its source.
+        if message_started and event_buffer.source_changed(new_source_key):
+            events_to_emit.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+            message_id = event_buffer.start_text_message()
+            event_buffer.current_source_key = new_source_key
+            # Mirror the first-message path: clear pending tool-call parent so a subsequent
+            # tool call inside the new source's segment parents to the new message_id, not the old.
+            event_buffer.clear_pending_tool_calls_parent_id()
+            events_to_emit.append(
+                TextMessageStartEvent(
+                    type=EventType.TEXT_MESSAGE_START,
+                    message_id=message_id,
+                    role="assistant",
+                    **source_metadata,
+                )
+            )
         # Handle the message start event, emitted once per message
-        if not message_started:
+        elif not message_started:
             message_started = True
             message_id = event_buffer.start_text_message()
+            event_buffer.current_source_key = new_source_key
 
             # Clear pending tool calls parent ID when starting new text message
             event_buffer.clear_pending_tool_calls_parent_id()
@@ -354,6 +395,7 @@ def _create_events_from_chunk(
                     type=EventType.TEXT_MESSAGE_START,
                     message_id=parent_message_id,
                     role="assistant",
+                    **source_metadata,
                 )
                 events_to_emit.append(text_start)
 
@@ -491,6 +533,7 @@ def _create_completion_events(
 ) -> List[BaseEvent]:
     """Create events for run completion."""
     events_to_emit: List[BaseEvent] = []
+    source_metadata = _extract_source_metadata(chunk)
 
     # Close orphaned reasoning session if stream ended mid-reasoning
     if event_buffer.reasoning_message_id is not None:
@@ -526,6 +569,7 @@ def _create_completion_events(
                 type=EventType.TEXT_MESSAGE_START,
                 message_id=assistant_message_id,
                 role="assistant",
+                **source_metadata,
             )
             events_to_emit.append(assistant_start_event)
 

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -1502,3 +1502,274 @@ def test_extract_agui_user_input_multimodal_content():
     result = extract_agui_user_input(messages)
 
     assert result == "describe this image"
+
+
+# ---------------------------------------------------------------------------
+# PR #6782 — source metadata + source-change boundary (issue #6141)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_source_metadata_agent_in_text_message_start():
+    """Agent chunks produce TEXT_MESSAGE_START with sourceType='agent' + sourceId/sourceName."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "hi from agent"
+        text.agent_id = "a-1"
+        text.agent_name = "Agent One"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "sourceType", None) == "agent"
+    assert getattr(starts[0], "sourceId", None) == "a-1"
+    assert getattr(starts[0], "sourceName", None) == "Agent One"
+
+
+@pytest.mark.asyncio
+async def test_source_metadata_team_in_text_message_start():
+    """Team chunks produce TEXT_MESSAGE_START with sourceType='team' + sourceId/sourceName."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "hi from team"
+        text.team_id = "t-1"
+        text.team_name = "Team One"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "sourceType", None) == "team"
+    assert getattr(starts[0], "sourceId", None) == "t-1"
+    assert getattr(starts[0], "sourceName", None) == "Team One"
+
+
+@pytest.mark.asyncio
+async def test_source_metadata_team_takes_precedence_over_agent():
+    """When both agent_id and team_id are set, sourceType is 'team'."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "both"
+        text.agent_id = "a-1"
+        text.team_id = "t-1"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "sourceType", None) == "team"
+    assert getattr(starts[0], "sourceId", None) == "t-1"
+
+
+@pytest.mark.asyncio
+async def test_source_metadata_absent_when_no_ids():
+    """Chunks without agent_id or team_id produce no source metadata on the start event."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "anon"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "sourceType", None) is None
+
+
+@pytest.mark.asyncio
+async def test_single_source_emits_no_extra_boundary():
+    """Multiple content chunks from the same source produce exactly 1 START + 1 END."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        for chunk_content in ["hello", " world", "!"]:
+            c = RunContentEvent()
+            c.event = RunEvent.run_content
+            c.content = chunk_content
+            c.agent_id = "a-1"
+            c.agent_name = "Agent"
+            yield c
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == 1, f"Expected 1 START, got {len(starts)}"
+    assert len(ends) == 1, f"Expected 1 END, got {len(ends)}"
+
+
+@pytest.mark.asyncio
+async def test_source_change_emits_message_boundary():
+    """When source changes mid-stream (e.g. sub-team -> member agent in nested teams),
+    a TEXT_MESSAGE_END + new TEXT_MESSAGE_START boundary is emitted with a distinct
+    messageId. Regression guard for issue #6141.
+    """
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        team_chunk = RunContentEvent()
+        team_chunk.event = RunEvent.run_content
+        team_chunk.content = "from team"
+        team_chunk.team_id = "team-A"
+        team_chunk.team_name = "TeamA"
+        yield team_chunk
+
+        agent_chunk = RunContentEvent()
+        agent_chunk.event = RunEvent.run_content
+        agent_chunk.content = "from agent"
+        agent_chunk.agent_id = "agent-X"
+        agent_chunk.agent_name = "AgentX"
+        yield agent_chunk
+
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == 2, f"Expected 2 STARTs (team + agent), got {len(starts)}"
+    assert len(ends) == 2, f"Expected 2 ENDs, got {len(ends)}"
+    assert starts[0].message_id != starts[1].message_id, "Boundary STARTs must have distinct messageIds"
+    assert getattr(starts[0], "sourceType", None) == "team"
+    assert getattr(starts[0], "sourceId", None) == "team-A"
+    assert getattr(starts[1], "sourceType", None) == "agent"
+    assert getattr(starts[1], "sourceId", None) == "agent-X"
+
+
+def test_eventbuffer_source_changed():
+    """Direct unit test of EventBuffer.source_changed semantics."""
+    b = EventBuffer()
+    assert b.source_changed("agent:a1") is False  # no prior source -> no trigger
+    b.current_source_key = "team:t1"
+    assert b.source_changed("team:t1") is False  # same
+    assert b.source_changed("agent:a1") is True  # different
+    assert b.source_changed("") is False  # empty new key -> no trigger
+
+
+@pytest.mark.asyncio
+async def test_tool_call_parent_carries_source_metadata():
+    """When tool calls fire without a preceding text message, the synthetic parent
+    TextMessageStartEvent (utils.py site #2) also carries source metadata.
+    """
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        tool_start = ToolCallStartedEvent()
+        tool_start.event = RunEvent.tool_call_started
+        tool_start.content = ""
+        tool_start.agent_id = "agent-X"
+        tool_start.agent_name = "AgentX"
+        tc = MagicMock()
+        tc.tool_call_id = "tc-1"
+        tc.tool_name = "search"
+        tc.tool_args = {}
+        tool_start.tool = tc
+        yield tool_start
+
+        tool_end = ToolCallCompletedEvent()
+        tool_end.event = RunEvent.tool_call_completed
+        tool_end.content = ""
+        tool_end.agent_id = "agent-X"
+        tool_end.tool = tc
+        yield tool_end
+
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    sourced_starts = [e for e in starts if getattr(e, "sourceType", None) == "agent"]
+    assert len(sourced_starts) == 1, f"Expected exactly 1 sourced TextMessageStartEvent, got {len(sourced_starts)}"
+
+
+@pytest.mark.asyncio
+async def test_attributed_followed_by_unattributed_no_spurious_boundary():
+    """Once a source is established, anonymous chunks (no agent_id/team_id) must NOT trigger
+    a source-change boundary. Regression guard for the ':' sentinel bug where an empty source
+    metadata dict produced a truthy key ':' that satisfied source_changed()'s guards.
+    """
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        c1 = RunContentEvent()
+        c1.event = RunEvent.run_content
+        c1.content = "from agent"
+        c1.agent_id = "a-1"
+        c1.agent_name = "Agent"
+        yield c1
+
+        # Anonymous chunk - no agent_id, no team_id. Must not trigger a boundary.
+        c2 = RunContentEvent()
+        c2.event = RunEvent.run_content
+        c2.content = " continuation"
+        yield c2
+
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == 1, f"Anonymous follow-up must not trigger new START, got {len(starts)}"
+    assert len(ends) == 1, f"Anonymous follow-up must not trigger spurious END, got {len(ends)}"


### PR DESCRIPTION
## Summary

Fixes #6141

Currently there is no way for AG-UI consumers to tell whether a `TEXT_MESSAGE_START` event originated from an agent or a team. This makes it difficult to render messages differently in the UI depending on the source.

This PR adds a `_extract_source_metadata()` helper in `agui/utils.py` that reads `agent_id`/`agent_name` or `team_id`/`team_name` from Agno run event chunks and injects them as extra fields into the `TextMessageStartEvent` payload:

```json
{
  "type": "TEXT_MESSAGE_START",
  "messageId": "...",
  "role": "assistant",
  "sourceType": "agent",
  "sourceId": "agent-123",
  "sourceName": "MyAgent"
}
```

This works because AG-UI's `BaseEvent` has `extra='allow'` in its Pydantic config. The field names use camelCase to stay consistent with the rest of the event schema.

All 33 existing AGUI unit tests pass.

---

## Type of change

- [x] New feature
- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (9 unit tests covering source metadata extraction and source-change boundary logic; see maintainer-additions section below)

---

## Maintainer additions (rebase + extended scope)

Rebased onto current `main` and extended to fully address #6141.

### Phase A — broader source metadata coverage

`_extract_source_metadata` is now applied at all 3 `TextMessageStartEvent` emit sites in `utils.py`, not just the content-branch start:

- `_create_events_from_chunk` content branch (Br1an67's original)
- `_create_events_from_chunk` tool-call parent (synthetic message when a tool fires without a preceding text message)
- `_create_completion_events` external-execution assistant (`RunPausedEvent` path)

`_create_completion_events` extracts source metadata at the top so site #3 has it in scope.

### Phase B — source-change boundary (root cause of #6141)

The root cause of #6141 is that `_create_events_from_chunk` emits a `TEXT_MESSAGE_START` only on the first content chunk. Once `message_started=True`, subsequent chunks reuse the same `message_id` regardless of whether the chunk's source (`agent_id`/`team_id`) changed. In a nested-team scenario with parallel member execution, sub-team and member chunks share one `messageId` with no intervening `TEXT_MESSAGE_END`, so consumers cannot delimit messages by source.

`EventBuffer` now tracks the active source:

- `current_source_key: str` field — `"<sourceType>:<sourceId>"` of the active text message
- `source_changed(new_source_key)` method — returns `True` only when both keys are non-empty AND differ

The content branch in `_create_events_from_chunk` detects mid-stream source change and emits `TEXT_MESSAGE_END` + fresh `TEXT_MESSAGE_START` with a new `message_id` and the new source's metadata. The boundary branch also clears the pending tool-call parent id (mirroring the first-message path) so a subsequent tool call parents to the new message, not the old one.

`new_source_key` is built as `""` when no `sourceType` is present, so anonymous chunks following attributed chunks do NOT fire a spurious boundary against the prior source key.

### Backward compatibility

| Flow | Behavior |
|---|---|
| Single agent (no team) | unchanged — source never changes |
| Single team (no nesting) | unchanged — source never changes |
| Agent with tool calls | unchanged — tool-call branch already creates boundaries |
| Nested team without tool calls between sources | **new boundary inserted** (the bug being fixed) |

### Tests added (9 in `libs/agno/tests/unit/app/test_agui_app.py`)

- `test_source_metadata_agent_in_text_message_start`
- `test_source_metadata_team_in_text_message_start`
- `test_source_metadata_team_takes_precedence_over_agent`
- `test_source_metadata_absent_when_no_ids`
- `test_single_source_emits_no_extra_boundary`
- `test_source_change_emits_message_boundary` — primary regression guard for #6141
- `test_eventbuffer_source_changed`
- `test_tool_call_parent_carries_source_metadata`
- `test_attributed_followed_by_unattributed_no_spurious_boundary` — guards the anonymous-chunk edge case

49/49 tests pass in `test_agui_app.py`. `ruff format`, `ruff check`, and `mypy` clean on the changed files.

### Manual verification

Tested end-to-end with a nested team `RootTeam → SubTeam → MemberAgent`:

- `curl /agui` produces 3 distinct `messageId`s with `sourceType` tags (`team`/`agent`) and balanced `TEXT_MESSAGE_END` counts
- CopilotKit dojo renders the response as separate text blocks per source (e.g. `__67__` from MemberAgent and `RootTeam confirms: 67` as two distinct chat bubbles)
- Side-by-side A/B against vanilla `origin/main` confirms the BEFORE state shows merged-bubble rendering with no `sourceType` field