### PR TITLE
fix(bedrock): group parallel tool results into a single user message

### DIFF
--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -235,8 +235,21 @@ class AwsBedrock(Model):
 
         formatted_messages: List[Dict[str, Any]] = []
         system_message = None
+        # Buffer consecutive tool-role messages so that parallel tool call results
+        # (multiple toolUse blocks in one assistant turn) are grouped into a single
+        # user message. Bedrock's ConverseStream API requires all toolResult blocks
+        # for a given assistant turn to appear in one user message; sending them as
+        # separate messages causes a ValidationException.
+        pending_tool_results: List[Dict[str, Any]] = []
+
+        def _flush_tool_results() -> None:
+            if pending_tool_results:
+                formatted_messages.append({"role": "user", "content": list(pending_tool_results)})
+                pending_tool_results.clear()
+
         for message in messages:
             if message.role == "system":
+                _flush_tool_results()
                 system_message = [{"text": message.content}]
             elif message.role == "tool":
                 content = message.get_content(use_compressed_content=compress_tool_results)
@@ -244,9 +257,9 @@ class AwsBedrock(Model):
                     "toolUseId": message.tool_call_id,
                     "content": [{"json": {"result": content}}],
                 }
-                formatted_message: Dict[str, Any] = {"role": "user", "content": [{"toolResult": tool_result}]}
-                formatted_messages.append(formatted_message)
+                pending_tool_results.append({"toolResult": tool_result})
             else:
+                _flush_tool_results()
                 formatted_message = {"role": message.role, "content": []}
                 if isinstance(message.content, list):
                     formatted_message["content"].extend(message.content)
@@ -355,6 +368,10 @@ class AwsBedrock(Model):
                         )
 
                 formatted_messages.append(formatted_message)
+
+        # Flush any tool results that appear at the end of the message list
+        _flush_tool_results()
+
         # TODO: Add caching: https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-call.html
         return formatted_messages, system_message
 


### PR DESCRIPTION
## Summary

When the model returns multiple `toolUse` blocks in one assistant turn (parallel tool calls), the Bedrock ConverseStream API requires **all corresponding `toolResult` blocks to be in a single user message**. The current code appends one user message per tool result, which causes Bedrock to reject the next request:

```
ValidationException: An error occurred (ValidationException) when calling the
ConverseStream operation: Expected toolResult blocks at messages.N.content for
the following Ids: <tool_use_id>
```

## Root Cause

In `_format_messages()`, each `role == "tool"` message is immediately appended as its own `{"role": "user", "content": [{"toolResult": ...}]}` message:

```python
# Before — one user message per result
formatted_message = {"role": "user", "content": [{"toolResult": tool_result}]}
formatted_messages.append(formatted_message)
```

For parallel tool calls this produces:
```
Assistant: [toolUse id-1] [toolUse id-2]
User:      [toolResult id-1]              ← split across two messages
User:      [toolResult id-2]              ← Bedrock rejects this ✗
```

## Fix

Buffer consecutive `tool`-role messages and flush them as a **single** user message whenever a non-tool message (or end-of-list) is encountered:

```
Assistant: [toolUse id-1] [toolUse id-2]
User:      [toolResult id-1] [toolResult id-2]  ← one message ✓
```

## Scope

This change is **AWS Bedrock only** — OpenAI and other providers use a different wire format where separate tool messages per result are valid. No other provider files are touched.

## Testing

Trigger parallel tool calls by asking the model to do two independent things simultaneously (e.g. check two shell commands at once). Before this fix the agent crashes with a `ValidationException`; after it completes successfully.