### PR TITLE
[fix] Serialize structured output in A2A message:stream

### DIFF
--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -83,6 +83,25 @@ from agno.run.agent import (
 from agno.run.base import RunStatus
 
 
+def _serialize_content_for_text_part(content: Any) -> str:
+    """Convert arbitrary run content into safe text for A2A text parts."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+
+    if hasattr(content, "model_dump_json"):
+        return cast(Any, content).model_dump_json()
+
+    if hasattr(content, "model_dump"):
+        return json.dumps(cast(Any, content).model_dump(), default=str)
+
+    try:
+        return json.dumps(content, default=str)
+    except TypeError:
+        return str(content)
+
+
 async def map_a2a_request_to_run_input(request_body: dict, stream: bool = True) -> RunInput:
     """Map A2A SendMessageRequest to Agno RunInput.
 
@@ -348,21 +367,12 @@ async def stream_a2a_response(
 
         # Send content events
         elif isinstance(event, (RunContentEvent, TeamRunContentEvent)) and event.content:
-            # Serialize content to str: Pydantic models (from output_schema) must be
-            # converted before str-concatenation or TextPart construction, otherwise
-            # "TypeError: can only concatenate str (not <Model>) to str" is raised.
-            raw_content = event.content
-            if hasattr(raw_content, "model_dump_json"):
-                content_str = raw_content.model_dump_json()
-            elif not isinstance(raw_content, str):
-                content_str = str(raw_content)
-            else:
-                content_str = raw_content
-            accumulated_content += content_str
+            text_content = _serialize_content_for_text_part(event.content)
+            accumulated_content += text_content
             message = A2AMessage(
                 message_id=message_id,
                 role=Role.agent,
-                parts=[Part(root=TextPart(text=content_str))],
+                parts=[Part(root=TextPart(text=text_content))],
                 context_id=context_id,
                 task_id=task_id,
                 metadata={"agno_content_category": "content"},
@@ -814,7 +824,7 @@ async def stream_a2a_response(
 
         final_parts: List[Part] = []
         if final_content:
-            final_parts.append(Part(root=TextPart(text=str(final_content))))
+            final_parts.append(Part(root=TextPart(text=_serialize_content_for_text_part(final_content))))
 
         # Handle all media artifacts
         artifacts: List[Artifact] = []

--- a/libs/agno/tests/unit/os/test_a2a_stream_output_schema_serialization.py
+++ b/libs/agno/tests/unit/os/test_a2a_stream_output_schema_serialization.py
@@ -1,0 +1,42 @@
+import json
+
+import pytest
+from pydantic import BaseModel
+
+from agno.os.interfaces.a2a.utils import stream_a2a_response
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunStartedEvent
+
+
+class AnalysisResult(BaseModel):
+    category: str
+    confidence: float
+
+
+def _extract_sse_payload(chunks: list[str], event_name: str) -> dict:
+    for chunk in chunks:
+        if chunk.startswith(f"event: {event_name}\n"):
+            data_line = next(line for line in chunk.splitlines() if line.startswith("data: "))
+            return json.loads(data_line.removeprefix("data: "))
+    raise AssertionError(f"event {event_name} not found")
+
+
+@pytest.mark.asyncio
+async def test_stream_a2a_response_serializes_pydantic_content_events() -> None:
+    structured = AnalysisResult(category="security", confidence=0.93)
+
+    async def event_stream():
+        yield RunStartedEvent(run_id="run-1", session_id="sess-1")
+        yield RunContentEvent(content=structured)
+        yield RunCompletedEvent(content=structured)
+
+    chunks = [chunk async for chunk in stream_a2a_response(event_stream(), request_id="req-1")]
+
+    message_payload = _extract_sse_payload(chunks, "Message")
+    final_task_payload = _extract_sse_payload(chunks, "Task")
+
+    message_text = message_payload["result"]["parts"][0]["text"]
+    final_text = final_task_payload["result"]["history"][0]["parts"][0]["text"]
+
+    expected_json = structured.model_dump_json()
+    assert message_text == expected_json
+    assert final_text == expected_json


### PR DESCRIPTION
## Summary
- fix A2A streaming text serialization for non-string content in `stream_a2a_response`
- serialize Pydantic/content objects before appending to accumulated text and SSE text parts
- add a focused unit test covering structured output (`BaseModel`) in stream content and completion events

Fixes #6850

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- `./scripts/format.sh`
- `./scripts/validate.sh`
- `uv run pytest libs/agno/tests/unit/os/test_a2a_stream_output_schema_serialization.py`

## Notes
- keeps `message:stream` behavior aligned with `message:send` for `output_schema` flows by ensuring stream text payloads are string-safe
