### PR TITLE
fix: support list-contains matching in LanceDB metadata filters

### DIFF
--- a/libs/agno/agno/vectordb/lancedb/lance_db.py
+++ b/libs/agno/agno/vectordb/lancedb/lance_db.py
@@ -531,7 +531,16 @@ class LanceDb(VectorDb):
                 # Check if all filter criteria match
                 match = True
                 for key, value in filters.items():
-                    if key not in doc.meta_data or doc.meta_data[key] != value:
+                    if key not in doc.meta_data:
+                        match = False
+                        break
+                    meta_value = doc.meta_data[key]
+                    # When metadata value is a list, check if the filter value is contained in it
+                    if isinstance(meta_value, list):
+                        if value not in meta_value:
+                            match = False
+                            break
+                    elif meta_value != value:
                         match = False
                         break
 


### PR DESCRIPTION
## Summary

Fix LanceDB metadata filtering when a metadata value is a list. Previously, filtering with `filters={"category": "sports"}` would fail to match documents where `meta_data["category"]` is `["sports", "news"]` because it used strict equality. Now when the metadata value is a list, the filter checks if the target value is contained in that list.

Closes #3994

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- Only changes the post-query Python-side filter logic in `lance_db.py`, not the LanceDB SQL `where` clause
- Preserves existing exact-match behavior for non-list metadata values
- Uses `value in meta_value` (membership test) when metadata value is a list