### PR TITLE
Add OSOP workflow example — research agent in portable format

### DIFF
--- a/cookbook/osop-research-agent/README.md
+++ b/cookbook/osop-research-agent/README.md
@@ -1,6 +1,6 @@
 # Research Agent Workflow — OSOP Workflow Example
 
-This directory contains a portable [OSOP](https://github.com/osopcloud/osop-spec) workflow definition for a multi-step research agent built with Agno (formerly Phidata).
+This directory contains a portable [OSOP](https://github.com/Archie0125/osop-spec) workflow definition for a multi-step research agent built with Agno (formerly Phidata).
 
 ## What is OSOP?
 
@@ -35,12 +35,12 @@ User Request → Web Search Agent → Analysis Agent → Report Generator → De
 The `.osop` file is a standalone YAML document. You can:
 
 - **Read it** to understand the agent workflow at a glance
-- **Validate it** with the [OSOP CLI](https://github.com/osopcloud/osop): `osop validate phidata-research-agent.osop`
-- **Visualize it** with the [OSOP Editor](https://github.com/osopcloud/osop-editor)
+- **Validate it** with the [OSOP CLI](https://github.com/Archie0125/osop): `osop validate phidata-research-agent.osop`
+- **Visualize it** with the [OSOP Editor](https://github.com/Archie0125/osop-editor)
 - **Use it as a reference** when building the equivalent Agno workflow in Python
 
 ## Links
 
-- [OSOP Spec](https://github.com/osopcloud/osop-spec)
-- [OSOP CLI](https://github.com/osopcloud/osop)
+- [OSOP Spec](https://github.com/Archie0125/osop-spec)
+- [OSOP CLI](https://github.com/Archie0125/osop)
 - [Agno Documentation](https://docs.agno.com/)

--- a/cookbook/osop-research-agent/README.md
+++ b/cookbook/osop-research-agent/README.md
@@ -1,0 +1,46 @@
+# Research Agent Workflow — OSOP Workflow Example
+
+This directory contains a portable [OSOP](https://github.com/osopcloud/osop-spec) workflow definition for a multi-step research agent built with Agno (formerly Phidata).
+
+## What is OSOP?
+
+**OSOP** (Open Standard for Orchestration Protocols) is a YAML-based format for describing multi-step workflows in a tool-agnostic way. It lets you define pipelines, agent workflows, and automation flows that can be understood by any compatible runtime — including Agno, LangChain, CrewAI, and others.
+
+Think of it as the **OpenAPI of workflows**: a single `.osop` file describes what your agent does, so teams can share, review, and port agent workflows across frameworks.
+
+## Workflow Overview
+
+The `phidata-research-agent.osop` file describes a research agent pipeline:
+
+```
+User Request → Web Search Agent → Analysis Agent → Report Generator → Deliver Report
+```
+
+| Step | OSOP Node Type | Agno Equivalent |
+|------|---------------|-----------------|
+| User Request | `human` | User input |
+| Web Search Agent | `agent` | `Agent` with `DuckDuckGoTools` + `NewspaperTools` |
+| Analysis Agent | `agent` | `Agent` with analysis instructions |
+| Report Generator | `agent` | `Agent` with report template |
+| Deliver Report | `api` | Output / file save |
+
+## Key Features Shown
+
+- **Tool integration**: The web search agent specifies tools (`duckduckgo_search`, `newspaper_reader`) — maps to Agno's tool system
+- **Temperature control**: Each agent step has explicit temperature settings for controlling creativity vs. precision
+- **Sequential flow**: Clean handoff between specialized agents — maps to Agno's `Workflow` class
+
+## Usage
+
+The `.osop` file is a standalone YAML document. You can:
+
+- **Read it** to understand the agent workflow at a glance
+- **Validate it** with the [OSOP CLI](https://github.com/osopcloud/osop): `osop validate phidata-research-agent.osop`
+- **Visualize it** with the [OSOP Editor](https://github.com/osopcloud/osop-editor)
+- **Use it as a reference** when building the equivalent Agno workflow in Python
+
+## Links
+
+- [OSOP Spec](https://github.com/osopcloud/osop-spec)
+- [OSOP CLI](https://github.com/osopcloud/osop)
+- [Agno Documentation](https://docs.agno.com/)

--- a/cookbook/osop-research-agent/phidata-research-agent.osop
+++ b/cookbook/osop-research-agent/phidata-research-agent.osop
@@ -1,0 +1,61 @@
+# Phidata Agent Workflow in OSOP Format
+osop_version: "1.0"
+id: phidata-research-agent
+name: Phidata Research Agent Workflow
+description: A multi-step research agent with web search, analysis, and report generation.
+tags: [phidata, agent, research, web-search]
+
+nodes:
+  - id: user-request
+    type: human
+    name: User Request
+    description: User provides a research topic or question.
+
+  - id: web-search
+    type: agent
+    name: Web Search Agent
+    description: Search the web for relevant information on the topic.
+    runtime:
+      provider: openai
+      model: gpt-4
+      config:
+        tools: [duckduckgo_search, newspaper_reader]
+
+  - id: analyze
+    type: agent
+    name: Analysis Agent
+    description: Analyze search results and extract key insights.
+    runtime:
+      provider: openai
+      model: gpt-4
+      config:
+        temperature: 0.2
+
+  - id: generate-report
+    type: agent
+    name: Report Generator
+    description: Compile findings into a structured research report.
+    runtime:
+      provider: openai
+      model: gpt-4
+      config:
+        temperature: 0.5
+
+  - id: deliver
+    type: api
+    name: Deliver Report
+    description: Save and deliver the final report.
+
+edges:
+  - from: user-request
+    to: web-search
+    mode: sequential
+  - from: web-search
+    to: analyze
+    mode: sequential
+  - from: analyze
+    to: generate-report
+    mode: sequential
+  - from: generate-report
+    to: deliver
+    mode: sequential


### PR DESCRIPTION
## Summary

- Adds a portable **OSOP** (Open Standard for Orchestration Protocols) workflow definition for a multi-step research agent
- Includes a `.osop` YAML file describing the workflow (web search, analysis, report generation) and a README explaining the mapping to Agno components
- Files are additive only — no existing files modified

## What is OSOP?

[OSOP](https://github.com/osopcloud/osop-spec) is a YAML-based standard for describing multi-step workflows in a tool-agnostic way — like OpenAPI, but for workflows. A single `.osop` file can be validated, visualized, and used as a portable reference across different orchestration tools.

## Files Added

- `cookbook/osop-research-agent/phidata-research-agent.osop` — The workflow definition
- `cookbook/osop-research-agent/README.md` — Explanation with Agno component mapping

## Test plan

- [x] Files are valid YAML
- [x] No existing files modified
- [x] README maps OSOP nodes to Agno Agent/Workflow equivalents

Fixes #7293