### PR TITLE
fix: resolve PostgreSQL polymorphic type error in rename_session

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -761,25 +761,32 @@ class AsyncPostgresDb(AsyncBaseDb):
             async with self.async_session_factory() as sess, sess.begin():
                 # Sanitize session_name to remove null bytes
                 sanitized_session_name = sanitize_postgres_string(session_name)
-                stmt = (
-                    update(table)
-                    .where(table.c.session_id == session_id)
-                    .where(table.c.session_type == session_type.value)
-                    .values(
-                        session_data=func.cast(
-                            func.jsonb_set(
-                                func.cast(table.c.session_data, postgresql.JSONB),
-                                text("'{session_name}'"),
-                                func.to_jsonb(sanitized_session_name),
-                            ),
-                            postgresql.JSON,
-                        )
-                    )
-                    .returning(*table.c)
-                )
+
+                # Use raw SQL with explicit type casting to avoid polymorphic type error
+                # Cast session_data to JSONB, use jsonb_set, then cast back to JSON
+                user_filter = "AND user_id = :user_id" if user_id is not None else ""
+                query = text(f"""
+                    UPDATE {self.db_schema}.{self.session_table_name}
+                    SET session_data = jsonb_set(
+                        COALESCE(session_data::jsonb, '{{}}'::jsonb),
+                        '{{session_name}}',
+                        to_jsonb(CAST(:session_name AS TEXT))
+                    )::json
+                    WHERE session_id = :session_id
+                    AND session_type = :session_type
+                    {user_filter}
+                    RETURNING *
+                """)
+
+                params = {
+                    "session_name": sanitized_session_name,
+                    "session_id": session_id,
+                    "session_type": session_type.value,
+                }
                 if user_id is not None:
-                    stmt = stmt.where(table.c.user_id == user_id)
-                result = await sess.execute(stmt)
+                    params["user_id"] = user_id
+
+                result = await sess.execute(query, params)
                 row = result.fetchone()
                 if not row:
                     return None

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -915,25 +915,32 @@ class PostgresDb(BaseDb):
             with self.Session() as sess, sess.begin():
                 # Sanitize session_name to remove null bytes
                 sanitized_session_name = sanitize_postgres_string(session_name)
-                stmt = (
-                    update(table)
-                    .where(table.c.session_id == session_id)
-                    .where(table.c.session_type == session_type.value)
-                    .values(
-                        session_data=func.cast(
-                            func.jsonb_set(
-                                func.cast(table.c.session_data, postgresql.JSONB),
-                                text("'{session_name}'"),
-                                func.to_jsonb(sanitized_session_name),
-                            ),
-                            postgresql.JSON,
-                        )
-                    )
-                    .returning(*table.c)
-                )
+
+                # Use raw SQL with explicit type casting to avoid polymorphic type error
+                # Cast session_data to JSONB, use jsonb_set, then cast back to JSON
+                user_filter = "AND user_id = :user_id" if user_id is not None else ""
+                query = text(f"""
+                    UPDATE {self.db_schema}.{self.session_table_name}
+                    SET session_data = jsonb_set(
+                        COALESCE(session_data::jsonb, '{{}}'::jsonb),
+                        '{{session_name}}',
+                        to_jsonb(CAST(:session_name AS TEXT))
+                    )::json
+                    WHERE session_id = :session_id
+                    AND session_type = :session_type
+                    {user_filter}
+                    RETURNING *
+                """)
+
+                params = {
+                    "session_name": sanitized_session_name,
+                    "session_id": session_id,
+                    "session_type": session_type.value,
+                }
                 if user_id is not None:
-                    stmt = stmt.where(table.c.user_id == user_id)
-                result = sess.execute(stmt)
+                    params["user_id"] = user_id
+
+                result = sess.execute(query, params)
                 row = result.fetchone()
                 if not row:
                     return None

--- a/libs/agno/tests/integration/db/async_postgres/test_session.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_session.py
@@ -279,3 +279,97 @@ async def test_rename_session(async_postgres_db_real: AsyncPostgresDb, sample_ag
         session_id="test_agent_session_1", session_type=SessionType.AGENT
     )
     assert retrieved.session_data["session_name"] == "New Session Name"
+
+
+@pytest.mark.asyncio
+async def test_rename_session_with_null_session_data(async_postgres_db_real: AsyncPostgresDb):
+    """Test renaming a session with null session_data (edge case for COALESCE)"""
+    # Create a session and manually set session_data to NULL
+    session = AgentSession(
+        session_id="null_data_session",
+        agent_id="agent_1",
+        user_id="user_1",
+        session_data=None,
+        created_at=int(time.time()),
+    )
+
+    # Insert with null session_data
+    sessions_table = await async_postgres_db_real._get_table("sessions")
+    async with async_postgres_db_real.async_session_factory() as sess:
+        await sess.execute(
+            sessions_table.insert().values(
+                session_id=session.session_id,
+                agent_id=session.agent_id,
+                user_id=session.user_id,
+                session_type=SessionType.AGENT.value,
+                session_data=None,
+                created_at=session.created_at,
+            )
+        )
+        await sess.commit()
+
+    # Rename should work even with null session_data
+    result = await async_postgres_db_real.rename_session(
+        session_id="null_data_session",
+        session_type=SessionType.AGENT,
+        session_name="New Name From Null",
+    )
+
+    assert result is not None
+    assert result.session_data is not None
+    assert result.session_data["session_name"] == "New Name From Null"
+
+
+@pytest.mark.asyncio
+async def test_rename_session_with_special_characters(
+    async_postgres_db_real: AsyncPostgresDb, sample_agent_session: AgentSession
+):
+    """Test renaming with special characters that might cause type casting issues"""
+    await async_postgres_db_real.upsert_session(sample_agent_session)
+
+    # Test with various special characters that could cause SQL/type issues
+    special_names = [
+        "Name with 'single quotes'",
+        'Name with "double quotes"',
+        "Name with {braces} and [brackets]",
+        "Name with special chars: !@#$%^&*()",
+        "Name with unicode: 你好世界 🎉",
+        "Name with newline\nand tab\there",
+    ]
+
+    for special_name in special_names:
+        result = await async_postgres_db_real.rename_session(
+            session_id=sample_agent_session.session_id,
+            session_type=SessionType.AGENT,
+            session_name=special_name,
+        )
+
+        assert result is not None
+        # Note: sanitize_postgres_string may modify some characters (like newlines)
+        assert result.session_data is not None
+        assert "session_name" in result.session_data
+
+
+@pytest.mark.asyncio
+async def test_rename_session_with_empty_session_data(async_postgres_db_real: AsyncPostgresDb):
+    """Test renaming a session with empty session_data dict"""
+    session = AgentSession(
+        session_id="empty_data_session",
+        agent_id="agent_1",
+        user_id="user_1",
+        session_data={},
+        created_at=int(time.time()),
+    )
+
+    await async_postgres_db_real.upsert_session(session)
+
+    # Rename session with empty dict
+    result = await async_postgres_db_real.rename_session(
+        session_id="empty_data_session",
+        session_type=SessionType.AGENT,
+        session_name="Name From Empty Dict",
+    )
+
+    assert result is not None
+    assert result.session_data is not None
+    assert result.session_data["session_name"] == "Name From Empty Dict"

--- a/libs/agno/tests/integration/db/postgres/test_session.py
+++ b/libs/agno/tests/integration/db/postgres/test_session.py
@@ -618,6 +618,95 @@ def test_rename_session_scoped_by_user_id(postgres_db_real: PostgresDb):
     assert result.session_data["session_name"] == "New Name"
 
 
+def test_rename_session_with_null_session_data(postgres_db_real: PostgresDb):
+    """Test renaming a session with null session_data (edge case for COALESCE)"""
+    # Create a session and manually set session_data to NULL
+    session = AgentSession(
+        session_id="null_data_session",
+        agent_id="agent_1",
+        user_id="user_1",
+        session_data=None,
+        created_at=int(time.time()),
+    )
+
+    # Insert with null session_data
+    with postgres_db_real.Session() as sess:
+        sessions_table = postgres_db_real._get_table("sessions", create_table_if_not_found=True)
+        sess.execute(
+            sessions_table.insert().values(
+                session_id=session.session_id,
+                agent_id=session.agent_id,
+                user_id=session.user_id,
+                session_type=SessionType.AGENT.value,
+                session_data=None,
+                created_at=session.created_at,
+            )
+        )
+        sess.commit()
+
+    # Rename should work even with null session_data
+    result = postgres_db_real.rename_session(
+        session_id="null_data_session",
+        session_type=SessionType.AGENT,
+        session_name="New Name From Null",
+    )
+
+    assert result is not None
+    assert result.session_data is not None
+    assert result.session_data["session_name"] == "New Name From Null"
+
+
+def test_rename_session_with_special_characters(postgres_db_real: PostgresDb, sample_agent_session: AgentSession):
+    """Test renaming with special characters that might cause type casting issues"""
+    postgres_db_real.upsert_session(sample_agent_session)
+
+    # Test with various special characters that could cause SQL/type issues
+    special_names = [
+        "Name with 'single quotes'",
+        'Name with "double quotes"',
+        "Name with {braces} and [brackets]",
+        "Name with special chars: !@#$%^&*()",
+        "Name with unicode: 你好世界 🎉",
+        "Name with newline\nand tab\there",
+    ]
+
+    for special_name in special_names:
+        result = postgres_db_real.rename_session(
+            session_id=sample_agent_session.session_id,
+            session_type=SessionType.AGENT,
+            session_name=special_name,
+        )
+
+        assert result is not None
+        # Note: sanitize_postgres_string may modify some characters (like newlines)
+        assert result.session_data is not None
+        assert "session_name" in result.session_data
+
+
+def test_rename_session_with_empty_session_data(postgres_db_real: PostgresDb):
+    """Test renaming a session with empty session_data dict"""
+    session = AgentSession(
+        session_id="empty_data_session",
+        agent_id="agent_1",
+        user_id="user_1",
+        session_data={},
+        created_at=int(time.time()),
+    )
+
+    postgres_db_real.upsert_session(session)
+
+    # Rename session with empty dict
+    result = postgres_db_real.rename_session(
+        session_id="empty_data_session",
+        session_type=SessionType.AGENT,
+        session_name="Name From Empty Dict",
+    )
+
+    assert result is not None
+    assert result.session_data is not None
+    assert result.session_data["session_name"] == "Name From Empty Dict"
+
+
 def test_session_type_polymorphism(
     postgres_db_real: PostgresDb, sample_agent_session: AgentSession, sample_team_session: TeamSession
 ):


### PR DESCRIPTION
Fixes psycopg2.errors.DatatypeMismatch error when renaming sessions by using raw SQL with explicit type casting instead of SQLAlchemy's jsonb_set function. The polymorphic type inference issue occurred because PostgreSQL couldn't determine the proper type when casting between JSON and JSONB.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
