### PR TITLE
fix: refresh tool registry during execution loop for dynamically added tools

### DIFF
--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -268,6 +268,29 @@ def add_tool(agent: Agent, tool: Union[Toolkit, Callable, Function, Dict]) -> No
         agent.tools = []
     agent.tools.append(tool)  # type: ignore[union-attr]
 
+    # If mid-execution, also add processed tool(s) to the active model tools list
+    # so they become visible in the current run's tool execution loop.
+    active_tools: Optional[list] = getattr(agent, "_active_model_tools", None)
+    if active_tools is not None:
+        if isinstance(tool, Function):
+            func = tool.model_copy(deep=True)
+            func.process_entrypoint()
+            func._agent = agent
+            active_tools.append(func)
+        elif isinstance(tool, dict):
+            active_tools.append(tool)
+        elif isinstance(tool, Toolkit):
+            for _name, func in tool.get_functions().items():
+                func = func.model_copy(deep=True)
+                func.process_entrypoint()
+                func._agent = agent
+                active_tools.append(func)
+        elif callable(tool):
+            func = Function.from_callable(tool)
+            func = func.model_copy(deep=True)
+            func._agent = agent
+            active_tools.append(func)
+
 
 def set_tools(agent: Agent, tools: Union[Sequence[Union[Toolkit, Callable, Function, Dict]], Callable]) -> None:
     from agno.utils.callables import is_callable_factory

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -474,6 +474,9 @@ def determine_tools_for_model(
                 func._audios = joint_audios
                 func._videos = joint_videos
 
+    # Store reference so add_tool() can append mid-execution
+    agent._active_model_tools = _functions
+
     return _functions
 
 

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -668,6 +668,7 @@ class Model(ABC):
 
             _tool_dicts = self._format_tools(tools) if tools is not None else []
             _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+            _num_tools = len(tools) if tools is not None else 0
 
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
@@ -829,6 +830,12 @@ class Model(ABC):
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
 
+                    # Refresh tool registry if tools were added during execution
+                    if tools is not None and len(tools) != _num_tools:
+                        _num_tools = len(tools)
+                        _tool_dicts = self._format_tools(tools)
+                        _functions = {t.name: t for t in tools if isinstance(t, Function)}
+
                     # Continue loop to get next response
                     continue
 
@@ -888,6 +895,7 @@ class Model(ABC):
 
             _tool_dicts = self._format_tools(tools) if tools is not None else []
             _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+            _num_tools = len(tools) if tools is not None else 0
 
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
@@ -1049,6 +1057,12 @@ class Model(ABC):
                     if run_response is not None and run_response.requirements:
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
+
+                    # Refresh tool registry if tools were added during execution
+                    if tools is not None and len(tools) != _num_tools:
+                        _num_tools = len(tools)
+                        _tool_dicts = self._format_tools(tools)
+                        _functions = {t.name: t for t in tools if isinstance(t, Function)}
 
                     # Continue loop to get next response
                     continue
@@ -1359,6 +1373,7 @@ class Model(ABC):
 
             _tool_dicts = self._format_tools(tools) if tools is not None else []
             _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+            _num_tools = len(tools) if tools is not None else 0
 
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
@@ -1535,6 +1550,12 @@ class Model(ABC):
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
 
+                    # Refresh tool registry if tools were added during execution
+                    if tools is not None and len(tools) != _num_tools:
+                        _num_tools = len(tools)
+                        _tool_dicts = self._format_tools(tools)
+                        _functions = {t.name: t for t in tools if isinstance(t, Function)}
+
                     # Continue loop to get next response
                     continue
 
@@ -1635,6 +1656,7 @@ class Model(ABC):
 
             _tool_dicts = self._format_tools(tools) if tools is not None else []
             _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+            _num_tools = len(tools) if tools is not None else 0
 
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
@@ -1810,6 +1832,12 @@ class Model(ABC):
                     if run_response is not None and run_response.requirements:
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
+
+                    # Refresh tool registry if tools were added during execution
+                    if tools is not None and len(tools) != _num_tools:
+                        _num_tools = len(tools)
+                        _tool_dicts = self._format_tools(tools)
+                        _functions = {t.name: t for t in tools if isinstance(t, Function)}
 
                     # Continue loop to get next response
                     continue


### PR DESCRIPTION
## Summary

Fixes #6299

When calling `agent.add_tool()` from within a tool execution, the newly added tools are not available during the current run. They only become visible on the next `agent.run()` call.

The root cause is that `_functions` and `_tool_dicts` are built once before the tool execution loop in `models/base.py`, and never refreshed even if the tools list grows mid-execution.

**Changes:**

1. **`agent/_tools.py`** — stores the active model tools list reference on the agent (`agent._active_model_tools`) so `add_tool()` can reach it during execution.

2. **`agent/_init.py`** — when `add_tool()` is called mid-execution, it now also processes the new tool into a `Function` and appends it to the active model tools list. Handles all tool types (Function, dict, Toolkit, callable).

3. **`models/base.py`** — all 4 response methods (`response`, `aresponse`, `response_stream`, `aresponse_stream`) now track the tools count and rebuild `_tool_dicts`/`_functions` before continuing the loop if the tools list grew.

---

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A