### PR TITLE
feat: per-request GitHubConfig repo + cookbook examples

### DIFF
--- a/cookbook/07_knowledge/05_integrations/cloud/05_github_dynamic_repo.py
+++ b/cookbook/07_knowledge/05_integrations/cloud/05_github_dynamic_repo.py
@@ -1,0 +1,80 @@
+"""
+GitHub Integration: Per-Request Repo Override
+=============================================
+Use a single GitHubConfig with no default repo to load content from
+multiple repositories by passing the repo at request time.
+
+GitHubConfig.repo is Optional, and GitHubConfig.file() / .folder() accept
+a ``repo`` argument that overrides whatever is on the config. This lets
+one configured GitHub source (and its auth credentials, including a
+GitHub App installation) serve many repositories.
+
+Features:
+- One config, many repos — share auth across multiple sources
+- Works for both single files and folders
+- Same auth (PAT or GitHub App) applies to every request
+
+Requirements:
+- PostgreSQL with pgvector: ./cookbook/scripts/run_pgvector.sh
+- For private repos: GITHUB_TOKEN env var with "Contents: read" permission
+
+Environment Variables:
+    GITHUB_TOKEN - Optional, for private repos (fine-grained PAT)
+"""
+
+import asyncio
+from os import getenv
+
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.remote_content import GitHubConfig
+from agno.vectordb.pgvector import PgVector
+
+github_config = GitHubConfig(
+    id="dynamic-repo",
+    name="Dynamic GitHub Source",
+    token=getenv("GITHUB_TOKEN"),
+    branch="main",
+)
+
+knowledge = Knowledge(
+    name="GitHub Dynamic Repo Knowledge",
+    vector_db=PgVector(
+        table_name="github_dynamic_repo",
+        db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+    ),
+    content_sources=[github_config],
+)
+
+
+if __name__ == "__main__":
+
+    async def main():
+        print("\n" + "=" * 60)
+        print("Loading README.md from agno-agi/agno")
+        print("=" * 60 + "\n")
+
+        await knowledge.ainsert(
+            name="Agno README",
+            remote_content=github_config.file("README.md", repo="agno-agi/agno"),
+        )
+
+        print("\n" + "=" * 60)
+        print("Loading LICENSE from anthropics/anthropic-sdk-python")
+        print("=" * 60 + "\n")
+
+        await knowledge.ainsert(
+            name="Anthropic SDK LICENSE",
+            remote_content=github_config.file(
+                "LICENSE", repo="anthropics/anthropic-sdk-python"
+            ),
+        )
+
+        print("\n" + "=" * 60)
+        print("Searching across both repos")
+        print("=" * 60 + "\n")
+
+        results = await knowledge.asearch("What is Agno?")
+        for doc in results:
+            print("- %s" % doc.name)
+
+    asyncio.run(main())

--- a/cookbook/07_knowledge/05_integrations/cloud/06_multi_source.py
+++ b/cookbook/07_knowledge/05_integrations/cloud/06_multi_source.py
@@ -1,0 +1,183 @@
+"""
+Multi-Source Remote Content
+===========================
+Combine multiple remote content sources in a single Knowledge instance.
+Sources dispatch by ``config_id`` and write into a shared vector DB.
+
+This cookbook runs end-to-end with only public GitHub access. Additional
+providers (S3, GCS, SharePoint, Azure Blob) are registered automatically
+when their environment variables are set, otherwise they are skipped.
+
+Features demonstrated:
+- Multiple configs of different providers in one ``Knowledge``
+- Two GitHub configs with different auth profiles (public + authenticated)
+- Per-request ``repo`` override so one stateless GitHub config can serve
+  many repositories (``GitHubConfig.repo`` is Optional)
+- Cross-source search against the unified vector index
+
+Requirements:
+- PostgreSQL with pgvector: ./cookbook/scripts/run_pgvector.sh
+
+Environment Variables (all optional):
+    GITHUB_TOKEN              - private GitHub repo access (second config)
+    S3_BUCKET_NAME            - enables S3 registration
+    AWS_REGION                - S3 region
+    GCS_BUCKET_NAME           - enables GCS registration
+    GCP_PROJECT               - GCS project
+    SHAREPOINT_TENANT_ID      - enables SharePoint registration
+    SHAREPOINT_CLIENT_ID
+    SHAREPOINT_CLIENT_SECRET
+    SHAREPOINT_HOSTNAME
+    AZURE_TENANT_ID           - enables Azure Blob registration
+    AZURE_CLIENT_ID
+    AZURE_CLIENT_SECRET
+    AZURE_STORAGE_ACCOUNT
+    AZURE_CONTAINER
+"""
+
+import asyncio
+from os import getenv
+
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.remote_content import (
+    AzureBlobConfig,
+    GcsConfig,
+    GitHubConfig,
+    S3Config,
+    SharePointConfig,
+)
+from agno.vectordb.pgvector import PgVector
+
+content_sources: list = []
+
+# GitHub: public repos (no token, no default repo).
+# One stateless config serves many repos via per-request override.
+github_public = GitHubConfig(
+    id="github-public",
+    name="GitHub (public, dynamic repo)",
+    branch="main",
+)
+content_sources.append(github_public)
+
+# GitHub: authenticated repos (PAT, default repo).
+# Only registered when GITHUB_TOKEN is set.
+github_private = None
+if getenv("GITHUB_TOKEN"):
+    github_private = GitHubConfig(
+        id="github-private",
+        name="GitHub (authenticated)",
+        repo=getenv("GITHUB_DEFAULT_REPO", "agno-agi/agno"),
+        token=getenv("GITHUB_TOKEN"),
+        branch="main",
+    )
+    content_sources.append(github_private)
+
+# S3: optional.
+if getenv("S3_BUCKET_NAME"):
+    content_sources.append(
+        S3Config(
+            id="s3-docs",
+            name="S3 Documents",
+            bucket_name=getenv("S3_BUCKET_NAME", ""),
+            region=getenv("AWS_REGION", "us-east-1"),
+        )
+    )
+
+# GCS: optional.
+if getenv("GCS_BUCKET_NAME"):
+    content_sources.append(
+        GcsConfig(
+            id="gcs-data",
+            name="GCS Data",
+            bucket_name=getenv("GCS_BUCKET_NAME", ""),
+            project=getenv("GCP_PROJECT", ""),
+        )
+    )
+
+# SharePoint: optional.
+if getenv("SHAREPOINT_TENANT_ID"):
+    content_sources.append(
+        SharePointConfig(
+            id="sharepoint-docs",
+            name="SharePoint Documents",
+            tenant_id=getenv("SHAREPOINT_TENANT_ID", ""),
+            client_id=getenv("SHAREPOINT_CLIENT_ID", ""),
+            client_secret=getenv("SHAREPOINT_CLIENT_SECRET", ""),
+            hostname=getenv("SHAREPOINT_HOSTNAME", ""),
+            site_id=getenv("SHAREPOINT_SITE_ID"),
+        )
+    )
+
+# Azure Blob: optional.
+if getenv("AZURE_TENANT_ID"):
+    content_sources.append(
+        AzureBlobConfig(
+            id="azure-blob",
+            name="Azure Blob",
+            tenant_id=getenv("AZURE_TENANT_ID", ""),
+            client_id=getenv("AZURE_CLIENT_ID", ""),
+            client_secret=getenv("AZURE_CLIENT_SECRET", ""),
+            storage_account=getenv("AZURE_STORAGE_ACCOUNT", ""),
+            container=getenv("AZURE_CONTAINER", ""),
+        )
+    )
+
+knowledge = Knowledge(
+    name="Multi-Source Knowledge",
+    vector_db=PgVector(
+        table_name="multi_source_knowledge",
+        db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+    ),
+    content_sources=content_sources,
+)
+
+
+if __name__ == "__main__":
+
+    async def main():
+        print("\n" + "=" * 60)
+        print("Registered content sources:")
+        print("=" * 60)
+        for src in content_sources:
+            print("- [%s] %s (%s)" % (src.id, src.name, type(src).__name__))
+
+        # Load two different public repos through one stateless GitHub config.
+        # Distinct names to avoid the content_hash collision that occurs when
+        # two uploads share the same logical name across different providers.
+        print("\n" + "=" * 60)
+        print("Loading README.md from agno-agi/agno (github-public)")
+        print("=" * 60 + "\n")
+        await knowledge.ainsert(
+            name="Agno README",
+            remote_content=github_public.file("README.md", repo="agno-agi/agno"),
+        )
+
+        print("\n" + "=" * 60)
+        print("Loading LICENSE from anthropics/anthropic-sdk-python (github-public)")
+        print("=" * 60 + "\n")
+        await knowledge.ainsert(
+            name="Anthropic SDK LICENSE",
+            remote_content=github_public.file(
+                "LICENSE", repo="anthropics/anthropic-sdk-python"
+            ),
+        )
+
+        # Load through the authenticated GitHub config if it was registered.
+        if github_private is not None:
+            print("\n" + "=" * 60)
+            print("Loading README.md from default repo (github-private)")
+            print("=" * 60 + "\n")
+            await knowledge.ainsert(
+                name="Private Repo README",
+                remote_content=github_private.file("README.md"),
+            )
+
+        # Cross-source search against the unified vector index.
+        print("\n" + "=" * 60)
+        print("Searching across all registered sources")
+        print("=" * 60 + "\n")
+        results = await knowledge.asearch("What is Agno?")
+        for doc in results:
+            print("- %s" % doc.name)
+
+    asyncio.run(main())

--- a/libs/agno/agno/knowledge/loaders/github.py
+++ b/libs/agno/agno/knowledge/loaders/github.py
@@ -251,6 +251,7 @@ class GitHubLoader(BaseLoader):
     def _build_github_metadata(
         self,
         gh_config: GitHubConfig,
+        repo: str,
         branch: str,
         file_path: str,
         file_name: str,
@@ -260,11 +261,21 @@ class GitHubLoader(BaseLoader):
             "source_type": "github",
             "source_config_id": gh_config.id,
             "source_config_name": gh_config.name,
-            "github_repo": gh_config.repo,
+            "github_repo": repo,
             "github_branch": branch,
             "github_path": file_path,
             "github_filename": file_name,
         }
+
+    @staticmethod
+    def _resolve_github_repo(remote_content: GitHubContent, gh_config: GitHubConfig) -> Optional[str]:
+        """Resolve the effective repo for this request.
+
+        Prefers the per-request override on the content reference, falls back
+        to the config's ``repo``. Returns ``None`` if neither is set; callers
+        should treat this as a configuration error.
+        """
+        return remote_content.repo or gh_config.repo
 
     def _build_github_virtual_path(self, repo: str, branch: str, file_path: str) -> str:
         """Build virtual path for GitHub content."""
@@ -339,6 +350,14 @@ class GitHubLoader(BaseLoader):
         if gh_config is None:
             return
 
+        repo = self._resolve_github_repo(remote_content, gh_config)
+        if not repo:
+            log_error(
+                f"GitHub repo not specified. Set 'repo' on GitHubConfig '{gh_config.id}' "
+                f"or pass it at request time on GitHubContent."
+            )
+            return
+
         headers = await self._abuild_github_headers(gh_config)
         branch = self._get_github_branch(remote_content, gh_config)
         path_to_process = self._get_github_path_to_process(remote_content)
@@ -350,7 +369,7 @@ class GitHubLoader(BaseLoader):
             async def list_files_recursive(folder: str) -> List[Dict[str, str]]:
                 """Recursively list all files in a GitHub folder."""
                 files: List[Dict[str, str]] = []
-                api_url = f"https://api.github.com/repos/{gh_config.repo}/contents/{folder}"
+                api_url = f"https://api.github.com/repos/{repo}/contents/{folder}"
                 if branch:
                     api_url += f"?ref={branch}"
 
@@ -374,7 +393,7 @@ class GitHubLoader(BaseLoader):
                 return files
 
             if path_to_process:
-                api_url = f"https://api.github.com/repos/{gh_config.repo}/contents/{path_to_process}"
+                api_url = f"https://api.github.com/repos/{repo}/contents/{path_to_process}"
                 if branch:
                     api_url += f"?ref={branch}"
 
@@ -408,8 +427,8 @@ class GitHubLoader(BaseLoader):
                 file_name = file_info["name"]
 
                 # Build metadata and virtual path using helpers
-                virtual_path = self._build_github_virtual_path(gh_config.repo, branch, file_path)
-                github_metadata = self._build_github_metadata(gh_config, branch, file_path, file_name)
+                virtual_path = self._build_github_virtual_path(repo, branch, file_path)
+                github_metadata = self._build_github_metadata(gh_config, repo, branch, file_path, file_name)
                 merged_metadata = self._merge_metadata(github_metadata, content.metadata)
 
                 # Compute content name using base helper
@@ -430,7 +449,7 @@ class GitHubLoader(BaseLoader):
                     continue
 
                 # Fetch file content
-                api_url = f"https://api.github.com/repos/{gh_config.repo}/contents/{file_path}"
+                api_url = f"https://api.github.com/repos/{repo}/contents/{file_path}"
                 if branch:
                     api_url += f"?ref={branch}"
                 try:
@@ -481,6 +500,14 @@ class GitHubLoader(BaseLoader):
         if gh_config is None:
             return
 
+        repo = self._resolve_github_repo(remote_content, gh_config)
+        if not repo:
+            log_error(
+                f"GitHub repo not specified. Set 'repo' on GitHubConfig '{gh_config.id}' "
+                f"or pass it at request time on GitHubContent."
+            )
+            return
+
         headers = self._build_github_headers(gh_config)
         branch = self._get_github_branch(remote_content, gh_config)
         path_to_process = self._get_github_path_to_process(remote_content)
@@ -492,7 +519,7 @@ class GitHubLoader(BaseLoader):
             def list_files_recursive(folder: str) -> List[Dict[str, str]]:
                 """Recursively list all files in a GitHub folder."""
                 files: List[Dict[str, str]] = []
-                api_url = f"https://api.github.com/repos/{gh_config.repo}/contents/{folder}"
+                api_url = f"https://api.github.com/repos/{repo}/contents/{folder}"
                 if branch:
                     api_url += f"?ref={branch}"
 
@@ -516,7 +543,7 @@ class GitHubLoader(BaseLoader):
                 return files
 
             if path_to_process:
-                api_url = f"https://api.github.com/repos/{gh_config.repo}/contents/{path_to_process}"
+                api_url = f"https://api.github.com/repos/{repo}/contents/{path_to_process}"
                 if branch:
                     api_url += f"?ref={branch}"
 
@@ -550,8 +577,8 @@ class GitHubLoader(BaseLoader):
                 file_name = file_info["name"]
 
                 # Build metadata and virtual path using helpers
-                virtual_path = self._build_github_virtual_path(gh_config.repo, branch, file_path)
-                github_metadata = self._build_github_metadata(gh_config, branch, file_path, file_name)
+                virtual_path = self._build_github_virtual_path(repo, branch, file_path)
+                github_metadata = self._build_github_metadata(gh_config, repo, branch, file_path, file_name)
                 merged_metadata = self._merge_metadata(github_metadata, content.metadata)
 
                 # Compute content name using base helper
@@ -572,7 +599,7 @@ class GitHubLoader(BaseLoader):
                     continue
 
                 # Fetch file content
-                api_url = f"https://api.github.com/repos/{gh_config.repo}/contents/{file_path}"
+                api_url = f"https://api.github.com/repos/{repo}/contents/{file_path}"
                 if branch:
                     api_url += f"?ref={branch}"
                 try:

--- a/libs/agno/agno/knowledge/remote_content/github.py
+++ b/libs/agno/agno/knowledge/remote_content/github.py
@@ -21,7 +21,7 @@ class GitHubConfig(BaseStorageConfig):
     installation access token automatically.  Requires ``PyJWT[crypto]``.
     """
 
-    repo: str
+    repo: Optional[str] = None
     token: Optional[str] = None
     branch: Optional[str] = None
     path: Optional[str] = None
@@ -55,12 +55,20 @@ class GitHubConfig(BaseStorageConfig):
             )
         return self
 
-    def file(self, file_path: str, branch: Optional[str] = None) -> "GitHubContent":
+    def file(
+        self,
+        file_path: str,
+        branch: Optional[str] = None,
+        repo: Optional[str] = None,
+    ) -> "GitHubContent":
         """Create a content reference for a specific file.
 
         Args:
             file_path: Path to the file in the repository.
             branch: Optional branch override.
+            repo: Optional ``owner/repo`` override. When omitted, the config's
+                ``repo`` is used. Allows reusing the same auth credentials
+                across multiple repositories.
 
         Returns:
             GitHubContent configured with this source's credentials.
@@ -71,14 +79,23 @@ class GitHubConfig(BaseStorageConfig):
             config_id=self.id,
             file_path=file_path,
             branch=branch or self.branch,
+            repo=repo,
         )
 
-    def folder(self, folder_path: str, branch: Optional[str] = None) -> "GitHubContent":
+    def folder(
+        self,
+        folder_path: str,
+        branch: Optional[str] = None,
+        repo: Optional[str] = None,
+    ) -> "GitHubContent":
         """Create a content reference for a folder.
 
         Args:
             folder_path: Path to the folder in the repository.
             branch: Optional branch override.
+            repo: Optional ``owner/repo`` override. When omitted, the config's
+                ``repo`` is used. Allows reusing the same auth credentials
+                across multiple repositories.
 
         Returns:
             GitHubContent configured with this source's credentials.
@@ -89,4 +106,5 @@ class GitHubConfig(BaseStorageConfig):
             config_id=self.id,
             folder_path=folder_path,
             branch=branch or self.branch,
+            repo=repo,
         )

--- a/libs/agno/agno/knowledge/remote_content/remote_content.py
+++ b/libs/agno/agno/knowledge/remote_content/remote_content.py
@@ -122,11 +122,13 @@ class GitHubContent:
         file_path: Optional[str] = None,
         folder_path: Optional[str] = None,
         branch: Optional[str] = None,
+        repo: Optional[str] = None,
     ):
         self.config_id = config_id
         self.file_path = file_path
         self.folder_path = folder_path
         self.branch = branch
+        self.repo = repo
 
         if self.file_path is None and self.folder_path is None:
             raise ValueError("Either file_path or folder_path must be provided")
@@ -139,6 +141,7 @@ class GitHubContent:
             "file_path": self.file_path,
             "folder_path": self.folder_path,
             "branch": self.branch,
+            "repo": self.repo,
         }
 
 

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -248,6 +248,13 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         background_tasks: BackgroundTasks,
         config_id: str = Form(..., description="ID of the configured remote content source (from /knowledge/config)"),
         path: str = Form(..., description="Path to file or folder in the remote source"),
+        repo: Optional[str] = Form(
+            None,
+            description=(
+                "GitHub only: 'owner/repo' to fetch from. Overrides the repo set on the GitHubConfig, "
+                "letting one configured GitHub source serve multiple repositories the credentials can access."
+            ),
+        ),
         name: Optional[str] = Form(None, description="Content name (auto-generated if not provided)"),
         description: Optional[str] = Form(None, description="Content description"),
         metadata: Optional[str] = Form(None, description="JSON metadata object"),
@@ -280,17 +287,39 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
             except json.JSONDecodeError:
                 parsed_metadata = {"value": metadata}
 
+        # GitHub configs accept an optional per-request repo override so a single
+        # configured source can serve multiple repositories sharing the same auth.
+        from agno.knowledge.remote_content.github import GitHubConfig
+
+        github_kwargs: dict = {}
+        if isinstance(config, GitHubConfig):
+            if not repo and config.repo is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"GitHub config '{config_id}' has no 'repo' set. "
+                        "Provide a 'repo' form field with the request, or configure a default on the source."
+                    ),
+                )
+            if repo:
+                github_kwargs["repo"] = repo
+        elif repo:
+            raise HTTPException(
+                status_code=400,
+                detail="The 'repo' parameter is only supported for GitHub content sources.",
+            )
+
         # Use the config's factory methods to create the remote content object
         # If path ends with '/', treat as folder, otherwise treat as file
         is_folder = path.endswith("/")
         if is_folder:
             if hasattr(config, "folder"):
-                remote_content = config.folder(path.rstrip("/"))
+                remote_content = config.folder(path.rstrip("/"), **github_kwargs)
             else:
                 raise HTTPException(status_code=400, detail=f"Config {config_id} does not support folder uploads")
         else:
             if hasattr(config, "file"):
-                remote_content = config.file(path)
+                remote_content = config.file(path, **github_kwargs)
             else:
                 raise HTTPException(status_code=400, detail=f"Config {config_id} does not support file uploads")
 

--- a/libs/agno/tests/integration/os/test_remote_content.py
+++ b/libs/agno/tests/integration/os/test_remote_content.py
@@ -168,6 +168,43 @@ def test_upload_github_folder_success(test_app):
         mock_process.assert_called_once()
 
 
+def test_upload_github_file_with_repo_override(test_app):
+    """The repo form field overrides the configured repo on a per-request basis."""
+    captured = {}
+
+    def fake_process(knowledge, content, *args, **kwargs):
+        captured["remote_content"] = content.remote_content
+
+    with patch("agno.os.routers.knowledge.knowledge.process_content", side_effect=fake_process):
+        response = test_app.post(
+            "/knowledge/remote-content",
+            data={
+                "config_id": "github-repo",
+                "path": "docs/README.md",
+                "repo": "other-org/other-repo",
+            },
+        )
+
+    assert response.status_code == 202
+    rc = captured["remote_content"]
+    assert rc.repo == "other-org/other-repo"
+    assert rc.file_path == "docs/README.md"
+
+
+def test_upload_github_repo_override_rejected_for_non_github(test_app):
+    """The repo override is GitHub-only and must be rejected for other sources."""
+    response = test_app.post(
+        "/knowledge/remote-content",
+        data={
+            "config_id": "s3-docs",
+            "path": "documents/report.pdf",
+            "repo": "owner/repo",
+        },
+    )
+    assert response.status_code == 400
+    assert "GitHub" in response.json()["detail"]
+
+
 def test_upload_gcs_file_success(test_app):
     """Test successful GCS file upload."""
     with patch("agno.os.routers.knowledge.knowledge.process_content") as mock_process:

--- a/libs/agno/tests/unit/knowledge/test_remote_content_config.py
+++ b/libs/agno/tests/unit/knowledge/test_remote_content_config.py
@@ -354,10 +354,30 @@ def test_github_config_folder_method_with_branch_override():
     assert content.branch == "feature-branch"
 
 
-def test_github_config_missing_repo():
-    """Test that missing repo raises ValidationError."""
-    with pytest.raises(ValidationError):
-        GitHubConfig(id="gh-source", name="My Repo")
+def test_github_config_repo_optional():
+    """Repo is optional; it can be supplied per request via file()/folder() instead."""
+    config = GitHubConfig(id="gh-source", name="My Repo")
+    assert config.repo is None
+
+
+def test_github_config_file_method_with_repo_override():
+    """file() accepts a per-request repo override."""
+    config = GitHubConfig(id="gh-source", name="My Repo", branch="main")
+    content = config.file("docs/README.md", repo="other-org/other-repo")
+
+    assert content.config_id == "gh-source"
+    assert content.file_path == "docs/README.md"
+    assert content.repo == "other-org/other-repo"
+    assert content.branch == "main"
+
+
+def test_github_config_folder_method_with_repo_override():
+    """folder() accepts a per-request repo override."""
+    config = GitHubConfig(id="gh-source", name="My Repo", repo="owner/default", branch="main")
+    content = config.folder("src/api", repo="owner/other")
+
+    assert content.folder_path == "src/api"
+    assert content.repo == "owner/other"
 
 
 def test_github_config_with_metadata():


### PR DESCRIPTION
## Summary

Adds two GitHub-related cookbook examples and exposes `GitHubConfig.repo` as a per-request parameter:

- `feat: allow GitHubConfig repo to be specified per request` — lets callers pick the repo per tool invocation instead of being hard-coded.
- `cookbook: add GitHub dynamic repo and multi-source integration examples` — demonstrates the new parameter plus multi-source knowledge integration.

## Why

The previous API required the repo to be pinned at config time, which prevented agents from working across multiple GitHub repos within a single session.

## Status: needs rebase

This branch was cut before several test files landed on `main` (resolve_db_from_config, citation_suppression, components_router, workflow_custom_table_names, etc.). A direct diff against `main` currently *appears* to delete ~1100 lines of tests — those tests actually exist on `main` and are missing from this branch's base. **Rebase onto current `main` before merging** to get a clean diff.

## Test plan

- [ ] Rebase onto current `main`
- [ ] Verify the two cookbook files run end-to-end
- [ ] Verify unit tests for `GitHubConfig` per-request repo still pass
