### PR TITLE
feat: add provider routing configuration for OpenRouter models

### DIFF
--- a/libs/agno/agno/models/openrouter/__init__.py
+++ b/libs/agno/agno/models/openrouter/__init__.py
@@ -1,7 +1,9 @@
 from agno.models.openrouter.openrouter import OpenRouter
+from agno.models.openrouter.provider_routing import ProviderRouting
 from agno.models.openrouter.responses import OpenRouterResponses
 
 __all__ = [
     "OpenRouter",
     "OpenRouterResponses",
+    "ProviderRouting",
 ]

--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from agno.exceptions import ModelAuthenticationError
 from agno.models.message import Message
 from agno.models.openai.like import OpenAILike
+from agno.models.openrouter.provider_routing import ProviderRouting
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 
@@ -27,6 +28,10 @@ class OpenRouter(OpenAILike):
         fallback_models (Optional[List[str]]): List of fallback model IDs to use if the primary model
             fails due to rate limits, timeouts, or unavailability. OpenRouter will automatically try
             these models in order. Example: ["anthropic/claude-sonnet-4", "deepseek/deepseek-r1"]
+        provider_routing (Optional[ProviderRouting]): Configuration for OpenRouter provider routing.
+            Controls how requests are routed to different providers. Supports fields like order,
+            allow_fallbacks, require_parameters, data_collection, sort, and more.
+            See: https://openrouter.ai/docs/guides/routing/provider-selection
     """
 
     id: str = "gpt-4o"
@@ -37,6 +42,9 @@ class OpenRouter(OpenAILike):
     base_url: str = "https://openrouter.ai/api/v1"
     max_tokens: int = 1024
     models: Optional[List[str]] = None  # Dynamic model routing https://openrouter.ai/docs/features/model-routing
+    provider_routing: Optional[ProviderRouting] = (
+        None  # Provider routing https://openrouter.ai/docs/guides/routing/provider-selection
+    )
 
     def _get_client_params(self) -> Dict[str, Any]:
         """
@@ -74,15 +82,16 @@ class OpenRouter(OpenAILike):
             response_format=response_format, tools=tools, tool_choice=tool_choice, run_response=run_response
         )
 
-        # Add fallback models to extra_body if specified
-        if self.models:
-            # Get existing extra_body or create new dict
+        # Add OpenRouter-specific params to extra_body if specified
+        if self.models or self.provider_routing:
             extra_body = request_params.get("extra_body") or {}
 
-            # Merge fallback models into extra_body
-            extra_body["models"] = self.models
+            if self.models:
+                extra_body["models"] = self.models
 
-            # Update request params
+            if self.provider_routing:
+                extra_body["provider"] = self.provider_routing.to_dict()
+
             request_params["extra_body"] = extra_body
 
         return request_params

--- a/libs/agno/agno/models/openrouter/provider_routing.py
+++ b/libs/agno/agno/models/openrouter/provider_routing.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, fields
+from typing import Any, Dict, List, Optional, Union
+
+
+@dataclass
+class ProviderRouting:
+    """Configuration for OpenRouter provider routing.
+
+    Controls how OpenRouter routes requests to different providers.
+    See: https://openrouter.ai/docs/guides/routing/provider-selection
+
+    Attributes:
+        order: List of provider slugs to try in order (e.g. ["anthropic", "openai"]).
+        allow_fallbacks: Whether to allow backup providers when the primary is unavailable.
+        require_parameters: Only use providers that support all parameters in your request.
+        data_collection: Control whether to use providers that may store data ("allow" or "deny").
+        zdr: Restrict routing to only ZDR (Zero Data Retention) endpoints.
+        enforce_distillable_text: Restrict routing to only models that allow text distillation.
+        only: List of provider slugs to allow for this request.
+        ignore: List of provider slugs to skip for this request.
+        quantizations: List of quantization levels to filter by (e.g. ["int4", "int8"]).
+        sort: Sort providers by price, throughput, or latency. Can be a string
+            (e.g. "price") or a dict with "by" and "partition" fields.
+        preferred_min_throughput: Preferred minimum throughput (tokens/sec). Can be a number
+            or a dict with percentile cutoffs (p50, p75, p90, p99).
+        preferred_max_latency: Preferred maximum latency (seconds). Can be a number
+            or a dict with percentile cutoffs (p50, p75, p90, p99).
+        max_price: The maximum pricing you want to pay for this request.
+    """
+
+    order: Optional[List[str]] = None
+    allow_fallbacks: Optional[bool] = None
+    require_parameters: Optional[bool] = None
+    data_collection: Optional[str] = None
+    zdr: Optional[bool] = None
+    enforce_distillable_text: Optional[bool] = None
+    only: Optional[List[str]] = None
+    ignore: Optional[List[str]] = None
+    quantizations: Optional[List[str]] = None
+    sort: Optional[Union[str, Dict[str, Any]]] = None
+    preferred_min_throughput: Optional[Union[int, float, Dict[str, Any]]] = None
+    preferred_max_latency: Optional[Union[int, float, Dict[str, Any]]] = None
+    max_price: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a dictionary, excluding None values."""
+        return {f.name: getattr(self, f.name) for f in fields(self) if getattr(self, f.name) is not None}

--- a/libs/agno/agno/models/openrouter/responses.py
+++ b/libs/agno/agno/models/openrouter/responses.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from agno.exceptions import ModelAuthenticationError
 from agno.models.message import Message
 from agno.models.openai.open_responses import OpenResponses
+from agno.models.openrouter.provider_routing import ProviderRouting
 
 
 @dataclass
@@ -32,6 +33,10 @@ class OpenRouterResponses(OpenResponses):
         models (Optional[List[str]]): List of fallback model IDs to use if the primary model
             fails due to rate limits, timeouts, or unavailability. OpenRouter will automatically
             try these models in order. Example: ["anthropic/claude-sonnet-4", "deepseek/deepseek-r1"]
+        provider_routing (Optional[ProviderRouting]): Configuration for OpenRouter provider routing.
+            Controls how requests are routed to different providers. Supports fields like order,
+            allow_fallbacks, require_parameters, data_collection, sort, and more.
+            See: https://openrouter.ai/docs/guides/routing/provider-selection
 
     Example:
         ```python
@@ -56,6 +61,10 @@ class OpenRouterResponses(OpenResponses):
     # Dynamic model routing - fallback models if primary fails
     # https://openrouter.ai/docs/features/model-routing
     models: Optional[List[str]] = None
+
+    # Provider routing - control how requests are routed to providers
+    # https://openrouter.ai/docs/guides/routing/provider-selection
+    provider_routing: Optional[ProviderRouting] = None
 
     # OpenRouter's Responses API is stateless
     store: Optional[bool] = False
@@ -120,15 +129,16 @@ class OpenRouterResponses(OpenResponses):
             tool_choice=tool_choice,
         )
 
-        # Add fallback models to extra_body if specified
-        if self.models:
-            # Get existing extra_body or create new dict
+        # Add OpenRouter-specific params to extra_body if specified
+        if self.models or self.provider_routing:
             extra_body = request_params.get("extra_body") or {}
 
-            # Merge fallback models into extra_body
-            extra_body["models"] = self.models
+            if self.models:
+                extra_body["models"] = self.models
 
-            # Update request params
+            if self.provider_routing:
+                extra_body["provider"] = self.provider_routing.to_dict()
+
             request_params["extra_body"] = extra_body
 
         return request_params


### PR DESCRIPTION
## Summary

Fixes #5565

OpenRouter supports a `provider` object in the request body for controlling how requests are routed to different providers (ordering, fallbacks, data collection, quantization, latency/throughput preferences, etc). This was not exposed in agno's OpenRouter integration.

This PR adds a `ProviderRouting` dataclass that covers all documented provider routing fields and integrates it into both `OpenRouter` and `OpenRouterResponses`. The routing config is passed via `extra_body["provider"]` following the same pattern already used for model fallbacks.

Usage:

```python
from agno.models.openrouter import OpenRouter, ProviderRouting

model = OpenRouter(
    id="anthropic/claude-sonnet-4",
    provider_routing=ProviderRouting(
        order=["anthropic", "google"],
        allow_fallbacks=True,
        require_parameters=True,
    ),
)
```

Reference: https://openrouter.ai/docs/guides/routing/provider-selection

---

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A