### PR TITLE
fix: catch async errors during `__aexit__` to avoid exception propagation

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -561,12 +561,22 @@ class MCPTools(Toolkit):
     async def __aexit__(self, _exc_type, _exc_val, _exc_tb):
         """Exit the async context manager."""
         if self._session_context is not None:
-            await self._session_context.__aexit__(_exc_type, _exc_val, _exc_tb)
+            # Catch the async exception here to avoid propagation
+            try:
+                await self._session_context.__aexit__(_exc_type, _exc_val, _exc_tb)
+            except (RuntimeError, BaseException):
+                # Silence any cleanup exceptions
+                pass
             self.session = None
             self._session_context = None
 
         if self._context is not None:
-            await self._context.__aexit__(_exc_type, _exc_val, _exc_tb)
+            # Catch the async exception here to avoid propagation
+            try:
+                await self._context.__aexit__(_exc_type, _exc_val, _exc_tb)
+            except (RuntimeError, BaseException):
+                # Silence any cleanup exceptions
+                pass
             self._context = None
 
         self._initialized = False


### PR DESCRIPTION

## Summary

Catch and silent errors during `__aexit__`, prevent them from propagating (triggering `During handling of the above exception, another exception occurred:`). Closes #7267 .

When I try to connect to a HTTP MCP server that doesn't exist, without this PR we get: 
```
an error occurred during closing of asynchronous generator <async_generator object streamable_http_client at 0x0000015FA1300040>
asyncgen: <async_generator object streamable_http_client at 0x0000015FA1300040>
  + Exception Group Traceback (most recent call last):
  |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 783, in __aexit__
  |     raise BaseExceptionGroup(
  |         "unhandled errors in a TaskGroup", self._exceptions
  |     ) from None
  | BaseExceptionGroup: unhandled errors in a TaskGroup (2 sub-exceptions)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_transports\default.py", line 101, in map_httpcore_exceptions
    |     yield
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_transports\default.py", line 394, in handle_async_request
    |     resp = await self._pool.handle_async_request(req)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_async\connection_pool.py", line 256, in handle_async_request
    |     raise exc from None
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_async\connection_pool.py", line 236, in handle_async_request
    |     response = await connection.handle_async_request(
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |         pool_request.request
    |         ^^^^^^^^^^^^^^^^^^^^
    |     )
    |     ^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_async\connection.py", line 101, in handle_async_request
    |     raise exc
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_async\connection.py", line 78, in handle_async_request
    |     stream = await self._connect(request)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_async\connection.py", line 124, in _connect
    |     stream = await self._network_backend.connect_tcp(**kwargs)
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_backends\auto.py", line 31, in connect_tcp
    |     return await self._backend.connect_tcp(
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     ...<5 lines>...
    |     )
    |     ^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_backends\anyio.py", line 113, in connect_tcp
    |     with map_exceptions(exc_map):
    |          ~~~~~~~~~~~~~~^^^^^^^^^
    |   File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\contextlib.py", line 162, in __exit__
    |     self.gen.throw(value)
    |     ~~~~~~~~~~~~~~^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpcore\_exceptions.py", line 14, in map_exceptions
    |     raise to_exc(exc) from exc
    | httpcore.ConnectError: All connection attempts failed
    | 
    | The above exception was the direct cause of the following exception:
    | 
    | Traceback (most recent call last):
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 565, in handle_request_async
    |     await self._handle_post_request(ctx)
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 340, in _handle_post_request
    |     async with ctx.client.stream(
    |                ~~~~~~~~~~~~~~~~~^
    |         "POST",
    |         ^^^^^^^
    |     ...<2 lines>...
    |         headers=headers,
    |         ^^^^^^^^^^^^^^^^
    |     ) as response:
    |     ^
    |   File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\contextlib.py", line 214, in __aenter__
    |     return await anext(self.gen)
    |            ^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_client.py", line 1583, in stream
    |     response = await self.send(
    |                ^^^^^^^^^^^^^^^^
    |     ...<4 lines>...
    |     )
    |     ^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_client.py", line 1629, in send
    |     response = await self._send_handling_auth(
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     ...<4 lines>...
    |     )
    |     ^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_client.py", line 1657, in _send_handling_auth
    |     response = await self._send_handling_redirects(
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |     ...<3 lines>...
    |     )
    |     ^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_client.py", line 1694, in _send_handling_redirects
    |     response = await self._send_single_request(request)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_client.py", line 1730, in _send_single_request
    |     response = await transport.handle_async_request(request)
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_transports\default.py", line 393, in handle_async_request
    |     with map_httpcore_exceptions():
    |          ~~~~~~~~~~~~~~~~~~~~~~~^^
    |   File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\contextlib.py", line 162, in __exit__
    |     self.gen.throw(value)
    |     ~~~~~~~~~~~~~~^^^^^^^
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\httpx\_transports\default.py", line 118, in map_httpcore_exceptions
    |     raise mapped_exc(message) from exc
    | httpx.ConnectError: All connection attempts failed
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 670, in streamable_http_client
    |     yield (
    |     ...<3 lines>...
    |     )
    | GeneratorExit
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 647, in streamable_http_client
    async with anyio.create_task_group() as tg:
               ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 789, in __aexit__
    if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):
       ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 461, in __exit__
    raise RuntimeError(
    ...<2 lines>...
    )
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
an error occurred during closing of asynchronous generator <async_generator object streamablehttp_client at 0x0000015FA11B2700>
asyncgen: <async_generator object streamablehttp_client at 0x0000015FA11B2700>
Traceback (most recent call last):
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 722, in streamablehttp_client
    yield streams
GeneratorExit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 717, in streamablehttp_client
    async with streamable_http_client(
               ~~~~~~~~~~~~~~~~~~~~~~^
        url,
        ^^^^
        http_client=client,
        ^^^^^^^^^^^^^^^^^^^
        terminate_on_close=terminate_on_close,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ) as streams:
    ^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\contextlib.py", line 235, in __aexit__
    await self.gen.athrow(value)
RuntimeError: athrow(): asynchronous generator is already running
Traceback (most recent call last):
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\client\adk_console_app.py", line 36, in <module>
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\asyncio\runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\asyncio\runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\asyncio\base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\client\adk_console_app.py", line 20, in main
    async with MCPTools(transport="streamable-http", url="http://localhost:8000/mcp") as mcp_tools:
               ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\tools\mcp\mcp.py", line 564, in __aexit__
    await self._session_context.__aexit__(_exc_type, _exc_val, _exc_tb)
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\shared\session.py", line 238, in __aexit__
    return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 787, in __aexit__
    raise exc_val
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\client\adk_console_app.py", line 32, in main
    result = await apprint_run_response(stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\utils\pprint.py", line 151, in apprint_run_response
    async for resp in run_response:
    ...<25 lines>...
        live_log.update(table)
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\agent\_run.py", line 2103, in _arun_stream
    async for event in ahandle_model_response_stream(
    ...<11 lines>...
        yield event
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\agent\_response.py", line 1226, in ahandle_model_response_stream
    async for model_response_event in model_response_stream:  # type: ignore
    ...<76 lines>...
            yield event
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\base.py", line 1686, in aresponse_stream
    async for model_response_delta in self.aprocess_response_stream(
    ...<11 lines>...
        yield model_response_delta
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\base.py", line 1586, in aprocess_response_stream
    async for response_delta in self._ainvoke_stream_with_retry(
    ...<15 lines>...
            yield model_response_delta
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\base.py", line 388, in _ainvoke_stream_with_retry
    async for response in self.ainvoke_stream(**kwargs):
        yield response
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\litellm\chat.py", line 322, in ainvoke_stream
    async_stream = await self.get_client().acompletion(**completion_kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\litellm\utils.py", line 1889, in wrapper_async
    result = await original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\litellm\main.py", line 612, in acompletion
    init_response = await loop.run_in_executor(None, func_with_context)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
asyncio.exceptions.CancelledError: Cancelled via cancel scope 15fa13042f0
```
Notice the error propagation in the error message: `During handling of the above exception, another exception occurred:`

After this PR: 
Nothing printed since the exception is supressed and silenced.  
If we still let it print out the exception caught we get: 
```
unhandled errors in a TaskGroup (1 sub-exception)
Traceback (most recent call last):
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\client\mre.py", line 36, in <module>
    asyncio.run(main())
    ~~~~~~~~~~~^^^^^^^^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\asyncio\runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\asyncio\runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "C:\Users\x1398\AppData\Roaming\uv\python\cpython-3.13-windows-x86_64-none\Lib\asyncio\base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 670, in streamable_http_client
    yield (
    ...<3 lines>...
    )
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\client\streamable_http.py", line 722, in streamablehttp_client
    yield streams
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\tools\mcp\mcp.py", line 565, in __aexit__
    await self._session_context.__aexit__(_exc_type, _exc_val, _exc_tb)
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\mcp\shared\session.py", line 238, in __aexit__
    return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 787, in __aexit__
    raise exc_val
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\client\mre.py", line 32, in main
    result = await apprint_run_response(stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\utils\pprint.py", line 151, in apprint_run_response
    async for resp in run_response:
    ...<25 lines>...
        live_log.update(table)
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\agent\_run.py", line 2103, in _arun_stream
    async for event in ahandle_model_response_stream(
    ...<11 lines>...
        yield event
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\agent\_response.py", line 1226, in ahandle_model_response_stream
    async for model_response_event in model_response_stream:  # type: ignore
    ...<76 lines>...
            yield event
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\base.py", line 1686, in aresponse_stream
    async for model_response_delta in self.aprocess_response_stream(
    ...<11 lines>...
        yield model_response_delta
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\base.py", line 1586, in aprocess_response_stream
    async for response_delta in self._ainvoke_stream_with_retry(
    ...<15 lines>...
            yield model_response_delta
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\base.py", line 388, in _ainvoke_stream_with_retry
    async for response in self.ainvoke_stream(**kwargs):
        yield response
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\agno\models\litellm\chat.py", line 322, in ainvoke_stream
    async_stream = await self.get_client().acompletion(**completion_kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\litellm\utils.py", line 1889, in wrapper_async
    result = await original_function(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\x1398\PycharmProjects\MultiAgentFund\.venv\Lib\site-packages\litellm\main.py", line 612, in acompletion
    init_response = await loop.run_in_executor(None, func_with_context)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
asyncio.exceptions.CancelledError: Cancelled via cancel scope 1e1fc828440
```
Notice that the exception is clean, no longer propagating. 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- ~Documentation updated (comments, docstrings)~ (Not applicable)
- ~Examples and guides: Relevant cookbook examples have been included or updated~ (Not applicable)
- [X] Tested in clean environment
- ~Tests added/updated~ (Not applicable)

### Duplicate and AI-Generated PR Check

- [X] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
