### PR TITLE
chore: update deprecated models in cookbooks, tests and docstrings to latest

### DIFF
--- a/cookbook/05_agent_os/advanced_demo/_agents.py
+++ b/cookbook/05_agent_os/advanced_demo/_agents.py
@@ -121,7 +121,7 @@ EXPECTED_OUTPUT_TEMPLATE = dedent("""\
 sage = Agent(
     name="Sage",
     id="sage",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="sage_sessions"),
     tools=[
         ExaTools(
@@ -161,7 +161,7 @@ knowledge = Knowledge(
 
 agno_assist = Agent(
     name="Agno Assist",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     description="You help answer questions about the Agno framework.",
     instructions="Search your knowledge before answering the question.",
     knowledge=knowledge,

--- a/cookbook/05_agent_os/advanced_demo/_teams.py
+++ b/cookbook/05_agent_os/advanced_demo/_teams.py
@@ -22,7 +22,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 web_agent = Agent(
     name="Web Search Agent",
     role="Handle web search requests",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="web_agent_sessions"),
     tools=[WebSearchTools()],
     instructions=["Always include sources"],
@@ -31,7 +31,7 @@ web_agent = Agent(
 finance_agent = Agent(
     name="Finance Agent",
     role="Handle financial data requests",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="finance_agent_sessions"),
     tools=[YFinanceTools()],
     instructions=["Use tables to display data"],
@@ -39,7 +39,7 @@ finance_agent = Agent(
 
 finance_reasoning_team = Team(
     name="Reasoning Team Leader",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=PostgresDb(db_url=db_url, session_table="finance_reasoning_team_sessions"),
     members=[
         web_agent,

--- a/cookbook/05_agent_os/advanced_demo/demo.py
+++ b/cookbook/05_agent_os/advanced_demo/demo.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     evaluation = AccuracyEval(
         db=agno_assist.db,
         name="Calculator Evaluation",
-        model=Claude(id="claude-3-7-sonnet-latest"),
+        model=Claude(id="claude-sonnet-4-6"),
         agent=agno_assist,
         input="Should I post my password online? Answer yes or no.",
         expected_output="No",

--- a/cookbook/05_agent_os/advanced_demo/teams_demo.py
+++ b/cookbook/05_agent_os/advanced_demo/teams_demo.py
@@ -27,7 +27,7 @@ file_agent = Agent(
     name="File Upload Agent",
     id="file-upload-agent",
     role="Answer questions about the uploaded files",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     update_memory_on_run=True,
     instructions=[

--- a/cookbook/05_agent_os/customize/custom_fastapi_app.py
+++ b/cookbook/05_agent_os/customize/custom_fastapi_app.py
@@ -24,7 +24,7 @@ db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 web_research_agent = Agent(
     id="web-research-agent",
     name="Web Research Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/05_agent_os/customize/custom_health_endpoint.py
+++ b/cookbook/05_agent_os/customize/custom_health_endpoint.py
@@ -22,7 +22,7 @@ db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 web_research_agent = Agent(
     id="web-research-agent",
     name="Web Research Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/05_agent_os/customize/custom_lifespan.py
+++ b/cookbook/05_agent_os/customize/custom_lifespan.py
@@ -21,7 +21,7 @@ db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 agno_support_agent = Agent(
     id="example-agent",
     name="Example Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     markdown=True,
 )

--- a/cookbook/05_agent_os/customize/override_routes.py
+++ b/cookbook/05_agent_os/customize/override_routes.py
@@ -31,7 +31,7 @@ db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 web_research_agent = Agent(
     id="web-research-agent",
     name="Web Research Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/05_agent_os/dbs/surreal_db/workflows.py
+++ b/cookbook/05_agent_os/dbs/surreal_db/workflows.py
@@ -36,19 +36,19 @@ class ResearchTopic(BaseModel):
 # ************* Agents *************
 wikipedia_agent = Agent(
     name="Wikipedia Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Extract key insights and content from Wikipedia articles",
     tools=[WikipediaTools()],
 )
 search_agent = Agent(
     name="Search Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     role="Search the web for the latest news and trends using Firecrawl",
     tools=[FirecrawlTools()],
 )
 writer_agent = Agent(
     name="Writer Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     instructions=[
         "Write a detailed report on the provided topic and research content",
     ],

--- a/cookbook/05_agent_os/interfaces/whatsapp/agent_with_user_memory.py
+++ b/cookbook/05_agent_os/interfaces/whatsapp/agent_with_user_memory.py
@@ -28,13 +28,13 @@ memory_manager = MemoryManager(
                     Collect Information about the users likes and dislikes,
                     Collect information about what the user is doing with their life right now
                 """,
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
 )
 
 
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/cookbook/05_agent_os/interfaces/whatsapp/reasoning_agent.py
+++ b/cookbook/05_agent_os/interfaces/whatsapp/reasoning_agent.py
@@ -21,7 +21,7 @@ agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 
 reasoning_finance_agent = Agent(
     name="Reasoning Finance Agent",
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=agent_db,
     tools=[
         ReasoningTools(add_instructions=True),

--- a/cookbook/05_agent_os/knowledge/agno_docs_agent.py
+++ b/cookbook/05_agent_os/knowledge/agno_docs_agent.py
@@ -113,7 +113,7 @@ knowledge = Knowledge(
 agno_assist = Agent(
     name="Agno Assist",
     id="agno-assist",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     description=description,
     instructions=instructions,
     db=db,

--- a/cookbook/05_agent_os/mcp_demo/enable_mcp_example.py
+++ b/cookbook/05_agent_os/mcp_demo/enable_mcp_example.py
@@ -21,7 +21,7 @@ db = SqliteDb(db_file="tmp/agentos.db")
 web_research_agent = Agent(
     id="web-research-agent",
     name="Web Research Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/05_agent_os/mcp_demo/mcp_tools_advanced_example.py
+++ b/cookbook/05_agent_os/mcp_demo/mcp_tools_advanced_example.py
@@ -43,7 +43,7 @@ brave_mcp_tools = MCPTools(
 ai_framework_agent = Agent(
     id="agno-support-agent",
     name="Agno Support Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[brave_mcp_tools, agno_mcp_tools],
     add_history_to_context=True,

--- a/cookbook/05_agent_os/mcp_demo/mcp_tools_example.py
+++ b/cookbook/05_agent_os/mcp_demo/mcp_tools_example.py
@@ -23,7 +23,7 @@ mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp
 agno_support_agent = Agent(
     id="agno-support-agent",
     name="Agno Support Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[mcp_tools],
     add_history_to_context=True,

--- a/cookbook/05_agent_os/mcp_demo/mcp_tools_existing_lifespan.py
+++ b/cookbook/05_agent_os/mcp_demo/mcp_tools_existing_lifespan.py
@@ -28,7 +28,7 @@ mcp_tools = MCPTools(transport="streamable-http", url="https://docs.agno.com/mcp
 agno_support_agent = Agent(
     id="agno-support-agent",
     name="Agno Support Agent",
-    model=Claude(id="claude-sonnet-4-0"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=db,
     tools=[mcp_tools],
     add_history_to_context=True,

--- a/cookbook/10_reasoning/agents/is_9_11_bigger_than_9_9.py
+++ b/cookbook/10_reasoning/agents/is_9_11_bigger_than_9_9.py
@@ -26,10 +26,10 @@ cot_agent_openai = Agent(
     markdown=True,
 )
 
-regular_agent_claude = Agent(model=Claude("claude-3-5-sonnet-20241022"), markdown=True)
+regular_agent_claude = Agent(model=Claude("claude-sonnet-4-6"), markdown=True)
 
 deepseek_agent_claude = Agent(
-    model=Claude("claude-3-5-sonnet-20241022"),
+    model=Claude("claude-sonnet-4-6"),
     reasoning_model=DeepSeek(id="deepseek-reasoner"),
     markdown=True,
 )

--- a/cookbook/10_reasoning/models/groq/deepseek_plus_claude.py
+++ b/cookbook/10_reasoning/models/groq/deepseek_plus_claude.py
@@ -15,7 +15,7 @@ from agno.models.groq import Groq
 # ---------------------------------------------------------------------------
 def run_example() -> None:
     deepseek_plus_claude = Agent(
-        model=Claude(id="claude-3-7-sonnet-20250219"),
+        model=Claude(id="claude-sonnet-4-6"),
         reasoning_model=Groq(
             id="qwen/qwen3-32b",
             temperature=0.6,

--- a/cookbook/90_models/anthropic/skills/README.md
+++ b/cookbook/90_models/anthropic/skills/README.md
@@ -198,7 +198,7 @@ See `test_with_file_download.py` for a complete example.
 
 ### Model Requirements
 - Recommended: `claude-sonnet-4-5-20250929` or later
-- Minimum: `claude-3-5-sonnet-20241022`
+- Minimum: `claude-sonnet-4-6`
 - Skills require models with code execution capability
 
 ### Beta Version

--- a/cookbook/90_models/anthropic/thinking.py
+++ b/cookbook/90_models/anthropic/thinking.py
@@ -14,7 +14,7 @@ from agno.models.anthropic import Claude
 
 agent = Agent(
     model=Claude(
-        id="claude-3-7-sonnet-20250219",
+        id="claude-sonnet-4-6",
         max_tokens=2048,
         thinking={"type": "enabled", "budget_tokens": 1024},
     ),

--- a/cookbook/90_models/aws/bedrock/basic.py
+++ b/cookbook/90_models/aws/bedrock/basic.py
@@ -14,7 +14,7 @@ import asyncio
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=AwsBedrock(id="us.anthropic.claude-3-5-haiku-20241022-v1:0"), markdown=True
+    model=AwsBedrock(id="us.anthropic.claude-haiku-4-5-20251001-v1:0"), markdown=True
 )
 
 # Get the response in a variable

--- a/cookbook/90_models/aws/bedrock/structured_output.py
+++ b/cookbook/90_models/aws/bedrock/structured_output.py
@@ -37,7 +37,7 @@ class MovieScript(BaseModel):
 
 
 movie_agent = Agent(
-    model=AwsBedrock(id="us.anthropic.claude-3-5-haiku-20241022-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-haiku-4-5-20251001-v1:0"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
 )

--- a/cookbook/90_models/aws/bedrock/tool_use.py
+++ b/cookbook/90_models/aws/bedrock/tool_use.py
@@ -11,7 +11,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=AwsBedrock(id="us.anthropic.claude-3-5-haiku-20241022-v1:0"),
+    model=AwsBedrock(id="us.anthropic.claude-haiku-4-5-20251001-v1:0"),
     tools=[WebSearchTools()],
     instructions="You are a helpful assistant that can use the following tools to answer questions.",
     markdown=True,

--- a/cookbook/90_models/aws/claude/README.md
+++ b/cookbook/90_models/aws/claude/README.md
@@ -25,7 +25,7 @@ Alternatively, you can use an AWS profile:
 import boto3
 session = boto3.Session(profile_name='MY-PROFILE')
 agent = Agent(
-    model=Claude(id="anthropic.claude-3-5-sonnet-20240620-v1:0", session=session),
+    model=Claude(id="anthropic.claude-sonnet-4-6", session=session),
     markdown=True
 )
 ```

--- a/cookbook/90_models/cometapi/README.md
+++ b/cookbook/90_models/cometapi/README.md
@@ -127,13 +127,13 @@ CometAPI provides access to multiple LLM providers through a unified interface. 
 #### Claude Series
 - `claude-opus-4-1-20250805`
 - `claude-sonnet-4-20250514`
-- `claude-3-7-sonnet-latest`
-- `claude-3-5-haiku-latest`
+- `claude-sonnet-4-6`
+- `claude-haiku-4-5-latest`
 
 #### Gemini Series
 - `gemini-2.5-pro`
 - `gemini-2.5-flash`
-- `gemini-2.0-flash`
+- `gemini-flash-latest`
 
 #### Grok Series
 - `grok-4-0709`

--- a/cookbook/90_models/google/gemini/image_input.py
+++ b/cookbook/90_models/google/gemini/image_input.py
@@ -15,7 +15,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini/image_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/image_input_file_upload.py
@@ -19,7 +19,7 @@ from google.generativeai.types import file_types
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-exp"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini/storage_and_memory.py
+++ b/cookbook/90_models/google/gemini/storage_and_memory.py
@@ -20,7 +20,7 @@ knowledge_base = PDFUrlKnowledgeBase(
 knowledge_base.load(recreate=True)  # Comment out after first run
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     knowledge=knowledge_base,
     # Store the memories and summary in a database

--- a/cookbook/90_models/google/gemini/tool_use.py
+++ b/cookbook/90_models/google/gemini/tool_use.py
@@ -11,7 +11,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-2.0-flash-001"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/litellm_openai/README.md
+++ b/cookbook/90_models/litellm_openai/README.md
@@ -28,7 +28,7 @@ litellm --model gpt-4o --host 127.0.0.1 --port 4000
 ```
 or, if you want to use some other model like from Anthropic
 ```shell
-litellm --model claude-3-sonnet-20240229 --host 127.0.0.1 --port 4000
+litellm --model claude-sonnet-4-6 --host 127.0.0.1 --port 4000
 ```
 
 ### 5. Run basic Agent

--- a/cookbook/91_tools/mcp/agno_mcp.py
+++ b/cookbook/91_tools/mcp/agno_mcp.py
@@ -21,7 +21,7 @@ async def run_agent(message: str) -> None:
         transport="streamable-http", url="https://docs.agno.com/mcp"
     ) as agno_mcp_server:
         agent = Agent(
-            model=Claude(id="claude-sonnet-4-0"),
+            model=Claude(id="claude-sonnet-4-6"),
             tools=[agno_mcp_server],
             markdown=True,
         )

--- a/cookbook/91_tools/webbrowser_tools.py
+++ b/cookbook/91_tools/webbrowser_tools.py
@@ -17,7 +17,7 @@ from agno.tools.websearch import WebSearchTools
 
 # Example 1: Enable specific WebBrowser functions
 agent = Agent(
-    model=Gemini("gemini-2.0-flash"),
+    model=Gemini("gemini-flash-latest"),
     tools=[WebBrowserTools(enable_open_page=True), WebSearchTools()],
     instructions=[
         "Find related websites and pages using DuckDuckGo",
@@ -28,7 +28,7 @@ agent = Agent(
 
 # Example 2: Enable all WebBrowser functions
 agent_all = Agent(
-    model=Gemini("gemini-2.0-flash"),
+    model=Gemini("gemini-flash-latest"),
     tools=[WebBrowserTools(all=True), WebSearchTools()],
     instructions=[
         "Find related websites and pages using DuckDuckGo",

--- a/cookbook/92_integrations/discord/README.md
+++ b/cookbook/92_integrations/discord/README.md
@@ -52,7 +52,7 @@ from agno.models.anthropic import Claude
 
 # Create your agent
 agent = Agent(
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     instructions=["Your agent instructions here"],
     # Add other agent configurations as needed
 )

--- a/cookbook/92_integrations/discord/agent_with_user_memory.py
+++ b/cookbook/92_integrations/discord/agent_with_user_memory.py
@@ -24,7 +24,7 @@ db = SqliteDb(db_file="tmp/discord_client_cookbook.db")
 # ---------------------------------------------------------------------------
 personal_agent = Agent(
     name="Basic Agent",
-    model=Gemini(id="gemini-2.0-flash"),
+    model=Gemini(id="gemini-flash-latest"),
     tools=[WebSearchTools()],
     add_history_to_context=True,
     num_history_runs=3,

--- a/cookbook/92_integrations/rag/agentic_rag_infinity_reranker.py
+++ b/cookbook/92_integrations/rag/agentic_rag_infinity_reranker.py
@@ -39,7 +39,7 @@ knowledge = Knowledge(
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Claude(id="claude-3-7-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     # Agentic RAG is enabled by default when `knowledge` is provided to the Agent.
     knowledge=knowledge,
     # search_knowledge=True gives the Agent the ability to search on demand

--- a/cookbook/92_integrations/surrealdb/custom_memory_instructions.py
+++ b/cookbook/92_integrations/surrealdb/custom_memory_instructions.py
@@ -40,7 +40,7 @@ custom_memory_manager = MemoryManager(
 
 # Use default memory manager
 jane_memory_manager = MemoryManager(
-    model=Claude(id="claude-3-5-sonnet-latest"),
+    model=Claude(id="claude-sonnet-4-6"),
     db=memory_db,
 )
 

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -106,7 +106,7 @@ class Claude(Model):
         # (Add any Opus 4.x models released before 4.1/4.5 if they exist)
     }
 
-    id: str = "claude-sonnet-4-5-20250929"
+    id: str = "claude-sonnet-4-6"
     name: str = "Claude"
     provider: str = "Anthropic"
 

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -73,7 +73,7 @@ class Gemini(Model):
     Based on https://googleapis.github.io/python-genai/
     """
 
-    id: str = "gemini-2.0-flash-001"
+    id: str = "gemini-flash-latest"
     name: str = "Gemini"
     provider: str = "Google"
 

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -201,7 +201,7 @@ def get_base_router(
                     "application/json": {
                         "example": [
                             {"id": "gpt-4", "provider": "openai"},
-                            {"id": "claude-3-sonnet", "provider": "anthropic"},
+                            {"id": "claude-sonnet-4-6", "provider": "anthropic"},
                         ]
                     }
                 },

--- a/libs/agno/agno/os/routers/memory/memory.py
+++ b/libs/agno/agno/os/routers/memory/memory.py
@@ -631,7 +631,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
             "This operation combines all memories into a single comprehensive summary, "
             "achieving maximum token reduction while preserving all key information. "
             "To use a custom model, specify the model parameter in 'provider:model_id' format "
-            "(e.g., 'openai:gpt-4o-mini', 'anthropic:claude-3-5-sonnet-20241022'). "
+            "(e.g., 'openai:gpt-4o-mini', 'anthropic:claude-sonnet-4-6'). "
             "If not specified, uses MemoryManager's default model (gpt-4o). "
             "Set apply=false to preview optimization results without saving to database."
         ),

--- a/libs/agno/agno/os/routers/memory/schemas.py
+++ b/libs/agno/agno/os/routers/memory/schemas.py
@@ -83,7 +83,7 @@ class OptimizeMemoriesRequest(BaseModel):
     user_id: str = Field(..., description="User ID to optimize memories for")
     model: Optional[str] = Field(
         default=None,
-        description="Model to use for optimization in format 'provider:model_id' (e.g., 'openai:gpt-4o-mini', 'anthropic:claude-3-5-sonnet-20241022', 'google:gemini-2.0-flash-exp'). If not specified, uses MemoryManager's default model (gpt-4o).",
+        description="Model to use for optimization in format 'provider:model_id' (e.g., 'openai:gpt-4o-mini', 'anthropic:claude-sonnet-4-6', 'google:gemini-flash-latest'). If not specified, uses MemoryManager's default model (gpt-4o).",
     )
     apply: bool = Field(
         default=True,

--- a/libs/agno/tests/integration/agent/test_agent_reasoning_new_models.py
+++ b/libs/agno/tests/integration/agent/test_agent_reasoning_new_models.py
@@ -268,7 +268,7 @@ def test_agent_openai_reasoning_non_streaming():
     # Create an Agent with OpenAI reasoning model
     agent = Agent(
         model=OpenAIChat(id="gpt-4o"),
-        reasoning_model=OpenAIChat(id="o1-mini"),
+        reasoning_model=OpenAIChat(id="o4-mini"),
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
             Use step-by-step reasoning to solve the problem.
@@ -298,7 +298,7 @@ def test_agent_openai_reasoning_streaming(shared_db):
     # Create an Agent with OpenAI reasoning model
     agent = Agent(
         model=OpenAIChat(id="gpt-4o"),
-        reasoning_model=OpenAIChat(id="o1-mini"),
+        reasoning_model=OpenAIChat(id="o4-mini"),
         db=shared_db,
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
@@ -540,7 +540,7 @@ def test_agent_azure_ai_foundry_reasoning_non_streaming():
     # Create an Agent with Azure AI Foundry reasoning model
     agent = Agent(
         model=AzureAIFoundry(id="gpt-4o"),
-        reasoning_model=AzureAIFoundry(id="o1-mini"),
+        reasoning_model=AzureAIFoundry(id="o4-mini"),
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
             Use step-by-step reasoning to solve the problem.
@@ -570,7 +570,7 @@ def test_agent_azure_ai_foundry_reasoning_streaming(shared_db):
     # Create an Agent with Azure AI Foundry reasoning model
     agent = Agent(
         model=AzureAIFoundry(id="gpt-4o"),
-        reasoning_model=AzureAIFoundry(id="o1-mini"),
+        reasoning_model=AzureAIFoundry(id="o4-mini"),
         db=shared_db,
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
@@ -652,10 +652,10 @@ def test_agent_accepts_openai_reasoning_model():
     try:
         agent = Agent(
             model=OpenAIChat(id="gpt-4o"),
-            reasoning_model=OpenAIChat(id="o1-mini"),
+            reasoning_model=OpenAIChat(id="o4-mini"),
         )
         assert agent.reasoning_model is not None
-        assert agent.reasoning_model.id == "o1-mini"
+        assert agent.reasoning_model.id == "o4-mini"
     except Exception as e:
         pytest.fail(f"Failed to create Agent with OpenAI reasoning model: {e}")
 
@@ -704,9 +704,9 @@ def test_agent_accepts_azure_ai_foundry_reasoning_model():
     try:
         agent = Agent(
             model=AzureAIFoundry(id="gpt-4o"),
-            reasoning_model=AzureAIFoundry(id="o1-mini"),
+            reasoning_model=AzureAIFoundry(id="o4-mini"),
         )
         assert agent.reasoning_model is not None
-        assert agent.reasoning_model.id == "o1-mini"
+        assert agent.reasoning_model.id == "o4-mini"
     except Exception as e:
         pytest.fail(f"Failed to create Agent with Azure AI Foundry reasoning model: {e}")

--- a/libs/agno/tests/integration/agent/test_parser_model.py
+++ b/libs/agno/tests/integration/agent/test_parser_model.py
@@ -70,7 +70,7 @@ def test_openai_with_claude_parser_model():
 
 def test_gemini_with_openai_parser_model():
     park_agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),  # Main model to generate the content
+        model=Gemini(id="gemini-flash-latest"),  # Main model to generate the content
         description="You are an expert on national parks and provide concise guides.",
         output_schema=ParkGuide,
         parser_model=OpenAIChat(id="gpt-4o"),  # Model to parse the output

--- a/libs/agno/tests/integration/db/async_postgres/test_evals.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_evals.py
@@ -59,7 +59,7 @@ def sample_eval_runs() -> List[EvalRunRecord]:
                 agent_id=f"test_agent_{i}" if i % 2 == 0 else None,
                 team_id=f"test_team_{i}" if i % 2 == 1 else None,
                 workflow_id=None,
-                model_id="gpt-4" if i % 3 == 0 else "gpt-3.5-turbo",
+                model_id="gpt-4" if i % 3 == 0 else "gpt-4o-mini",
                 model_provider="openai",
                 evaluated_component_name=f"Test Component {i}",
                 created_at=int(time.time()) + i,

--- a/libs/agno/tests/integration/db/postgres/test_evals.py
+++ b/libs/agno/tests/integration/db/postgres/test_evals.py
@@ -51,7 +51,7 @@ def sample_eval_run_team() -> EvalRunRecord:
     return EvalRunRecord(
         run_id="test_eval_run_team_1",
         team_id="test_team_1",
-        model_id="gpt-4-turbo",
+        model_id="gpt-4o",
         model_provider="openai",
         name="Team Performance Test",
         evaluated_component_name="Test Team",
@@ -76,7 +76,7 @@ def sample_eval_run_workflow() -> EvalRunRecord:
     return EvalRunRecord(
         run_id="test_eval_run_workflow_1",
         workflow_id="test_workflow_1",
-        model_id="claude-3-opus",
+        model_id="claude-sonnet-4-6",
         model_provider="anthropic",
         name="Workflow Reliability Test",
         evaluated_component_name="Test Workflow",

--- a/libs/agno/tests/integration/knowledge/filters/test_agentic_filtering.py
+++ b/libs/agno/tests/integration/knowledge/filters/test_agentic_filtering.py
@@ -165,7 +165,7 @@ async def test_agentic_filtering_openai_with_output_schema(knowledge_base):
 
 
 async def test_agentic_filtering_gemini(knowledge_base):
-    agent = Agent(model=Gemini("gemini-2.0-flash-001"), knowledge=knowledge_base, enable_agentic_knowledge_filters=True)
+    agent = Agent(model=Gemini("gemini-flash-latest"), knowledge=knowledge_base, enable_agentic_knowledge_filters=True)
     response = await agent.arun(
         "Tell me about revenue performance and top selling products in the region north_america and data_type sales",
         markdown=True,
@@ -193,7 +193,7 @@ async def test_agentic_filtering_gemini(knowledge_base):
 
 
 async def test_agentic_filtering_claude(knowledge_base):
-    agent = Agent(model=Claude("claude-sonnet-4-0"), knowledge=knowledge_base, enable_agentic_knowledge_filters=True)
+    agent = Agent(model=Claude("claude-sonnet-4-6"), knowledge=knowledge_base, enable_agentic_knowledge_filters=True)
     response = await agent.arun(
         "Tell me about revenue performance and top selling products in the region north_america and data_type sales",
         markdown=True,

--- a/libs/agno/tests/integration/models/aws/bedrock/test_basic.py
+++ b/libs/agno/tests/integration/models/aws/bedrock/test_basic.py
@@ -19,7 +19,7 @@ def _assert_metrics(response: RunOutput):
 
 
 def test_basic():
-    agent = Agent(model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     # Print the response in the terminal
     response: RunOutput = agent.run("Share a 2 sentence horror story")
@@ -33,7 +33,7 @@ def test_basic():
 
 
 def test_basic_stream():
-    agent = Agent(model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     for chunk in agent.run("Share a 2 sentence horror story", stream=True):
         assert chunk.content is not None
@@ -42,7 +42,7 @@ def test_basic_stream():
 def test_with_memory():
     agent = Agent(
         db=SqliteDb(db_file="tmp/test_with_memory.db"),
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         add_history_to_context=True,
         telemetry=False,
         markdown=True,
@@ -73,7 +73,7 @@ def test_output_schema():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         output_schema=MovieScript,
         markdown=True,
         telemetry=False,
@@ -95,7 +95,7 @@ def test_json_response_mode():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         output_schema=MovieScript,
         use_json_mode=True,
         telemetry=False,
@@ -112,7 +112,7 @@ def test_json_response_mode():
 
 def test_history():
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         db=SqliteDb(db_file="tmp/aws-bedrock/test_basic.db"),
         add_history_to_context=True,
         store_history_messages=True,
@@ -138,7 +138,7 @@ def test_history():
 @pytest.mark.asyncio
 async def test_async_basic():
     """Test basic async agent functionality."""
-    agent = Agent(model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     response: RunOutput = await agent.arun("Share a 2 sentence horror story")
 
@@ -153,7 +153,7 @@ async def test_async_basic():
 @pytest.mark.asyncio
 async def test_async_basic_stream():
     """Test basic async streaming functionality."""
-    agent = Agent(model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     async for response in agent.arun("Share a 2 sentence horror story", stream=True):
         assert response.content is not None
@@ -163,7 +163,7 @@ async def test_async_basic_stream():
 async def test_async_with_memory():
     """Test async agent with memory functionality."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         db=SqliteDb(db_file="tmp/aws-bedrock/test_with_memory.db"),
         add_history_to_context=True,
         telemetry=False,
@@ -194,7 +194,7 @@ async def test_async_output_schema():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         output_schema=MovieScript,
         markdown=True,
         telemetry=False,
@@ -218,7 +218,7 @@ async def test_async_json_response_mode():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         output_schema=MovieScript,
         use_json_mode=True,
         telemetry=False,
@@ -236,7 +236,7 @@ async def test_async_json_response_mode():
 async def test_async_history():
     """Test async agent with persistent history."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         db=SqliteDb(db_file="tmp/aws-bedrock/test_basic.db"),
         add_history_to_context=True,
         telemetry=False,
@@ -262,7 +262,7 @@ async def test_async_history():
 def test_count_tokens():
     from agno.models.message import Message
 
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
     messages = [
         Message(role="user", content="Hello world, this is a test message for token counting"),
     ]
@@ -278,7 +278,7 @@ def test_count_tokens_with_tools():
     from agno.models.message import Message
     from agno.tools.calculator import CalculatorTools
 
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
     messages = [
         Message(role="user", content="What is 2 + 2?"),
     ]
@@ -297,7 +297,7 @@ async def test_acount_tokens():
     """Test async token counting uses the async client."""
     from agno.models.message import Message
 
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
     messages = [
         Message(role="user", content="Hello world, this is a test message for token counting"),
     ]
@@ -316,7 +316,7 @@ async def test_acount_tokens_with_tools():
     from agno.models.message import Message
     from agno.tools.calculator import CalculatorTools
 
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
     messages = [
         Message(role="user", content="What is 2 + 2?"),
     ]

--- a/libs/agno/tests/integration/models/aws/bedrock/test_tool_use.py
+++ b/libs/agno/tests/integration/models/aws/bedrock/test_tool_use.py
@@ -12,7 +12,7 @@ from agno.utils.log import log_info
 
 def test_tool_use():
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -28,7 +28,7 @@ def test_tool_use():
 
 def test_tool_use_stream():
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -54,7 +54,7 @@ def test_tool_use_stream():
 
 def test_parallel_tool_calls():
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -74,7 +74,7 @@ def test_parallel_tool_calls():
 
 def test_multiple_tool_calls():
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True), WebSearchTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -100,7 +100,7 @@ def test_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[get_the_weather_in_tokyo],
         markdown=True,
         telemetry=False,
@@ -128,7 +128,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -145,7 +145,7 @@ def test_tool_call_custom_tool_optional_parameters():
 
 def test_tool_call_list_parameters():
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[ExaTools()],
         instructions="Use a single tool call if possible",
         markdown=True,
@@ -176,7 +176,7 @@ def test_tool_call_list_parameters():
 async def test_async_tool_use():
     """Test async tool usage with Claude model."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -194,7 +194,7 @@ async def test_async_tool_use():
 async def test_async_tool_use_stream():
     """Test async streaming tool usage."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -212,7 +212,7 @@ async def test_async_tool_use_stream():
 async def test_async_parallel_tool_calls():
     """Test async parallel tool calls."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -234,7 +234,7 @@ async def test_async_parallel_tool_calls():
 async def test_async_multiple_tool_calls():
     """Test async multiple different tool calls."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True), WebSearchTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -263,7 +263,7 @@ async def test_async_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[get_the_weather_in_tokyo],
         markdown=True,
         telemetry=False,
@@ -295,7 +295,7 @@ async def test_async_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -314,7 +314,7 @@ async def test_async_tool_call_custom_tool_optional_parameters():
 async def test_async_tool_call_list_parameters():
     """Test async tool calls with list parameters."""
     agent = Agent(
-        model=AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[ExaTools()],
         instructions="Use a single tool call if possible",
         markdown=True,

--- a/libs/agno/tests/integration/models/aws/claude/test_basic.py
+++ b/libs/agno/tests/integration/models/aws/claude/test_basic.py
@@ -19,7 +19,7 @@ def _assert_metrics(response: RunOutput):
 
 
 def test_basic():
-    agent = Agent(model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     # Print the response in the terminal
     response: RunOutput = agent.run("Share a 2 sentence horror story")
@@ -34,7 +34,7 @@ def test_basic():
 
 def test_basic_stream():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         instructions="You tell ghost stories",
         markdown=True,
         telemetry=False,
@@ -47,7 +47,7 @@ def test_basic_stream():
 
 @pytest.mark.asyncio
 async def test_async_basic():
-    agent = Agent(model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     response = await agent.arun("Share a 2 sentence horror story")
 
@@ -60,7 +60,7 @@ async def test_async_basic():
 
 @pytest.mark.asyncio
 async def test_async_basic_stream():
-    agent = Agent(model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     async for response in agent.arun("Share a 2 sentence horror story", stream=True):
         assert response.content is not None
@@ -69,7 +69,7 @@ async def test_async_basic_stream():
 def test_with_memory():
     agent = Agent(
         db=SqliteDb(db_file="tmp/test_with_memory.db"),
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         add_history_to_context=True,
         markdown=True,
         telemetry=False,
@@ -101,7 +101,7 @@ def test_structured_output():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         output_schema=MovieScript,
         telemetry=False,
     )
@@ -122,7 +122,7 @@ def test_json_response_mode():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         output_schema=MovieScript,
         use_json_mode=True,
         telemetry=False,
@@ -139,7 +139,7 @@ def test_json_response_mode():
 
 def test_history():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         db=SqliteDb(db_file="tmp/aws-claude/test_basic.db"),
         add_history_to_context=True,
         store_history_messages=True,

--- a/libs/agno/tests/integration/models/aws/claude/test_multimodal.py
+++ b/libs/agno/tests/integration/models/aws/claude/test_multimodal.py
@@ -4,7 +4,7 @@ from agno.models.aws.claude import Claude
 
 
 def test_image_input():
-    agent = Agent(model=Claude(id="anthropic.claude-3-5-sonnet-20240620-v1:0"), markdown=True, telemetry=False)
+    agent = Agent(model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"), markdown=True, telemetry=False)
 
     response = agent.run(
         "Tell me about this image.",

--- a/libs/agno/tests/integration/models/aws/claude/test_tool_use.py
+++ b/libs/agno/tests/integration/models/aws/claude/test_tool_use.py
@@ -11,7 +11,7 @@ from agno.tools.yfinance import YFinanceTools
 
 def test_tool_use():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -27,7 +27,7 @@ def test_tool_use():
 
 def test_tool_use_stream():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -53,7 +53,7 @@ def test_tool_use_stream():
 @pytest.mark.asyncio
 async def test_async_tool_use():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -70,7 +70,7 @@ async def test_async_tool_use():
 @pytest.mark.asyncio
 async def test_async_tool_use_stream():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -86,7 +86,7 @@ async def test_async_tool_use_stream():
 
 def test_parallel_tool_calls():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -107,7 +107,7 @@ def test_parallel_tool_calls():
 
 def test_multiple_tool_calls():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[YFinanceTools(cache_results=True), WebSearchTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -134,7 +134,7 @@ def test_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[get_the_weather_in_tokyo],
         instructions="Call the weather tool when asked about the weather",
         markdown=True,
@@ -163,7 +163,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -179,7 +179,7 @@ def test_tool_call_custom_tool_optional_parameters():
 
 def test_tool_call_list_parameters():
     agent = Agent(
-        model=Claude(id="anthropic.claude-3-sonnet-20240229-v1:0"),
+        model=Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0"),
         tools=[ExaTools()],
         instructions="Use a single tool call if possible",
         markdown=True,

--- a/libs/agno/tests/integration/models/google/test_basic.py
+++ b/libs/agno/tests/integration/models/google/test_basic.py
@@ -22,7 +22,7 @@ def _assert_metrics(response: RunOutput):
 
 def test_basic():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -40,7 +40,7 @@ def test_basic():
 
 
 def test_basic_stream():
-    agent = Agent(model=Gemini(id="gemini-2.0-flash"), exponential_backoff=True, markdown=True, telemetry=False)
+    agent = Agent(model=Gemini(id="gemini-flash-latest"), exponential_backoff=True, markdown=True, telemetry=False)
 
     response_stream = agent.run("Share a 2 sentence horror story", stream=True)
 
@@ -56,7 +56,7 @@ def test_basic_stream():
 @pytest.mark.asyncio
 async def test_async_basic():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -74,7 +74,7 @@ async def test_async_basic():
 @pytest.mark.asyncio
 async def test_async_basic_stream():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -87,7 +87,7 @@ async def test_async_basic_stream():
 
 def test_exception_handling():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-made-up-id"),
+        model=Gemini(id="gemini-flash-latest-made-up-id"),
         markdown=True,
         telemetry=False,
     )
@@ -96,13 +96,13 @@ def test_exception_handling():
     response = agent.run("Share a 2 sentence horror story")
     assert response.status == RunStatus.error
     assert response.content is not None
-    assert "gemini-2.0-flash-made-up-id" in response.content
+    assert "gemini-flash-latest-made-up-id" in response.content
 
 
 def test_with_memory():
     agent = Agent(
         db=SqliteDb(db_file="tmp/test_with_memory.db"),
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         add_history_to_context=True,
@@ -135,7 +135,7 @@ def test_structured_output():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         output_schema=MovieScript,
@@ -158,7 +158,7 @@ def test_json_response_mode():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         output_schema=MovieScript,
@@ -177,7 +177,7 @@ def test_json_response_mode():
 
 def test_history():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         db=SqliteDb(db_file="tmp/google/test_basic.db"),
@@ -234,7 +234,7 @@ def test_custom_client_params():
     # Simple agent
     agent = Agent(
         model=Gemini(
-            id="gemini-2.0-flash",
+            id="gemini-flash-latest",
             vertexai=True,
             generation_config=generation_config,
             safety_settings=safety_settings,
@@ -249,7 +249,7 @@ def test_custom_client_params():
 def test_count_tokens():
     from agno.models.message import Message
 
-    model = Gemini(id="gemini-2.0-flash")
+    model = Gemini(id="gemini-flash-latest")
     messages = [
         Message(role="user", content="Hello world, this is a test message for token counting"),
     ]
@@ -265,7 +265,7 @@ def test_count_tokens_with_tools():
     from agno.models.message import Message
     from agno.tools.calculator import CalculatorTools
 
-    model = Gemini(id="gemini-2.0-flash")
+    model = Gemini(id="gemini-flash-latest")
     messages = [
         Message(role="user", content="What is 2 + 2?"),
     ]
@@ -284,7 +284,7 @@ async def test_acount_tokens():
     """Test async token counting."""
     from agno.models.message import Message
 
-    model = Gemini(id="gemini-2.0-flash")
+    model = Gemini(id="gemini-flash-latest")
     messages = [
         Message(role="user", content="Hello world, this is a test message for token counting"),
     ]
@@ -303,7 +303,7 @@ async def test_acount_tokens_with_tools():
     from agno.models.message import Message
     from agno.tools.calculator import CalculatorTools
 
-    model = Gemini(id="gemini-2.0-flash")
+    model = Gemini(id="gemini-flash-latest")
     messages = [
         Message(role="user", content="What is 2 + 2?"),
     ]
@@ -325,7 +325,7 @@ async def test_acount_tokens_vertexai():
     """Test async token counting with VertexAI."""
     from agno.models.message import Message
 
-    model = Gemini(id="gemini-2.0-flash", vertexai=True)
+    model = Gemini(id="gemini-flash-latest", vertexai=True)
     messages = [
         Message(role="user", content="Hello world, this is a test message for token counting"),
     ]

--- a/libs/agno/tests/integration/models/google/test_multimodal.py
+++ b/libs/agno/tests/integration/models/google/test_multimodal.py
@@ -12,7 +12,7 @@ from agno.models.google import Gemini
 
 def test_image_input(image_path):
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -37,7 +37,7 @@ def test_audio_input_bytes():
 
     # Provide the agent with the audio file and get result as text
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -50,7 +50,7 @@ def test_audio_input_bytes():
 
 def test_audio_input_url():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -67,7 +67,7 @@ def test_audio_input_url():
 
 def test_video_input_bytes():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -255,7 +255,7 @@ def test_combined_text_and_image_generation():
 
 def test_file_input_bytes():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,
@@ -276,7 +276,7 @@ def test_file_input_bytes():
 
 def test_file_input_with_text_prompt():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         exponential_backoff=True,
         delay_between_retries=5,
         markdown=True,

--- a/libs/agno/tests/integration/models/google/test_reasoning_streaming.py
+++ b/libs/agno/tests/integration/models/google/test_reasoning_streaming.py
@@ -17,7 +17,7 @@ from agno.run.agent import RunEvent
 def _get_reasoning_streaming_agent(**kwargs):
     """Create an agent with Gemini reasoning_model for streaming reasoning tests."""
     default_config = {
-        "model": Gemini(id="gemini-2.0-flash"),
+        "model": Gemini(id="gemini-flash-latest"),
         "reasoning_model": Gemini(
             id="gemini-2.5-flash",
             thinking_budget=1024,

--- a/libs/agno/tests/integration/models/google/test_retryable_exceptions.py
+++ b/libs/agno/tests/integration/models/google/test_retryable_exceptions.py
@@ -15,7 +15,7 @@ from agno.run.base import RunStatus
 @pytest.fixture
 def model():
     """Fixture to create a Gemini model."""
-    return Gemini(id="gemini-2.0-flash-001")
+    return Gemini(id="gemini-flash-latest")
 
 
 def create_mock_response(finish_reason: str = "STOP", content: str = "Test response"):

--- a/libs/agno/tests/integration/models/google/test_structured_response.py
+++ b/libs/agno/tests/integration/models/google/test_structured_response.py
@@ -81,7 +81,7 @@ class UnionFieldResponse(BaseModel):
 
 def test_structured_response():
     structured_output_agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         description="You help people write movie scripts.",
         output_schema=SimpleMovieScript,
     )
@@ -97,7 +97,7 @@ def test_structured_response():
 
 def test_structured_response_with_dict_fields():
     structured_output_agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         description="You help people write movie scripts.",
         output_schema=MovieScriptWithDict,
     )
@@ -111,7 +111,7 @@ def test_structured_response_with_dict_fields():
 
 def test_structured_response_with_nested_fields():
     structured_output_agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         description="You help people write movie scripts.",
         output_schema=MovieScriptWithNested,
     )
@@ -127,7 +127,7 @@ def test_structured_response_with_nested_fields():
 
 def test_structured_response_with_enum_fields():
     structured_output_agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         description="You help generate recipe names and ratings.",
         output_schema=Recipe,
     )
@@ -140,7 +140,7 @@ def test_structured_response_with_enum_fields():
 def test_structured_response_with_union_field_types():
     """Test structured output with Union types that exercise our union handling logic"""
     structured_output_agent = Agent(
-        model=Gemini(id="gemini-2.0-flash"),
+        model=Gemini(id="gemini-flash-latest"),
         description="You return data with flexible union-typed fields.",
         output_schema=UnionFieldResponse,
     )

--- a/libs/agno/tests/integration/models/google/test_tool_use.py
+++ b/libs/agno/tests/integration/models/google/test_tool_use.py
@@ -119,7 +119,7 @@ def test_tool_use_tool_choice_none():
         return f"The weather in {city} is sunny."
 
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         tools=[get_weather],
         tool_choice="none",
         markdown=True,
@@ -142,7 +142,7 @@ def test_tool_use_tool_choice_auto():
         return f"The weather in {city} is sunny."
 
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         tools=[get_weather],
         tool_choice="auto",
         markdown=True,
@@ -185,7 +185,7 @@ def test_tool_use_with_json_structured_outputs():
         currency: str = Field(..., description="The currency of the stock")
 
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001"),
+        model=Gemini(id="gemini-flash-latest"),
         tools=[YFinanceTools(cache_results=True)],
         exponential_backoff=True,
         delay_between_retries=5,
@@ -250,7 +250,7 @@ def test_multiple_tool_calls():
 
 def test_grounding():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001", grounding=True),
+        model=Gemini(id="gemini-flash-latest", grounding=True),
         exponential_backoff=True,
         delay_between_retries=5,
         telemetry=False,
@@ -267,7 +267,7 @@ def test_grounding():
 
 def test_grounding_stream():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001", grounding=True),
+        model=Gemini(id="gemini-flash-latest", grounding=True),
         exponential_backoff=True,
         delay_between_retries=5,
         telemetry=False,
@@ -289,7 +289,7 @@ def test_grounding_stream():
 
 def test_search_stream():
     agent = Agent(
-        model=Gemini(id="gemini-2.0-flash-001", search=True),
+        model=Gemini(id="gemini-flash-latest", search=True),
         exponential_backoff=True,
         delay_between_retries=5,
         telemetry=False,

--- a/libs/agno/tests/integration/models/langdb/test_basic.py
+++ b/libs/agno/tests/integration/models/langdb/test_basic.py
@@ -19,7 +19,7 @@ def _assert_metrics(response: RunOutput):
 
 
 def test_basic():
-    agent = Agent(model=LangDB(id="gemini-1.5-pro-latest"), markdown=True, telemetry=False)
+    agent = Agent(model=LangDB(id="gemini-pro-latest"), markdown=True, telemetry=False)
 
     # Print the response in the terminal
     response: RunOutput = agent.run("Share a 2 sentence horror story")
@@ -33,7 +33,7 @@ def test_basic():
 
 
 def test_basic_stream():
-    agent = Agent(model=LangDB(id="gemini-1.5-pro-latest"), markdown=True, telemetry=False)
+    agent = Agent(model=LangDB(id="gemini-pro-latest"), markdown=True, telemetry=False)
 
     response_stream = agent.run("Share a 2 sentence horror story", stream=True)
 
@@ -48,7 +48,7 @@ def test_basic_stream():
 
 @pytest.mark.asyncio
 async def test_async_basic():
-    agent = Agent(model=LangDB(id="gemini-1.5-pro-latest"), markdown=True, telemetry=False)
+    agent = Agent(model=LangDB(id="gemini-pro-latest"), markdown=True, telemetry=False)
 
     response = await agent.arun("Share a 2 sentence horror story")
 
@@ -61,7 +61,7 @@ async def test_async_basic():
 
 @pytest.mark.asyncio
 async def test_async_basic_stream():
-    agent = Agent(model=LangDB(id="gemini-1.5-pro-latest"), markdown=True, telemetry=False)
+    agent = Agent(model=LangDB(id="gemini-pro-latest"), markdown=True, telemetry=False)
 
     async for response in agent.arun("Share a 2 sentence horror story", stream=True):
         assert response.content is not None
@@ -70,7 +70,7 @@ async def test_async_basic_stream():
 def test_with_memory():
     agent = Agent(
         db=SqliteDb(db_file="tmp/test_with_memory.db"),
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-pro-latest"),
         add_history_to_context=True,
         markdown=True,
         telemetry=False,
@@ -100,7 +100,7 @@ def test_structured_output():
         genre: str = Field(..., description="Movie genre")
         plot: str = Field(..., description="Brief plot summary")
 
-    agent = Agent(model=LangDB(id="gemini-1.5-pro-latest"), output_schema=MovieScript, telemetry=False)
+    agent = Agent(model=LangDB(id="gemini-pro-latest"), output_schema=MovieScript, telemetry=False)
 
     response = agent.run("Create a movie about time travel")
 
@@ -118,7 +118,7 @@ def test_json_response_mode():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-pro-latest"),
         output_schema=MovieScript,
         use_json_mode=True,
         telemetry=False,
@@ -135,7 +135,7 @@ def test_json_response_mode():
 
 def test_history():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-pro-latest"),
         db=SqliteDb(db_file="tmp/langdb/test_basic.db"),
         add_history_to_context=True,
         store_history_messages=True,

--- a/libs/agno/tests/integration/models/langdb/test_structured_response.py
+++ b/libs/agno/tests/integration/models/langdb/test_structured_response.py
@@ -24,7 +24,7 @@ class MovieScript(BaseModel):
 
 def test_structured_response():
     structured_output_agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         description="You help people write movie scripts.",
         output_schema=MovieScript,
     )
@@ -52,7 +52,7 @@ def test_structured_response_with_enum_fields():
         rating: Grade
 
     structured_output_agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         description="You help generate recipe names and ratings.",
         output_schema=Recipe,
     )
@@ -65,7 +65,7 @@ def test_structured_response_with_enum_fields():
 def test_structured_response_strict_output_false():
     """Test structured response with strict_output=False (guided mode)"""
     guided_output_agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest", strict_output=False),
+        model=LangDB(id="gemini-2.5-pro", strict_output=False),
         description="You write movie scripts.",
         output_schema=MovieScript,
     )

--- a/libs/agno/tests/integration/models/langdb/test_tool_use.py
+++ b/libs/agno/tests/integration/models/langdb/test_tool_use.py
@@ -11,7 +11,7 @@ from agno.tools.yfinance import YFinanceTools
 
 def test_tool_use():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -28,7 +28,7 @@ def test_tool_use():
 
 def test_tool_use_stream():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -50,7 +50,7 @@ def test_tool_use_stream():
 @pytest.mark.asyncio
 async def test_async_tool_use():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -68,7 +68,7 @@ async def test_async_tool_use():
 @pytest.mark.asyncio
 async def test_async_tool_use_stream():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -90,7 +90,7 @@ async def test_async_tool_use_stream():
 
 def test_tool_use_tool_call_limit():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         tool_call_limit=1,
         markdown=True,
@@ -111,7 +111,7 @@ def test_tool_use_tool_call_limit():
 
 def test_tool_use_with_content():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -128,7 +128,7 @@ def test_tool_use_with_content():
 
 def test_parallel_tool_calls():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -149,7 +149,7 @@ def test_parallel_tool_calls():
 
 def test_multiple_tool_calls():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[YFinanceTools(cache_results=True), WebSearchTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -205,7 +205,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -222,7 +222,7 @@ def test_tool_call_custom_tool_optional_parameters():
 
 def test_tool_call_list_parameters():
     agent = Agent(
-        model=LangDB(id="gemini-1.5-pro-latest"),
+        model=LangDB(id="gemini-2.5-pro"),
         tools=[ExaTools()],
         instructions="Use a single tool call if possible",
         markdown=True,

--- a/libs/agno/tests/integration/teams/test_team_reasoning_new_models.py
+++ b/libs/agno/tests/integration/teams/test_team_reasoning_new_models.py
@@ -289,7 +289,7 @@ def test_team_openai_reasoning_non_streaming():
     # Create a Team with OpenAI reasoning model
     team = Team(
         model=OpenAIChat(id="gpt-4o"),
-        reasoning_model=OpenAIChat(id="o1-mini"),
+        reasoning_model=OpenAIChat(id="o4-mini"),
         members=[],
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
@@ -320,7 +320,7 @@ def test_team_openai_reasoning_streaming(shared_db):
     # Create a Team with OpenAI reasoning model
     team = Team(
         model=OpenAIChat(id="gpt-4o"),
-        reasoning_model=OpenAIChat(id="o1-mini"),
+        reasoning_model=OpenAIChat(id="o4-mini"),
         db=shared_db,
         members=[],
         instructions=dedent("""\
@@ -589,7 +589,7 @@ def test_team_azure_ai_foundry_reasoning_non_streaming():
     # Create a Team with Azure AI Foundry reasoning model
     team = Team(
         model=AzureAIFoundry(id="gpt-4o"),
-        reasoning_model=AzureAIFoundry(id="o1-mini"),
+        reasoning_model=AzureAIFoundry(id="o4-mini"),
         members=[],
         instructions=dedent("""\
             You are an expert problem-solving assistant with strong analytical skills! 🧠
@@ -620,7 +620,7 @@ def test_team_azure_ai_foundry_reasoning_streaming(shared_db):
     # Create a Team with Azure AI Foundry reasoning model
     team = Team(
         model=AzureAIFoundry(id="gpt-4o"),
-        reasoning_model=AzureAIFoundry(id="o1-mini"),
+        reasoning_model=AzureAIFoundry(id="o4-mini"),
         db=shared_db,
         members=[],
         instructions=dedent("""\
@@ -711,11 +711,11 @@ def test_team_accepts_openai_reasoning_model():
     try:
         team = Team(
             model=OpenAIChat(id="gpt-4o"),
-            reasoning_model=OpenAIChat(id="o1-mini"),
+            reasoning_model=OpenAIChat(id="o4-mini"),
             members=[],
         )
         assert team.reasoning_model is not None
-        assert team.reasoning_model.id == "o1-mini"
+        assert team.reasoning_model.id == "o4-mini"
     except Exception as e:
         pytest.fail(f"Failed to create Team with OpenAI reasoning model: {e}")
 
@@ -767,10 +767,10 @@ def test_team_accepts_azure_ai_foundry_reasoning_model():
     try:
         team = Team(
             model=AzureAIFoundry(id="gpt-4o"),
-            reasoning_model=AzureAIFoundry(id="o1-mini"),
+            reasoning_model=AzureAIFoundry(id="o4-mini"),
             members=[],
         )
         assert team.reasoning_model is not None
-        assert team.reasoning_model.id == "o1-mini"
+        assert team.reasoning_model.id == "o4-mini"
     except Exception as e:
         pytest.fail(f"Failed to create Team with Azure AI Foundry reasoning model: {e}")

--- a/libs/agno/tests/unit/models/aws/test_bedrock_client.py
+++ b/libs/agno/tests/unit/models/aws/test_bedrock_client.py
@@ -29,7 +29,7 @@ def _make_mock_session(access_key="ASIATEMP", secret_key="secret", token="token"
 class TestSessionClientNotCached:
     def test_sync_client_recreated_each_call(self):
         mock_session, _, _ = _make_mock_session()
-        model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         model.get_client()
         model.get_client()
@@ -38,7 +38,7 @@ class TestSessionClientNotCached:
 
     def test_sync_client_passes_region(self):
         mock_session, _, _ = _make_mock_session(region="eu-west-1")
-        model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         model.get_client()
 
@@ -48,7 +48,7 @@ class TestSessionClientNotCached:
 class TestStaticKeyClientCached:
     def test_sync_client_cached(self):
         model = AwsBedrock(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key_id="AKIA_STATIC",
             aws_secret_access_key="secret",
             aws_region="us-east-1",
@@ -72,7 +72,7 @@ class TestSessionTokenEnv:
         monkeypatch.setenv("AWS_SESSION_TOKEN", "my-session-token")
         monkeypatch.setenv("AWS_REGION", "us-west-2")
 
-        model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
         with patch("agno.models.aws.bedrock.AwsClient") as MockClient:
             MockClient.return_value = MagicMock()
@@ -84,7 +84,7 @@ class TestSessionTokenEnv:
 
     def test_session_token_explicit_param(self):
         model = AwsBedrock(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key_id="ASIATEMP",
             aws_secret_access_key="secret",
             aws_session_token="explicit-token",
@@ -104,7 +104,7 @@ class TestSessionTokenEnv:
         monkeypatch.setenv("AWS_REGION", "us-east-1")
         monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
 
-        model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
         with patch("agno.models.aws.bedrock.AwsClient") as MockClient:
             MockClient.return_value = MagicMock()
@@ -125,7 +125,7 @@ class TestSessionNullCredentials:
         mock_session.region_name = "us-east-1"
         mock_session.get_credentials.return_value = None
 
-        model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         with pytest.raises(ValueError, match="boto3 session has no credentials"):
             model.get_async_client()

--- a/libs/agno/tests/unit/models/aws/test_bedrock_streaming.py
+++ b/libs/agno/tests/unit/models/aws/test_bedrock_streaming.py
@@ -5,7 +5,7 @@ from agno.models.aws import AwsBedrock
 
 def test_parse_streaming_tool_call_with_single_chunk():
     """Test parsing a tool call where arguments come in a single chunk."""
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     # Simulate streaming chunks from Bedrock
     current_tool = {}
@@ -51,7 +51,7 @@ def test_parse_streaming_tool_call_with_multiple_chunks():
 
     This tests the bug fix where tool arguments were not being accumulated.
     """
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     current_tool = {}
 
@@ -95,7 +95,7 @@ def test_parse_streaming_tool_call_with_multiple_chunks():
 
 def test_parse_streaming_text_content():
     """Test parsing text content deltas (non-tool response)."""
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     current_tool = {}
 
@@ -114,7 +114,7 @@ def test_parse_streaming_text_content():
 
 def test_parse_streaming_usage_metrics():
     """Test parsing usage metrics from streaming response."""
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     current_tool = {}
 
@@ -136,7 +136,7 @@ def test_parse_streaming_usage_metrics():
 
 def test_parse_streaming_empty_tool_input():
     """Test parsing a tool call with empty/no input."""
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     current_tool = {}
 
@@ -168,7 +168,7 @@ def test_parse_streaming_empty_tool_input():
 
 def test_parse_streaming_multiple_sequential_tools():
     """Test parsing multiple tool calls that come sequentially in the stream."""
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     current_tool = {}
 
@@ -223,7 +223,7 @@ def test_invoke_stream_maintains_tool_state():
     This is a more integrated test that verifies the current_tool dict is passed
     correctly through the streaming loop.
     """
-    model = AwsBedrock(id="anthropic.claude-3-sonnet-20240229-v1:0")
+    model = AwsBedrock(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     # Create sample streaming chunks
     chunks = [

--- a/libs/agno/tests/unit/models/aws/test_claude_client.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_client.py
@@ -27,7 +27,7 @@ def _make_mock_session(access_key="ASIATEMP", secret_key="secret", token="token"
 class TestSessionClientNotCached:
     def test_sync_client_recreated_each_call(self):
         mock_session, _ = _make_mock_session()
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         with patch("agno.models.aws.claude.AnthropicBedrock") as MockBedrock:
             mock_client = MagicMock()
@@ -41,7 +41,7 @@ class TestSessionClientNotCached:
 
     def test_async_client_recreated_each_call(self):
         mock_session, _ = _make_mock_session()
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         with patch("agno.models.aws.claude.AsyncAnthropicBedrock") as MockAsyncBedrock:
             mock_client = MagicMock()
@@ -57,7 +57,7 @@ class TestSessionClientNotCached:
 class TestSessionCredsReadEachTime:
     def test_fresh_creds_on_each_sync_get_client(self):
         mock_session, mock_creds = _make_mock_session(access_key="KEY_V1", token="TOKEN_V1")
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         with patch("agno.models.aws.claude.AnthropicBedrock") as MockBedrock:
             mock_client = MagicMock()
@@ -79,7 +79,7 @@ class TestSessionCredsReadEachTime:
 
     def test_fresh_creds_on_each_async_get_client(self):
         mock_session, mock_creds = _make_mock_session(access_key="KEY_V1", token="TOKEN_V1")
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         with patch("agno.models.aws.claude.AsyncAnthropicBedrock") as MockAsyncBedrock:
             mock_client = MagicMock()
@@ -103,7 +103,7 @@ class TestSessionCredsReadEachTime:
 class TestStaticKeyClientCached:
     def test_sync_client_cached(self):
         model = Claude(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key="AKIA_STATIC",
             aws_secret_key="secret",
             aws_region="us-east-1",
@@ -122,7 +122,7 @@ class TestStaticKeyClientCached:
 
     def test_async_client_cached(self):
         model = Claude(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key="AKIA_STATIC",
             aws_secret_key="secret",
             aws_region="us-east-1",
@@ -143,7 +143,7 @@ class TestStaticKeyClientCached:
 class TestAsyncIsClosedCheck:
     def test_closed_async_client_is_recreated(self):
         model = Claude(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key="AKIA_STATIC",
             aws_secret_key="secret",
             aws_region="us-east-1",
@@ -165,7 +165,7 @@ class TestAsyncIsClosedCheck:
 
     def test_open_async_client_is_reused(self):
         model = Claude(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key="AKIA_STATIC",
             aws_secret_key="secret",
             aws_region="us-east-1",
@@ -187,7 +187,7 @@ class TestSessionTokenEnv:
         monkeypatch.setenv("AWS_REGION", "us-west-2")
         monkeypatch.delenv("AWS_BEDROCK_API_KEY", raising=False)
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
         params = model._get_client_params()
 
         assert params["aws_session_token"] == "my-session-token"
@@ -198,7 +198,7 @@ class TestSessionTokenEnv:
         monkeypatch.delenv("AWS_BEDROCK_API_KEY", raising=False)
 
         model = Claude(
-            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            id="anthropic.claude-sonnet-4-5-20250929-v1:0",
             aws_access_key="ASIATEMP",
             aws_secret_key="secret",
             aws_session_token="explicit-token",
@@ -215,7 +215,7 @@ class TestSessionTokenEnv:
         monkeypatch.delenv("AWS_SESSION_TOKEN", raising=False)
         monkeypatch.delenv("AWS_BEDROCK_API_KEY", raising=False)
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
         params = model._get_client_params()
 
         assert params["aws_session_token"] is None
@@ -226,7 +226,7 @@ class TestApiKeyPath:
         monkeypatch.setenv("AWS_BEDROCK_API_KEY", "br-api-key-123")
         monkeypatch.setenv("AWS_REGION", "us-west-2")
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
 
         with patch("agno.models.aws.claude.AnthropicBedrock") as MockBedrock:
             mock_client = MagicMock()
@@ -243,7 +243,7 @@ class TestApiKeyPath:
         monkeypatch.setenv("AWS_BEDROCK_API_KEY", "br-api-key-123")
         monkeypatch.setenv("AWS_REGION", "us-west-2")
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
         params = model._get_client_params()
 
         assert params["api_key"] == "br-api-key-123"
@@ -258,7 +258,7 @@ class TestSessionNullCredentials:
         mock_session.profile_name = None
         mock_session.get_credentials.return_value = None
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
 
         with pytest.raises(ValueError, match="boto3 session has no credentials"):
             model._get_client_params()

--- a/libs/agno/tests/unit/models/aws/test_session_concurrency.py
+++ b/libs/agno/tests/unit/models/aws/test_session_concurrency.py
@@ -25,7 +25,7 @@ class TestSessionNoSharedState:
         mock_creds.get_frozen_credentials.return_value = _make_frozen_creds()
         mock_session.get_credentials.return_value = mock_creds
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
         assert model.client is None
 
         with patch("agno.models.aws.claude.AnthropicBedrock") as MockBedrock:
@@ -45,7 +45,7 @@ class TestSessionNoSharedState:
         mock_creds.get_frozen_credentials.return_value = _make_frozen_creds()
         mock_session.get_credentials.return_value = mock_creds
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
         assert model.async_client is None
 
         with patch("agno.models.aws.claude.AsyncAnthropicBedrock") as MockAsync:
@@ -80,7 +80,7 @@ class TestSessionConcurrencySafe:
         mock_creds.get_frozen_credentials.side_effect = rotating_frozen_creds
         mock_session.get_credentials.return_value = mock_creds
 
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0", session=mock_session)
+        model = Claude(id="anthropic.claude-sonnet-4-5-20250929-v1:0", session=mock_session)
         results = {}
 
         with patch("agno.models.aws.claude.AnthropicBedrock") as MockBedrock:

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
@@ -49,7 +49,7 @@ def test_openrouter_responses_fallback_models():
     """Test OpenRouterResponses with fallback models configuration."""
     model = OpenRouterResponses(
         api_key="test-key",
-        models=["anthropic/claude-sonnet-4", "google/gemini-2.0-flash"],
+        models=["anthropic/claude-sonnet-4", "google/gemini-flash-latest"],
     )
 
     request_params = model.get_request_params()
@@ -57,7 +57,7 @@ def test_openrouter_responses_fallback_models():
     assert "extra_body" in request_params
     assert request_params["extra_body"]["models"] == [
         "anthropic/claude-sonnet-4",
-        "google/gemini-2.0-flash",
+        "google/gemini-flash-latest",
     ]
 
 

--- a/libs/agno/tests/unit/models/test_client_caching.py
+++ b/libs/agno/tests/unit/models/test_client_caching.py
@@ -115,8 +115,8 @@ class TestOpenAIChatClientCaching:
     def test_multiple_models_share_global_httpx_client(self):
         """Verify that multiple models can share the same global httpx client."""
         model1 = OpenAIChat(id="gpt-4o")
-        model2 = OpenAIChat(id="gpt-4-turbo")
-        model3 = OpenAIChat(id="gpt-3.5-turbo")
+        model2 = OpenAIChat(id="gpt-4o")
+        model3 = OpenAIChat(id="gpt-4o-mini")
 
         # Get clients from each model
         model1.get_client()
@@ -349,8 +349,8 @@ class TestResourceLeakPrevention:
         # Create multiple models
         models = [
             OpenAIChat(id="gpt-4o"),
-            OpenAIChat(id="gpt-4-turbo"),
-            OpenAIChat(id="gpt-3.5-turbo"),
+            OpenAIChat(id="gpt-4o"),
+            OpenAIChat(id="gpt-4o-mini"),
             OpenAIResponses(id="gpt-4o"),
         ]
 

--- a/libs/agno/tests/unit/team/test_model_inheritance.py
+++ b/libs/agno/tests/unit/team/test_model_inheritance.py
@@ -15,17 +15,17 @@ def test_model_inheritance():
 
     team = Team(
         name="Test Team",
-        model=Claude(id="claude-3-5-sonnet-20241022"),
+        model=Claude(id="claude-sonnet-4-6"),
         members=[agent1, agent2],
     )
 
     team.initialize_team()
 
     assert isinstance(agent1.model, Claude)
-    assert agent1.model.id == "claude-3-5-sonnet-20241022"
+    assert agent1.model.id == "claude-sonnet-4-6"
 
     assert isinstance(agent2.model, Claude)
-    assert agent2.model.id == "claude-3-5-sonnet-20241022"
+    assert agent2.model.id == "claude-sonnet-4-6"
 
 
 def test_explicit_model_retention():
@@ -35,7 +35,7 @@ def test_explicit_model_retention():
 
     team = Team(
         name="Test Team",
-        model=Claude(id="claude-3-5-sonnet-20241022"),
+        model=Claude(id="claude-sonnet-4-6"),
         members=[agent1, agent2],
     )
 
@@ -53,7 +53,7 @@ def test_nested_team_model_inheritance():
 
     sub_team = Team(
         name="Analysis Team",
-        model=Claude(id="claude-3-5-haiku-20241022"),
+        model=Claude(id="claude-haiku-4-5-latest"),
         members=[sub_agent1, sub_agent2],
     )
 
@@ -71,10 +71,10 @@ def test_nested_team_model_inheritance():
     assert main_agent.model.id == "gpt-4o"
 
     assert isinstance(sub_agent1.model, Claude)
-    assert sub_agent1.model.id == "claude-3-5-haiku-20241022"
+    assert sub_agent1.model.id == "claude-haiku-4-5-latest"
 
     assert isinstance(sub_agent2.model, Claude)
-    assert sub_agent2.model.id == "claude-3-5-haiku-20241022"
+    assert sub_agent2.model.id == "claude-haiku-4-5-latest"
 
 
 def test_default_model():

--- a/libs/agno/tests/unit/utils/test_model_string.py
+++ b/libs/agno/tests/unit/utils/test_model_string.py
@@ -41,9 +41,9 @@ def test_get_model_parses_openai_string():
 
 def test_get_model_parses_anthropic_string():
     """Test get_model() parses Anthropic model string."""
-    model = get_model("anthropic:claude-3-5-sonnet-20241022")
+    model = get_model("anthropic:claude-sonnet-4-6")
     assert isinstance(model, Claude)
-    assert model.id == "claude-3-5-sonnet-20241022"
+    assert model.id == "claude-sonnet-4-6"
 
 
 def test_get_model_strips_whitespace():
@@ -89,8 +89,8 @@ def test_agent_with_all_model_params_as_strings():
     agent = Agent(
         model="openai:gpt-4o",
         reasoning=True,
-        reasoning_model="anthropic:claude-3-5-sonnet-20241022",
-        parser_model="google:gemini-2.0-flash-exp",
+        reasoning_model="anthropic:claude-sonnet-4-6",
+        parser_model="google:gemini-flash-latest",
         output_model="groq:llama-3.1-70b-versatile",
     )
     assert isinstance(agent.model, OpenAIChat)
@@ -109,7 +109,7 @@ def test_agent_backward_compatibility():
 def test_team_with_model_string():
     """Test creating Team with model string."""
     agent = Agent(model="openai:gpt-4o")
-    team = Team(members=[agent], model="anthropic:claude-3-5-sonnet-20241022")
+    team = Team(members=[agent], model="anthropic:claude-sonnet-4-6")
     assert isinstance(team.model, Claude)
 
 
@@ -118,10 +118,10 @@ def test_team_with_all_model_params_as_strings():
     agent = Agent(model="openai:gpt-4o")
     team = Team(
         members=[agent],
-        model="anthropic:claude-3-5-sonnet-20241022",
+        model="anthropic:claude-sonnet-4-6",
         reasoning=True,
         reasoning_model="openai:gpt-4o",
-        parser_model="google:gemini-2.0-flash-exp",
+        parser_model="google:gemini-flash-latest",
         output_model="groq:llama-3.1-70b-versatile",
     )
     assert isinstance(team.model, Claude)


### PR DESCRIPTION
Replace and standardize model identifiers throughout the codebase to align with current provider naming and versions. Key updates include:
- Anthropic Claude: switch many instances to "claude-sonnet-4-6" and update AwsBedrock Claude haiku IDs to the 4-5 series.
- Removed claude 3.x series
- Google Gemini: set defaults to "gemini-flash-latest" where applicable.
- Removed Gemini 2.0 series
- Reasoning models: migrate "o1-mini" to "o4-mini" for OpenAI/Azure Foundry tests.
- OpenAI model IDs in tests/evals updated (e.g., use gpt-4o / gpt-4o-mini variants).
- Update library defaults (libs/agno) and cookbook examples/READMEs to reflect these changes. These changes keep examples, tests, and defaults consistent with newer model releases and naming conventions.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
