### PR TITLE
feat: add_team_media_to_delegation for delegated member kwargs

### DIFF
--- a/cookbook/03_teams/01_quickstart/10_team_media_delegation.py
+++ b/cookbook/03_teams/01_quickstart/10_team_media_delegation.py
@@ -1,0 +1,78 @@
+"""
+Team media on delegated member runs
+=====================================
+
+Shows ``add_team_media_to_delegation`` on :class:`Team`: when the leader delegates,
+prior team-level run inputs and team-visible message attachments can be merged into
+``member_agent.run`` / ``arun`` kwargs (``images``, ``videos``, ``audio``, ``files``),
+bounded by ``num_history_runs`` / ``num_history_messages``.
+
+Requires a persisted session (``db``) so earlier team runs exist in ``TeamSession``.
+
+First turn uploads an image; second turn asks the leader to delegate to the vision
+member about that earlier image. With the flag on, the member receives the historical
+image in kwargs, not only the current text turn.
+"""
+
+from uuid import uuid4
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.media import Image
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+
+# ---------------------------------------------------------------------------
+# Members
+# ---------------------------------------------------------------------------
+vision_member = Agent(
+    name="Image Analyst",
+    role="Answer questions about images using the images passed into your run.",
+    model=OpenAIResponses(id="gpt-5.4"),
+    instructions=[
+        "Use the images supplied to your run when answering.",
+        "If no image is supplied, say you cannot see one.",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Team
+# ---------------------------------------------------------------------------
+team = Team(
+    name="Vision delegation demo",
+    model=OpenAIResponses(id="gpt-5.4"),
+    members=[vision_member],
+    instructions=[
+        "You coordinate a single vision specialist.",
+        "When the user asks about an image from an earlier turn, call delegate_task_to_member",
+        "with the Image Analyst member id and a clear task (for example: describe the image).",
+    ],
+    db=SqliteDb(db_file="tmp/team_media_delegation.db"),
+    add_history_to_context=True,
+    add_team_media_to_delegation=True,
+    num_history_runs=5,
+)
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    session_id = f"session_{uuid4()}"
+    sample_image_url = (
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/"
+        "Gfp-wisconsin-madison-the-nature-boardwalk.jpg/"
+        "2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+    )
+
+    team.print_response(
+        "Here is a landscape reference image for our session.",
+        images=[Image(url=sample_image_url)],
+        stream=True,
+        session_id=session_id,
+    )
+
+    team.print_response(
+        "Delegate to the Image Analyst: in one sentence, what setting does the image show?",
+        stream=True,
+        session_id=session_id,
+    )

--- a/cookbook/03_teams/01_quickstart/README.md
+++ b/cookbook/03_teams/01_quickstart/README.md
@@ -20,5 +20,6 @@ Examples for team workflows in 01_quickstart.
 - 08_concurrent_member_agents.py - Demonstrates concurrent member agents.
 - broadcast_mode.py - Demonstrates broadcast mode.
 - 09_caching.py - Demonstrates cache team response.
+- 10_team_media_delegation.py - ``add_team_media_to_delegation``: merge prior team run and team message media into delegated member kwargs.
 - nested_teams.py - Demonstrates nested teams.
 - task_mode.py - Demonstrates task mode.

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -419,6 +419,19 @@ def _get_delegate_task_function(
     if not files:
         files = []
 
+    if team.add_team_media_to_delegation and session:
+        from agno.team._media_delegation import merge_team_media_for_delegation
+
+        images, videos, audio, files = merge_team_media_for_delegation(
+            team=team,
+            session=session,
+            current_run_id=run_response.run_id,
+            images=images,
+            videos=videos,
+            audio=audio,
+            files=files,
+        )
+
     def _setup_delegate_task_to_member(member_agent: Union[Agent, "Team"], task: str):
         # 1. Initialize the member agent
 

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -116,6 +116,7 @@ def __init__(
     knowledge_retriever: Optional[Callable[..., Optional[List[Union[Dict, str]]]]] = None,
     references_format: Literal["json", "yaml"] = "json",
     share_member_interactions: bool = False,
+    add_team_media_to_delegation: bool = False,
     get_member_information_tool: bool = False,
     search_knowledge: bool = True,
     add_search_knowledge_instructions: bool = True,
@@ -291,6 +292,7 @@ def __init__(
     team.references_format = references_format
 
     team.share_member_interactions = share_member_interactions
+    team.add_team_media_to_delegation = add_team_media_to_delegation
     team.get_member_information_tool = get_member_information_tool
     team.search_knowledge = search_knowledge
     team.add_search_knowledge_instructions = add_search_knowledge_instructions

--- a/libs/agno/agno/team/_media_delegation.py
+++ b/libs/agno/agno/team/_media_delegation.py
@@ -1,0 +1,169 @@
+"""Merge team-scoped media into kwargs for delegated member runs.
+
+Used when ``Team.add_team_media_to_delegation`` is enabled so
+``member_agent.run`` / ``arun`` receive prior team-level inputs and team-visible
+attachments from ``TeamSession``, not only the current team turn.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Sequence, Set, Tuple, cast
+
+from agno.media import Audio, File, Image, Video
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunInput, TeamRunOutput
+from agno.session import TeamSession
+
+
+def _fingerprint_artifact(artifact: Any) -> str:
+    """Stable key for deduplication within a modality."""
+    oid = getattr(artifact, "id", None)
+    if oid is not None and str(oid).strip() != "":
+        return f"id:{oid}"
+    for attr in ("url", "filepath", "filename", "name"):
+        v = getattr(artifact, attr, None)
+        if v is not None and str(v).strip() != "":
+            return f"{attr}:{v}"
+    content = getattr(artifact, "content", None)
+    if isinstance(content, (bytes, bytearray)):
+        return f"bytes:{len(content)}"
+    if content is not None:
+        return f"content:{hash(str(content))}"
+    ext = getattr(artifact, "external", None)
+    if ext is not None:
+        return f"external:{id(ext)}"
+    return f"obj:{id(artifact)}"
+
+
+def _seed_seen(
+    images: Sequence[Image],
+    videos: Sequence[Video],
+    audio: Sequence[Audio],
+    files: Sequence[File],
+) -> Set[str]:
+    seen: Set[str] = set()
+    for prefix, seq in (
+        ("i", images),
+        ("v", videos),
+        ("a", audio),
+        ("f", files),
+    ):
+        for item in seq:
+            seen.add(f"{prefix}:{_fingerprint_artifact(item)}")
+    return seen
+
+
+def _append_unique(
+    out: List[Any],
+    items: Optional[Sequence[Any]],
+    seen: Set[str],
+    prefix: str,
+) -> None:
+    if not items:
+        return
+    for item in items:
+        key = f"{prefix}:{_fingerprint_artifact(item)}"
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+
+
+def _team_leader_runs_for_media(session: TeamSession, team_id: str) -> List[TeamRunOutput]:
+    """Top-level team runs for this team (excludes member runs)."""
+    out: List[TeamRunOutput] = []
+    for run in session.runs or []:
+        if not isinstance(run, TeamRunOutput):
+            continue
+        if getattr(run, "parent_run_id", None):
+            continue
+        if getattr(run, "team_id", None) != team_id:
+            continue
+        st = getattr(run, "status", None)
+        if st is not None and st in (RunStatus.paused, RunStatus.cancelled, RunStatus.error):
+            continue
+        out.append(run)
+    return out
+
+
+def _history_window_runs(team: Any) -> int:
+    """How many prior team leader runs may contribute run-input media."""
+    if team.num_history_messages is not None:
+        return team.num_team_history_runs
+    if team.num_history_runs is not None:
+        return team.num_history_runs
+    return 3
+
+
+def merge_team_media_for_delegation(
+    team: Any,
+    session: TeamSession,
+    current_run_id: Optional[str],
+    images: Optional[Sequence[Image]],
+    videos: Optional[Sequence[Video]],
+    audio: Optional[Sequence[Audio]],
+    files: Optional[Sequence[File]],
+) -> Tuple[List[Image], List[Video], List[Audio], List[File]]:
+    """Return media lists for member ``run`` / ``arun`` kwargs.
+
+    When ``team.add_team_media_to_delegation`` is false, returns shallow copies of the
+    current sequences only.
+
+    When true, order is: **current turn** first, then media from prior **team leader**
+    runs (``TeamRunInput`` on top-level ``TeamRunOutput`` rows), then attachments on
+    **team-scoped** session messages (see ``TeamSession.get_messages`` with
+    ``team_id`` / ``skip_member_messages``). Duplicates are dropped using stable
+    fingerprints per modality. The **current** team run id is excluded from run-input
+    history so the same assets are not merged twice with current kwargs.
+
+    Bounds follow ``num_history_runs`` / ``num_history_messages`` (and
+    ``num_team_history_runs`` for the team-run window when only message limits apply).
+    """
+    out_images: List[Image] = list(images) if images else []
+    out_videos: List[Video] = list(videos) if videos else []
+    out_audio: List[Audio] = list(audio) if audio else []
+    out_files: List[File] = list(files) if files else []
+
+    if not getattr(team, "add_team_media_to_delegation", False):
+        return out_images, out_videos, out_audio, out_files
+
+    if session is None or not session.runs:
+        return out_images, out_videos, out_audio, out_files
+
+    team_id = team.id
+    if not team_id:
+        return out_images, out_videos, out_audio, out_files
+
+    seen = _seed_seen(out_images, out_videos, out_audio, out_files)
+
+    window = _history_window_runs(team)
+    leader_runs = _team_leader_runs_for_media(session, team_id)
+    historical = [r for r in leader_runs if current_run_id is None or r.run_id != current_run_id]
+    if window > 0:
+        historical = historical[-window:]
+
+    for run in historical:
+        run_input = run.input
+        if not isinstance(run_input, TeamRunInput):
+            continue
+        _append_unique(out_images, run_input.images, seen, "i")
+        _append_unique(out_videos, run_input.videos, seen, "v")
+        _append_unique(out_audio, run_input.audios, seen, "a")
+        _append_unique(out_files, run_input.files, seen, "f")
+
+    last_n = team.num_history_runs if team.num_history_messages is None else None
+    limit = team.num_history_messages
+    team_messages = session.get_messages(
+        team_id=team_id,
+        skip_member_messages=True,
+        last_n_runs=last_n,
+        limit=limit,
+        skip_history_messages=False,
+    )
+    for msg in team_messages:
+        _append_unique(out_images, cast(Optional[Sequence[Image]], msg.images), seen, "i")
+        _append_unique(out_videos, cast(Optional[Sequence[Video]], msg.videos), seen, "v")
+        _append_unique(out_audio, cast(Optional[Sequence[Audio]], msg.audio), seen, "a")
+        _append_unique(out_files, cast(Optional[Sequence[File]], msg.files), seen, "f")
+
+    return out_images, out_videos, out_audio, out_files

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -466,6 +466,8 @@ def to_dict(team: "Team") -> Dict[str, Any]:
         config["num_team_history_runs"] = team.num_team_history_runs
     if team.share_member_interactions:
         config["share_member_interactions"] = team.share_member_interactions
+    if team.add_team_media_to_delegation:
+        config["add_team_media_to_delegation"] = team.add_team_media_to_delegation
     if team.search_past_sessions:
         config["search_past_sessions"] = team.search_past_sessions
     if team.num_past_sessions_to_search is not None:
@@ -903,6 +905,7 @@ def from_dict(
             add_team_history_to_members=config.get("add_team_history_to_members", False),
             num_team_history_runs=config.get("num_team_history_runs", 3),
             share_member_interactions=config.get("share_member_interactions", False),
+            add_team_media_to_delegation=config.get("add_team_media_to_delegation", False),
             search_past_sessions=config.get("search_past_sessions", config.get("search_session_history", False)),
             num_past_sessions_to_search=config.get("num_past_sessions_to_search", config.get("num_history_sessions")),
             num_past_session_runs_in_search=config.get(

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -81,6 +81,19 @@ def _get_task_management_tools(
     _audio: List[Audio] = list(audio) if audio else []
     _files: List[File] = list(files) if files else []
 
+    if team.add_team_media_to_delegation and session:
+        from agno.team._media_delegation import merge_team_media_for_delegation
+
+        _images, _videos, _audio, _files = merge_team_media_for_delegation(
+            team=team,
+            session=session,
+            current_run_id=run_response.run_id,
+            images=_images,
+            videos=_videos,
+            audio=_audio,
+            files=_files,
+        )
+
     from agno.team._init import _initialize_member
     from agno.team._run import _update_team_media
     from agno.team._tools import (

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -137,6 +137,10 @@ class Team:
     num_team_history_runs: int = 3
     # If True, send all member interactions (request/response) during the current run to members that have been delegated a task to
     share_member_interactions: bool = False
+    # If True, merge media from prior team-level runs and team-visible session messages into delegated
+    # member ``run()`` / ``arun`` kwargs (images, videos, audio, files), bounded like ``num_history_runs`` /
+    # ``num_history_messages``. Current-turn media is unchanged; this adds historical team context only.
+    add_team_media_to_delegation: bool = False
 
     # If True, adds a tool to allow searching through previous sessions
     search_past_sessions: Optional[bool] = False
@@ -482,6 +486,7 @@ class Team:
         knowledge_retriever: Optional[Callable[..., Optional[List[Union[Dict, str]]]]] = None,
         references_format: Literal["json", "yaml"] = "json",
         share_member_interactions: bool = False,
+        add_team_media_to_delegation: bool = False,
         get_member_information_tool: bool = False,
         search_knowledge: bool = True,
         add_search_knowledge_instructions: bool = True,
@@ -604,6 +609,7 @@ class Team:
             knowledge_retriever=knowledge_retriever,
             references_format=references_format,
             share_member_interactions=share_member_interactions,
+            add_team_media_to_delegation=add_team_media_to_delegation,
             get_member_information_tool=get_member_information_tool,
             search_knowledge=search_knowledge,
             add_search_knowledge_instructions=add_search_knowledge_instructions,

--- a/libs/agno/tests/unit/team/test_media_delegation.py
+++ b/libs/agno/tests/unit/team/test_media_delegation.py
@@ -1,0 +1,93 @@
+"""Tests for team media merge into delegated member kwargs."""
+
+from agno.media import Image
+from agno.models.message import Message
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunInput, TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team._media_delegation import merge_team_media_for_delegation
+from agno.team.team import Team
+
+
+def _team(**kwargs) -> Team:
+    return Team(members=[], id="team-1", **kwargs)
+
+
+def test_flag_off_returns_current_only():
+    team = _team(add_team_media_to_delegation=False)
+    session = TeamSession(session_id="s1", runs=[])
+    cur = Image(url="https://example.com/current.png")
+    imgs, v, a, f = merge_team_media_for_delegation(
+        team, session, "run-1", images=[cur], videos=None, audio=None, files=None
+    )
+    assert len(imgs) == 1
+    assert imgs[0].url == "https://example.com/current.png"
+
+
+def test_merges_prior_team_run_input_media():
+    team = _team(add_team_media_to_delegation=True, num_history_runs=5)
+    old = Image(url="https://example.com/old.png")
+    prev = TeamRunOutput(
+        run_id="run-prev",
+        team_id=team.id,
+        status=RunStatus.completed,
+        input=TeamRunInput(input_content="past", images=[old]),
+    )
+    session = TeamSession(session_id="s1", runs=[prev])
+    cur = Image(url="https://example.com/current.png")
+    imgs, _, _, _ = merge_team_media_for_delegation(
+        team, session, "run-now", images=[cur], videos=None, audio=None, files=None
+    )
+    assert len(imgs) == 2
+    assert imgs[0].url == "https://example.com/current.png"
+    assert imgs[1].url == "https://example.com/old.png"
+
+
+def test_excludes_current_run_from_history_sources():
+    team = _team(add_team_media_to_delegation=True, num_history_runs=5)
+    same = Image(url="https://example.com/same.png")
+    current = TeamRunOutput(
+        run_id="run-now",
+        team_id=team.id,
+        status=RunStatus.running,
+        input=TeamRunInput(input_content="x", images=[same]),
+    )
+    session = TeamSession(session_id="s1", runs=[current])
+    imgs, _, _, _ = merge_team_media_for_delegation(
+        team, session, "run-now", images=[same], videos=None, audio=None, files=None
+    )
+    assert len(imgs) == 1
+
+
+def test_deduplicates_same_url():
+    team = _team(add_team_media_to_delegation=True, num_history_runs=5)
+    shared = Image(url="https://example.com/x.png")
+    prev = TeamRunOutput(
+        run_id="run-prev",
+        team_id=team.id,
+        status=RunStatus.completed,
+        input=TeamRunInput(input_content="past", images=[shared]),
+    )
+    session = TeamSession(session_id="s1", runs=[prev])
+    imgs, _, _, _ = merge_team_media_for_delegation(
+        team, session, "run-now", images=[shared], videos=None, audio=None, files=None
+    )
+    assert len(imgs) == 1
+
+
+def test_team_message_attachments():
+    team = _team(add_team_media_to_delegation=True, num_history_runs=5)
+    msg_img = Image(url="https://example.com/from-msg.png")
+    tr = TeamRunOutput(
+        run_id="run-1",
+        team_id=team.id,
+        status=RunStatus.completed,
+        input=TeamRunInput(input_content="hi"),
+        messages=[Message(role="user", content="see", images=[msg_img])],
+    )
+    session = TeamSession(session_id="s1", runs=[tr])
+    imgs, _, _, _ = merge_team_media_for_delegation(
+        team, session, "run-2", images=[], videos=None, audio=None, files=None
+    )
+    assert len(imgs) == 1
+    assert imgs[0].url == "https://example.com/from-msg.png"


### PR DESCRIPTION
Implements **[Feature Request] `add_team_media_to_delegation`** from issue [#7472](https://github.com/agno-agi/agno/issues/7472).

When **`Team.add_team_media_to_delegation`** is **`True`**, delegated **`member_agent.run` / `arun`** calls receive merged **`images`**, **`videos`**, **`audio`**, and **`files`**: current-turn kwargs first, then media from prior **team-level** runs (`TeamRunInput` on top-level `TeamRunOutput` rows) and from **team-scoped** session messages (`TeamSession.get_messages` with `team_id`, bounded by **`num_history_runs`** / **`num_history_messages`**). Duplicates are dropped via stable per-modality fingerprints. Default remains **`False`**.

**Implementation:** `merge_team_media_for_delegation` in `libs/agno/agno/team/_media_delegation.py`, invoked from `libs/agno/agno/team/_default_tools.py` and `libs/agno/agno/team/_task_tools.py`. **`Team`** API, **`_init.py`**, and **`_storage.py`** updated for the flag.

**Tests:** `libs/agno/tests/unit/team/test_media_delegation.py`.

**Cookbook:** `cookbook/03_teams/01_quickstart/10_team_media_delegation.py` and quickstart README entry.

Closes #7472

**(If applicable, issue number: #7472)**

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](https://github.com/agno-agi/agno/pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- **Cookbook:** requires **`OPENAI_API_KEY`** and, for `SqliteDb`, **`sqlalchemy`** / **`aiosqlite`** in the environment used to run the example (e.g. demo venv or `uv pip install sqlalchemy aiosqlite`).
- Complete format/validate and tick remaining checklist items before merge.