### PR TITLE
fix: make AgentOS SSE streaming robust to serialization failures

### DIFF
--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -196,14 +196,33 @@ def format_sse_event(event: Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRu
         # offending event class is visible in production logs, then emit a
         # valid SSE error frame so the ASGI response completes cleanly.
         log_error(f"Failed to serialize SSE event {type(event).__name__} (event_type={event_type}): {e}")
+        error_event_name = _fallback_error_event_name(event)
         fallback = json.dumps(
             {
-                "event": "RunError",
+                "event": error_event_name,
                 "content": f"Failed to serialize {type(event).__name__}: {e}",
             },
             separators=(",", ":"),
         )
-        return f"event: RunError\ndata: {fallback}\n\n"
+        return f"event: {error_event_name}\ndata: {fallback}\n\n"
+
+
+def _fallback_error_event_name(event: Any) -> str:
+    """Derive the terminal-error event name for a stream family.
+
+    Downstream parsers branch on the event name (e.g. team and workflow runners
+    have their own terminal-error contracts), so a serialization failure in a
+    team or workflow stream must still surface under that family's error name
+    rather than the agent default.
+    """
+    from agno.run.team import BaseTeamRunEvent
+    from agno.run.workflow import BaseWorkflowRunOutputEvent
+
+    if isinstance(event, BaseWorkflowRunOutputEvent):
+        return "WorkflowError"
+    if isinstance(event, BaseTeamRunEvent):
+        return "TeamRunError"
+    return "RunError"
 
 
 async def get_db(

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -21,7 +21,7 @@ from agno.run.team import TeamRunOutputEvent
 from agno.run.workflow import WorkflowRunOutputEvent
 from agno.team import RemoteTeam, Team
 from agno.tools import Function, Toolkit
-from agno.utils.log import log_warning, logger
+from agno.utils.log import log_error, log_warning, logger
 from agno.workflow import RemoteWorkflow, Workflow
 
 
@@ -186,17 +186,24 @@ def format_sse_event(event: Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRu
         data: { ... }
         ```
     """
+    event_type = getattr(event, "event", None) or "message"
     try:
-        # Parse the JSON to extract the event type
-        event_type = event.event or "message"
-
         # Serialize to valid JSON with double quotes and no newlines
         clean_json = event.to_json(separators=(",", ":"), indent=None)
-
         return f"event: {event_type}\ndata: {clean_json}\n\n"
-    except json.JSONDecodeError:
-        clean_json = event.to_json(separators=(",", ":"), indent=None)
-        return f"event: message\ndata: {clean_json}\n\n"
+    except Exception as e:
+        # Never let a single bad event kill the stream. Log loudly so the
+        # offending event class is visible in production logs, then emit a
+        # valid SSE error frame so the ASGI response completes cleanly.
+        log_error(f"Failed to serialize SSE event {type(event).__name__} (event_type={event_type}): {e}")
+        fallback = json.dumps(
+            {
+                "event": "RunError",
+                "content": f"Failed to serialize {type(event).__name__}: {e}",
+            },
+            separators=(",", ":"),
+        )
+        return f"event: RunError\ndata: {fallback}\n\n"
 
 
 async def get_db(

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -142,3 +142,40 @@ def test_format_sse_event_defaults_missing_event_type():
     """Events without an `event` attribute fall back to 'message'."""
     frame = format_sse_event(_EventMissingType())  # type: ignore[arg-type]
     assert frame.startswith("event: message\ndata: ")
+
+
+def test_format_sse_event_preserves_team_error_family():
+    """Team event serialization failures must surface as TeamRunError.
+
+    Downstream parsers branch on the event name. If a team stream emits a
+    RunError (the agent name) on serialization failure, team terminal-error
+    handling is skipped.
+    """
+    from agno.run.team import BaseTeamRunEvent
+
+    class _BadTeamEvent(BaseTeamRunEvent):
+        event = "TeamRunContent"
+
+        def to_json(self, **kwargs):
+            raise TypeError("unserializable field")
+
+    frame = format_sse_event(_BadTeamEvent())  # type: ignore[arg-type]
+    assert frame.startswith("event: TeamRunError\ndata: ")
+    body = json.loads(frame.split("\n")[1][len("data: ") :])
+    assert body["event"] == "TeamRunError"
+
+
+def test_format_sse_event_preserves_workflow_error_family():
+    """Workflow event serialization failures must surface as WorkflowError."""
+    from agno.run.workflow import BaseWorkflowRunOutputEvent
+
+    class _BadWorkflowEvent(BaseWorkflowRunOutputEvent):
+        event = "StepStarted"
+
+        def to_json(self, **kwargs):
+            raise TypeError("unserializable field")
+
+    frame = format_sse_event(_BadWorkflowEvent())  # type: ignore[arg-type]
+    assert frame.startswith("event: WorkflowError\ndata: ")
+    body = json.loads(frame.split("\n")[1][len("data: ") :])
+    assert body["event"] == "WorkflowError"

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -1,8 +1,9 @@
 """Unit tests for OS utility functions."""
 
+import json
 from datetime import datetime, timezone
 
-from agno.os.utils import to_utc_datetime
+from agno.os.utils import format_sse_event, to_utc_datetime
 
 
 def test_returns_none_for_none_input():
@@ -89,3 +90,55 @@ def test_handles_negative_timestamp():
     assert result.year == 1969
     assert result.month == 12
     assert result.day == 31
+
+
+class _GoodEvent:
+    event = "RunContent"
+
+    def to_json(self, **kwargs):
+        return json.dumps({"event": self.event, "content": "hello"}, **kwargs)
+
+
+class _BadEvent:
+    event = "RunContent"
+
+    def to_json(self, **kwargs):
+        raise TypeError("Object of type bytes is not JSON serializable")
+
+
+class _EventMissingType:
+    event = None
+
+    def to_json(self, **kwargs):
+        return json.dumps({"content": "x"}, **kwargs)
+
+
+def test_format_sse_event_happy_path():
+    """Well-formed events serialize to a valid SSE frame."""
+    frame = format_sse_event(_GoodEvent())  # type: ignore[arg-type]
+    assert frame.startswith("event: RunContent\ndata: ")
+    assert frame.endswith("\n\n")
+    payload_line = frame.split("\n")[1]
+    body = payload_line[len("data: ") :]
+    assert json.loads(body) == {"event": "RunContent", "content": "hello"}
+
+
+def test_format_sse_event_swallows_serialization_errors():
+    """A failing to_json() must not raise - it must return a valid error SSE frame.
+
+    Regression guard for "ASGI callable returned without complete response":
+    if this raises, the streaming generator exits mid-stream and Starlette
+    closes the socket without a terminating chunk.
+    """
+    frame = format_sse_event(_BadEvent())  # type: ignore[arg-type]
+    assert frame.startswith("event: RunError\ndata: ")
+    assert frame.endswith("\n\n")
+    body = json.loads(frame.split("\n")[1][len("data: ") :])
+    assert body["event"] == "RunError"
+    assert "_BadEvent" in body["content"]
+
+
+def test_format_sse_event_defaults_missing_event_type():
+    """Events without an `event` attribute fall back to 'message'."""
+    frame = format_sse_event(_EventMissingType())  # type: ignore[arg-type]
+    assert frame.startswith("event: message\ndata: ")


### PR DESCRIPTION
## Summary

A user reported `ASGI callable returned without complete response` server-side, and `transfer failed / partial file` in Postman, when hitting AgentOS streaming endpoints in production. Works fine with `stream=False`.

Root cause is in `libs/agno/agno/os/utils.py::format_sse_event`:

```python
try:
    clean_json = event.to_json(separators=(",", ":"), indent=None)
    return f"event: {event_type}\ndata: {clean_json}\n\n"
except json.JSONDecodeError:
    clean_json = event.to_json(separators=(",", ":"), indent=None)  # same call, will raise again
    return f"event: message\ndata: {clean_json}\n\n"
```

`to_json()` emits JSON, it does not parse it, so it never raises `json.JSONDecodeError`. A real failure (`TypeError`/`ValueError` from a non-JSON-serializable field inside a run event - e.g. bytes, numpy arrays, custom objects embedded in a tool result or content event) propagates out of the streaming generator. Starlette then closes the socket without a terminating chunk, which the ASGI server logs as `ASGI callable returned without complete response` and Postman surfaces as a partial transfer.

This PR:

- Catches `Exception` instead of the never-firing `JSONDecodeError`.
- Logs the offending event class and event type via `log_error` so the culprit shows up in the user's production logs on the next failure.
- Emits a valid SSE `RunError` frame so the streaming response always completes cleanly.
- Hardens the `event_type` fallback with `getattr(..., "event", None) or "message"`.

Tests added in `libs/agno/tests/unit/os/test_utils.py`:

- Happy-path frame format.
- Regression guard: an event whose `to_json` raises must produce a valid `RunError` SSE frame rather than propagating the exception.
- Events missing an `event` attribute fall back to `"message"`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The bug has existed since `6078ca9a4` (release 2.3.9, Dec 9 2025), so it is not a regression from a specific recent branch - it only surfaces when a run event happens to contain a non-JSON-serializable field, which is data-dependent.

Follow-up for whoever picks up the user's report: once this deploys, their AgentOS logs will show `Failed to serialize SSE event <ClassName> (event_type=...): <error>` on the next failing run, pinpointing the exact event class and field causing the serialization error.