### PR TITLE
[fix] Preserve function metadata in Toolkit bound methods via functools.wraps

### DIFF
--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -1,3 +1,4 @@
+import functools
 from collections import OrderedDict
 from inspect import iscoroutinefunction
 from pathlib import Path
@@ -243,20 +244,18 @@ class Toolkit:
             if is_async:
 
                 def make_bound_method(func, instance):
+                    @functools.wraps(func)
                     async def bound(*args, **kwargs):
                         return await func(instance, *args, **kwargs)
 
-                    bound.__name__ = getattr(func, "__name__", tool_name)
-                    bound.__doc__ = getattr(func, "__doc__", None)
                     return bound
             else:
 
                 def make_bound_method(func, instance):
+                    @functools.wraps(func)
                     def bound(*args, **kwargs):
                         return func(instance, *args, **kwargs)
 
-                    bound.__name__ = getattr(func, "__name__", tool_name)
-                    bound.__doc__ = getattr(func, "__doc__", None)
                     return bound
 
             bound_method = make_bound_method(original_func, self)

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -1,3 +1,4 @@
+import functools
 from collections import OrderedDict
 from inspect import iscoroutinefunction
 from pathlib import Path
@@ -241,20 +242,18 @@ class Toolkit:
             if is_async:
 
                 def make_bound_method(func, instance):
+                    @functools.wraps(func)
                     async def bound(*args, **kwargs):
                         return await func(instance, *args, **kwargs)
 
-                    bound.__name__ = getattr(func, "__name__", tool_name)
-                    bound.__doc__ = getattr(func, "__doc__", None)
                     return bound
             else:
 
                 def make_bound_method(func, instance):
+                    @functools.wraps(func)
                     def bound(*args, **kwargs):
                         return func(instance, *args, **kwargs)
 
-                    bound.__name__ = getattr(func, "__name__", tool_name)
-                    bound.__doc__ = getattr(func, "__doc__", None)
                     return bound
 
             bound_method = make_bound_method(original_func, self)

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -856,3 +856,146 @@ def test_check_path_restrict_false_returns_false_on_nul_byte(basic_toolkit):
         ok, path = basic_toolkit._check_path("name\x00", base, restrict_to_base_dir=False)
         assert ok is False
         assert path == base
+
+
+# ---------------------------------------------------------------------------
+# Tests for functools.wraps preservation in bound methods (#7569)
+# ---------------------------------------------------------------------------
+
+
+class SyncToolkitForWraps(Toolkit):
+    def __init__(self):
+        super().__init__(name="sync_wraps_toolkit", tools=[self.my_sync_tool])
+
+    @tool(description="A sync tool with type annotations.")
+    def my_sync_tool(self, x: int) -> str:
+        """My sync docstring."""
+        return str(x)
+
+
+class AsyncToolkitForWraps(Toolkit):
+    def __init__(self):
+        super().__init__(name="async_wraps_toolkit", tools=[self.my_async_tool])
+
+    @tool(description="An async tool with type annotations.")
+    async def my_async_tool(self, x: int) -> str:
+        """My async docstring."""
+        return str(x)
+
+
+def test_sync_bound_method_preserves_name():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__name__ == "my_sync_tool"
+
+
+def test_sync_bound_method_preserves_qualname():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__qualname__ == "SyncToolkitForWraps.my_sync_tool"
+
+
+def test_sync_bound_method_preserves_doc():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__doc__ == "My sync docstring."
+
+
+def test_sync_bound_method_preserves_annotations():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__annotations__ == {"x": int, "return": str}
+
+
+def test_sync_bound_method_sets_wrapped():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert hasattr(fn, "__wrapped__")
+
+
+def test_async_bound_method_preserves_name():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__name__ == "my_async_tool"
+
+
+def test_async_bound_method_preserves_qualname():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__qualname__ == "AsyncToolkitForWraps.my_async_tool"
+
+
+def test_async_bound_method_preserves_annotations():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__annotations__ == {"x": int, "return": str}
+
+
+def test_async_bound_method_preserves_doc():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__doc__ == "My async docstring."
+
+
+def test_async_bound_method_sets_wrapped():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert hasattr(fn, "__wrapped__")
+
+
+# --- Schema integrity: self must not leak into the tool parameter schema ---
+
+
+def test_sync_bound_method_schema_correct():
+    t = SyncToolkitForWraps()
+    params = t.functions["my_sync_tool"].parameters
+    assert "x" in params["properties"]
+    assert "self" not in params["properties"]
+    assert params["required"] == ["x"]
+
+
+def test_async_bound_method_schema_correct():
+    t = AsyncToolkitForWraps()
+    params = t.async_functions["my_async_tool"].parameters
+    assert "x" in params["properties"]
+    assert "self" not in params["properties"]
+    assert params["required"] == ["x"]
+
+
+# --- Execution: instance binding must survive functools.wraps ---
+
+
+def test_sync_bound_method_executes_correctly():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn(x=42) == "42"
+
+
+@pytest.mark.asyncio
+async def test_async_bound_method_executes_correctly():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert await fn(x=99) == "99"
+
+
+# --- inspect.unwrap must reach the original function ---
+
+
+def test_sync_bound_method_unwrap_reaches_original():
+    import inspect
+
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    original = inspect.unwrap(fn)
+    assert original.__name__ == "my_sync_tool"
+    assert "self" in inspect.signature(original).parameters
+
+
+def test_async_bound_method_unwrap_reaches_original():
+    import inspect
+
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    original = inspect.unwrap(fn)
+    assert original.__name__ == "my_async_tool"
+    assert "self" in inspect.signature(original).parameters

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -795,3 +795,146 @@ def test_partial_async_get_async_functions():
     assert async_funcs["tool_a"].entrypoint == toolkit.atool_a
     # tool_b should still be sync version (no async variant)
     assert async_funcs["tool_b"].entrypoint == toolkit.tool_b
+
+
+# ---------------------------------------------------------------------------
+# Tests for functools.wraps preservation in bound methods (#7569)
+# ---------------------------------------------------------------------------
+
+
+class SyncToolkitForWraps(Toolkit):
+    def __init__(self):
+        super().__init__(name="sync_wraps_toolkit", tools=[self.my_sync_tool])
+
+    @tool(description="A sync tool with type annotations.")
+    def my_sync_tool(self, x: int) -> str:
+        """My sync docstring."""
+        return str(x)
+
+
+class AsyncToolkitForWraps(Toolkit):
+    def __init__(self):
+        super().__init__(name="async_wraps_toolkit", tools=[self.my_async_tool])
+
+    @tool(description="An async tool with type annotations.")
+    async def my_async_tool(self, x: int) -> str:
+        """My async docstring."""
+        return str(x)
+
+
+def test_sync_bound_method_preserves_name():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__name__ == "my_sync_tool"
+
+
+def test_sync_bound_method_preserves_qualname():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__qualname__ == "SyncToolkitForWraps.my_sync_tool"
+
+
+def test_sync_bound_method_preserves_doc():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__doc__ == "My sync docstring."
+
+
+def test_sync_bound_method_preserves_annotations():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn.__annotations__ == {"x": int, "return": str}
+
+
+def test_sync_bound_method_sets_wrapped():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert hasattr(fn, "__wrapped__")
+
+
+def test_async_bound_method_preserves_name():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__name__ == "my_async_tool"
+
+
+def test_async_bound_method_preserves_qualname():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__qualname__ == "AsyncToolkitForWraps.my_async_tool"
+
+
+def test_async_bound_method_preserves_annotations():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__annotations__ == {"x": int, "return": str}
+
+
+def test_async_bound_method_preserves_doc():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert fn.__doc__ == "My async docstring."
+
+
+def test_async_bound_method_sets_wrapped():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert hasattr(fn, "__wrapped__")
+
+
+# --- Schema integrity: self must not leak into the tool parameter schema ---
+
+
+def test_sync_bound_method_schema_correct():
+    t = SyncToolkitForWraps()
+    params = t.functions["my_sync_tool"].parameters
+    assert "x" in params["properties"]
+    assert "self" not in params["properties"]
+    assert params["required"] == ["x"]
+
+
+def test_async_bound_method_schema_correct():
+    t = AsyncToolkitForWraps()
+    params = t.async_functions["my_async_tool"].parameters
+    assert "x" in params["properties"]
+    assert "self" not in params["properties"]
+    assert params["required"] == ["x"]
+
+
+# --- Execution: instance binding must survive functools.wraps ---
+
+
+def test_sync_bound_method_executes_correctly():
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    assert fn(x=42) == "42"
+
+
+@pytest.mark.asyncio
+async def test_async_bound_method_executes_correctly():
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    assert await fn(x=99) == "99"
+
+
+# --- inspect.unwrap must reach the original function ---
+
+
+def test_sync_bound_method_unwrap_reaches_original():
+    import inspect
+
+    t = SyncToolkitForWraps()
+    fn = t.functions["my_sync_tool"].entrypoint
+    original = inspect.unwrap(fn)
+    assert original.__name__ == "my_sync_tool"
+    assert "self" in inspect.signature(original).parameters
+
+
+def test_async_bound_method_unwrap_reaches_original():
+    import inspect
+
+    t = AsyncToolkitForWraps()
+    fn = t.async_functions["my_async_tool"].entrypoint
+    original = inspect.unwrap(fn)
+    assert original.__name__ == "my_async_tool"
+    assert "self" in inspect.signature(original).parameters


### PR DESCRIPTION
## Summary

When `_register_decorated_tool` wraps a `@tool`-decorated method into a bound closure, it manually assigned only `__name__` and `__doc__`. This left `__qualname__`, `__annotations__`, and `__wrapped__` with incorrect or missing values on the resulting bound method.

Fixes #7569

## Problem

```python
class MyTools(Toolkit):
    def __init__(self):
        super().__init__(name="my_tools", tools=[self.my_tool])

    @tool(description="A test tool")
    def my_tool(self, x: int) -> str:
        """My docstring."""
        return str(x)

t = MyTools()
fn = t.functions["my_tool"].entrypoint

print(fn.__qualname__)    # "make_bound_method.<locals>.bound"  ← wrong
print(fn.__annotations__) # {}  ← type hints dropped
print(hasattr(fn, "__wrapped__"))  # False  ← unwrap chain broken
```

## Solution

Replace the two manual attribute assignments with `functools.wraps`, which is the standard Python idiom for wrapping functions and preserves all relevant metadata in a single call. Applied to both the `async` and sync branches of `make_bound_method`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [pull requests](../../pulls) and confirmed no other PR addresses this.
- [x] Check if this PR was entirely AI-generated: This PR was developed with **Antigravity AI**, incorporating technical feedback and requirements from Issue #7569.
