### PR TITLE
feat: support URL-based media in AgentOS run endpoints

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -32,6 +32,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
+    deserialize_media_from_form,
     format_sse_event,
     get_agent_by_id,
     get_request_kwargs,
@@ -346,6 +347,14 @@ def get_agent_router(
                         continue
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
+
+        # Deserialize JSON-encoded media from form data (URL-based media and SDK client fix)
+        form_data = await request.form()
+        url_images, url_audios, url_videos, url_files = deserialize_media_from_form(kwargs, form_data)
+        base64_images.extend(url_images)
+        base64_audios.extend(url_audios)
+        base64_videos.extend(url_videos)
+        input_files.extend(url_files)
 
         # Extract auth token for remote agents
         auth_token = get_auth_token_from_request(request)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -29,6 +29,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
+    deserialize_media_from_form,
     format_sse_event,
     get_request_kwargs,
     get_team_by_id,
@@ -264,6 +265,14 @@ def get_team_router(
                         document_files.append(document_file)
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
+
+        # Deserialize JSON-encoded media from form data (URL-based media and SDK client fix)
+        form_data = await request.form()
+        url_images, url_audios, url_videos, url_files = deserialize_media_from_form(kwargs, form_data)
+        base64_images.extend(url_images)
+        base64_audios.extend(url_audios)
+        base64_videos.extend(url_videos)
+        document_files.extend(url_files)
 
         # Extract auth token for remote teams
         auth_token = get_auth_token_from_request(request)

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -456,6 +456,57 @@ def extract_input_media(run_dict: Dict[str, Any]) -> Dict[str, Any]:
     return input_media
 
 
+def deserialize_media_from_form(
+    kwargs: Dict[str, Any],
+    form_data: Any = None,
+) -> tuple:
+    """Deserialize JSON-encoded media fields from form data.
+
+    Fixes the SDK client flow where media objects are serialized as JSON strings
+    in form fields. Without this:
+    - images/audio/videos in kwargs cause "TypeError: got multiple values"
+    - files JSON is silently dropped (filtered as known field, can't bind as UploadFile)
+
+    Args:
+        kwargs: The kwargs dict from get_request_kwargs (modified in-place to pop media fields)
+        form_data: The raw form data from the request (for extracting files JSON)
+
+    Returns:
+        Tuple of (images, audios, videos, files) media object lists
+    """
+    images: List[Image] = []
+    audios: List[Audio] = []
+    videos: List[Video] = []
+    files: List[FileMedia] = []
+
+    for field_name, media_cls, target in [
+        ("images", Image, images),
+        ("audio", Audio, audios),
+        ("videos", Video, videos),
+    ]:
+        json_str = kwargs.pop(field_name, None)
+        if json_str and isinstance(json_str, str):
+            try:
+                for item in json.loads(json_str):
+                    if isinstance(item, dict):
+                        target.append(media_cls(**item))
+            except (json.JSONDecodeError, Exception) as e:
+                logger.warning(f"Failed to deserialize {field_name} from form data: {e}")
+
+    # Extract files JSON from form_data (filtered from kwargs as a known field)
+    if form_data is not None:
+        files_value = form_data.get("files")
+        if isinstance(files_value, str):
+            try:
+                for item in json.loads(files_value):
+                    if isinstance(item, dict):
+                        files.append(FileMedia(**item))
+            except (json.JSONDecodeError, Exception) as e:
+                logger.warning(f"Failed to deserialize files from form data: {e}")
+
+    return images, audios, videos, files
+
+
 def process_image(file: UploadFile) -> Image:
     content = file.file.read()
     if not content:


### PR DESCRIPTION
## Summary

Add support for URL-based media (images, audio, videos, files) in the AgentOS REST API run endpoints. Previously only binary multipart uploads were supported. This fixes the SDK client flow where `Image(url="https://...")` objects are serialized as JSON strings in form fields.

Closes #6669

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- New `deserialize_media_from_form()` utility in `os/utils.py` that parses JSON-encoded media fields from form data
- Integrated into both agent and team routers after the existing binary file processing
- Handles `images`, `audio`, `videos` fields from kwargs and `files` from raw form data (since it is filtered as a known field name)
- Includes proper error handling with warnings on malformed JSON