### PR TITLE
[fix] initialize E2BTools sandbox lazily on first tool call

### DIFF
--- a/libs/agno/agno/tools/e2b.py
+++ b/libs/agno/agno/tools/e2b.py
@@ -31,6 +31,10 @@ class E2BTools(Toolkit):
     ):
         """Initialize E2B toolkit for code interpretation and running Python code in a sandbox.
 
+        The sandbox is created lazily on the first tool call, not at construction time.
+        This prevents unnecessary sandbox creation when agents are registered with AgentOS
+        but haven't yet received a request that uses E2B tools.
+
         Args:
             api_key: E2B API key (defaults to E2B_API_KEY environment variable)
             timeout: Timeout in seconds for the sandbox (default: 5 minutes)
@@ -41,15 +45,9 @@ class E2BTools(Toolkit):
         if not self.api_key:
             raise ValueError("E2B_API_KEY not set. Please set the E2B_API_KEY environment variable.")
 
-        # Create the sandbox once and reuse it
         self.sandbox_options = sandbox_options or {}
-
-        # According to official docs, the parameter is 'timeout' (in seconds), not 'timeout_ms'
-        try:
-            self.sandbox = Sandbox.create(api_key=self.api_key, timeout=timeout, **self.sandbox_options)
-        except Exception as e:
-            logger.exception("Warning: Could not create sandbox")
-            raise e
+        self._timeout = timeout
+        self._sandbox: Optional[Any] = None
 
         # Last execution result for reference
         self.last_execution = None
@@ -84,6 +82,19 @@ class E2BTools(Toolkit):
         ]
 
         super().__init__(name="e2b_tools", tools=tools, **kwargs)
+
+    @property
+    def sandbox(self) -> Any:
+        """Return the sandbox, creating it on first access (lazy initialization)."""
+        if self._sandbox is None:
+            try:
+                self._sandbox = Sandbox.create(
+                    api_key=self.api_key, timeout=self._timeout, **self.sandbox_options
+                )
+            except Exception as e:
+                logger.exception("Warning: Could not create sandbox")
+                raise e
+        return self._sandbox
 
     # Code Execution Functions
     def run_python_code(self, code: str) -> str:
@@ -647,7 +658,7 @@ class E2BTools(Toolkit):
         """
         try:
             # Collect sandbox information
-            sandbox_id = getattr(self.sandbox, "id", "Unknown")
+            sandbox_id = getattr(self._sandbox, "id", "Unknown")
 
             return sandbox_id
 
@@ -662,7 +673,10 @@ class E2BTools(Toolkit):
             str: Success message or error message
         """
         try:
-            cont = self.sandbox.kill()
+            if self._sandbox is None:
+                return json.dumps({"status": "success", "message": "No sandbox is running"})
+            cont = self._sandbox.kill()
+            self._sandbox = None
             return json.dumps({"status": "success", "message": "Sandbox shut down successfully", "content": cont})
         except Exception as e:
             return json.dumps({"status": "error", "message": f"Error shutting down sandbox: {str(e)}"})
@@ -675,7 +689,7 @@ class E2BTools(Toolkit):
             str: JSON string containing information about running sandboxes or error message
         """
         try:
-            running_sandboxes = self.sandbox.list()
+            running_sandboxes = Sandbox.list(api_key=self.api_key)
 
             if not running_sandboxes:
                 return json.dumps({"status": "success", "message": "No running sandboxes found", "sandboxes": []})

--- a/libs/agno/tests/unit/tools/test_e2b.py
+++ b/libs/agno/tests/unit/tools/test_e2b.py
@@ -36,14 +36,15 @@ def mock_e2b_tools():
     with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
         # Set up our mock sandbox instance
         mock_sandbox = Mock()
-        mock_sandbox_class.return_value = mock_sandbox
+        # Sandbox is created via Sandbox.create(), not Sandbox()
+        mock_sandbox_class.create.return_value = mock_sandbox
 
         # Set up sandbox attributes and methods
         mock_sandbox.files = Mock()
         mock_sandbox.commands = Mock()
         mock_sandbox.get_host = Mock(return_value="example.com:8080")
         mock_sandbox.kill = Mock()
-        mock_sandbox.list = Mock()
+        mock_sandbox_class.list = Mock()
         mock_sandbox.id = "test-sandbox-123"
 
         # Create the E2BTools instance with our patched Sandbox
@@ -312,3 +313,41 @@ def test_list_running_sandboxes(mock_e2b_tools):
     assert '"status": "success"' in result
     assert '"message": "Found 2 running sandboxes"' in result
     assert '"sandbox_id": "sb-123"' in result
+
+
+def test_lazy_init_no_sandbox_on_construction():
+    """Sandbox.create() must NOT be called during E2BTools.__init__."""
+    with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
+        mock_sandbox_class.create.return_value = Mock()
+        with patch.dict("os.environ", {"E2B_API_KEY": TEST_API_KEY}):
+            tools = E2BTools()
+        mock_sandbox_class.create.assert_not_called()
+        assert tools._sandbox is None
+
+
+def test_lazy_init_sandbox_created_on_first_access():
+    """Sandbox.create() is called exactly once on first sandbox property access."""
+    with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
+        mock_sandbox = Mock()
+        mock_sandbox_class.create.return_value = mock_sandbox
+        with patch.dict("os.environ", {"E2B_API_KEY": TEST_API_KEY}):
+            tools = E2BTools(timeout=120)
+
+        # Access sandbox property twice — create() must only be called once
+        _ = tools.sandbox
+        _ = tools.sandbox
+        mock_sandbox_class.create.assert_called_once_with(
+            api_key=TEST_API_KEY, timeout=120
+        )
+        assert tools._sandbox is mock_sandbox
+
+
+def test_shutdown_sandbox_no_op_when_never_started():
+    """shutdown_sandbox() should be a no-op and not create a sandbox if never used."""
+    with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
+        mock_sandbox_class.create.return_value = Mock()
+        with patch.dict("os.environ", {"E2B_API_KEY": TEST_API_KEY}):
+            tools = E2BTools()
+        result = tools.shutdown_sandbox()
+        mock_sandbox_class.create.assert_not_called()
+        assert '"No sandbox is running"' in result


### PR DESCRIPTION
Fixes #7215

## Problem

`E2BTools.__init__` was calling `Sandbox.create()` immediately at construction time, which caused three problems:

1. **Wasted sandboxes** — if the agent never uses E2B tools in a session, a sandbox is still created and held until timeout (300 s default)
2. **Duplicate sandboxes on restart** — every process restart creates a new sandbox while the old one lingers
3. **Broken AgentOS deployments** — `AgentOS` constructs `Agent` instances at startup, which triggered `E2BTools.__init__`, which spun up live sandboxes before any user request arrived

This was confirmed by maintainer @ashpreetbedi in the issue comments.

## Solution

Replace the eager `Sandbox.create()` call with a lazy `sandbox` property backed by `self._sandbox = None`. The sandbox is created only on the first access to `self.sandbox` (i.e. the first actual tool call).

**What changed in `libs/agno/agno/tools/e2b.py`:**

- `__init__` stores `self._sandbox = None` and `self._timeout = timeout` instead of calling `Sandbox.create()`
- Added a `sandbox` property: calls `Sandbox.create(...)` on first access, caches the result in `self._sandbox`, and returns it on subsequent calls — zero changes to any tool method signatures
- `shutdown_sandbox()`: returns a "no sandbox running" message when `self._sandbox is None` instead of creating one just to kill it; clears `self._sandbox` after killing
- `get_sandbox_status()`: reads `self._sandbox` directly to avoid triggering lazy creation when the sandbox hasn't been used
- `list_running_sandboxes()`: calls `Sandbox.list(api_key=self.api_key)` directly (class-level call) instead of routing through the instance, so it doesn't spin up a sandbox

## Testing

Added 3 new unit tests to `libs/agno/tests/unit/tools/test_e2b.py`:

- `test_lazy_init_no_sandbox_on_construction` — verifies `Sandbox.create()` is NOT called during `__init__`
- `test_lazy_init_sandbox_created_on_first_access` — verifies `Sandbox.create()` is called exactly once on first `sandbox` property access
- `test_shutdown_sandbox_no_op_when_never_started` — verifies `shutdown_sandbox()` is a no-op and does not create a sandbox when none has been started

All 26 tests pass (`pytest libs/agno/tests/unit/tools/test_e2b.py`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)