### PR TITLE
fix(team): yield explicit tool completion after delegate_task_to_member stream

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -598,6 +598,24 @@ def _get_delegate_task_function(
                     member_agent_run_output_event.parent_run_id or run_response.run_id
                 )
                 yield member_agent_run_output_event  # type: ignore
+
+            # Explicitly yield a completion event for the delegate tool call
+            # This ensures the stream signals completion immediately after member run ends
+            # rather than waiting for provider-level timeout (often 60s)
+            from agno.utils.events import create_team_tool_call_completed_event
+            from agno.run.team import ToolExecution
+
+            delegate_tool = ToolExecution(
+                id=run_response.tools[0].id if run_response.tools else "",  # type: ignore
+                name="delegate_task_to_member",
+                args={"member_id": member_id, "task": task},
+            )
+            if member_agent_run_response is not None:
+                yield create_team_tool_call_completed_event(
+                    from_run_response=run_response,  # type: ignore
+                    tool=delegate_tool,
+                    content=member_agent_run_response.content,  # type: ignore
+                )
         else:
             member_agent_run_response = member_agent.run(  # type: ignore
                 input=member_agent_task if not history else history,  # type: ignore


### PR DESCRIPTION
## What
Adds explicit `ToolCallCompletedEvent` emission after the member run stream completes in `delegate_task_to_member`.

## Why
When using `delegate_task_to_member` with streaming, the tool completion event was not being emitted. The stream stayed open waiting for the provider-level timeout (often 60s) before signaling completion. This created a 60s delay after all member agents finished before the tool call was marked as completed.

See: #7294

## How
After the member agent run stream loop completes, the function now explicitly yields a `TeamToolCallCompletedEvent` with the member run's content. This signals to the caller that the delegate tool has finished, without waiting for provider timeout.

## Testing
- This is a logical fix based on event emission patterns
- The fix follows the same pattern as other tool completion events in the codebase

## Checklist
- [ ] Tests would require integration testing with a running team
- [ ] Linter passes (code style matches existing patterns)

Closes #7294