### PR TITLE
fix: resolve data loss atomicity bug in optimization (fixes #7051)

### DIFF
--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -843,18 +843,24 @@ class MemoryManager:
                 log_warning("Memory DB not provided. Cannot apply optimized memories.")
                 return optimized_memories
 
-            # Clear all existing memories for the user
-            self.clear_user_memories(user_id=user_id)
-
-            # Add all optimized memories
+            # Ensure memory has an ID (generate if needed for new memories)
             for opt_mem in optimized_memories:
-                # Ensure memory has an ID (generate if needed for new memories)
                 if not opt_mem.memory_id:
                     from uuid import uuid4
 
                     opt_mem.memory_id = str(uuid4())
 
+            # Upsert new optimized memories first to prevent data loss if connection drops
+            for opt_mem in optimized_memories:
                 self.db.upsert_user_memory(memory=opt_mem)
+
+            # Delete old memories that are no longer present
+            old_memory_ids = [mem.memory_id for mem in memories if mem.memory_id]
+            new_memory_ids = {opt_mem.memory_id for opt_mem in optimized_memories if opt_mem.memory_id}
+            ids_to_delete = [mid for mid in old_memory_ids if mid not in new_memory_ids]
+
+            if ids_to_delete:
+                self.db.delete_user_memories(memory_ids=ids_to_delete, user_id=user_id)
 
         optimized_tokens = strategy_instance.count_tokens(optimized_memories)
         log_debug(f"Optimization complete. New token count: {optimized_tokens}")
@@ -913,21 +919,30 @@ class MemoryManager:
                 log_warning("Memory DB not provided. Cannot apply optimized memories.")
                 return optimized_memories
 
-            # Clear all existing memories for the user
-            await self.aclear_user_memories(user_id=user_id)
-
-            # Add all optimized memories
+            # Ensure memory has an ID (generate if needed for new memories)
             for opt_mem in optimized_memories:
-                # Ensure memory has an ID (generate if needed for new memories)
                 if not opt_mem.memory_id:
                     from uuid import uuid4
 
                     opt_mem.memory_id = str(uuid4())
 
+            # Upsert new optimized memories first to prevent data loss if connection drops
+            for opt_mem in optimized_memories:
                 if isinstance(self.db, AsyncBaseDb):
                     await self.db.upsert_user_memory(memory=opt_mem)
                 elif isinstance(self.db, BaseDb):
                     self.db.upsert_user_memory(memory=opt_mem)
+
+            # Delete old memories that are no longer present
+            old_memory_ids = [mem.memory_id for mem in memories if mem.memory_id]
+            new_memory_ids = {opt_mem.memory_id for opt_mem in optimized_memories if opt_mem.memory_id}
+            ids_to_delete = [mid for mid in old_memory_ids if mid not in new_memory_ids]
+
+            if ids_to_delete:
+                if isinstance(self.db, AsyncBaseDb):
+                    await self.db.delete_user_memories(memory_ids=ids_to_delete, user_id=user_id)
+                elif isinstance(self.db, BaseDb):
+                    self.db.delete_user_memories(memory_ids=ids_to_delete, user_id=user_id)
 
         optimized_tokens = strategy_instance.count_tokens(optimized_memories)
         log_debug(f"Memory optimization complete. New token count: {optimized_tokens}")

--- a/libs/agno/tests/unit/memory/test_memory_optimization.py
+++ b/libs/agno/tests/unit/memory/test_memory_optimization.py
@@ -57,7 +57,6 @@ def test_optimize_memories_success(mock_db, mock_model, mock_strategy, sample_me
     # Setup
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=sample_memories)
-    manager.clear_user_memories = MagicMock()
 
     # Mock factory to return our mock strategy
     with patch(
@@ -78,7 +77,7 @@ def test_optimize_memories_success(mock_db, mock_model, mock_strategy, sample_me
         mock_strategy.optimize.assert_called_once_with(memories=sample_memories, model=mock_model)
 
         # Verify DB operations (apply=True)
-        manager.clear_user_memories.assert_called_once_with(user_id="user-1")
+        mock_db.delete_user_memories.assert_called_once_with(memory_ids=["m1", "m2"], user_id="user-1")
         mock_db.upsert_user_memory.assert_called()
         assert mock_db.upsert_user_memory.call_count == len(optimized_memories)
         assert result == optimized_memories
@@ -88,7 +87,6 @@ def test_optimize_memories_apply_false(mock_db, mock_model, mock_strategy, sampl
     """Test optimization without applying changes to DB."""
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=sample_memories)
-    manager.clear_user_memories = MagicMock()
 
     with patch("agno.memory.strategies.MemoryOptimizationStrategyFactory.create_strategy", return_value=mock_strategy):
         mock_strategy.optimize.return_value = optimized_memories
@@ -96,7 +94,7 @@ def test_optimize_memories_apply_false(mock_db, mock_model, mock_strategy, sampl
         result = manager.optimize_memories(user_id="user-1", apply=False)
 
         # Verify DB was NOT touched
-        manager.clear_user_memories.assert_not_called()
+        mock_db.delete_user_memories.assert_not_called()
         mock_db.upsert_user_memory.assert_not_called()
         assert result == optimized_memories
 
@@ -119,7 +117,6 @@ def test_optimize_memories_custom_strategy_instance(
     """Test optimization passing a strategy instance directly."""
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=sample_memories)
-    manager.clear_user_memories = MagicMock()
 
     mock_strategy.optimize.return_value = optimized_memories
 
@@ -145,7 +142,6 @@ async def test_aoptimize_memories_success(
     """Test successful async memory optimization."""
     manager = MemoryManager(db=mock_async_db, model=mock_model)
     manager.aget_user_memories = AsyncMock(return_value=sample_memories)
-    manager.aclear_user_memories = AsyncMock()
 
     with patch("agno.memory.strategies.MemoryOptimizationStrategyFactory.create_strategy", return_value=mock_strategy):
         mock_strategy.aoptimize = AsyncMock(return_value=optimized_memories)
@@ -156,7 +152,7 @@ async def test_aoptimize_memories_success(
 
         # Verify async calls
         mock_strategy.aoptimize.assert_called_once_with(memories=sample_memories, model=mock_model)
-        manager.aclear_user_memories.assert_called_once_with(user_id="user-1")
+        mock_async_db.delete_user_memories.assert_called_once_with(memory_ids=["m1", "m2"], user_id="user-1")
         assert mock_async_db.upsert_user_memory.await_count == len(optimized_memories)
         assert result == optimized_memories
 
@@ -168,14 +164,13 @@ async def test_aoptimize_memories_apply_false(
     """Test async optimization without applying to DB."""
     manager = MemoryManager(db=mock_async_db, model=mock_model)
     manager.aget_user_memories = AsyncMock(return_value=sample_memories)
-    manager.aclear_user_memories = AsyncMock()
 
     with patch("agno.memory.strategies.MemoryOptimizationStrategyFactory.create_strategy", return_value=mock_strategy):
         mock_strategy.aoptimize = AsyncMock(return_value=optimized_memories)
 
         result = await manager.aoptimize_memories(user_id="user-1", apply=False)
 
-        manager.aclear_user_memories.assert_not_called()
+        mock_async_db.delete_user_memories.assert_not_called()
         mock_async_db.upsert_user_memory.assert_not_called()
         assert result == optimized_memories
 
@@ -199,7 +194,6 @@ async def test_aoptimize_memories_sync_db_compatibility(
     manager = MemoryManager(db=mock_db, model=mock_model)
     # Note: With sync DB, it calls get_user_memories (sync) not aget
     manager.get_user_memories = MagicMock(return_value=sample_memories)
-    manager.clear_user_memories = MagicMock()
     # But upsert/clear might be handled differently depending on implementation
     # The code handles `isinstance(self.db, AsyncBaseDb)` checks.
 


### PR DESCRIPTION
## Summary

This PR addresses the critical data loss behavior identified in #7051 where both `optimize_memories` and `aoptimize_memories` utilize a non-atomic `Delete -> Insert` flow. Previously, if the database connection dropped or crashed after the deletion stage but before the inserts completed, all of a user's original memories were permanently lost.

Following the approach outlined in the issue, this PR reorders operations to an "insert-before-delete" approach:
1. Ensure all new optimized memories have unique UUIDs.
2. Upsert the new optimized memories to the database **first**.
3. Identify the original memory IDs and explicitly delete only those old memories *after* the upserts naturally succeed.

This eliminates the data wipe risk across both sync and async database implementations without negatively impacting base compatibility or requiring cross-database native transactions. 

fixes #7051

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The unit tests inside `libs/agno/tests/unit/memory/test_memory_optimization.py` were adjusted since the legacy mock logic asserted against `manager.clear_user_memories()`, which is deliberately bypassed by this internal logic now directly invoking targeted `db.delete_user_memories(memory_ids=...)`. All new assertions comprehensively pass.
