### PR TITLE
fix: set strict=False on Skills functions to prevent output_schema conflict

### DIFF
--- a/libs/agno/agno/skills/agent_skills.py
+++ b/libs/agno/agno/skills/agent_skills.py
@@ -159,6 +159,7 @@ class Skills:
                 name="get_skill_instructions",
                 description="Load the full instructions for a skill. Use this when you need to follow a skill's guidance.",
                 entrypoint=self._get_skill_instructions,
+                strict=False,
             )
         )
 
@@ -168,6 +169,7 @@ class Skills:
                 name="get_skill_reference",
                 description="Load a reference document from a skill's references. Use this to access detailed documentation.",
                 entrypoint=self._get_skill_reference,
+                strict=False,
             )
         )
 
@@ -177,6 +179,7 @@ class Skills:
                 name="get_skill_script",
                 description="Read or execute a script from a skill. Set execute=True to run the script and get output, or execute=False (default) to read the script content.",
                 entrypoint=self._get_skill_script,
+                strict=False,
             )
         )
 

--- a/libs/agno/tests/unit/skills/test_agent_skills.py
+++ b/libs/agno/tests/unit/skills/test_agent_skills.py
@@ -271,6 +271,15 @@ def test_get_tools_returns_three_functions(mock_loader: MockSkillLoader) -> None
     assert "get_skill_script" in tool_names
 
 
+def test_get_tools_have_strict_false(mock_loader: MockSkillLoader) -> None:
+    """Test that all skill tools have strict=False to avoid conflicts with output_schema."""
+    skills = Skills(loaders=[mock_loader])
+    tools = skills.get_tools()
+
+    for tool in tools:
+        assert tool.strict is False, f"Tool '{tool.name}' should have strict=False"
+
+
 # --- Skill Instructions Tool Tests ---
 
 


### PR DESCRIPTION
## Summary

Fixes #7096

When an Agent uses both `Skills(loaders=[LocalSkills(...)])` and `output_schema`, the skills stop working. The root cause is in `Skills.get_tools()` — the three Function objects (`get_skill_instructions`, `get_skill_reference`, `get_skill_script`) are created without setting the `strict` field, leaving it as `None`. In `parse_tools()`, when `strict` is `None`, it inherits the global `strict=True` from `output_schema`, causing `process_schema_for_strict()` to corrupt the Skills function schemas.

Fix: Set `strict=False` explicitly on each Function created in `Skills.get_tools()`. This is the minimal change — `parse_tools()` already respects explicit `strict` settings. This mirrors the approach from PR #7062 (which handles MCP Toolkits) but applies to the Skills case.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added `test_get_tools_have_strict_false` test to verify all Functions returned by `Skills.get_tools()` have `strict=False`, ensuring they won't be overridden by `output_schema`'s global strict flag.