### PR TITLE
feat: add N8nTools toolkit for n8n workflow automation

### DIFF
--- a/cookbook/91_tools/n8n_tools.py
+++ b/cookbook/91_tools/n8n_tools.py
@@ -1,0 +1,61 @@
+"""
+n8n Tools
+
+Setup:
+1. Generate an API key in your n8n instance:
+   Settings -> API -> Create API Key
+2. Set environment variables:
+   - N8N_API_KEY: Your n8n API key
+   - N8N_BASE_URL: Optional base URL (defaults to http://localhost:5678)
+"""
+
+from os import getenv
+
+from agno.agent import Agent
+from agno.tools.n8n import N8nTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+base_url = getenv("N8N_BASE_URL", "http://localhost:5678")
+
+agent = Agent(
+    instructions=[
+        "Use n8n tools to monitor and manage workflow automations.",
+        "When listing workflows, summarize their name, active status, and last update.",
+        "When reporting executions, highlight any failures and suggest next steps.",
+    ],
+    tools=[
+        N8nTools(
+            base_url=base_url,
+            enable_list_workflows=True,
+            enable_get_workflow=True,
+            enable_activate_workflow=True,
+            enable_deactivate_workflow=True,
+            enable_list_executions=True,
+            enable_get_execution=True,
+            enable_delete_execution=True,
+        )
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "List all workflows and their status, then show the last 5 executions and flag any failures.",
+        markdown=True,
+    )
+
+    # Async variant:
+    # import asyncio
+    #
+    # async def run_async():
+    #     await agent.aprint_response(
+    #         "List all active workflows and check for recent failed executions.",
+    #         markdown=True,
+    #     )
+    #
+    # asyncio.run(run_async())

--- a/libs/agno/agno/tools/n8n.py
+++ b/libs/agno/agno/tools/n8n.py
@@ -1,0 +1,564 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, logger
+
+
+class N8nTools(Toolkit):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:5678",
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+        all: bool = False,
+        enable_list_workflows: bool = True,
+        enable_get_workflow: bool = True,
+        enable_activate_workflow: bool = True,
+        enable_deactivate_workflow: bool = True,
+        enable_list_executions: bool = True,
+        enable_get_execution: bool = True,
+        enable_delete_execution: bool = True,
+        **kwargs: Any,
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key or getenv("N8N_API_KEY")
+        if not self.api_key:
+            logger.warning("No n8n API key provided. Set N8N_API_KEY or pass api_key.")
+        self.timeout = timeout
+        self._async_client: Optional[httpx.AsyncClient] = None
+
+        tools: List[Any] = []
+        async_tools: List[tuple[Any, str]] = []
+
+        if all or enable_list_workflows:
+            tools.append(self.list_workflows)
+            async_tools.append((self.alist_workflows, "list_workflows"))
+        if all or enable_get_workflow:
+            tools.append(self.get_workflow)
+            async_tools.append((self.aget_workflow, "get_workflow"))
+        if all or enable_activate_workflow:
+            tools.append(self.activate_workflow)
+            async_tools.append((self.aactivate_workflow, "activate_workflow"))
+        if all or enable_deactivate_workflow:
+            tools.append(self.deactivate_workflow)
+            async_tools.append((self.adeactivate_workflow, "deactivate_workflow"))
+        if all or enable_list_executions:
+            tools.append(self.list_executions)
+            async_tools.append((self.alist_executions, "list_executions"))
+        if all or enable_get_execution:
+            tools.append(self.get_execution)
+            async_tools.append((self.aget_execution, "get_execution"))
+        if all or enable_delete_execution:
+            tools.append(self.delete_execution)
+            async_tools.append((self.adelete_execution, "delete_execution"))
+
+        super().__init__(name="n8n", tools=tools, async_tools=async_tools, **kwargs)
+
+    # ---- Internal helpers ----
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Build HTTP headers for n8n API requests."""
+        headers: Dict[str, str] = {"Accept": "application/json"}
+        if self.api_key:
+            headers["X-N8N-API-KEY"] = self.api_key
+        return headers
+
+    def _build_url(self, endpoint: str) -> str:
+        """Build full URL for the given n8n API endpoint."""
+        path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+        return f"{self.base_url}/api/v1{path}"
+
+    def _json_error(self, message: str) -> str:
+        """Return a JSON-encoded error string."""
+        return json.dumps({"error": message})
+
+    def _http_error_message(self, response: httpx.Response) -> str:
+        """Extract a human-readable error message from an HTTP response."""
+        detail: Optional[str] = None
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                msg = payload.get("message") or payload.get("error")
+                if msg is not None:
+                    detail = json.dumps(msg) if isinstance(msg, (dict, list)) else str(msg)
+            elif isinstance(payload, list):
+                detail = json.dumps(payload)
+        except Exception:
+            detail = None
+
+        if not detail:
+            raw_text = response.text.strip()
+            detail = raw_text or response.reason_phrase or "HTTP error"
+        return f"{response.status_code}: {detail}"
+
+    def _get_async_client(self) -> httpx.AsyncClient:
+        """Return a lazily-initialized async HTTP client."""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(timeout=self.timeout)
+        return self._async_client
+
+    async def aclose(self) -> None:
+        """Close the async HTTP client and release resources."""
+        if self._async_client is not None:
+            await self._async_client.aclose()
+            self._async_client = None
+
+    # ---- Sync methods ----
+
+    def list_workflows(self, active_only: bool = False, limit: int = 100, cursor: Optional[str] = None) -> str:
+        """List workflows in the n8n instance.
+
+        Args:
+            active_only: If True, return only active workflows.
+            limit: Maximum number of workflows to return.
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            JSON string containing workflow data, count, and nextCursor.
+        """
+        try:
+            params: Dict[str, Any] = {"limit": limit}
+            if cursor:
+                params["cursor"] = cursor
+            log_debug(f"Listing n8n workflows (active_only={active_only})")
+            response = httpx.get(
+                self._build_url("/workflows"),
+                headers=self._build_headers(),
+                params=params,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            next_cursor = data.get("nextCursor") if isinstance(data, dict) else None
+            workflows = data.get("data", data) if isinstance(data, dict) else data
+            if active_only and isinstance(workflows, list):
+                workflows = [w for w in workflows if w.get("active")]
+            return json.dumps({"data": workflows, "count": len(workflows), "nextCursor": next_cursor}, indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while listing workflows: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while listing workflows: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception("Unexpected error while listing n8n workflows")
+            return self._json_error(str(e))
+
+    def get_workflow(self, workflow_id: str) -> str:
+        """Get details of a specific workflow.
+
+        Args:
+            workflow_id: The ID of the workflow to retrieve.
+
+        Returns:
+            JSON string containing workflow details.
+        """
+        try:
+            log_debug(f"Getting n8n workflow: {workflow_id}")
+            response = httpx.get(
+                self._build_url(f"/workflows/{workflow_id}"),
+                headers=self._build_headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while getting workflow {workflow_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while getting workflow {workflow_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while getting n8n workflow {workflow_id}")
+            return self._json_error(str(e))
+
+    def activate_workflow(self, workflow_id: str) -> str:
+        """Activate a workflow so it can be triggered.
+
+        Args:
+            workflow_id: The ID of the workflow to activate.
+
+        Returns:
+            JSON string confirming activation.
+        """
+        try:
+            log_debug(f"Activating n8n workflow: {workflow_id}")
+            response = httpx.post(
+                self._build_url(f"/workflows/{workflow_id}/activate"),
+                headers=self._build_headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while activating workflow {workflow_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while activating workflow {workflow_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while activating n8n workflow {workflow_id}")
+            return self._json_error(str(e))
+
+    def deactivate_workflow(self, workflow_id: str) -> str:
+        """Deactivate a workflow so it stops being triggered.
+
+        Args:
+            workflow_id: The ID of the workflow to deactivate.
+
+        Returns:
+            JSON string confirming deactivation.
+        """
+        try:
+            log_debug(f"Deactivating n8n workflow: {workflow_id}")
+            response = httpx.post(
+                self._build_url(f"/workflows/{workflow_id}/deactivate"),
+                headers=self._build_headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while deactivating workflow {workflow_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while deactivating workflow {workflow_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while deactivating n8n workflow {workflow_id}")
+            return self._json_error(str(e))
+
+    def list_executions(self, workflow_id: Optional[str] = None, limit: int = 20, cursor: Optional[str] = None) -> str:
+        """List workflow executions.
+
+        Args:
+            workflow_id: Optional workflow ID to filter executions.
+            limit: Maximum number of executions to return.
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            JSON string containing execution data, count, and nextCursor.
+        """
+        try:
+            params: Dict[str, Any] = {"limit": limit}
+            if workflow_id:
+                params["workflowId"] = workflow_id
+            if cursor:
+                params["cursor"] = cursor
+            log_debug(f"Listing n8n executions with params: {params}")
+            response = httpx.get(
+                self._build_url("/executions"),
+                headers=self._build_headers(),
+                params=params,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            data = response.json()
+            next_cursor = data.get("nextCursor") if isinstance(data, dict) else None
+            executions = data.get("data", data) if isinstance(data, dict) else data
+            return json.dumps({"data": executions, "count": len(executions), "nextCursor": next_cursor}, indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while listing executions: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while listing executions: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception("Unexpected error while listing n8n executions")
+            return self._json_error(str(e))
+
+    def get_execution(self, execution_id: str) -> str:
+        """Get details of a specific execution.
+
+        Args:
+            execution_id: The ID of the execution to retrieve.
+
+        Returns:
+            JSON string containing execution details.
+        """
+        try:
+            log_debug(f"Getting n8n execution: {execution_id}")
+            response = httpx.get(
+                self._build_url(f"/executions/{execution_id}"),
+                headers=self._build_headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while getting execution {execution_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while getting execution {execution_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while getting n8n execution {execution_id}")
+            return self._json_error(str(e))
+
+    def delete_execution(self, execution_id: str) -> str:
+        """Delete a specific execution record.
+
+        Args:
+            execution_id: The ID of the execution to delete.
+
+        Returns:
+            JSON string confirming deletion.
+        """
+        try:
+            log_debug(f"Deleting n8n execution: {execution_id}")
+            response = httpx.delete(
+                self._build_url(f"/executions/{execution_id}"),
+                headers=self._build_headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return json.dumps({"status": "deleted", "execution_id": execution_id}, indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while deleting execution {execution_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while deleting execution {execution_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while deleting n8n execution {execution_id}")
+            return self._json_error(str(e))
+
+    # ---- Async methods ----
+
+    async def alist_workflows(self, active_only: bool = False, limit: int = 100, cursor: Optional[str] = None) -> str:
+        """List workflows in the n8n instance using async HTTP requests.
+
+        Args:
+            active_only: If True, return only active workflows.
+            limit: Maximum number of workflows to return.
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            JSON string containing workflow data, count, and nextCursor.
+        """
+        try:
+            params: Dict[str, Any] = {"limit": limit}
+            if cursor:
+                params["cursor"] = cursor
+            log_debug(f"Listing n8n workflows async (active_only={active_only})")
+            client = self._get_async_client()
+            response = await client.get(
+                self._build_url("/workflows"),
+                headers=self._build_headers(),
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+            next_cursor = data.get("nextCursor") if isinstance(data, dict) else None
+            workflows = data.get("data", data) if isinstance(data, dict) else data
+            if active_only and isinstance(workflows, list):
+                workflows = [w for w in workflows if w.get("active")]
+            return json.dumps({"data": workflows, "count": len(workflows), "nextCursor": next_cursor}, indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while listing workflows: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while listing workflows: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception("Unexpected error while listing n8n workflows")
+            return self._json_error(str(e))
+
+    async def aget_workflow(self, workflow_id: str) -> str:
+        """Get details of a specific workflow using async HTTP requests.
+
+        Args:
+            workflow_id: The ID of the workflow to retrieve.
+
+        Returns:
+            JSON string containing workflow details.
+        """
+        try:
+            log_debug(f"Getting n8n workflow async: {workflow_id}")
+            client = self._get_async_client()
+            response = await client.get(
+                self._build_url(f"/workflows/{workflow_id}"),
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while getting workflow {workflow_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while getting workflow {workflow_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while getting n8n workflow {workflow_id}")
+            return self._json_error(str(e))
+
+    async def aactivate_workflow(self, workflow_id: str) -> str:
+        """Activate a workflow using async HTTP requests.
+
+        Args:
+            workflow_id: The ID of the workflow to activate.
+
+        Returns:
+            JSON string confirming activation.
+        """
+        try:
+            log_debug(f"Activating n8n workflow async: {workflow_id}")
+            client = self._get_async_client()
+            response = await client.post(
+                self._build_url(f"/workflows/{workflow_id}/activate"),
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while activating workflow {workflow_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while activating workflow {workflow_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while activating n8n workflow {workflow_id}")
+            return self._json_error(str(e))
+
+    async def adeactivate_workflow(self, workflow_id: str) -> str:
+        """Deactivate a workflow using async HTTP requests.
+
+        Args:
+            workflow_id: The ID of the workflow to deactivate.
+
+        Returns:
+            JSON string confirming deactivation.
+        """
+        try:
+            log_debug(f"Deactivating n8n workflow async: {workflow_id}")
+            client = self._get_async_client()
+            response = await client.post(
+                self._build_url(f"/workflows/{workflow_id}/deactivate"),
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while deactivating workflow {workflow_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while deactivating workflow {workflow_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while deactivating n8n workflow {workflow_id}")
+            return self._json_error(str(e))
+
+    async def alist_executions(
+        self, workflow_id: Optional[str] = None, limit: int = 20, cursor: Optional[str] = None
+    ) -> str:
+        """List workflow executions using async HTTP requests.
+
+        Args:
+            workflow_id: Optional workflow ID to filter executions.
+            limit: Maximum number of executions to return.
+            cursor: Pagination cursor from a previous response.
+
+        Returns:
+            JSON string containing execution data, count, and nextCursor.
+        """
+        try:
+            params: Dict[str, Any] = {"limit": limit}
+            if workflow_id:
+                params["workflowId"] = workflow_id
+            if cursor:
+                params["cursor"] = cursor
+            log_debug(f"Listing n8n executions async with params: {params}")
+            client = self._get_async_client()
+            response = await client.get(
+                self._build_url("/executions"),
+                headers=self._build_headers(),
+                params=params,
+            )
+            response.raise_for_status()
+            data = response.json()
+            next_cursor = data.get("nextCursor") if isinstance(data, dict) else None
+            executions = data.get("data", data) if isinstance(data, dict) else data
+            return json.dumps({"data": executions, "count": len(executions), "nextCursor": next_cursor}, indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while listing executions: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while listing executions: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception("Unexpected error while listing n8n executions")
+            return self._json_error(str(e))
+
+    async def aget_execution(self, execution_id: str) -> str:
+        """Get details of a specific execution using async HTTP requests.
+
+        Args:
+            execution_id: The ID of the execution to retrieve.
+
+        Returns:
+            JSON string containing execution details.
+        """
+        try:
+            log_debug(f"Getting n8n execution async: {execution_id}")
+            client = self._get_async_client()
+            response = await client.get(
+                self._build_url(f"/executions/{execution_id}"),
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+            return json.dumps(response.json(), indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while getting execution {execution_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while getting execution {execution_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while getting n8n execution {execution_id}")
+            return self._json_error(str(e))
+
+    async def adelete_execution(self, execution_id: str) -> str:
+        """Delete a specific execution record using async HTTP requests.
+
+        Args:
+            execution_id: The ID of the execution to delete.
+
+        Returns:
+            JSON string confirming deletion.
+        """
+        try:
+            log_debug(f"Deleting n8n execution async: {execution_id}")
+            client = self._get_async_client()
+            response = await client.delete(
+                self._build_url(f"/executions/{execution_id}"),
+                headers=self._build_headers(),
+            )
+            response.raise_for_status()
+            return json.dumps({"status": "deleted", "execution_id": execution_id}, indent=2)
+        except httpx.HTTPStatusError as e:
+            message = self._http_error_message(e.response)
+            logger.error(f"n8n API error while deleting execution {execution_id}: {message}")
+            return self._json_error(message)
+        except httpx.RequestError as e:
+            logger.error(f"n8n request error while deleting execution {execution_id}: {e}")
+            return self._json_error(str(e))
+        except Exception as e:
+            logger.exception(f"Unexpected error while deleting n8n execution {execution_id}")
+            return self._json_error(str(e))

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -144,6 +144,7 @@ zep = ["zep-cloud"]
 daytona = ["daytona"]
 oxylabs = ["oxylabs"]
 trafilatura = ["trafilatura"]
+n8n = ["httpx"]
 neo4j = ["neo4j"]
 telegram = ["pyTelegramBotAPI>=4.32.0", "aiohttp"]
 
@@ -277,6 +278,7 @@ tools = [
   "agno[redshift]",
   "agno[reportlab]",
   "agno[trafilatura]",
+  "agno[n8n]",
   "agno[neo4j]",
 ]
 

--- a/libs/agno/tests/unit/tools/test_n8n.py
+++ b/libs/agno/tests/unit/tools/test_n8n.py
@@ -1,0 +1,454 @@
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from agno.tools.n8n import N8nTools
+
+
+class TestN8nTools:
+    @pytest.fixture
+    def n8n_tools(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="test-key")
+        return tools
+
+    # ---- Init tests ----
+
+    def test_init_with_explicit_params(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="my-key", timeout=60)
+
+        assert tools.base_url == "http://n8n.local:5678"
+        assert tools.api_key == "my-key"
+        assert tools.timeout == 60
+
+    def test_init_strips_trailing_slash(self):
+        tools = N8nTools(base_url="http://n8n.local:5678/", api_key="key")
+
+        assert tools.base_url == "http://n8n.local:5678"
+
+    def test_init_uses_environment_variable(self):
+        with patch.dict(os.environ, {"N8N_API_KEY": "env-key"}):
+            tools = N8nTools(base_url="http://localhost:5678")
+
+        assert tools.api_key == "env-key"
+
+    def test_init_without_key_logs_warning(self):
+        with patch.dict(os.environ, {}, clear=True):
+            tools = N8nTools(base_url="http://localhost:5678", api_key=None)
+
+        assert tools.api_key is None
+
+    # ---- Flag registration tests ----
+
+    def test_all_tools_registered_by_default(self):
+        tools = N8nTools(base_url="http://localhost:5678", api_key="key")
+
+        assert set(tools.functions.keys()) == {
+            "list_workflows",
+            "get_workflow",
+            "activate_workflow",
+            "deactivate_workflow",
+            "list_executions",
+            "get_execution",
+            "delete_execution",
+        }
+        assert set(tools.async_functions.keys()) == set(tools.functions.keys())
+
+    def test_enable_flags_register_selected_tools_only(self):
+        tools = N8nTools(
+            base_url="http://localhost:5678",
+            api_key="key",
+            enable_list_workflows=True,
+            enable_get_workflow=True,
+            enable_activate_workflow=False,
+            enable_deactivate_workflow=False,
+            enable_list_executions=False,
+            enable_get_execution=False,
+            enable_delete_execution=False,
+        )
+
+        assert set(tools.functions.keys()) == {"list_workflows", "get_workflow"}
+        assert set(tools.async_functions.keys()) == {"list_workflows", "get_workflow"}
+
+    def test_all_flag_overrides_individual_flags(self):
+        tools = N8nTools(
+            base_url="http://localhost:5678",
+            api_key="key",
+            all=True,
+            enable_list_workflows=False,
+            enable_get_workflow=False,
+        )
+
+        assert len(tools.functions) == 7
+        assert len(tools.async_functions) == 7
+
+    def test_no_flags_registers_nothing(self):
+        tools = N8nTools(
+            base_url="http://localhost:5678",
+            api_key="key",
+            enable_list_workflows=False,
+            enable_get_workflow=False,
+            enable_activate_workflow=False,
+            enable_deactivate_workflow=False,
+            enable_list_executions=False,
+            enable_get_execution=False,
+            enable_delete_execution=False,
+        )
+
+        assert len(tools.functions) == 0
+        assert len(tools.async_functions) == 0
+
+    def test_async_tools_registered_with_sync_names(self):
+        tools = N8nTools(base_url="http://localhost:5678", api_key="key")
+
+        assert "list_workflows" in tools.async_functions
+        assert "alist_workflows" not in tools.async_functions
+
+    # ---- Helper tests ----
+
+    def test_build_url(self, n8n_tools):
+        assert n8n_tools._build_url("/workflows") == "http://n8n.local:5678/api/v1/workflows"
+        assert n8n_tools._build_url("/workflows/abc") == "http://n8n.local:5678/api/v1/workflows/abc"
+        assert n8n_tools._build_url("/executions") == "http://n8n.local:5678/api/v1/executions"
+
+    def test_build_headers_with_key(self, n8n_tools):
+        headers = n8n_tools._build_headers()
+
+        assert headers["X-N8N-API-KEY"] == "test-key"
+        assert headers["Accept"] == "application/json"
+
+    def test_build_headers_without_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            tools = N8nTools(base_url="http://localhost:5678", api_key=None)
+
+        headers = tools._build_headers()
+        assert "X-N8N-API-KEY" not in headers
+        assert headers["Accept"] == "application/json"
+
+    def test_json_error(self, n8n_tools):
+        result = json.loads(n8n_tools._json_error("something broke"))
+
+        assert result == {"error": "something broke"}
+
+    def test_http_error_message_json_body(self, n8n_tools):
+        response = httpx.Response(
+            status_code=401,
+            json={"message": "unauthorized"},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+
+        assert n8n_tools._http_error_message(response) == "401: unauthorized"
+
+    def test_http_error_message_plain_text(self, n8n_tools):
+        response = httpx.Response(
+            status_code=500,
+            text="Internal Server Error",
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+
+        assert n8n_tools._http_error_message(response) == "500: Internal Server Error"
+
+    # ---- Sync method tests ----
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_list_workflows_success(self, mock_get, n8n_tools):
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            json={"data": [{"id": "wf1", "name": "My WF", "active": True}], "nextCursor": None},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+
+        result = json.loads(n8n_tools.list_workflows())
+
+        assert result["count"] == 1
+        assert result["data"][0]["name"] == "My WF"
+        assert result["nextCursor"] is None
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_list_workflows_active_only(self, mock_get, n8n_tools):
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            json={
+                "data": [
+                    {"id": "wf1", "name": "Active", "active": True},
+                    {"id": "wf2", "name": "Inactive", "active": False},
+                ],
+                "nextCursor": None,
+            },
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+
+        result = json.loads(n8n_tools.list_workflows(active_only=True))
+
+        assert result["count"] == 1
+        assert result["data"][0]["name"] == "Active"
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_list_workflows_with_pagination(self, mock_get, n8n_tools):
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            json={"data": [{"id": "wf1", "name": "WF", "active": True}], "nextCursor": "abc123"},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+
+        result = json.loads(n8n_tools.list_workflows(limit=1, cursor="prev_cursor"))
+
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["params"]["limit"] == 1
+        assert call_kwargs.kwargs["params"]["cursor"] == "prev_cursor"
+        assert result["nextCursor"] == "abc123"
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_get_workflow_success(self, mock_get, n8n_tools):
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            json={"id": "wf1", "name": "My WF", "active": False, "nodes": []},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows/wf1"),
+        )
+
+        result = json.loads(n8n_tools.get_workflow("wf1"))
+
+        assert result["id"] == "wf1"
+        assert result["name"] == "My WF"
+
+    @patch("agno.tools.n8n.httpx.post")
+    def test_activate_workflow_success(self, mock_post, n8n_tools):
+        mock_post.return_value = httpx.Response(
+            status_code=200,
+            json={"id": "wf1", "active": True},
+            request=httpx.Request("POST", "http://n8n.local:5678/api/v1/workflows/wf1/activate"),
+        )
+
+        result = json.loads(n8n_tools.activate_workflow("wf1"))
+
+        assert result["active"] is True
+
+    @patch("agno.tools.n8n.httpx.post")
+    def test_deactivate_workflow_success(self, mock_post, n8n_tools):
+        mock_post.return_value = httpx.Response(
+            status_code=200,
+            json={"id": "wf1", "active": False},
+            request=httpx.Request("POST", "http://n8n.local:5678/api/v1/workflows/wf1/deactivate"),
+        )
+
+        result = json.loads(n8n_tools.deactivate_workflow("wf1"))
+
+        assert result["active"] is False
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_list_executions_success(self, mock_get, n8n_tools):
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            json={
+                "data": [{"id": "1", "workflowId": "wf1", "status": "success", "finished": True}],
+                "nextCursor": None,
+            },
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/executions"),
+        )
+
+        result = json.loads(n8n_tools.list_executions(workflow_id="wf1", limit=5))
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["params"]["workflowId"] == "wf1"
+        assert call_kwargs.kwargs["params"]["limit"] == 5
+        assert result["count"] == 1
+        assert result["data"][0]["status"] == "success"
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_get_execution_success(self, mock_get, n8n_tools):
+        mock_get.return_value = httpx.Response(
+            status_code=200,
+            json={"id": "42", "workflowId": "wf1", "status": "success"},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/executions/42"),
+        )
+
+        result = json.loads(n8n_tools.get_execution("42"))
+
+        assert result["id"] == "42"
+        assert result["status"] == "success"
+
+    @patch("agno.tools.n8n.httpx.delete")
+    def test_delete_execution_success(self, mock_delete, n8n_tools):
+        mock_delete.return_value = httpx.Response(
+            status_code=200,
+            request=httpx.Request("DELETE", "http://n8n.local:5678/api/v1/executions/42"),
+        )
+
+        result = json.loads(n8n_tools.delete_execution("42"))
+
+        assert result["status"] == "deleted"
+        assert result["execution_id"] == "42"
+
+    # ---- Error handling tests ----
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_list_workflows_http_error(self, mock_get, n8n_tools):
+        response = httpx.Response(
+            status_code=401,
+            json={"message": "unauthorized"},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+        mock_get.return_value = response
+        mock_get.return_value.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("401", request=response.request, response=response)
+        )
+
+        result = json.loads(n8n_tools.list_workflows())
+
+        assert "error" in result
+        assert "401" in result["error"]
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_list_workflows_connection_error(self, mock_get, n8n_tools):
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+        result = json.loads(n8n_tools.list_workflows())
+
+        assert "error" in result
+        assert "Connection refused" in result["error"]
+
+    @patch("agno.tools.n8n.httpx.get")
+    def test_get_workflow_not_found(self, mock_get, n8n_tools):
+        response = httpx.Response(
+            status_code=404,
+            json={"message": "Not Found"},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows/bad-id"),
+        )
+        mock_get.return_value = response
+        mock_get.return_value.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("404", request=response.request, response=response)
+        )
+
+        result = json.loads(n8n_tools.get_workflow("bad-id"))
+
+        assert "error" in result
+        assert "404" in result["error"]
+
+    # ---- Async method tests ----
+
+    @pytest.mark.asyncio
+    async def test_alist_workflows_success(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="key")
+        mock_response = httpx.Response(
+            status_code=200,
+            json={"data": [{"id": "wf1", "name": "Async WF", "active": True}], "nextCursor": None},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("agno.tools.n8n.httpx.AsyncClient", return_value=mock_client):
+            result = json.loads(await tools.alist_workflows())
+
+        assert result["count"] == 1
+        assert result["data"][0]["name"] == "Async WF"
+
+    @pytest.mark.asyncio
+    async def test_alist_workflows_active_only(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="key")
+        mock_response = httpx.Response(
+            status_code=200,
+            json={
+                "data": [
+                    {"id": "wf1", "name": "Active", "active": True},
+                    {"id": "wf2", "name": "Inactive", "active": False},
+                ],
+                "nextCursor": None,
+            },
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("agno.tools.n8n.httpx.AsyncClient", return_value=mock_client):
+            result = json.loads(await tools.alist_workflows(active_only=True))
+
+        assert result["count"] == 1
+        assert result["data"][0]["name"] == "Active"
+
+    @pytest.mark.asyncio
+    async def test_aactivate_workflow_success(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="key")
+        mock_response = httpx.Response(
+            status_code=200,
+            json={"id": "wf1", "active": True},
+            request=httpx.Request("POST", "http://n8n.local:5678/api/v1/workflows/wf1/activate"),
+        )
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch("agno.tools.n8n.httpx.AsyncClient", return_value=mock_client):
+            result = json.loads(await tools.aactivate_workflow("wf1"))
+
+        assert result["active"] is True
+
+    @pytest.mark.asyncio
+    async def test_adelete_execution_success(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="key")
+        mock_response = httpx.Response(
+            status_code=200,
+            request=httpx.Request("DELETE", "http://n8n.local:5678/api/v1/executions/99"),
+        )
+        mock_client = MagicMock()
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch("agno.tools.n8n.httpx.AsyncClient", return_value=mock_client):
+            result = json.loads(await tools.adelete_execution("99"))
+
+        assert result["status"] == "deleted"
+        assert result["execution_id"] == "99"
+
+    @pytest.mark.asyncio
+    async def test_alist_workflows_http_error(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="bad-key")
+        response = httpx.Response(
+            status_code=401,
+            json={"message": "unauthorized"},
+            request=httpx.Request("GET", "http://n8n.local:5678/api/v1/workflows"),
+        )
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=response)
+        mock_client.get.return_value.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("401", request=response.request, response=response)
+        )
+
+        with patch("agno.tools.n8n.httpx.AsyncClient", return_value=mock_client):
+            result = json.loads(await tools.alist_workflows())
+
+        assert "error" in result
+        assert "401" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_alist_workflows_connection_error(self):
+        tools = N8nTools(base_url="http://localhost:9999", api_key="key")
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+
+        with patch("agno.tools.n8n.httpx.AsyncClient", return_value=mock_client):
+            result = json.loads(await tools.alist_workflows())
+
+        assert "error" in result
+        assert "Connection refused" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_aclose_clears_client(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="key")
+        mock_client = AsyncMock()
+        tools._async_client = mock_client
+
+        await tools.aclose()
+
+        mock_client.aclose.assert_awaited_once()
+        assert tools._async_client is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_noop_when_no_client(self):
+        tools = N8nTools(base_url="http://n8n.local:5678", api_key="key")
+        assert tools._async_client is None
+
+        await tools.aclose()
+
+        assert tools._async_client is None


### PR DESCRIPTION
## Summary

Adds `N8nTools` — a toolkit for interacting with self-hosted n8n workflow
automation instances via the n8n REST API v1.

Closes #7338

### What was added

- **`libs/agno/agno/tools/n8n.py`** — `N8nTools` class with 7 sync + 7 async methods:
  - `list_workflows` / `alist_workflows` (with `active_only` filter, `limit`/`cursor` pagination)
  - `get_workflow` / `aget_workflow`
  - `activate_workflow` / `aactivate_workflow`
  - `deactivate_workflow` / `adeactivate_workflow`
  - `list_executions` / `alist_executions` (with `workflow_id` filter, `limit`/`cursor` pagination)
  - `get_execution` / `aget_execution`
  - `delete_execution` / `adelete_execution`
- **`libs/agno/pyproject.toml`** — `n8n` optional extra added + entry in `tools` list
- **`cookbook/91_tools/n8n_tools.py`** — cookbook example showing an agent monitoring n8n workflows

### Pattern followed

Built following the same patterns as:
- `GitlabTools` — REST API + async httpx + flag-based registration + async_tools tuples
- `SerpApiTools` — API key handling via `getenv()` + `all` flag

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Testing

- Tested locally against n8n (Docker, latest version) with full API key scopes
- All 7 sync + 7 async methods verified against live n8n instance
- Edge cases tested: invalid API key (401), offline server (connection error), non-existent IDs (404)
- Pagination verified with `limit`/`cursor` across multiple pages
- `all` flag verified to override individual `enable_*` flags
- All responses are JSON strings, no exceptions thrown to caller
- `./scripts/format.sh` — 0 errors
- `./scripts/validate.sh` (ruff check) — 0 errors

## Additional Notes

- `httpx` is already a core dependency of agno, so no additional package installation is needed
- The n8n REST API v1 uses cursor-based pagination; both `list_workflows` and `list_executions` expose `limit` and `cursor` parameters and return `nextCursor` in the response
- This PR was generated with assistance from Claude Code