### PR TITLE
feat: add CommuneTools for email and SMS

### DIFF
--- a/libs/agno/agno/tools/commune.py
+++ b/libs/agno/agno/tools/commune.py
@@ -1,0 +1,415 @@
+"""Commune email and SMS tools for AI agents.
+
+Commune provides a programmable email and SMS API built for AI agents.
+Unlike SMTP-based solutions, Commune is API-first: agents get a dedicated
+inbox address, no SMTP credentials or mail server configuration required.
+"""
+
+import re
+from datetime import datetime, timezone
+from os import getenv
+from typing import Any, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+try:
+    from commune import Commune
+except ImportError:
+    raise ImportError(
+        "commune-mail is required for CommuneTools. "
+        "Install it with: pip install commune-mail"
+    )
+
+
+def _relative_time(dt_str: str) -> str:
+    """Convert an ISO-8601 timestamp to a human-readable relative time string."""
+    try:
+        if dt_str.endswith("Z"):
+            dt_str = dt_str[:-1] + "+00:00"
+        dt = datetime.fromisoformat(dt_str)
+        now = datetime.now(tz=timezone.utc)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        diff = now - dt
+        seconds = int(diff.total_seconds())
+        if seconds < 60:
+            return f"{seconds}s ago"
+        if seconds < 3600:
+            return f"{seconds // 60}m ago"
+        if seconds < 86400:
+            return f"{seconds // 3600}h ago"
+        return f"{seconds // 86400}d ago"
+    except Exception:
+        return dt_str
+
+
+def _format_email_list(emails: List[Any]) -> str:
+    """Render a list of email objects into a human-readable, agent-scannable string."""
+    if not emails:
+        return "No emails found."
+
+    lines: List[str] = []
+    for idx, email in enumerate(emails, start=1):
+        unread_tag = " | UNREAD" if not email.get("read", True) else ""
+        received = _relative_time(email.get("received_at", ""))
+        preview_raw = email.get("body", "").strip().replace("\n", " ")
+        preview = preview_raw[:80] + "..." if len(preview_raw) > 80 else preview_raw
+
+        header = (
+            f"[{idx}] From: {email.get('from_address', 'unknown')} "
+            f"| Subject: {email.get('subject', '(no subject)')} "
+            f"| Received: {received}{unread_tag}"
+        )
+        lines.append(header)
+        if preview:
+            lines.append(f"    Preview: {preview}")
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def _format_sms_list(messages: List[Any]) -> str:
+    """Render a list of SMS objects into a human-readable, agent-scannable string."""
+    if not messages:
+        return "No SMS messages found."
+
+    lines: List[str] = []
+    for idx, msg in enumerate(messages, start=1):
+        direction = msg.get("direction", "unknown")
+        received = _relative_time(msg.get("received_at", ""))
+        body_raw = msg.get("body", "").strip().replace("\n", " ")
+        body = body_raw[:100] + "..." if len(body_raw) > 100 else body_raw
+
+        if direction == "inbound":
+            contact = msg.get("from_number", "unknown")
+            direction_label = "FROM"
+        else:
+            contact = msg.get("to_number", "unknown")
+            direction_label = "TO"
+
+        lines.append(f"[{idx}] {direction_label}: {contact} | {received} | {body}")
+
+    return "\n".join(lines)
+
+
+_E164_RE = re.compile(r"^\+[1-9]\d{1,14}$")
+
+
+def _validate_e164(number: str) -> bool:
+    """Return True if *number* matches the E.164 format (+CCCNNNNNNNNN)."""
+    return bool(_E164_RE.match(number))
+
+
+class CommuneTools(Toolkit):
+    """Agno toolkit that wraps the Commune email and SMS API.
+
+    Commune gives AI agents a dedicated inbox and SMS number through a simple
+    REST API.  Unlike SMTP-based tools there is no mail server to configure —
+    just an API key.
+
+    Args:
+        api_key: Commune API key.  Falls back to the ``COMMUNE_API_KEY``
+            environment variable when not supplied.
+        from_address: Default sender address used by :meth:`send_email` when
+            no *from_address* is passed at call time.
+        enable_email: Register all email-related tools (default ``True``).
+        enable_sms: Register all SMS-related tools (default ``True``).
+        **kwargs: Forwarded to :class:`agno.tools.Toolkit`.
+
+    Raises:
+        ValueError: When neither *api_key* nor ``COMMUNE_API_KEY`` is set.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        from_address: Optional[str] = None,
+        enable_email: bool = True,
+        enable_sms: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        resolved_key = api_key or getenv("COMMUNE_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "A Commune API key is required. Pass api_key= or set the "
+                "COMMUNE_API_KEY environment variable."
+            )
+
+        self._client = Commune(api_key=resolved_key)
+        self.from_address = from_address
+
+        tools: List[Any] = []
+        if enable_email:
+            tools.extend(
+                [
+                    self.send_email,
+                    self.read_inbox,
+                    self.search_emails,
+                    self.get_email,
+                ]
+            )
+        if enable_sms:
+            tools.extend(
+                [
+                    self.send_sms,
+                    self.read_sms,
+                ]
+            )
+        # Credits tool is always available regardless of feature flags.
+        tools.append(self.get_credits)
+
+        super().__init__(name="commune", tools=tools, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Email tools
+    # ------------------------------------------------------------------
+
+    def send_email(
+        self,
+        to: str,
+        subject: str,
+        body: str,
+        from_address: Optional[str] = None,
+    ) -> str:
+        """Send an email via Commune.
+
+        Use this tool whenever you need to send an outgoing email — for
+        example to reply to a support request, notify a user, or deliver a
+        report.  The recipient receives a standard email; no special client
+        is required on their side.
+
+        Args:
+            to: Recipient email address, e.g. ``alice@example.com``.
+            subject: Subject line of the email.
+            body: Plain-text body of the email.
+            from_address: Sender address.  Overrides the default
+                ``from_address`` set at initialisation.  When neither is
+                provided the Commune API uses your account's default address.
+
+        Returns:
+            str: Confirmation string that includes the Commune message ID on
+            success, or an error message beginning with ``"Error:"`` on
+            failure.
+        """
+        if not to:
+            return "Error: recipient address (to) cannot be empty."
+        if not subject:
+            return "Error: subject cannot be empty."
+        if not body:
+            return "Error: body cannot be empty."
+
+        sender = from_address or self.from_address
+        try:
+            kwargs: dict = {"to": to, "subject": subject, "body": body}
+            if sender:
+                kwargs["from_address"] = sender
+            result = self._client.emails.send(**kwargs)
+            msg_id = result.get("id", "unknown")
+            status = result.get("status", "unknown")
+            logger.debug(f"Email sent: id={msg_id} status={status}")
+            return f"Email sent successfully. ID: {msg_id}, status: {status}."
+        except Exception as e:
+            logger.error(f"send_email failed: {e}")
+            return f"Error sending email: {e}"
+
+    def read_inbox(self, limit: int = 10, unread_only: bool = False) -> str:
+        """Retrieve and display recent emails from the Commune inbox.
+
+        Use this tool to check what emails have arrived — for example when
+        polling for incoming customer support requests, checking for replies,
+        or reviewing unread messages before deciding what to act on.
+
+        Args:
+            limit: Maximum number of emails to return (default ``10``, max
+                determined by Commune plan).
+            unread_only: When ``True`` only unread emails are returned
+                (default ``False``).
+
+        Returns:
+            str: A formatted, human-readable list of emails.  Each entry
+            shows the sender, subject, relative receive time, read status,
+            and a short body preview.  Returns ``"No emails found."`` when
+            the inbox is empty.
+
+            Example output::
+
+                [1] From: alice@example.com | Subject: Meeting tomorrow | Received: 2h ago | UNREAD
+                    Preview: Can we move our 3pm meeting to 4pm?
+
+                [2] From: bob@co.com | Subject: Invoice #1042 | Received: 1d ago
+                    Preview: Please find attached invoice for...
+        """
+        try:
+            emails = self._client.emails.list(limit=limit, unread_only=unread_only)
+            return _format_email_list(emails)
+        except Exception as e:
+            logger.error(f"read_inbox failed: {e}")
+            return f"Error reading inbox: {e}"
+
+    def search_emails(self, query: str, limit: int = 5) -> str:
+        """Search emails in the Commune inbox by keyword or phrase.
+
+        Use this tool when you need to find a specific email — for example
+        to locate a confirmation, look up a previous conversation, or find
+        all emails mentioning a particular topic or sender.
+
+        Args:
+            query: Search string.  Matched against sender, subject, and body.
+                Example: ``"invoice"`` or ``"from:alice@example.com refund"``.
+            limit: Maximum number of matching emails to return (default ``5``).
+
+        Returns:
+            str: A formatted list of matching emails in the same layout as
+            :meth:`read_inbox`.  Returns ``"No emails found."`` when nothing
+            matches.
+        """
+        if not query:
+            return "Error: search query cannot be empty."
+        try:
+            emails = self._client.emails.search(query=query, limit=limit)
+            return _format_email_list(emails)
+        except Exception as e:
+            logger.error(f"search_emails failed: {e}")
+            return f"Error searching emails: {e}"
+
+    def get_email(self, email_id: str) -> str:
+        """Fetch the full content of a single email by its ID.
+
+        Use this tool when you need the complete body of an email — for
+        example after spotting a relevant message in the inbox list and
+        wanting to read it in full before drafting a reply.
+
+        Args:
+            email_id: The Commune message ID returned by :meth:`read_inbox`
+                or :meth:`search_emails`, e.g. ``"msg_abc123"``.
+
+        Returns:
+            str: A formatted string containing the full email details:
+            sender, recipient, subject, timestamp, and the complete body.
+            Returns an error message on failure.
+        """
+        if not email_id:
+            return "Error: email_id cannot be empty."
+        try:
+            email = self._client.emails.get(email_id)
+            received = _relative_time(email.get("received_at", ""))
+            read_status = "read" if email.get("read", False) else "unread"
+            output = (
+                f"ID: {email.get('id', email_id)}\n"
+                f"From: {email.get('from_address', 'unknown')}\n"
+                f"To: {email.get('to', 'unknown')}\n"
+                f"Subject: {email.get('subject', '(no subject)')}\n"
+                f"Received: {received} ({read_status})\n"
+                f"---\n"
+                f"{email.get('body', '')}"
+            )
+            # Mark as read after fetching
+            try:
+                self._client.emails.mark_read(email_id)
+            except Exception:
+                pass  # Non-fatal; best-effort
+            return output
+        except Exception as e:
+            logger.error(f"get_email failed: {e}")
+            return f"Error fetching email {email_id}: {e}"
+
+    # ------------------------------------------------------------------
+    # SMS tools
+    # ------------------------------------------------------------------
+
+    def send_sms(self, to: str, body: str) -> str:
+        """Send an SMS message via Commune.
+
+        Use this tool to send a text message to a phone number — for example
+        to alert a user, send an OTP, or notify on-call staff.
+
+        Args:
+            to: Destination phone number in E.164 format, e.g.
+                ``"+15551234567"``.  The number must start with ``+``
+                followed by the country code.
+            body: Text content of the SMS message.
+
+        Returns:
+            str: Confirmation string with the Commune SMS ID and status on
+            success.  Returns an error message (beginning with ``"Error:"``)
+            when the number is invalid or the API call fails.
+        """
+        if not to:
+            return "Error: recipient phone number (to) cannot be empty."
+        if not _validate_e164(to):
+            return (
+                f'Error: "{to}" is not a valid E.164 phone number. '
+                "Use the format +<country_code><number>, e.g. +15551234567."
+            )
+        if not body:
+            return "Error: SMS body cannot be empty."
+        try:
+            result = self._client.sms.send(to=to, body=body)
+            msg_id = result.get("id", "unknown")
+            status = result.get("status", "unknown")
+            logger.debug(f"SMS sent: id={msg_id} status={status}")
+            return f"SMS sent successfully. ID: {msg_id}, status: {status}."
+        except Exception as e:
+            logger.error(f"send_sms failed: {e}")
+            return f"Error sending SMS: {e}"
+
+    def read_sms(self, limit: int = 10) -> str:
+        """Retrieve and display recent SMS messages.
+
+        Use this tool to check incoming or recent SMS activity — for example
+        to see replies from users, verify delivery of outbound messages, or
+        process inbound texts as part of a support workflow.
+
+        Args:
+            limit: Maximum number of messages to return (default ``10``).
+
+        Returns:
+            str: A formatted, human-readable list of SMS messages showing
+            direction (inbound/outbound), contact number, relative time, and
+            the message body.  Returns ``"No SMS messages found."`` when
+            there are no messages.
+
+            Example output::
+
+                [1] FROM: +15551234567 | 5m ago | Hi, I need help with my order
+                [2] TO: +15559876543 | 1h ago | Your code is 482910
+        """
+        try:
+            messages = self._client.sms.list(limit=limit)
+            return _format_sms_list(messages)
+        except Exception as e:
+            logger.error(f"read_sms failed: {e}")
+            return f"Error reading SMS messages: {e}"
+
+    # ------------------------------------------------------------------
+    # Credits / account
+    # ------------------------------------------------------------------
+
+    def get_credits(self) -> str:
+        """Check the remaining Commune credit balance.
+
+        Use this tool before starting a high-volume send operation to confirm
+        there is sufficient credit, or any time you need to report the
+        account's current balance.
+
+        Returns:
+            str: A human-readable balance string, e.g.
+            ``"Credit balance: $42.50 USD"``.  Includes a low-balance
+            warning when the balance is below $5.00.  Returns an error
+            message on failure.
+        """
+        try:
+            info = self._client.credits.get()
+            balance = float(info.get("balance", 0))
+            currency = info.get("currency", "USD")
+            message = f"Credit balance: ${balance:.2f} {currency}."
+            if balance < 5.0:
+                message += (
+                    f" Warning: balance is low (${balance:.2f}). "
+                    "Top up to avoid send failures."
+                )
+            return message
+        except Exception as e:
+            logger.error(f"get_credits failed: {e}")
+            return f"Error fetching credit balance: {e}"

--- a/libs/agno/tests/unit/tools/test_commune.py
+++ b/libs/agno/tests/unit/tools/test_commune.py
@@ -1,0 +1,525 @@
+"""Unit tests for CommuneTools."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers: patch the commune import before loading the module under test
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_commune_import():
+    """Provide a fake 'commune' package so the real SDK need not be installed."""
+    fake_commune_pkg = MagicMock()
+    with patch.dict("sys.modules", {"commune": fake_commune_pkg}):
+        yield fake_commune_pkg
+
+
+# We import the module inside each test (or use the fixture below) so the
+# patched sys.modules is already in place.
+
+def _make_tools(api_key="test-key", **kwargs):
+    """Import CommuneTools fresh (after the commune mock is active) and return an instance."""
+    # Re-import every time so the module-level `from commune import Commune` runs
+    # inside the patched context.
+    import importlib
+    import sys
+
+    # Remove cached module so we re-execute it with the mock in place.
+    sys.modules.pop("agno.tools.commune", None)
+
+    with patch("agno.tools.commune.Commune") as MockCommune:
+        mock_client = MagicMock()
+        MockCommune.return_value = mock_client
+        from agno.tools.commune import CommuneTools
+
+        tools = CommuneTools(api_key=api_key, **kwargs)
+        tools._client = mock_client  # expose for assertions
+        return tools, mock_client
+
+
+# ---------------------------------------------------------------------------
+# Initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCommuneToolsInit:
+    def test_init_with_explicit_api_key(self):
+        tools, _ = _make_tools(api_key="explicit-key")
+        assert tools.name == "commune"
+
+    def test_init_falls_back_to_env_var(self, monkeypatch):
+        monkeypatch.setenv("COMMUNE_API_KEY", "env-key")
+        import sys
+
+        sys.modules.pop("agno.tools.commune", None)
+        with patch("agno.tools.commune.Commune") as MockCommune:
+            MockCommune.return_value = MagicMock()
+            from agno.tools.commune import CommuneTools
+
+            tools = CommuneTools()
+            assert tools.name == "commune"
+
+    def test_init_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("COMMUNE_API_KEY", raising=False)
+        import sys
+
+        sys.modules.pop("agno.tools.commune", None)
+        with patch("agno.tools.commune.Commune"):
+            from agno.tools.commune import CommuneTools
+
+            with pytest.raises(ValueError, match="COMMUNE_API_KEY"):
+                CommuneTools()
+
+    def test_email_tools_registered_by_default(self):
+        tools, _ = _make_tools()
+        tool_names = [t.__name__ if callable(t) else str(t) for t in tools.functions.values()]
+        # Check the four email method names appear in registered functions
+        assert "send_email" in tools.functions
+        assert "read_inbox" in tools.functions
+        assert "search_emails" in tools.functions
+        assert "get_email" in tools.functions
+
+    def test_sms_tools_registered_by_default(self):
+        tools, _ = _make_tools()
+        assert "send_sms" in tools.functions
+        assert "read_sms" in tools.functions
+
+    def test_credits_always_registered(self):
+        tools, _ = _make_tools(enable_email=False, enable_sms=False)
+        assert "get_credits" in tools.functions
+
+    def test_email_disabled(self):
+        tools, _ = _make_tools(enable_email=False)
+        assert "send_email" not in tools.functions
+        assert "read_inbox" not in tools.functions
+
+    def test_sms_disabled(self):
+        tools, _ = _make_tools(enable_sms=False)
+        assert "send_sms" not in tools.functions
+        assert "read_sms" not in tools.functions
+
+    def test_from_address_stored(self):
+        tools, _ = _make_tools(from_address="agent@example.com")
+        assert tools.from_address == "agent@example.com"
+
+
+# ---------------------------------------------------------------------------
+# send_email
+# ---------------------------------------------------------------------------
+
+
+class TestSendEmail:
+    def test_send_email_success(self):
+        tools, client = _make_tools()
+        client.emails.send.return_value = {"id": "msg_001", "status": "sent"}
+
+        result = tools.send_email(
+            to="alice@example.com",
+            subject="Hello",
+            body="Hi there!",
+        )
+
+        assert "msg_001" in result
+        assert "sent" in result
+        client.emails.send.assert_called_once_with(
+            to="alice@example.com", subject="Hello", body="Hi there!"
+        )
+
+    def test_send_email_uses_instance_from_address(self):
+        tools, client = _make_tools(from_address="agent@example.com")
+        client.emails.send.return_value = {"id": "msg_002", "status": "sent"}
+
+        tools.send_email(to="bob@example.com", subject="S", body="B")
+
+        call_kwargs = client.emails.send.call_args[1]
+        assert call_kwargs["from_address"] == "agent@example.com"
+
+    def test_send_email_per_call_from_address_overrides(self):
+        tools, client = _make_tools(from_address="default@example.com")
+        client.emails.send.return_value = {"id": "msg_003", "status": "sent"}
+
+        tools.send_email(
+            to="bob@example.com",
+            subject="S",
+            body="B",
+            from_address="override@example.com",
+        )
+
+        call_kwargs = client.emails.send.call_args[1]
+        assert call_kwargs["from_address"] == "override@example.com"
+
+    def test_send_email_empty_to(self):
+        tools, client = _make_tools()
+        result = tools.send_email(to="", subject="S", body="B")
+        assert result.startswith("Error:")
+        client.emails.send.assert_not_called()
+
+    def test_send_email_empty_subject(self):
+        tools, client = _make_tools()
+        result = tools.send_email(to="x@example.com", subject="", body="B")
+        assert result.startswith("Error:")
+        client.emails.send.assert_not_called()
+
+    def test_send_email_empty_body(self):
+        tools, client = _make_tools()
+        result = tools.send_email(to="x@example.com", subject="S", body="")
+        assert result.startswith("Error:")
+        client.emails.send.assert_not_called()
+
+    def test_send_email_api_error(self):
+        tools, client = _make_tools()
+        client.emails.send.side_effect = RuntimeError("network timeout")
+
+        result = tools.send_email(to="x@example.com", subject="S", body="B")
+
+        assert result.startswith("Error")
+        assert "network timeout" in result
+
+
+# ---------------------------------------------------------------------------
+# read_inbox
+# ---------------------------------------------------------------------------
+
+
+class TestReadInbox:
+    def _sample_emails(self):
+        return [
+            {
+                "id": "msg_a",
+                "from_address": "alice@example.com",
+                "subject": "Meeting tomorrow",
+                "body": "Can we move our 3pm meeting to 4pm?",
+                "received_at": "2024-01-01T10:00:00Z",
+                "read": False,
+            },
+            {
+                "id": "msg_b",
+                "from_address": "bob@co.com",
+                "subject": "Invoice #1042",
+                "body": "Please find attached invoice for services rendered.",
+                "received_at": "2024-01-01T09:00:00Z",
+                "read": True,
+            },
+        ]
+
+    def test_read_inbox_returns_formatted_string(self):
+        tools, client = _make_tools()
+        client.emails.list.return_value = self._sample_emails()
+
+        result = tools.read_inbox()
+
+        assert "[1]" in result
+        assert "[2]" in result
+        assert "alice@example.com" in result
+        assert "Meeting tomorrow" in result
+        assert "UNREAD" in result
+        assert "bob@co.com" in result
+
+    def test_read_inbox_empty(self):
+        tools, client = _make_tools()
+        client.emails.list.return_value = []
+
+        result = tools.read_inbox()
+
+        assert result == "No emails found."
+
+    def test_read_inbox_passes_limit(self):
+        tools, client = _make_tools()
+        client.emails.list.return_value = []
+
+        tools.read_inbox(limit=25)
+
+        client.emails.list.assert_called_once_with(limit=25, unread_only=False)
+
+    def test_read_inbox_unread_only(self):
+        tools, client = _make_tools()
+        client.emails.list.return_value = []
+
+        tools.read_inbox(unread_only=True)
+
+        client.emails.list.assert_called_once_with(limit=10, unread_only=True)
+
+    def test_read_inbox_preview_truncated(self):
+        tools, client = _make_tools()
+        long_body = "A" * 200
+        client.emails.list.return_value = [
+            {
+                "id": "msg_long",
+                "from_address": "x@example.com",
+                "subject": "Long",
+                "body": long_body,
+                "received_at": "2024-01-01T10:00:00Z",
+                "read": True,
+            }
+        ]
+
+        result = tools.read_inbox()
+
+        # Preview must be truncated with ellipsis
+        assert "..." in result
+        # Full body should not appear
+        assert long_body not in result
+
+    def test_read_inbox_api_error(self):
+        tools, client = _make_tools()
+        client.emails.list.side_effect = RuntimeError("server error")
+
+        result = tools.read_inbox()
+
+        assert result.startswith("Error")
+
+
+# ---------------------------------------------------------------------------
+# search_emails
+# ---------------------------------------------------------------------------
+
+
+class TestSearchEmails:
+    def test_search_returns_results(self):
+        tools, client = _make_tools()
+        client.emails.search.return_value = [
+            {
+                "id": "msg_s1",
+                "from_address": "vendor@example.com",
+                "subject": "Invoice #999",
+                "body": "Please pay invoice 999.",
+                "received_at": "2024-01-01T08:00:00Z",
+                "read": False,
+            }
+        ]
+
+        result = tools.search_emails(query="invoice")
+
+        assert "[1]" in result
+        assert "Invoice #999" in result
+        client.emails.search.assert_called_once_with(query="invoice", limit=5)
+
+    def test_search_empty_query(self):
+        tools, client = _make_tools()
+
+        result = tools.search_emails(query="")
+
+        assert result.startswith("Error:")
+        client.emails.search.assert_not_called()
+
+    def test_search_no_results(self):
+        tools, client = _make_tools()
+        client.emails.search.return_value = []
+
+        result = tools.search_emails(query="nonexistent")
+
+        assert result == "No emails found."
+
+
+# ---------------------------------------------------------------------------
+# send_sms — E.164 validation
+# ---------------------------------------------------------------------------
+
+
+class TestSendSms:
+    def test_send_sms_valid_number(self):
+        tools, client = _make_tools()
+        client.sms.send.return_value = {"id": "sms_001", "status": "sent"}
+
+        result = tools.send_sms(to="+15551234567", body="Hello!")
+
+        assert "sms_001" in result
+        assert "sent" in result
+        client.sms.send.assert_called_once_with(to="+15551234567", body="Hello!")
+
+    def test_send_sms_missing_plus(self):
+        tools, client = _make_tools()
+
+        result = tools.send_sms(to="15551234567", body="Hello!")
+
+        assert result.startswith("Error:")
+        assert "E.164" in result
+        client.sms.send.assert_not_called()
+
+    def test_send_sms_letters_in_number(self):
+        tools, client = _make_tools()
+
+        result = tools.send_sms(to="+1555ABC4567", body="Hello!")
+
+        assert result.startswith("Error:")
+        client.sms.send.assert_not_called()
+
+    def test_send_sms_empty_to(self):
+        tools, client = _make_tools()
+
+        result = tools.send_sms(to="", body="Hello!")
+
+        assert result.startswith("Error:")
+        client.sms.send.assert_not_called()
+
+    def test_send_sms_empty_body(self):
+        tools, client = _make_tools()
+
+        result = tools.send_sms(to="+15551234567", body="")
+
+        assert result.startswith("Error:")
+        client.sms.send.assert_not_called()
+
+    def test_send_sms_api_error(self):
+        tools, client = _make_tools()
+        client.sms.send.side_effect = RuntimeError("carrier rejected")
+
+        result = tools.send_sms(to="+15551234567", body="Hi")
+
+        assert result.startswith("Error")
+        assert "carrier rejected" in result
+
+    @pytest.mark.parametrize(
+        "number",
+        [
+            "+15551234567",        # US
+            "+442071234567",       # UK
+            "+819012345678",       # Japan
+            "+61412345678",        # Australia
+        ],
+    )
+    def test_send_sms_valid_e164_numbers(self, number):
+        tools, client = _make_tools()
+        client.sms.send.return_value = {"id": "sms_x", "status": "sent"}
+
+        result = tools.send_sms(to=number, body="test")
+
+        assert "Error" not in result
+
+    @pytest.mark.parametrize(
+        "number",
+        [
+            "0015551234567",   # No leading +
+            "+1",              # Too short
+            "+",               # Just a plus
+            "555-123-4567",    # Dashes, no plus
+            "+0155512345678",  # Leading zero after +
+        ],
+    )
+    def test_send_sms_invalid_e164_numbers(self, number):
+        tools, client = _make_tools()
+
+        result = tools.send_sms(to=number, body="test")
+
+        assert result.startswith("Error:")
+
+
+# ---------------------------------------------------------------------------
+# get_credits — low balance warning
+# ---------------------------------------------------------------------------
+
+
+class TestGetCredits:
+    def test_get_credits_normal_balance(self):
+        tools, client = _make_tools()
+        client.credits.get.return_value = {"balance": 42.50, "currency": "USD"}
+
+        result = tools.get_credits()
+
+        assert "$42.50" in result
+        assert "USD" in result
+        assert "Warning" not in result
+
+    def test_get_credits_low_balance_warning(self):
+        tools, client = _make_tools()
+        client.credits.get.return_value = {"balance": 2.00, "currency": "USD"}
+
+        result = tools.get_credits()
+
+        assert "Warning" in result
+        assert "$2.00" in result
+
+    def test_get_credits_zero_balance(self):
+        tools, client = _make_tools()
+        client.credits.get.return_value = {"balance": 0.0, "currency": "USD"}
+
+        result = tools.get_credits()
+
+        assert "Warning" in result
+        assert "$0.00" in result
+
+    def test_get_credits_exactly_five_no_warning(self):
+        """Balance of exactly $5.00 should NOT trigger the warning."""
+        tools, client = _make_tools()
+        client.credits.get.return_value = {"balance": 5.0, "currency": "USD"}
+
+        result = tools.get_credits()
+
+        assert "Warning" not in result
+
+    def test_get_credits_api_error(self):
+        tools, client = _make_tools()
+        client.credits.get.side_effect = RuntimeError("auth failed")
+
+        result = tools.get_credits()
+
+        assert result.startswith("Error")
+        assert "auth failed" in result
+
+
+# ---------------------------------------------------------------------------
+# get_email
+# ---------------------------------------------------------------------------
+
+
+class TestGetEmail:
+    def test_get_email_success(self):
+        tools, client = _make_tools()
+        client.emails.get.return_value = {
+            "id": "msg_xyz",
+            "from_address": "sender@example.com",
+            "to": "agent@commune.io",
+            "subject": "Follow up",
+            "body": "Just checking in.",
+            "received_at": "2024-06-01T12:00:00Z",
+            "read": False,
+        }
+        client.emails.mark_read.return_value = {"success": True}
+
+        result = tools.get_email("msg_xyz")
+
+        assert "msg_xyz" in result
+        assert "sender@example.com" in result
+        assert "Follow up" in result
+        assert "Just checking in." in result
+        client.emails.mark_read.assert_called_once_with("msg_xyz")
+
+    def test_get_email_empty_id(self):
+        tools, client = _make_tools()
+
+        result = tools.get_email("")
+
+        assert result.startswith("Error:")
+        client.emails.get.assert_not_called()
+
+    def test_get_email_mark_read_failure_is_nonfatal(self):
+        """mark_read raising should not cause get_email to return an error."""
+        tools, client = _make_tools()
+        client.emails.get.return_value = {
+            "id": "msg_abc",
+            "from_address": "a@b.com",
+            "to": "c@d.com",
+            "subject": "Test",
+            "body": "Body text.",
+            "received_at": "2024-06-01T12:00:00Z",
+            "read": False,
+        }
+        client.emails.mark_read.side_effect = RuntimeError("mark_read failed")
+
+        result = tools.get_email("msg_abc")
+
+        # Should still succeed
+        assert "msg_abc" in result
+        assert "Body text." in result
+
+    def test_get_email_api_error(self):
+        tools, client = _make_tools()
+        client.emails.get.side_effect = RuntimeError("not found")
+
+        result = tools.get_email("msg_missing")
+
+        assert result.startswith("Error")


### PR DESCRIPTION
## What is Commune?

[Commune](https://commune.sh) is a programmable email and SMS API built for AI agents. Unlike traditional email tools that wrap SMTP, Commune is API-first: each agent gets a **dedicated inbox address and SMS number** via a REST API. No mail server to configure, no SMTP credentials, no port 25 headaches — just an API key.

## Why this is different from `EmailTools` (SMTP)

| | `EmailTools` (existing) | `CommuneTools` (this PR) |
|---|---|---|
| Protocol | SMTP | REST API |
| Receiving email | Not supported | Built-in inbox polling |
| Credentials needed | SMTP host, port, user, password | One API key |
| Agent inbox | No | Yes — dedicated address per agent |
| SMS | No | Yes — send and receive |
| Search | No | Full-text search across inbox |

## Real use case: customer support agent

```python
from agno.agent import Agent
from agno.tools.commune import CommuneTools

support_agent = Agent(
    name="Support Agent",
    tools=[CommuneTools(api_key="...", from_address="support@myapp.commune.sh")],
    instructions=[
        "You are a customer support agent.",
        "Periodically check your inbox with read_inbox(unread_only=True).",
        "For each unread email: read its full content with get_email, "
        "classify the issue, draft a reply, and send it with send_email.",
        "If the customer included a phone number and the issue is urgent, "
        "also send an SMS confirmation with send_sms.",
    ],
)

support_agent.print_response("Check the inbox and handle any open tickets.")
```

## Tools included

| Tool | Description |
|---|---|
| `send_email(to, subject, body, from_address?)` | Send an outbound email |
| `read_inbox(limit, unread_only)` | List recent emails in a scannable format |
| `search_emails(query, limit)` | Full-text search across the inbox |
| `get_email(email_id)` | Fetch complete email content; marks as read |
| `send_sms(to, body)` | Send SMS — validates E.164 format before calling API |
| `read_sms(limit)` | List recent inbound and outbound SMS messages |
| `get_credits()` | Check account balance; warns when below $5.00 |

All tools return plain strings so they compose cleanly with any LLM.

## Feature flags

Feature groups can be toggled at init time:

```python
# Email-only agent
CommuneTools(api_key="...", enable_sms=False)

# SMS-only agent
CommuneTools(api_key="...", enable_email=False)
```

`get_credits` is always registered regardless of flags.

## Installation

```bash
pip install commune-mail
```

```python
import os
os.environ["COMMUNE_API_KEY"] = "your-key"
```

## Files changed

- `libs/agno/agno/tools/commune.py` — full toolkit implementation
- `libs/agno/tests/unit/tools/test_commune.py` — pytest unit tests (mock-based, no real API calls)

## Notes

- `commune-mail` is MIT licensed and available on PyPI
- E.164 validation is done locally before any API call to give fast, clear error messages
- `get_email` marks the email as read after fetching (best-effort; failure is non-fatal)
- Low-balance warning in `get_credits` fires below $5.00 to help agents self-monitor