### PR TITLE
fix: catch CancelledError and run cleanup in agent async handlers

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -1753,10 +1753,27 @@ async def _arun(
 
                 return run_response
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError) as cancel_exc:
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
                 run_response.content = "Operation cancelled by user"
+                # Queue cleanup as fire-and-forget so session data is persisted.
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                # Re-raise CancelledError to propagate system cancellation;
+                # KeyboardInterrupt returns the response to the caller.
+                if isinstance(cancel_exc, asyncio.CancelledError):
+                    raise
                 return run_response
             except Exception as e:
                 # Check if this is the last attempt
@@ -2375,8 +2392,24 @@ async def _arun_stream(
                 yield run_error
                 break
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError) as cancel_exc:
                 run_response = cast(RunOutput, run_response)
+                run_response.status = RunStatus.cancelled
+                run_response.content = "Operation cancelled by user"
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                if isinstance(cancel_exc, asyncio.CancelledError):
+                    raise
                 yield handle_event(  # type: ignore
                     create_run_cancelled_event(from_run_response=run_response, reason="Operation cancelled by user"),
                     run_response,
@@ -3861,10 +3894,24 @@ async def _acontinue_run(
 
                 return run_response
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError) as cancel_exc:
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
                 run_response.content = "Operation cancelled by user"
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                if isinstance(cancel_exc, asyncio.CancelledError):
+                    raise
                 return run_response
             except Exception as e:
                 run_response = cast(RunOutput, run_response)
@@ -4339,10 +4386,26 @@ async def _acontinue_run_stream(
                 # Yield the error event
                 yield run_error
                 break
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError) as cancel_exc:
                 if run_response is None:
                     run_response = RunOutput(run_id=run_id)
                 run_response = cast(RunOutput, run_response)
+                run_response.status = RunStatus.cancelled
+                run_response.content = "Operation cancelled by user"
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                if isinstance(cancel_exc, asyncio.CancelledError):
+                    raise
                 yield handle_event(  # type: ignore
                     create_run_cancelled_event(from_run_response=run_response, reason="Operation cancelled by user"),
                     run_response,


### PR DESCRIPTION
Fixes #7318
Related: #6235
Supersedes #7325

## Summary

- Add `asyncio.CancelledError` to the exception tuple in 4 agent async handlers (`_arun`, `_arun_stream`, `_acontinue_run`, `_acontinue_run_stream`)
- Both `KeyboardInterrupt` and `CancelledError` now queue `acleanup_and_store` as a fire-and-forget task via the existing `_background_tasks` registry (line 112)
- **`CancelledError` is re-raised** after queuing cleanup to properly propagate system cancellation
- `KeyboardInterrupt` returns/yields as before (user action, not system cancellation)
- Agent `_run.py` previously only caught `KeyboardInterrupt` — `CancelledError` (BaseException) propagated unhandled, skipping session persistence entirely
- Brings agent parity with team `_run.py` which already catches `(KeyboardInterrupt, asyncio.CancelledError)`

## Pattern

```python
except (KeyboardInterrupt, asyncio.CancelledError) as cancel_exc:
    run_response.status = RunStatus.cancelled
    if agent_session is not None:
        _cleanup = asyncio.create_task(acleanup_and_store(...))
        _background_tasks.add(_cleanup)
        _cleanup.add_done_callback(_background_tasks.discard)
    # Re-raise CancelledError to propagate system cancellation;
    # KeyboardInterrupt returns the response to the caller.
    if isinstance(cancel_exc, asyncio.CancelledError):
        raise
    return run_response
```

- `create_task` + `_background_tasks` ensures cleanup runs independently (strong ref, no GC)
- CancelledError re-raised — does not suppress shutdown/timeout cancellations
- KeyboardInterrupt returns normally — user-initiated, not system cancellation

## Test plan

- [ ] Existing tests pass
- [ ] Unit: raise `asyncio.CancelledError` during model response, verify cleanup task created and CancelledError propagates
- [ ] Verify `_background_tasks` is empty after cleanup completes