### PR TITLE
[fix] sanitize_response_schema marks optional fields as required 

### DIFF
--- a/libs/agno/agno/utils/models/openai_responses.py
+++ b/libs/agno/agno/utils/models/openai_responses.py
@@ -102,7 +102,7 @@ def sanitize_response_schema(schema: dict):
     - Removes "default": null from optional fields.
     - Ensures that all fields defined in "properties" are listed in "required",
       making every property explicitly required as per OpenAI's expectations,
-      EXCEPT for Dict fields which should not be in the required array.
+      EXCEPT for Dict fields and optional fields (with default: null) which should not be in the required array.
     """
     if isinstance(schema, dict):
         # Enforce additionalProperties: false for object types, but preserve Dict schemas
@@ -121,9 +121,13 @@ def sanitize_response_schema(schema: dict):
 
                 required_fields = []
                 for prop_name, prop_schema in schema["properties"].items():
-                    # Use the utility function to check if this is a Dict field
-                    if not is_dict_field(prop_schema):
-                        required_fields.append(prop_name)
+                    # Skip Dict fields
+                    if is_dict_field(prop_schema):
+                        continue
+                    # Skip optional fields (have default: null) — must check before defaults are stripped below
+                    if "default" in prop_schema and prop_schema["default"] is None:
+                        continue
+                    required_fields.append(prop_name)
 
                 schema["required"] = required_fields
 

--- a/libs/agno/tests/unit/utils/test_openai_responses.py
+++ b/libs/agno/tests/unit/utils/test_openai_responses.py
@@ -81,7 +81,7 @@ def test_sanitize_response_schema_regular_fields_required():
 
 
 def test_sanitize_response_schema_removes_null_defaults():
-    """Test that null defaults are removed"""
+    """Test that null defaults are removed and optional fields are not required"""
     original_schema = OptionalModel.model_json_schema()
     schema = copy.deepcopy(original_schema)
 
@@ -91,6 +91,11 @@ def test_sanitize_response_schema_removes_null_defaults():
 
     # Should not have default: null
     assert "default" not in optional_field or optional_field.get("default") is not None
+
+    # Optional field should NOT be in required
+    required_fields = schema.get("required", [])
+    assert "name" in required_fields
+    assert "optional_field" not in required_fields
 
 
 def test_sanitize_response_schema_nested_objects():
@@ -220,3 +225,54 @@ def test_sanitize_response_schema_preserves_non_object_types():
     assert schema1["type"] == "string"
     assert schema2["type"] == "array"
     assert schema2["items"]["type"] == "integer"
+
+
+def test_sanitize_response_schema_optional_fields_not_required():
+    """Test that optional fields with default None are not marked as required"""
+
+    class MixedModel(BaseModel):
+        required_name: str = Field(..., description="Required name")
+        required_age: int = Field(..., description="Required age")
+        optional_attrs: Optional[Dict[str, str]] = Field(None, description="Optional attributes")
+        optional_content: Optional[str] = Field(None, description="Optional content")
+        optional_type: Optional[str] = Field(None, description="Optional type")
+
+    original_schema = MixedModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+
+    sanitize_response_schema(schema)
+
+    required_fields = schema.get("required", [])
+
+    # Required fields should be in required
+    assert "required_name" in required_fields
+    assert "required_age" in required_fields
+
+    # Optional fields should NOT be in required
+    assert "optional_attrs" not in required_fields
+    assert "optional_content" not in required_fields
+    assert "optional_type" not in required_fields
+
+
+def test_sanitize_response_schema_optional_nested_objects_not_required():
+    """Test that optional nested object fields are not marked as required"""
+
+    class InnerModel(BaseModel):
+        value: str = Field(..., description="Inner value")
+
+    class OuterModel(BaseModel):
+        name: str = Field(..., description="Name")
+        inner: Optional[InnerModel] = Field(None, description="Optional inner model")
+
+    original_schema = OuterModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+
+    sanitize_response_schema(schema)
+
+    required_fields = schema.get("required", [])
+
+    # Required field should be in required
+    assert "name" in required_fields
+
+    # Optional nested object should NOT be in required
+    assert "inner" not in required_fields


### PR DESCRIPTION
## Summary

`sanitize_response_schema()` unconditionally marks all non-Dict properties as required, even when Pydantic fields have `default: null` (i.e., `Optional` fields). This causes intermittent structured output failures with OpenAI's strict mode — when the LLM omits an optional field, OpenAI rejects the response or forces unexpected output.

The fix skips fields with `default: null` when building the required array, before the defaults are stripped later in the function.

Fixes #7066

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Updated docstring in `sanitize_response_schema()` to document the new behavior.
- Added 2 new tests and updated 1 existing test to verify optional fields are excluded from `required`.
- All 13 tests in `test_openai_responses.py` pass.
