### PR TITLE
Fix MCPTools race condition: shared session killed by parallel run cleanup

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -186,6 +186,10 @@ class MCPTools(Toolkit):
         self._session_ttl_seconds: float = 300.0  # 5 minutes TTL for MCP sessions
         self._session_lock: Optional[asyncio.Lock] = None  # Lazily created lock for session creation
 
+        # Reference counting for shared session across parallel runs
+        self._ref_count: int = 0
+        self._ref_count_lock: Optional[asyncio.Lock] = None  # Lazily created lock for ref counting
+
         def cleanup():
             """Cancel active connections"""
             if self._connection_task and not self._connection_task.done():
@@ -204,6 +208,13 @@ class MCPTools(Toolkit):
         if self._session_lock is None:
             self._session_lock = asyncio.Lock()
         return self._session_lock
+
+    @property
+    def _connection_ref_lock(self) -> asyncio.Lock:
+        """Lazily create an asyncio lock for reference counting."""
+        if self._ref_count_lock is None:
+            self._ref_count_lock = asyncio.Lock()
+        return self._ref_count_lock
 
     def _call_header_provider(
         self,
@@ -451,7 +462,11 @@ class MCPTools(Toolkit):
             return False
 
     async def connect(self, force: bool = False):
-        """Initialize a MCPTools instance and connect to the contextual MCP server"""
+        """Initialize a MCPTools instance and connect to the contextual MCP server.
+
+        Uses reference counting so that parallel agent runs sharing the same
+        MCPTools instance keep the connection alive until the last run calls close().
+        """
 
         if force:
             # Clean up the session and context so we force a new connection
@@ -461,6 +476,10 @@ class MCPTools(Toolkit):
             self._initialized = False
             self._connection_task = None
             self._active_contexts = []
+            self._ref_count = 0
+
+        async with self._connection_ref_lock:
+            self._ref_count += 1
 
         if self._initialized:
             return
@@ -468,6 +487,9 @@ class MCPTools(Toolkit):
         try:
             await self._connect()
         except (RuntimeError, BaseException) as e:
+            # Roll back the ref count on failure
+            async with self._connection_ref_lock:
+                self._ref_count = max(0, self._ref_count - 1)
             log_error(f"Failed to connect to {str(self)}: {e}")
 
     async def _connect(self) -> None:
@@ -517,9 +539,21 @@ class MCPTools(Toolkit):
         await self.initialize()
 
     async def close(self) -> None:
-        """Close the MCP connection and clean up resources"""
+        """Close the MCP connection and clean up resources.
+
+        Uses reference counting so that when multiple parallel agent runs share
+        this MCPTools instance, the underlying connection is only closed when the
+        last run finishes. This prevents one run's cleanup from killing sessions
+        still in use by other runs.
+        """
         if not self._initialized:
             return
+
+        async with self._connection_ref_lock:
+            self._ref_count = max(0, self._ref_count - 1)
+            if self._ref_count > 0:
+                # Other runs still using this connection — skip teardown
+                return
 
         import warnings
 

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -167,6 +167,10 @@ class MultiMCPTools(Toolkit):
         self._session_ttl_seconds: float = 300.0  # 5 minutes default TTL
         self._session_lock: Optional[asyncio.Lock] = None  # Lazily created lock for session creation
 
+        # Reference counting for shared session across parallel runs
+        self._ref_count: int = 0
+        self._ref_count_lock: Optional[asyncio.Lock] = None  # Lazily created lock for ref counting
+
         self.allow_partial_failure = allow_partial_failure
 
         def cleanup():
@@ -187,6 +191,13 @@ class MultiMCPTools(Toolkit):
         if self._session_lock is None:
             self._session_lock = asyncio.Lock()
         return self._session_lock
+
+    @property
+    def _connection_ref_lock(self) -> asyncio.Lock:
+        """Lazily create an asyncio lock for reference counting."""
+        if self._ref_count_lock is None:
+            self._ref_count_lock = asyncio.Lock()
+        return self._ref_count_lock
 
     async def is_alive(self) -> bool:
         try:
@@ -423,7 +434,11 @@ class MultiMCPTools(Toolkit):
             self._run_session_contexts.pop(cache_key, None)
 
     async def connect(self, force: bool = False):
-        """Initialize a MultiMCPTools instance and connect to the MCP servers"""
+        """Initialize a MultiMCPTools instance and connect to the MCP servers.
+
+        Uses reference counting so that parallel agent runs sharing the same
+        MultiMCPTools instance keep connections alive until the last run calls close().
+        """
 
         if force:
             # Clean up the session and context so we force a new connection
@@ -431,6 +446,10 @@ class MultiMCPTools(Toolkit):
             self._successful_connections = 0
             self._initialized = False
             self._connection_task = None
+            self._ref_count = 0
+
+        async with self._connection_ref_lock:
+            self._ref_count += 1
 
         if self._initialized:
             return
@@ -438,6 +457,9 @@ class MultiMCPTools(Toolkit):
         try:
             await self._connect()
         except (RuntimeError, BaseException) as e:
+            # Roll back the ref count on failure
+            async with self._connection_ref_lock:
+                self._ref_count = max(0, self._ref_count - 1)
             log_error(f"Failed to connect to {str(self)}: {e}")
 
     @classmethod
@@ -533,9 +555,20 @@ class MultiMCPTools(Toolkit):
             self._initialized = True
 
     async def close(self) -> None:
-        """Close the MCP connections and clean up resources"""
+        """Close the MCP connections and clean up resources.
+
+        Uses reference counting so that when multiple parallel agent runs share
+        this MultiMCPTools instance, connections are only closed when the last
+        run finishes.
+        """
         if not self._initialized:
             return
+
+        async with self._connection_ref_lock:
+            self._ref_count = max(0, self._ref_count - 1)
+            if self._ref_count > 0:
+                # Other runs still using these connections — skip teardown
+                return
 
         import warnings
 

--- a/libs/agno/tests/unit/tools/test_mcp_ref_counting.py
+++ b/libs/agno/tests/unit/tools/test_mcp_ref_counting.py
@@ -1,0 +1,429 @@
+"""Tests for reference counting in MCPTools and MultiMCPTools connect/close.
+
+These tests verify that parallel agent runs sharing the same MCPTools or
+MultiMCPTools instance do not kill each other's sessions. The reference
+counting mechanism ensures the underlying connection is only torn down
+when the last run calls close().
+"""
+
+import asyncio
+import warnings
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.tools.mcp import MCPTools, MultiMCPTools
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _make_mcptools(**kwargs) -> MCPTools:
+    """Create an MCPTools instance with a mock session (no real MCP server)."""
+    tools = MCPTools(url="http://localhost:8080/mcp", **kwargs)
+    return tools
+
+
+def _make_multimcptools(**kwargs) -> MultiMCPTools:
+    """Create a MultiMCPTools instance (no real MCP server)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        tools = MultiMCPTools(urls=["http://localhost:8080/mcp"], **kwargs)
+    return tools
+
+
+async def _fake_connect(tools):
+    """Simulate a successful _connect by setting _initialized = True."""
+    tools._initialized = True
+
+
+async def _fake_multi_connect(tools):
+    """Simulate a successful _connect for MultiMCPTools."""
+    tools._initialized = True
+    tools._successful_connections = 1
+
+
+def _patch_mcp_connect(tools):
+    """Patch _connect on MCPTools to simulate successful connection."""
+    async def fake(*args, **kwargs):
+        await _fake_connect(tools)
+    return patch.object(tools, "_connect", side_effect=fake)
+
+
+def _patch_multi_connect(tools):
+    """Patch _connect on MultiMCPTools to simulate successful connection."""
+    async def fake(*args, **kwargs):
+        await _fake_multi_connect(tools)
+    return patch.object(tools, "_connect", side_effect=fake)
+
+
+# =============================================================================
+# MCPTools — basic ref counting
+# =============================================================================
+
+
+class TestMCPToolsRefCounting:
+    """Tests for MCPTools reference counting on connect/close."""
+
+    def test_ref_count_starts_at_zero(self):
+        tools = _make_mcptools()
+        assert tools._ref_count == 0
+
+    async def test_connect_increments_ref_count(self):
+        tools = _make_mcptools()
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+        assert tools._ref_count == 1
+
+    async def test_multiple_connects_increment_ref_count(self):
+        tools = _make_mcptools()
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+            await tools.connect()
+            await tools.connect()
+        assert tools._ref_count == 3
+
+    async def test_close_decrements_ref_count(self):
+        tools = _make_mcptools()
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+            await tools.connect()
+        assert tools._ref_count == 2
+
+        await tools.close()
+        assert tools._ref_count == 1
+        # Connection should still be alive
+        assert tools._initialized is True
+
+    async def test_close_tears_down_at_zero(self):
+        tools = _make_mcptools()
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+        assert tools._ref_count == 1
+
+        await tools.close()
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_close_does_not_go_negative(self):
+        tools = _make_mcptools()
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+        await tools.close()
+        # Extra close calls should not make ref_count negative
+        await tools.close()
+        await tools.close()
+        assert tools._ref_count == 0
+
+    async def test_close_skips_teardown_when_not_initialized(self):
+        """close() should be a no-op if never connected."""
+        tools = _make_mcptools()
+        assert tools._initialized is False
+        await tools.close()
+        assert tools._ref_count == 0
+
+    async def test_connect_rollback_on_failure(self):
+        """If _connect raises, the ref count should be rolled back."""
+        tools = _make_mcptools()
+
+        async def failing_connect():
+            raise RuntimeError("Connection refused")
+
+        with patch.object(tools, "_connect", side_effect=failing_connect):
+            await tools.connect()
+
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_connect_force_resets_ref_count(self):
+        """force=True should reset ref_count to 0 before reconnecting."""
+        tools = _make_mcptools()
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+            await tools.connect()
+            await tools.connect()
+        assert tools._ref_count == 3
+
+        # Force reconnect — resets ref_count to 0, then increments to 1
+        tools._initialized = False  # So _connect is called again
+        with _patch_mcp_connect(tools):
+            await tools.connect(force=True)
+        assert tools._ref_count == 1
+
+    async def test_force_connect_clears_state(self):
+        """force=True should clear session, context, and initialized flag."""
+        tools = _make_mcptools()
+        tools.session = MagicMock()
+        tools._context = MagicMock()
+        tools._session_context = MagicMock()
+        tools._initialized = True
+        tools._ref_count = 5
+
+        with _patch_mcp_connect(tools):
+            await tools.connect(force=True)
+
+        # After force, ref_count is reset to 0, then incremented to 1
+        assert tools._ref_count == 1
+
+
+# =============================================================================
+# MCPTools — parallel connect/close cycles
+# =============================================================================
+
+
+class TestMCPToolsParallelRefCounting:
+    """Tests for concurrent connect/close with MCPTools."""
+
+    async def test_parallel_connects_all_increment(self):
+        """Multiple concurrent connect() calls should each increment ref_count."""
+        tools = _make_mcptools()
+        connect_count = 10
+
+        with _patch_mcp_connect(tools):
+            await asyncio.gather(*[tools.connect() for _ in range(connect_count)])
+
+        assert tools._ref_count == connect_count
+
+    async def test_parallel_connect_close_cycle(self):
+        """Simulate N parallel agent runs: each connects, then closes."""
+        tools = _make_mcptools()
+        n_runs = 5
+
+        with _patch_mcp_connect(tools):
+            # All runs connect
+            await asyncio.gather(*[tools.connect() for _ in range(n_runs)])
+
+        assert tools._ref_count == n_runs
+        assert tools._initialized is True
+
+        # Close runs one by one — only the last close should tear down
+        for i in range(n_runs - 1):
+            await tools.close()
+            assert tools._initialized is True, f"Torn down too early at close #{i+1}"
+            assert tools._ref_count == n_runs - 1 - i
+
+        # Final close tears down
+        await tools.close()
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_parallel_close_is_safe(self):
+        """Multiple concurrent close() calls should be safe."""
+        tools = _make_mcptools()
+
+        with _patch_mcp_connect(tools):
+            await tools.connect()
+            await tools.connect()
+
+        assert tools._ref_count == 2
+
+        # Close both in parallel
+        await asyncio.gather(tools.close(), tools.close())
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_interleaved_connect_close(self):
+        """Interleaved connect/close should maintain correct ref count."""
+        tools = _make_mcptools()
+
+        with _patch_mcp_connect(tools):
+            await tools.connect()  # ref=1
+            await tools.connect()  # ref=2
+            await tools.close()   # ref=1, still alive
+            assert tools._initialized is True
+            await tools.connect()  # ref=2
+            await tools.close()   # ref=1, still alive
+            assert tools._initialized is True
+            await tools.close()   # ref=0, tear down
+            assert tools._initialized is False
+
+
+# =============================================================================
+# MCPTools — ref count lock
+# =============================================================================
+
+
+class TestMCPToolsRefCountLock:
+    """Tests for the lazily-created ref count lock."""
+
+    def test_ref_count_lock_initially_none(self):
+        tools = _make_mcptools()
+        assert tools._ref_count_lock is None
+
+    def test_ref_count_lock_lazily_created(self):
+        tools = _make_mcptools()
+        lock = tools._connection_ref_lock
+        assert isinstance(lock, asyncio.Lock)
+
+    def test_ref_count_lock_same_instance(self):
+        tools = _make_mcptools()
+        lock1 = tools._connection_ref_lock
+        lock2 = tools._connection_ref_lock
+        assert lock1 is lock2
+
+
+# =============================================================================
+# MultiMCPTools — basic ref counting
+# =============================================================================
+
+
+class TestMultiMCPToolsRefCounting:
+    """Tests for MultiMCPTools reference counting on connect/close."""
+
+    def test_ref_count_starts_at_zero(self):
+        tools = _make_multimcptools()
+        assert tools._ref_count == 0
+
+    async def test_connect_increments_ref_count(self):
+        tools = _make_multimcptools()
+        with _patch_multi_connect(tools):
+            await tools.connect()
+        assert tools._ref_count == 1
+
+    async def test_multiple_connects_increment_ref_count(self):
+        tools = _make_multimcptools()
+        with _patch_multi_connect(tools):
+            await tools.connect()
+            await tools.connect()
+            await tools.connect()
+        assert tools._ref_count == 3
+
+    async def test_close_decrements_ref_count(self):
+        tools = _make_multimcptools()
+        with _patch_multi_connect(tools):
+            await tools.connect()
+            await tools.connect()
+
+        await tools.close()
+        assert tools._ref_count == 1
+        assert tools._initialized is True
+
+    async def test_close_tears_down_at_zero(self):
+        tools = _make_multimcptools()
+        with _patch_multi_connect(tools):
+            await tools.connect()
+
+        await tools.close()
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_close_does_not_go_negative(self):
+        tools = _make_multimcptools()
+        with _patch_multi_connect(tools):
+            await tools.connect()
+        await tools.close()
+        await tools.close()
+        await tools.close()
+        assert tools._ref_count == 0
+
+    async def test_connect_rollback_on_failure(self):
+        tools = _make_multimcptools()
+
+        async def failing_connect():
+            raise RuntimeError("Connection refused")
+
+        with patch.object(tools, "_connect", side_effect=failing_connect):
+            await tools.connect()
+
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_connect_force_resets_ref_count(self):
+        tools = _make_multimcptools()
+        with _patch_multi_connect(tools):
+            await tools.connect()
+            await tools.connect()
+            await tools.connect()
+        assert tools._ref_count == 3
+
+        tools._initialized = False
+        with _patch_multi_connect(tools):
+            await tools.connect(force=True)
+        assert tools._ref_count == 1
+
+    async def test_force_connect_clears_state(self):
+        tools = _make_multimcptools()
+        tools._sessions = [MagicMock()]
+        tools._successful_connections = 1
+        tools._initialized = True
+        tools._ref_count = 5
+
+        with _patch_multi_connect(tools):
+            await tools.connect(force=True)
+
+        assert tools._ref_count == 1
+
+
+# =============================================================================
+# MultiMCPTools — parallel connect/close cycles
+# =============================================================================
+
+
+class TestMultiMCPToolsParallelRefCounting:
+    """Tests for concurrent connect/close with MultiMCPTools."""
+
+    async def test_parallel_connects_all_increment(self):
+        tools = _make_multimcptools()
+        connect_count = 10
+
+        with _patch_multi_connect(tools):
+            await asyncio.gather(*[tools.connect() for _ in range(connect_count)])
+
+        assert tools._ref_count == connect_count
+
+    async def test_parallel_connect_close_cycle(self):
+        tools = _make_multimcptools()
+        n_runs = 5
+
+        with _patch_multi_connect(tools):
+            await asyncio.gather(*[tools.connect() for _ in range(n_runs)])
+
+        assert tools._ref_count == n_runs
+        assert tools._initialized is True
+
+        for i in range(n_runs - 1):
+            await tools.close()
+            assert tools._initialized is True
+            assert tools._ref_count == n_runs - 1 - i
+
+        await tools.close()
+        assert tools._ref_count == 0
+        assert tools._initialized is False
+
+    async def test_interleaved_connect_close(self):
+        tools = _make_multimcptools()
+
+        with _patch_multi_connect(tools):
+            await tools.connect()  # ref=1
+            await tools.connect()  # ref=2
+            await tools.close()   # ref=1
+            assert tools._initialized is True
+            await tools.connect()  # ref=2
+            await tools.close()   # ref=1
+            assert tools._initialized is True
+            await tools.close()   # ref=0
+            assert tools._initialized is False
+
+
+# =============================================================================
+# MultiMCPTools — ref count lock
+# =============================================================================
+
+
+class TestMultiMCPToolsRefCountLock:
+    def test_ref_count_lock_initially_none(self):
+        tools = _make_multimcptools()
+        assert tools._ref_count_lock is None
+
+    def test_ref_count_lock_lazily_created(self):
+        tools = _make_multimcptools()
+        lock = tools._connection_ref_lock
+        assert isinstance(lock, asyncio.Lock)
+
+    def test_ref_count_lock_same_instance(self):
+        tools = _make_multimcptools()
+        lock1 = tools._connection_ref_lock
+        lock2 = tools._connection_ref_lock
+        assert lock1 is lock2


### PR DESCRIPTION
## Summary

Fixes #7347

**Root cause:** When multiple agent runs share a single `MCPTools` (or `MultiMCPTools`) instance, they all use the same underlying `ClientSession`. The agent lifecycle calls `connect()` at the start and `close()` at the end of each run (via `connect_mcp_tools` / `disconnect_mcp_tools` in `_init.py`). When runs execute in parallel, the first run to finish calls `close()`, which tears down the shared session and transport — killing all other in-flight runs.

The existing per-run session mechanism (`_run_sessions`, `get_session_for_run`) only creates isolated sessions when `header_provider` is set. Without it, every run shares `self.session`, making the race condition the default behavior for parallel runs.

**The fix:** Add reference counting to `connect()` and `close()` in both `MCPTools` and `MultiMCPTools`:

- `connect()` increments `_ref_count` (protected by an asyncio lock)
- `close()` decrements `_ref_count` and only performs actual teardown when the count reaches zero
- `connect(force=True)` resets the ref count, preserving existing force-reconnect semantics

## Backward compatibility

- **Single-run behavior unchanged:** ref count goes 1 → 0, `close()` proceeds normally — identical to current behavior
- **Context manager usage (`async with`) unaffected:** `__aenter__`/`__aexit__` don't go through `connect()`/`close()`, so no change
- **`header_provider` per-run sessions still work:** the ref counting is orthogonal to `_run_sessions`; both mechanisms coexist
- **No new public API:** all new attributes are private (`_ref_count`, `_ref_count_lock`, `_connection_ref_lock`)

## Changes

- `libs/agno/agno/tools/mcp/mcp.py` — Add ref counting to `MCPTools.connect()` and `MCPTools.close()`
- `libs/agno/agno/tools/mcp/multi_mcp.py` — Add ref counting to `MultiMCPTools.connect()` and `MultiMCPTools.close()`

## Test plan

- [ ] Verify single agent run still connects and disconnects cleanly
- [ ] Verify parallel agent runs sharing one `MCPTools` instance: second run's tools still work after first run finishes
- [ ] Verify `connect(force=True)` still force-reconnects
- [ ] Verify context manager usage (`async with MCPTools(...)`) is unaffected
- [ ] Verify `header_provider` per-run sessions still work correctly alongside ref counting

🤖 Generated with [Claude Code](https://claude.com/claude-code)