### PR TITLE
Add support for OpenAI response API

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -3047,3 +3047,11 @@ class Model(ABC):
                     setattr(new_model, k, v)
 
         return new_model
+
+
+class SupportsInternalToolFieldsMixin:
+    def _supports_internal_tool_fields(self) -> bool:
+        if hasattr(self, "provider"):
+            return self.provider not in ["AIMLAPI", "Fireworks", "Nvidia", "VLLM"]
+        else:
+            return False

--- a/libs/agno/agno/models/litellm/__init__.py
+++ b/libs/agno/agno/models/litellm/__init__.py
@@ -1,7 +1,8 @@
 from agno.models.litellm.chat import LiteLLM
+from agno.models.litellm.responses import LiteLLMResponses
 
 try:
-    from agno.models.litellm.litellm_openai import LiteLLMOpenAI
+    from agno.models.litellm.litellm_openai import LiteLLMOpenAI, LiteLLMOpenResponses
 except ImportError:
 
     class LiteLLMOpenAI:  # type: ignore
@@ -11,4 +12,7 @@ except ImportError:
 
 __all__ = [
     "LiteLLM",
+    "LiteLLMResponses",
+    "LiteLLMOpenAI",
+    "LiteLLMOpenResponses"
 ]

--- a/libs/agno/agno/models/litellm/__init__.py
+++ b/libs/agno/agno/models/litellm/__init__.py
@@ -1,11 +1,19 @@
 from agno.models.litellm.chat import LiteLLM
-from agno.models.litellm.responses import LiteLLMResponses
+
 
 try:
+    from agno.models.litellm.responses import LiteLLMResponses
     from agno.models.litellm.litellm_openai import LiteLLMOpenAI, LiteLLMOpenResponses
 except ImportError:
+    class LiteLLMResponses:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("`openai` not installed. Please install using `pip install openai`")
 
     class LiteLLMOpenAI:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError("`openai` not installed. Please install using `pip install openai`")
+
+    class LiteLLMOpenResponses:  # type: ignore
         def __init__(self, *args, **kwargs):
             raise ImportError("`openai` not installed. Please install using `pip install openai`")
 
@@ -14,5 +22,5 @@ __all__ = [
     "LiteLLM",
     "LiteLLMResponses",
     "LiteLLMOpenAI",
-    "LiteLLMOpenResponses"
+    "LiteLLMOpenResponses",
 ]

--- a/libs/agno/agno/models/litellm/litellm_openai.py
+++ b/libs/agno/agno/models/litellm/litellm_openai.py
@@ -1,13 +1,52 @@
 from dataclasses import dataclass, field
 from os import getenv
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
+
+import httpx
 
 from agno.exceptions import ModelAuthenticationError
+from agno.models.openai import OpenResponses
 from agno.models.openai.like import OpenAILike
+
 
 
 @dataclass
 class LiteLLMOpenAI(OpenAILike):
+    """
+    A class for interacting with LiteLLM.
+
+    Attributes:
+        id (str): The id of the LiteLLM model. Default is "gpt-4o".
+        name (str): The name of this chat model instance. Default is "LiteLLM".
+        provider (str): The provider of the model. Default is "LiteLLM".
+        base_url (str): The base url to which the requests are sent.
+    """
+
+    id: str = "gpt-4o"
+    name: str = "LiteLLM"
+    provider: str = "LiteLLM"
+
+    api_key: Optional[str] = field(default_factory=lambda: getenv("LITELLM_API_KEY"))
+    base_url: str = "http://0.0.0.0:4000"
+
+    def _get_client_params(self) -> Dict[str, Any]:
+        """
+        Returns client parameters for API requests, checking for LITELLM_API_KEY.
+
+        Returns:
+            Dict[str, Any]: A dictionary of client parameters for API requests.
+        """
+        if not self.api_key:
+            self.api_key = getenv("LITELLM_API_KEY")
+            if not self.api_key:
+                raise ModelAuthenticationError(
+                    message="LITELLM_API_KEY not set. Please set the LITELLM_API_KEY environment variable.",
+                    model_name=self.name,
+                )
+        return super()._get_client_params()
+
+@dataclass
+class LiteLLMOpenResponses(OpenResponses):
     """
     A class for interacting with LiteLLM.
 

--- a/libs/agno/agno/models/litellm/litellm_openai.py
+++ b/libs/agno/agno/models/litellm/litellm_openai.py
@@ -29,6 +29,10 @@ class LiteLLMOpenAI(OpenAILike):
     api_key: Optional[str] = field(default_factory=lambda: getenv("LITELLM_API_KEY"))
     base_url: str = "http://0.0.0.0:4000"
 
+    # Remove non-standard fields like `requires_confirmation` by default
+    def _supports_internal_tool_fields(self) -> bool:
+        return False
+
     def _get_client_params(self) -> Dict[str, Any]:
         """
         Returns client parameters for API requests, checking for LITELLM_API_KEY.
@@ -63,6 +67,10 @@ class LiteLLMOpenResponses(OpenResponses):
 
     api_key: Optional[str] = field(default_factory=lambda: getenv("LITELLM_API_KEY"))
     base_url: str = "http://0.0.0.0:4000"
+
+    # Remove non-standard fields like `requires_confirmation` by default
+    def _supports_internal_tool_fields(self) -> bool:
+        return False
 
     def _get_client_params(self) -> Dict[str, Any]:
         """

--- a/libs/agno/agno/models/litellm/litellm_openai.py
+++ b/libs/agno/agno/models/litellm/litellm_openai.py
@@ -1,13 +1,10 @@
 from dataclasses import dataclass, field
 from os import getenv
-from typing import Any, Dict, Optional, Union
-
-import httpx
+from typing import Any, Dict, Optional
 
 from agno.exceptions import ModelAuthenticationError
 from agno.models.openai import OpenResponses
 from agno.models.openai.like import OpenAILike
-
 
 
 @dataclass

--- a/libs/agno/agno/models/litellm/responses.py
+++ b/libs/agno/agno/models/litellm/responses.py
@@ -1,0 +1,235 @@
+﻿import copy
+from dataclasses import dataclass
+from os import getenv
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Type, Union
+
+from pydantic import BaseModel
+
+from agno.models.message import Message
+from agno.models.openai import OpenResponses
+from agno.models.response import ModelResponse
+from agno.run.agent import RunOutput
+from agno.utils.log import log_debug, log_error, log_warning
+
+try:
+    import litellm
+    from litellm import validate_environment
+except ImportError:
+    raise ImportError("`litellm` not installed. Please install it via `pip install litellm`")
+
+
+@dataclass
+class LiteLLMResponses(OpenResponses):
+    """
+    A class for interacting with LiteLLM Python SDK, using the Responses API
+
+    LiteLLM allows you to use a unified interface for various LLM providers.
+    For more information, see: https://docs.litellm.ai/docs/
+    """
+
+    id: str = "gpt-4o"
+    name: str = "LiteLLM"
+    provider: str = "LiteLLM"
+
+    client: Optional[Any] = None
+
+    # Store the original client to preserve it across copies (e.g., for Router instances)
+    _original_client: Optional[Any] = None
+
+    def __post_init__(self):
+        """Initialize the model after the dataclass initialization."""
+        super().__post_init__()
+
+        # Store the original client if provided (e.g., Router instance)
+        # This ensures the client is preserved when the model is copied for background tasks
+        if self.client is not None and self._original_client is None:
+            self._original_client = self.client
+
+        # Set up API key from environment variable if not already set
+        if not self.client and not self.api_key:
+            self.api_key = getenv("LITELLM_API_KEY")
+            if not self.api_key:
+                # Check for other present valid keys, e.g. OPENAI_API_KEY if self.id is an OpenAI model
+                env_validation = validate_environment(model=self.id, api_base=self.api_base)
+                if not env_validation.get("keys_in_environment"):
+                    log_error(
+                        "LITELLM_API_KEY not set. Please set the LITELLM_API_KEY or other valid environment variables."
+                    )
+
+    def get_client(self) -> Any:
+        """
+        Returns a LiteLLM client.
+
+        Returns:
+            Any: An instance of the LiteLLM client.
+        """
+        # First check if we have a current client
+        if self.client is not None:
+            return self.client
+
+        # Check if we have an original client (e.g., Router) that was preserved
+        # This handles the case where the model was copied for background tasks
+        if self._original_client is not None:
+            self.client = self._original_client
+            return self.client
+
+        self.client = litellm
+        return self.client
+
+    def __deepcopy__(self, memo: Dict[int, Any]) -> "LiteLLMResponses":
+        """
+        Custom deepcopy to preserve the client (e.g., Router) across copies.
+
+        This is needed because when the model is copied for background tasks
+        (memory, summarization), the client reference needs to be preserved.
+        """
+        # Create a shallow copy first
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        # Copy all attributes, but keep the same client reference
+        for k, v in self.__dict__.items():
+            if k in ("client", "_original_client"):
+                # Keep the same client reference (don't deepcopy Router instances)
+                setattr(result, k, v)
+            else:
+                setattr(result, k, copy.deepcopy(v, memo))
+
+        return result
+
+    def invoke(
+        self,
+        messages: List[Message],
+        assistant_message: Message,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        run_response: Optional[RunOutput] = None,
+        compress_tool_results: bool = False,
+    ) -> ModelResponse:
+        """Sends a chat completion request to the LiteLLM API."""
+
+        request_params = self.get_request_params(
+            messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
+        )
+
+        assistant_message.metrics.start_timer()
+
+        provider_response = self.get_client().responses(
+            model=self.id,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
+            **request_params,
+        )
+
+        assistant_message.metrics.stop_timer()
+
+        model_response = self._parse_provider_response(provider_response, response_format=response_format)
+
+        return model_response
+
+    def invoke_stream(
+        self,
+        messages: List[Message],
+        assistant_message: Message,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        run_response: Optional[RunOutput] = None,
+        compress_tool_results: bool = False,
+    ) -> Iterator[ModelResponse]:
+        """Sends a streaming chat completion request to the LiteLLM API."""
+        request_params = self.get_request_params(messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice)
+        tool_use: Dict[str, Any] = {}
+
+        assistant_message.metrics.start_timer()
+
+        for chunk in self.get_client().responses(
+            model=self.id,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
+            stream=True,
+            **request_params,
+        ):
+            model_response, tool_use = self._parse_provider_response_delta(
+                stream_event=chunk,  # type: ignore
+                assistant_message=assistant_message,
+                tool_use=tool_use,  # type: ignore
+            )
+            yield model_response
+
+        assistant_message.metrics.stop_timer()
+
+    async def ainvoke(
+        self,
+        messages: List[Message],
+        assistant_message: Message,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        run_response: Optional[RunOutput] = None,
+        compress_tool_results: bool = False,
+    ) -> ModelResponse:
+        """Sends an asynchronous chat completion request to the LiteLLM API."""
+        request_params = self.get_request_params(
+            messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
+        )
+
+        assistant_message.metrics.start_timer()
+
+        provider_response = await self.get_client().aresponses(
+            model=self.id,
+            api_key=self.api_key,
+            base_url=self.base_url,
+            input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
+            **request_params,
+        )
+
+        assistant_message.metrics.stop_timer()
+
+        model_response = self._parse_provider_response(provider_response, response_format=response_format)
+
+        return model_response
+
+    async def ainvoke_stream(
+        self,
+        messages: List[Message],
+        assistant_message: Message,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        run_response: Optional[RunOutput] = None,
+        compress_tool_results: bool = False,
+    ) -> AsyncIterator[ModelResponse]:
+        """Sends an asynchronous streaming chat request to the LiteLLM API."""
+        request_params = self.get_request_params(
+            messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
+        )
+        tool_use: Dict[str, Any] = {}
+
+        assistant_message.metrics.start_timer()
+
+        try:
+            # litellm.acompletion returns a coroutine that resolves to an async iterator
+            # We need to await it first to get the actual async iterator
+            async_stream = await self.get_client().aresponses(
+                model=self.id,
+                api_key=self.api_key,
+                base_url=self.base_url,
+                input=self._format_messages(messages, compress_tool_results, tools=tools),  # type: ignore
+                stream=True,
+                **request_params,
+            )
+            async for chunk in async_stream:  # type: ignore
+                model_response, tool_use = self._parse_provider_response_delta(chunk, assistant_message,
+                                                                               tool_use)  # type: ignore
+                yield model_response
+
+            assistant_message.metrics.stop_timer()
+
+        except Exception as e:
+            log_error(f"Error in streaming response: {e}")
+            raise

--- a/libs/agno/agno/models/litellm/responses.py
+++ b/libs/agno/agno/models/litellm/responses.py
@@ -36,6 +36,10 @@ class LiteLLMResponses(OpenResponses):
     # Store the original client to preserve it across copies (e.g., for Router instances)
     _original_client: Optional[Any] = None
 
+    # Remove non-standard fields like `requires_confirmation` by default
+    def _supports_internal_tool_fields(self) -> bool:
+        return False
+
     def __post_init__(self):
         """Initialize the model after the dataclass initialization."""
         super().__post_init__()

--- a/libs/agno/agno/models/litellm/responses.py
+++ b/libs/agno/agno/models/litellm/responses.py
@@ -1,4 +1,4 @@
-﻿import copy
+import copy
 from dataclasses import dataclass
 from os import getenv
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Type, Union
@@ -231,9 +231,8 @@ class LiteLLMResponses(OpenResponses):
                 model_response, tool_use = self._parse_provider_response_delta(chunk, assistant_message,
                                                                                tool_use)  # type: ignore
                 yield model_response
-
-            assistant_message.metrics.stop_timer()
-
         except Exception as e:
             log_error(f"Error in streaming response: {e}")
             raise
+        finally:
+            assistant_message.metrics.stop_timer()

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -99,6 +99,9 @@ class OpenAIChat(Model):
         "model": "assistant",
     }
 
+    def _supports_internal_tool_fields(self) -> bool:
+        return self.provider not in ["AIMLAPI", "Fireworks", "Nvidia", "VLLM"]
+
     def get_provider(self) -> str:
         return f"{super().get_provider()} Chat"
 
@@ -195,6 +198,7 @@ class OpenAIChat(Model):
         tools: Optional[List[Dict[str, Any]]] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         run_response: Optional[Union[RunOutput, TeamRunOutput]] = None,
+        remove_extension_tool_fields: bool = False,
     ) -> Dict[str, Any]:
         """
         Returns keyword arguments for API requests.
@@ -253,7 +257,7 @@ class OpenAIChat(Model):
         # Add tools
         if tools is not None and len(tools) > 0:
             # Remove unsupported fields for OpenAILike models
-            if self.provider in ["AIMLAPI", "Fireworks", "Nvidia", "VLLM"]:
+            if not self._supports_internal_tool_fields():
                 for tool in tools:
                     if tool.get("type") == "function":
                         for _internal_key in ("requires_confirmation", "external_execution", "approval_type"):

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from agno.exceptions import ContextWindowExceededError, ModelAuthenticationError, ModelProviderError
 from agno.media import Audio
-from agno.models.base import Model
+from agno.models.base import Model, SupportsInternalToolFieldsMixin
 from agno.models.message import Message
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -32,7 +32,7 @@ except (ImportError, ModuleNotFoundError):
 
 
 @dataclass
-class OpenAIChat(Model):
+class OpenAIChat(Model, SupportsInternalToolFieldsMixin):
     """
     A class for interacting with OpenAI models using the Chat completions API.
 
@@ -98,9 +98,6 @@ class OpenAIChat(Model):
         "tool": "tool",
         "model": "assistant",
     }
-
-    def _supports_internal_tool_fields(self) -> bool:
-        return self.provider not in ["AIMLAPI", "Fireworks", "Nvidia", "VLLM"]
 
     def get_provider(self) -> str:
         return f"{super().get_provider()} Chat"

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -97,6 +97,9 @@ class OpenAIResponses(Model):
         """Return True if the contextual used model is a known reasoning model."""
         return self.id.startswith("o3") or self.id.startswith("o4-mini") or self.id.startswith("gpt-5")
 
+    def _supports_internal_tool_fields(self) -> bool:
+        return self.provider not in ["AIMLAPI", "Fireworks", "Nvidia", "VLLM"]
+
     def _set_reasoning_request_param(self, base_params: Dict[str, Any]) -> Dict[str, Any]:
         """Set the reasoning request parameter."""
         base_params["reasoning"] = self.reasoning or {}
@@ -264,7 +267,15 @@ class OpenAIResponses(Model):
                 log_debug(f"Added web_search_preview tool for deep research model: {self.id}")
 
         if tools:
-            request_params["tools"] = self._format_tool_params(messages=messages, tools=tools)  # type: ignore
+            formatted_tools = self._format_tool_params(messages=messages, tools=tools)  # type: ignore
+
+            if not self._supports_internal_tool_fields():
+                for tool in formatted_tools:
+                    if tool.get("type") == "function":
+                        for _internal_key in ("requires_confirmation", "external_execution", "approval_type"):
+                            tool.pop(_internal_key, None)
+
+            request_params["tools"] = formatted_tools
 
         if tool_choice is not None:
             request_params["tool_choice"] = tool_choice
@@ -1084,7 +1095,7 @@ class OpenAIResponses(Model):
                         "type": "function",
                         "function": {
                             "name": output.name,
-                            "arguments": output.arguments,
+                            "arguments": getattr(output, "arguments", ""),
                         },
                     }
                 )
@@ -1186,7 +1197,7 @@ class OpenAIResponses(Model):
                     "type": "function",
                     "function": {
                         "name": item.name,
-                        "arguments": item.arguments,
+                        "arguments": getattr(item, "arguments", ""),
                     },
                 }
 

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 
 from agno.exceptions import ContextWindowExceededError, ModelAuthenticationError, ModelProviderError
 from agno.media import File
-from agno.models.base import Model
+from agno.models.base import Model, SupportsInternalToolFieldsMixin
 from agno.models.message import Citations, Message, UrlCitation
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -28,7 +28,7 @@ except ImportError as e:
 
 
 @dataclass
-class OpenAIResponses(Model):
+class OpenAIResponses(Model, SupportsInternalToolFieldsMixin):
     """
     A class for interacting with OpenAI models using the Responses API.
 
@@ -96,9 +96,6 @@ class OpenAIResponses(Model):
     def _using_reasoning_model(self) -> bool:
         """Return True if the contextual used model is a known reasoning model."""
         return self.id.startswith("o3") or self.id.startswith("o4-mini") or self.id.startswith("gpt-5")
-
-    def _supports_internal_tool_fields(self) -> bool:
-        return self.provider not in ["AIMLAPI", "Fireworks", "Nvidia", "VLLM"]
 
     def _set_reasoning_request_param(self, base_params: Dict[str, Any]) -> Dict[str, Any]:
         """Set the reasoning request parameter."""
@@ -1087,6 +1084,8 @@ class OpenAIResponses(Model):
             elif output.type == "function_call":
                 if model_response.tool_calls is None:
                     model_response.tool_calls = []
+                if not hasattr(output, "arguments"):
+                    log_warning("Function call missing required field `arguments`. Some vendors may not strictly follow the standard, omitting this field when there's no arguments. ")
                 model_response.tool_calls.append(
                     {
                         "id": output.id,


### PR DESCRIPTION
## Summary

Add two LiteLLM adapters that uses the Response API rather than chat completion API: `LiteLLMResponses` and `LiteLLMOpenResponses`. The former uses LiteLLM SDK and the latter is a connector to LiteLLM proxy. 

Closes #7242 . 

Tested against `volcengine/doubao-seed-2-0-mini-260215` (a LiteLLM supported model that supports Response API). 
Upon testing, #5521 blocks me from receiving responses. So this PR also includes a fix for that issue. Closes #5521. 

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [X] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
