### PR TITLE
feat: add ToolCallFailed and ToolCallCancelled events

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -49,6 +49,7 @@ from agno.utils.events import (
     create_run_output_content_event,
     create_tool_call_completed_event,
     create_tool_call_error_event,
+    create_tool_call_failed_event,
     create_tool_call_started_event,
     handle_event,
 )
@@ -1652,6 +1653,14 @@ def handle_model_response_chunk(
                         if tool_call.tool_call_error:
                             yield handle_event(  # type: ignore
                                 create_tool_call_error_event(
+                                    from_run_response=run_response, tool=tool_call, error=str(tool_call.result)
+                                ),
+                                run_response,
+                                events_to_skip=agent.events_to_skip,  # type: ignore
+                                store_events=agent.store_events,
+                            )
+                            yield handle_event(  # type: ignore
+                                create_tool_call_failed_event(
                                     from_run_response=run_response, tool=tool_call, error=str(tool_call.result)
                                 ),
                                 run_response,

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -35,8 +35,10 @@ from agno.utils.agent import (
     collect_joint_videos,
 )
 from agno.utils.events import (
+    create_tool_call_cancelled_event,
     create_tool_call_completed_event,
     create_tool_call_error_event,
+    create_tool_call_failed_event,
     create_tool_call_started_event,
     handle_event,
 )
@@ -644,6 +646,14 @@ def run_tool(
                             events_to_skip=agent.events_to_skip,  # type: ignore
                             store_events=agent.store_events,
                         )
+                        yield handle_event(  # type: ignore
+                            create_tool_call_failed_event(
+                                from_run_response=run_response, tool=tool, error=str(tool.result)
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
         # Yield CustomEvent instances from sync tool generators
         elif isinstance(call_result, CustomEvent):
             if stream_events:
@@ -712,6 +722,14 @@ async def arun_tool(
                     if tool.tool_call_error:
                         yield handle_event(  # type: ignore
                             create_tool_call_error_event(
+                                from_run_response=run_response, tool=tool, error=str(tool.result)
+                            ),
+                            run_response,
+                            events_to_skip=agent.events_to_skip,  # type: ignore
+                            store_events=agent.store_events,
+                        )
+                        yield handle_event(  # type: ignore
+                            create_tool_call_failed_event(
                                 from_run_response=run_response, tool=tool, error=str(tool.result)
                             ),
                             run_response,
@@ -798,6 +816,15 @@ def handle_tool_call_updates_stream(
                 _t.confirmed = False
                 _t.confirmation_note = _t.confirmation_note or "Tool call was rejected"
                 _t.tool_call_error = True
+                if stream_events:
+                    yield handle_event(  # type: ignore
+                        create_tool_call_cancelled_event(
+                            from_run_response=run_response, tool=_t, reason=_t.confirmation_note
+                        ),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
             _maybe_create_audit_approval(agent, _t, run_response, "approved" if _t.confirmed is True else "rejected")
             _t.requires_confirmation = False
 
@@ -900,6 +927,15 @@ async def ahandle_tool_call_updates_stream(
                 _t.confirmed = False
                 _t.confirmation_note = _t.confirmation_note or "Tool call was rejected"
                 _t.tool_call_error = True
+                if stream_events:
+                    yield handle_event(  # type: ignore
+                        create_tool_call_cancelled_event(
+                            from_run_response=run_response, tool=_t, reason=_t.confirmation_note
+                        ),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
             await _amaybe_create_audit_approval(
                 agent, _t, run_response, "approved" if _t.confirmed is True else "rejected"
             )

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -154,6 +154,8 @@ class RunEvent(str, Enum):
     tool_call_started = "ToolCallStarted"
     tool_call_completed = "ToolCallCompleted"
     tool_call_error = "ToolCallError"
+    tool_call_failed = "ToolCallFailed"
+    tool_call_cancelled = "ToolCallCancelled"
 
     reasoning_started = "ReasoningStarted"
     reasoning_step = "ReasoningStep"
@@ -421,6 +423,20 @@ class ToolCallErrorEvent(BaseAgentRunEvent):
 
 
 @dataclass
+class ToolCallFailedEvent(BaseAgentRunEvent):
+    event: str = RunEvent.tool_call_failed.value
+    tool: Optional[ToolExecution] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class ToolCallCancelledEvent(BaseAgentRunEvent):
+    event: str = RunEvent.tool_call_cancelled.value
+    tool: Optional[ToolExecution] = None
+    reason: Optional[str] = None
+
+
+@dataclass
 class ParserModelResponseStartedEvent(BaseAgentRunEvent):
     event: str = RunEvent.parser_model_response_started.value
 
@@ -519,6 +535,8 @@ RunOutputEvent = Union[
     ToolCallStartedEvent,
     ToolCallCompletedEvent,
     ToolCallErrorEvent,
+    ToolCallFailedEvent,
+    ToolCallCancelledEvent,
     ParserModelResponseStartedEvent,
     ParserModelResponseCompletedEvent,
     OutputModelResponseStartedEvent,
@@ -557,6 +575,8 @@ RUN_EVENT_TYPE_REGISTRY = {
     RunEvent.tool_call_started.value: ToolCallStartedEvent,
     RunEvent.tool_call_completed.value: ToolCallCompletedEvent,
     RunEvent.tool_call_error.value: ToolCallErrorEvent,
+    RunEvent.tool_call_failed.value: ToolCallFailedEvent,
+    RunEvent.tool_call_cancelled.value: ToolCallCancelledEvent,
     RunEvent.parser_model_response_started.value: ParserModelResponseStartedEvent,
     RunEvent.parser_model_response_completed.value: ParserModelResponseCompletedEvent,
     RunEvent.output_model_response_started.value: OutputModelResponseStartedEvent,

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -147,6 +147,8 @@ class TeamRunEvent(str, Enum):
     tool_call_started = "TeamToolCallStarted"
     tool_call_completed = "TeamToolCallCompleted"
     tool_call_error = "TeamToolCallError"
+    tool_call_failed = "TeamToolCallFailed"
+    tool_call_cancelled = "TeamToolCallCancelled"
 
     reasoning_started = "TeamReasoningStarted"
     reasoning_step = "TeamReasoningStep"
@@ -428,6 +430,20 @@ class ToolCallErrorEvent(BaseTeamRunEvent):
 
 
 @dataclass
+class ToolCallFailedEvent(BaseTeamRunEvent):
+    event: str = TeamRunEvent.tool_call_failed.value
+    tool: Optional[ToolExecution] = None
+    error: Optional[str] = None
+
+
+@dataclass
+class ToolCallCancelledEvent(BaseTeamRunEvent):
+    event: str = TeamRunEvent.tool_call_cancelled.value
+    tool: Optional[ToolExecution] = None
+    reason: Optional[str] = None
+
+
+@dataclass
 class ParserModelResponseStartedEvent(BaseTeamRunEvent):
     event: str = TeamRunEvent.parser_model_response_started.value
 
@@ -550,6 +566,8 @@ TeamRunOutputEvent = Union[
     ToolCallStartedEvent,
     ToolCallCompletedEvent,
     ToolCallErrorEvent,
+    ToolCallFailedEvent,
+    ToolCallCancelledEvent,
     ParserModelResponseStartedEvent,
     ParserModelResponseCompletedEvent,
     OutputModelResponseStartedEvent,
@@ -590,6 +608,8 @@ TEAM_RUN_EVENT_TYPE_REGISTRY = {
     TeamRunEvent.tool_call_started.value: ToolCallStartedEvent,
     TeamRunEvent.tool_call_completed.value: ToolCallCompletedEvent,
     TeamRunEvent.tool_call_error.value: ToolCallErrorEvent,
+    TeamRunEvent.tool_call_failed.value: ToolCallFailedEvent,
+    TeamRunEvent.tool_call_cancelled.value: ToolCallCancelledEvent,
     TeamRunEvent.parser_model_response_started.value: ParserModelResponseStartedEvent,
     TeamRunEvent.parser_model_response_completed.value: ParserModelResponseCompletedEvent,
     TeamRunEvent.output_model_response_started.value: OutputModelResponseStartedEvent,

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -37,8 +37,10 @@ from agno.run.agent import (
     RunStartedEvent,
     SessionSummaryCompletedEvent,
     SessionSummaryStartedEvent,
+    ToolCallCancelledEvent,
     ToolCallCompletedEvent,
     ToolCallErrorEvent,
+    ToolCallFailedEvent,
     ToolCallStartedEvent,
 )
 from agno.run.requirement import RunRequirement
@@ -74,8 +76,10 @@ from agno.run.team import TaskIterationCompletedEvent as TeamTaskIterationComple
 from agno.run.team import TaskIterationStartedEvent as TeamTaskIterationStartedEvent
 from agno.run.team import TaskStateUpdatedEvent as TeamTaskStateUpdatedEvent
 from agno.run.team import TeamRunEvent, TeamRunInput, TeamRunOutput, TeamRunOutputEvent
+from agno.run.team import ToolCallCancelledEvent as TeamToolCallCancelledEvent
 from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
 from agno.run.team import ToolCallErrorEvent as TeamToolCallErrorEvent
+from agno.run.team import ToolCallFailedEvent as TeamToolCallFailedEvent
 from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
 from agno.session.summary import SessionSummary
 
@@ -630,6 +634,58 @@ def create_team_tool_call_error_event(
         run_id=from_run_response.run_id,
         tool=tool,
         error=error,
+    )
+
+
+def create_tool_call_failed_event(
+    from_run_response: RunOutput, tool: ToolExecution, error: Optional[str] = None
+) -> ToolCallFailedEvent:
+    return ToolCallFailedEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        tool=tool,
+        error=error,
+    )
+
+
+def create_team_tool_call_failed_event(
+    from_run_response: TeamRunOutput, tool: ToolExecution, error: Optional[str] = None
+) -> TeamToolCallFailedEvent:
+    return TeamToolCallFailedEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        tool=tool,
+        error=error,
+    )
+
+
+def create_tool_call_cancelled_event(
+    from_run_response: RunOutput, tool: ToolExecution, reason: Optional[str] = None
+) -> ToolCallCancelledEvent:
+    return ToolCallCancelledEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        tool=tool,
+        reason=reason,
+    )
+
+
+def create_team_tool_call_cancelled_event(
+    from_run_response: TeamRunOutput, tool: ToolExecution, reason: Optional[str] = None
+) -> TeamToolCallCancelledEvent:
+    return TeamToolCallCancelledEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+        tool=tool,
+        reason=reason,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #6705

Currently agno only emits `ToolCallStarted` and `ToolCallCompleted` events. When a tool call fails with an exception or gets cancelled (e.g. user rejects a confirmation prompt), no dedicated event is emitted — the consumer has no way to distinguish between a successful completion and an error/cancellation.

This PR adds two new event types:

- **`ToolCallFailed`** — emitted when a tool call raises an exception or returns an error result. Includes the error message.
- **`ToolCallCancelled`** — emitted when a tool call requiring confirmation is rejected by the user. Includes the rejection reason.

Both events are added to the agent and team run event registries so they can be consumed through the standard event stream. The existing `ToolCallError` event is preserved for backward compatibility since it serves a slightly different role (validation errors before execution).

---

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A