### PR TITLE
[fix] Patch the SSE parser so it handles the delegated RunOutput event shape correctly

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -390,10 +390,23 @@ class AgentOSClient:
                     # Extract and parse JSON payload
                     json_str = line[6:]  # Remove "data: " prefix
                     event_dict = json.loads(json_str)
+                    # Some streaming paths emit a full RunOutput/TeamRunOutput object
+                    # containing an `events` list instead of a single `event` object.
+                    # Normalize both payload shapes into a sequence of event dictionaries.
+                    if "event" in event_dict:
+                        event_payloads = [event_dict]
+                    elif isinstance(event_dict.get("events"), list):
+                        event_payloads = event_dict["events"]
+                    else:
+                        event_payloads = [event_dict]
 
-                    # Parse into typed event using provided factory
-                    event = event_parser(event_dict)
-                    yield event
+                    for event_payload in event_payloads:
+                        if not isinstance(event_payload, dict):
+                            logger.error(f"Invalid SSE event payload (expected dict): {event_payload}")
+                            continue
+                        # Parse into typed event using provided factory
+                        event = event_parser(event_payload)
+                        yield event
 
                 except json.JSONDecodeError:
                     logger.exception(f"Failed to parse SSE JSON: {line[:100]}...")

--- a/libs/agno/tests/unit/os/test_client.py
+++ b/libs/agno/tests/unit/os/test_client.py
@@ -724,6 +724,33 @@ async def test_stream_handles_unknown_event_type():
 
 
 @pytest.mark.asyncio
+async def test_stream_handles_run_output_payload_with_events_list():
+    """Verify stream parser supports RunOutput-shaped payloads with `events`."""
+    from agno.run.agent import RunCompletedEvent, RunStartedEvent
+
+    client = AgentOSClient(base_url="http://localhost:7777")
+
+    mock_lines = [
+        'data: {"run_id": "run-123", "events": [{"event": "RunStarted", "run_id": "run-123", "agent_id": "agent-1", "created_at": 1234567890}, {"event": "RunCompleted", "run_id": "run-123", "agent_id": "agent-1", "created_at": 1234567890}]}',
+    ]
+
+    async def async_generator():
+        for line in mock_lines:
+            yield line
+
+    with patch.object(client, "_astream_post_form_data") as mock_stream:
+        mock_stream.return_value = async_generator()
+
+        events = []
+        async for event in client.run_agent_stream("agent-123", "test"):
+            events.append(event)
+
+        assert len(events) == 2
+        assert isinstance(events[0], RunStartedEvent)
+        assert isinstance(events[1], RunCompletedEvent)
+
+
+@pytest.mark.asyncio
 async def test_stream_handles_empty_lines():
     """Verify empty lines and comments are skipped."""
     from agno.run.agent import RunCompletedEvent, RunStartedEvent


### PR DESCRIPTION
## Summary

Patched the SSE parser so it handles the delegated RunOutput event shape correctly (events vs event).

Fixed the streaming parser bug for delegated remote-member runs.

Updated AgentOSClient._parse_sse_events in libs/agno/agno/client/os.py to support both SSE payload shapes:

  - single event payloads with event
  - run-output payloads with events (list of event dicts)

The parser now normalizes payloads and parses each event item, so delegated calls that stream RunOutput no longer trigger ValueError("Unknown event type: ...") just because the top-level object has events instead of event.

Added a regression test in libs/agno/tests/unit/os/test_client.py:

  - test_stream_handles_run_output_payload_with_events_list
  - Verifies that a streamed data: frame containing {"run_id": "...", "events": [...]} correctly yields typed RunStartedEvent and RunCompletedEvent.

(If applicable, issue number: #7517)

## Type of change

- [*] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
