### PR TITLE
fix: add extend_existing=True to SQLAlchemy Table() calls

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -238,7 +238,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns, schema=self.db_schema)
+            table = Table(table_name, self.metadata, *columns, schema=self.db_schema, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:
@@ -454,7 +454,9 @@ class AsyncPostgresDb(AsyncBaseDb):
             async with self.db_engine.connect() as conn:
 
                 def create_table(connection):
-                    return Table(table_name, self.metadata, schema=self.db_schema, autoload_with=connection)
+                    return Table(
+                        table_name, self.metadata, schema=self.db_schema, autoload_with=connection, extend_existing=True
+                    )
 
                 table = await conn.run_sync(create_table)
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -303,7 +303,7 @@ class PostgresDb(BaseDb):
                 columns.append(Column(*column_args, **column_kwargs))
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns, schema=self.db_schema)
+            table = Table(table_name, self.metadata, *columns, schema=self.db_schema, extend_existing=True)
 
             # Composite PK
             if schema_primary_key is not None:
@@ -614,7 +614,9 @@ class PostgresDb(BaseDb):
             raise ValueError(f"Table {self.db_schema}.{table_name} has an invalid schema")
 
         try:
-            table = Table(table_name, self.metadata, schema=self.db_schema, autoload_with=self.db_engine)
+            table = Table(
+                table_name, self.metadata, schema=self.db_schema, autoload_with=self.db_engine, extend_existing=True
+            )
             return table
 
         except Exception as e:


### PR DESCRIPTION
Fixes #7319

## Summary

- Add `extend_existing=True` to all 4 `Table()` constructor calls in `async_postgres.py` and `postgres.py`
- Prevents `InvalidRequestError: Table 'X' is already defined for this MetaData instance` when `_create_table` or `_get_or_create_table` is called more than once for the same table (e.g., after a connection failure + retry)
- Standard SQLAlchemy pattern — safe because `table.create(checkfirst=True)` already handles DDL idempotency
- No behavioral change for single-call paths

## Test plan

- [ ] Existing tests pass
- [ ] Manual: call `_create_table` twice for the same table name on the same db instance — no `InvalidRequestError` on second call