### PR TITLE
cookbook: add bedrock claude test log after #7492

### DIFF
--- a/cookbook/90_models/aws/claude/TEST_LOG.md
+++ b/cookbook/90_models/aws/claude/TEST_LOG.md
@@ -1,3 +1,21 @@
 # TEST_LOG
 
-No cookbook tests have been recorded for this directory yet.
+### basic.py
+
+**Status:** PASS
+
+**Description:** Runs Claude via Bedrock (global.anthropic.claude-sonnet-4-5-20250929-v1:0) across sync, sync+stream, async, async+stream to verify PR #7492 did not regress the env-var-credentials path.
+
+**Result:** All 4 variants returned a response (9.2s / 6.5s / 3.4s / 4.5s). No warnings. Confirms the "no session" path works end-to-end against real Bedrock after the shared-HTTP/2-client injection was removed.
+
+---
+
+### tool_use.py
+
+**Status:** PASS
+
+**Description:** Runs Claude via Bedrock with WebSearchTools across sync, sync+stream, async+stream to validate tool_use on the main code path after PR #7492.
+
+**Result:** All variants executed search and produced responses (longest ~11.5s). No warnings, no regressions.
+
+---


### PR DESCRIPTION
## Summary

Adds TEST_LOG entries for `cookbook/90_models/aws/claude/basic.py` and `tool_use.py`, recording pass results against `global.anthropic.claude-sonnet-4-5-20250929-v1:0` via Bedrock.

These runs verify that the env-var-credentials code path still works end-to-end after PR #7492 removed the shared HTTP/2 client injection. Timings captured (~3.4s–11.5s per variant) for future regression reference.

## Why

Closes a verification gap: after #7492 landed, there was no recorded evidence that the "no session" Bedrock path was still exercised. This log makes future regressions in that area easier to spot.

## Test plan

- [x] sync variant — PASS
- [x] sync+stream variant — PASS
- [x] async variant — PASS
- [x] async+stream variant — PASS
- [x] tool_use.py with WebSearchTools — PASS