### PR TITLE
[fix] support AGUI reasoning role variants

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -4,7 +4,7 @@ import json
 import uuid
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass, is_dataclass
-from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple, Union, get_args
 
 from ag_ui.core import (
     BaseEvent,
@@ -41,6 +41,20 @@ from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunEvent, TeamRunOutputEvent
 from agno.utils.log import log_warning
 from agno.utils.message import get_text_from_message
+
+
+def _get_reasoning_message_role() -> str:
+    """Return the AG-UI reasoning role supported by the installed ag-ui-protocol version."""
+    role_field = ReasoningMessageStartEvent.model_fields.get("role")
+    if role_field is None:
+        return "assistant"
+
+    supported_roles = get_args(role_field.annotation)
+    if "assistant" in supported_roles:
+        return "assistant"
+    if supported_roles:
+        return str(supported_roles[0])
+    return "assistant"
 
 
 def validate_agui_state(state: Any, thread_id: str) -> Optional[Dict[str, Any]]:
@@ -381,7 +395,9 @@ def _create_events_from_chunk(
         events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
         events_to_emit.append(
             ReasoningMessageStartEvent(
-                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                type=EventType.REASONING_MESSAGE_START,
+                message_id=reasoning_id,
+                role=_get_reasoning_message_role(),
             )
         )
 
@@ -392,7 +408,9 @@ def _create_events_from_chunk(
             events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
             events_to_emit.append(
                 ReasoningMessageStartEvent(
-                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                    type=EventType.REASONING_MESSAGE_START,
+                    message_id=reasoning_id,
+                    role=_get_reasoning_message_role(),
                 )
             )
         if chunk.reasoning_content:
@@ -410,7 +428,9 @@ def _create_events_from_chunk(
             events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
             events_to_emit.append(
                 ReasoningMessageStartEvent(
-                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                    type=EventType.REASONING_MESSAGE_START,
+                    message_id=reasoning_id,
+                    role=_get_reasoning_message_role(),
                 )
             )
         step_num = event_buffer.next_reasoning_step()

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -6,6 +6,7 @@ from ag_ui.core.types import AssistantMessage, SystemMessage, TextInputContent, 
 
 from agno.os.interfaces.agui.utils import (
     EventBuffer,
+    _get_reasoning_message_role,
     async_stream_agno_response_as_agui_events,
     extract_agui_user_input,
 )
@@ -614,6 +615,9 @@ async def test_reasoning_events_handling():
     r_end = event_types.index(EventType.REASONING_END)
     assert r_start < r_msg_start < r_content < r_msg_end < r_end
 
+    reasoning_start_event = next(event for event in events if event.type == EventType.REASONING_MESSAGE_START)
+    assert reasoning_start_event.role == _get_reasoning_message_role()
+
     # Should have text content after reasoning
     assert EventType.TEXT_MESSAGE_CONTENT in event_types
     assert EventType.RUN_FINISHED in event_types
@@ -698,6 +702,9 @@ async def test_orphaned_reasoning_cleanup():
     assert EventType.REASONING_MESSAGE_END in event_types, "Orphaned session should be closed"
     assert EventType.REASONING_END in event_types, "Orphaned session should be closed"
     assert EventType.RUN_FINISHED in event_types, "Should still emit RUN_FINISHED"
+
+    reasoning_start_event = next(event for event in events if event.type == EventType.REASONING_MESSAGE_START)
+    assert reasoning_start_event.role == _get_reasoning_message_role()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make AGUI reasoning start events choose a role supported by the installed `ag-ui-protocol` schema
- keep reasoning streams compatible across protocol versions that expect either `assistant` or `reasoning`
- add regression assertions for reasoning start events in the AGUI unit tests

Fixes #7556

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run in this workspace:
- `ruff format libs/agno/agno/os/interfaces/agui/utils.py libs/agno/tests/unit/app/test_agui_app.py`
- `ruff check libs/agno/agno/os/interfaces/agui/utils.py libs/agno/tests/unit/app/test_agui_app.py`
- `PYTHONPATH=libs/agno /Users/kitt/.openclaw/workspace/agents/charlie/repos/agno/libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/app/test_agui_app.py -k 'reasoning' -q`

I did not run `./scripts/validate.sh` because fresh `uv` resolution in this repo currently fails on unrelated optional dependency conflicts (`a2a-sdk` vs `brave-search`) in this environment.
