### PR TITLE
fix(CodingTools): block interpreter flag injection in _check_command [Security]

### DIFF
--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -235,6 +235,14 @@ class CodingTools(Toolkit):
 
     # Shell operators that enable command chaining or substitution
     _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
+    # Interpreter commands whose flags can bypass the metacharacter check
+    _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "ruby", "perl", "node", "nodejs", "php", "lua"]
+    # Flags that execute inline code strings; blocked in restricted mode
+    _CODE_INJECTION_FLAGS: List[str] = ["-c", "-e", "--eval", "--execute"]
+    # Interpreter commands that support inline code execution via flags like -c/-e
+    _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "ruby", "perl", "node", "nodejs", "php", "lua"]
+    # Flags that pass code strings directly to interpreters; blocked in restricted mode
+    _CODE_INJECTION_FLAGS: List[str] = ["-c", "-e", "--eval", "--execute"]
 
     def _check_command(self, command: str) -> Optional[str]:
         """Check if a shell command is safe to execute.
@@ -270,6 +278,22 @@ class CodingTools(Toolkit):
             # Skip the command itself (already validated by allowlist above)
             if i == 0:
                 continue
+            # Block interpreter flags that allow inline code execution (-c, -e, etc.)
+            if token in self._CODE_INJECTION_FLAGS:
+                _base = Path(tokens[0]).name
+                if _base in self._INTERPRETER_COMMANDS:
+                    return (
+                        f"Error: Flag '{token}' is not allowed for interpreter "
+                        f"'{_base}' in restricted mode. Use PythonTools instead."
+                    )
+            # Block interpreter flags that allow inline code execution
+            if token in self._CODE_INJECTION_FLAGS:
+                _base = Path(tokens[0]).name
+                if _base in self._INTERPRETER_COMMANDS:
+                    return (
+                        f"Error: Flag '{token}' is not allowed for interpreter "
+                        f"'{_base}' in restricted mode. Use PythonTools instead."
+                    )
             # Skip flags
             if token.startswith("-"):
                 continue

--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -1,4 +1,5 @@
 import functools
+import re
 import shlex
 import subprocess
 import tempfile
@@ -236,7 +237,7 @@ class CodingTools(Toolkit):
     # Shell operators that enable command chaining or substitution
     _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
     # Interpreter commands that support inline code execution via flags like -c/-e
-    _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "ruby", "perl", "node", "nodejs", "php", "lua"]
+    _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "ruby", "perl", "node", "nodejs", "php", "lua", "bash", "sh", "zsh", "dash", "ksh"]
     # Flags that pass code strings directly to interpreters; blocked in restricted mode
     _CODE_INJECTION_FLAGS: List[str] = ["-c", "-e", "--eval", "--execute"]
 
@@ -281,6 +282,14 @@ class CodingTools(Toolkit):
                     return (
                         f"Error: Flag '{token}' is not allowed for interpreter "
                         f"'{_base}' in restricted mode. Use PythonTools instead."
+                    )
+            # Also block flags glued to code without a space (e.g. python3 -cprint(...))
+            _base2 = Path(tokens[0]).name
+            if _base2 in self._INTERPRETER_COMMANDS:
+                if re.match(r'^(-c|-e|--eval|--execute)\S', token):
+                    return (
+                        f"Error: Interpreter flag injection detected in token '{token[:20]}' "
+                        f"for '{_base2}' in restricted mode."
                     )
             # Skip flags
             if token.startswith("-"):

--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -235,10 +235,6 @@ class CodingTools(Toolkit):
 
     # Shell operators that enable command chaining or substitution
     _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
-    # Interpreter commands whose flags can bypass the metacharacter check
-    _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "ruby", "perl", "node", "nodejs", "php", "lua"]
-    # Flags that execute inline code strings; blocked in restricted mode
-    _CODE_INJECTION_FLAGS: List[str] = ["-c", "-e", "--eval", "--execute"]
     # Interpreter commands that support inline code execution via flags like -c/-e
     _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "ruby", "perl", "node", "nodejs", "php", "lua"]
     # Flags that pass code strings directly to interpreters; blocked in restricted mode
@@ -278,14 +274,6 @@ class CodingTools(Toolkit):
             # Skip the command itself (already validated by allowlist above)
             if i == 0:
                 continue
-            # Block interpreter flags that allow inline code execution (-c, -e, etc.)
-            if token in self._CODE_INJECTION_FLAGS:
-                _base = Path(tokens[0]).name
-                if _base in self._INTERPRETER_COMMANDS:
-                    return (
-                        f"Error: Flag '{token}' is not allowed for interpreter "
-                        f"'{_base}' in restricted mode. Use PythonTools instead."
-                    )
             # Block interpreter flags that allow inline code execution
             if token in self._CODE_INJECTION_FLAGS:
                 _base = Path(tokens[0]).name

--- a/libs/agno/tests/unit/tools/test_coding_tools.py
+++ b/libs/agno/tests/unit/tools/test_coding_tools.py
@@ -667,3 +667,104 @@ def test_default_allowed_commands():
         assert "python" in tools.allowed_commands
         assert "git" in tools.allowed_commands
         assert "pytest" in tools.allowed_commands
+
+
+# --- interpreter flag injection tests (CVE security fix) ---
+
+
+def test_run_shell_blocks_python_dash_c():
+    """Test that python -c inline code execution is blocked (interpreter flag injection)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("python -c \"__import__('os').system('id')\"")
+        assert "Error" in result
+        assert "-c" in result
+
+
+def test_run_shell_blocks_python3_dash_c():
+    """Test that python3 -c inline code execution is blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("python3 -c \"print('injected')\"")
+        assert "Error" in result
+        assert "-c" in result
+
+
+def test_run_shell_blocks_node_dash_e():
+    """Test that node -e inline code execution is blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("node -e \"console.log('pwned')\"")
+        assert "Error" in result
+
+
+def test_run_shell_blocks_ruby_dash_e():
+    """Test that ruby -e inline code execution is blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("ruby -e \"system('id')\"")
+        assert "Error" in result
+
+
+def test_run_shell_blocks_perl_dash_e():
+    """Test that perl -e inline code execution is blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("perl -e \"system('id')\"")
+        assert "Error" in result
+
+
+def test_run_shell_blocks_node_eval_flag():
+    """Test that node --eval inline code execution is blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("node --eval \"require('child_process').execSync('id')\"")
+        assert "Error" in result
+
+
+def test_run_shell_allows_python_script_file():
+    """Test that running a python script file still works after the interpreter flag fix."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        (base_dir / "safe_script.py").write_text("print('safe output')\n")
+        result = tools.run_shell("python3 safe_script.py")
+        assert "Exit code: 0" in result
+        assert "safe output" in result
+
+
+def test_run_shell_allows_non_injection_python_flags():
+    """Test that python3 --version is not blocked (not an injection flag)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("python3 --version")
+        # --version is not in _CODE_INJECTION_FLAGS; the command should succeed
+        assert "Exit code: 0" in result
+
+
+def test_run_shell_unrestricted_allows_interpreter_flags():
+    """Test that restrict_to_base_dir=False permits interpreter flags (sandbox off)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir, restrict_to_base_dir=False)
+        result = tools.run_shell("python3 -c \"print('unrestricted')\"")
+        assert "Exit code: 0" in result
+        assert "unrestricted" in result
+
+
+def test_run_shell_interpreter_error_names_flag_and_interpreter():
+    """Test that the block error message identifies both the flag and interpreter."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+        result = tools.run_shell("python -c \"print('pwned')\"")
+        assert "Error" in result
+        assert "-c" in result
+        assert "python" in result.lower()

--- a/libs/agno/tests/unit/tools/test_coding_tools.py
+++ b/libs/agno/tests/unit/tools/test_coding_tools.py
@@ -767,4 +767,28 @@ def test_run_shell_interpreter_error_names_flag_and_interpreter():
         result = tools.run_shell("python -c \"print('pwned')\"")
         assert "Error" in result
         assert "-c" in result
+
+
+def test_run_shell_blocks_bash_dash_c():
+    """bash -c should be blocked (shell interpreter injection)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))
+        result = tools.run_shell("bash -c 'id'")
+        assert "Error" in result
+
+
+def test_run_shell_blocks_sh_dash_c():
+    """sh -c should be blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))
+        result = tools.run_shell("sh -c 'id'")
+        assert "Error" in result
+
+
+def test_run_shell_blocks_spaceless_flag():
+    """python3 -cprint(...) with no space should be blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = CodingTools(base_dir=Path(tmp_dir))
+        result = tools.run_shell('python3 -cprint("pwned")')
+        assert "Error" in result
         assert "python" in result.lower()


### PR DESCRIPTION
## Security Fix: CodingTools Interpreter Flag Injection (RCE)

### Summary

`_check_command()` in `CodingTools` validates the command name against an allowlist and blocks shell metacharacters, but never inspects the content of flag arguments passed to interpreter commands. This allows a complete bypass of the `restrict_to_base_dir` sandbox.

### Vulnerability

`python` and `python3` are on the `DEFAULT_ALLOWED_COMMANDS` list. The `_check_command()` token loop skips any token starting with `-`, so the `-c` flag is never examined. The argument to `-c` has no `/` or `..` — the path-traversal check doesn't apply either.

Payload that passes all three checks:
```
python -c "__import__('os').system('id')"
```
- No shell metacharacters: no `&&`, `;`, `|`, ````, etc.
- `python` is on the allowlist: passes.
- `-c` starts with `-`: skipped by the loop.
- Argument has no path separators: skipped by the path check.

Then `subprocess.run(command, shell=True)` executes it. Live output from a clean agno==2.5.10 environment:
```
uid=1000(user) gid=1000(user) groups=1000(user)
```

Escalation paths: read arbitrary files, write outside `base_dir`, network access, reverse shell — all via pure Python socket/subprocess API with no shell metacharacters.

This is **distinct** from Issue #7065 (newline `\n` injection). That bypass uses a separator character; this one uses a trusted interpreter as a code-execution channel. Two different root causes; two different fixes required.

**CVSSv3.1**: AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H = **9.8 Critical**  
Affected versions: v2.5.1 – v2.5.10 (all `CodingTools` releases)

### Fix

Add two class attributes to `CodingTools`:
- `_INTERPRETER_COMMANDS`: set of commands that accept inline code via flags
- `_CODE_INJECTION_FLAGS`: flags that pass code strings to interpreters (`-c`, `-e`, `--eval`, `--execute`)

In the token loop of `_check_command()`, before the existing flag-skip, check whether the flag is a code-injection flag AND the command is a known interpreter. If so, return an error directing the caller to use `PythonTools` instead.

### What is NOT broken by this fix

- `python3 script.py` — no `-c`/`-e` flag, passes
- `pytest tests/` — not in `_INTERPRETER_COMMANDS`, passes
- `pip install foo` — not in `_INTERPRETER_COMMANDS`, passes
- `git commit -m "x"` — not in `_INTERPRETER_COMMANDS`, passes
- `node server.js` — no code-injection flag, passes

### Recommended additional hardening (not in this PR)

Consider removing interpreter commands from the default shell allowlist entirely and routing all code execution through `PythonTools.run_python_code()`.

---
Reported by: Rajat Rai ([@rajatrai00](https://github.com/rajatrai00))