### PR TITLE
fix: preserve tool output in traces when custom events are yielded

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2112,8 +2112,15 @@ class Model(ABC):
         function_call_output: str = ""
 
         if isinstance(function_execution_result.result, (GeneratorType, collections.abc.Iterator)):
+            generator_return_value = None
             try:
-                for item in function_execution_result.result:
+                _iter = iter(function_execution_result.result)
+                while True:
+                    try:
+                        item = next(_iter)
+                    except StopIteration as _stop:
+                        generator_return_value = _stop.value
+                        break
                     # This function yields agent/team/workflow run events
                     if (
                         isinstance(item, tuple(get_args(RunOutputEvent)))
@@ -2132,7 +2139,6 @@ class Model(ABC):
                                 yield ModelResponse(content=item.content)
 
                         if isinstance(item, CustomEvent):
-                            function_call_output += str(item)
                             item.tool_call_id = function_call.call_id
 
                         # For WorkflowCompletedEvent, extract content for final output
@@ -2156,6 +2162,10 @@ class Model(ABC):
                 log_error(f"Error while iterating function result generator for {function_call.function.name}: {e}")
                 function_call.error = str(e)
                 function_call_success = False
+
+            # If the generator returned a value, use it as the tool output
+            if generator_return_value is not None:
+                function_call_output = str(generator_return_value)
 
             # For generators, re-capture updated_session_state after consumption
             # since session_state modifications were made during iteration
@@ -2663,7 +2673,6 @@ class Model(ABC):
                                 continue
 
                         if isinstance(item, CustomEvent):
-                            function_call_output += str(item)
                             item.tool_call_id = function_call.call_id
 
                             # For WorkflowCompletedEvent, extract content for final output
@@ -2773,8 +2782,15 @@ class Model(ABC):
                 function_call_output = async_function_call_output
                 # Events from async generators were already yielded in real-time above
             elif isinstance(function_call.result, (GeneratorType, collections.abc.Iterator)):
+                generator_return_value = None
                 try:
-                    for item in function_call.result:
+                    _iter = iter(function_call.result)
+                    while True:
+                        try:
+                            item = next(_iter)
+                        except StopIteration as _stop:
+                            generator_return_value = _stop.value
+                            break
                         # This function yields agent/team/workflow run events
                         if isinstance(
                             item,
@@ -2795,7 +2811,6 @@ class Model(ABC):
                                     continue
 
                             elif isinstance(item, CustomEvent):
-                                function_call_output += str(item)
                                 item.tool_call_id = function_call.call_id
 
                             # Yield the event itself to bubble it up
@@ -2808,6 +2823,10 @@ class Model(ABC):
                     log_error(f"Error while iterating function result generator for {function_call.function.name}: {e}")
                     function_call.error = str(e)
                     function_call_success = False
+
+                # If the generator returned a value, use it as the tool output
+                if generator_return_value is not None:
+                    function_call_output = str(generator_return_value)
 
             # For generators (sync or async), re-capture updated_session_state after consumption
             # since session_state modifications were made during iteration


### PR DESCRIPTION
## Summary

Fixes #5738

When a tool function yields `CustomEvent` instances alongside a return value, the trace output is incorrect. Two issues:

1. Each `CustomEvent` was being stringified and appended to `function_call_output`, so the trace showed the string representation of the events rather than the actual tool result.
2. Generator return values (via `return` in a generator function) were silently discarded because `for item in generator` does not capture `StopIteration.value`.

This PR fixes both problems:

- Removes the `function_call_output += str(item)` line for `CustomEvent` instances — custom events are already yielded as separate events in the stream and should not pollute the tool output string.
- Captures the generator return value by manually iterating with `next()` and catching `StopIteration.value`, then uses it as the tool output when present.

The fix is applied in both the sync and async code paths in `models/base.py`.

---

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A