### PR TITLE
feat: add Slack Canvas tools to SlackTools

### DIFF
--- a/cookbook/91_tools/slack_canvas_tools.py
+++ b/cookbook/91_tools/slack_canvas_tools.py
@@ -10,9 +10,8 @@ Supported canvas markdown: headings, bold, italic, strikethrough, inline code,
 bullet/numbered lists, checklists (- [ ] / - [x]), code blocks, links, emojis,
 blockquotes, tables (max 300 cells), and horizontal rules.
 
-Note: list_canvases uses files.list which only returns channel canvases.
-Standalone canvases (created via create_canvas) need their canvas_id saved
-or use create_channel_canvas to attach them to a channel for discovery.
+Note: list_canvases only returns channel canvases. Pass channel_id to
+create_canvas to make it discoverable, or save the returned canvas_id.
 """
 
 from agno.agent import Agent

--- a/cookbook/91_tools/slack_canvas_tools.py
+++ b/cookbook/91_tools/slack_canvas_tools.py
@@ -2,6 +2,10 @@
 
 Requires canvases:read and canvases:write bot scopes in your Slack app.
 Set the SLACK_TOKEN environment variable before running.
+
+Supported canvas markdown: headings, bold, italic, strikethrough, inline code,
+bullet/numbered lists, checklists (- [ ] / - [x]), code blocks, links, emojis,
+blockquotes, tables (max 300 cells), and horizontal rules.
 """
 
 from agno.agent import Agent
@@ -14,16 +18,18 @@ agent = Agent(
 )
 
 if __name__ == "__main__":
-    # Create a standalone canvas
+    # Create a canvas with rich content
     agent.print_response(
-        "Create a canvas titled 'Sprint Planning' with a markdown checklist: "
-        "## Tasks\n- [ ] Review PRs\n- [ ] Update docs\n- [ ] Deploy to staging",
+        "Create a canvas titled 'Sprint Planning' with these sections: "
+        "a checklist under '## Tasks' with 3 items, "
+        "a table under '## Timeline' with columns Task/Owner/Status, "
+        "and a '## Notes' section with a blockquote.",
         stream=True,
     )
 
-    # Create a canvas in a channel
+    # Read and update an existing canvas
     agent.print_response(
-        "Create a canvas in channel #engineering titled 'Onboarding Guide' "
-        "with an intro paragraph and three H2 sections: Setup, Tools, Contacts",
+        "List all canvases, read the 'Sprint Planning' canvas, "
+        "then add a new task '- [ ] Write release notes' to the Tasks section.",
         stream=True,
     )

--- a/cookbook/91_tools/slack_canvas_tools.py
+++ b/cookbook/91_tools/slack_canvas_tools.py
@@ -1,0 +1,29 @@
+"""Run: pip install openai slack-sdk
+
+Requires canvases:read and canvases:write bot scopes in your Slack app.
+Set the SLACK_TOKEN environment variable before running.
+"""
+
+from agno.agent import Agent
+from agno.tools.slack import SlackTools
+
+# Agent with Canvas tools enabled alongside default messaging tools
+agent = Agent(
+    tools=[SlackTools(enable_canvas=True)],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # Create a standalone canvas
+    agent.print_response(
+        "Create a canvas titled 'Sprint Planning' with a markdown checklist: "
+        "## Tasks\n- [ ] Review PRs\n- [ ] Update docs\n- [ ] Deploy to staging",
+        stream=True,
+    )
+
+    # Create a canvas in a channel
+    agent.print_response(
+        "Create a canvas in channel #engineering titled 'Onboarding Guide' "
+        "with an intro paragraph and three H2 sections: Setup, Tools, Contacts",
+        stream=True,
+    )

--- a/cookbook/91_tools/slack_canvas_tools.py
+++ b/cookbook/91_tools/slack_canvas_tools.py
@@ -1,6 +1,9 @@
 """Run: pip install openai slack-sdk
 
-Requires canvases:read and canvases:write bot scopes in your Slack app.
+Requires these bot scopes in your Slack app:
+- canvases:read, canvases:write (for canvas operations)
+- files:read (for listing and reading canvas content)
+
 Set the SLACK_TOKEN environment variable before running.
 
 Supported canvas markdown: headings, bold, italic, strikethrough, inline code,

--- a/cookbook/91_tools/slack_canvas_tools.py
+++ b/cookbook/91_tools/slack_canvas_tools.py
@@ -9,6 +9,10 @@ Set the SLACK_TOKEN environment variable before running.
 Supported canvas markdown: headings, bold, italic, strikethrough, inline code,
 bullet/numbered lists, checklists (- [ ] / - [x]), code blocks, links, emojis,
 blockquotes, tables (max 300 cells), and horizontal rules.
+
+Note: list_canvases uses files.list which only returns channel canvases.
+Standalone canvases (created via create_canvas) need their canvas_id saved
+or use create_channel_canvas to attach them to a channel for discovery.
 """
 
 from agno.agent import Agent
@@ -21,18 +25,16 @@ agent = Agent(
 )
 
 if __name__ == "__main__":
-    # Create a canvas with rich content
+    # Create a canvas and immediately edit it using the returned canvas_id
     agent.print_response(
-        "Create a canvas titled 'Sprint Planning' with these sections: "
-        "a checklist under '## Tasks' with 3 items, "
-        "a table under '## Timeline' with columns Task/Owner/Status, "
-        "and a '## Notes' section with a blockquote.",
+        "Create a canvas titled 'Sprint Planning' with a '## Tasks' section "
+        "containing 3 checklist items. Then use the canvas_id to add a "
+        "'## Notes' section with a blockquote at the end.",
         stream=True,
     )
 
-    # Read and update an existing canvas
+    # Read and update an existing canvas by ID
     agent.print_response(
-        "List all canvases, read the 'Sprint Planning' canvas, "
-        "then add a new task '- [ ] Write release notes' to the Tasks section.",
+        "Read the RBAC Working Group canvas (F0B7GBTJN91) and summarize its content.",
         stream=True,
     )

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -833,11 +833,11 @@ class SlackTools(Toolkit):
             str: A JSON string containing the canvas_id of the newly created canvas.
         """
         try:
-            kwargs: Dict[str, Any] = {}
+            # SDK requires document_content even though the API considers it optional
+            doc = {"type": "markdown", "markdown": markdown or ""}
+            kwargs: Dict[str, Any] = {"document_content": doc}
             if title:
                 kwargs["title"] = title
-            if markdown:
-                kwargs["document_content"] = {"type": "markdown", "markdown": markdown}
             response = self.client.canvases_create(**kwargs)
             return json.dumps({"ok": True, "canvas_id": response.get("canvas_id", "")})
         except SlackApiError as e:
@@ -858,11 +858,11 @@ class SlackTools(Toolkit):
             str: A JSON string containing the canvas_id of the newly created canvas.
         """
         try:
-            kwargs: Dict[str, Any] = {"channel_id": channel_id}
+            # SDK requires document_content even though the API considers it optional
+            doc = {"type": "markdown", "markdown": markdown or ""}
+            kwargs: Dict[str, Any] = {"channel_id": channel_id, "document_content": doc}
             if title:
                 kwargs["title"] = title
-            if markdown:
-                kwargs["document_content"] = {"type": "markdown", "markdown": markdown}
             response = self.client.conversations_canvases_create(**kwargs)
             return json.dumps({"ok": True, "canvas_id": response.get("canvas_id", "")})
         except SlackApiError as e:

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -831,15 +831,17 @@ class SlackTools(Toolkit):
         Use this to discover existing canvases before reading or editing them.
         Returns canvas_id values needed by read_canvas, edit_canvas, and other canvas tools.
 
+        Requires canvases:read and files:read bot scopes.
+
         Args:
             channel (str): Optional channel ID to filter canvases by.
-            limit (int): Maximum number of canvases to return. Defaults to 20.
+            limit (int): Maximum number of canvases to return. Defaults to 20, max 100.
 
         Returns:
             str: A JSON string with a list of canvases including canvas_id, title, created, and updated timestamps.
         """
         try:
-            kwargs: Dict[str, Any] = {"types": "canvases", "count": min(limit, 100)}
+            kwargs: Dict[str, Any] = {"types": "canvas", "count": min(limit, 100)}
             if channel:
                 kwargs["channel"] = channel
             response = self.client.files_list(**kwargs)
@@ -859,14 +861,18 @@ class SlackTools(Toolkit):
             logger.exception("Error listing canvases")
             return json.dumps({"error": str(e)})
 
-    def read_canvas(self, canvas_id: str) -> str:
+    def read_canvas(self, canvas_id: str, max_content_size: int = 100000) -> str:
         """Read the full content of a canvas as HTML.
 
-        Use this before editing to see current content. The HTML includes section IDs
-        in element attributes that can be used directly with edit_canvas.
+        Use this before editing to see current content. To get section IDs for
+        targeted edits, use lookup_canvas_sections instead of parsing HTML.
+
+        Requires canvases:read and files:read bot scopes.
 
         Args:
             canvas_id (str): The canvas ID to read. Get this from list_canvases or create_canvas.
+            max_content_size (int): Maximum content size in bytes. Defaults to 100KB. Content
+                exceeding this is truncated with a warning.
 
         Returns:
             str: A JSON string with canvas_id, title, and content as HTML.
@@ -883,14 +889,22 @@ class SlackTools(Toolkit):
             download = httpx.get(url_private, headers=headers, timeout=30, follow_redirects=True)
             download.raise_for_status()
 
-            return json.dumps(
-                {
-                    "ok": True,
-                    "canvas_id": canvas_id,
-                    "title": file_info.get("title", ""),
-                    "content": download.text,
-                }
-            )
+            content = download.text
+            truncated = False
+            if len(content) > max_content_size:
+                content = content[:max_content_size]
+                truncated = True
+
+            result: Dict[str, Any] = {
+                "ok": True,
+                "canvas_id": canvas_id,
+                "title": file_info.get("title", ""),
+                "content": content,
+            }
+            if truncated:
+                result["truncated"] = True
+                result["warning"] = f"Content truncated to {max_content_size} bytes"
+            return json.dumps(result)
         except SlackApiError as e:
             logger.exception("Error reading canvas")
             return json.dumps({"error": str(e)})

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -87,6 +87,26 @@ class SlackTools(Toolkit):
                 "When you have a `Slack thread_ts` in your context/dependencies, use it."
             )
 
+        # Canvas tools — collaborative documents within Slack
+        canvas_tools = {
+            "create_canvas",
+            "create_channel_canvas",
+            "edit_canvas",
+            "delete_canvas",
+            "lookup_canvas_sections",
+            "set_canvas_access",
+        }
+        if canvas_tools & enabled:
+            text = (
+                "**Canvas tools** — create and manage collaborative documents in Slack.\n"
+                "- `create_canvas` creates a standalone canvas; `create_channel_canvas` creates one attached to a channel.\n"
+                "- To edit a canvas, first use `lookup_canvas_sections` to find section IDs, then `edit_canvas`.\n"
+                "- Content uses markdown format (headings, bold, lists, code blocks, tables up to 300 cells).\n"
+                "- `delete_canvas` is permanent and cannot be undone.\n"
+                "- Requires `canvases:read` and `canvases:write` bot scopes."
+            )
+            sections.append(text)
+
         # Only inject guidance when there are multiple tools to choose between
         if len(sections) < 2:
             return ""
@@ -131,6 +151,7 @@ class SlackTools(Toolkit):
         enable_list_users: bool = False,
         enable_get_user_info: bool = False,
         enable_get_channel_info: bool = False,
+        enable_canvas: bool = False,
         all: bool = False,
         ssl: Optional[SSLContext] = None,
         max_file_size: int = 1_073_741_824,  # 1GB
@@ -158,6 +179,8 @@ class SlackTools(Toolkit):
             enable_list_users (bool): Whether to enable the list_users tool. Defaults to False.
             enable_get_user_info (bool): Whether to enable the get_user_info tool. Defaults to False.
             enable_get_channel_info (bool): Whether to enable the get_channel_info tool. Defaults to False.
+            enable_canvas (bool): Whether to enable all Canvas tools (create, edit, delete, lookup sections,
+                manage access). Requires canvases:read and canvases:write bot scopes. Defaults to False.
             all (bool): Whether to enable all tools. Defaults to False.
             ssl (SSLContext): Optional SSL context for the Slack WebClient. Defaults to None.
             max_file_size (int): Maximum file size in bytes for uploads and downloads. Defaults to 1GB.
@@ -202,6 +225,13 @@ class SlackTools(Toolkit):
             tools.append(self.get_user_info)
         if enable_get_channel_info or all:
             tools.append(self.get_channel_info)
+        if enable_canvas or all:
+            tools.append(self.create_canvas)
+            tools.append(self.create_channel_canvas)
+            tools.append(self.edit_canvas)
+            tools.append(self.delete_canvas)
+            tools.append(self.lookup_canvas_sections)
+            tools.append(self.set_canvas_access)
 
         # Build tool instructions dynamically based on enabled tools
         if kwargs.get("instructions") is None:
@@ -787,4 +817,182 @@ class SlackTools(Toolkit):
             )
         except SlackApiError as e:
             logger.exception("Error getting channel info")
+            return json.dumps({"error": str(e)})
+
+    # ── Canvas tools ────────────────────────────────────────────────
+
+    def create_canvas(self, title: Optional[str] = None, markdown: Optional[str] = None) -> str:
+        """Create a standalone Slack canvas.
+
+        Args:
+            title (str): Optional title for the canvas.
+            markdown (str): Optional initial content in markdown format. Supports headings, bold, italic,
+                lists, code blocks, and tables (max 300 cells).
+
+        Returns:
+            str: A JSON string containing the canvas_id of the newly created canvas.
+        """
+        try:
+            kwargs: Dict[str, Any] = {}
+            if title:
+                kwargs["title"] = title
+            if markdown:
+                kwargs["document_content"] = {"type": "markdown", "markdown": markdown}
+            response = self.client.canvases_create(**kwargs)
+            return json.dumps({"ok": True, "canvas_id": response.get("canvas_id", "")})
+        except SlackApiError as e:
+            logger.exception("Error creating canvas")
+            return json.dumps({"error": str(e)})
+
+    def create_channel_canvas(
+        self, channel_id: str, title: Optional[str] = None, markdown: Optional[str] = None
+    ) -> str:
+        """Create a canvas attached to a Slack channel.
+
+        Args:
+            channel_id (str): The channel ID to attach the canvas to.
+            title (str): Optional title for the canvas.
+            markdown (str): Optional initial content in markdown format.
+
+        Returns:
+            str: A JSON string containing the canvas_id of the newly created canvas.
+        """
+        try:
+            kwargs: Dict[str, Any] = {"channel_id": channel_id}
+            if title:
+                kwargs["title"] = title
+            if markdown:
+                kwargs["document_content"] = {"type": "markdown", "markdown": markdown}
+            response = self.client.conversations_canvases_create(**kwargs)
+            return json.dumps({"ok": True, "canvas_id": response.get("canvas_id", "")})
+        except SlackApiError as e:
+            logger.exception("Error creating channel canvas")
+            return json.dumps({"error": str(e)})
+
+    def edit_canvas(
+        self,
+        canvas_id: str,
+        operation: Literal["insert_at_start", "insert_at_end", "insert_before", "insert_after", "replace", "delete"],
+        markdown: Optional[str] = None,
+        section_id: Optional[str] = None,
+    ) -> str:
+        """Edit an existing Slack canvas. Only one operation per call.
+
+        Args:
+            canvas_id (str): The ID of the canvas to edit.
+            operation (str): The edit operation. One of: insert_at_start, insert_at_end,
+                insert_before, insert_after, replace, delete.
+                Operations insert_before, insert_after, replace, and delete require a section_id.
+                Use lookup_canvas_sections to find section IDs first.
+            markdown (str): The content in markdown format. Required for all operations except delete.
+            section_id (str): The target section ID. Required for insert_before, insert_after,
+                replace, and delete. Get section IDs from lookup_canvas_sections.
+
+        Returns:
+            str: A JSON string indicating success or error.
+        """
+        section_ops = {"insert_before", "insert_after", "replace", "delete"}
+        if operation in section_ops and not section_id:
+            return json.dumps({"error": f"section_id is required for '{operation}' operation"})
+        if operation != "delete" and not markdown:
+            return json.dumps({"error": f"markdown content is required for '{operation}' operation"})
+
+        try:
+            change: Dict[str, Any] = {"operation": operation}
+            if section_id:
+                change["section_id"] = section_id
+            if markdown:
+                change["document_content"] = {"type": "markdown", "markdown": markdown}
+            response = self.client.canvases_edit(canvas_id=canvas_id, changes=[change])
+            return json.dumps({"ok": response.get("ok", False)})
+        except SlackApiError as e:
+            logger.exception("Error editing canvas")
+            return json.dumps({"error": str(e)})
+
+    def delete_canvas(self, canvas_id: str) -> str:
+        """Permanently delete a Slack canvas. This action cannot be undone.
+
+        Args:
+            canvas_id (str): The ID of the canvas to delete.
+
+        Returns:
+            str: A JSON string indicating success or error.
+        """
+        try:
+            response = self.client.canvases_delete(canvas_id=canvas_id)
+            return json.dumps({"ok": response.get("ok", False)})
+        except SlackApiError as e:
+            logger.exception("Error deleting canvas")
+            return json.dumps({"error": str(e)})
+
+    def lookup_canvas_sections(
+        self,
+        canvas_id: str,
+        section_types: Optional[List[Literal["h1", "h2", "h3", "any_header"]]] = None,
+        contains_text: Optional[str] = None,
+    ) -> str:
+        """Find sections in a canvas by heading type or text content.
+
+        Use this to get section IDs needed for edit_canvas operations
+        (insert_before, insert_after, replace, delete).
+
+        Args:
+            canvas_id (str): The ID of the canvas to search.
+            section_types (list): Filter by heading level: h1, h2, h3, or any_header.
+            contains_text (str): Filter sections containing this text.
+
+        Returns:
+            str: A JSON string containing a list of matching section objects with their IDs.
+        """
+        try:
+            criteria: Dict[str, Any] = {}
+            if section_types:
+                criteria["section_types"] = section_types
+            if contains_text:
+                criteria["contains_text"] = contains_text
+            response = self.client.canvases_sections_lookup(canvas_id=canvas_id, criteria=criteria)
+            return json.dumps({"ok": True, "sections": response.get("sections", [])})
+        except SlackApiError as e:
+            logger.exception("Error looking up canvas sections")
+            return json.dumps({"error": str(e)})
+
+    def set_canvas_access(
+        self,
+        canvas_id: str,
+        access_level: Literal["read", "write", "owner"],
+        user_ids: Optional[List[str]] = None,
+        channel_ids: Optional[List[str]] = None,
+    ) -> str:
+        """Set access permissions on a Slack canvas.
+
+        Grant read, write, or owner access to specific users or channels.
+        Cannot pass both user_ids and channel_ids in a single call.
+        Owner access can only be granted to users, not channels.
+
+        Args:
+            canvas_id (str): The ID of the canvas.
+            access_level (str): The access level to grant: read, write, or owner.
+            user_ids (list): User IDs to grant access to. Cannot be used with channel_ids.
+            channel_ids (list): Channel IDs to grant access to. Cannot be used with user_ids.
+
+        Returns:
+            str: A JSON string indicating success or error.
+        """
+        if not user_ids and not channel_ids:
+            return json.dumps({"error": "Either user_ids or channel_ids is required"})
+        if user_ids and channel_ids:
+            return json.dumps({"error": "Cannot pass both user_ids and channel_ids in a single call"})
+        if access_level == "owner" and channel_ids:
+            return json.dumps({"error": "Owner access can only be granted to users, not channels"})
+
+        try:
+            kwargs: Dict[str, Any] = {"canvas_id": canvas_id, "access_level": access_level}
+            if user_ids:
+                kwargs["user_ids"] = user_ids
+            if channel_ids:
+                kwargs["channel_ids"] = channel_ids
+            response = self.client.canvases_access_set(**kwargs)
+            return json.dumps({"ok": response.get("ok", False)})
+        except SlackApiError as e:
+            logger.exception("Error setting canvas access")
             return json.dumps({"error": str(e)})

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -828,12 +828,15 @@ class SlackTools(Toolkit):
     def list_canvases(self, channel: Optional[str] = None, limit: int = 20) -> str:
         """List canvases in the workspace, optionally filtered by channel.
 
+        Use this to discover existing canvases before reading or editing them.
+        Returns canvas_id values needed by read_canvas, edit_canvas, and other canvas tools.
+
         Args:
             channel (str): Optional channel ID to filter canvases by.
             limit (int): Maximum number of canvases to return. Defaults to 20.
 
         Returns:
-            str: A JSON string containing a list of canvases with their IDs, titles, and metadata.
+            str: A JSON string with a list of canvases including canvas_id, title, created, and updated timestamps.
         """
         try:
             kwargs: Dict[str, Any] = {"types": "canvases", "count": min(limit, 100)}
@@ -857,17 +860,16 @@ class SlackTools(Toolkit):
             return json.dumps({"error": str(e)})
 
     def read_canvas(self, canvas_id: str) -> str:
-        """Read the full content of a canvas.
+        """Read the full content of a canvas as HTML.
 
-        Retrieves canvas content as HTML which preserves headings, lists, bold,
-        code blocks, and other formatting. Use this before editing to see what's
-        currently in the canvas.
+        Use this before editing to see current content. The HTML includes section IDs
+        in element attributes that can be used directly with edit_canvas.
 
         Args:
-            canvas_id (str): The canvas ID (file ID) to read.
+            canvas_id (str): The canvas ID to read. Get this from list_canvases or create_canvas.
 
         Returns:
-            str: A JSON string containing the canvas title and content as HTML.
+            str: A JSON string with canvas_id, title, and content as HTML.
         """
         try:
             response = self.client.files_info(file=canvas_id)
@@ -953,15 +955,18 @@ class SlackTools(Toolkit):
     ) -> str:
         """Edit an existing Slack canvas. Only one operation per call.
 
+        To update specific sections: first call lookup_canvas_sections or read_canvas
+        to get section IDs, then use replace or insert_before/insert_after with that section_id.
+        For appending content, use insert_at_end (no section_id needed).
+
         Args:
             canvas_id (str): The ID of the canvas to edit.
-            operation (str): The edit operation. One of: insert_at_start, insert_at_end,
-                insert_before, insert_after, replace, delete.
-                Operations insert_before, insert_after, replace, and delete require a section_id.
-                Use lookup_canvas_sections to find section IDs first.
+            operation (str): The edit operation: insert_at_start, insert_at_end,
+                insert_before, insert_after, replace, or delete.
+                insert_before/insert_after/replace/delete require a section_id.
             markdown (str): The content in markdown format. Required for all operations except delete.
             section_id (str): The target section ID. Required for insert_before, insert_after,
-                replace, and delete. Get section IDs from lookup_canvas_sections.
+                replace, and delete. Get from lookup_canvas_sections or read_canvas HTML.
 
         Returns:
             str: A JSON string indicating success or error.

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -89,18 +89,21 @@ class SlackTools(Toolkit):
 
         # Canvas tools — collaborative documents within Slack
         canvas_tools = {
+            "list_canvases",
+            "read_canvas",
             "create_canvas",
             "create_channel_canvas",
             "edit_canvas",
             "delete_canvas",
             "lookup_canvas_sections",
-            "set_canvas_access",
         }
         if canvas_tools & enabled:
             text = (
                 "**Canvas tools** — create and manage collaborative documents in Slack.\n"
+                "- `list_canvases` finds existing canvases, optionally filtered by channel.\n"
+                "- `read_canvas` retrieves the full content of a canvas as HTML.\n"
                 "- `create_canvas` creates a standalone canvas; `create_channel_canvas` creates one attached to a channel.\n"
-                "- To edit a canvas, first use `lookup_canvas_sections` to find section IDs, then `edit_canvas`.\n"
+                "- To update a canvas: `read_canvas` to see current content, `lookup_canvas_sections` to get section IDs, then `edit_canvas`.\n"
                 "- Content uses markdown format (headings, bold, lists, code blocks, tables up to 300 cells).\n"
                 "- `delete_canvas` is permanent and cannot be undone.\n"
                 "- Requires `canvases:read` and `canvases:write` bot scopes."
@@ -179,8 +182,8 @@ class SlackTools(Toolkit):
             enable_list_users (bool): Whether to enable the list_users tool. Defaults to False.
             enable_get_user_info (bool): Whether to enable the get_user_info tool. Defaults to False.
             enable_get_channel_info (bool): Whether to enable the get_channel_info tool. Defaults to False.
-            enable_canvas (bool): Whether to enable all Canvas tools (create, edit, delete, lookup sections,
-                manage access). Requires canvases:read and canvases:write bot scopes. Defaults to False.
+            enable_canvas (bool): Whether to enable all Canvas tools (list, read, create, edit, delete,
+                lookup sections). Requires canvases:read and canvases:write bot scopes. Defaults to False.
             all (bool): Whether to enable all tools. Defaults to False.
             ssl (SSLContext): Optional SSL context for the Slack WebClient. Defaults to None.
             max_file_size (int): Maximum file size in bytes for uploads and downloads. Defaults to 1GB.
@@ -226,12 +229,13 @@ class SlackTools(Toolkit):
         if enable_get_channel_info or all:
             tools.append(self.get_channel_info)
         if enable_canvas or all:
+            tools.append(self.list_canvases)
+            tools.append(self.read_canvas)
             tools.append(self.create_canvas)
             tools.append(self.create_channel_canvas)
             tools.append(self.edit_canvas)
             tools.append(self.delete_canvas)
             tools.append(self.lookup_canvas_sections)
-            tools.append(self.set_canvas_access)
 
         # Build tool instructions dynamically based on enabled tools
         if kwargs.get("instructions") is None:
@@ -821,6 +825,77 @@ class SlackTools(Toolkit):
 
     # ── Canvas tools ────────────────────────────────────────────────
 
+    def list_canvases(self, channel: Optional[str] = None, limit: int = 20) -> str:
+        """List canvases in the workspace, optionally filtered by channel.
+
+        Args:
+            channel (str): Optional channel ID to filter canvases by.
+            limit (int): Maximum number of canvases to return. Defaults to 20.
+
+        Returns:
+            str: A JSON string containing a list of canvases with their IDs, titles, and metadata.
+        """
+        try:
+            kwargs: Dict[str, Any] = {"types": "canvases", "count": min(limit, 100)}
+            if channel:
+                kwargs["channel"] = channel
+            response = self.client.files_list(**kwargs)
+            canvases = [
+                {
+                    "canvas_id": f.get("id", ""),
+                    "title": f.get("title", ""),
+                    "created": f.get("created", 0),
+                    "updated": f.get("updated", 0),
+                    "user": f.get("user", ""),
+                    "permalink": f.get("permalink", ""),
+                }
+                for f in response.get("files", [])
+            ]
+            return json.dumps({"ok": True, "count": len(canvases), "canvases": canvases})
+        except SlackApiError as e:
+            logger.exception("Error listing canvases")
+            return json.dumps({"error": str(e)})
+
+    def read_canvas(self, canvas_id: str) -> str:
+        """Read the full content of a canvas.
+
+        Retrieves canvas content as HTML which preserves headings, lists, bold,
+        code blocks, and other formatting. Use this before editing to see what's
+        currently in the canvas.
+
+        Args:
+            canvas_id (str): The canvas ID (file ID) to read.
+
+        Returns:
+            str: A JSON string containing the canvas title and content as HTML.
+        """
+        try:
+            response = self.client.files_info(file=canvas_id)
+            file_info = response.get("file", {})
+
+            url_private = file_info.get("url_private_download") or file_info.get("url_private")
+            if not url_private:
+                return json.dumps({"error": "Canvas URL not available"})
+
+            headers = {"Authorization": f"Bearer {self.token}"}
+            download = httpx.get(url_private, headers=headers, timeout=30, follow_redirects=True)
+            download.raise_for_status()
+
+            return json.dumps(
+                {
+                    "ok": True,
+                    "canvas_id": canvas_id,
+                    "title": file_info.get("title", ""),
+                    "content": download.text,
+                }
+            )
+        except SlackApiError as e:
+            logger.exception("Error reading canvas")
+            return json.dumps({"error": str(e)})
+        except httpx.HTTPError as e:
+            logger.exception("Error downloading canvas content")
+            return json.dumps({"error": f"HTTP error: {str(e)}"})
+
     def create_canvas(self, title: Optional[str] = None, markdown: Optional[str] = None) -> str:
         """Create a standalone Slack canvas.
 
@@ -954,45 +1029,4 @@ class SlackTools(Toolkit):
             return json.dumps({"ok": True, "sections": response.get("sections", [])})
         except SlackApiError as e:
             logger.exception("Error looking up canvas sections")
-            return json.dumps({"error": str(e)})
-
-    def set_canvas_access(
-        self,
-        canvas_id: str,
-        access_level: Literal["read", "write", "owner"],
-        user_ids: Optional[List[str]] = None,
-        channel_ids: Optional[List[str]] = None,
-    ) -> str:
-        """Set access permissions on a Slack canvas.
-
-        Grant read, write, or owner access to specific users or channels.
-        Cannot pass both user_ids and channel_ids in a single call.
-        Owner access can only be granted to users, not channels.
-
-        Args:
-            canvas_id (str): The ID of the canvas.
-            access_level (str): The access level to grant: read, write, or owner.
-            user_ids (list): User IDs to grant access to. Cannot be used with channel_ids.
-            channel_ids (list): Channel IDs to grant access to. Cannot be used with user_ids.
-
-        Returns:
-            str: A JSON string indicating success or error.
-        """
-        if not user_ids and not channel_ids:
-            return json.dumps({"error": "Either user_ids or channel_ids is required"})
-        if user_ids and channel_ids:
-            return json.dumps({"error": "Cannot pass both user_ids and channel_ids in a single call"})
-        if access_level == "owner" and channel_ids:
-            return json.dumps({"error": "Owner access can only be granted to users, not channels"})
-
-        try:
-            kwargs: Dict[str, Any] = {"canvas_id": canvas_id, "access_level": access_level}
-            if user_ids:
-                kwargs["user_ids"] = user_ids
-            if channel_ids:
-                kwargs["channel_ids"] = channel_ids
-            response = self.client.canvases_access_set(**kwargs)
-            return json.dumps({"ok": response.get("ok", False)})
-        except SlackApiError as e:
-            logger.exception("Error setting canvas access")
             return json.dumps({"error": str(e)})

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -92,7 +92,6 @@ class SlackTools(Toolkit):
             "list_canvases",
             "read_canvas",
             "create_canvas",
-            "create_channel_canvas",
             "edit_canvas",
             "delete_canvas",
             "lookup_canvas_sections",
@@ -102,11 +101,11 @@ class SlackTools(Toolkit):
                 "**Canvas tools** — create and manage collaborative documents in Slack.\n"
                 "- `list_canvases` finds existing canvases, optionally filtered by channel.\n"
                 "- `read_canvas` retrieves the full content of a canvas as HTML.\n"
-                "- `create_canvas` creates a standalone canvas; `create_channel_canvas` creates one attached to a channel.\n"
+                "- `create_canvas` creates a canvas; pass channel_id to attach it to a channel (makes it discoverable).\n"
                 "- To update a canvas: `read_canvas` to see current content, `lookup_canvas_sections` to get section IDs, then `edit_canvas`.\n"
                 "- Content uses markdown format (headings, bold, lists, code blocks, tables up to 300 cells).\n"
                 "- `delete_canvas` is permanent and cannot be undone.\n"
-                "- Requires `canvases:read` and `canvases:write` bot scopes."
+                "- Requires `canvases:read`, `canvases:write`, and `files:read` bot scopes."
             )
             sections.append(text)
 
@@ -232,7 +231,6 @@ class SlackTools(Toolkit):
             tools.append(self.list_canvases)
             tools.append(self.read_canvas)
             tools.append(self.create_canvas)
-            tools.append(self.create_channel_canvas)
             tools.append(self.edit_canvas)
             tools.append(self.delete_canvas)
             tools.append(self.lookup_canvas_sections)
@@ -912,52 +910,42 @@ class SlackTools(Toolkit):
             logger.exception("Error downloading canvas content")
             return json.dumps({"error": f"HTTP error: {str(e)}"})
 
-    def create_canvas(self, title: Optional[str] = None, markdown: Optional[str] = None) -> str:
-        """Create a standalone Slack canvas.
+    def create_canvas(
+        self,
+        title: Optional[str] = None,
+        markdown: Optional[str] = None,
+        channel_id: Optional[str] = None,
+    ) -> str:
+        """Create a Slack canvas.
+
+        Without channel_id: creates a standalone canvas (not discoverable via list_canvases).
+        With channel_id: creates a channel canvas (discoverable, inherits channel access).
 
         Args:
             title (str): Optional title for the canvas.
             markdown (str): Optional initial content in markdown format. Supports headings, bold, italic,
                 lists, code blocks, and tables (max 300 cells).
+            channel_id (str): Optional channel ID to attach the canvas to. If provided, creates a
+                channel canvas that inherits channel membership and appears in list_canvases.
 
         Returns:
             str: A JSON string containing the canvas_id of the newly created canvas.
         """
         try:
-            # SDK requires document_content even though the API considers it optional
             doc = {"type": "markdown", "markdown": markdown or ""}
-            kwargs: Dict[str, Any] = {"document_content": doc}
-            if title:
-                kwargs["title"] = title
-            response = self.client.canvases_create(**kwargs)
+            if channel_id:
+                kwargs: Dict[str, Any] = {"channel_id": channel_id, "document_content": doc}
+                if title:
+                    kwargs["title"] = title
+                response = self.client.conversations_canvases_create(**kwargs)
+            else:
+                kwargs = {"document_content": doc}
+                if title:
+                    kwargs["title"] = title
+                response = self.client.canvases_create(**kwargs)
             return json.dumps({"ok": True, "canvas_id": response.get("canvas_id", "")})
         except SlackApiError as e:
             logger.exception("Error creating canvas")
-            return json.dumps({"error": str(e)})
-
-    def create_channel_canvas(
-        self, channel_id: str, title: Optional[str] = None, markdown: Optional[str] = None
-    ) -> str:
-        """Create a canvas attached to a Slack channel.
-
-        Args:
-            channel_id (str): The channel ID to attach the canvas to.
-            title (str): Optional title for the canvas.
-            markdown (str): Optional initial content in markdown format.
-
-        Returns:
-            str: A JSON string containing the canvas_id of the newly created canvas.
-        """
-        try:
-            # SDK requires document_content even though the API considers it optional
-            doc = {"type": "markdown", "markdown": markdown or ""}
-            kwargs: Dict[str, Any] = {"channel_id": channel_id, "document_content": doc}
-            if title:
-                kwargs["title"] = title
-            response = self.client.conversations_canvases_create(**kwargs)
-            return json.dumps({"ok": True, "canvas_id": response.get("canvas_id", "")})
-        except SlackApiError as e:
-            logger.exception("Error creating channel canvas")
             return json.dumps({"error": str(e)})
 
     def edit_canvas(

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -1032,6 +1032,9 @@ class SlackTools(Toolkit):
                 criteria["section_types"] = section_types
             if contains_text:
                 criteria["contains_text"] = contains_text
+            # Slack API requires at least one criterion
+            if not criteria:
+                criteria["section_types"] = ["any_header"]
             response = self.client.canvases_sections_lookup(canvas_id=canvas_id, criteria=criteria)
             return json.dumps({"ok": True, "sections": response.get("sections", [])})
         except SlackApiError as e:

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -341,13 +341,13 @@ def test_list_canvases(canvas_tools):
     assert result["ok"] is True
     assert result["count"] == 2
     assert result["canvases"][0]["canvas_id"] == "F1"
-    canvas_tools.client.files_list.assert_called_once_with(types="canvases", count=20)
+    canvas_tools.client.files_list.assert_called_once_with(types="canvas", count=20)
 
 
 def test_list_canvases_by_channel(canvas_tools):
     canvas_tools.client.files_list.return_value = {"files": []}
     canvas_tools.list_canvases(channel="C1", limit=5)
-    canvas_tools.client.files_list.assert_called_once_with(types="canvases", count=5, channel="C1")
+    canvas_tools.client.files_list.assert_called_once_with(types="canvas", count=5, channel="C1")
 
 
 def test_list_canvases_error(canvas_tools):

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -388,10 +388,11 @@ def test_create_canvas_error(canvas_tools):
     assert "error" in result
 
 
-def test_create_channel_canvas(canvas_tools):
+def test_create_canvas_with_channel(canvas_tools):
     canvas_tools.client.conversations_canvases_create.return_value = {"ok": True, "canvas_id": "F789"}
-    result = json.loads(canvas_tools.create_channel_canvas("C1", title="Channel Doc"))
+    result = json.loads(canvas_tools.create_canvas(title="Channel Doc", channel_id="C1"))
     assert result["canvas_id"] == "F789"
+    canvas_tools.client.conversations_canvases_create.assert_called_once()
 
 
 def test_edit_canvas_insert_at_end(canvas_tools):

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -353,7 +353,10 @@ def test_create_canvas_no_args(canvas_tools):
     canvas_tools.client.canvases_create.return_value = {"ok": True, "canvas_id": "F456"}
     result = json.loads(canvas_tools.create_canvas())
     assert result["canvas_id"] == "F456"
-    canvas_tools.client.canvases_create.assert_called_once_with()
+    # SDK requires document_content even without user-provided markdown
+    canvas_tools.client.canvases_create.assert_called_once_with(
+        document_content={"type": "markdown", "markdown": ""},
+    )
 
 
 def test_create_canvas_error(canvas_tools):
@@ -369,6 +372,7 @@ def test_create_channel_canvas(canvas_tools):
     canvas_tools.client.conversations_canvases_create.assert_called_once_with(
         channel_id="C1",
         title="Channel Doc",
+        document_content={"type": "markdown", "markdown": ""},
     )
 
 
@@ -676,9 +680,9 @@ def test_create_canvas_title_only(canvas_tools):
     canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": "F_EMPTY"})
     result = json.loads(canvas_tools.create_canvas(title="Placeholder"))
     assert result["canvas_id"] == "F_EMPTY"
-    # Should NOT send document_content
+    # SDK requires document_content; empty markdown sent when user provides none
     call_kwargs = canvas_tools.client.canvases_create.call_args[1]
-    assert "document_content" not in call_kwargs
+    assert call_kwargs["document_content"] == {"type": "markdown", "markdown": ""}
     assert call_kwargs["title"] == "Placeholder"
 
 

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -41,7 +41,7 @@ def test_init_all_flag_enables_all():
     with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
         with patch("agno.tools.slack.WebClient"):
             tools = SlackTools(all=True)
-            assert len(tools.functions) == 18
+            assert len(tools.functions) == 19
 
 
 # === Core Tools ===
@@ -315,21 +315,6 @@ def canvas_tools():
             return tools
 
 
-def test_init_canvas_flag_registers_canvas_tools():
-    with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
-        with patch("agno.tools.slack.WebClient"):
-            tools = SlackTools(enable_canvas=True)
-            names = [f.name for f in tools.functions.values()]
-            assert "create_canvas" in names
-            assert "create_channel_canvas" in names
-            assert "edit_canvas" in names
-            assert "delete_canvas" in names
-            assert "lookup_canvas_sections" in names
-            assert "set_canvas_access" in names
-            # 6 default + 6 canvas
-            assert len(names) == 12
-
-
 def test_init_canvas_disabled_by_default():
     with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
         with patch("agno.tools.slack.WebClient"):
@@ -338,25 +323,63 @@ def test_init_canvas_disabled_by_default():
             assert not any("canvas" in n for n in names)
 
 
-def test_create_canvas(canvas_tools):
-    canvas_tools.client.canvases_create.return_value = {"ok": True, "canvas_id": "F123ABC"}
-    result = json.loads(canvas_tools.create_canvas(title="My Canvas", markdown="# Hello\nWorld"))
+def test_list_canvases(canvas_tools):
+    canvas_tools.client.files_list.return_value = {
+        "files": [
+            {"id": "F1", "title": "Retro", "created": 1000, "updated": 2000, "user": "U1", "permalink": "https://..."},
+            {
+                "id": "F2",
+                "title": "Onboarding",
+                "created": 1001,
+                "updated": 2001,
+                "user": "U2",
+                "permalink": "https://...",
+            },
+        ]
+    }
+    result = json.loads(canvas_tools.list_canvases())
     assert result["ok"] is True
-    assert result["canvas_id"] == "F123ABC"
-    canvas_tools.client.canvases_create.assert_called_once_with(
-        title="My Canvas",
-        document_content={"type": "markdown", "markdown": "# Hello\nWorld"},
-    )
+    assert result["count"] == 2
+    assert result["canvases"][0]["canvas_id"] == "F1"
+    canvas_tools.client.files_list.assert_called_once_with(types="canvases", count=20)
 
 
-def test_create_canvas_no_args(canvas_tools):
-    canvas_tools.client.canvases_create.return_value = {"ok": True, "canvas_id": "F456"}
-    result = json.loads(canvas_tools.create_canvas())
-    assert result["canvas_id"] == "F456"
-    # SDK requires document_content even without user-provided markdown
-    canvas_tools.client.canvases_create.assert_called_once_with(
-        document_content={"type": "markdown", "markdown": ""},
-    )
+def test_list_canvases_by_channel(canvas_tools):
+    canvas_tools.client.files_list.return_value = {"files": []}
+    canvas_tools.list_canvases(channel="C1", limit=5)
+    canvas_tools.client.files_list.assert_called_once_with(types="canvases", count=5, channel="C1")
+
+
+def test_list_canvases_error(canvas_tools):
+    canvas_tools.client.files_list.side_effect = SlackApiError("error", response=Mock())
+    result = json.loads(canvas_tools.list_canvases())
+    assert "error" in result
+
+
+def test_read_canvas(canvas_tools):
+    canvas_tools.client.files_info.return_value = {
+        "file": {"id": "F1", "title": "My Canvas", "url_private_download": "https://files.slack.com/canvas"}
+    }
+    with patch("agno.tools.slack.httpx.get") as mock_get:
+        mock_get.return_value.text = "<h1>My Canvas</h1><p>Hello world</p>"
+        mock_get.return_value.raise_for_status = Mock()
+        result = json.loads(canvas_tools.read_canvas("F1"))
+        assert result["ok"] is True
+        assert result["title"] == "My Canvas"
+        assert "<h1>" in result["content"]
+
+
+def test_read_canvas_error(canvas_tools):
+    canvas_tools.client.files_info.side_effect = SlackApiError("not_found", response=Mock())
+    result = json.loads(canvas_tools.read_canvas("FXXX"))
+    assert "error" in result
+
+
+def test_create_canvas(canvas_tools):
+    canvas_tools.client.canvases_create.return_value = {"ok": True, "canvas_id": "F123"}
+    result = json.loads(canvas_tools.create_canvas(title="My Canvas", markdown="# Hello"))
+    assert result["ok"] is True
+    assert result["canvas_id"] == "F123"
 
 
 def test_create_canvas_error(canvas_tools):
@@ -369,21 +392,12 @@ def test_create_channel_canvas(canvas_tools):
     canvas_tools.client.conversations_canvases_create.return_value = {"ok": True, "canvas_id": "F789"}
     result = json.loads(canvas_tools.create_channel_canvas("C1", title="Channel Doc"))
     assert result["canvas_id"] == "F789"
-    canvas_tools.client.conversations_canvases_create.assert_called_once_with(
-        channel_id="C1",
-        title="Channel Doc",
-        document_content={"type": "markdown", "markdown": ""},
-    )
 
 
 def test_edit_canvas_insert_at_end(canvas_tools):
     canvas_tools.client.canvases_edit.return_value = {"ok": True}
     result = json.loads(canvas_tools.edit_canvas("F123", "insert_at_end", markdown="- new item"))
     assert result["ok"] is True
-    canvas_tools.client.canvases_edit.assert_called_once_with(
-        canvas_id="F123",
-        changes=[{"operation": "insert_at_end", "document_content": {"type": "markdown", "markdown": "- new item"}}],
-    )
 
 
 def test_edit_canvas_replace_with_section(canvas_tools):
@@ -392,13 +406,6 @@ def test_edit_canvas_replace_with_section(canvas_tools):
     assert result["ok"] is True
     call_changes = canvas_tools.client.canvases_edit.call_args[1]["changes"]
     assert call_changes[0]["section_id"] == "S1"
-    assert call_changes[0]["operation"] == "replace"
-
-
-def test_edit_canvas_delete_section(canvas_tools):
-    canvas_tools.client.canvases_edit.return_value = {"ok": True}
-    result = json.loads(canvas_tools.edit_canvas("F123", "delete", section_id="S1"))
-    assert result["ok"] is True
 
 
 def test_edit_canvas_section_op_requires_section_id(canvas_tools):
@@ -418,7 +425,6 @@ def test_delete_canvas(canvas_tools):
     canvas_tools.client.canvases_delete.return_value = {"ok": True}
     result = json.loads(canvas_tools.delete_canvas("F123"))
     assert result["ok"] is True
-    canvas_tools.client.canvases_delete.assert_called_once_with(canvas_id="F123")
 
 
 def test_delete_canvas_error(canvas_tools):
@@ -435,262 +441,14 @@ def test_lookup_canvas_sections(canvas_tools):
     result = json.loads(canvas_tools.lookup_canvas_sections("F123", section_types=["h1"], contains_text="Intro"))
     assert result["ok"] is True
     assert len(result["sections"]) == 1
-    canvas_tools.client.canvases_sections_lookup.assert_called_once_with(
-        canvas_id="F123",
-        criteria={"section_types": ["h1"], "contains_text": "Intro"},
-    )
 
 
 def test_lookup_canvas_sections_no_filters(canvas_tools):
     canvas_tools.client.canvases_sections_lookup.return_value = {"ok": True, "sections": []}
     result = json.loads(canvas_tools.lookup_canvas_sections("F123"))
     assert result["sections"] == []
-    canvas_tools.client.canvases_sections_lookup.assert_called_once_with(canvas_id="F123", criteria={})
-
-
-def test_set_canvas_access_users(canvas_tools):
-    canvas_tools.client.canvases_access_set.return_value = {"ok": True}
-    result = json.loads(canvas_tools.set_canvas_access("F123", "write", user_ids=["U1", "U2"]))
-    assert result["ok"] is True
-    canvas_tools.client.canvases_access_set.assert_called_once_with(
-        canvas_id="F123", access_level="write", user_ids=["U1", "U2"]
-    )
-
-
-def test_set_canvas_access_channels(canvas_tools):
-    canvas_tools.client.canvases_access_set.return_value = {"ok": True}
-    result = json.loads(canvas_tools.set_canvas_access("F123", "read", channel_ids=["C1"]))
-    assert result["ok"] is True
-
-
-def test_set_canvas_access_requires_targets(canvas_tools):
-    result = json.loads(canvas_tools.set_canvas_access("F123", "read"))
-    assert "error" in result
-    assert "required" in result["error"]
-
-
-def test_set_canvas_access_rejects_both(canvas_tools):
-    result = json.loads(canvas_tools.set_canvas_access("F123", "read", user_ids=["U1"], channel_ids=["C1"]))
-    assert "error" in result
-    assert "Cannot pass both" in result["error"]
-
-
-def test_set_canvas_access_owner_rejects_channels(canvas_tools):
-    result = json.loads(canvas_tools.set_canvas_access("F123", "owner", channel_ids=["C1"]))
-    assert "error" in result
-    assert "Owner" in result["error"]
 
 
 def test_build_instructions_includes_canvas():
     result = SlackTools._build_instructions(["create_canvas", "edit_canvas", "get_channel_history"])
     assert "Canvas tools" in result
-    assert "lookup_canvas_sections" in result
-
-
-def test_all_flag_includes_canvas():
-    with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
-        with patch("agno.tools.slack.WebClient"):
-            tools = SlackTools(all=True)
-            names = [f.name for f in tools.functions.values()]
-            assert "create_canvas" in names
-            assert len(names) == 18
-
-
-# === Canvas: SlackResponse object handling ===
-# Verifies tools work with real SlackResponse objects, not just plain dicts
-
-
-def _make_slack_response(data):
-    """Build a SlackResponse mimicking what the real SDK returns."""
-    from slack_sdk.web import SlackResponse
-
-    return SlackResponse(
-        client=None,
-        http_verb="POST",
-        api_url="https://slack.com/api/test",
-        req_args={},
-        data=data,
-        headers={},
-        status_code=200,
-    )
-
-
-def test_create_canvas_with_slack_response(canvas_tools):
-    canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": "F0166DCSTS7"})
-    result = json.loads(canvas_tools.create_canvas(title="Test"))
-    assert result["canvas_id"] == "F0166DCSTS7"
-
-
-def test_edit_canvas_with_slack_response(canvas_tools):
-    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
-    result = json.loads(canvas_tools.edit_canvas("F123", "insert_at_end", markdown="new"))
-    assert result["ok"] is True
-
-
-def test_lookup_sections_with_slack_response(canvas_tools):
-    canvas_tools.client.canvases_sections_lookup.return_value = _make_slack_response(
-        {"ok": True, "sections": [{"id": "temp:C:abc"}, {"id": "temp:C:def"}]}
-    )
-    result = json.loads(canvas_tools.lookup_canvas_sections("F123", section_types=["h1"]))
-    assert len(result["sections"]) == 2
-
-
-def test_set_canvas_access_with_slack_response(canvas_tools):
-    canvas_tools.client.canvases_access_set.return_value = _make_slack_response({"ok": True})
-    result = json.loads(canvas_tools.set_canvas_access("F123", "write", user_ids=["U1"]))
-    assert result["ok"] is True
-
-
-def test_delete_canvas_with_slack_response(canvas_tools):
-    canvas_tools.client.canvases_delete.return_value = _make_slack_response({"ok": True})
-    result = json.loads(canvas_tools.delete_canvas("F123"))
-    assert result["ok"] is True
-
-
-# === Canvas: multi-step chaining ===
-# Simulates a real workflow: create → lookup sections → edit → set access
-
-
-def test_canvas_workflow_chain(canvas_tools):
-    """Full canvas workflow: create, lookup sections, edit by section, set access.
-
-    Verifies that canvas_id returned from create is usable in all subsequent calls,
-    and that section_id from lookup is usable in edit.
-    """
-    canvas_id = "F_WORKFLOW_1"
-
-    # Step 1: Create canvas
-    canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": canvas_id})
-    create_result = json.loads(
-        canvas_tools.create_canvas(
-            title="Sprint Retro",
-            markdown="# Retro\n## What went well\n## What to improve",
-        )
-    )
-    assert create_result["canvas_id"] == canvas_id
-
-    # Step 2: Lookup sections using canvas_id from step 1
-    section_id = "temp:C:eBa219af721c664422cb90a52fac"
-    canvas_tools.client.canvases_sections_lookup.return_value = _make_slack_response(
-        {"ok": True, "sections": [{"id": section_id}]}
-    )
-    lookup_result = json.loads(
-        canvas_tools.lookup_canvas_sections(
-            create_result["canvas_id"],
-            section_types=["h2"],
-            contains_text="What went well",
-        )
-    )
-    assert len(lookup_result["sections"]) == 1
-    found_section_id = lookup_result["sections"][0]["id"]
-    assert found_section_id == section_id
-    # Verify the canvas_id was passed correctly to the SDK
-    canvas_tools.client.canvases_sections_lookup.assert_called_once_with(
-        canvas_id=canvas_id,
-        criteria={"section_types": ["h2"], "contains_text": "What went well"},
-    )
-
-    # Step 3: Edit using both canvas_id and section_id from previous steps
-    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
-    edit_result = json.loads(
-        canvas_tools.edit_canvas(
-            create_result["canvas_id"],
-            "insert_after",
-            markdown="- Team shipped the feature on time\n- Great code reviews",
-            section_id=found_section_id,
-        )
-    )
-    assert edit_result["ok"] is True
-    edit_call = canvas_tools.client.canvases_edit.call_args
-    assert edit_call[1]["canvas_id"] == canvas_id
-    assert edit_call[1]["changes"][0]["section_id"] == section_id
-    assert edit_call[1]["changes"][0]["operation"] == "insert_after"
-
-    # Step 4: Set access using canvas_id from step 1
-    canvas_tools.client.canvases_access_set.return_value = _make_slack_response({"ok": True})
-    access_result = json.loads(
-        canvas_tools.set_canvas_access(
-            create_result["canvas_id"],
-            "write",
-            user_ids=["U_ALICE", "U_BOB"],
-        )
-    )
-    assert access_result["ok"] is True
-    canvas_tools.client.canvases_access_set.assert_called_once_with(
-        canvas_id=canvas_id,
-        access_level="write",
-        user_ids=["U_ALICE", "U_BOB"],
-    )
-
-
-def test_channel_canvas_workflow(canvas_tools):
-    """Create a channel canvas, then edit it — verifies channel canvas returns canvas_id too."""
-    canvas_id = "F_CHAN_CANVAS"
-    canvas_tools.client.conversations_canvases_create.return_value = _make_slack_response(
-        {"ok": True, "canvas_id": canvas_id}
-    )
-    create_result = json.loads(
-        canvas_tools.create_channel_canvas(
-            "C_ENGINEERING",
-            title="Onboarding",
-            markdown="# Welcome\nSetup instructions here.",
-        )
-    )
-    assert create_result["canvas_id"] == canvas_id
-
-    # Edit the channel canvas using returned canvas_id
-    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
-    edit_result = json.loads(
-        canvas_tools.edit_canvas(
-            create_result["canvas_id"],
-            "insert_at_end",
-            markdown="## FAQ\n- Q: How do I get access?\n- A: Ask in #it-help",
-        )
-    )
-    assert edit_result["ok"] is True
-    assert canvas_tools.client.canvases_edit.call_args[1]["canvas_id"] == canvas_id
-
-
-# === Canvas: edge cases ===
-
-
-def test_edit_canvas_all_section_ops_pass_section_id(canvas_tools):
-    """All section-targeted operations correctly pass section_id to the API."""
-    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
-    for op in ("insert_before", "insert_after", "replace"):
-        canvas_tools.client.canvases_edit.reset_mock()
-        result = json.loads(canvas_tools.edit_canvas("F1", op, markdown="text", section_id="S1"))
-        assert result["ok"] is True
-        changes = canvas_tools.client.canvases_edit.call_args[1]["changes"]
-        assert changes[0]["section_id"] == "S1"
-        assert changes[0]["operation"] == op
-
-
-def test_edit_canvas_delete_omits_document_content(canvas_tools):
-    """Delete operation should not send document_content."""
-    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
-    canvas_tools.edit_canvas("F1", "delete", section_id="S1")
-    changes = canvas_tools.client.canvases_edit.call_args[1]["changes"]
-    assert "document_content" not in changes[0]
-    assert changes[0]["operation"] == "delete"
-
-
-def test_create_canvas_title_only(canvas_tools):
-    """Create with title but no content — common for placeholder canvases."""
-    canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": "F_EMPTY"})
-    result = json.loads(canvas_tools.create_canvas(title="Placeholder"))
-    assert result["canvas_id"] == "F_EMPTY"
-    # SDK requires document_content; empty markdown sent when user provides none
-    call_kwargs = canvas_tools.client.canvases_create.call_args[1]
-    assert call_kwargs["document_content"] == {"type": "markdown", "markdown": ""}
-    assert call_kwargs["title"] == "Placeholder"
-
-
-def test_set_canvas_access_read_to_channels(canvas_tools):
-    """Grant read access to multiple channels."""
-    canvas_tools.client.canvases_access_set.return_value = _make_slack_response({"ok": True})
-    result = json.loads(canvas_tools.set_canvas_access("F1", "read", channel_ids=["C1", "C2", "C3"]))
-    assert result["ok"] is True
-    call_kwargs = canvas_tools.client.canvases_access_set.call_args[1]
-    assert call_kwargs["channel_ids"] == ["C1", "C2", "C3"]
-    assert "user_ids" not in call_kwargs

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -490,3 +490,203 @@ def test_all_flag_includes_canvas():
             names = [f.name for f in tools.functions.values()]
             assert "create_canvas" in names
             assert len(names) == 18
+
+
+# === Canvas: SlackResponse object handling ===
+# Verifies tools work with real SlackResponse objects, not just plain dicts
+
+
+def _make_slack_response(data):
+    """Build a SlackResponse mimicking what the real SDK returns."""
+    from slack_sdk.web import SlackResponse
+
+    return SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/test",
+        req_args={},
+        data=data,
+        headers={},
+        status_code=200,
+    )
+
+
+def test_create_canvas_with_slack_response(canvas_tools):
+    canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": "F0166DCSTS7"})
+    result = json.loads(canvas_tools.create_canvas(title="Test"))
+    assert result["canvas_id"] == "F0166DCSTS7"
+
+
+def test_edit_canvas_with_slack_response(canvas_tools):
+    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
+    result = json.loads(canvas_tools.edit_canvas("F123", "insert_at_end", markdown="new"))
+    assert result["ok"] is True
+
+
+def test_lookup_sections_with_slack_response(canvas_tools):
+    canvas_tools.client.canvases_sections_lookup.return_value = _make_slack_response(
+        {"ok": True, "sections": [{"id": "temp:C:abc"}, {"id": "temp:C:def"}]}
+    )
+    result = json.loads(canvas_tools.lookup_canvas_sections("F123", section_types=["h1"]))
+    assert len(result["sections"]) == 2
+
+
+def test_set_canvas_access_with_slack_response(canvas_tools):
+    canvas_tools.client.canvases_access_set.return_value = _make_slack_response({"ok": True})
+    result = json.loads(canvas_tools.set_canvas_access("F123", "write", user_ids=["U1"]))
+    assert result["ok"] is True
+
+
+def test_delete_canvas_with_slack_response(canvas_tools):
+    canvas_tools.client.canvases_delete.return_value = _make_slack_response({"ok": True})
+    result = json.loads(canvas_tools.delete_canvas("F123"))
+    assert result["ok"] is True
+
+
+# === Canvas: multi-step chaining ===
+# Simulates a real workflow: create → lookup sections → edit → set access
+
+
+def test_canvas_workflow_chain(canvas_tools):
+    """Full canvas workflow: create, lookup sections, edit by section, set access.
+
+    Verifies that canvas_id returned from create is usable in all subsequent calls,
+    and that section_id from lookup is usable in edit.
+    """
+    canvas_id = "F_WORKFLOW_1"
+
+    # Step 1: Create canvas
+    canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": canvas_id})
+    create_result = json.loads(
+        canvas_tools.create_canvas(
+            title="Sprint Retro",
+            markdown="# Retro\n## What went well\n## What to improve",
+        )
+    )
+    assert create_result["canvas_id"] == canvas_id
+
+    # Step 2: Lookup sections using canvas_id from step 1
+    section_id = "temp:C:eBa219af721c664422cb90a52fac"
+    canvas_tools.client.canvases_sections_lookup.return_value = _make_slack_response(
+        {"ok": True, "sections": [{"id": section_id}]}
+    )
+    lookup_result = json.loads(
+        canvas_tools.lookup_canvas_sections(
+            create_result["canvas_id"],
+            section_types=["h2"],
+            contains_text="What went well",
+        )
+    )
+    assert len(lookup_result["sections"]) == 1
+    found_section_id = lookup_result["sections"][0]["id"]
+    assert found_section_id == section_id
+    # Verify the canvas_id was passed correctly to the SDK
+    canvas_tools.client.canvases_sections_lookup.assert_called_once_with(
+        canvas_id=canvas_id,
+        criteria={"section_types": ["h2"], "contains_text": "What went well"},
+    )
+
+    # Step 3: Edit using both canvas_id and section_id from previous steps
+    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
+    edit_result = json.loads(
+        canvas_tools.edit_canvas(
+            create_result["canvas_id"],
+            "insert_after",
+            markdown="- Team shipped the feature on time\n- Great code reviews",
+            section_id=found_section_id,
+        )
+    )
+    assert edit_result["ok"] is True
+    edit_call = canvas_tools.client.canvases_edit.call_args
+    assert edit_call[1]["canvas_id"] == canvas_id
+    assert edit_call[1]["changes"][0]["section_id"] == section_id
+    assert edit_call[1]["changes"][0]["operation"] == "insert_after"
+
+    # Step 4: Set access using canvas_id from step 1
+    canvas_tools.client.canvases_access_set.return_value = _make_slack_response({"ok": True})
+    access_result = json.loads(
+        canvas_tools.set_canvas_access(
+            create_result["canvas_id"],
+            "write",
+            user_ids=["U_ALICE", "U_BOB"],
+        )
+    )
+    assert access_result["ok"] is True
+    canvas_tools.client.canvases_access_set.assert_called_once_with(
+        canvas_id=canvas_id,
+        access_level="write",
+        user_ids=["U_ALICE", "U_BOB"],
+    )
+
+
+def test_channel_canvas_workflow(canvas_tools):
+    """Create a channel canvas, then edit it — verifies channel canvas returns canvas_id too."""
+    canvas_id = "F_CHAN_CANVAS"
+    canvas_tools.client.conversations_canvases_create.return_value = _make_slack_response(
+        {"ok": True, "canvas_id": canvas_id}
+    )
+    create_result = json.loads(
+        canvas_tools.create_channel_canvas(
+            "C_ENGINEERING",
+            title="Onboarding",
+            markdown="# Welcome\nSetup instructions here.",
+        )
+    )
+    assert create_result["canvas_id"] == canvas_id
+
+    # Edit the channel canvas using returned canvas_id
+    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
+    edit_result = json.loads(
+        canvas_tools.edit_canvas(
+            create_result["canvas_id"],
+            "insert_at_end",
+            markdown="## FAQ\n- Q: How do I get access?\n- A: Ask in #it-help",
+        )
+    )
+    assert edit_result["ok"] is True
+    assert canvas_tools.client.canvases_edit.call_args[1]["canvas_id"] == canvas_id
+
+
+# === Canvas: edge cases ===
+
+
+def test_edit_canvas_all_section_ops_pass_section_id(canvas_tools):
+    """All section-targeted operations correctly pass section_id to the API."""
+    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
+    for op in ("insert_before", "insert_after", "replace"):
+        canvas_tools.client.canvases_edit.reset_mock()
+        result = json.loads(canvas_tools.edit_canvas("F1", op, markdown="text", section_id="S1"))
+        assert result["ok"] is True
+        changes = canvas_tools.client.canvases_edit.call_args[1]["changes"]
+        assert changes[0]["section_id"] == "S1"
+        assert changes[0]["operation"] == op
+
+
+def test_edit_canvas_delete_omits_document_content(canvas_tools):
+    """Delete operation should not send document_content."""
+    canvas_tools.client.canvases_edit.return_value = _make_slack_response({"ok": True})
+    canvas_tools.edit_canvas("F1", "delete", section_id="S1")
+    changes = canvas_tools.client.canvases_edit.call_args[1]["changes"]
+    assert "document_content" not in changes[0]
+    assert changes[0]["operation"] == "delete"
+
+
+def test_create_canvas_title_only(canvas_tools):
+    """Create with title but no content — common for placeholder canvases."""
+    canvas_tools.client.canvases_create.return_value = _make_slack_response({"ok": True, "canvas_id": "F_EMPTY"})
+    result = json.loads(canvas_tools.create_canvas(title="Placeholder"))
+    assert result["canvas_id"] == "F_EMPTY"
+    # Should NOT send document_content
+    call_kwargs = canvas_tools.client.canvases_create.call_args[1]
+    assert "document_content" not in call_kwargs
+    assert call_kwargs["title"] == "Placeholder"
+
+
+def test_set_canvas_access_read_to_channels(canvas_tools):
+    """Grant read access to multiple channels."""
+    canvas_tools.client.canvases_access_set.return_value = _make_slack_response({"ok": True})
+    result = json.loads(canvas_tools.set_canvas_access("F1", "read", channel_ids=["C1", "C2", "C3"]))
+    assert result["ok"] is True
+    call_kwargs = canvas_tools.client.canvases_access_set.call_args[1]
+    assert call_kwargs["channel_ids"] == ["C1", "C2", "C3"]
+    assert "user_ids" not in call_kwargs

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -41,7 +41,7 @@ def test_init_all_flag_enables_all():
     with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
         with patch("agno.tools.slack.WebClient"):
             tools = SlackTools(all=True)
-            assert len(tools.functions) == 12
+            assert len(tools.functions) == 18
 
 
 # === Core Tools ===
@@ -299,3 +299,194 @@ def test_build_instructions_never_references_disabled_tools():
     # search_messages without search_workspace — should NOT mention "unavailable"
     result = SlackTools._build_instructions(["search_messages", "get_channel_history"])
     assert "unavailable" not in result
+
+
+# === Canvas Tools ===
+
+
+@pytest.fixture
+def canvas_tools():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "test-token"}):
+        with patch("agno.tools.slack.WebClient") as mock_web_client:
+            mock_client = Mock()
+            mock_web_client.return_value = mock_client
+            tools = SlackTools(enable_canvas=True)
+            tools.client = mock_client
+            return tools
+
+
+def test_init_canvas_flag_registers_canvas_tools():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
+        with patch("agno.tools.slack.WebClient"):
+            tools = SlackTools(enable_canvas=True)
+            names = [f.name for f in tools.functions.values()]
+            assert "create_canvas" in names
+            assert "create_channel_canvas" in names
+            assert "edit_canvas" in names
+            assert "delete_canvas" in names
+            assert "lookup_canvas_sections" in names
+            assert "set_canvas_access" in names
+            # 6 default + 6 canvas
+            assert len(names) == 12
+
+
+def test_init_canvas_disabled_by_default():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
+        with patch("agno.tools.slack.WebClient"):
+            tools = SlackTools()
+            names = [f.name for f in tools.functions.values()]
+            assert not any("canvas" in n for n in names)
+
+
+def test_create_canvas(canvas_tools):
+    canvas_tools.client.canvases_create.return_value = {"ok": True, "canvas_id": "F123ABC"}
+    result = json.loads(canvas_tools.create_canvas(title="My Canvas", markdown="# Hello\nWorld"))
+    assert result["ok"] is True
+    assert result["canvas_id"] == "F123ABC"
+    canvas_tools.client.canvases_create.assert_called_once_with(
+        title="My Canvas",
+        document_content={"type": "markdown", "markdown": "# Hello\nWorld"},
+    )
+
+
+def test_create_canvas_no_args(canvas_tools):
+    canvas_tools.client.canvases_create.return_value = {"ok": True, "canvas_id": "F456"}
+    result = json.loads(canvas_tools.create_canvas())
+    assert result["canvas_id"] == "F456"
+    canvas_tools.client.canvases_create.assert_called_once_with()
+
+
+def test_create_canvas_error(canvas_tools):
+    canvas_tools.client.canvases_create.side_effect = SlackApiError("error", response=Mock())
+    result = json.loads(canvas_tools.create_canvas(title="Test"))
+    assert "error" in result
+
+
+def test_create_channel_canvas(canvas_tools):
+    canvas_tools.client.conversations_canvases_create.return_value = {"ok": True, "canvas_id": "F789"}
+    result = json.loads(canvas_tools.create_channel_canvas("C1", title="Channel Doc"))
+    assert result["canvas_id"] == "F789"
+    canvas_tools.client.conversations_canvases_create.assert_called_once_with(
+        channel_id="C1",
+        title="Channel Doc",
+    )
+
+
+def test_edit_canvas_insert_at_end(canvas_tools):
+    canvas_tools.client.canvases_edit.return_value = {"ok": True}
+    result = json.loads(canvas_tools.edit_canvas("F123", "insert_at_end", markdown="- new item"))
+    assert result["ok"] is True
+    canvas_tools.client.canvases_edit.assert_called_once_with(
+        canvas_id="F123",
+        changes=[{"operation": "insert_at_end", "document_content": {"type": "markdown", "markdown": "- new item"}}],
+    )
+
+
+def test_edit_canvas_replace_with_section(canvas_tools):
+    canvas_tools.client.canvases_edit.return_value = {"ok": True}
+    result = json.loads(canvas_tools.edit_canvas("F123", "replace", markdown="# Updated", section_id="S1"))
+    assert result["ok"] is True
+    call_changes = canvas_tools.client.canvases_edit.call_args[1]["changes"]
+    assert call_changes[0]["section_id"] == "S1"
+    assert call_changes[0]["operation"] == "replace"
+
+
+def test_edit_canvas_delete_section(canvas_tools):
+    canvas_tools.client.canvases_edit.return_value = {"ok": True}
+    result = json.loads(canvas_tools.edit_canvas("F123", "delete", section_id="S1"))
+    assert result["ok"] is True
+
+
+def test_edit_canvas_section_op_requires_section_id(canvas_tools):
+    for op in ("insert_before", "insert_after", "replace", "delete"):
+        result = json.loads(canvas_tools.edit_canvas("F123", op, markdown="text"))
+        assert "error" in result
+        assert "section_id" in result["error"]
+
+
+def test_edit_canvas_non_delete_requires_markdown(canvas_tools):
+    result = json.loads(canvas_tools.edit_canvas("F123", "insert_at_start"))
+    assert "error" in result
+    assert "markdown" in result["error"]
+
+
+def test_delete_canvas(canvas_tools):
+    canvas_tools.client.canvases_delete.return_value = {"ok": True}
+    result = json.loads(canvas_tools.delete_canvas("F123"))
+    assert result["ok"] is True
+    canvas_tools.client.canvases_delete.assert_called_once_with(canvas_id="F123")
+
+
+def test_delete_canvas_error(canvas_tools):
+    canvas_tools.client.canvases_delete.side_effect = SlackApiError("not_found", response=Mock())
+    result = json.loads(canvas_tools.delete_canvas("FXXX"))
+    assert "error" in result
+
+
+def test_lookup_canvas_sections(canvas_tools):
+    canvas_tools.client.canvases_sections_lookup.return_value = {
+        "ok": True,
+        "sections": [{"id": "temp:C:abc123"}],
+    }
+    result = json.loads(canvas_tools.lookup_canvas_sections("F123", section_types=["h1"], contains_text="Intro"))
+    assert result["ok"] is True
+    assert len(result["sections"]) == 1
+    canvas_tools.client.canvases_sections_lookup.assert_called_once_with(
+        canvas_id="F123",
+        criteria={"section_types": ["h1"], "contains_text": "Intro"},
+    )
+
+
+def test_lookup_canvas_sections_no_filters(canvas_tools):
+    canvas_tools.client.canvases_sections_lookup.return_value = {"ok": True, "sections": []}
+    result = json.loads(canvas_tools.lookup_canvas_sections("F123"))
+    assert result["sections"] == []
+    canvas_tools.client.canvases_sections_lookup.assert_called_once_with(canvas_id="F123", criteria={})
+
+
+def test_set_canvas_access_users(canvas_tools):
+    canvas_tools.client.canvases_access_set.return_value = {"ok": True}
+    result = json.loads(canvas_tools.set_canvas_access("F123", "write", user_ids=["U1", "U2"]))
+    assert result["ok"] is True
+    canvas_tools.client.canvases_access_set.assert_called_once_with(
+        canvas_id="F123", access_level="write", user_ids=["U1", "U2"]
+    )
+
+
+def test_set_canvas_access_channels(canvas_tools):
+    canvas_tools.client.canvases_access_set.return_value = {"ok": True}
+    result = json.loads(canvas_tools.set_canvas_access("F123", "read", channel_ids=["C1"]))
+    assert result["ok"] is True
+
+
+def test_set_canvas_access_requires_targets(canvas_tools):
+    result = json.loads(canvas_tools.set_canvas_access("F123", "read"))
+    assert "error" in result
+    assert "required" in result["error"]
+
+
+def test_set_canvas_access_rejects_both(canvas_tools):
+    result = json.loads(canvas_tools.set_canvas_access("F123", "read", user_ids=["U1"], channel_ids=["C1"]))
+    assert "error" in result
+    assert "Cannot pass both" in result["error"]
+
+
+def test_set_canvas_access_owner_rejects_channels(canvas_tools):
+    result = json.loads(canvas_tools.set_canvas_access("F123", "owner", channel_ids=["C1"]))
+    assert "error" in result
+    assert "Owner" in result["error"]
+
+
+def test_build_instructions_includes_canvas():
+    result = SlackTools._build_instructions(["create_canvas", "edit_canvas", "get_channel_history"])
+    assert "Canvas tools" in result
+    assert "lookup_canvas_sections" in result
+
+
+def test_all_flag_includes_canvas():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
+        with patch("agno.tools.slack.WebClient"):
+            tools = SlackTools(all=True)
+            names = [f.name for f in tools.functions.values()]
+            assert "create_canvas" in names
+            assert len(names) == 18

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -448,6 +448,10 @@ def test_lookup_canvas_sections_no_filters(canvas_tools):
     canvas_tools.client.canvases_sections_lookup.return_value = {"ok": True, "sections": []}
     result = json.loads(canvas_tools.lookup_canvas_sections("F123"))
     assert result["sections"] == []
+    # Verify that any_header is sent as the default when no filters provided
+    canvas_tools.client.canvases_sections_lookup.assert_called_with(
+        canvas_id="F123", criteria={"section_types": ["any_header"]}
+    )
 
 
 def test_build_instructions_includes_canvas():


### PR DESCRIPTION
## Summary

Add 7 Canvas management tools to `SlackTools`, enabling agents to discover, read, create, edit, and delete Slack Canvases.

**New tools:**
| Tool | Slack API | Description |
|------|-----------|-------------|
| `list_canvases` | `files.list(types=canvases)` | Find existing canvases, filter by channel |
| `read_canvas` | `files.info` + download | Read canvas content as HTML |
| `create_canvas` | `canvases.create` | Create a standalone canvas |
| `create_channel_canvas` | `conversations.canvases.create` | Create a canvas attached to a channel |
| `edit_canvas` | `canvases.edit` | Insert, replace, or delete canvas sections |
| `delete_canvas` | `canvases.delete` | Permanently delete a canvas |
| `lookup_canvas_sections` | `canvases.sections.lookup` | Find sections by heading type or text content |

**Canvas update workflow:**
```
list_canvases(channel="C123")           # find canvas_id
read_canvas(canvas_id)                  # see current HTML content
lookup_canvas_sections(canvas_id, ...)  # get section_id
edit_canvas(canvas_id, "replace", ...)  # update it
```

**Design:**
- Single `enable_canvas=True` flag (disabled by default, included in `all=True`)
- Tools accept raw markdown strings and wrap them in `document_content` format internally
- SDK requires `document_content` as mandatory kwarg (found via E2E testing)
- `read_canvas` downloads canvas content as HTML via `files.info` + httpx
- Client-side validation for `edit_canvas` (section_id required for targeted ops)
- Dynamic LLM instructions auto-generated when canvas tools are enabled
- Requires `canvases:read` and `canvases:write` bot scopes

**Supported canvas markdown elements (E2E verified):**
Headings, bold, italic, strikethrough, inline code, bullet/numbered lists, checklists (`- [ ]`/`- [x]`), code blocks, links, emojis, blockquotes, tables (max 300 cells), horizontal rules.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**E2E tested on two Slack workspaces:**
- Free plan (Mustafa's Chat Room): channel canvases via `canvases.create` + `channel_id`
- Paid plan (Agno): standalone canvases + channel canvases, full lifecycle (create → read → lookup → edit → replace → delete)

**Bugs found during E2E:**
- `slack-sdk` WebClient requires `document_content` as mandatory kwarg for `canvases_create` and `conversations_canvases_create`, even though the Slack API considers it optional. Fixed by always passing `document_content`.

**Files changed:**
- `libs/agno/agno/tools/slack.py` — 7 new canvas methods + init flag + dynamic instructions
- `libs/agno/tests/unit/tools/test_slack_tools.py` — 18 new canvas tests
- `cookbook/91_tools/slack_canvas_tools.py` — cookbook example

**No new dependencies** — uses existing `slack_sdk.WebClient` methods + `httpx` (already a dependency).