### PR TITLE
feat: add file text extraction for models rejecting file content blocks

### DIFF
--- a/cookbook/02_agents/12_multimodal/file_text_extraction.py
+++ b/cookbook/02_agents/12_multimodal/file_text_extraction.py
@@ -1,0 +1,65 @@
+"""
+File Text Extraction for Models
+================================
+
+Some models and providers reject the ``{"type": "file"}`` content format used
+by OpenAI-compatible APIs.  The ``extract_file_text`` flag on ``OpenAIChat``,
+``DeepSeek``, and ``LiteLLM`` model classes extracts text from uploaded files
+and sends them as ``{"type": "text"}`` content blocks instead.
+
+Supported formats:
+- Text files (txt, csv, json, html, css, py, js, md, xml, etc.)
+- PDF files (requires ``pypdf``)
+- DOCX files (requires ``python-docx``)
+
+If extraction fails for a given file, the original ``{"type": "file"}``
+format is used as a fallback.
+
+Usage:
+    Set ``extract_file_text=True`` on the model to enable text extraction.
+
+Run this cookbook:
+    .venvs/demo/bin/python cookbook/02_agents/12_multimodal/file_text_extraction.py
+"""
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIChat
+
+# ---------------------------------------------------------------------------
+# Example: Agent with text extraction enabled
+# ---------------------------------------------------------------------------
+# Models like gpt-4.1-mini via Azure OpenAI reject {"type": "file"} content
+# blocks.  Setting extract_file_text=True extracts text from supported
+# document types and sends it as plain text instead.
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini", extract_file_text=True),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # Text file
+    print("--- Text file extraction ---")
+    agent.print_response(
+        "Summarize this file",
+        files=[
+            File(
+                content=b"Project Status Report\n\nThe migration is 80% complete.\nRemaining: testing and docs.",
+                filename="status.txt",
+                mime_type="text/plain",
+            )
+        ],
+    )
+
+    # Python source file
+    print("--- Python file extraction ---")
+    agent.print_response(
+        "What does this code do?",
+        files=[
+            File(
+                content=b"def fibonacci(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a",
+                filename="fib.py",
+                mime_type="text/x-python",
+            )
+        ],
+    )

--- a/libs/agno/agno/models/deepseek/deepseek.py
+++ b/libs/agno/agno/models/deepseek/deepseek.py
@@ -32,6 +32,9 @@ class DeepSeek(OpenAILike):
     # Their support for structured outputs is currently broken
     supports_native_structured_outputs: bool = False
 
+    # When True, extract text from files and send as {"type": "text"} instead of {"type": "file"}.
+    extract_file_text: bool = False
+
     def _get_client_params(self) -> Dict[str, Any]:
         # Fetch API key from env if not already set
         if not self.api_key:
@@ -117,7 +120,7 @@ class DeepSeek(OpenAILike):
                 message_dict["content"] = []
             # Insert each file part before text parts
             for file in message.files:
-                file_part = _format_file_for_message(file)
+                file_part = _format_file_for_message(file, extract_text=self.extract_file_text)
                 if file_part:
                     message_dict["content"].insert(0, file_part)
 

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -47,6 +47,9 @@ class LiteLLM(Model):
     extra_body: Optional[Dict[str, Any]] = None
     request_params: Optional[Dict[str, Any]] = None
 
+    # When True, extract text from files and send as {"type": "text"} instead of {"type": "file"}.
+    extract_file_text: bool = False
+
     client: Optional[Any] = None
 
     # Store the original client to preserve it across copies (e.g., for Router instances)
@@ -146,7 +149,7 @@ class LiteLLM(Model):
                 else:
                     content_list = msg["content"] if isinstance(msg["content"], list) else []
                 for file in m.files:
-                    file_part = _format_file_for_message(file)
+                    file_part = _format_file_for_message(file, extract_text=self.extract_file_text)
                     if file_part:
                         content_list.append(file_part)
                 msg["content"] = content_list

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -75,6 +75,10 @@ class OpenAIChat(Model):
     request_params: Optional[Dict[str, Any]] = None
     role_map: Optional[Dict[str, str]] = None
 
+    # When True, extract text from files and send as {"type": "text"} instead of {"type": "file"}.
+    # Useful for models that reject the file content type (e.g. gpt-4.1-mini via Azure OpenAI).
+    extract_file_text: bool = False
+
     # Client parameters
     api_key: Optional[str] = None
     organization: Optional[str] = None
@@ -370,7 +374,7 @@ class OpenAIChat(Model):
                 message_dict["content"] = []
             # Insert each file part before text parts
             for file in message.files:
-                file_part = _format_file_for_message(file)
+                file_part = _format_file_for_message(file, extract_text=self.extract_file_text)
                 if file_part:
                     message_dict["content"].insert(0, file_part)
 

--- a/libs/agno/agno/utils/openai.py
+++ b/libs/agno/agno/utils/openai.py
@@ -210,13 +210,114 @@ def images_to_message(images: Sequence[Image]) -> List[Dict[str, Any]]:
     return image_messages
 
 
-def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
+def _extract_text_from_file(content: bytes, mime_type: Optional[str], filename: Optional[str]) -> Optional[str]:
+    """Extract plain text from file content based on MIME type.
+
+    Returns extracted text, or ``None`` if the format is unsupported or
+    extraction fails.  Libraries for PDF and DOCX are imported lazily so
+    they remain optional dependencies.
+    """
+    if mime_type is None and filename:
+        mime_type = mimetypes.guess_type(filename)[0]
+
+    if mime_type is None:
+        return None
+
+    # Text-based MIME types: decode directly
+    _text_mime_types = {
+        "text/plain",
+        "text/csv",
+        "text/html",
+        "text/css",
+        "text/xml",
+        "text/rtf",
+        "text/md",
+        "text/markdown",
+        "text/javascript",
+        "application/json",
+        "application/x-javascript",
+        "application/x-python",
+        "text/x-python",
+    }
+    if mime_type in _text_mime_types or mime_type.startswith("text/"):
+        try:
+            return content.decode("utf-8", errors="replace")
+        except Exception:
+            return None
+
+    # PDF extraction via pypdf
+    if mime_type == "application/pdf":
+        try:
+            from io import BytesIO
+
+            from pypdf import PdfReader
+
+            reader = PdfReader(BytesIO(content))
+            pages = [page.extract_text() or "" for page in reader.pages]
+            text = "\n".join(pages).strip()
+            return text if text else None
+        except Exception:
+            return None
+
+    # DOCX extraction via python-docx
+    if mime_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+        try:
+            from io import BytesIO
+
+            from docx import Document as DocxDocument  # type: ignore
+
+            doc = DocxDocument(BytesIO(content))
+            text = "\n\n".join(para.text for para in doc.paragraphs).strip()
+            return text if text else None
+        except Exception:
+            return None
+
+    return None
+
+
+def _format_file_for_message(file: File, extract_text: bool = False) -> Optional[Dict[str, Any]]:
     """
     Add a document url, base64 encoded content or OpenAI file to a message.
+
+    When *extract_text* is ``True``, the function attempts to extract plain
+    text from the file and returns a ``{"type": "text", ...}`` content block
+    instead of ``{"type": "file", ...}``.  This is useful for models that do
+    not support the ``file`` content type (e.g. ``gpt-4.1-mini`` via Azure).
+    Falls back to the standard ``file`` format if extraction fails.
     """
     import base64
     import mimetypes
     from pathlib import Path
+
+    # When extract_text is requested, try to extract text first
+    if extract_text:
+        content_bytes: Optional[bytes] = None
+        _filename: Optional[str] = file.filename
+        _mime: Optional[str] = file.mime_type
+
+        if file.url is not None:
+            from urllib.parse import urlparse
+
+            result = file.file_url_content
+            if result:
+                content_bytes, url_mime = result
+                _filename = _filename or Path(urlparse(file.url).path).name or "file"
+                _mime = _mime or url_mime
+        elif file.filepath is not None:
+            path = Path(file.filepath)
+            if path.is_file():
+                content_bytes = path.read_bytes()
+                _filename = _filename or path.name
+                _mime = _mime or mimetypes.guess_type(path.name)[0]
+        elif file.content is not None:
+            content_bytes = file.content if isinstance(file.content, bytes) else file.content.encode("utf-8")
+            _filename = _filename or "file"
+
+        if content_bytes is not None:
+            extracted = _extract_text_from_file(content_bytes, _mime, _filename)
+            if extracted is not None:
+                display_name = _filename or "file"
+                return {"type": "text", "text": f"[File: {display_name}]\n{extracted}"}
 
     # Case 1: Document is a URL
     if file.url is not None:
@@ -226,11 +327,11 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
         if not result:
             log_error(f"Failed to fetch file from URL: {file.url}")
             return None
-        content_bytes, mime_type = result
+        content_bytes_url, mime_type = result
         name = Path(urlparse(file.url).path).name or "file"
-        _mime = mime_type or file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
-        _encoded = base64.b64encode(content_bytes).decode("utf-8")
-        _data_url = f"data:{_mime};base64,{_encoded}"
+        _mime_url = mime_type or file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
+        _encoded = base64.b64encode(content_bytes_url).decode("utf-8")
+        _data_url = f"data:{_mime_url};base64,{_encoded}"
         return {"type": "file", "file": {"filename": name, "file_data": _data_url}}
 
     # Case 2: Document is a local file path
@@ -241,17 +342,17 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
             return None
         data = path.read_bytes()
 
-        _mime = file.mime_type or mimetypes.guess_type(path.name)[0] or "application/pdf"
+        _mime_path = file.mime_type or mimetypes.guess_type(path.name)[0] or "application/pdf"
         _encoded = base64.b64encode(data).decode("utf-8")
-        _data_url = f"data:{_mime};base64,{_encoded}"
+        _data_url = f"data:{_mime_path};base64,{_encoded}"
         return {"type": "file", "file": {"filename": path.name, "file_data": _data_url}}
 
     # Case 3: Document is bytes content
     if file.content is not None:
         name = file.filename or "file"
-        _mime = file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
+        _mime_bytes = file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
         _encoded = base64.b64encode(file.content).decode("utf-8")
-        _data_url = f"data:{_mime};base64,{_encoded}"
+        _data_url = f"data:{_mime_bytes};base64,{_encoded}"
         return {"type": "file", "file": {"filename": name, "file_data": _data_url}}
 
     return None

--- a/libs/agno/tests/unit/utils/test_openai.py
+++ b/libs/agno/tests/unit/utils/test_openai.py
@@ -3,12 +3,12 @@
 import base64
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from agno.media import Audio, File, Image
-from agno.utils.openai import _format_file_for_message, audio_to_message, images_to_message
+from agno.utils.openai import _extract_text_from_file, _format_file_for_message, audio_to_message, images_to_message
 
 
 # Helper function to create dummy file
@@ -405,3 +405,145 @@ def test_format_file_raw_bytes_no_filename():
     data_url = msg["file"]["file_data"]
     assert data_url.startswith("data:application/pdf;base64,")
     assert base64.b64decode(data_url.split(",", 1)[1]) == content
+
+
+# --- Tests for _extract_text_from_file --- #
+
+
+def test_extract_text_plain_text():
+    """Test text extraction from plain text content."""
+    content = b"Hello, world!\nLine two."
+    result = _extract_text_from_file(content, "text/plain", "test.txt")
+    assert result == "Hello, world!\nLine two."
+
+
+def test_extract_text_json():
+    """Test text extraction from JSON content."""
+    content = b'{"key": "value"}'
+    result = _extract_text_from_file(content, "application/json", "data.json")
+    assert result == '{"key": "value"}'
+
+
+def test_extract_text_csv():
+    """Test text extraction from CSV content."""
+    content = b"name,age\nAlice,30"
+    result = _extract_text_from_file(content, "text/csv", "data.csv")
+    assert result == "name,age\nAlice,30"
+
+
+def test_extract_text_python():
+    """Test text extraction from Python source code."""
+    content = b'def hello():\n    print("hi")'
+    result = _extract_text_from_file(content, "text/x-python", "script.py")
+    assert "def hello" in result
+
+
+def test_extract_text_unsupported_mime():
+    """Test that unsupported MIME types return None."""
+    content = b"\x00\x01\x02binary"
+    result = _extract_text_from_file(content, "application/octet-stream", "data.bin")
+    assert result is None
+
+
+def test_extract_text_none_mime_with_txt_filename():
+    """Test MIME type guessing from filename when mime_type is None."""
+    content = b"some text"
+    result = _extract_text_from_file(content, None, "readme.txt")
+    assert result == "some text"
+
+
+def test_extract_text_none_mime_none_filename():
+    """Test that None mime and None filename returns None."""
+    content = b"something"
+    result = _extract_text_from_file(content, None, None)
+    assert result is None
+
+
+def test_extract_text_decode_with_replacement():
+    """Test that invalid UTF-8 still produces output with replacement characters."""
+    content = b"valid \xff\xfe invalid"
+    result = _extract_text_from_file(content, "text/plain", "test.txt")
+    assert result is not None
+    assert "\ufffd" in result  # Replacement character
+
+
+def test_extract_text_pdf():
+    """Test text extraction from PDF content."""
+    mock_page1 = MagicMock()
+    mock_page1.extract_text.return_value = "Page one text"
+    mock_page2 = MagicMock()
+    mock_page2.extract_text.return_value = "Page two text"
+
+    mock_reader = MagicMock()
+    mock_reader.pages = [mock_page1, mock_page2]
+
+    mock_pypdf = MagicMock()
+    mock_pypdf.PdfReader.return_value = mock_reader
+
+    with patch.dict("sys.modules", {"pypdf": mock_pypdf}):
+        result = _extract_text_from_file(b"%PDF-fake", "application/pdf", "doc.pdf")
+    assert result == "Page one text\nPage two text"
+
+
+def test_extract_text_docx():
+    """Test text extraction from DOCX content."""
+    mock_para1 = MagicMock()
+    mock_para1.text = "Paragraph one"
+    mock_para2 = MagicMock()
+    mock_para2.text = "Paragraph two"
+
+    mock_doc = MagicMock()
+    mock_doc.paragraphs = [mock_para1, mock_para2]
+
+    mock_docx = MagicMock()
+    mock_docx.Document.return_value = mock_doc
+
+    with patch.dict("sys.modules", {"docx": mock_docx}):
+        result = _extract_text_from_file(
+            b"PK\x03\x04fake",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "doc.docx",
+        )
+    assert result == "Paragraph one\n\nParagraph two"
+
+
+# --- Tests for _format_file_for_message with extract_text --- #
+
+
+def test_format_file_extract_text_true():
+    """Test that extract_text=True returns a text content block."""
+    content = b"Hello from file"
+    f = File(content=content, filename="notes.txt", mime_type="text/plain")
+    msg = _format_file_for_message(f, extract_text=True)
+    assert msg["type"] == "text"
+    assert "[File: notes.txt]" in msg["text"]
+    assert "Hello from file" in msg["text"]
+
+
+def test_format_file_extract_text_fallback():
+    """Test that extract_text=True falls back to file format when extraction fails."""
+    # Use a PDF MIME type but with invalid content that will fail extraction
+    content = b"\x00\x01\x02not-a-real-pdf"
+    f = File(content=content, filename="broken.pdf", mime_type="application/pdf")
+    msg = _format_file_for_message(f, extract_text=True)
+    # Should fall back to file format since PDF extraction fails on invalid content
+    assert msg["type"] == "file"
+
+
+def test_format_file_extract_text_false_default():
+    """Test that extract_text defaults to False and preserves original behavior."""
+    content = b"text content"
+    f = File(content=content, filename="test.txt", mime_type="text/plain")
+    msg = _format_file_for_message(f)  # No extract_text param
+    assert msg["type"] == "file"  # Default behavior
+
+
+def test_format_file_extract_text_filepath(tmp_path):
+    """Test extract_text=True with a file path."""
+    p = tmp_path / "readme.md"
+    p.write_text("# Heading\nSome content")
+    f = File(filepath=str(p), mime_type="text/md")
+    msg = _format_file_for_message(f, extract_text=True)
+    assert msg["type"] == "text"
+    assert "# Heading" in msg["text"]
+    assert "Some content" in msg["text"]


### PR DESCRIPTION
## Summary

- Add opt-in `extract_file_text` flag to `OpenAIChat`, `DeepSeek`, and `LiteLLM` model classes that converts document files to text content blocks instead of native `{"type": "file"}` blocks
- Add `_extract_text_from_file()` utility supporting text/\*, JSON, CSV, Python, PDF (via pypdf), and DOCX (via python-docx) with graceful fallback
- Add cookbook example for file text extraction

This enables models like `gpt-4.1-mini` that reject `{"type": "file"}` content blocks to process document content by extracting the text first.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- The flag is opt-in (`extract_file_text=False` by default) so existing behavior is unchanged
- Only added to OpenAI-compatible models (OpenAIChat, DeepSeek, LiteLLM) since Gemini and Claude handle file blocks natively
- PDF extraction requires `pypdf`, DOCX requires `python-docx` (both lazy-imported)
- On extraction failure, falls back to the original `{"type": "file"}` format
- 14 unit tests covering text extraction for various MIME types and the format_file_for_message integration