### PR TITLE
[feat] Add Amazon Titan Embed v2 support to AwsBedrockEmbedder

### DIFF
--- a/libs/agno/agno/knowledge/embedder/aws_bedrock.py
+++ b/libs/agno/agno/knowledge/embedder/aws_bedrock.py
@@ -36,7 +36,7 @@ OutputDimension = Literal[256, 512, 1024, 1536]
 @dataclass
 class AwsBedrockEmbedder(Embedder):
     """
-    AWS Bedrock embedder supporting Cohere Embed v3 and v4 models.
+    AWS Bedrock embedder supporting Cohere Embed v3/v4 and Amazon Titan Embed v2 models.
 
     To use this embedder, you need to either:
     1. Set the following environment variables:
@@ -47,27 +47,30 @@ class AwsBedrockEmbedder(Embedder):
 
     Args:
         id (str): The model ID to use. Default is 'cohere.embed-multilingual-v3'.
-            - v3 models: 'cohere.embed-multilingual-v3', 'cohere.embed-english-v3'
-            - v4 model: 'cohere.embed-v4:0'
+            - Cohere v3 models: 'cohere.embed-multilingual-v3', 'cohere.embed-english-v3'
+            - Cohere v4 model: 'cohere.embed-v4:0'
+            - Titan v2 model: 'amazon.titan-embed-text-v2:0'
         dimensions (Optional[int]): The dimensions of the embeddings.
-            - v3: Fixed at 1024
-            - v4: Configurable via output_dimension (256, 512, 1024, 1536). Default 1536.
-        input_type (str): Prepends special tokens to differentiate types. Options:
+            - Cohere v3: Fixed at 1024
+            - Cohere v4: Configurable via output_dimension (256, 512, 1024, 1536). Default 1536.
+            - Titan v2: 256, 512, or 1024 (default 1024). Pass via request_params: {"dimensions": 512}.
+        input_type (str): (Cohere only) Prepends special tokens to differentiate types. Options:
             'search_document', 'search_query', 'classification', 'clustering'. Default is 'search_query'.
-        truncate (Optional[str]): How to handle inputs longer than the maximum token length.
+        truncate (Optional[str]): (Cohere only) How to handle inputs longer than the maximum token length.
             - v3: 'NONE', 'START', 'END'
             - v4: 'NONE', 'LEFT', 'RIGHT'
-        embedding_types (Optional[List[str]]): Types of embeddings to return. Options:
+        embedding_types (Optional[List[str]]): (Cohere only) Types of embeddings to return. Options:
             'float', 'int8', 'uint8', 'binary', 'ubinary'. Default is ['float'].
-        output_dimension (Optional[int]): (v4 only) Vector length. Options: 256, 512, 1024, 1536.
+        output_dimension (Optional[int]): (Cohere v4 only) Vector length. Options: 256, 512, 1024, 1536.
             Default is 1536 if unspecified.
-        max_tokens (Optional[int]): (v4 only) Truncation budget per input object.
+        max_tokens (Optional[int]): (Cohere v4 only) Truncation budget per input object.
             The model supports up to ~128,000 tokens.
         aws_region (Optional[str]): The AWS region to use.
         aws_access_key_id (Optional[str]): The AWS access key ID to use.
         aws_secret_access_key (Optional[str]): The AWS secret access key to use.
         session (Optional[Session]): A boto3 Session object to use for authentication.
         request_params (Optional[Dict[str, Any]]): Additional parameters to pass to the API requests.
+            For Titan v2, supports optional keys: 'dimensions' (256|512|1024), 'normalize' (bool).
         client_params (Optional[Dict[str, Any]]): Additional parameters to pass to the boto3 client.
     """
 
@@ -96,7 +99,10 @@ class AwsBedrockEmbedder(Embedder):
             self.enable_batch = False
 
         # Set appropriate default dimensions based on model version
-        if self._is_v4_model():
+        if self._is_titan_model():
+            # Titan Embed v2: default 1024 dimensions (256|512|1024 supported)
+            self.dimensions = 1024
+        elif self._is_v4_model():
             # v4 default is 1536, but can be overridden by output_dimension
             if self.output_dimension:
                 self.dimensions = self.output_dimension
@@ -105,6 +111,10 @@ class AwsBedrockEmbedder(Embedder):
         else:
             # v3 models are fixed at 1024
             self.dimensions = 1024
+
+    def _is_titan_model(self) -> bool:
+        """Check if the current model is an Amazon Titan Embed model."""
+        return "titan-embed" in self.id.lower()
 
     def _is_v4_model(self) -> bool:
         """Check if the current model is a Cohere Embed v4 model."""
@@ -209,7 +219,16 @@ class AwsBedrockEmbedder(Embedder):
         Returns:
             str: The formatted request body as a JSON string.
         """
-        request_body: Dict[str, Any] = {
+        if self._is_titan_model():
+            # Amazon Titan Embed v2 schema
+            request_body: Dict[str, Any] = {"inputText": text}
+            # request_params can pass optional: dimensions (256|512|1024), normalize (bool)
+            if self.request_params:
+                request_body.update(self.request_params)
+            return json.dumps(request_body)
+
+        # Cohere v3/v4 schema
+        request_body = {
             "texts": [text],
             "input_type": self.input_type,
         }
@@ -292,7 +311,7 @@ class AwsBedrockEmbedder(Embedder):
 
     def _extract_embeddings(self, response_body: Dict[str, Any]) -> List[float]:
         """
-        Extract embeddings from the response body, handling both v3 and v4 formats.
+        Extract embeddings from the response body, handling Titan v2, Cohere v3, and Cohere v4 formats.
 
         Args:
             response_body: The parsed response body from the API.
@@ -301,6 +320,11 @@ class AwsBedrockEmbedder(Embedder):
             List[float]: The embedding vector.
         """
         try:
+            # Titan Embed v2 returns {"embedding": [...], "inputTextTokenCount": n}
+            if "embedding" in response_body:
+                return response_body["embedding"]
+
+            # Cohere v3/v4 returns {"embeddings": [[...]] or {"embeddings": {"float": [[...]], ...}}}
             if "embeddings" in response_body:
                 embeddings = response_body["embeddings"]
 

--- a/libs/agno/tests/unit/knowledge/test_aws_bedrock_embedder.py
+++ b/libs/agno/tests/unit/knowledge/test_aws_bedrock_embedder.py
@@ -1,0 +1,171 @@
+"""Unit tests for AwsBedrockEmbedder — Amazon Titan Embed v2 support.
+
+These are pure-logic tests that do NOT require AWS credentials or network
+access.  All tested methods operate only on local state (model id, request
+body formatting, response parsing).
+"""
+
+import json
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_titan(model_id: str = "amazon.titan-embed-text-v2:0", **kwargs):
+    """Return an AwsBedrockEmbedder configured for a Titan model."""
+    from agno.knowledge.embedder.aws_bedrock import AwsBedrockEmbedder
+
+    return AwsBedrockEmbedder(id=model_id, **kwargs)
+
+
+def _make_cohere(model_id: str = "cohere.embed-english-v3", **kwargs):
+    """Return an AwsBedrockEmbedder configured for a Cohere model."""
+    from agno.knowledge.embedder.aws_bedrock import AwsBedrockEmbedder
+
+    return AwsBedrockEmbedder(id=model_id, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# _is_titan_model()
+# ---------------------------------------------------------------------------
+
+
+class TestIsTitanModel:
+    def test_titan_embed_text_v2_returns_true(self):
+        embedder = _make_titan("amazon.titan-embed-text-v2:0")
+        assert embedder._is_titan_model() is True
+
+    def test_cohere_english_returns_false(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        assert embedder._is_titan_model() is False
+
+    def test_cohere_multilingual_returns_false(self):
+        embedder = _make_cohere("cohere.embed-multilingual-v3")
+        assert embedder._is_titan_model() is False
+
+    def test_cohere_v4_returns_false(self):
+        embedder = _make_cohere("cohere.embed-v4:0")
+        assert embedder._is_titan_model() is False
+
+
+# ---------------------------------------------------------------------------
+# Default dimensions after __post_init__
+# ---------------------------------------------------------------------------
+
+
+class TestTitanDimensions:
+    def test_titan_default_dimensions_are_1024(self):
+        embedder = _make_titan()
+        assert embedder.dimensions == 1024
+
+    def test_cohere_v3_dimensions_are_1024(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        assert embedder.dimensions == 1024
+
+    def test_cohere_v4_default_dimensions_are_1536(self):
+        embedder = _make_cohere("cohere.embed-v4:0")
+        assert embedder.dimensions == 1536
+
+
+# ---------------------------------------------------------------------------
+# _format_request_body()  — Titan path
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRequestBodyTitan:
+    def test_titan_uses_inputText_key(self):
+        embedder = _make_titan()
+        body = json.loads(embedder._format_request_body("hello"))
+        assert "inputText" in body
+        assert body["inputText"] == "hello"
+
+    def test_titan_does_not_include_texts_key(self):
+        embedder = _make_titan()
+        body = json.loads(embedder._format_request_body("hello"))
+        assert "texts" not in body
+
+    def test_titan_does_not_include_input_type_key(self):
+        embedder = _make_titan()
+        body = json.loads(embedder._format_request_body("hello"))
+        assert "input_type" not in body
+
+    def test_titan_request_params_are_merged(self):
+        embedder = _make_titan(request_params={"dimensions": 512, "normalize": True})
+        body = json.loads(embedder._format_request_body("hello"))
+        assert body["inputText"] == "hello"
+        assert body["dimensions"] == 512
+        assert body["normalize"] is True
+
+
+# ---------------------------------------------------------------------------
+# _format_request_body()  — Cohere path (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRequestBodyCohere:
+    def test_cohere_uses_texts_key(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        body = json.loads(embedder._format_request_body("hello"))
+        assert "texts" in body
+        assert body["texts"] == ["hello"]
+
+    def test_cohere_includes_input_type(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        body = json.loads(embedder._format_request_body("hello"))
+        assert "input_type" in body
+
+    def test_cohere_does_not_include_inputText_key(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        body = json.loads(embedder._format_request_body("hello"))
+        assert "inputText" not in body
+
+
+# ---------------------------------------------------------------------------
+# _extract_embeddings()  — Titan response format
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmbeddingsTitan:
+    def test_titan_embedding_key_returns_vector(self):
+        embedder = _make_titan()
+        result = embedder._extract_embeddings({"embedding": [0.1, 0.2], "inputTextTokenCount": 3})
+        assert result == [0.1, 0.2]
+
+    def test_titan_single_element_vector(self):
+        embedder = _make_titan()
+        result = embedder._extract_embeddings({"embedding": [0.5]})
+        assert result == [0.5]
+
+    def test_titan_empty_embedding_returns_empty_list(self):
+        embedder = _make_titan()
+        result = embedder._extract_embeddings({"embedding": []})
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _extract_embeddings()  — Cohere response format (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmbeddingsCohere:
+    def test_cohere_list_format(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        result = embedder._extract_embeddings({"embeddings": [[0.1, 0.2]]})
+        assert result == [0.1, 0.2]
+
+    def test_cohere_dict_float_format(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        result = embedder._extract_embeddings({"embeddings": {"float": [[0.3, 0.4]]}})
+        assert result == [0.3, 0.4]
+
+    def test_cohere_dict_fallback_to_first_type(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        result = embedder._extract_embeddings({"embeddings": {"int8": [[1, 2, 3]]}})
+        assert result == [1, 2, 3]
+
+    def test_no_known_key_returns_empty_list(self):
+        embedder = _make_cohere("cohere.embed-english-v3")
+        result = embedder._extract_embeddings({"unexpected_key": "value"})
+        assert result == []


### PR DESCRIPTION
  ## Summary

  `AwsBedrockEmbedder` was previously hardcoded for Cohere Embed v3/v4 only. Using it with `amazon.titan-embed-text-v2:0` caused `ValidationException: Malformed input request: 3 schema violations` because the Cohere request schema (`texts`, `input_type`, `truncate`) is incompatible with the Titan Embed v2 API.

  This PR adds native Titan Embed v2 support with the correct request and response format.

  ## Changes

  - `_is_titan_model()`: new helper that detects Titan models via `"titan-embed"` in the model ID
  - `__post_init__`: Titan branch sets `dimensions = 1024` (Titan v2 default) before Cohere logic
  - `_format_request_body()`: Titan path sends `{"inputText": text}` with optional `dimensions`/`normalize` via request_params`; Cohere path is unchanged
  - `_extract_embeddings()`: checks for `"embedding"` key (Titan singular) before `"embeddings"` (Cohere plural); both paths preserved

  ## Tests

  21 new unit tests added in `libs/agno/tests/unit/knowledge/test_aws_bedrock_embedder.py` covering:
  - Titan and Cohere model detection
  - Dimension defaults for Titan, Cohere v3, and Cohere v4
  - Request body format for Titan (inputText) and Cohere (texts/input_type) with regression guards
  - Response extraction for both Titan and all Cohere embedding type variants