### PR TITLE
fix: respect determine_input_for_members setting in team delegation

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -472,7 +472,9 @@ def _get_delegate_task_function(
         if member_agent_run_response is not None:
             _update_team_media(team, member_agent_run_response)  # type: ignore
 
-    def delegate_task_to_member(member_id: str, task: str) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
+    def delegate_task_to_member(
+        member_id: str, task: str = ""
+    ) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to the selected team member.
         You must provide a clear and concise description of the task the member should achieve AND the expected output.
 
@@ -611,7 +613,7 @@ def _get_delegate_task_function(
         )
 
     async def adelegate_task_to_member(
-        member_id: str, task: str
+        member_id: str, task: str = ""
     ) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to the selected team member.
         You must provide a clear and concise description of the task the member should achieve AND the expected output.
@@ -747,7 +749,7 @@ def _get_delegate_task_function(
         )
 
     # When the task should be delegated to all members
-    def delegate_task_to_members(task: str) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
+    def delegate_task_to_members(task: str = "") -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """
         Use this function to delegate a task to all the member agents and return a response.
         You must provide a clear and concise description of the task the member should achieve AND the expected output.
@@ -875,7 +877,9 @@ def _get_delegate_task_function(
         use_team_logger()
 
     # When the task should be delegated to all members
-    async def adelegate_task_to_members(task: str) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
+    async def adelegate_task_to_members(
+        task: str = "",
+    ) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, str]]:
         """Use this function to delegate a task to all the member agents and return a response.
         You must provide a clear and concise description of the task to send to member agents.
 
@@ -1101,6 +1105,18 @@ def _get_delegate_task_function(
             delegate_function = delegate_task_to_member  # type: ignore
 
         delegate_func = Function.from_callable(delegate_function, name="delegate_task_to_member")
+
+    if team.determine_input_for_members is False:
+        # Remove 'task' from the tool schema so the LLM does not craft its own prompt.
+        # The user's original message is forwarded directly to the member.
+        delegate_func.parameters.get("properties", {}).pop("task", None)
+        required = delegate_func.parameters.get("required", [])
+        if "task" in required:
+            required.remove("task")
+        delegate_func.description = (
+            "Use this function to delegate the user's message directly to the selected team member. "
+            "The user's original message will be forwarded to the member without modification."
+        )
 
     if team.respond_directly:
         delegate_func.stop_after_tool_call = True


### PR DESCRIPTION
## Summary

Fixes #6732

When `determine_input_for_members` is set to `False`, the team leader still crafts its own prompt for the `delegate_task_to_member` tool call instead of forwarding the user's original message directly.

The root cause is that the `task` parameter remains in the tool schema as a required argument, so the LLM always generates a value for it. This PR:

1. Makes the `task` parameter optional (default `""`) on both sync and async delegate functions so the LLM can omit it.
2. When `determine_input_for_members=False`, removes `task` from the tool schema entirely and updates the tool description to indicate that the user's message is forwarded as-is.

This way the team leader cannot rewrite the input — it simply picks which member to route to.

---

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A