### PR TITLE
Remove allowed commands restriction in MCP

### DIFF
--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -183,28 +183,6 @@ def prepare_command(command: str) -> list[str]:
     if not parts:
         raise ValueError("MCP command can't be empty")
 
-    # Only allow specific executables
-    ALLOWED_COMMANDS = {
-        # Python
-        "python",
-        "python3",
-        "uv",
-        "uvx",
-        "pipx",
-        # Node
-        "node",
-        "npm",
-        "npx",
-        "yarn",
-        "pnpm",
-        "bun",
-        # Other runtimes
-        "deno",
-        "java",
-        "ruby",
-        "docker",
-    }
-
     executable = parts[0].split("/")[-1]
 
     # Check if it's a relative path starting with ./ or ../
@@ -225,9 +203,6 @@ def prepare_command(command: str) -> list[str]:
     # Check if it's a binary in PATH
     if shutil.which(executable):
         return parts
-
-    if executable not in ALLOWED_COMMANDS:
-        raise ValueError(f"MCP command needs to use one of the following executables: {ALLOWED_COMMANDS}")
 
     first_part = parts[0]
     executable = first_part.split("/")[-1]


### PR DESCRIPTION
Removed the restriction on allowed executables in MCP command.

Allowing the python command lets you execute arbitrary code already. This just makes it harder to implement security features like running the command with firejail, bubblewrap, or inside of a container.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
