### PR TITLE
fix: serialize non-string content in A2A streaming to prevent TypeError

### DIFF
--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -348,11 +348,12 @@ async def stream_a2a_response(
 
         # Send content events
         elif isinstance(event, (RunContentEvent, TeamRunContentEvent)) and event.content:
-            accumulated_content += event.content
+            content_str = event.content if isinstance(event.content, str) else str(event.content)
+            accumulated_content += content_str
             message = A2AMessage(
                 message_id=message_id,
                 role=Role.agent,
-                parts=[Part(root=TextPart(text=event.content))],
+                parts=[Part(root=TextPart(text=content_str))],
                 context_id=context_id,
                 task_id=task_id,
                 metadata={"agno_content_category": "content"},


### PR DESCRIPTION
## Summary

Fix `TypeError: can only concatenate str (not "AnalysisResult") to str` when using `message:stream` with agents that have `output_schema` set.

Fixes #6850.

## Problem

In `stream_a2a_response_with_error_handling`, `RunContentEvent.content` is concatenated directly to `accumulated_content` (a string) and passed to `TextPart(text=...)`. When the agent has `output_schema` set, `event.content` can be a Pydantic model instance, not a string, causing a `TypeError` on concatenation.

The non-streaming path (`map_run_output_to_a2a_task`) already handles this correctly with `str(run_output.content)` on line 213, but the streaming path was missing the same conversion.

## Fix

Convert `event.content` to string before accumulation and TextPart construction:

```python
# Before
accumulated_content += event.content
parts=[Part(root=TextPart(text=event.content))]

# After
content_str = event.content if isinstance(event.content, str) else str(event.content)
accumulated_content += content_str
parts=[Part(root=TextPart(text=content_str))]
```

This matches the pattern already used in the non-streaming endpoint.

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin
