### PR TITLE
fix: handle dict content type in structured output processing

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2124,6 +2124,8 @@ class Model(ABC):
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
                                 function_call_output += item.content.model_dump_json()
+                            elif item.content is not None and isinstance(item.content, dict):
+                                function_call_output += json.dumps(item.content)
                             else:
                                 # Capture output
                                 function_call_output += item.content or ""
@@ -2142,6 +2144,8 @@ class Model(ABC):
                             if item.content is not None:
                                 if isinstance(item.content, BaseModel):
                                     function_call_output += item.content.model_dump_json()
+                                elif isinstance(item.content, dict):
+                                    function_call_output += json.dumps(item.content)
                                 else:
                                     function_call_output += str(item.content)
 
@@ -2654,6 +2658,8 @@ class Model(ABC):
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
                                 function_call_output += item.content.model_dump_json()
+                            elif item.content is not None and isinstance(item.content, dict):
+                                function_call_output += json.dumps(item.content)
                             else:
                                 # Capture output
                                 function_call_output += item.content or ""
@@ -2673,6 +2679,8 @@ class Model(ABC):
                                 if item.content is not None:
                                     if isinstance(item.content, BaseModel):
                                         function_call_output += item.content.model_dump_json()
+                                    elif isinstance(item.content, dict):
+                                        function_call_output += json.dumps(item.content)
                                     else:
                                         function_call_output += str(item.content)
 
@@ -2786,6 +2794,8 @@ class Model(ABC):
                             if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                                 if item.content is not None and isinstance(item.content, BaseModel):
                                     function_call_output += item.content.model_dump_json()
+                                elif item.content is not None and isinstance(item.content, dict):
+                                    function_call_output += json.dumps(item.content)
                                 else:
                                     # Capture output
                                     function_call_output += item.content or ""

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
@@ -299,11 +300,12 @@ class TeamSession:
             # Get response
             response_str = ""
             if run.content:
-                response_str = (
-                    run.content.model_dump_json(indent=2, exclude_none=True)
-                    if isinstance(run.content, BaseModel)
-                    else str(run.content)
-                )
+                if isinstance(run.content, BaseModel):
+                    response_str = run.content.model_dump_json(indent=2, exclude_none=True)
+                elif isinstance(run.content, dict):
+                    response_str = json.dumps(run.content, indent=2)
+                else:
+                    response_str = str(run.content)
 
             history_data.append((input_str, response_str))
 

--- a/libs/agno/agno/workflow/agent.py
+++ b/libs/agno/agno/workflow/agent.py
@@ -1,5 +1,6 @@
 """WorkflowAgent - A restricted Agent for workflow orchestration"""
 
+import json
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from agno.agent import Agent
@@ -178,6 +179,8 @@ Guidelines:
                     return result.content
                 elif isinstance(result.content, BaseModel):
                     return result.content.model_dump_json(exclude_none=True)
+                elif isinstance(result.content, dict):
+                    return json.dumps(result.content)
                 else:
                     return str(result.content)
 
@@ -293,6 +296,8 @@ Guidelines:
                     yield result.content
                 elif isinstance(result.content, BaseModel):
                     yield result.content.model_dump_json(exclude_none=True)
+                elif isinstance(result.content, dict):
+                    yield json.dumps(result.content)
                 else:
                     yield str(result.content)
 


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'dict' object has no attribute 'model_dump_json'` when using `output_schema` with a plain `dict` type. The code assumed `content` was always a `BaseModel` instance, but when `output_schema` is `dict`, the LLM returns a raw dict that needs `json.dumps()` instead.

Closes #6294

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- Added `isinstance(content, dict)` checks before the `BaseModel.model_dump_json()` calls in `models/base.py` (sync + async streaming paths), `session/team.py` (history serialization), and `workflow/agent.py` (workflow result handling)
- Uses `json.dumps()` for dict content serialization