### PR TITLE
fix: prevent output_schema from breaking MCP tool schemas

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -370,6 +370,14 @@ def parse_tools(
         elif isinstance(tool, Toolkit):
             # For each function in the toolkit and process entrypoint
             toolkit_functions = tool.get_async_functions() if async_mode else tool.get_functions()
+
+            # Detect MCP tools: output_schema strict mode should NOT be applied to MCP tools
+            # because MCP tools define their own schemas from the MCP server.
+            is_mcp_tool = hasattr(type(tool), "__mro__") and any(
+                c.__name__ in ["MCPTools", "MultiMCPTools"] for c in type(tool).__mro__
+            )
+            toolkit_strict = False if is_mcp_tool else strict
+
             for name, _func in toolkit_functions.items():
                 if name in _function_names:
                     continue
@@ -379,9 +387,9 @@ def parse_tools(
                 if agent._team is not None:
                     _func._team = agent._team
                 # Respect the function's explicit strict setting if set
-                effective_strict = strict if _func.strict is None else _func.strict
+                effective_strict = toolkit_strict if _func.strict is None else _func.strict
                 _func.process_entrypoint(strict=effective_strict)
-                if strict and _func.strict is None:
+                if toolkit_strict and _func.strict is None:
                     _func.strict = True
                 if agent.tool_hooks is not None:
                     _func.tool_hooks = agent.tool_hooks


### PR DESCRIPTION
## Summary

Fixes #7024

When an `Agent` has `output_schema` set and uses MCP tools, the `strict` mode derived from `output_schema` was incorrectly applied to MCP tool definitions in `parse_tools()`. MCP tools define their own schemas from the MCP server and should not have the agent's output_schema strict mode forced onto them.

This caused OpenAI API to reject MCP tool calls with:
> "Invalid schema for function 'mcp_tool': schema must have a 'type' key."

## Changes

- In `parse_tools()` (`libs/agno/agno/agent/_tools.py`), detect MCP toolkits (`MCPTools`/`MultiMCPTools`) and skip the output_schema-derived `strict` flag for their functions
- Uses the same MCP detection pattern already used elsewhere in the codebase (`aget_tools()`)
- Non-MCP tools continue to receive the `strict` flag as before

## Root Cause

In `parse_tools()`, the `strict` flag is set to `True` when `output_schema` is present. This flag was then applied uniformly to all tools, including MCP tools via `process_entrypoint(strict=True)`. For MCP functions (which have `skip_entrypoint_processing=True`), this triggered `process_schema_for_strict()` which modified the MCP tool's input schema — adding `additionalProperties: false`, modifying `required` fields, and potentially adding/changing `type` keys — breaking the schema that the MCP server defined.

## Test plan

- [ ] Create an agent with both `output_schema` and MCP tools, verify MCP tool calls succeed
- [ ] Verify that non-MCP tools still get strict mode when `output_schema` is set
- [ ] Verify that MCP tools with explicit `strict=True` set on the function still respect that setting