### PR TITLE
feat: add Socket Mode support to the Slack interface

### DIFF
--- a/cookbook/05_agent_os/interfaces/slack/socket_mode.py
+++ b/cookbook/05_agent_os/interfaces/slack/socket_mode.py
@@ -1,0 +1,65 @@
+"""
+Slack Socket Mode Agent
+=======================
+
+Runs a Slack bot using Socket Mode instead of the default HTTP webhook transport.
+Socket Mode connects outbound to Slack over a WebSocket, so no public URL or
+reverse proxy is needed.  This is ideal for local development and internal
+deployments behind a firewall.
+
+Key differences from the HTTP mode (basic.py):
+  - ``socket_mode=True`` — enables the WebSocket transport
+  - ``app_token`` — App-Level Token (``xapp-...``) for the WebSocket handshake
+  - ``slack.start()`` — blocks until stopped (no FastAPI / uvicorn needed)
+
+Setup:
+  1. In your Slack app settings, go to Settings → Socket Mode and enable it.
+  2. Generate an App-Level Token with the ``connections:write`` scope and copy it.
+  3. Set environment variables::
+
+       export SLACK_TOKEN=xoxb-...
+       export SLACK_APP_TOKEN=xapp-...
+
+  4. Run the script::
+
+       .venvs/demo/bin/python cookbook/05_agent_os/interfaces/slack/socket_mode.py
+
+Slack scopes: app_mentions:read, assistant:write, chat:write, im:history
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os.interfaces.slack import Slack
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+agent_db = SqliteDb(session_table="agent_sessions", db_file="tmp/persistent_memory.db")
+
+agent = Agent(
+    name="Socket Mode Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=agent_db,
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    instructions="You are a helpful assistant running in a Slack workspace.",
+)
+
+slack = Slack(
+    agent=agent,
+    reply_to_mentions_only=True,
+    socket_mode=True,
+    # app_token can be passed here or read from SLACK_APP_TOKEN env var
+    # app_token="xapp-...",
+)
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Blocks until stopped (Ctrl-C). No web server required.
+    slack.start()

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -685,6 +685,12 @@ class AgentOS:
             if self.enable_mcp_server and self._mcp_app:
                 lifespans.append(self._mcp_app.lifespan)
 
+            # Interface lifespans (e.g. Slack Socket Mode)
+            for interface in self.interfaces:
+                iface_lifespan = interface.get_lifespan()
+                if iface_lifespan is not None:
+                    lifespans.append(iface_lifespan)
+
             # The async database lifespan
             lifespans.append(partial(db_lifespan, agent_os=self))
 
@@ -716,6 +722,12 @@ class AgentOS:
 
                 self._mcp_app = get_mcp_server(self)
                 lifespans.append(self._mcp_app.lifespan)
+
+            # Interface lifespans (e.g. Slack Socket Mode)
+            for interface in self.interfaces:
+                iface_lifespan = interface.get_lifespan()
+                if iface_lifespan is not None:
+                    lifespans.append(iface_lifespan)
 
             # Async database initialization lifespan
             lifespans.append(partial(db_lifespan, agent_os=self))  # type: ignore

--- a/libs/agno/agno/os/interfaces/base.py
+++ b/libs/agno/agno/os/interfaces/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from fastapi import APIRouter
 
@@ -23,3 +23,13 @@ class BaseInterface(ABC):
     @abstractmethod
     def get_router(self, use_async: bool = True, **kwargs) -> APIRouter:
         pass
+
+    def get_lifespan(self) -> Optional[Any]:
+        """Return an optional asynccontextmanager lifespan for this interface.
+
+        Interfaces that need startup/shutdown behaviour (e.g. Slack Socket Mode)
+        can override this method.  AgentOS will include the returned lifespan in
+        its combined app lifespan so the interface starts and stops alongside the
+        FastAPI application.
+        """
+        return None

--- a/libs/agno/agno/os/interfaces/slack/_processing.py
+++ b/libs/agno/agno/os/interfaces/slack/_processing.py
@@ -1,0 +1,450 @@
+"""Shared event processing logic for both HTTP and Socket Mode Slack interfaces."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from ssl import SSLContext
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.slack.events import process_event
+from agno.os.interfaces.slack.helpers import (
+    build_run_metadata,
+    download_event_files_async,
+    extract_event_context,
+    resolve_channel_name,
+    resolve_slack_user,
+    send_slack_message_async,
+    should_respond,
+    strip_bot_mention,
+    upload_response_media_async,
+)
+from agno.os.interfaces.slack.state import StreamState
+from agno.team import RemoteTeam, Team
+from agno.tools.slack import SlackTools
+from agno.utils.log import log_error
+from agno.workflow import RemoteWorkflow, Workflow
+
+# Slack sends lifecycle events for bots with these subtypes. Without this
+# filter the router would try to process its own messages, causing infinite loops.
+IGNORED_SUBTYPES = frozenset(
+    {
+        "bot_message",
+        "bot_add",
+        "bot_remove",
+        "bot_enable",
+        "bot_disable",
+        "message_changed",
+        "message_deleted",
+    }
+)
+
+_ERROR_MESSAGE = "Sorry, there was an error processing your message."
+
+# Slack caps streamed messages at ~40K total payload (text + task card blocks)
+_STREAM_CHAR_LIMIT = 39000
+_STREAM_CARD_LIMIT = 45
+
+
+@dataclass
+class ProcessingConfig:
+    """Holds all configuration needed by the event processing functions."""
+
+    entity: Any
+    entity_type: Literal["agent", "team", "workflow"]
+    entity_name: str
+    entity_id: str
+    slack_tools: SlackTools
+    ssl: Optional[SSLContext]
+    loading_text: str
+    loading_messages: Optional[List[str]]
+    resolve_user_identity: bool
+    reply_to_mentions_only: bool
+    streaming: bool
+    suggested_prompts: Optional[List[Dict[str, str]]]
+    buffer_size: int
+    task_display_mode: str
+
+
+def build_processing_config(
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
+    reply_to_mentions_only: bool = True,
+    token: Optional[str] = None,
+    streaming: bool = True,
+    loading_messages: Optional[List[str]] = None,
+    task_display_mode: str = "plan",
+    loading_text: str = "Thinking...",
+    suggested_prompts: Optional[List[Dict[str, str]]] = None,
+    ssl: Optional[SSLContext] = None,
+    buffer_size: int = 100,
+    max_file_size: int = 1_073_741_824,
+    resolve_user_identity: bool = False,
+) -> ProcessingConfig:
+    entity = agent or team or workflow
+    entity_type: Literal["agent", "team", "workflow"] = "agent" if agent else "team" if team else "workflow"
+    raw_name = getattr(entity, "name", None)
+    entity_name = raw_name if isinstance(raw_name, str) else entity_type
+    entity_id = getattr(entity, "id", None) or entity_name
+    slack_tools = SlackTools(token=token, ssl=ssl, max_file_size=max_file_size)
+    return ProcessingConfig(
+        entity=entity,
+        entity_type=entity_type,
+        entity_name=entity_name,
+        entity_id=entity_id,
+        slack_tools=slack_tools,
+        ssl=ssl,
+        loading_text=loading_text,
+        loading_messages=loading_messages,
+        resolve_user_identity=resolve_user_identity,
+        reply_to_mentions_only=reply_to_mentions_only,
+        streaming=streaming,
+        suggested_prompts=suggested_prompts,
+        buffer_size=buffer_size,
+        task_display_mode=task_display_mode,
+    )
+
+
+async def process_slack_event(data: dict, config: ProcessingConfig) -> None:
+    """Non-streaming path: run the agent and send the full response as a message."""
+    event = data["event"]
+    if not should_respond(event, config.reply_to_mentions_only):
+        return
+
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    ctx = extract_event_context(event)
+
+    # Strip the bot's own @mention from the message text
+    bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
+    ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id)
+
+    # Namespace with entity_id so threads don't collide across mounted interfaces
+    session_id = f"{config.entity_id}:{ctx['thread_id']}"
+    async_client = AsyncWebClient(token=config.slack_tools.token, ssl=config.ssl)
+
+    try:
+        await async_client.assistant_threads_setStatus(
+            channel_id=ctx["channel_id"],
+            thread_ts=ctx["thread_id"],
+            status=config.loading_text,
+        )
+    except Exception:
+        pass
+
+    try:
+        # Resolve Slack user ID to email + display name when opted in
+        resolved_user_id = ctx["user"]
+        display_name = None
+        if config.resolve_user_identity:
+            resolved_user_id, display_name = await resolve_slack_user(async_client, ctx["user"])
+
+        channel_name = await resolve_channel_name(async_client, ctx["channel_id"])
+
+        files, images, videos, audio, skipped = await download_event_files_async(
+            config.slack_tools.token, event, config.slack_tools.max_file_size
+        )
+
+        message_text = ctx["message_text"]
+        if skipped:
+            notice = "[Skipped files: " + ", ".join(skipped) + "]"
+            message_text = f"{notice}\n{message_text}"
+        run_kwargs: Dict[str, Any] = {
+            "user_id": resolved_user_id,
+            "session_id": session_id,
+            "metadata": build_run_metadata(display_name, resolved_user_id, ctx),
+            "dependencies": {
+                "Slack channel": f"#{channel_name}" if channel_name else ctx["channel_id"],
+                "Slack channel_id": ctx["channel_id"],
+                "Slack thread_ts": ctx["thread_id"],
+            },
+            "add_dependencies_to_context": True,
+            "files": files or None,
+            "images": images or None,
+            "videos": videos or None,
+            "audio": audio or None,
+        }
+
+        response = await config.entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
+
+        if response:
+            if response.status == "ERROR":
+                log_error(f"Error processing message: {response.content}")
+                await send_slack_message_async(
+                    async_client,
+                    channel=ctx["channel_id"],
+                    message=f"{_ERROR_MESSAGE} Please try again later.",
+                    thread_ts=ctx["thread_id"],
+                )
+                return
+
+            if hasattr(response, "reasoning_content") and response.reasoning_content:
+                rc = str(response.reasoning_content)
+                formatted = "*Reasoning:*\n> " + rc.replace("\n", "\n> ")
+                await send_slack_message_async(
+                    async_client,
+                    channel=ctx["channel_id"],
+                    message=formatted,
+                    thread_ts=ctx["thread_id"],
+                )
+
+            content = str(response.content) if response.content else ""
+            await send_slack_message_async(
+                async_client,
+                channel=ctx["channel_id"],
+                message=content,
+                thread_ts=ctx["thread_id"],
+            )
+            await upload_response_media_async(async_client, response, ctx["channel_id"], ctx["thread_id"])
+    except Exception as e:
+        log_error(f"Error processing slack event: {e}")
+        await send_slack_message_async(
+            async_client,
+            channel=ctx["channel_id"],
+            message=_ERROR_MESSAGE,
+            thread_ts=ctx["thread_id"],
+        )
+    finally:
+        # Clear "Thinking..." status. In streaming mode stream.stop() handles
+        # this automatically, but the non-streaming path must clear explicitly.
+        try:
+            await async_client.assistant_threads_setStatus(
+                channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
+            )
+        except Exception:
+            pass
+
+
+async def stream_slack_response(data: dict, config: ProcessingConfig) -> None:
+    """Streaming path: open a Slack chat_stream and deliver tokens in real time."""
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    event = data["event"]
+    if not should_respond(event, config.reply_to_mentions_only):
+        return
+
+    ctx = extract_event_context(event)
+
+    # Strip the bot's own @mention from the message text
+    bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
+    ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id)
+
+    session_id = f"{config.entity_id}:{ctx['thread_id']}"
+
+    # Not consistently placed across Slack event envelope shapes
+    team_id = data.get("team_id") or event.get("team")
+    # CRITICAL: recipient_user_id must be the HUMAN user, not the bot.
+    # event["user"] = human who sent the message. data["authorizations"][0]["user_id"]
+    # = the bot's own user ID. Using the bot ID causes Slack to stream content
+    # to an invisible recipient, resulting in a blank bubble until stopStream.
+    user_id = ctx["user"]
+
+    async_client = AsyncWebClient(token=config.slack_tools.token, ssl=config.ssl)
+    state = StreamState(entity_type=config.entity_type, entity_name=config.entity_name)
+    stream = None
+
+    try:
+        try:
+            status_kwargs: Dict[str, Any] = {
+                "channel_id": ctx["channel_id"],
+                "thread_ts": ctx["thread_id"],
+                "status": config.loading_text,
+            }
+            if config.loading_messages:
+                status_kwargs["loading_messages"] = config.loading_messages
+            await async_client.assistant_threads_setStatus(**status_kwargs)
+        except Exception:
+            pass
+
+        # Resolve Slack user ID to email + display name when opted in
+        resolved_user_id = ctx["user"]
+        display_name = None
+        if config.resolve_user_identity:
+            resolved_user_id, display_name = await resolve_slack_user(async_client, ctx["user"])
+
+        channel_name = await resolve_channel_name(async_client, ctx["channel_id"])
+
+        files, images, videos, audio, skipped = await download_event_files_async(
+            config.slack_tools.token, event, config.slack_tools.max_file_size
+        )
+
+        message_text = ctx["message_text"]
+        if skipped:
+            notice = "[Skipped files: " + ", ".join(skipped) + "]"
+            message_text = f"{notice}\n{message_text}"
+        run_kwargs: Dict[str, Any] = {
+            "stream": True,
+            # Enables event-level chunks for task card and tool lifecycle rendering
+            "stream_events": True,
+            "user_id": resolved_user_id,
+            "session_id": session_id,
+            "metadata": build_run_metadata(display_name, resolved_user_id, ctx),
+            "dependencies": {
+                "Slack channel": f"#{channel_name}" if channel_name else ctx["channel_id"],
+                "Slack channel_id": ctx["channel_id"],
+                "Slack thread_ts": ctx["thread_id"],
+            },
+            "add_dependencies_to_context": True,
+            "files": files or None,
+            "images": images or None,
+            "videos": videos or None,
+            "audio": audio or None,
+        }
+
+        response_stream = config.entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
+
+        if response_stream is None:
+            try:
+                await async_client.assistant_threads_setStatus(
+                    channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
+                )
+            except Exception:
+                pass
+            return
+
+        # Deferred so "Thinking..." indicator stays visible during file
+        # download and agent startup (opening earlier shows a blank bubble)
+        stream = await async_client.chat_stream(
+            channel=ctx["channel_id"],
+            thread_ts=ctx["thread_id"],
+            recipient_team_id=team_id,
+            recipient_user_id=user_id,
+            task_display_mode=config.task_display_mode,
+            buffer_size=config.buffer_size,
+        )
+
+        async def _rotate_stream(pending_text: str = "") -> None:
+            """Close current stream and open a new one, carrying over in-progress cards."""
+            nonlocal stream
+            assert stream is not None  # Caller only invokes after stream is opened
+            in_progress = [(k, v.title) for k, v in state.task_cards.items() if v.status == "in_progress"]
+            rotate_stop: Dict[str, Any] = {}
+            if state.task_cards:
+                rotate_stop["chunks"] = state.resolve_all_pending("complete")
+            await stream.stop(**rotate_stop)
+            new_stream = await async_client.chat_stream(
+                channel=ctx["channel_id"],
+                thread_ts=ctx["thread_id"],
+                recipient_team_id=team_id,
+                recipient_user_id=user_id,
+                task_display_mode=config.task_display_mode,
+                buffer_size=config.buffer_size,
+            )
+            # Only mutate state after both async ops succeed
+            state.task_cards.clear()
+            state.stream_chars_sent = 0
+            stream = new_stream
+            # Re-open in-progress cards so the user sees continuity
+            for key, card_title in in_progress:
+                state.track_task(key, card_title)
+                await stream.append(
+                    markdown_text="",
+                    chunks=[{"type": "task_update", "id": key, "title": card_title, "status": "in_progress"}],
+                )
+            if pending_text:
+                continued = "_(continued)_\n" + pending_text
+                await stream.append(markdown_text=continued)
+                state.stream_chars_sent = len(continued)
+
+        async for chunk in response_stream:
+            state.collect_media(chunk)
+
+            ev = getattr(chunk, "event", None)
+            if ev:
+                if await process_event(ev, chunk, state, stream):
+                    break
+
+            # Card overflow: rotate before Slack rejects the payload
+            if len(state.task_cards) >= _STREAM_CARD_LIMIT:
+                await _rotate_stream(state.flush() if state.has_content() else "")
+
+            if state.has_content():
+                if not state.title_set:
+                    state.title_set = True
+                    title = ctx["message_text"][:50].strip() or "New conversation"
+                    try:
+                        await async_client.assistant_threads_setTitle(
+                            channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], title=title
+                        )
+                    except Exception:
+                        pass
+
+                content = state.flush()
+                content_len = len(content)
+                if state.stream_chars_sent + content_len <= _STREAM_CHAR_LIMIT:
+                    await stream.append(markdown_text=content)
+                    state.stream_chars_sent += content_len
+                else:
+                    await _rotate_stream(content)
+
+        # Default to complete when no terminal error/cancel event arrived
+        final_status: Literal["in_progress", "complete", "error"] = state.terminal_status or "complete"
+        completion_chunks = state.resolve_all_pending(final_status) if state.task_cards else []
+        stop_kwargs: Dict[str, Any] = {}
+        if state.has_content():
+            stop_kwargs["markdown_text"] = state.flush()
+        if completion_chunks:
+            stop_kwargs["chunks"] = completion_chunks
+        await stream.stop(**stop_kwargs)
+
+        await upload_response_media_async(async_client, state, ctx["channel_id"], ctx["thread_id"])
+
+    except Exception as e:
+        # Check structured response first (cheap); fall back to str(e) only if needed
+        slack_resp = getattr(e, "response", None)
+        slack_body = slack_resp.data if slack_resp else None
+        slack_error = slack_body.get("error", "") if isinstance(slack_body, dict) else ""
+        is_msg_too_long = "msg_too_long" in slack_error or "msg_blocks_too_long" in slack_error
+        if not is_msg_too_long:
+            is_msg_too_long = "msg_too_long" in str(e)
+        if not is_msg_too_long:
+            log_error(
+                f"Error streaming slack response: {e} [channel={ctx['channel_id']}, thread={ctx['thread_id']}, user={user_id}]"
+            )
+        try:
+            await async_client.assistant_threads_setStatus(
+                channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
+            )
+        except Exception:
+            pass
+        # Clean up open stream so Slack doesn't show stuck progress indicators
+        if stream is not None:
+            try:
+                stop_kwargs_err: Dict[str, Any] = {}
+                if state.task_cards:
+                    stop_kwargs_err["chunks"] = state.resolve_all_pending(
+                        "complete" if is_msg_too_long else "error"
+                    )
+                await stream.stop(**stop_kwargs_err)
+            except Exception:
+                pass
+        if not is_msg_too_long:
+            await send_slack_message_async(
+                async_client,
+                channel=ctx["channel_id"],
+                message=_ERROR_MESSAGE,
+                thread_ts=ctx["thread_id"],
+            )
+
+
+async def handle_thread_started(event: dict, config: ProcessingConfig) -> None:
+    """Handle assistant_thread_started: set suggested prompts for the new thread."""
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    async_client = AsyncWebClient(token=config.slack_tools.token, ssl=config.ssl)
+    thread_info = event.get("assistant_thread", {})
+    channel_id = thread_info.get("channel_id", "")
+    thread_ts = thread_info.get("thread_ts", "")
+    if not channel_id or not thread_ts:
+        return
+
+    prompts = config.suggested_prompts or [
+        {"title": "Help", "message": "What can you help me with?"},
+        {"title": "Search", "message": "Search the web for..."},
+    ]
+    try:
+        await async_client.assistant_threads_setSuggestedPrompts(
+            channel_id=channel_id, thread_ts=thread_ts, prompts=prompts
+        )
+    except Exception as e:
+        log_error(f"Failed to set suggested prompts: {e}")

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -1,51 +1,22 @@
 from __future__ import annotations
 
 from ssl import SSLContext
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from agno.agent import Agent, RemoteAgent
-from agno.os.interfaces.slack.events import process_event
-from agno.os.interfaces.slack.helpers import (
-    build_run_metadata,
-    download_event_files_async,
-    extract_event_context,
-    resolve_channel_name,
-    resolve_slack_user,
-    send_slack_message_async,
-    should_respond,
-    strip_bot_mention,
-    upload_response_media_async,
+from agno.os.interfaces.slack._processing import (
+    IGNORED_SUBTYPES,
+    build_processing_config,
+    handle_thread_started,
+    process_slack_event,
+    stream_slack_response,
 )
 from agno.os.interfaces.slack.security import verify_slack_signature
-from agno.os.interfaces.slack.state import StreamState
 from agno.team import RemoteTeam, Team
-from agno.tools.slack import SlackTools
-from agno.utils.log import log_error
 from agno.workflow import RemoteWorkflow, Workflow
-
-# Slack sends lifecycle events for bots with these subtypes. Without this
-# filter the router would try to process its own messages, causing infinite loops.
-_IGNORED_SUBTYPES = frozenset(
-    {
-        "bot_message",
-        "bot_add",
-        "bot_remove",
-        "bot_enable",
-        "bot_disable",
-        "message_changed",
-        "message_deleted",
-    }
-)
-
-# User-facing error message for failed requests
-_ERROR_MESSAGE = "Sorry, there was an error processing your message."
-
-# Slack caps streamed messages at ~40K total payload (text + task card blocks)
-_STREAM_CHAR_LIMIT = 39000
-_STREAM_CARD_LIMIT = 45
 
 
 class SlackEventResponse(BaseModel):
@@ -74,19 +45,26 @@ def attach_routes(
     max_file_size: int = 1_073_741_824,  # 1GB
     resolve_user_identity: bool = False,
 ) -> APIRouter:
-    # Inner functions capture config via closure to keep each instance isolated
-    entity = agent or team or workflow
-    # entity_type drives event dispatch (agent vs team vs workflow events)
-    entity_type: Literal["agent", "team", "workflow"] = "agent" if agent else "team" if team else "workflow"
-    raw_name = getattr(entity, "name", None)
-    # entity_name labels task cards; entity_id namespaces session IDs
-    entity_name = raw_name if isinstance(raw_name, str) else entity_type
+    config = build_processing_config(
+        agent=agent,
+        team=team,
+        workflow=workflow,
+        reply_to_mentions_only=reply_to_mentions_only,
+        token=token,
+        streaming=streaming,
+        loading_messages=loading_messages,
+        task_display_mode=task_display_mode,
+        loading_text=loading_text,
+        suggested_prompts=suggested_prompts,
+        ssl=ssl,
+        buffer_size=buffer_size,
+        max_file_size=max_file_size,
+        resolve_user_identity=resolve_user_identity,
+    )
+
     # Multiple Slack instances can be mounted on one FastAPI app (e.g. /research
     # and /analyst). op_suffix makes each operation_id unique to avoid collisions.
-    op_suffix = entity_name.lower().replace(" ", "_")
-    entity_id = getattr(entity, "id", None) or entity_name
-
-    slack_tools = SlackTools(token=token, ssl=ssl, max_file_size=max_file_size)
+    op_suffix = config.entity_name.lower().replace(" ", "_")
 
     @router.post(
         "/events",
@@ -131,359 +109,21 @@ def attach_routes(
             event_type = event.get("type")
             # setSuggestedPrompts requires "Agents & AI Apps" mode (streaming UX only)
             if event_type == "assistant_thread_started" and streaming:
-                background_tasks.add_task(_handle_thread_started, event)
+                background_tasks.add_task(handle_thread_started, event, config)
             # Bot self-loop prevention: check bot_id at both the top-level event
             # and inside message_changed's nested "message" object. Without the
             # nested check, edited bot messages would be reprocessed as new events.
             elif (
                 event.get("bot_id")
                 or (event.get("message") or {}).get("bot_id")
-                or event.get("subtype") in _IGNORED_SUBTYPES
+                or event.get("subtype") in IGNORED_SUBTYPES
             ):
                 pass
             elif streaming:
-                background_tasks.add_task(_stream_slack_response, data)
+                background_tasks.add_task(stream_slack_response, data, config)
             else:
-                background_tasks.add_task(_process_slack_event, data)
+                background_tasks.add_task(process_slack_event, data, config)
 
         return SlackEventResponse(status="ok")
-
-    async def _process_slack_event(data: dict):
-        event = data["event"]
-        if not should_respond(event, reply_to_mentions_only):
-            return
-
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        ctx = extract_event_context(event)
-
-        # Strip the bot's own @mention from the message text
-        bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
-        ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id)
-
-        # Namespace with entity_id so threads don't collide across mounted interfaces
-        session_id = f"{entity_id}:{ctx['thread_id']}"
-        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
-
-        try:
-            await async_client.assistant_threads_setStatus(
-                channel_id=ctx["channel_id"],
-                thread_ts=ctx["thread_id"],
-                status=loading_text,
-            )
-        except Exception:
-            pass
-
-        try:
-            # Resolve Slack user ID to email + display name when opted in
-            resolved_user_id = ctx["user"]
-            display_name = None
-            if resolve_user_identity:
-                resolved_user_id, display_name = await resolve_slack_user(async_client, ctx["user"])
-
-            channel_name = await resolve_channel_name(async_client, ctx["channel_id"])
-
-            files, images, videos, audio, skipped = await download_event_files_async(
-                slack_tools.token, event, slack_tools.max_file_size
-            )
-
-            message_text = ctx["message_text"]
-            if skipped:
-                notice = "[Skipped files: " + ", ".join(skipped) + "]"
-                message_text = f"{notice}\n{message_text}"
-            run_kwargs: Dict[str, Any] = {
-                "user_id": resolved_user_id,
-                "session_id": session_id,
-                "metadata": build_run_metadata(display_name, resolved_user_id, ctx),
-                "dependencies": {
-                    "Slack channel": f"#{channel_name}" if channel_name else ctx["channel_id"],
-                    "Slack channel_id": ctx["channel_id"],
-                    "Slack thread_ts": ctx["thread_id"],
-                },
-                "add_dependencies_to_context": True,
-                "files": files or None,
-                "images": images or None,
-                "videos": videos or None,
-                "audio": audio or None,
-            }
-
-            response = await entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
-
-            if response:
-                if response.status == "ERROR":
-                    log_error(f"Error processing message: {response.content}")
-                    await send_slack_message_async(
-                        async_client,
-                        channel=ctx["channel_id"],
-                        message=f"{_ERROR_MESSAGE} Please try again later.",
-                        thread_ts=ctx["thread_id"],
-                    )
-                    return
-
-                if hasattr(response, "reasoning_content") and response.reasoning_content:
-                    rc = str(response.reasoning_content)
-                    formatted = "*Reasoning:*\n> " + rc.replace("\n", "\n> ")
-                    await send_slack_message_async(
-                        async_client,
-                        channel=ctx["channel_id"],
-                        message=formatted,
-                        thread_ts=ctx["thread_id"],
-                    )
-
-                content = str(response.content) if response.content else ""
-                await send_slack_message_async(
-                    async_client,
-                    channel=ctx["channel_id"],
-                    message=content,
-                    thread_ts=ctx["thread_id"],
-                )
-                await upload_response_media_async(async_client, response, ctx["channel_id"], ctx["thread_id"])
-        except Exception as e:
-            log_error(f"Error processing slack event: {e}")
-            await send_slack_message_async(
-                async_client,
-                channel=ctx["channel_id"],
-                message=_ERROR_MESSAGE,
-                thread_ts=ctx["thread_id"],
-            )
-        finally:
-            # Clear "Thinking..." status. In streaming mode stream.stop() handles
-            # this automatically, but the non-streaming path must clear explicitly.
-            try:
-                await async_client.assistant_threads_setStatus(
-                    channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
-                )
-            except Exception:
-                pass
-
-    async def _stream_slack_response(data: dict):
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        event = data["event"]
-        if not should_respond(event, reply_to_mentions_only):
-            return
-
-        ctx = extract_event_context(event)
-
-        # Strip the bot's own @mention from the message text
-        bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
-        ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id)
-
-        session_id = f"{entity_id}:{ctx['thread_id']}"
-
-        # Not consistently placed across Slack event envelope shapes
-        team_id = data.get("team_id") or event.get("team")
-        # CRITICAL: recipient_user_id must be the HUMAN user, not the bot.
-        # event["user"] = human who sent the message. data["authorizations"][0]["user_id"]
-        # = the bot's own user ID. Using the bot ID causes Slack to stream content
-        # to an invisible recipient, resulting in a blank bubble until stopStream.
-        user_id = ctx["user"]
-
-        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
-        state = StreamState(entity_type=entity_type, entity_name=entity_name)
-        stream = None
-
-        try:
-            try:
-                status_kwargs: Dict[str, Any] = {
-                    "channel_id": ctx["channel_id"],
-                    "thread_ts": ctx["thread_id"],
-                    "status": loading_text,
-                }
-                if loading_messages:
-                    status_kwargs["loading_messages"] = loading_messages
-                await async_client.assistant_threads_setStatus(**status_kwargs)
-            except Exception:
-                pass
-
-            # Resolve Slack user ID to email + display name when opted in
-            resolved_user_id = ctx["user"]
-            display_name = None
-            if resolve_user_identity:
-                resolved_user_id, display_name = await resolve_slack_user(async_client, ctx["user"])
-
-            channel_name = await resolve_channel_name(async_client, ctx["channel_id"])
-
-            files, images, videos, audio, skipped = await download_event_files_async(
-                slack_tools.token, event, slack_tools.max_file_size
-            )
-
-            message_text = ctx["message_text"]
-            if skipped:
-                notice = "[Skipped files: " + ", ".join(skipped) + "]"
-                message_text = f"{notice}\n{message_text}"
-            run_kwargs: Dict[str, Any] = {
-                "stream": True,
-                # Enables event-level chunks for task card and tool lifecycle rendering
-                "stream_events": True,
-                "user_id": resolved_user_id,
-                "session_id": session_id,
-                "metadata": build_run_metadata(display_name, resolved_user_id, ctx),
-                "dependencies": {
-                    "Slack channel": f"#{channel_name}" if channel_name else ctx["channel_id"],
-                    "Slack channel_id": ctx["channel_id"],
-                    "Slack thread_ts": ctx["thread_id"],
-                },
-                "add_dependencies_to_context": True,
-                "files": files or None,
-                "images": images or None,
-                "videos": videos or None,
-                "audio": audio or None,
-            }
-
-            response_stream = entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
-
-            if response_stream is None:
-                try:
-                    await async_client.assistant_threads_setStatus(
-                        channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
-                    )
-                except Exception:
-                    pass
-                return
-
-            # Deferred so "Thinking..." indicator stays visible during file
-            # download and agent startup (opening earlier shows a blank bubble)
-            stream = await async_client.chat_stream(
-                channel=ctx["channel_id"],
-                thread_ts=ctx["thread_id"],
-                recipient_team_id=team_id,
-                recipient_user_id=user_id,
-                task_display_mode=task_display_mode,
-                buffer_size=buffer_size,
-            )
-
-            async def _rotate_stream(pending_text: str = ""):
-                """Close current stream and open a new one, carrying over in-progress cards."""
-                nonlocal stream
-                assert stream is not None  # Caller only invokes after stream is opened
-                in_progress = [(k, v.title) for k, v in state.task_cards.items() if v.status == "in_progress"]
-                rotate_stop: Dict[str, Any] = {}
-                if state.task_cards:
-                    rotate_stop["chunks"] = state.resolve_all_pending("complete")
-                await stream.stop(**rotate_stop)
-                new_stream = await async_client.chat_stream(
-                    channel=ctx["channel_id"],
-                    thread_ts=ctx["thread_id"],
-                    recipient_team_id=team_id,
-                    recipient_user_id=user_id,
-                    task_display_mode=task_display_mode,
-                    buffer_size=buffer_size,
-                )
-                # Only mutate state after both async ops succeed
-                state.task_cards.clear()
-                state.stream_chars_sent = 0
-                stream = new_stream
-                # Re-open in-progress cards so the user sees continuity
-                for key, card_title in in_progress:
-                    state.track_task(key, card_title)
-                    await stream.append(
-                        markdown_text="",
-                        chunks=[{"type": "task_update", "id": key, "title": card_title, "status": "in_progress"}],
-                    )
-                if pending_text:
-                    continued = "_(continued)_\n" + pending_text
-                    await stream.append(markdown_text=continued)
-                    state.stream_chars_sent = len(continued)
-
-            async for chunk in response_stream:
-                state.collect_media(chunk)
-
-                ev = getattr(chunk, "event", None)
-                if ev:
-                    if await process_event(ev, chunk, state, stream):
-                        break
-
-                # Card overflow: rotate before Slack rejects the payload
-                if len(state.task_cards) >= _STREAM_CARD_LIMIT:
-                    await _rotate_stream(state.flush() if state.has_content() else "")
-
-                if state.has_content():
-                    if not state.title_set:
-                        state.title_set = True
-                        title = ctx["message_text"][:50].strip() or "New conversation"
-                        try:
-                            await async_client.assistant_threads_setTitle(
-                                channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], title=title
-                            )
-                        except Exception:
-                            pass
-
-                    content = state.flush()
-                    content_len = len(content)
-                    if state.stream_chars_sent + content_len <= _STREAM_CHAR_LIMIT:
-                        await stream.append(markdown_text=content)
-                        state.stream_chars_sent += content_len
-                    else:
-                        await _rotate_stream(content)
-            # Default to complete when no terminal error/cancel event arrived
-            final_status: Literal["in_progress", "complete", "error"] = state.terminal_status or "complete"
-            completion_chunks = state.resolve_all_pending(final_status) if state.task_cards else []
-            stop_kwargs: Dict[str, Any] = {}
-            if state.has_content():
-                stop_kwargs["markdown_text"] = state.flush()
-            if completion_chunks:
-                stop_kwargs["chunks"] = completion_chunks
-            await stream.stop(**stop_kwargs)
-
-            await upload_response_media_async(async_client, state, ctx["channel_id"], ctx["thread_id"])
-
-        except Exception as e:
-            # Check structured response first (cheap); fall back to str(e) only if needed
-            slack_resp = getattr(e, "response", None)
-            slack_body = slack_resp.data if slack_resp else None
-            slack_error = slack_body.get("error", "") if isinstance(slack_body, dict) else ""
-            is_msg_too_long = "msg_too_long" in slack_error or "msg_blocks_too_long" in slack_error
-            if not is_msg_too_long:
-                is_msg_too_long = "msg_too_long" in str(e)
-            if not is_msg_too_long:
-                log_error(
-                    f"Error streaming slack response: {e} [channel={ctx['channel_id']}, thread={ctx['thread_id']}, user={user_id}]"
-                )
-            try:
-                await async_client.assistant_threads_setStatus(
-                    channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
-                )
-            except Exception:
-                pass
-            # Clean up open stream so Slack doesn't show stuck progress indicators
-            if stream is not None:
-                try:
-                    stop_kwargs_err: Dict[str, Any] = {}
-                    if state.task_cards:
-                        stop_kwargs_err["chunks"] = state.resolve_all_pending(
-                            "complete" if is_msg_too_long else "error"
-                        )
-                    await stream.stop(**stop_kwargs_err)
-                except Exception:
-                    pass
-            if not is_msg_too_long:
-                await send_slack_message_async(
-                    async_client,
-                    channel=ctx["channel_id"],
-                    message=_ERROR_MESSAGE,
-                    thread_ts=ctx["thread_id"],
-                )
-
-    async def _handle_thread_started(event: dict):
-        from slack_sdk.web.async_client import AsyncWebClient
-
-        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
-        thread_info = event.get("assistant_thread", {})
-        channel_id = thread_info.get("channel_id", "")
-        thread_ts = thread_info.get("thread_ts", "")
-        if not channel_id or not thread_ts:
-            return
-
-        prompts = suggested_prompts or [
-            {"title": "Help", "message": "What can you help me with?"},
-            {"title": "Search", "message": "Search the web for..."},
-        ]
-        try:
-            await async_client.assistant_threads_setSuggestedPrompts(
-                channel_id=channel_id, thread_ts=thread_ts, prompts=prompts
-            )
-        except Exception as e:
-            log_error(f"Failed to set suggested prompts: {e}")
 
     return router

--- a/libs/agno/agno/os/interfaces/slack/slack.py
+++ b/libs/agno/agno/os/interfaces/slack/slack.py
@@ -1,7 +1,8 @@
 import asyncio
 import os
+from contextlib import asynccontextmanager
 from ssl import SSLContext
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi.routing import APIRouter
 
@@ -64,6 +65,13 @@ class Slack(BaseInterface):
             raise ValueError("Slack requires an agent, team, or workflow")
 
     def get_router(self) -> APIRouter:
+        # Socket Mode does not use HTTP routes — events arrive over a WebSocket
+        # that is started via get_lifespan().  Return an empty router so AgentOS
+        # can still call get_router() uniformly without mounting unused endpoints.
+        if self.socket_mode:
+            self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
+            return self.router
+
         self.router = attach_routes(
             router=APIRouter(prefix=self.prefix, tags=self.tags),  # type: ignore
             agent=self.agent,
@@ -85,6 +93,35 @@ class Slack(BaseInterface):
 
         return self.router
 
+    def get_lifespan(self) -> Optional[Any]:
+        """Return a lifespan context manager that runs Socket Mode in the background.
+
+        When this interface is added to an AgentOS app, the app includes this
+        lifespan so the WebSocket connection to Slack starts with the FastAPI
+        server and is cleanly cancelled on shutdown.
+
+        Returns ``None`` when ``socket_mode=False`` so HTTP-mode instances do
+        not affect the app lifespan.
+        """
+        if not self.socket_mode:
+            return None
+
+        slack_interface = self
+
+        @asynccontextmanager
+        async def _socket_mode_lifespan(app: Any):
+            task = asyncio.create_task(slack_interface.astart())
+            try:
+                yield
+            finally:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        return _socket_mode_lifespan
+
     async def astart(self) -> None:
         """Start the Slack bot using Socket Mode.
 
@@ -101,8 +138,7 @@ class Slack(BaseInterface):
         """
         if not self.socket_mode:
             raise RuntimeError(
-                "astart() is only available in Socket Mode. "
-                "Set socket_mode=True when creating the Slack interface."
+                "astart() is only available in Socket Mode. Set socket_mode=True when creating the Slack interface."
             )
 
         app_token = self.app_token or os.environ.get("SLACK_APP_TOKEN")

--- a/libs/agno/agno/os/interfaces/slack/slack.py
+++ b/libs/agno/agno/os/interfaces/slack/slack.py
@@ -1,3 +1,5 @@
+import asyncio
+import os
 from ssl import SSLContext
 from typing import Dict, List, Optional, Union
 
@@ -34,6 +36,9 @@ class Slack(BaseInterface):
         buffer_size: int = 100,
         max_file_size: int = 1_073_741_824,  # 1GB
         resolve_user_identity: bool = False,
+        # Socket Mode
+        socket_mode: bool = False,
+        app_token: Optional[str] = None,
     ):
         self.agent = agent
         self.team = team
@@ -52,6 +57,8 @@ class Slack(BaseInterface):
         self.buffer_size = buffer_size
         self.max_file_size = max_file_size
         self.resolve_user_identity = resolve_user_identity
+        self.socket_mode = socket_mode
+        self.app_token = app_token
 
         if not (self.agent or self.team or self.workflow):
             raise ValueError("Slack requires an agent, team, or workflow")
@@ -77,3 +84,66 @@ class Slack(BaseInterface):
         )
 
         return self.router
+
+    async def astart(self) -> None:
+        """Start the Slack bot using Socket Mode.
+
+        Connects to Slack over a persistent WebSocket so no public HTTP endpoint
+        is required.  Blocks until the connection is closed or the task is
+        cancelled (e.g. via Ctrl-C).
+
+        Requires ``socket_mode=True`` and either ``app_token`` set on this
+        instance or the ``SLACK_APP_TOKEN`` environment variable.
+
+        Raises:
+            RuntimeError: If called without ``socket_mode=True``.
+            ValueError: If no App-Level Token is available.
+        """
+        if not self.socket_mode:
+            raise RuntimeError(
+                "astart() is only available in Socket Mode. "
+                "Set socket_mode=True when creating the Slack interface."
+            )
+
+        app_token = self.app_token or os.environ.get("SLACK_APP_TOKEN")
+        if not app_token:
+            raise ValueError(
+                "Socket Mode requires an App-Level Token. "
+                "Pass app_token='xapp-...' or set the SLACK_APP_TOKEN environment variable."
+            )
+
+        from agno.os.interfaces.slack._processing import build_processing_config
+        from agno.os.interfaces.slack.socket_mode import start_socket_mode
+
+        config = build_processing_config(
+            agent=self.agent,
+            team=self.team,
+            workflow=self.workflow,
+            reply_to_mentions_only=self.reply_to_mentions_only,
+            token=self.token,
+            streaming=self.streaming,
+            loading_messages=self.loading_messages,
+            task_display_mode=self.task_display_mode,
+            loading_text=self.loading_text,
+            suggested_prompts=self.suggested_prompts,
+            ssl=self.ssl,
+            buffer_size=self.buffer_size,
+            max_file_size=self.max_file_size,
+            resolve_user_identity=self.resolve_user_identity,
+        )
+
+        await start_socket_mode(config, app_token)
+
+    def start(self) -> None:
+        """Start the Slack bot using Socket Mode (synchronous wrapper).
+
+        Calls :meth:`astart` inside a new event loop via ``asyncio.run()``.
+        Use this as the entry point in scripts that do not already have a
+        running event loop.
+
+        Example::
+
+            slack = Slack(agent=my_agent, socket_mode=True)
+            slack.start()
+        """
+        asyncio.run(self.astart())

--- a/libs/agno/agno/os/interfaces/slack/socket_mode.py
+++ b/libs/agno/agno/os/interfaces/slack/socket_mode.py
@@ -1,0 +1,116 @@
+"""Socket Mode transport for the Slack interface.
+
+Socket Mode lets the bot receive events without exposing a public HTTP endpoint.
+The app connects outbound to Slack over a WebSocket using an App-Level Token
+(``xapp-...``), so it works behind firewalls and in local development without a
+tunnel.
+
+Usage::
+
+    slack = Slack(agent=my_agent, socket_mode=True, app_token="xapp-...")
+    await slack.astart()          # async — blocks until stopped
+    # or
+    slack.start()                 # sync wrapper around asyncio.run
+
+Required Slack app configuration:
+- Enable Socket Mode in your app settings (Settings → Socket Mode)
+- Generate an App-Level Token with the ``connections:write`` scope
+- Keep the same bot token scopes as HTTP mode
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Dict
+
+from agno.os.interfaces.slack._processing import (
+    IGNORED_SUBTYPES,
+    ProcessingConfig,
+    handle_thread_started,
+    process_slack_event,
+    stream_slack_response,
+)
+from agno.utils.log import log_info
+
+# Optional runtime imports — guarded so this module is importable even when
+# slack-sdk[aiohttp] is not installed. start_socket_mode() raises ImportError
+# with a helpful message when SocketModeClient is None.
+try:
+    from slack_sdk.socket_mode.aiohttp import SocketModeClient
+    from slack_sdk.socket_mode.response import SocketModeResponse
+    from slack_sdk.web.async_client import AsyncWebClient
+except ImportError:
+    SocketModeClient = None  # type: ignore[assignment,misc]
+    SocketModeResponse = None  # type: ignore[assignment,misc]
+    AsyncWebClient = None  # type: ignore[assignment,misc]
+
+
+def _make_handler(config: ProcessingConfig) -> Callable:
+    """Return the Socket Mode event handler closure for the given config.
+
+    Extracted as a module-level factory so it can be tested independently of
+    the WebSocket connection lifecycle.
+    """
+
+    async def _handler(client: Any, req: Any) -> None:
+        # ACK immediately — Slack expects acknowledgment within 3 seconds.
+        # Processing happens in the background so long-running agent calls
+        # never block the acknowledgment.
+        await client.send_socket_mode_response(SocketModeResponse(envelope_id=req.envelope_id))
+
+        if req.type != "events_api":
+            return
+
+        data: Dict[str, Any] = req.payload
+        event = data.get("event", {})
+        event_type = event.get("type")
+
+        # setSuggestedPrompts requires "Agents & AI Apps" mode (streaming UX only)
+        if event_type == "assistant_thread_started" and config.streaming:
+            asyncio.create_task(handle_thread_started(event, config))
+        # Bot self-loop prevention: check bot_id at both the top-level event
+        # and inside message_changed's nested "message" object.
+        elif (
+            event.get("bot_id")
+            or (event.get("message") or {}).get("bot_id")
+            or event.get("subtype") in IGNORED_SUBTYPES
+        ):
+            pass
+        elif config.streaming:
+            asyncio.create_task(stream_slack_response(data, config))
+        else:
+            asyncio.create_task(process_slack_event(data, config))
+
+    return _handler
+
+
+async def start_socket_mode(config: ProcessingConfig, app_token: str) -> None:
+    """Connect to Slack via Socket Mode and process events until cancelled.
+
+    This coroutine blocks indefinitely. Run it with ``asyncio.run()`` or
+    schedule it as a task inside a running event loop.
+
+    Args:
+        config: Shared processing configuration (entity, tokens, options).
+        app_token: Slack App-Level Token (``xapp-...``).  Required for Socket
+            Mode; distinct from the bot token stored in ``config.slack_tools``.
+    """
+    if SocketModeClient is None:
+        raise ImportError(
+            "slack-sdk with aiohttp support is required for Socket Mode. "
+            "Install it with: pip install 'slack-sdk[aiohttp]'"
+        )
+
+    web_client = AsyncWebClient(token=config.slack_tools.token, ssl=config.ssl)
+    socket_client = SocketModeClient(app_token=app_token, web_client=web_client)
+    socket_client.socket_mode_request_listeners.append(_make_handler(config))
+
+    log_info("Connecting to Slack via Socket Mode...")
+    await socket_client.connect()
+    log_info("Slack Socket Mode connected.")
+
+    try:
+        # Block forever; cancelled when the caller shuts down (e.g. Ctrl-C).
+        await asyncio.Future()
+    finally:
+        await socket_client.close()
+        log_info("Slack Socket Mode disconnected.")

--- a/libs/agno/tests/unit/os/routers/conftest.py
+++ b/libs/agno/tests/unit/os/routers/conftest.py
@@ -4,6 +4,11 @@ import json
 import time
 from unittest.mock import AsyncMock, Mock
 
+# Pre-load submodule so mock.patch("slack_sdk.web.async_client.AsyncWebClient", ...)
+# can resolve the dotted path on Python 3.12+ (which uses pkgutil.resolve_name and
+# requires the submodule to already be in sys.modules as an attribute of its parent).
+import slack_sdk.web.async_client  # noqa: F401
+
 import pytest
 from fastapi import APIRouter, FastAPI
 from fastapi.testclient import TestClient

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -35,7 +35,7 @@ async def test_session_id_namespaced_with_entity_id():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
@@ -71,7 +71,7 @@ async def test_user_id_is_raw_slack_id_by_default():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
@@ -105,7 +105,7 @@ async def test_user_id_resolved_to_email_when_opted_in():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False, resolve_user_identity=True)
@@ -139,7 +139,7 @@ async def test_user_name_passed_as_metadata_when_opted_in():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False, resolve_user_identity=True)
@@ -173,7 +173,7 @@ async def test_bot_mention_stripped_from_message():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
@@ -211,7 +211,7 @@ async def test_mixed_files_categorized_correctly():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
         patch("agno.os.interfaces.slack.helpers.httpx.AsyncClient", return_value=mock_httpx),
         patch.dict("os.environ", {"SLACK_TOKEN": "test"}),
@@ -248,7 +248,7 @@ async def test_non_whitelisted_mime_type_passes_none():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
         patch("agno.os.interfaces.slack.helpers.httpx.AsyncClient", return_value=mock_httpx),
         patch.dict("os.environ", {"SLACK_TOKEN": "test"}),
@@ -271,7 +271,7 @@ async def test_non_whitelisted_mime_type_passes_none():
 def test_explicit_token_passed_to_slack_tools():
     agent_mock = make_agent_mock()
     with (
-        patch("agno.os.interfaces.slack.router.SlackTools") as mock_cls,
+        patch("agno.os.interfaces.slack._processing.SlackTools") as mock_cls,
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
     ):
         mock_cls.return_value = make_slack_mock()
@@ -284,7 +284,7 @@ def test_explicit_signing_secret_used():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True) as mock_verify,
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
     ):
         app = build_app(agent_mock, signing_secret="my-secret")
         from fastapi.testclient import TestClient
@@ -311,7 +311,7 @@ def test_operation_id_unique_across_instances():
     agent_b.name = "Analyst Agent"
 
     with (
-        patch("agno.os.interfaces.slack.router.SlackTools"),
+        patch("agno.os.interfaces.slack._processing.SlackTools"),
         patch.dict("os.environ", {"SLACK_TOKEN": "test"}),
     ):
         app = FastAPI()
@@ -332,7 +332,7 @@ def test_bot_subtype_blocked():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
         from fastapi.testclient import TestClient
@@ -361,7 +361,7 @@ async def test_file_share_subtype_not_blocked():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=make_async_client_mock()),
         patch("agno.os.interfaces.slack.helpers.httpx.AsyncClient", return_value=make_httpx_mock(b"file-data")),
     ):
@@ -402,7 +402,7 @@ async def test_thread_reply_blocked_when_mentions_only():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=True)
         from fastapi.testclient import TestClient
@@ -433,7 +433,7 @@ async def test_non_streaming_clears_status_after_response():
     mock_client = make_async_client_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
@@ -466,7 +466,7 @@ def test_retry_header_skips_processing():
     mock_slack = make_slack_mock()
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
     ):
         app = build_app(agent_mock)
         from fastapi.testclient import TestClient
@@ -521,7 +521,7 @@ class TestStreamingHappyPath:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -549,7 +549,7 @@ class TestStreamingHappyPath:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -577,7 +577,7 @@ class TestRecipientUserId:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -612,7 +612,7 @@ class TestStreamingUserIsolation:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False, resolve_user_identity=True)
@@ -651,7 +651,7 @@ class TestStreamingFallbacks:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -689,7 +689,7 @@ class TestStreamingFallbacks:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -721,7 +721,7 @@ class TestStreamingFallbacks:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -765,7 +765,7 @@ class TestErrorResolvesTaskCards:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -795,7 +795,7 @@ class TestStreamingTitle:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -820,7 +820,7 @@ class TestStreamingTitle:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -844,7 +844,7 @@ class TestThreadStarted:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)
@@ -876,7 +876,7 @@ class TestThreadStarted:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False, suggested_prompts=custom)
@@ -906,7 +906,7 @@ class TestThreadStarted:
 
         with (
             patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
             patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
         ):
             app = build_app(agent, streaming=True, reply_to_mentions_only=False)

--- a/libs/agno/tests/unit/os/routers/test_slack_socket_mode.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_socket_mode.py
@@ -1,0 +1,407 @@
+"""
+Unit tests for the Slack Socket Mode transport.
+
+Tests cover:
+- _make_handler: event dispatch, ACK behaviour, bot filtering, subtype filtering
+- start_socket_mode: connection lifecycle (connect / close / import guard)
+- Slack.astart() / Slack.start(): token resolution, error conditions
+"""
+import asyncio
+import os
+from typing import Any
+from unittest.mock import ANY, AsyncMock, Mock, patch
+
+import pytest
+
+from agno.os.interfaces.slack._processing import ProcessingConfig, build_processing_config
+from agno.os.interfaces.slack.socket_mode import _make_handler, start_socket_mode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(streaming: bool = True) -> ProcessingConfig:
+    agent = AsyncMock()
+    agent.name = "Test Agent"
+    agent.id = "test-agent"
+    with patch("agno.os.interfaces.slack._processing.SlackTools"):
+        return build_processing_config(agent=agent, token="xoxb-test", streaming=streaming)
+
+
+def _events_api_req(event: dict, envelope_id: str = "env-001") -> Mock:
+    req = Mock()
+    req.type = "events_api"
+    req.envelope_id = envelope_id
+    req.payload = {"event": event}
+    return req
+
+
+def _msg(**kwargs: Any) -> dict:
+    return {
+        "type": "message",
+        "channel_type": "im",
+        "text": "hello",
+        "user": "U123",
+        "channel": "C123",
+        "ts": "1234567890.000001",
+        **kwargs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# ACK behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSocketModeHandlerAck:
+    """The handler must ACK every request before doing any processing."""
+
+    @pytest.mark.asyncio
+    async def test_acks_events_api_request(self):
+        client = AsyncMock()
+        req = _events_api_req(_msg())
+
+        with patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock):
+            await _make_handler(_make_config())(client, req)
+            await asyncio.sleep(0)
+
+        client.send_socket_mode_response.assert_called_once()
+        response_obj = client.send_socket_mode_response.call_args.args[0]
+        assert response_obj.envelope_id == "env-001"
+
+    @pytest.mark.asyncio
+    async def test_acks_non_events_api_request(self):
+        """Handler ACKs even when it has nothing to dispatch."""
+        client = AsyncMock()
+        req = Mock(type="slash_commands", envelope_id="env-002")
+
+        await _make_handler(_make_config())(client, req)
+
+        client.send_socket_mode_response.assert_called_once()
+        response_obj = client.send_socket_mode_response.call_args.args[0]
+        assert response_obj.envelope_id == "env-002"
+
+    @pytest.mark.asyncio
+    async def test_acks_before_dispatching(self):
+        """ACK must happen even when the downstream handler raises."""
+        client = AsyncMock()
+        req = _events_api_req(_msg())
+
+        with patch(
+            "agno.os.interfaces.slack.socket_mode.stream_slack_response",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            # The task raised but ACK already happened
+            await _make_handler(_make_config())(client, req)
+            await asyncio.sleep(0.05)
+
+        client.send_socket_mode_response.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Event routing
+# ---------------------------------------------------------------------------
+
+
+class TestSocketModeHandlerRouting:
+    """Handler dispatches events to the correct processing function."""
+
+    @pytest.mark.asyncio
+    async def test_message_routes_to_stream_when_streaming(self):
+        client = AsyncMock()
+        req = _events_api_req(_msg())
+
+        with (
+            patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream,
+            patch("agno.os.interfaces.slack.socket_mode.process_slack_event", new_callable=AsyncMock) as mock_process,
+        ):
+            await _make_handler(_make_config(streaming=True))(client, req)
+            await asyncio.sleep(0)
+
+        mock_stream.assert_called_once_with(req.payload, ANY)
+        mock_process.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_message_routes_to_process_when_not_streaming(self):
+        client = AsyncMock()
+        req = _events_api_req(_msg())
+
+        with (
+            patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream,
+            patch("agno.os.interfaces.slack.socket_mode.process_slack_event", new_callable=AsyncMock) as mock_process,
+        ):
+            await _make_handler(_make_config(streaming=False))(client, req)
+            await asyncio.sleep(0)
+
+        mock_process.assert_called_once_with(req.payload, ANY)
+        mock_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_thread_started_routes_to_handle_thread_started(self):
+        client = AsyncMock()
+        event = {"type": "assistant_thread_started", "assistant_thread": {"channel_id": "C1", "thread_ts": "t1"}}
+        req = _events_api_req(event)
+
+        with patch(
+            "agno.os.interfaces.slack.socket_mode.handle_thread_started", new_callable=AsyncMock
+        ) as mock_handle:
+            await _make_handler(_make_config(streaming=True))(client, req)
+            await asyncio.sleep(0)
+
+        mock_handle.assert_called_once_with(event, ANY)
+
+    @pytest.mark.asyncio
+    async def test_thread_started_not_dispatched_when_not_streaming(self):
+        """assistant_thread_started falls through to process_slack_event when streaming=False."""
+        client = AsyncMock()
+        event = {"type": "assistant_thread_started", "assistant_thread": {"channel_id": "C1", "thread_ts": "t1"}}
+        req = _events_api_req(event)
+
+        with (
+            patch("agno.os.interfaces.slack.socket_mode.handle_thread_started", new_callable=AsyncMock) as mock_handle,
+            patch("agno.os.interfaces.slack.socket_mode.process_slack_event", new_callable=AsyncMock),
+        ):
+            await _make_handler(_make_config(streaming=False))(client, req)
+            await asyncio.sleep(0)
+
+        mock_handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_events_api_type_not_dispatched(self):
+        client = AsyncMock()
+        req = Mock(type="slash_commands", envelope_id="env-003")
+
+        with (
+            patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream,
+            patch("agno.os.interfaces.slack.socket_mode.process_slack_event", new_callable=AsyncMock) as mock_process,
+        ):
+            await _make_handler(_make_config())(client, req)
+            await asyncio.sleep(0)
+
+        mock_stream.assert_not_called()
+        mock_process.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Bot self-loop prevention and subtype filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSocketModeHandlerFiltering:
+    """Handler must not dispatch bot events or ignored subtypes."""
+
+    @pytest.mark.asyncio
+    async def test_bot_id_suppresses_dispatch(self):
+        client = AsyncMock()
+        req = _events_api_req(_msg(bot_id="B123"))
+
+        with patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream:
+            await _make_handler(_make_config())(client, req)
+            await asyncio.sleep(0)
+
+        mock_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nested_message_bot_id_suppresses_dispatch(self):
+        """message_changed events carry bot_id inside event.message, not at the top level."""
+        client = AsyncMock()
+        event = _msg(subtype="message_changed")
+        event["message"] = {"bot_id": "B123", "text": "edited"}
+        req = _events_api_req(event)
+
+        with patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream:
+            await _make_handler(_make_config())(client, req)
+            await asyncio.sleep(0)
+
+        mock_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "subtype",
+        ["bot_message", "bot_add", "bot_remove", "bot_enable", "bot_disable", "message_changed", "message_deleted"],
+    )
+    async def test_ignored_subtype_suppresses_dispatch(self, subtype: str):
+        client = AsyncMock()
+        req = _events_api_req(_msg(subtype=subtype))
+
+        with patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream:
+            await _make_handler(_make_config())(client, req)
+            await asyncio.sleep(0)
+
+        mock_stream.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_file_share_subtype_not_filtered(self):
+        """file_share is NOT in IGNORED_SUBTYPES — file messages should be processed."""
+        client = AsyncMock()
+        req = _events_api_req(_msg(subtype="file_share"))
+
+        with patch("agno.os.interfaces.slack.socket_mode.stream_slack_response", new_callable=AsyncMock) as mock_stream:
+            await _make_handler(_make_config(streaming=True))(client, req)
+            await asyncio.sleep(0)
+
+        mock_stream.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStartSocketMode:
+    """Tests for the start_socket_mode connection lifecycle."""
+
+    async def _run_briefly(self, coro):
+        """Start a coroutine, let it run one tick, then cancel and await cleanup."""
+        task = asyncio.create_task(coro)
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_creates_client_with_app_token(self):
+        config = _make_config()
+        mock_socket = AsyncMock()
+        mock_socket.socket_mode_request_listeners = []
+
+        with patch("agno.os.interfaces.slack.socket_mode.SocketModeClient", return_value=mock_socket) as mock_cls:
+            await self._run_briefly(start_socket_mode(config, "xapp-test-token"))
+
+        mock_cls.assert_called_once_with(app_token="xapp-test-token", web_client=ANY)
+
+    @pytest.mark.asyncio
+    async def test_registers_exactly_one_handler(self):
+        config = _make_config()
+        mock_socket = AsyncMock()
+        mock_socket.socket_mode_request_listeners = []
+
+        with patch("agno.os.interfaces.slack.socket_mode.SocketModeClient", return_value=mock_socket):
+            await self._run_briefly(start_socket_mode(config, "xapp-test"))
+
+        assert len(mock_socket.socket_mode_request_listeners) == 1
+        assert callable(mock_socket.socket_mode_request_listeners[0])
+
+    @pytest.mark.asyncio
+    async def test_calls_connect(self):
+        config = _make_config()
+        mock_socket = AsyncMock()
+        mock_socket.socket_mode_request_listeners = []
+
+        with patch("agno.os.interfaces.slack.socket_mode.SocketModeClient", return_value=mock_socket):
+            await self._run_briefly(start_socket_mode(config, "xapp-test"))
+
+        mock_socket.connect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_calls_close_on_cancellation(self):
+        config = _make_config()
+        mock_socket = AsyncMock()
+        mock_socket.socket_mode_request_listeners = []
+
+        with patch("agno.os.interfaces.slack.socket_mode.SocketModeClient", return_value=mock_socket):
+            await self._run_briefly(start_socket_mode(config, "xapp-test"))
+
+        mock_socket.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_raises_import_error_when_not_installed(self):
+        config = _make_config()
+
+        with patch("agno.os.interfaces.slack.socket_mode.SocketModeClient", None):
+            with pytest.raises(ImportError, match="slack-sdk"):
+                await start_socket_mode(config, "xapp-test")
+
+
+# ---------------------------------------------------------------------------
+# Slack.astart() / Slack.start()
+# ---------------------------------------------------------------------------
+
+
+class TestSlackAstart:
+    """Tests for the Slack class socket mode entry points."""
+
+    def _slack(self, **kwargs):
+        from agno.os.interfaces.slack import Slack
+
+        agent = AsyncMock()
+        agent.name = "Test Agent"
+        return Slack(agent=agent, **kwargs)
+
+    @pytest.mark.asyncio
+    async def test_raises_without_socket_mode_flag(self):
+        with pytest.raises(RuntimeError, match="socket_mode=True"):
+            await self._slack(socket_mode=False).astart()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_app_token_anywhere(self):
+        slack = self._slack(socket_mode=True)
+        env = {k: v for k, v in os.environ.items() if k != "SLACK_APP_TOKEN"}
+        with patch.dict("os.environ", env, clear=True):
+            with pytest.raises(ValueError, match="App-Level Token"):
+                await slack.astart()
+
+    @pytest.mark.asyncio
+    async def test_reads_app_token_from_env(self):
+        slack = self._slack(socket_mode=True)
+
+        with (
+            patch.dict("os.environ", {"SLACK_APP_TOKEN": "xapp-from-env"}),
+            patch("agno.os.interfaces.slack.socket_mode.start_socket_mode", new_callable=AsyncMock) as mock_start,
+            patch("agno.os.interfaces.slack._processing.SlackTools"),
+        ):
+            await slack.astart()
+
+        _config, token = mock_start.call_args.args
+        assert token == "xapp-from-env"
+
+    @pytest.mark.asyncio
+    async def test_explicit_app_token_takes_precedence_over_env(self):
+        slack = self._slack(socket_mode=True, app_token="xapp-explicit")
+
+        with (
+            patch.dict("os.environ", {"SLACK_APP_TOKEN": "xapp-from-env"}),
+            patch("agno.os.interfaces.slack.socket_mode.start_socket_mode", new_callable=AsyncMock) as mock_start,
+            patch("agno.os.interfaces.slack._processing.SlackTools"),
+        ):
+            await slack.astart()
+
+        _config, token = mock_start.call_args.args
+        assert token == "xapp-explicit"
+
+    def test_start_is_sync_wrapper_around_astart(self):
+        """start() should call asyncio.run(astart()) and complete without blocking."""
+        slack = self._slack(socket_mode=True, app_token="xapp-test")
+
+        with (
+            patch("agno.os.interfaces.slack.socket_mode.start_socket_mode", new_callable=AsyncMock) as mock_start,
+            patch("agno.os.interfaces.slack._processing.SlackTools"),
+        ):
+            slack.start()
+
+        mock_start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_astart_passes_correct_config_to_start_socket_mode(self):
+        """Config built by astart() should reflect the Slack instance's settings."""
+        slack = self._slack(
+            socket_mode=True,
+            app_token="xapp-test",
+            streaming=False,
+            reply_to_mentions_only=False,
+        )
+
+        with (
+            patch("agno.os.interfaces.slack.socket_mode.start_socket_mode", new_callable=AsyncMock) as mock_start,
+            patch("agno.os.interfaces.slack._processing.SlackTools"),
+        ):
+            await slack.astart()
+
+        config, _token = mock_start.call_args.args
+        assert config.streaming is False
+        assert config.reply_to_mentions_only is False

--- a/libs/agno/tests/unit/os/routers/test_slack_store_media.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_store_media.py
@@ -98,7 +98,7 @@ async def test_non_streaming_store_media_false_uploads_media():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
@@ -149,9 +149,9 @@ async def test_non_streaming_store_media_false_response_has_images():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
-        patch("agno.os.interfaces.slack.router.upload_response_media_async") as mock_upload,
+        patch("agno.os.interfaces.slack._processing.upload_response_media_async") as mock_upload,
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
         from fastapi.testclient import TestClient
@@ -196,9 +196,9 @@ async def test_non_streaming_real_agent_store_media_false():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
-        patch("agno.os.interfaces.slack.router.upload_response_media_async") as mock_upload,
+        patch("agno.os.interfaces.slack._processing.upload_response_media_async") as mock_upload,
     ):
         from agno.os.interfaces.slack.router import attach_routes
 
@@ -281,9 +281,9 @@ async def test_streaming_store_media_false_collects_media_from_completion():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
-        patch("agno.os.interfaces.slack.router.upload_response_media_async") as mock_upload,
+        patch("agno.os.interfaces.slack._processing.upload_response_media_async") as mock_upload,
     ):
         app = build_app(agent, streaming=True, reply_to_mentions_only=False)
         from fastapi.testclient import TestClient
@@ -337,9 +337,9 @@ async def test_streaming_content_chunks_with_images_collected():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
-        patch("agno.os.interfaces.slack.router.upload_response_media_async") as mock_upload,
+        patch("agno.os.interfaces.slack._processing.upload_response_media_async") as mock_upload,
     ):
         app = build_app(agent, streaming=True, reply_to_mentions_only=False)
         from fastapi.testclient import TestClient
@@ -373,9 +373,9 @@ async def test_streaming_real_agent_store_media_false():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
-        patch("agno.os.interfaces.slack.router.upload_response_media_async") as mock_upload,
+        patch("agno.os.interfaces.slack._processing.upload_response_media_async") as mock_upload,
     ):
         from agno.os.interfaces.slack.router import attach_routes
 
@@ -420,9 +420,9 @@ async def test_non_streaming_store_media_true_still_uploads():
 
     with (
         patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
-        patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        patch("agno.os.interfaces.slack._processing.SlackTools", return_value=mock_slack),
         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=mock_client),
-        patch("agno.os.interfaces.slack.router.upload_response_media_async") as mock_upload,
+        patch("agno.os.interfaces.slack._processing.upload_response_media_async") as mock_upload,
     ):
         app = build_app(agent_mock, reply_to_mentions_only=False)
         from fastapi.testclient import TestClient


### PR DESCRIPTION
Adds WebSocket-based Socket Mode transport alongside the existing HTTP webhook path. Socket Mode lets bots receive events without a public URL, making local development and firewall-restricted deployments practical.

Key changes:

- `_processing.py` (new): extracts the shared event-processing logic (`process_slack_event`, `stream_slack_response`, `handle_thread_started`, `ProcessingConfig`) from `router.py` into a shared module so both HTTP and Socket Mode can use the same handlers without duplication.

- `socket_mode.py` (new): implements `start_socket_mode()` which opens a persistent WebSocket via `slack_sdk.socket_mode.aiohttp.SocketModeClient`, ACKs events immediately (satisfying Slack's 3-second rule), and dispatches to the shared processing functions via `asyncio.create_task`. Also exposes `_make_handler()` for independent testability.

- `slack.py`: adds `socket_mode: bool` and `app_token: Optional[str]` constructor params; adds `astart()` (async, reads `SLACK_APP_TOKEN` env var) and `start()` (sync `asyncio.run` wrapper).

- `router.py`: refactored to delegate to `_processing.py`; behaviour is identical to before.

- `test_slack_socket_mode.py` (new): 29 tests covering ACK behaviour, event routing, bot/subtype filtering, connection lifecycle, and `Slack.astart()`.

- Test infrastructure: updated patch paths after the refactor (`router.SlackTools` → `_processing.SlackTools`, etc.); added `import slack_sdk.web.async_client` to conftest to fix Python 3.12 `pkgutil.resolve_name` compatibility for `mock.patch`.

- `cookbook/05_agent_os/interfaces/slack/socket_mode.py` (new): minimal runnable example showing the Socket Mode usage pattern.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
