### PR TITLE
fix: improve WhatsApp multi-instance logging, error handling, and per-instance signature validation

### DIFF
--- a/cookbook/05_agent_os/interfaces/whatsapp/multiple_instances.py
+++ b/cookbook/05_agent_os/interfaces/whatsapp/multiple_instances.py
@@ -9,8 +9,8 @@ Setup:
   1. Create two WhatsApp Business apps at https://developers.facebook.com
   2. Each app gets its own phone number, access token, and verify token
   3. Set each app's webhook callback URL to its prefix:
-       - Basic Bot       ->  https://myapp.com/basic/webhook
-       - Research Bot     ->  https://myapp.com/web-research/webhook
+       - Assistant       ->  https://myapp.com/basic/webhook
+       - Web Research Assistant     ->  https://myapp.com/web-research/webhook
   4. Set environment variables (or pass tokens directly):
        BASIC_WHATSAPP_ACCESS_TOKEN, BASIC_WHATSAPP_PHONE_NUMBER_ID, BASIC_WHATSAPP_VERIFY_TOKEN
        RESEARCH_WHATSAPP_ACCESS_TOKEN, RESEARCH_WHATSAPP_PHONE_NUMBER_ID, RESEARCH_WHATSAPP_VERIFY_TOKEN
@@ -40,9 +40,16 @@ basic_agent = Agent(
     name="Basic Agent",
     model=OpenAIChat(id="gpt-5-mini"),
     db=agent_db,
+    instructions=[
+        "You are a friendly and helpful WhatsApp assistant.",
+        "When asked who you are, introduce yourself as a friendly WhatsApp assistant here to help.",
+        "Keep responses conversational, natural, and concise.",
+        "Keep each paragraph to 1-3 sentences max.",
+    ],
     add_history_to_context=True,
     num_history_runs=3,
     add_datetime_to_context=True,
+    markdown=True,
 )
 
 web_research_agent = Agent(
@@ -50,9 +57,17 @@ web_research_agent = Agent(
     model=OpenAIChat(id="gpt-5-mini"),
     db=agent_db,
     tools=[WebSearchTools()],
+    instructions=[
+        "You are 'Web Research Assistant', a web research assistant on WhatsApp.",
+        "When asked who you are, say you are Web Research Assistant — a WhatsApp assistant that can search the web.",
+        "Search the web for relevant information to answer the user's question.",
+        "Keep responses concise and conversational — this is a WhatsApp chat.",
+        "Use bullet points for lists and bold for emphasis.",
+    ],
     add_history_to_context=True,
     num_history_runs=3,
     add_datetime_to_context=True,
+    markdown=True,
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/05_agent_os/interfaces/whatsapp/multiple_instances.py
+++ b/cookbook/05_agent_os/interfaces/whatsapp/multiple_instances.py
@@ -12,8 +12,8 @@ Setup:
        - Assistant       ->  https://myapp.com/basic/webhook
        - Web Research Assistant     ->  https://myapp.com/web-research/webhook
   4. Set environment variables (or pass tokens directly):
-       BASIC_WHATSAPP_ACCESS_TOKEN, BASIC_WHATSAPP_PHONE_NUMBER_ID, BASIC_WHATSAPP_VERIFY_TOKEN
-       RESEARCH_WHATSAPP_ACCESS_TOKEN, RESEARCH_WHATSAPP_PHONE_NUMBER_ID, RESEARCH_WHATSAPP_VERIFY_TOKEN
+       BASIC_WHATSAPP_ACCESS_TOKEN, BASIC_WHATSAPP_PHONE_NUMBER_ID, BASIC_WHATSAPP_VERIFY_TOKEN, BASIC_WHATSAPP_APP_SECRET
+       RESEARCH_WHATSAPP_ACCESS_TOKEN, RESEARCH_WHATSAPP_PHONE_NUMBER_ID, RESEARCH_WHATSAPP_VERIFY_TOKEN, RESEARCH_WHATSAPP_APP_SECRET
 
 Note: Unlike Slack (where each app can have its own Event Subscription URL),
 Meta only allows ONE webhook callback URL per WhatsApp Business app.
@@ -83,6 +83,7 @@ agent_os = AgentOS(
             access_token=getenv("BASIC_WHATSAPP_ACCESS_TOKEN"),
             phone_number_id=getenv("BASIC_WHATSAPP_PHONE_NUMBER_ID"),
             verify_token=getenv("BASIC_WHATSAPP_VERIFY_TOKEN"),
+            app_secret=getenv("BASIC_WHATSAPP_APP_SECRET"),
         ),
         Whatsapp(
             agent=web_research_agent,
@@ -90,6 +91,7 @@ agent_os = AgentOS(
             access_token=getenv("RESEARCH_WHATSAPP_ACCESS_TOKEN"),
             phone_number_id=getenv("RESEARCH_WHATSAPP_PHONE_NUMBER_ID"),
             verify_token=getenv("RESEARCH_WHATSAPP_VERIFY_TOKEN"),
+            app_secret=getenv("RESEARCH_WHATSAPP_APP_SECRET"),
         ),
     ],
 )

--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -50,10 +50,6 @@ _WA_TOOL_NAMES = frozenset(
     }
 )
 
-# Tracks entity IDs registered in the current startup cycle.
-# Cleared on each module reload; warns when the same entity_id is used twice.
-_registered_entity_ids: dict = {}  # entity_id -> count
-
 
 class _SessionConfig(NamedTuple):
     session_type: SessionType
@@ -150,12 +146,15 @@ def attach_routes(
 
     _log_prefix = f"[{entity_name}]"
 
-    _registered_entity_ids[entity_id] = _registered_entity_ids.get(entity_id, 0) + 1
-    if _registered_entity_ids[entity_id] > 1:
-        log_warning(
-            f"{_log_prefix} entity_id '{entity_id}' is already registered. "
-            "Multiple routers sharing the same entity_id will collide on session namespaces."
-        )
+    # Detect duplicate entity_id by checking existing operation_ids on this router
+    _expected_op = f"whatsapp_webhook_{op_suffix}"
+    for route in getattr(router, "routes", []):
+        if getattr(route, "operation_id", None) == _expected_op:
+            log_warning(
+                f"{_log_prefix} entity_id '{entity_id}' is already registered on this router. "
+                "Multiple routers sharing the same entity_id will collide on session namespaces."
+            )
+            break
 
     # Used by /new handler (create sessions) and process_message (find latest)
     session_config = _resolve_session_config(entity, entity_type)

--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -50,6 +50,10 @@ _WA_TOOL_NAMES = frozenset(
     }
 )
 
+# Tracks entity IDs registered in the current startup cycle.
+# Cleared on each module reload; warns when the same entity_id is used twice.
+_registered_entity_ids: dict = {}  # entity_id -> count
+
 
 class _SessionConfig(NamedTuple):
     session_type: SessionType
@@ -125,6 +129,7 @@ def attach_routes(
     access_token: Optional[str] = None,
     phone_number_id: Optional[str] = None,
     verify_token: Optional[str] = None,
+    app_secret: Optional[str] = None,
     media_timeout: int = 30,
     enable_encryption: bool = False,
     encryption_key: Optional[bytes] = None,
@@ -142,6 +147,15 @@ def attach_routes(
     # Multiple WhatsApp routers on one app need unique operation_ids
     op_suffix = entity_name.lower().replace(" ", "_")
     entity_id = getattr(entity, "id", None) or entity_name
+
+    _log_prefix = f"[{entity_name}]"
+
+    _registered_entity_ids[entity_id] = _registered_entity_ids.get(entity_id, 0) + 1
+    if _registered_entity_ids[entity_id] > 1:
+        log_warning(
+            f"{_log_prefix} entity_id '{entity_id}' is already registered. "
+            "Multiple routers sharing the same entity_id will collide on session namespaces."
+        )
 
     # Used by /new handler (create sessions) and process_message (find latest)
     session_config = _resolve_session_config(entity, entity_type)
@@ -193,14 +207,14 @@ def attach_routes(
         payload = await request.body()
         signature = request.headers.get("X-Hub-Signature-256")
 
-        if not validate_webhook_signature(payload, signature):
-            log_warning("Invalid webhook signature")
+        if not validate_webhook_signature(payload, signature, app_secret=app_secret):
+            log_warning(f"{_log_prefix} Invalid webhook signature")
             raise HTTPException(status_code=403, detail="Invalid signature")
 
         body = await request.json()
 
         if body.get("object") != "whatsapp_business_account":
-            log_warning(f"Received non-WhatsApp webhook object: {body.get('object')}")
+            log_warning(f"{_log_prefix} Received non-WhatsApp webhook object: {body.get('object')}")
             return WhatsAppWebhookResponse(status="ignored")
 
         # ACK immediately, process in background. Meta retries if no 200 within ~20s
@@ -215,7 +229,7 @@ def attach_routes(
         # Extract early so error handler can notify the user
         phone_number = message.get("from")
         if not phone_number:
-            log_warning("Message missing 'from' field, skipping")
+            log_warning(f"{_log_prefix} Message missing 'from' field, skipping")
             return
         # Splits identity: user_id (possibly encrypted) for DB storage, phone_number (raw) for API sends
         user_id = _encrypt_phone(phone_number, encryption_key) if enable_encryption and encryption_key else phone_number
@@ -254,11 +268,11 @@ def attach_routes(
                         session_config.db.upsert_session(new_session)
                     await send_whatsapp_message_async(phone_number, _SESSION_RESET_MESSAGE, config)
                 except Exception as e:
-                    log_warning(f"Failed to persist /new session: {e}")
+                    log_warning(f"{_log_prefix} Failed to persist /new session: {e}")
                     await send_whatsapp_message_async(phone_number, _ERROR_MESSAGE, config)
                 return
 
-            log_info(f"Processing message from {user_id[:12]}: {parsed.text}")
+            log_info(f"{_log_prefix} Processing message from {user_id[:12]}: {parsed.text}")
 
             # Resolve session: check DB for latest, fall back to deterministic ID
             default_session_id = f"wa:{entity_id}:{user_id}"
@@ -281,7 +295,7 @@ def attach_routes(
                     if sessions:
                         session_id = sessions[0].session_id
                 except Exception as e:
-                    log_warning(f"Session lookup failed, using default: {e}")
+                    log_warning(f"{_log_prefix} Session lookup failed, using default: {e}")
 
             # Download media from Meta servers and wrap as Agno media objects
             media_kwargs, skipped_media = await download_event_media_async(parsed, config)
@@ -321,7 +335,7 @@ def attach_routes(
 
             if response.status == "ERROR":
                 await send_whatsapp_message_async(phone_number, _ERROR_MESSAGE, config)
-                log_error(response.content)
+                log_error(f"{_log_prefix} {response.content}")
                 return
 
             if show_reasoning and hasattr(response, "reasoning_content") and response.reasoning_content:
@@ -353,10 +367,10 @@ def attach_routes(
                 await send_whatsapp_message_async(phone_number, response.content, config)
 
         except Exception as e:
-            log_error(f"Error processing message: {e}")
+            log_error(f"{_log_prefix} Error processing message: {repr(e)}", exc_info=True)
             try:
                 await send_whatsapp_message_async(phone_number, _ERROR_MESSAGE, config)
             except Exception as send_error:
-                log_error(f"Error sending error message: {send_error}")
+                log_error(f"{_log_prefix} Error sending error message: {repr(send_error)}")
 
     return router

--- a/libs/agno/agno/os/interfaces/whatsapp/security.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/security.py
@@ -8,9 +8,13 @@ from fastapi import HTTPException
 from agno.utils.log import log_warning
 
 
-def validate_webhook_signature(payload: bytes, signature_header: Optional[str]) -> bool:
-    app_secret = os.getenv("WHATSAPP_APP_SECRET")
-    if not app_secret:
+def validate_webhook_signature(
+    payload: bytes,
+    signature_header: Optional[str],
+    app_secret: Optional[str] = None,
+) -> bool:
+    secret = app_secret or os.getenv("WHATSAPP_APP_SECRET")
+    if not secret:
         # Explicit opt-out: operator must deliberately set this for local dev
         if os.getenv("WHATSAPP_SKIP_SIGNATURE_VALIDATION", "").lower() == "true":
             log_warning("WHATSAPP_SKIP_SIGNATURE_VALIDATION=true — signature check disabled")
@@ -26,7 +30,7 @@ def validate_webhook_signature(payload: bytes, signature_header: Optional[str]) 
     # Header format: "sha256=<hex>"; strip prefix to compare digests
     expected_signature = signature_header.removeprefix("sha256=")
 
-    hmac_obj = hmac.new(app_secret.encode(), payload, hashlib.sha256)
+    hmac_obj = hmac.new(secret.encode(), payload, hashlib.sha256)
     calculated_signature = hmac_obj.hexdigest()
 
     # Constant-time comparison prevents timing side-channels

--- a/libs/agno/agno/os/interfaces/whatsapp/whatsapp.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/whatsapp.py
@@ -28,6 +28,7 @@ class Whatsapp(BaseInterface):
         access_token: Optional[str] = None,
         phone_number_id: Optional[str] = None,
         verify_token: Optional[str] = None,
+        app_secret: Optional[str] = None,
         # Timeout in seconds for media downloads/uploads (images, video, docs)
         media_timeout: int = 30,
         enable_encryption: bool = False,
@@ -44,6 +45,7 @@ class Whatsapp(BaseInterface):
         self.access_token = access_token
         self.phone_number_id = phone_number_id
         self.verify_token = verify_token
+        self.app_secret = app_secret
         self.media_timeout = media_timeout
         self.enable_encryption = enable_encryption
 
@@ -74,6 +76,7 @@ class Whatsapp(BaseInterface):
             access_token=self.access_token,
             phone_number_id=self.phone_number_id,
             verify_token=self.verify_token,
+            app_secret=self.app_secret,
             media_timeout=self.media_timeout,
             enable_encryption=self.enable_encryption,
             encryption_key=self._encryption_key,

--- a/libs/agno/tests/unit/os/interfaces/test_whatsapp_security.py
+++ b/libs/agno/tests/unit/os/interfaces/test_whatsapp_security.py
@@ -106,3 +106,40 @@ def test_app_env_development_does_not_bypass():
     with patch.dict("os.environ", {"WHATSAPP_APP_SECRET": APP_SECRET, "APP_ENV": "development"}):
         assert validate_webhook_signature(payload, None) is False
         assert validate_webhook_signature(payload, "sha256=invalid") is False
+
+
+# === Per-instance app_secret override ===
+
+
+def test_per_instance_secret_validates_correctly():
+    """Per-instance app_secret should validate against its own secret."""
+    instance_secret = "per-instance-secret-xyz"
+    payload = b'{"event": "message"}'
+    signature = _make_signature(payload, secret=instance_secret)
+    with patch.dict("os.environ", {}, clear=True):
+        assert validate_webhook_signature(payload, signature, app_secret=instance_secret) is True
+
+
+def test_per_instance_secret_rejects_wrong_signature():
+    """Per-instance app_secret should reject signatures made with a different secret."""
+    payload = b'{"event": "message"}'
+    wrong_signature = _make_signature(payload, secret="wrong-secret")
+    with patch.dict("os.environ", {}, clear=True):
+        assert validate_webhook_signature(payload, wrong_signature, app_secret="correct-secret") is False
+
+
+def test_per_instance_secret_overrides_env_var():
+    """Per-instance app_secret takes priority over WHATSAPP_APP_SECRET env var."""
+    instance_secret = "instance-level-secret"
+    payload = b'{"event": "message"}'
+    signature = _make_signature(payload, secret=instance_secret)
+    # Env var is set to a DIFFERENT secret, but instance secret should win
+    with patch.dict("os.environ", {"WHATSAPP_APP_SECRET": "env-level-secret"}):
+        assert validate_webhook_signature(payload, signature, app_secret=instance_secret) is True
+
+
+def test_per_instance_none_falls_back_to_env():
+    """app_secret=None should fall back to WHATSAPP_APP_SECRET env var."""
+    payload = b'{"test": "data"}'
+    signature = _make_signature(payload, secret=APP_SECRET)
+    assert validate_webhook_signature(payload, signature, app_secret=None) is True


### PR DESCRIPTION
## Summary

Follow-up to #6466. While testing `multiple_instances.py` with two WhatsApp bots on one server, we found and fixed these issues:

**1. Can't tell which bot is which in terminal**

When both bots run together, terminal showed:
```
INFO Processing message from 1234567890: Hello
INFO Processing message from 1234567890: Search cricket
```
No way to know which bot handled which message. Added `[entity_name]` prefix to all log calls:
```
INFO [Basic Agent] Processing message from 1234567890: Hello
INFO [Web Research Agent] Processing message from 1234567890: Search cricket
```

**2. Errors logged with empty messages**

When a web search failed, terminal showed:
```
ERROR    Error processing message:
```
No error details, no traceback. Changed to `repr(e)` + `exc_info=True` so errors now show the full cause and traceback.

**3. Bot 2 always got 403 Forbidden**

`WHATSAPP_APP_SECRET` is a single global env var. Bot 2 has a different Meta app with a different secret — so its webhooks always failed signature validation. Added per-instance `app_secret` parameter to `Whatsapp()`. Falls back to env var when not passed, so existing single-bot setups are unaffected.

**4. No warning if two bots share the same name**

If two agents accidentally share the same `name` and no `id`, their sessions collide silently in the database. Added a startup warning when duplicate `entity_id` is detected.

**5. `multiple_instances.py` bots say "I'm ChatGPT by OpenAI"**

No `instructions` on either agent, so both defaulted to OpenAI's base identity. Added identity instructions and `markdown=True`.

## Files Changed
- `libs/agno/agno/os/interfaces/whatsapp/security.py` — per-instance `app_secret` parameter
- `libs/agno/agno/os/interfaces/whatsapp/whatsapp.py` — thread `app_secret` through init
- `libs/agno/agno/os/interfaces/whatsapp/router.py` — log prefix, better error handling, collision warning
- `cookbook/05_agent_os/interfaces/whatsapp/multiple_instances.py` — added instructions and markdown

## Test plan
- [x] All 109 existing WhatsApp unit tests pass
- [x] Ruff format and lint pass
- [x] Backward compatibility verified — single-bot setups unaffected
- [x] Live tested with two WhatsApp bots on one server
- [x] Cross-bot session isolation verified