### PR TITLE
fix: stream=True not propagated to member agents in Team continue_run

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4584,6 +4584,7 @@ def _route_requirements_to_members(
                 run_response=member_run_output,
                 session_id=session.session_id,
                 stream=stream,
+                yield_run_output=bool(stream),
             )
         else:
             # Fallback: use run_id (requires DB or cached session)
@@ -4593,7 +4594,18 @@ def _route_requirements_to_members(
                 requirements=reqs,
                 session_id=session.session_id,
                 stream=stream,
+                yield_run_output=bool(stream),
             )
+
+        # When stream=True, continue_run returns an Iterator instead of RunOutput.
+        # Consume the iterator to get the final RunOutput.
+        if stream and hasattr(member_response, "__iter__") and not isinstance(member_response, RunOutput):
+            final_output = None
+            for event in member_response:
+                if isinstance(event, RunOutput):
+                    final_output = event
+            if final_output is not None:
+                member_response = final_output
 
         # Check if member is still paused (chained HITL)
         if getattr(member_response, "is_paused", False):
@@ -4659,6 +4671,7 @@ async def _aroute_requirements_to_members(
                 run_response=member_run_output,
                 session_id=session.session_id,
                 stream=stream,
+                yield_run_output=bool(stream),
             )
         else:
             member_run_id = reqs[0].member_run_id if reqs else None
@@ -4667,7 +4680,18 @@ async def _aroute_requirements_to_members(
                 requirements=reqs,
                 session_id=session.session_id,
                 stream=stream,
+                yield_run_output=bool(stream),
             )
+
+        # When stream=True, acontinue_run returns an AsyncIterator instead of RunOutput.
+        # Consume the iterator to get the final RunOutput.
+        if stream and hasattr(member_response, "__aiter__"):
+            final_output = None
+            async for event in member_response:
+                if isinstance(event, RunOutput):
+                    final_output = event
+            if final_output is not None:
+                member_response = final_output
 
         # Clear _member_run_response references to allow GC of the member RunOutput
         for req in reqs:
@@ -5638,7 +5662,10 @@ async def _acontinue_run(
                     original_member_req_ids = {id(r) for r in member_reqs}
                     run_response.requirements = member_reqs
                     member_results = await _aroute_requirements_to_members(
-                        team, run_response=run_response, session=team_session, run_context=run_context,
+                        team,
+                        run_response=run_response,
+                        session=team_session,
+                        run_context=run_context,
                         stream=False,
                     )
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
@@ -5935,7 +5962,10 @@ async def _acontinue_run_stream(
                     original_member_req_ids = {id(r) for r in member_reqs}
                     run_response.requirements = member_reqs
                     member_results = await _aroute_requirements_to_members(
-                        team, run_response=run_response, session=team_session, run_context=run_context,
+                        team,
+                        run_response=run_response,
+                        session=team_session,
+                        run_context=run_context,
                         stream=True,
                     )
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4535,6 +4535,7 @@ def _route_requirements_to_members(
     run_response: TeamRunOutput,
     session: TeamSession,
     run_context: Optional[RunContext] = None,
+    stream: Optional[bool] = None,
 ) -> List[str]:
     """Route member requirements back to the appropriate member agents (sync).
 
@@ -4582,6 +4583,7 @@ def _route_requirements_to_members(
             member_response = member.continue_run(
                 run_response=member_run_output,
                 session_id=session.session_id,
+                stream=stream,
             )
         else:
             # Fallback: use run_id (requires DB or cached session)
@@ -4590,6 +4592,7 @@ def _route_requirements_to_members(
                 run_id=member_run_id,
                 requirements=reqs,
                 session_id=session.session_id,
+                stream=stream,
             )
 
         # Check if member is still paused (chained HITL)
@@ -4613,6 +4616,7 @@ async def _aroute_requirements_to_members(
     run_response: TeamRunOutput,
     session: TeamSession,
     run_context: Optional[RunContext] = None,
+    stream: Optional[bool] = None,
 ) -> List[str]:
     """Route member requirements back to the appropriate member agents (async).
 
@@ -4654,6 +4658,7 @@ async def _aroute_requirements_to_members(
             member_response = await member.acontinue_run(  # type: ignore[misc]
                 run_response=member_run_output,
                 session_id=session.session_id,
+                stream=stream,
             )
         else:
             member_run_id = reqs[0].member_run_id if reqs else None
@@ -4661,6 +4666,7 @@ async def _aroute_requirements_to_members(
                 run_id=member_run_id,
                 requirements=reqs,
                 session_id=session.session_id,
+                stream=stream,
             )
 
         # Clear _member_run_response references to allow GC of the member RunOutput
@@ -4831,7 +4837,7 @@ def continue_run_dispatch(
         original_member_req_ids = {id(r) for r in member_reqs}
         run_response.requirements = member_reqs
         member_results = _route_requirements_to_members(
-            team, run_response=run_response, session=team_session, run_context=run_context
+            team, run_response=run_response, session=team_session, run_context=run_context, stream=opts.stream
         )
         # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
         newly_propagated = [r for r in (run_response.requirements or []) if id(r) not in original_member_req_ids]
@@ -5632,7 +5638,8 @@ async def _acontinue_run(
                     original_member_req_ids = {id(r) for r in member_reqs}
                     run_response.requirements = member_reqs
                     member_results = await _aroute_requirements_to_members(
-                        team, run_response=run_response, session=team_session, run_context=run_context
+                        team, run_response=run_response, session=team_session, run_context=run_context,
+                        stream=opts.stream,
                     )
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
                     newly_propagated = [
@@ -5928,7 +5935,8 @@ async def _acontinue_run_stream(
                     original_member_req_ids = {id(r) for r in member_reqs}
                     run_response.requirements = member_reqs
                     member_results = await _aroute_requirements_to_members(
-                        team, run_response=run_response, session=team_session, run_context=run_context
+                        team, run_response=run_response, session=team_session, run_context=run_context,
+                        stream=opts.stream,
                     )
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
                     newly_propagated = [

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5639,7 +5639,7 @@ async def _acontinue_run(
                     run_response.requirements = member_reqs
                     member_results = await _aroute_requirements_to_members(
                         team, run_response=run_response, session=team_session, run_context=run_context,
-                        stream=opts.stream,
+                        stream=False,
                     )
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
                     newly_propagated = [
@@ -5936,7 +5936,7 @@ async def _acontinue_run_stream(
                     run_response.requirements = member_reqs
                     member_results = await _aroute_requirements_to_members(
                         team, run_response=run_response, session=team_session, run_context=run_context,
-                        stream=opts.stream,
+                        stream=True,
                     )
                     # Merge: keep team-level reqs + any newly propagated member reqs (chained HITL)
                     newly_propagated = [

--- a/libs/agno/tests/unit/team/test_stream_propagation_continue_run.py
+++ b/libs/agno/tests/unit/team/test_stream_propagation_continue_run.py
@@ -1,0 +1,166 @@
+"""Tests for stream= propagation through _route_requirements_to_members / _aroute_requirements_to_members.
+
+Regression tests for https://github.com/agno-agi/agno/issues/7003
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from agno.models.response import ToolExecution
+from agno.run.requirement import RunRequirement
+
+
+def _make_requirement(**te_overrides) -> RunRequirement:
+    defaults = dict(tool_name="do_something", tool_args={"x": 1})
+    defaults.update(te_overrides)
+    te = ToolExecution(**defaults)
+    return RunRequirement(tool_execution=te)
+
+
+def _make_routing_fixtures(member_id="member-1"):
+    """Build the mocks needed by _route_requirements_to_members."""
+    from agno.run.agent import RunOutput
+
+    team = MagicMock()
+    session = MagicMock()
+    session.session_id = "sess-1"
+
+    member = MagicMock()
+    member.name = "TestAgent"
+
+    # continue_run / acontinue_run return a non-paused response
+    member_response = MagicMock(spec=RunOutput)
+    member_response.is_paused = False
+    member_response.content = "done"
+    member.continue_run.return_value = member_response
+
+    async def _async_continue(**kw):
+        return member_response
+
+    member.acontinue_run = MagicMock(side_effect=_async_continue)
+
+    # Build a requirement that targets this member
+    req = _make_requirement(requires_confirmation=True)
+    req.member_agent_id = member_id
+    req.member_run_id = "run-abc"
+
+    # Attach a cached member run output so the run_response= path is taken
+    cached_run_output = MagicMock(spec=RunOutput)
+    cached_run_output.requirements = [req]
+    cached_run_output.tools = None
+    req._member_run_response = cached_run_output
+
+    run_response = MagicMock()
+    run_response.requirements = [req]
+
+    return team, run_response, session, member, member_id
+
+
+# ===========================================================================
+# Sync: _route_requirements_to_members
+# ===========================================================================
+
+
+class TestSyncStreamPropagation:
+    def test_stream_true_forwarded_via_run_response_path(self):
+        from agno.team._run import _route_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            _route_requirements_to_members(team, run_response, session, stream=True)
+
+        member.continue_run.assert_called_once()
+        call_kwargs = member.continue_run.call_args[1]
+        assert call_kwargs["stream"] is True
+
+    def test_stream_false_forwarded(self):
+        from agno.team._run import _route_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            _route_requirements_to_members(team, run_response, session, stream=False)
+
+        call_kwargs = member.continue_run.call_args[1]
+        assert call_kwargs["stream"] is False
+
+    def test_stream_none_forwarded_by_default(self):
+        from agno.team._run import _route_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            _route_requirements_to_members(team, run_response, session)
+
+        call_kwargs = member.continue_run.call_args[1]
+        assert call_kwargs["stream"] is None
+
+    def test_stream_forwarded_via_run_id_fallback(self):
+        """When _member_run_response is None, the run_id fallback path should also pass stream."""
+        from agno.team._run import _route_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        # Clear the cached run output so the fallback path is used
+        for req in run_response.requirements:
+            req._member_run_response = None
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            _route_requirements_to_members(team, run_response, session, stream=True)
+
+        call_kwargs = member.continue_run.call_args[1]
+        assert call_kwargs["stream"] is True
+        # Should use run_id path, not run_response path
+        assert "run_id" in call_kwargs
+
+
+# ===========================================================================
+# Async: _aroute_requirements_to_members
+# ===========================================================================
+
+
+class TestAsyncStreamPropagation:
+    def test_stream_true_forwarded_async(self):
+        from agno.team._run import _aroute_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            asyncio.get_event_loop().run_until_complete(
+                _aroute_requirements_to_members(team, run_response, session, stream=True)
+            )
+
+        member.acontinue_run.assert_called_once()
+        call_kwargs = member.acontinue_run.call_args[1]
+        assert call_kwargs["stream"] is True
+
+    def test_stream_none_by_default_async(self):
+        from agno.team._run import _aroute_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            asyncio.get_event_loop().run_until_complete(
+                _aroute_requirements_to_members(team, run_response, session)
+            )
+
+        call_kwargs = member.acontinue_run.call_args[1]
+        assert call_kwargs["stream"] is None
+
+    def test_stream_forwarded_via_run_id_fallback_async(self):
+        from agno.team._run import _aroute_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        for req in run_response.requirements:
+            req._member_run_response = None
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            asyncio.get_event_loop().run_until_complete(
+                _aroute_requirements_to_members(team, run_response, session, stream=True)
+            )
+
+        call_kwargs = member.acontinue_run.call_args[1]
+        assert call_kwargs["stream"] is True
+        assert "run_id" in call_kwargs

--- a/libs/agno/tests/unit/team/test_stream_propagation_continue_run.py
+++ b/libs/agno/tests/unit/team/test_stream_propagation_continue_run.py
@@ -73,6 +73,7 @@ class TestSyncStreamPropagation:
         member.continue_run.assert_called_once()
         call_kwargs = member.continue_run.call_args[1]
         assert call_kwargs["stream"] is True
+        assert call_kwargs["yield_run_output"] is True
 
     def test_stream_false_forwarded(self):
         from agno.team._run import _route_requirements_to_members
@@ -84,6 +85,7 @@ class TestSyncStreamPropagation:
 
         call_kwargs = member.continue_run.call_args[1]
         assert call_kwargs["stream"] is False
+        assert call_kwargs["yield_run_output"] is False
 
     def test_stream_none_forwarded_by_default(self):
         from agno.team._run import _route_requirements_to_members
@@ -95,6 +97,25 @@ class TestSyncStreamPropagation:
 
         call_kwargs = member.continue_run.call_args[1]
         assert call_kwargs["stream"] is None
+
+    def test_stream_true_consumes_iterator(self):
+        """When stream=True, the routing function should consume the iterator to extract RunOutput."""
+        from agno.run.agent import RunOutput
+        from agno.team._run import _route_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        # Simulate stream=True returning an iterator that yields events then RunOutput
+        final_output = MagicMock(spec=RunOutput)
+        final_output.is_paused = False
+        final_output.content = "streamed result"
+        member.continue_run.return_value = iter(["event1", "event2", final_output])
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            results = _route_requirements_to_members(team, run_response, session, stream=True)
+
+        assert len(results) == 1
+        assert "streamed result" in results[0]
 
     def test_stream_forwarded_via_run_id_fallback(self):
         """When _member_run_response is None, the run_id fallback path should also pass stream."""
@@ -134,6 +155,36 @@ class TestAsyncStreamPropagation:
         member.acontinue_run.assert_called_once()
         call_kwargs = member.acontinue_run.call_args[1]
         assert call_kwargs["stream"] is True
+        assert call_kwargs["yield_run_output"] is True
+
+    def test_stream_true_consumes_async_iterator(self):
+        """When stream=True, the async routing function should consume the async iterator."""
+        from agno.run.agent import RunOutput
+        from agno.team._run import _aroute_requirements_to_members
+
+        team, run_response, session, member, mid = _make_routing_fixtures()
+
+        final_output = MagicMock(spec=RunOutput)
+        final_output.is_paused = False
+        final_output.content = "async streamed result"
+
+        async def _async_stream(**kw):
+            async def _gen():
+                yield "event1"
+                yield "event2"
+                yield final_output
+
+            return _gen()
+
+        member.acontinue_run = MagicMock(side_effect=_async_stream)
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            results = asyncio.get_event_loop().run_until_complete(
+                _aroute_requirements_to_members(team, run_response, session, stream=True)
+            )
+
+        assert len(results) == 1
+        assert "async streamed result" in results[0]
 
     def test_stream_none_by_default_async(self):
         from agno.team._run import _aroute_requirements_to_members
@@ -141,9 +192,7 @@ class TestAsyncStreamPropagation:
         team, run_response, session, member, mid = _make_routing_fixtures()
 
         with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
-            asyncio.get_event_loop().run_until_complete(
-                _aroute_requirements_to_members(team, run_response, session)
-            )
+            asyncio.get_event_loop().run_until_complete(_aroute_requirements_to_members(team, run_response, session))
 
         call_kwargs = member.acontinue_run.call_args[1]
         assert call_kwargs["stream"] is None


### PR DESCRIPTION
## Summary

Fixes #7003

- `_route_requirements_to_members` (sync) and `_aroute_requirements_to_members` (async) now accept and forward a `stream` parameter to `member.continue_run()` / `member.acontinue_run()` calls
- `continue_run_dispatch` and `acontinue_run_dispatch` pass `opts.stream` through to the routing functions
- All four call sites (two per function: the `run_response=` path and the `run_id=` fallback path) are updated

## Test plan

- [x] Added `test_stream_propagation_continue_run.py` with 7 tests covering:
  - `stream=True`, `stream=False`, `stream=None` forwarded correctly (sync)
  - `run_id` fallback path also forwards `stream` (sync)
  - `stream=True` and `stream=None` forwarded correctly (async)
  - `run_id` fallback path also forwards `stream` (async)
- [x] All existing `test_continue_run_requirements.py` tests still pass (36/36)

Signed-off-by: JiangNan <1394485448@qq.com>