### PR TITLE
feat: add enable_team_leader_response option to force delegation

### DIFF
--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -69,6 +69,7 @@ def __init__(
     respond_directly: bool = False,
     determine_input_for_members: bool = True,
     delegate_to_all_members: bool = False,
+    enable_team_leader_response: bool = True,
     max_iterations: int = 10,
     user_id: Optional[str] = None,
     session_id: Optional[str] = None,
@@ -183,6 +184,7 @@ def __init__(
     team.respond_directly = respond_directly
     team.determine_input_for_members = determine_input_for_members
     team.delegate_to_all_members = delegate_to_all_members
+    team.enable_team_leader_response = enable_team_leader_response
     team.max_iterations = max_iterations
 
     # Resolve TeamMode: explicit mode wins, otherwise infer from booleans

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -109,12 +109,27 @@ def get_members_system_message_content(
     return content
 
 
-def _get_opening_prompt() -> str:
+def _get_opening_prompt(team: "Team") -> str:
     """Opening identity statement for the team leader."""
+    if not team.enable_team_leader_response:
+        return (
+            "You coordinate a team of specialized AI agents to fulfill the user's request. "
+            "You must ALWAYS delegate to a member — never respond to the user directly.\n"
+        )
     return (
         "You coordinate a team of specialized AI agents to fulfill the user's request. "
         "Delegate to members when their expertise or tools are needed. "
         "For straightforward requests you can handle directly — including using your own tools — respond without delegating.\n"
+    )
+
+
+def _get_direct_response_preamble(team: "Team") -> str:
+    """Sentence describing when the leader may respond directly vs must delegate."""
+    if not team.enable_team_leader_response:
+        return "You must ALWAYS delegate to a member — never respond to the user directly."
+    return (
+        "For requests you can handle directly — simple questions, using your own tools, "
+        "or general conversation — respond without delegating."
     )
 
 
@@ -123,6 +138,7 @@ def _get_mode_instructions(team: "Team") -> str:
     from agno.team.mode import TeamMode
 
     content = "\n<how_to_respond>\n"
+    direct = _get_direct_response_preamble(team)
 
     if team.mode == TeamMode.tasks:
         content += (
@@ -147,10 +163,9 @@ def _get_mode_instructions(team: "Team") -> str:
         )
     elif team.mode == TeamMode.route:
         content += (
-            "You operate in route mode. For requests that need member expertise, "
-            "identify the single best member and delegate to them — their response is returned directly to the user. "
-            "For requests you can handle directly — simple questions, using your own tools, or general conversation — "
-            "respond without delegating.\n\n"
+            f"You operate in route mode. For requests that need member expertise, "
+            f"identify the single best member and delegate to them — their response is returned directly to the user. "
+            f"{direct}\n\n"
             "When routing to a member:\n"
             "- Analyze the request to determine which member's role and tools are the best match.\n"
             "- Delegate to exactly one member. Use only the member's ID — do not prefix it with the team ID.\n"
@@ -159,10 +174,9 @@ def _get_mode_instructions(team: "Team") -> str:
         )
     elif team.mode == TeamMode.broadcast:
         content += (
-            "You operate in broadcast mode. For requests that benefit from multiple perspectives, "
-            "send the request to all members simultaneously and synthesize their collective responses. "
-            "For requests you can handle directly — simple questions, using your own tools, or general conversation — "
-            "respond without delegating.\n\n"
+            f"You operate in broadcast mode. For requests that benefit from multiple perspectives, "
+            f"send the request to all members simultaneously and synthesize their collective responses. "
+            f"{direct}\n\n"
             "When broadcasting:\n"
             "- Call `delegate_task_to_members` exactly once with a clear task description. "
             "This sends the task to every member in parallel.\n"
@@ -175,10 +189,9 @@ def _get_mode_instructions(team: "Team") -> str:
     else:
         # coordinate mode (default)
         content += (
-            "You operate in coordinate mode. For requests that need member expertise, "
-            "select the best member(s), delegate with clear task descriptions, and synthesize their outputs "
-            "into a unified response. For requests you can handle directly — simple questions, "
-            "using your own tools, or general conversation — respond without delegating.\n\n"
+            f"You operate in coordinate mode. For requests that need member expertise, "
+            f"select the best member(s), delegate with clear task descriptions, and synthesize their outputs "
+            f"into a unified response. {direct}\n\n"
             "Delegation:\n"
             "- Match each sub-task to the member whose role and tools are the best fit. "
             "Delegate to multiple members when the request spans different areas of expertise.\n"
@@ -208,7 +221,7 @@ def _build_team_context(
     content = ""
     resolved_members = get_resolved_members(team, run_context)
     if resolved_members is not None and len(resolved_members) > 0:
-        content += _get_opening_prompt()
+        content += _get_opening_prompt(team)
         content += "\n<team_members>\n"
         content += team.get_members_system_message_content(run_context=run_context)
         if team.get_member_information_tool:

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -440,6 +440,8 @@ def to_dict(team: "Team") -> Dict[str, Any]:
         config["delegate_to_all_members"] = team.delegate_to_all_members
     if not team.determine_input_for_members:  # default is True
         config["determine_input_for_members"] = team.determine_input_for_members
+    if not team.enable_team_leader_response:  # default is True
+        config["enable_team_leader_response"] = team.enable_team_leader_response
 
     # --- User settings ---
     if team.user_id is not None:
@@ -887,6 +889,7 @@ def from_dict(
             respond_directly=config.get("respond_directly", False),
             delegate_to_all_members=config.get("delegate_to_all_members", False),
             determine_input_for_members=config.get("determine_input_for_members", True),
+            enable_team_leader_response=config.get("enable_team_leader_response", True),
             # --- User settings ---
             user_id=config.get("user_id"),
             # --- Session settings ---

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -101,6 +101,8 @@ class Team:
     respond_directly: bool = False
     # If True, the team leader will delegate the task to all members, instead of deciding for a subset
     delegate_to_all_members: bool = False
+    # If False, the team leader will never respond directly to the user — it will always delegate to a member.
+    enable_team_leader_response: bool = True
     # Set to false if you want to send the run input directly to the member agents
     determine_input_for_members: bool = True
     # Maximum number of iterations for autonomous task loop (mode=tasks)
@@ -413,6 +415,7 @@ class Team:
         respond_directly: bool = False,
         determine_input_for_members: bool = True,
         delegate_to_all_members: bool = False,
+        enable_team_leader_response: bool = True,
         max_iterations: int = 10,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
@@ -525,6 +528,7 @@ class Team:
             respond_directly=respond_directly,
             determine_input_for_members=determine_input_for_members,
             delegate_to_all_members=delegate_to_all_members,
+            enable_team_leader_response=enable_team_leader_response,
             max_iterations=max_iterations,
             user_id=user_id,
             session_id=session_id,


### PR DESCRIPTION
## Summary

Fixes #6737

Adds an `enable_team_leader_response` parameter (default `True`) to the `Team` class. When set to `False`, the team leader is instructed to always delegate to a member and never respond to the user directly.

This is useful for scenarios where you want the team leader to act purely as a router/coordinator — for example, when building a customer support pipeline where every request must be handled by a specialized agent.

The implementation modifies the system prompt generation to swap in a "must always delegate" preamble when the option is disabled, without duplicating the mode-specific instruction blocks.

```python
team = Team(
    members=[agent_a, agent_b],
    enable_team_leader_response=False,  # leader always delegates
)
```

The setting is persisted via `to_dict`/`from_dict` for session serialization.

---

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A