### PR TITLE
Add OpenAI reasoning summary stream metadata

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1253,7 +1253,6 @@ class OpenAIResponses(Model):
             ModelResponse: Parsed response delta
         """
         model_response = ModelResponse()
-
         # 1. Add response ID
         if stream_event.type == "response.created":
             if stream_event.response.id:
@@ -1293,9 +1292,34 @@ class OpenAIResponses(Model):
             if self.reasoning is not None and self.reasoning_summary is None:
                 model_response.reasoning_content = stream_event.delta
 
-        # 3.1 Stream reasoning summary deltas
+        # 3.1 Stream reasoning summary part boundaries and deltas
+        elif stream_event.type == "response.reasoning_summary_part.added":
+            model_response.provider_data = {
+                "reasoning_summary_event": "part_added",
+                "reasoning_summary_index": getattr(stream_event, "summary_index", 0),
+                "reasoning_summary_part_text": getattr(getattr(stream_event, "part", None), "text", ""),
+            }
+
         elif stream_event.type == "response.reasoning_summary_text.delta":
             model_response.reasoning_content = stream_event.delta
+            model_response.provider_data = {
+                "reasoning_summary_event": "text_delta",
+                "reasoning_summary_index": getattr(stream_event, "summary_index", 0),
+            }
+
+        elif stream_event.type == "response.reasoning_summary_text.done":
+            model_response.provider_data = {
+                "reasoning_summary_event": "text_done",
+                "reasoning_summary_index": getattr(stream_event, "summary_index", 0),
+                "reasoning_summary_text": getattr(stream_event, "text", ""),
+            }
+
+        elif stream_event.type == "response.reasoning_summary_part.done":
+            model_response.provider_data = {
+                "reasoning_summary_event": "part_done",
+                "reasoning_summary_index": getattr(stream_event, "summary_index", 0),
+                "reasoning_summary_part_text": getattr(getattr(stream_event, "part", None), "text", ""),
+            }
 
         # 4. Add tool calls information
 


### PR DESCRIPTION
## Summary

This change improves native OpenAI Responses reasoning-summary streaming by forwarding summary part boundaries and indices alongside the already-streamed summary text deltas. This allows for proper display of reasoning in sections.


(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

