### PR TITLE
[feat] add Merge Agent Handler toolkit

### DIFF
--- a/cookbook/91_tools/merge_agent_handler_tools.py
+++ b/cookbook/91_tools/merge_agent_handler_tools.py
@@ -1,0 +1,40 @@
+"""
+Merge Agent Handler Tools
+=========================
+
+Demonstrates how to use Merge Agent Handler tools from Agno.
+
+Prerequisites:
+1. Set MERGE_API_KEY environment variable.
+2. Create a tool pack and registered user in Merge Agent Handler.
+3. Set TOOL_PACK_ID and REGISTERED_USER_ID placeholders below.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.merge_agent_handler import MergeAgentHandlerTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[
+        MergeAgentHandlerTools(
+            tool_pack_id="YOUR_TOOL_PACK_ID",
+            registered_user_id="YOUR_REGISTERED_USER_ID",
+        )
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "List the available tools in my Merge tool pack, then use the right one to fetch the latest Gong users.",
+        markdown=True,
+    )

--- a/libs/agno/agno/tools/merge_agent_handler.py
+++ b/libs/agno/agno/tools/merge_agent_handler.py
@@ -1,0 +1,295 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, logger
+
+BASE_URL = "https://ah-api.merge.dev/api/v1"
+
+
+class MergeAgentHandlerTools(Toolkit):
+    """Toolkit for calling Merge Agent Handler tool packs through MCP."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        tool_pack_id: Optional[str] = None,
+        registered_user_id: Optional[str] = None,
+        environment: str = "production",
+        enable_list_tool_packs: bool = True,
+        enable_list_registered_users: bool = True,
+        enable_list_tools: bool = True,
+        enable_call_tool: bool = True,
+        all: bool = False,
+        timeout: float = 30.0,
+        **kwargs,
+    ):
+        """
+        Initialize Merge Agent Handler toolkit.
+
+        Args:
+            api_key: Merge Agent Handler API key. If not provided, uses MERGE_API_KEY environment variable.
+            tool_pack_id: Default tool pack ID used by list_tools and call_tool.
+            registered_user_id: Default registered user ID used by list_tools and call_tool.
+            environment: Default environment used by list_registered_users. Must be "production" or "test".
+            enable_list_tool_packs: Enable list_tool_packs tool.
+            enable_list_registered_users: Enable list_registered_users tool.
+            enable_list_tools: Enable list_tools tool.
+            enable_call_tool: Enable call_tool tool.
+            all: Enable all tools regardless of individual flags.
+            timeout: HTTP timeout (seconds) for Merge API calls.
+        """
+        self.api_key = api_key or getenv("MERGE_API_KEY")
+        if not self.api_key:
+            raise ValueError("Merge API key is required. Provide api_key or set MERGE_API_KEY environment variable.")
+
+        self.tool_pack_id = tool_pack_id
+        self.registered_user_id = registered_user_id
+        self.environment = environment
+
+        self._client = httpx.Client(
+            base_url=BASE_URL,
+            timeout=timeout,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "X-Source": "agno-toolkit",
+            },
+        )
+
+        tools: List[Any] = []
+        if all or enable_list_tool_packs:
+            tools.append(self.list_tool_packs)
+        if all or enable_list_registered_users:
+            tools.append(self.list_registered_users)
+        if all or enable_list_tools:
+            tools.append(self.list_tools)
+        if all or enable_call_tool:
+            tools.append(self.call_tool)
+
+        super().__init__(name="merge_agent_handler_tools", tools=tools, **kwargs)
+
+    def close(self) -> None:
+        """Close the shared HTTP client."""
+        self._client.close()
+
+    def _resolve_environment(self, environment: Optional[str]) -> str:
+        resolved_environment = (environment or self.environment or "production").strip().lower()
+        if resolved_environment not in {"production", "test"}:
+            raise ValueError("environment must be either 'production' or 'test'")
+        return resolved_environment
+
+    def _resolve_identifiers(
+        self,
+        tool_pack_id: Optional[str],
+        registered_user_id: Optional[str],
+    ) -> Tuple[str, str]:
+        resolved_tool_pack_id = tool_pack_id or self.tool_pack_id
+        resolved_registered_user_id = registered_user_id or self.registered_user_id
+
+        if not resolved_tool_pack_id:
+            raise ValueError("tool_pack_id is required. Pass it in __init__ or this tool call.")
+        if not resolved_registered_user_id:
+            raise ValueError("registered_user_id is required. Pass it in __init__ or this tool call.")
+
+        return resolved_tool_pack_id, resolved_registered_user_id
+
+    def _fetch_all_pages(self, path: str, params: Optional[Dict[str, str]] = None) -> List[Dict[str, Any]]:
+        all_results: List[Dict[str, Any]] = []
+        page = 1
+        query: Dict[str, str] = dict(params or {})
+
+        while True:
+            response = self._client.get(path, params={**query, "page": str(page)})
+            response.raise_for_status()
+            payload = response.json()
+
+            if isinstance(payload, list):
+                return [item for item in payload if isinstance(item, dict)]
+
+            if not isinstance(payload, dict):
+                raise ValueError("Unexpected API response format.")
+
+            results = payload.get("results", [])
+            if not isinstance(results, list):
+                raise ValueError("Unexpected API response format for `results`.")
+
+            for result in results:
+                if isinstance(result, dict):
+                    all_results.append(result)
+
+            if not payload.get("next"):
+                break
+            page += 1
+
+        return all_results
+
+    def _post_mcp(
+        self,
+        tool_pack_id: str,
+        registered_user_id: str,
+        rpc_request: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        path = f"/tool-packs/{tool_pack_id}/registered-users/{registered_user_id}/mcp"
+        response = self._client.post(path, json=rpc_request)
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Unexpected MCP response format.")
+        return payload
+
+    def _parse_arguments(self, arguments: str) -> Dict[str, Any]:
+        try:
+            parsed_arguments = json.loads(arguments)
+        except json.JSONDecodeError as e:
+            raise ValueError("arguments must be a valid JSON string representing an object.") from e
+
+        if parsed_arguments is None:
+            return {}
+        if not isinstance(parsed_arguments, dict):
+            raise ValueError("arguments must decode to a JSON object.")
+
+        return parsed_arguments
+
+    def _extract_text(self, content: Any) -> str:
+        if not isinstance(content, list):
+            return ""
+        text_chunks: List[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+                text_chunks.append(item["text"])
+        return "\n".join(text_chunks).strip()
+
+    def list_tool_packs(self) -> str:
+        """List Merge tool packs available to the API key."""
+        try:
+            log_debug("Listing Merge tool packs")
+            tool_packs = self._fetch_all_pages("/tool-packs/")
+            normalized_tool_packs: List[Dict[str, Any]] = []
+
+            for tool_pack in tool_packs:
+                raw_connectors = tool_pack.get("connectors")
+                connectors = raw_connectors if isinstance(raw_connectors, list) else []
+                normalized_tool_packs.append(
+                    {
+                        "id": tool_pack.get("id"),
+                        "name": tool_pack.get("name"),
+                        "description": tool_pack.get("description"),
+                        "connectors": [
+                            {"name": connector.get("name"), "slug": connector.get("slug")}
+                            for connector in connectors
+                            if isinstance(connector, dict)
+                        ],
+                    }
+                )
+
+            return json.dumps(normalized_tool_packs)
+        except Exception as e:
+            logger.exception(e)
+            return json.dumps({"error": str(e)})
+
+    def list_registered_users(self, environment: Optional[str] = None) -> str:
+        """List registered users filtered by environment (`production` or `test`)."""
+        try:
+            resolved_environment = self._resolve_environment(environment)
+            is_test = resolved_environment == "test"
+            users = self._fetch_all_pages("/registered-users", {"is_test": str(is_test).lower()})
+            normalized_users: List[Dict[str, Any]] = []
+
+            for user in users:
+                normalized_users.append(
+                    {
+                        "id": user.get("id"),
+                        "origin_user_id": user.get("origin_user_id"),
+                        "origin_user_name": user.get("origin_user_name"),
+                        "shared_credential_group": user.get("shared_credential_group"),
+                        "user_type": user.get("user_type"),
+                        "authenticated_connectors": user.get("authenticated_connectors"),
+                        "is_test": user.get("is_test"),
+                    }
+                )
+
+            return json.dumps(normalized_users)
+        except Exception as e:
+            logger.exception(e)
+            return json.dumps({"error": str(e)})
+
+    def list_tools(self, tool_pack_id: Optional[str] = None, registered_user_id: Optional[str] = None) -> str:
+        """List MCP tools for a tool pack and registered user."""
+        try:
+            resolved_tool_pack_id, resolved_registered_user_id = self._resolve_identifiers(
+                tool_pack_id=tool_pack_id, registered_user_id=registered_user_id
+            )
+            rpc_request = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+            response = self._post_mcp(resolved_tool_pack_id, resolved_registered_user_id, rpc_request)
+
+            if "error" in response:
+                error = response.get("error", {})
+                if isinstance(error, dict):
+                    return json.dumps(
+                        {
+                            "error": f"MCP tools/list failed: {error.get('message', 'Unknown error')}",
+                            "code": error.get("code"),
+                            "data": error.get("data"),
+                        }
+                    )
+                return json.dumps({"error": "MCP tools/list failed: Unknown error"})
+
+            tools = response.get("result", {}).get("tools", [])
+            return json.dumps(tools)
+        except Exception as e:
+            logger.exception(e)
+            return json.dumps({"error": str(e)})
+
+    def call_tool(
+        self,
+        tool_name: str,
+        arguments: str = "{}",
+        tool_pack_id: Optional[str] = None,
+        registered_user_id: Optional[str] = None,
+    ) -> str:
+        """Call an MCP tool in Merge Agent Handler."""
+        try:
+            resolved_tool_pack_id, resolved_registered_user_id = self._resolve_identifiers(
+                tool_pack_id=tool_pack_id, registered_user_id=registered_user_id
+            )
+            parsed_arguments = self._parse_arguments(arguments)
+
+            rpc_request = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": tool_name,
+                    "arguments": {"input": parsed_arguments},
+                },
+            }
+            response = self._post_mcp(resolved_tool_pack_id, resolved_registered_user_id, rpc_request)
+
+            if "error" in response:
+                error = response.get("error", {})
+                if isinstance(error, dict):
+                    return json.dumps(
+                        {
+                            "error": f'Tool "{tool_name}" returned error: {error.get("message", "Unknown error")}',
+                            "code": error.get("code"),
+                            "data": error.get("data"),
+                        }
+                    )
+                return json.dumps({"error": f'Tool "{tool_name}" returned error: Unknown error'})
+
+            result = response.get("result")
+            if not isinstance(result, dict):
+                return json.dumps({"error": "MCP response was missing a result payload."})
+
+            if result.get("isError"):
+                error_text = self._extract_text(result.get("content")) or "Unknown error"
+                return json.dumps({"error": f'Tool "{tool_name}" failed: {error_text}'})
+
+            return json.dumps(result)
+        except Exception as e:
+            logger.exception(e)
+            return json.dumps({"error": str(e)})

--- a/libs/agno/tests/unit/tools/test_merge_agent_handler.py
+++ b/libs/agno/tests/unit/tools/test_merge_agent_handler.py
@@ -1,0 +1,203 @@
+"""Unit tests for MergeAgentHandlerTools."""
+
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agno.tools.merge_agent_handler import MergeAgentHandlerTools
+
+
+@pytest.fixture
+def merge_tools():
+    """Create MergeAgentHandlerTools with defaults for tests."""
+    tools = MergeAgentHandlerTools(
+        api_key="test_api_key",
+        tool_pack_id="tp_default",
+        registered_user_id="ru_default",
+    )
+    yield tools
+    tools.close()
+
+
+def _response(payload):
+    """Create a mocked HTTP response with JSON payload."""
+    mocked_response = Mock()
+    mocked_response.raise_for_status = Mock()
+    mocked_response.json.return_value = payload
+    return mocked_response
+
+
+def test_initialization_defaults():
+    """Test default initialization registers all tools."""
+    tools = MergeAgentHandlerTools(api_key="test_api_key")
+    function_names = [func.name for func in tools.functions.values()]
+
+    assert "list_tool_packs" in function_names
+    assert "list_registered_users" in function_names
+    assert "list_tools" in function_names
+    assert "call_tool" in function_names
+    assert tools.name == "merge_agent_handler_tools"
+    tools.close()
+
+
+def test_initialization_with_all_flag():
+    """Test that all=True enables all tools regardless of individual flags."""
+    tools = MergeAgentHandlerTools(
+        api_key="test_api_key",
+        enable_list_tool_packs=False,
+        enable_list_registered_users=False,
+        enable_list_tools=False,
+        enable_call_tool=False,
+        all=True,
+    )
+    function_names = [func.name for func in tools.functions.values()]
+    assert set(function_names) == {"list_tool_packs", "list_registered_users", "list_tools", "call_tool"}
+    tools.close()
+
+
+def test_initialization_without_api_key():
+    """Test initialization without API key fails."""
+    with patch.dict("os.environ", clear=True):
+        with pytest.raises(ValueError, match="Merge API key is required"):
+            MergeAgentHandlerTools()
+
+
+def test_env_var_fallback_for_api_key():
+    """Test MERGE_API_KEY fallback when api_key is not provided."""
+    with patch.dict("os.environ", {"MERGE_API_KEY": "env_key"}):
+        tools = MergeAgentHandlerTools(
+            enable_list_tool_packs=False,
+            enable_list_registered_users=False,
+            enable_list_tools=False,
+            enable_call_tool=False,
+        )
+        assert tools.api_key == "env_key"
+        tools.close()
+
+
+def test_enable_flags_control_tool_registration():
+    """Test enable flags control which tools are registered."""
+    tools = MergeAgentHandlerTools(
+        api_key="test_api_key",
+        enable_list_tool_packs=False,
+        enable_list_registered_users=False,
+        enable_list_tools=False,
+        enable_call_tool=True,
+    )
+    function_names = [func.name for func in tools.functions.values()]
+    assert function_names == ["call_tool"]
+    tools.close()
+
+
+def test_list_tool_packs_with_pagination(merge_tools):
+    """Test list_tool_packs fetches paginated responses."""
+    first_page = {
+        "results": [{"id": "tp_1", "name": "Pack One", "connectors": [{"name": "Gong", "slug": "gong"}]}],
+        "next": "https://ah-api.merge.dev/api/v1/tool-packs/?page=2",
+    }
+    second_page = {"results": [{"id": "tp_2", "name": "Pack Two", "connectors": []}], "next": None}
+
+    with patch.object(merge_tools._client, "get", side_effect=[_response(first_page), _response(second_page)]) as get:
+        result = json.loads(merge_tools.list_tool_packs())
+
+    assert [pack["id"] for pack in result] == ["tp_1", "tp_2"]
+    assert result[0]["connectors"][0]["slug"] == "gong"
+    assert get.call_count == 2
+    assert get.call_args_list[0].kwargs["params"]["page"] == "1"
+    assert get.call_args_list[1].kwargs["params"]["page"] == "2"
+
+
+def test_list_registered_users_with_test_environment(merge_tools):
+    """Test list_registered_users passes is_test filter."""
+    payload = {
+        "results": [{"id": "ru_1", "origin_user_name": "Alex", "is_test": True}],
+        "next": None,
+    }
+    with patch.object(merge_tools._client, "get", return_value=_response(payload)) as get:
+        result = json.loads(merge_tools.list_registered_users(environment="test"))
+
+    assert result[0]["id"] == "ru_1"
+    assert result[0]["is_test"] is True
+    assert get.call_args.kwargs["params"]["is_test"] == "true"
+
+
+def test_list_registered_users_invalid_environment(merge_tools):
+    """Test list_registered_users handles invalid environment input."""
+    result = json.loads(merge_tools.list_registered_users(environment="staging"))
+    assert "error" in result
+    assert "environment must be either 'production' or 'test'" in result["error"]
+
+
+def test_list_tools_sends_tools_list_rpc(merge_tools):
+    """Test list_tools sends tools/list MCP request and parses tools."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"tools": [{"name": "gong__get_user", "description": "Get user", "inputSchema": {"type": "object"}}]},
+    }
+    with patch.object(merge_tools._client, "post", return_value=_response(payload)) as post:
+        result = json.loads(merge_tools.list_tools())
+
+    assert result[0]["name"] == "gong__get_user"
+    request_payload = post.call_args.kwargs["json"]
+    assert request_payload["method"] == "tools/list"
+    assert request_payload["params"] == {}
+
+
+def test_call_tool_wraps_input_arguments(merge_tools):
+    """Test call_tool wraps arguments under input."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": "ok"}], "isError": False},
+    }
+    with patch.object(merge_tools._client, "post", return_value=_response(payload)) as post:
+        result = json.loads(merge_tools.call_tool("gong__get_user", arguments='{"id": "usr_123"}'))
+
+    assert result["isError"] is False
+    request_payload = post.call_args.kwargs["json"]
+    assert request_payload["method"] == "tools/call"
+    assert request_payload["params"]["name"] == "gong__get_user"
+    assert request_payload["params"]["arguments"] == {"input": {"id": "usr_123"}}
+
+
+def test_call_tool_returns_error_for_mcp_error(merge_tools):
+    """Test call_tool handles MCP error payload."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": 500, "message": "boom"},
+    }
+    with patch.object(merge_tools._client, "post", return_value=_response(payload)):
+        result = json.loads(merge_tools.call_tool("gong__get_user", arguments="{}"))
+
+    assert result["code"] == 500
+    assert 'Tool "gong__get_user" returned error: boom' in result["error"]
+
+
+def test_call_tool_handles_is_error_content(merge_tools):
+    """Test call_tool handles MCP isError responses."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"isError": True, "content": [{"type": "text", "text": "permission denied"}]},
+    }
+    with patch.object(merge_tools._client, "post", return_value=_response(payload)):
+        result = json.loads(merge_tools.call_tool("gong__get_user", arguments='{"id": "usr_123"}'))
+
+    assert 'Tool "gong__get_user" failed: permission denied' in result["error"]
+
+
+def test_call_tool_invalid_arguments_json(merge_tools):
+    """Test call_tool rejects invalid JSON string for arguments."""
+    result = json.loads(merge_tools.call_tool("gong__get_user", arguments="{invalid"))
+    assert "arguments must be a valid JSON string representing an object." in result["error"]
+
+
+def test_call_tool_missing_identifiers_without_defaults():
+    """Test call_tool returns error when required IDs are missing."""
+    tools = MergeAgentHandlerTools(api_key="test_api_key", tool_pack_id=None, registered_user_id=None)
+    result = json.loads(tools.call_tool("gong__get_user", arguments='{"id": "usr_123"}'))
+    assert "tool_pack_id is required" in result["error"]
+    tools.close()


### PR DESCRIPTION
## Summary

This PR adds a new `MergeAgentHandlerTools` toolkit that lets Agno agents discover and call Merge Agent Handler MCP tools.

Changes included:
- New toolkit: `libs/agno/agno/tools/merge_agent_handler.py`
- New cookbook example: `cookbook/91_tools/merge_agent_handler_tools.py`
- New unit tests: `libs/agno/tests/unit/tools/test_merge_agent_handler.py`

Toolkit capabilities:
- `list_tool_packs()`
- `list_registered_users(environment)`
- `list_tools(tool_pack_id, registered_user_id)`
- `call_tool(tool_name, arguments, tool_pack_id, registered_user_id)`

Authentication uses `api_key` or `MERGE_API_KEY` env var.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Validation and tests run locally:
- `./scripts/dev_setup.sh`
- `./scripts/format.sh`
- `./scripts/validate.sh`
- `pytest libs/agno/tests/unit/tools/test_merge_agent_handler.py -q`

All passed.
