### PR TITLE
[feat] Add XquikTools for read-only X/Twitter access

### DIFF
--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -10,6 +10,16 @@
 
 ---
 
+### xquik_tools.py
+
+**Status:** PASS
+
+**Description:** Added `XquikTools` for read-only X search, profile lookup, post lookup, user posts, and trends. Sync and async tools share response formatting. Search results retain pagination cursors and canonical permalinks, redirects are rejected, and profile timelines respect the API's 100-item page limit.
+
+**Result:** All 21 focused offline tests pass. Ruff, mypy, Python compilation, and Git diff validation pass. The current Xquik OpenAPI contract matches all five routes, parameters, and response envelopes. Trend results retain region and total metadata. The live cookbook was not run because it requires model and Xquik API credentials.
+
+---
+
 ### file_generation_tools.py (generate_code_file)
 
 **Status:** PASS

--- a/cookbook/91_tools/xquik_tools.py
+++ b/cookbook/91_tools/xquik_tools.py
@@ -1,0 +1,67 @@
+"""
+Xquik Tools
+=============================
+
+Demonstrates advanced Twitter search, user lookup, post reading, and trends
+via the Xquik API. Only requires XQUIK_API_KEY (1 env var).
+
+For write operations (posting, replying, DMs), use XTools instead.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.xquik import XquikTools
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+"""
+1. Get an API key at https://dashboard.xquik.com/dashboard/account?tab=api-keys
+2. Set the environment variable:
+   export XQUIK_API_KEY="xq_your_api_key_here"
+"""
+
+# Initialize the Xquik toolkit
+xquik_tools = XquikTools()
+
+# Create an agent with Xquik tools
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=[
+        "Use your tools to search and read X (Twitter) content",
+        "When presenting search results, highlight the most engaging posts",
+        "Include engagement metrics when they add context",
+        "Never post or interact. This toolkit is read-only",
+    ],
+    tools=[xquik_tools],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Search for posts about a topic
+    agent.print_response(
+        "Search X for what people are saying about AI agents", markdown=True
+    )
+
+    # # Look up a user profile
+    # agent.print_response(
+    #     "Get the profile info for @AgnoAgi on X", markdown=True
+    # )
+
+    # # Read recent posts from a user
+    # agent.print_response(
+    #     "Show recent posts from @AgnoAgi on X", markdown=True
+    # )
+
+    # # Check trending topics
+    # agent.print_response(
+    #     "What's trending on X right now?", markdown=True
+    # )
+
+    # # Read a specific tweet
+    # agent.print_response(
+    #     "Read this tweet: 1234567890", markdown=True
+    # )

--- a/libs/agno/agno/tools/xquik.py
+++ b/libs/agno/agno/tools/xquik.py
@@ -1,0 +1,456 @@
+"""Read-only X (Twitter) tools backed by the Xquik API."""
+
+import json
+from os import getenv
+from typing import Any, Dict, List, Literal, Optional, Tuple
+from urllib.parse import quote
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_info, logger
+
+_BASE_URL = "https://xquik.com/api/v1"
+_MAX_SEARCH_RESULTS = 200
+_MAX_TIMELINE_RESULTS = 100
+_MAX_TRENDS = 50
+
+
+class XquikTools(Toolkit):
+    """Provide read-only access to X posts, profiles, timelines, and trends.
+
+    Xquik is an independent third-party service. Use ``XTools`` for write
+    operations such as posting, replying, or sending direct messages.
+
+    Args:
+        api_key: Xquik API key. Falls back to ``XQUIK_API_KEY``.
+        include_post_metrics: Include engagement metrics in post results.
+        timeout: Request timeout in seconds.
+        enable_search_posts: Enable advanced X post search.
+        enable_get_user_info: Enable user profile lookup.
+        enable_get_tweet: Enable single-post lookup.
+        enable_get_user_posts: Enable user timeline lookup.
+        enable_get_trends: Enable regional trend lookup.
+        all: Enable every tool regardless of individual flags.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        include_post_metrics: bool = True,
+        timeout: float = 15.0,
+        enable_search_posts: bool = True,
+        enable_get_user_info: bool = True,
+        enable_get_tweet: bool = True,
+        enable_get_user_posts: bool = True,
+        enable_get_trends: bool = True,
+        all: bool = False,
+        **kwargs: Any,
+    ):
+        self.api_key = api_key or getenv("XQUIK_API_KEY")
+        if not self.api_key:
+            logger.error(
+                "XQUIK_API_KEY not set. Get a key at https://dashboard.xquik.com/dashboard/account?tab=api-keys"
+            )
+        self.include_post_metrics = include_post_metrics
+        self.timeout = timeout
+
+        tools: List[Any] = []
+        async_tools: List[Tuple[Any, str]] = []
+        registrations = [
+            (all or enable_search_posts, self.search_posts, self.asearch_posts, "search_posts"),
+            (all or enable_get_user_info, self.get_user_info, self.aget_user_info, "get_user_info"),
+            (all or enable_get_tweet, self.get_tweet, self.aget_tweet, "get_tweet"),
+            (all or enable_get_user_posts, self.get_user_posts, self.aget_user_posts, "get_user_posts"),
+            (all or enable_get_trends, self.get_trends, self.aget_trends, "get_trends"),
+        ]
+        for is_enabled, sync_tool, async_tool, name in registrations:
+            if is_enabled:
+                tools.append(sync_tool)
+                async_tools.append((async_tool, name))
+
+        super().__init__(name="xquik", tools=tools, async_tools=async_tools, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        if not self.api_key:
+            raise ValueError("XQUIK_API_KEY not set. Set the environment variable or pass api_key.")
+        return {
+            "Accept": "application/json",
+            "User-Agent": "agno-xquik",
+            "x-api-key": self.api_key,
+        }
+
+    @staticmethod
+    def _params(params: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            key: str(value).lower() if isinstance(value, bool) else value
+            for key, value in params.items()
+            if value is not None
+        }
+
+    @staticmethod
+    def _decode(response: httpx.Response) -> Dict[str, Any]:
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):
+            raise ValueError("Xquik returned an invalid JSON response.")
+        return data
+
+    def _api_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        with httpx.Client(headers=self._headers(), timeout=self.timeout, follow_redirects=False) as client:
+            response = client.get(f"{_BASE_URL}{path}", params=self._params(params or {}))
+        return self._decode(response)
+
+    async def _api_get_async(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        async with httpx.AsyncClient(headers=self._headers(), timeout=self.timeout, follow_redirects=False) as client:
+            response = await client.get(f"{_BASE_URL}{path}", params=self._params(params or {}))
+        return self._decode(response)
+
+    def _format_tweet(self, tweet: Dict[str, Any]) -> Dict[str, Any]:
+        author = tweet.get("author") or {}
+        if not isinstance(author, dict):
+            raise ValueError("Xquik returned an invalid tweet author.")
+        tweet_id = tweet.get("id", "")
+        username = author.get("username") or "unknown"
+        provided_url = tweet.get("url")
+        url = (
+            provided_url
+            if isinstance(provided_url, str) and provided_url.startswith("https://x.com/")
+            else f"https://x.com/{username}/status/{tweet_id}"
+        )
+        post_data = {
+            "id": tweet_id,
+            "text": tweet.get("text", ""),
+            "created_at": tweet.get("createdAt", ""),
+            "author": {
+                "id": author.get("id", ""),
+                "name": author.get("name", ""),
+                "username": author.get("username", ""),
+                "verified": author.get("verified", False),
+            },
+            "url": url,
+        }
+        if self.include_post_metrics:
+            post_data["metrics"] = {
+                "like_count": tweet.get("likeCount", 0),
+                "retweet_count": tweet.get("retweetCount", 0),
+                "reply_count": tweet.get("replyCount", 0),
+                "quote_count": tweet.get("quoteCount", 0),
+                "view_count": tweet.get("viewCount", 0),
+                "bookmark_count": tweet.get("bookmarkCount", 0),
+            }
+        return post_data
+
+    def _format_posts(self, data: Dict[str, Any]) -> List[Dict[str, Any]]:
+        tweets = data.get("tweets", [])
+        if not isinstance(tweets, list) or any(not isinstance(tweet, dict) for tweet in tweets):
+            raise ValueError("Xquik returned an invalid tweets response.")
+        return [self._format_tweet(tweet) for tweet in tweets]
+
+    @staticmethod
+    def _bounded_count(value: int, name: str, maximum: int) -> int:
+        if value <= 0:
+            raise ValueError(f"{name} must be greater than 0.")
+        return min(value, maximum)
+
+    @staticmethod
+    def _identifier(value: str, name: str) -> str:
+        normalized = value.lstrip("@").strip()
+        if not normalized:
+            raise ValueError(f"Please provide a {name}.")
+        return quote(normalized, safe="")
+
+    @staticmethod
+    def _error(message: str, error: Exception, **context: Any) -> str:
+        logger.exception(message)
+        return json.dumps({"error": str(error), **context})
+
+    def _search_result(self, query: str, data: Dict[str, Any]) -> str:
+        posts = self._format_posts(data)
+        log_info(f"Xquik: found {len(posts)} posts for query: {query}")
+        return json.dumps(
+            {
+                "query": query,
+                "count": len(posts),
+                "posts": posts,
+                "has_next_page": data.get("has_next_page", False),
+                "next_cursor": data.get("next_cursor"),
+            },
+            indent=2,
+        )
+
+    def search_posts(
+        self,
+        query: str,
+        max_results: int = 20,
+        cursor: Optional[str] = None,
+        query_type: Literal["Latest", "Top"] = "Top",
+    ) -> str:
+        """Run an advanced X (Twitter) search.
+
+        Args:
+            query: Keywords or X search operators such as ``from:user``.
+            max_results: Result cap for this agent response (1-200).
+            cursor: Cursor returned by the previous response.
+            query_type: ``Latest`` for chronology or ``Top`` for engagement.
+
+        Returns:
+            JSON with posts, metrics, and pagination cursors.
+        """
+        try:
+            normalized_query = query.strip()
+            if not normalized_query:
+                return json.dumps({"error": "Please provide a query to search for."})
+            limit = self._bounded_count(max_results, "max_results", _MAX_SEARCH_RESULTS)
+            log_debug(f"Searching X via Xquik for: {normalized_query}, max results: {limit}")
+            data = self._api_get(
+                "/x/tweets/search",
+                {"q": normalized_query, "limit": limit, "queryType": query_type, "cursor": cursor},
+            )
+            return self._search_result(normalized_query, data)
+        except Exception as error:
+            return self._error("Error searching posts via Xquik", error, query=query)
+
+    async def asearch_posts(
+        self,
+        query: str,
+        max_results: int = 20,
+        cursor: Optional[str] = None,
+        query_type: Literal["Latest", "Top"] = "Top",
+    ) -> str:
+        """Run an advanced X (Twitter) search asynchronously.
+
+        Args:
+            query: Keywords or X search operators such as ``from:user``.
+            max_results: Result cap for this agent response (1-200).
+            cursor: Cursor returned by the previous response.
+            query_type: ``Latest`` for chronology or ``Top`` for engagement.
+
+        Returns:
+            JSON with posts, metrics, and pagination cursors.
+        """
+        try:
+            normalized_query = query.strip()
+            if not normalized_query:
+                return json.dumps({"error": "Please provide a query to search for."})
+            limit = self._bounded_count(max_results, "max_results", _MAX_SEARCH_RESULTS)
+            data = await self._api_get_async(
+                "/x/tweets/search",
+                {"q": normalized_query, "limit": limit, "queryType": query_type, "cursor": cursor},
+            )
+            return self._search_result(normalized_query, data)
+        except Exception as error:
+            return self._error("Error searching posts via Xquik", error, query=query)
+
+    @staticmethod
+    def _user_result(username: str, data: Dict[str, Any]) -> str:
+        return json.dumps(
+            {
+                "id": data.get("id", ""),
+                "name": data.get("name", ""),
+                "username": data.get("username", ""),
+                "description": data.get("description", ""),
+                "followers_count": data.get("followers", 0),
+                "following_count": data.get("following", 0),
+                "tweet_count": data.get("statusesCount", 0),
+                "verified": data.get("verified", False),
+                "url": f"https://x.com/{data.get('username') or username.lstrip('@')}",
+            },
+            indent=2,
+        )
+
+    def get_user_info(self, username: str) -> str:
+        """Retrieve an X user profile by username or ID.
+
+        Args:
+            username: X username, with or without ``@``, or a user ID.
+
+        Returns:
+            JSON with profile details, counts, verification, and profile URL.
+        """
+        try:
+            user_id = self._identifier(username, "username or user ID")
+            return self._user_result(username, self._api_get(f"/x/users/{user_id}"))
+        except Exception as error:
+            return self._error("Error fetching user info via Xquik", error)
+
+    async def aget_user_info(self, username: str) -> str:
+        """Retrieve an X user profile asynchronously.
+
+        Args:
+            username: X username, with or without ``@``, or a user ID.
+
+        Returns:
+            JSON with profile details, counts, verification, and profile URL.
+        """
+        try:
+            user_id = self._identifier(username, "username or user ID")
+            return self._user_result(username, await self._api_get_async(f"/x/users/{user_id}"))
+        except Exception as error:
+            return self._error("Error fetching user info via Xquik", error)
+
+    def _tweet_result(self, data: Dict[str, Any]) -> str:
+        tweet = data.get("tweet")
+        if not isinstance(tweet, dict):
+            return json.dumps({"error": "Xquik returned an invalid tweet response."})
+        return json.dumps(self._format_tweet({**tweet, "author": data.get("author")}), indent=2)
+
+    def get_tweet(self, tweet_id: str) -> str:
+        """Retrieve one X post by ID.
+
+        Args:
+            tweet_id: X post ID.
+
+        Returns:
+            JSON with the post, author, engagement metrics, and URL.
+        """
+        try:
+            encoded_id = self._identifier(tweet_id, "tweet ID")
+            return self._tweet_result(self._api_get(f"/x/tweets/{encoded_id}"))
+        except Exception as error:
+            return self._error("Error fetching tweet via Xquik", error)
+
+    async def aget_tweet(self, tweet_id: str) -> str:
+        """Retrieve one X post by ID asynchronously.
+
+        Args:
+            tweet_id: X post ID.
+
+        Returns:
+            JSON with the post, author, engagement metrics, and URL.
+        """
+        try:
+            encoded_id = self._identifier(tweet_id, "tweet ID")
+            return self._tweet_result(await self._api_get_async(f"/x/tweets/{encoded_id}"))
+        except Exception as error:
+            return self._error("Error fetching tweet via Xquik", error)
+
+    def _user_posts_result(self, username: str, data: Dict[str, Any]) -> str:
+        posts = self._format_posts(data)
+        return json.dumps(
+            {
+                "username": username.lstrip("@"),
+                "count": len(posts),
+                "posts": posts,
+                "has_next_page": data.get("has_next_page", False),
+                "next_cursor": data.get("next_cursor"),
+            },
+            indent=2,
+        )
+
+    @staticmethod
+    def _user_posts_params(
+        cursor: Optional[str], include_replies: bool, include_parent_tweet: bool, max_results: int
+    ) -> Dict[str, Any]:
+        return {
+            "cursor": cursor,
+            "includeReplies": include_replies,
+            "includeParentTweet": include_parent_tweet,
+            "pageSize": XquikTools._bounded_count(max_results, "max_results", _MAX_TIMELINE_RESULTS),
+        }
+
+    def get_user_posts(
+        self,
+        username: str,
+        cursor: Optional[str] = None,
+        include_replies: bool = False,
+        include_parent_tweet: bool = False,
+        max_results: int = 20,
+    ) -> str:
+        """Retrieve a user's recent X posts with pagination.
+
+        Args:
+            username: X username, with or without ``@``, or a user ID.
+            cursor: Cursor returned by the previous response.
+            include_replies: Include the user's replies.
+            include_parent_tweet: Include parent posts for replies.
+            max_results: Result cap for this agent response (1-100).
+
+        Returns:
+            JSON with posts, metrics, and pagination cursors.
+        """
+        try:
+            user_id = self._identifier(username, "username or user ID")
+            data = self._api_get(
+                f"/x/users/{user_id}/tweets",
+                self._user_posts_params(cursor, include_replies, include_parent_tweet, max_results),
+            )
+            return self._user_posts_result(username, data)
+        except Exception as error:
+            return self._error("Error fetching user posts via Xquik", error)
+
+    async def aget_user_posts(
+        self,
+        username: str,
+        cursor: Optional[str] = None,
+        include_replies: bool = False,
+        include_parent_tweet: bool = False,
+        max_results: int = 20,
+    ) -> str:
+        """Retrieve a user's recent X posts asynchronously.
+
+        Args:
+            username: X username, with or without ``@``, or a user ID.
+            cursor: Cursor returned by the previous response.
+            include_replies: Include the user's replies.
+            include_parent_tweet: Include parent posts for replies.
+            max_results: Result cap for this agent response (1-100).
+
+        Returns:
+            JSON with posts, metrics, and pagination cursors.
+        """
+        try:
+            user_id = self._identifier(username, "username or user ID")
+            data = await self._api_get_async(
+                f"/x/users/{user_id}/tweets",
+                self._user_posts_params(cursor, include_replies, include_parent_tweet, max_results),
+            )
+            return self._user_posts_result(username, data)
+        except Exception as error:
+            return self._error("Error fetching user posts via Xquik", error)
+
+    @staticmethod
+    def _trends_result(data: Dict[str, Any]) -> str:
+        trends = data.get("trends", [])
+        total = data.get("total")
+        woeid = data.get("woeid")
+        if (
+            not isinstance(trends, list)
+            or any(not isinstance(trend, dict) for trend in trends)
+            or not isinstance(total, int)
+            or not isinstance(woeid, int)
+        ):
+            raise ValueError("Xquik returned an invalid trends response.")
+        return json.dumps({"trends": trends, "total": total, "woeid": woeid}, indent=2)
+
+    def get_trends(self, woeid: int = 1, count: int = 20) -> str:
+        """Retrieve trending X topics for a Yahoo WOEID region.
+
+        Args:
+            woeid: Region code. Use 1 for worldwide trends.
+            count: Number of trends to return (1-50).
+
+        Returns:
+            JSON with the region's trending topics.
+        """
+        try:
+            limit = self._bounded_count(count, "count", _MAX_TRENDS)
+            return self._trends_result(self._api_get("/trends", {"woeid": woeid, "count": limit}))
+        except Exception as error:
+            return self._error("Error fetching trends via Xquik", error)
+
+    async def aget_trends(self, woeid: int = 1, count: int = 20) -> str:
+        """Retrieve trending X topics asynchronously.
+
+        Args:
+            woeid: Region code. Use 1 for worldwide trends.
+            count: Number of trends to return (1-50).
+
+        Returns:
+            JSON with the region's trending topics.
+        """
+        try:
+            limit = self._bounded_count(count, "count", _MAX_TRENDS)
+            return self._trends_result(await self._api_get_async("/trends", {"woeid": woeid, "count": limit}))
+        except Exception as error:
+            return self._error("Error fetching trends via Xquik", error)

--- a/libs/agno/tests/unit/tools/test_xquik.py
+++ b/libs/agno/tests/unit/tools/test_xquik.py
@@ -1,0 +1,360 @@
+"""Unit tests for XquikTools."""
+
+import inspect
+import json
+from collections.abc import Callable
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+from agno.tools.xquik import XquikTools
+
+_SYNC_CLIENT = httpx.Client
+_ASYNC_CLIENT = httpx.AsyncClient
+
+
+@pytest.fixture
+def xquik_tools() -> XquikTools:
+    return XquikTools(api_key="xq_test_key")
+
+
+def _response(request: httpx.Request, data: Any, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=data, request=request)
+
+
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> List[httpx.Request]:
+    requests: List[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler(request)
+
+    transport = httpx.MockTransport(capture)
+    monkeypatch.setattr(
+        "agno.tools.xquik.httpx.Client",
+        lambda **kwargs: _SYNC_CLIENT(transport=transport, **kwargs),
+    )
+    monkeypatch.setattr(
+        "agno.tools.xquik.httpx.AsyncClient",
+        lambda **kwargs: _ASYNC_CLIENT(transport=transport, **kwargs),
+    )
+    return requests
+
+
+def _tweet(author: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    return {
+        "id": "123456",
+        "text": "Hello world",
+        "createdAt": "2026-04-10T12:00:00Z",
+        "author": author
+        if author is not None
+        else {"id": "789", "name": "Test User", "username": "testuser", "verified": True},
+        "likeCount": 42,
+        "retweetCount": 5,
+        "replyCount": 3,
+        "quoteCount": 1,
+        "viewCount": 1000,
+        "bookmarkCount": 2,
+    }
+
+
+def test_init_registers_matching_sync_and_async_tools() -> None:
+    tools = XquikTools(api_key="xq_test_key")
+
+    expected = {"search_posts", "get_user_info", "get_tweet", "get_user_posts", "get_trends"}
+    assert set(tools.get_functions()) == expected
+    assert set(tools.get_async_functions()) == expected
+    assert all(inspect.iscoroutinefunction(function.entrypoint) for function in tools.get_async_functions().values())
+
+
+def test_init_respects_tool_flags() -> None:
+    tools = XquikTools(
+        api_key="xq_test_key",
+        enable_search_posts=True,
+        enable_get_user_info=False,
+        enable_get_tweet=False,
+        enable_get_user_posts=False,
+        enable_get_trends=False,
+    )
+
+    assert set(tools.get_functions()) == {"search_posts"}
+    assert set(tools.get_async_functions()) == {"search_posts"}
+
+
+def test_all_overrides_disabled_tool_flags() -> None:
+    tools = XquikTools(
+        api_key="xq_test_key",
+        enable_search_posts=False,
+        enable_get_user_info=False,
+        enable_get_tweet=False,
+        enable_get_user_posts=False,
+        enable_get_trends=False,
+        all=True,
+    )
+
+    assert len(tools.get_functions()) == 5
+    assert len(tools.get_async_functions()) == 5
+
+
+def test_search_posts_formats_results_and_preserves_cursor(
+    xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests = _install_transport(
+        monkeypatch,
+        lambda request: _response(
+            request,
+            {"tweets": [_tweet()], "has_next_page": True, "next_cursor": "cursor-2"},
+        ),
+    )
+
+    result = json.loads(xquik_tools.search_posts("advanced Twitter search", cursor="cursor-1"))
+
+    assert result == {
+        "query": "advanced Twitter search",
+        "count": 1,
+        "posts": [
+            {
+                "id": "123456",
+                "text": "Hello world",
+                "created_at": "2026-04-10T12:00:00Z",
+                "author": {
+                    "id": "789",
+                    "name": "Test User",
+                    "username": "testuser",
+                    "verified": True,
+                },
+                "url": "https://x.com/testuser/status/123456",
+                "metrics": {
+                    "like_count": 42,
+                    "retweet_count": 5,
+                    "reply_count": 3,
+                    "quote_count": 1,
+                    "view_count": 1000,
+                    "bookmark_count": 2,
+                },
+            }
+        ],
+        "has_next_page": True,
+        "next_cursor": "cursor-2",
+    }
+    assert requests[0].url.path == "/api/v1/x/tweets/search"
+    assert requests[0].url.params["q"] == "advanced Twitter search"
+    assert requests[0].url.params["cursor"] == "cursor-1"
+    assert requests[0].headers["x-api-key"] == "xq_test_key"
+
+
+@pytest.mark.asyncio
+async def test_async_search_posts_uses_the_same_contract(
+    xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests = _install_transport(
+        monkeypatch,
+        lambda request: _response(request, {"tweets": [], "has_next_page": False, "next_cursor": ""}),
+    )
+
+    result = json.loads(await xquik_tools.asearch_posts("agents"))
+
+    assert result["posts"] == []
+    assert requests[0].url.params["queryType"] == "Top"
+
+
+def test_search_posts_caps_agent_output_and_rejects_invalid_input(
+    xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests = _install_transport(monkeypatch, lambda request: _response(request, {"tweets": []}))
+
+    xquik_tools.search_posts("agents", max_results=500)
+
+    assert requests[0].url.params["limit"] == "200"
+    assert json.loads(xquik_tools.search_posts(""))["error"] == "Please provide a query to search for."
+    assert "greater than 0" in json.loads(xquik_tools.search_posts("agents", max_results=0))["error"]
+    assert len(requests) == 1
+
+
+def test_search_posts_retains_tweets_with_nullable_authors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tools = XquikTools(api_key="xq_test_key", include_post_metrics=False)
+    tweet = _tweet()
+    tweet["author"] = None
+    tweet["url"] = "https://x.com/testuser/status/123456"
+    _install_transport(monkeypatch, lambda request: _response(request, {"tweets": [tweet]}))
+
+    result = json.loads(tools.search_posts("agents"))
+
+    assert result["posts"][0]["author"] == {
+        "id": "",
+        "name": "",
+        "username": "",
+        "verified": False,
+    }
+    assert result["posts"][0]["url"] == "https://x.com/testuser/status/123456"
+    assert "metrics" not in result["posts"][0]
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 307, 308])
+def test_requests_reject_redirects_without_forwarding_credentials(
+    xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch, status_code: int
+) -> None:
+    requests = _install_transport(
+        monkeypatch,
+        lambda request: httpx.Response(
+            status_code,
+            headers={"location": "https://attacker.example/collect"},
+            request=request,
+        ),
+    )
+
+    result = json.loads(xquik_tools.search_posts("agents"))
+
+    assert "error" in result
+    assert len(requests) == 1
+    assert requests[0].url.host == "xquik.com"
+
+
+def test_get_user_info_encodes_identifier(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    requests = _install_transport(
+        monkeypatch,
+        lambda request: _response(
+            request,
+            {
+                "id": "1",
+                "name": "Agno",
+                "username": "AgnoAgi",
+                "description": "Build agents",
+                "followers": 50000,
+                "following": 100,
+                "statusesCount": 2000,
+                "verified": True,
+            },
+        ),
+    )
+
+    result = json.loads(xquik_tools.get_user_info("@team/user"))
+
+    assert requests[0].url.path == "/api/v1/x/users/team/user"
+    assert requests[0].url.raw_path.endswith(b"team%2Fuser")
+    assert result["username"] == "AgnoAgi"
+    assert result["followers_count"] == 50000
+
+
+@pytest.mark.asyncio
+async def test_async_get_user_info(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(
+        monkeypatch,
+        lambda request: _response(request, {"id": "1", "name": "Agno", "username": "AgnoAgi"}),
+    )
+
+    result = json.loads(await xquik_tools.aget_user_info("AgnoAgi"))
+
+    assert result["url"] == "https://x.com/AgnoAgi"
+
+
+def test_get_tweet_maps_response_envelope(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    data = {
+        "tweet": {key: value for key, value in _tweet().items() if key != "author"},
+        "author": {"id": "789", "name": "Test User", "username": "testuser", "verified": True},
+    }
+    requests = _install_transport(monkeypatch, lambda request: _response(request, data))
+
+    result = json.loads(xquik_tools.get_tweet("12/34"))
+
+    assert requests[0].url.raw_path.endswith(b"12%2F34")
+    assert result["author"]["username"] == "testuser"
+
+
+@pytest.mark.asyncio
+async def test_async_get_tweet_rejects_invalid_envelope(
+    xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_transport(monkeypatch, lambda request: _response(request, {"tweet": None}))
+
+    result = json.loads(await xquik_tools.aget_tweet("123"))
+
+    assert result == {"error": "Xquik returned an invalid tweet response."}
+
+
+def test_get_user_posts_sends_bounded_page_size_and_filters(
+    xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requests = _install_transport(
+        monkeypatch,
+        lambda request: _response(
+            request,
+            {"tweets": [], "has_next_page": True, "next_cursor": "cursor-2"},
+        ),
+    )
+
+    result = json.loads(
+        xquik_tools.get_user_posts(
+            "@AgnoAgi",
+            max_results=500,
+            cursor="cursor-1",
+            include_replies=True,
+            include_parent_tweet=True,
+        )
+    )
+
+    params = requests[0].url.params
+    assert params["pageSize"] == "100"
+    assert params["includeReplies"] == "true"
+    assert params["includeParentTweet"] == "true"
+    assert result["next_cursor"] == "cursor-2"
+
+
+@pytest.mark.asyncio
+async def test_async_get_user_posts(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(monkeypatch, lambda request: _response(request, {"tweets": [_tweet()]}))
+
+    result = json.loads(await xquik_tools.aget_user_posts("AgnoAgi"))
+
+    assert result["count"] == 1
+
+
+def test_get_trends_uses_current_route(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    requests = _install_transport(
+        monkeypatch,
+        lambda request: _response(request, {"total": 1, "trends": [{"name": "#AI"}], "woeid": 1}),
+    )
+
+    result = json.loads(xquik_tools.get_trends(count=100))
+
+    assert requests[0].url.path == "/api/v1/trends"
+    assert requests[0].url.params["count"] == "50"
+    assert result == {"trends": [{"name": "#AI"}], "total": 1, "woeid": 1}
+
+
+@pytest.mark.asyncio
+async def test_async_get_trends(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(
+        monkeypatch,
+        lambda request: _response(request, {"total": 0, "trends": [], "woeid": 23424969}),
+    )
+
+    result = json.loads(await xquik_tools.aget_trends(woeid=23424969))
+
+    assert result == {"trends": [], "total": 0, "woeid": 23424969}
+
+
+def test_get_trends_rejects_invalid_response(xquik_tools: XquikTools, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_transport(monkeypatch, lambda request: _response(request, {"trends": ["invalid"]}))
+
+    result = json.loads(xquik_tools.get_trends())
+
+    assert result["error"] == "Xquik returned an invalid trends response."
+
+
+def test_missing_key_and_http_errors_return_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("XQUIK_API_KEY", raising=False)
+    tools = XquikTools()
+    result = json.loads(tools.search_posts("agents"))
+    assert result["error"] == "XQUIK_API_KEY not set. Set the environment variable or pass api_key."
+
+    keyed_tools = XquikTools(api_key="xq_test_key")
+    _install_transport(monkeypatch, lambda request: _response(request, {"error": "limited"}, 429))
+    result = json.loads(keyed_tools.search_posts("agents"))
+    assert "429" in result["error"]


### PR DESCRIPTION
Closes #7468

## Summary

Adds XquikTools, a read-only X (Twitter) toolkit backed by the Xquik REST API.

- Provides advanced post search, user lookup, post lookup, user timelines, and regional trends.
- Registers native synchronous and asynchronous implementations for every tool.
- Preserves search and timeline pagination cursors with route-specific response limits.
- Uses the existing httpx dependency with a fixed HTTPS origin, a 15-second default timeout, and redirects disabled.
- Maps nullable authors, canonical post URLs, and complete regional trend metadata.
- Adds a focused cookbook and 21 offline contract tests.

The existing XTools remains the write-capable official X API integration. XquikTools is an optional read-only surface with one API key.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (./scripts/format.sh and ./scripts/validate.sh)
- [x] Self-review completed
- [x] Documentation updated
- [x] Relevant cookbook example included
- [x] Tested in a clean environment
- [x] Tests added

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and found no duplicate
- [x] No similar PR requires comparison
- [x] AI assistance disclosed below

Claude Code helped with the original contribution. Codex helped rebase, refactor, and expand the current validation. I reviewed the final implementation and test evidence.

---

## Validation

- 21 focused offline tests passed.
- Repository format script passed across Agno, agnoctl, agno_infra, and cookbooks.
- Repository validation passed Ruff, mypy for 960 Agno files and 21 agnoctl files, plus cookbook checks.
- Python 3.9 syntax compilation passed for the toolkit, tests, and cookbook.
- Git diff checks passed.
- Current Xquik OpenAPI and Stainless SDK audit confirmed all five routes, query parameters, and response envelopes.

## Dependency Choice

The current Stainless-generated Xquik Python SDK requires Python 3.10 or newer. Agno supports Python 3.9, so this toolkit uses Agno existing httpx dependency and preserves the supported Python range.

## Security

- Requests use a fixed https://xquik.com/api/v1 origin.
- Redirect following is disabled, so the API key cannot be forwarded to another origin.
- Tests cover 301, 302, 307, and 308 responses.
- Tests are offline and do not call Xquik.

The live cookbook was not run because it requires model and Xquik credentials.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
