### PR TITLE
Add CRW web scraping toolkit

### DIFF
--- a/cookbook/91_tools/crw_extraction_tools.py
+++ b/cookbook/91_tools/crw_extraction_tools.py
@@ -1,0 +1,36 @@
+"""
+This is an example of how to use CrwTools for structured data extraction.
+
+Uses CRW's LLM-powered extraction with JSON Schema to pull specific fields
+from web pages. Requires LLM extraction to be configured on the CRW server.
+
+Prerequisites:
+- A running CRW server with LLM extraction configured
+    cargo install crw-server && crw-server
+"""
+
+from agno.agent import Agent
+from agno.tools.crw import CrwTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    tools=[
+        CrwTools(
+            api_url="http://localhost:3000",
+            enable_scrape=True,
+            enable_extract=True,
+        )
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Extract the product name, price, and rating from https://example.com/product"
+    )

--- a/cookbook/91_tools/crw_tools.py
+++ b/cookbook/91_tools/crw_tools.py
@@ -1,0 +1,46 @@
+"""
+This is an example of how to use CrwTools.
+
+CRW is a high-performance, Firecrawl-compatible web scraper for AI agents.
+Single binary, ~6 MB idle RAM, 5.5x faster than Firecrawl.
+
+Prerequisites:
+- A running CRW server (self-hosted or fastcrw.com cloud)
+    # Option A: Self-hosted
+    cargo install crw-server && crw-server
+
+    # Option B: Cloud
+    export CRW_API_KEY="fc-..."
+"""
+
+from agno.agent import Agent
+from agno.tools.crw import CrwTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    tools=[
+        CrwTools(
+            api_url="http://localhost:3000",
+            enable_scrape=True,
+            enable_crawl=True,
+            enable_map=True,
+        )
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Scrape a single page
+    agent.print_response("Summarize the content of https://news.ycombinator.com")
+
+    # Map site structure
+    agent.print_response("List all pages on https://docs.agno.com")
+
+    # Crawl multiple pages
+    agent.print_response("Crawl https://docs.agno.com/introduction/ and give me a summary")

--- a/libs/agno/agno/tools/crw.py
+++ b/libs/agno/agno/tools/crw.py
@@ -99,10 +99,21 @@ class CrwTools(Toolkit):
             headers["Authorization"] = f"Bearer {self.api_key}"
         return headers
 
-    def _truncate(self, content: str) -> str:
-        if len(content) > self.max_content_length:
-            return content[: self.max_content_length] + "\n... (content truncated)"
-        return content
+    def _truncate_data(self, data: Any) -> Any:
+        """Truncate large text fields in data before JSON serialization.
+
+        Instead of truncating the final JSON string (which produces invalid JSON),
+        this method truncates individual text fields that exceed max_content_length.
+        """
+        if isinstance(data, str):
+            if len(data) > self.max_content_length:
+                return data[: self.max_content_length] + "\n... (content truncated)"
+            return data
+        if isinstance(data, list):
+            return [self._truncate_data(item) for item in data]
+        if isinstance(data, dict):
+            return {key: self._truncate_data(value) for key, value in data.items()}
+        return data
 
     def scrape_url(self, url: str) -> str:
         """Scrape a single URL and return its content as markdown.
@@ -137,7 +148,7 @@ class CrwTools(Toolkit):
             if not result.get("success"):
                 return json.dumps({"error": result.get("error", "Unknown error")})
 
-            return self._truncate(json.dumps(result["data"], ensure_ascii=False))
+            return json.dumps(self._truncate_data(result["data"]), ensure_ascii=False)
 
         except Exception as e:
             error_msg = f"Error scraping {url}: {str(e)}"
@@ -184,8 +195,11 @@ class CrwTools(Toolkit):
 
             job_id = result["id"]
 
-            # Poll for completion
-            while True:
+            # Poll for completion with a deadline to avoid infinite loops
+            max_wait = self.crawl_max_pages * self.timeout
+            deadline = time.monotonic() + max_wait
+
+            while time.monotonic() < deadline:
                 time.sleep(self.crawl_poll_interval)
                 status_response = httpx.get(
                     f"{self.api_url}/v1/crawl/{job_id}",
@@ -196,11 +210,17 @@ class CrwTools(Toolkit):
                 status = status_response.json()
 
                 if status["status"] == "completed":
-                    return self._truncate(
-                        json.dumps(status["data"], ensure_ascii=False)
+                    return json.dumps(
+                        self._truncate_data(status["data"]), ensure_ascii=False
                     )
                 elif status["status"] == "failed":
                     return json.dumps({"error": "Crawl job failed", "job_id": job_id})
+
+            return json.dumps({
+                "error": f"Crawl timed out after {max_wait}s",
+                "job_id": job_id,
+                "status": "timeout",
+            })
 
         except Exception as e:
             error_msg = f"Error crawling {url}: {str(e)}"

--- a/libs/agno/agno/tools/crw.py
+++ b/libs/agno/agno/tools/crw.py
@@ -1,0 +1,288 @@
+"""CRW Tools — High-performance web scraper toolkit for Agno agents.
+
+CRW is a Firecrawl-compatible web scraper optimized for AI agents.
+Single binary, ~6 MB idle RAM, 5.5x faster than Firecrawl.
+
+Works with both self-hosted CRW and fastcrw.com cloud.
+No external SDK needed — uses httpx (already an Agno dependency).
+
+Usage:
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+    from agno.tools.crw import CrwTools
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o"),
+        tools=[CrwTools()],  # connects to localhost:3000
+    )
+    agent.print_response("Summarize https://example.com")
+"""
+
+import json
+import time
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+
+class CrwTools(Toolkit):
+    """
+    CRW is a high-performance web scraper built for AI agents.
+    Firecrawl-compatible API, single binary, ~6 MB idle RAM.
+
+    Works with both self-hosted CRW and fastcrw.com cloud.
+
+    Args:
+        api_url: Base URL of the CRW server. Default: http://localhost:3000
+        api_key: Bearer token for authentication. Falls back to CRW_API_KEY env var.
+        formats: Output formats for scraping. Default: ["markdown"]
+        max_content_length: Truncate response content to this many characters. Default: 50000
+        timeout: HTTP request timeout in seconds. Default: 120
+        render_js: Force JS rendering. None = auto-detect (recommended). Default: None
+        only_main_content: Strip navigation, footer, sidebar. Default: True
+        enable_scrape: Enable the scrape_url tool. Default: True
+        enable_crawl: Enable the crawl_site tool. Default: False
+        enable_map: Enable the map_site tool. Default: False
+        enable_extract: Enable the extract_data tool. Default: False
+        all: Enable all tools. Overrides individual flags. Default: False
+    """
+
+    def __init__(
+        self,
+        api_url: str = "http://localhost:3000",
+        api_key: Optional[str] = None,
+        formats: Optional[List[str]] = None,
+        max_content_length: int = 50000,
+        timeout: int = 120,
+        render_js: Optional[bool] = None,
+        only_main_content: bool = True,
+        crawl_max_pages: int = 100,
+        crawl_max_depth: int = 2,
+        crawl_poll_interval: int = 5,
+        enable_scrape: bool = True,
+        enable_crawl: bool = False,
+        enable_map: bool = False,
+        enable_extract: bool = False,
+        all: bool = False,
+        **kwargs,
+    ):
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key or getenv("CRW_API_KEY")
+        self.formats = formats or ["markdown"]
+        self.max_content_length = max_content_length
+        self.timeout = timeout
+        self.render_js = render_js
+        self.only_main_content = only_main_content
+        self.crawl_max_pages = crawl_max_pages
+        self.crawl_max_depth = crawl_max_depth
+        self.crawl_poll_interval = crawl_poll_interval
+
+        tools: List[Any] = []
+        if all or enable_scrape:
+            tools.append(self.scrape_url)
+        if all or enable_crawl:
+            tools.append(self.crawl_site)
+        if all or enable_map:
+            tools.append(self.map_site)
+        if all or enable_extract:
+            tools.append(self.extract_data)
+
+        super().__init__(name="crw_tools", tools=tools, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _truncate(self, content: str) -> str:
+        if len(content) > self.max_content_length:
+            return content[: self.max_content_length] + "\n... (content truncated)"
+        return content
+
+    def scrape_url(self, url: str) -> str:
+        """Scrape a single URL and return its content as markdown.
+
+        Use this tool to fetch and extract the main content from any webpage.
+        Returns clean markdown by default, stripping navigation, ads, and boilerplate.
+
+        Args:
+            url: The URL to scrape (must be http or https).
+
+        Returns:
+            JSON string with markdown content and metadata (title, status code, etc.).
+        """
+        try:
+            payload: Dict[str, Any] = {
+                "url": url,
+                "formats": self.formats,
+                "onlyMainContent": self.only_main_content,
+            }
+            if self.render_js is not None:
+                payload["renderJs"] = self.render_js
+
+            response = httpx.post(
+                f"{self.api_url}/v1/scrape",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            if not result.get("success"):
+                return json.dumps({"error": result.get("error", "Unknown error")})
+
+            return self._truncate(json.dumps(result["data"], ensure_ascii=False))
+
+        except Exception as e:
+            error_msg = f"Error scraping {url}: {str(e)}"
+            logger.error(error_msg)
+            return json.dumps({"error": error_msg})
+
+    def crawl_site(self, url: str, max_pages: Optional[int] = None) -> str:
+        """Crawl a website starting from the given URL and return content from multiple pages.
+
+        Use this tool to scrape an entire site or section. Follows links (BFS) up to
+        a configurable depth and page limit. Returns markdown for each discovered page.
+
+        This is an async operation — the tool starts the crawl, polls for completion,
+        and returns all results once finished.
+
+        Args:
+            url: The starting URL to crawl from.
+            max_pages: Maximum number of pages to crawl. Default: 100.
+
+        Returns:
+            JSON string with an array of page results (markdown + metadata per page).
+        """
+        try:
+            payload: Dict[str, Any] = {
+                "url": url,
+                "maxDepth": self.crawl_max_depth,
+                "maxPages": max_pages or self.crawl_max_pages,
+                "formats": self.formats,
+                "onlyMainContent": self.only_main_content,
+            }
+
+            # Start crawl job
+            response = httpx.post(
+                f"{self.api_url}/v1/crawl",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            if not result.get("success"):
+                return json.dumps({"error": result.get("error", "Unknown error")})
+
+            job_id = result["id"]
+
+            # Poll for completion
+            while True:
+                time.sleep(self.crawl_poll_interval)
+                status_response = httpx.get(
+                    f"{self.api_url}/v1/crawl/{job_id}",
+                    headers=self._headers(),
+                    timeout=self.timeout,
+                )
+                status_response.raise_for_status()
+                status = status_response.json()
+
+                if status["status"] == "completed":
+                    return self._truncate(
+                        json.dumps(status["data"], ensure_ascii=False)
+                    )
+                elif status["status"] == "failed":
+                    return json.dumps({"error": "Crawl job failed", "job_id": job_id})
+
+        except Exception as e:
+            error_msg = f"Error crawling {url}: {str(e)}"
+            logger.error(error_msg)
+            return json.dumps({"error": error_msg})
+
+    def map_site(self, url: str) -> str:
+        """Discover all URLs on a website without scraping their content.
+
+        Use this tool to get a site map — a list of all pages found on a domain.
+        Useful for understanding site structure before deciding which pages to scrape.
+
+        Args:
+            url: The URL to discover links from.
+
+        Returns:
+            JSON string with an array of discovered URLs.
+        """
+        try:
+            payload: Dict[str, Any] = {"url": url}
+
+            response = httpx.post(
+                f"{self.api_url}/v1/map",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            if not result.get("success"):
+                return json.dumps({"error": result.get("error", "Unknown error")})
+
+            return json.dumps(result["data"], ensure_ascii=False)
+
+        except Exception as e:
+            error_msg = f"Error mapping {url}: {str(e)}"
+            logger.error(error_msg)
+            return json.dumps({"error": error_msg})
+
+    def extract_data(self, url: str, json_schema: dict) -> str:
+        """Scrape a URL and extract structured data using LLM-powered extraction.
+
+        Use this tool when you need specific fields from a webpage (e.g., product name
+        and price, article title and author). Provide a JSON Schema describing the
+        desired output format, and the LLM will extract matching data from the page.
+
+        Requires LLM extraction to be configured on the CRW server.
+
+        Args:
+            url: The URL to scrape and extract data from.
+            json_schema: A JSON Schema object describing the desired output structure.
+                Example: {"type": "object", "properties": {"title": {"type": "string"}}}
+
+        Returns:
+            JSON string with the extracted structured data.
+        """
+        try:
+            payload: Dict[str, Any] = {
+                "url": url,
+                "formats": ["json"],
+                "jsonSchema": json_schema,
+                "onlyMainContent": self.only_main_content,
+            }
+            if self.render_js is not None:
+                payload["renderJs"] = self.render_js
+
+            response = httpx.post(
+                f"{self.api_url}/v1/scrape",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            if not result.get("success"):
+                return json.dumps({"error": result.get("error", "Unknown error")})
+
+            return json.dumps(result["data"].get("json", {}), ensure_ascii=False)
+
+        except Exception as e:
+            error_msg = f"Error extracting data from {url}: {str(e)}"
+            logger.error(error_msg)
+            return json.dumps({"error": error_msg})

--- a/libs/agno/tests/unit/tools/test_crw.py
+++ b/libs/agno/tests/unit/tools/test_crw.py
@@ -1,0 +1,214 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from agno.tools.crw import CrwTools
+
+
+@pytest.fixture
+def crw_tools():
+    """Create a CrwTools instance with all tools enabled."""
+    return CrwTools(api_url="http://localhost:3000", api_key="test-key", all=True)
+
+
+# --- Initialization ---
+
+
+def test_init_defaults():
+    tools = CrwTools()
+    assert tools.api_url == "http://localhost:3000"
+    assert tools.formats == ["markdown"]
+    assert tools.max_content_length == 50000
+    assert tools.only_main_content is True
+
+
+def test_init_with_params():
+    tools = CrwTools(
+        api_url="http://custom:8080/",
+        api_key="my-key",
+        formats=["html"],
+        max_content_length=1000,
+        timeout=30,
+    )
+    assert tools.api_url == "http://custom:8080"  # trailing slash stripped
+    assert tools.api_key == "my-key"
+    assert tools.formats == ["html"]
+    assert tools.max_content_length == 1000
+    assert tools.timeout == 30
+
+
+def test_init_api_key_from_env():
+    with patch.dict("os.environ", {"CRW_API_KEY": "env-key"}):
+        tools = CrwTools()
+        assert tools.api_key == "env-key"
+
+
+def test_init_tool_registration():
+    tools_scrape_only = CrwTools(enable_scrape=True, enable_crawl=False)
+    func_names = [fn.name for fn in tools_scrape_only.functions.values()]
+    assert "scrape_url" in func_names
+    assert "crawl_site" not in func_names
+
+    tools_all = CrwTools(all=True)
+    func_names_all = [fn.name for fn in tools_all.functions.values()]
+    assert "scrape_url" in func_names_all
+    assert "crawl_site" in func_names_all
+    assert "map_site" in func_names_all
+    assert "extract_data" in func_names_all
+
+
+# --- _truncate_data ---
+
+
+def test_truncate_data_short_string(crw_tools):
+    assert crw_tools._truncate_data("short") == "short"
+
+
+def test_truncate_data_long_string(crw_tools):
+    crw_tools.max_content_length = 10
+    result = crw_tools._truncate_data("a" * 100)
+    assert result == "a" * 10 + "\n... (content truncated)"
+
+
+def test_truncate_data_nested_dict(crw_tools):
+    crw_tools.max_content_length = 5
+    data = {"markdown": "abcdefghij", "title": "ok"}
+    result = crw_tools._truncate_data(data)
+    assert result["markdown"] == "abcde\n... (content truncated)"
+    assert result["title"] == "ok"
+
+
+def test_truncate_data_list(crw_tools):
+    crw_tools.max_content_length = 3
+    data = [{"text": "abcdef"}, {"text": "xy"}]
+    result = crw_tools._truncate_data(data)
+    assert result[0]["text"] == "abc\n... (content truncated)"
+    assert result[1]["text"] == "xy"
+
+
+def test_truncate_data_produces_valid_json(crw_tools):
+    """Truncation must produce valid JSON when serialized."""
+    crw_tools.max_content_length = 20
+    data = {"markdown": "x" * 1000, "url": "https://example.com"}
+    truncated = crw_tools._truncate_data(data)
+    serialized = json.dumps(truncated, ensure_ascii=False)
+    parsed = json.loads(serialized)
+    assert isinstance(parsed, dict)
+    assert "url" in parsed
+
+
+# --- scrape_url ---
+
+
+def _mock_response(data: dict, status_code: int = 200):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_scrape_url_success(crw_tools):
+    mock_data = {
+        "success": True,
+        "data": {
+            "markdown": "# Hello",
+            "metadata": {"title": "Test", "statusCode": 200},
+        },
+    }
+    with patch("agno.tools.crw.httpx.post", return_value=_mock_response(mock_data)):
+        result = json.loads(crw_tools.scrape_url("https://example.com"))
+        assert result["markdown"] == "# Hello"
+        assert result["metadata"]["title"] == "Test"
+
+
+def test_scrape_url_api_error(crw_tools):
+    mock_data = {"success": False, "error": "Rate limited"}
+    with patch("agno.tools.crw.httpx.post", return_value=_mock_response(mock_data)):
+        result = json.loads(crw_tools.scrape_url("https://example.com"))
+        assert result["error"] == "Rate limited"
+
+
+def test_scrape_url_http_error(crw_tools):
+    with patch("agno.tools.crw.httpx.post", side_effect=httpx.HTTPStatusError(
+        "Server error", request=MagicMock(), response=MagicMock(status_code=500)
+    )):
+        result = json.loads(crw_tools.scrape_url("https://example.com"))
+        assert "error" in result
+
+
+# --- crawl_site ---
+
+
+def test_crawl_site_success(crw_tools):
+    start_resp = _mock_response({"success": True, "id": "job-123"})
+    poll_resp = _mock_response({
+        "status": "completed",
+        "data": [{"markdown": "# Page 1"}],
+    })
+    with patch("agno.tools.crw.httpx.post", return_value=start_resp), \
+         patch("agno.tools.crw.httpx.get", return_value=poll_resp), \
+         patch("agno.tools.crw.time.sleep"):
+        result = json.loads(crw_tools.crawl_site("https://example.com"))
+        assert result[0]["markdown"] == "# Page 1"
+
+
+def test_crawl_site_failed_job(crw_tools):
+    start_resp = _mock_response({"success": True, "id": "job-456"})
+    poll_resp = _mock_response({"status": "failed"})
+    with patch("agno.tools.crw.httpx.post", return_value=start_resp), \
+         patch("agno.tools.crw.httpx.get", return_value=poll_resp), \
+         patch("agno.tools.crw.time.sleep"):
+        result = json.loads(crw_tools.crawl_site("https://example.com"))
+        assert result["error"] == "Crawl job failed"
+
+
+def test_crawl_site_timeout(crw_tools):
+    """Crawl polling must respect the deadline and return a timeout error."""
+    crw_tools.crawl_max_pages = 1
+    crw_tools.timeout = 1  # max_wait = 1 * 1 = 1 second
+
+    start_resp = _mock_response({"success": True, "id": "job-789"})
+    poll_resp = _mock_response({"status": "scraping"})
+
+    # Simulate time passing beyond deadline
+    start_time = 1000.0
+    times = iter([start_time, start_time + 2.0])  # second call exceeds deadline
+
+    with patch("agno.tools.crw.httpx.post", return_value=start_resp), \
+         patch("agno.tools.crw.httpx.get", return_value=poll_resp), \
+         patch("agno.tools.crw.time.sleep"), \
+         patch("agno.tools.crw.time.monotonic", side_effect=times):
+        result = json.loads(crw_tools.crawl_site("https://example.com"))
+        assert result["status"] == "timeout"
+        assert "job-789" in result["job_id"]
+
+
+# --- map_site ---
+
+
+def test_map_site_success(crw_tools):
+    mock_data = {
+        "success": True,
+        "data": ["https://example.com/a", "https://example.com/b"],
+    }
+    with patch("agno.tools.crw.httpx.post", return_value=_mock_response(mock_data)):
+        result = json.loads(crw_tools.map_site("https://example.com"))
+        assert len(result) == 2
+
+
+# --- extract_data ---
+
+
+def test_extract_data_success(crw_tools):
+    mock_data = {
+        "success": True,
+        "data": {"json": {"title": "Example", "price": 42}},
+    }
+    with patch("agno.tools.crw.httpx.post", return_value=_mock_response(mock_data)):
+        schema = {"type": "object", "properties": {"title": {"type": "string"}}}
+        result = json.loads(crw_tools.extract_data("https://example.com", schema))
+        assert result["title"] == "Example"
+        assert result["price"] == 42


### PR DESCRIPTION
Fixes #7202

## Summary
Add CRW web scraping toolkit to Agno with three tools:
- `CrwScrapeWebsite` — scrape a single URL, return clean markdown
- `CrwCrawlWebsite` — async BFS crawl with polling
- `CrwMapWebsite` — discover all URLs via sitemap + link traversal

## Changes
- `libs/agno/agno/tools/crw.py` — CRW toolkit implementation
- `libs/agno/tests/unit/tools/test_crw.py` — Unit tests with mocked HTTP
- `cookbook/91_tools/crw_tools.py` — Basic usage example
- `cookbook/91_tools/crw_extraction_tools.py` — LLM extraction example

## What is CRW?
[CRW](https://github.com/us/crw) is an open-source web scraper built for AI agents. Single Rust binary, ~6 MB idle RAM, Firecrawl-compatible API. Self-hosted (free) or cloud ([fastcrw.com](https://fastcrw.com)).

## Test plan
- [x] Unit tests included (`test_crw.py`) with mocked HTTP responses
- [x] Tests cover scrape, crawl polling, map, error handling
- [x] Cookbook examples included