### PR TITLE
refactor: add direct user memory clearing to db backends

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import date, datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
@@ -32,6 +32,15 @@ class BaseDb(ABC):
 
     # We assume the database to be up to date with the 2.0.0 release
     default_schema_version = "2.0.0"
+
+    @staticmethod
+    def _get_memory_id(memory_record: Union[UserMemory, Dict[str, Any]]) -> Optional[str]:
+        if isinstance(memory_record, UserMemory):
+            return memory_record.memory_id
+        if isinstance(memory_record, dict):
+            memory_id = memory_record.get("memory_id")
+            return memory_id if isinstance(memory_id, str) else None
+        return None
 
     def __init__(
         self,
@@ -213,6 +222,18 @@ class BaseDb(ABC):
     @abstractmethod
     def clear_memories(self) -> None:
         raise NotImplementedError
+
+    def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories for the provided user, with a safe fallback implementation."""
+        memories = self.get_user_memories(user_id=user_id, deserialize=True)
+        if isinstance(memories, tuple):
+            memory_records = cast(List[Union[UserMemory, Dict[str, Any]]], memories[0])
+        else:
+            memory_records = cast(List[Union[UserMemory, Dict[str, Any]]], memories)
+
+        memory_ids = [memory_id for memory in memory_records if (memory_id := self._get_memory_id(memory)) is not None]
+        if memory_ids:
+            self.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
 
     @abstractmethod
     def delete_user_memory(self, memory_id: str, user_id: Optional[str] = None) -> None:
@@ -1226,6 +1247,20 @@ class AsyncBaseDb(ABC):
     @abstractmethod
     async def clear_memories(self) -> None:
         raise NotImplementedError
+
+    async def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories for the provided user, with a safe fallback implementation."""
+        memories = await self.get_user_memories(user_id=user_id, deserialize=True)
+        if isinstance(memories, tuple):
+            memory_records = cast(List[Union[UserMemory, Dict[str, Any]]], memories[0])
+        else:
+            memory_records = cast(List[Union[UserMemory, Dict[str, Any]]], memories)
+
+        memory_ids = [
+            memory_id for memory in memory_records if (memory_id := BaseDb._get_memory_id(memory)) is not None
+        ]
+        if memory_ids:
+            await self.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
 
     @abstractmethod
     async def delete_user_memory(self, memory_id: str, user_id: Optional[str] = None) -> None:

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -1177,6 +1177,27 @@ class AsyncMySQLDb(AsyncBaseDb):
         except Exception as e:
             log_error(f"Error deleting user memories: {e}")
 
+    async def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = await self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            async with self.async_session_factory() as sess, sess.begin():
+                delete_stmt = table.delete()
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+                result = await sess.execute(delete_stmt)
+
+                if result.rowcount == 0:  # type: ignore
+                    log_debug(f"No user memories found for user_id: {user_id}")
+                else:
+                    log_debug(f"Successfully cleared {result.rowcount} user memories")  # type: ignore
+
+        except Exception as e:
+            log_error(f"Error clearing user memories: {e}")
+
     async def get_all_memory_topics(self, user_id: Optional[str] = None) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -1169,6 +1169,26 @@ class MySQLDb(BaseDb):
         except Exception as e:
             log_error(f"Error deleting user memories: {e}")
 
+    def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            with self.Session() as sess, sess.begin():
+                delete_stmt = table.delete()
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+                result = sess.execute(delete_stmt)
+                if result.rowcount == 0:
+                    log_debug(f"No user memories found for user_id: {user_id}")
+                else:
+                    log_debug(f"Successfully cleared {result.rowcount} user memories")
+
+        except Exception as e:
+            log_error(f"Error clearing user memories: {e}")
+
     def get_all_memory_topics(self, user_id: Optional[str] = None) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -1033,6 +1033,29 @@ class AsyncPostgresDb(AsyncBaseDb):
         except Exception as e:
             log_error(f"Error deleting user memories: {e}")
 
+    async def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = await self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            async with self.async_session_factory() as sess, sess.begin():
+                delete_stmt = table.delete()
+
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+
+                result = await sess.execute(delete_stmt)
+
+                if result.rowcount == 0:  # type: ignore
+                    log_debug(f"No user memories found for user_id: {user_id}")
+                else:
+                    log_debug(f"Successfully cleared {result.rowcount} user memories")  # type: ignore
+
+        except Exception as e:
+            log_error(f"Error clearing user memories: {e}")
+
     async def get_all_memory_topics(self, user_id: Optional[str] = None) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1406,6 +1406,30 @@ class PostgresDb(BaseDb):
             log_error(f"Error deleting user memories: {e}")
             raise e
 
+    def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            with self.Session() as sess, sess.begin():
+                delete_stmt = table.delete()
+
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+
+                result = sess.execute(delete_stmt)
+
+                if result.rowcount == 0:
+                    log_debug(f"No user memories found for user_id: {user_id}")
+                else:
+                    log_debug(f"Successfully cleared {result.rowcount} user memories")
+
+        except Exception as e:
+            log_error(f"Error clearing user memories: {e}")
+            raise e
+
     def get_all_memory_topics(self) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -1228,6 +1228,27 @@ class SingleStoreDb(BaseDb):
             log_error(f"Error deleting memories: {e}")
             raise e
 
+    def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            with self.Session() as sess, sess.begin():
+                delete_stmt = table.delete()
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+                result = sess.execute(delete_stmt)
+                if result.rowcount == 0:
+                    log_debug(f"No memories found for user_id: {user_id}")
+                else:
+                    log_debug(f"Successfully cleared {result.rowcount} user memories")
+
+        except Exception as e:
+            log_error(f"Error clearing memories: {e}")
+            raise e
+
     def get_all_memory_topics(self) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -1182,6 +1182,25 @@ class AsyncSqliteDb(AsyncBaseDb):
             log_error(f"Error deleting user memories: {e}")
             raise e
 
+    async def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = await self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            async with self.async_session_factory() as sess, sess.begin():
+                delete_stmt = table.delete()
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+                result = await sess.execute(delete_stmt)
+                if result.rowcount == 0:  # type: ignore
+                    log_debug(f"No user memories found for user_id: {user_id}")
+
+        except Exception as e:
+            log_error(f"Error clearing user memories: {e}")
+            raise e
+
     async def get_all_memory_topics(self) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1350,6 +1350,25 @@ class SqliteDb(BaseDb):
             log_error(f"Error deleting user memories: {e}")
             raise e
 
+    def clear_user_memories(self, user_id: Optional[str] = None) -> None:
+        """Delete all user memories, optionally scoped to a single user."""
+        try:
+            table = self._get_table(table_type="memories")
+            if table is None:
+                return
+
+            with self.Session() as sess, sess.begin():
+                delete_stmt = table.delete()
+                if user_id is not None:
+                    delete_stmt = delete_stmt.where(table.c.user_id == user_id)
+                result = sess.execute(delete_stmt)
+                if result.rowcount == 0:
+                    log_debug(f"No user memories found for user_id: {user_id}")
+
+        except Exception as e:
+            log_error(f"Error clearing user memories: {e}")
+            raise e
+
     def get_all_memory_topics(self) -> List[str]:
         """Get all memory topics from the database.
 

--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -315,21 +315,8 @@ class MemoryManager:
                 "clear_user_memories() is not supported with an async DB. Please use aclear_user_memories() instead."
             )
 
-        # TODO: This is inefficient - we fetch all memories just to get their IDs.
-        # Extend delete_user_memories() to accept just user_id and delete all memories
-        # for that user directly without requiring a list of memory_ids.
-        memories = self.get_user_memories(user_id=user_id)
-        if not memories:
-            log_debug(f"No memories found for user {user_id}")
-            return
-
-        # Extract memory IDs
-        memory_ids = [mem.memory_id for mem in memories if mem.memory_id]
-
-        if memory_ids:
-            # Delete all memories in a single batch operation
-            self.db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-            log_debug(f"Cleared {len(memory_ids)} memories for user {user_id}")
+        self.db.clear_user_memories(user_id=user_id)
+        log_debug(f"Cleared memories for user {user_id}")
 
     async def aclear_user_memories(self, user_id: Optional[str] = None) -> None:
         """Clear all memories for a specific user (async).
@@ -345,24 +332,10 @@ class MemoryManager:
             return
 
         if isinstance(self.db, AsyncBaseDb):
-            memories = await self.aget_user_memories(user_id=user_id)
+            await self.db.clear_user_memories(user_id=user_id)
         else:
-            memories = self.get_user_memories(user_id=user_id)
-
-        if not memories:
-            log_debug(f"No memories found for user {user_id}")
-            return
-
-        # Extract memory IDs
-        memory_ids = [mem.memory_id for mem in memories if mem.memory_id]
-
-        if memory_ids:
-            # Delete all memories in a single batch operation
-            if isinstance(self.db, AsyncBaseDb):
-                await self.db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-            else:
-                self.db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-            log_debug(f"Cleared {len(memory_ids)} memories for user {user_id}")
+            self.db.clear_user_memories(user_id=user_id)
+        log_debug(f"Cleared memories for user {user_id}")
 
     # -*- Agent Functions
     def create_user_memories(

--- a/libs/agno/tests/unit/memory/test_memory_manager_async.py
+++ b/libs/agno/tests/unit/memory/test_memory_manager_async.py
@@ -1,5 +1,6 @@
 from types import MethodType
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -47,6 +48,7 @@ class DummyAsyncMemoryDb(AsyncBaseDb):
 
     async def delete_user_memories(self, memory_ids, user_id: Optional[str] = None) -> None:
         user = user_id or "default"
+        self.calls.append(("delete_user_memories", user))
         user_memories = self._memories.get(user, {})
         for memory_id in memory_ids:
             user_memories.pop(memory_id, None)
@@ -275,3 +277,30 @@ async def test_aupdate_memory_task_refreshes_async_db():
     saved_memories = await manager.aget_user_memories(user_id="user-2")
     assert len(saved_memories) == 1
     assert saved_memories[0].memory == "Task: Sync state"
+
+
+@pytest.mark.asyncio
+async def test_aclear_user_memories_with_async_db_uses_db_method():
+    async_db = DummyAsyncMemoryDb()
+    manager = MemoryManager(db=async_db)
+
+    await async_db.upsert_user_memory(UserMemory(memory="First", user_id="user-1", memory_id="mem-1"))
+    await async_db.upsert_user_memory(UserMemory(memory="Second", user_id="user-1", memory_id="mem-2"))
+
+    await manager.aclear_user_memories(user_id="user-1")
+
+    remaining = await manager.aget_user_memories(user_id="user-1")
+    assert remaining == []
+    assert ("get_user_memories", "user-1") in async_db.calls
+    assert ("delete_user_memories", "user-1") in async_db.calls
+
+
+@pytest.mark.asyncio
+async def test_aclear_user_memories_with_sync_db_uses_db_method():
+    sync_db = MagicMock()
+    sync_db.clear_user_memories = MagicMock(return_value=None)
+    manager = MemoryManager(db=sync_db)
+
+    await manager.aclear_user_memories(user_id="user-1")
+
+    sync_db.clear_user_memories.assert_called_once_with(user_id="user-1")

--- a/libs/agno/tests/unit/memory/test_memory_manager_crud.py
+++ b/libs/agno/tests/unit/memory/test_memory_manager_crud.py
@@ -20,6 +20,7 @@ def mock_db():
     db.get_user_memories = MagicMock(return_value=[])
     db.upsert_user_memory = MagicMock(return_value=None)
     db.delete_user_memory = MagicMock(return_value=None)
+    db.clear_user_memories = MagicMock(return_value=None)
     db.clear_memories = MagicMock(return_value=None)
     return db
 
@@ -343,21 +344,15 @@ class TestClear:
 
 class TestClearUserMemories:
     def test_clear_user_memories(self, manager, mock_db, sample_memories):
-        """Clears all memories for a specific user via batch delete."""
-        user1_memories = [m for m in sample_memories if m.user_id == "user1"]
-        mock_db.get_user_memories.return_value = user1_memories
-        mock_db.delete_user_memories = MagicMock()
+        """Delegates user-scoped clearing directly to the DB."""
         manager.clear_user_memories(user_id="user1")
-        mock_db.delete_user_memories.assert_called_once()
-        call_args = mock_db.delete_user_memories.call_args
-        assert call_args.kwargs["user_id"] == "user1"
-        assert len(call_args.kwargs["memory_ids"]) == 2
+        mock_db.clear_user_memories.assert_called_once_with(user_id="user1")
+        mock_db.get_user_memories.assert_not_called()
 
     def test_clear_user_memories_default_user(self, manager, mock_db):
         """Uses 'default' user_id when none provided."""
-        mock_db.get_user_memories.return_value = []
         manager.clear_user_memories()
-        mock_db.get_user_memories.assert_called_with(user_id="default")
+        mock_db.clear_user_memories.assert_called_with(user_id="default")
 
     def test_clear_user_memories_no_db(self):
         """Does nothing when no db."""


### PR DESCRIPTION
## Summary

Refactors user memory clearing to use a dedicated DB-level API instead of fetching all memories first just to collect IDs for deletion.

This improves the `MemoryManager.clear_user_memories()` / `aclear_user_memories()` flow and adds direct backend support for efficient user-scoped deletes in the main SQL backends.

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Key changes:
- Added sync/async `clear_user_memories(user_id)` methods to the DB base classes with a backward-compatible fallback implementation.
- Updated `MemoryManager.clear_user_memories()` and `MemoryManager.aclear_user_memories()` to delegate directly to the DB layer.
- Added optimized direct user-scoped delete implementations for:
  - `SqliteDb`
  - `AsyncSqliteDb`
  - `PostgresDb`
  - `AsyncPostgresDb`
  - `MySQLDb`
  - `AsyncMySQLDb`
  - `SingleStoreDb`

Tests and validation:
- `python -m pytest libs/agno/tests/unit/memory/test_memory_manager_crud.py libs/agno/tests/unit/memory/test_memory_manager_async.py -q` -> **47 passed**
- `python -m ruff check ...` on changed files -> **passed**

Notes:
- The change is backward compatible: existing `delete_user_memories(memory_ids=..., user_id=...)` behavior is unchanged.
- This PR is intentionally scoped to the memory clear redesign and related tests only.