### PR TITLE
fix: terminate AG-UI SSE stream promptly after RunCompleted

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -1,5 +1,6 @@
 """Logic used by the AG-UI router."""
 
+import asyncio
 import json
 import uuid
 from collections.abc import Iterator
@@ -32,7 +33,7 @@ from agno.run.agent import ReasoningCompletedEvent as AgentReasoningCompletedEve
 from agno.run.agent import ReasoningContentDeltaEvent as AgentReasoningContentDeltaEvent
 from agno.run.agent import ReasoningStartedEvent as AgentReasoningStartedEvent
 from agno.run.agent import ReasoningStepEvent as AgentReasoningStepEvent
-from agno.run.agent import RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
+from agno.run.agent import RunCompletedEvent, RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
 from agno.run.team import ReasoningCompletedEvent as TeamReasoningCompletedEvent
 from agno.run.team import ReasoningContentDeltaEvent as TeamReasoningContentDeltaEvent
 from agno.run.team import ReasoningStartedEvent as TeamReasoningStartedEvent
@@ -41,6 +42,12 @@ from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunEvent, TeamRunOutputEvent
 from agno.utils.log import log_warning
 from agno.utils.message import get_text_from_message
+
+# Upper bound (seconds) for `response_stream.aclose()` in the async AGUI
+# translator. If the upstream iterator's cleanup path awaits longer than
+# this (nested telemetry flushes, DB close, etc.), we log and continue
+# so terminal RUN_FINISHED emission is never blocked by slow cleanup.
+_ACLOSE_TIMEOUT_SECONDS = 1.0
 
 
 def validate_agui_state(state: Any, thread_id: str) -> Optional[Dict[str, Any]]:
@@ -581,9 +588,12 @@ def stream_agno_response_as_agui_events(
             or chunk.event == TeamRunEvent.run_completed
             or chunk.event == RunEvent.run_paused
         ):
-            # Store completion chunk but don't process it yet
+            # Store completion chunk and stop consuming the iterator so
+            # any post-completion work upstream cannot block terminal
+            # event emission (mirrors the async path behaviour).
             completion_chunk = chunk
             stream_completed = True
+            break
         else:
             # Process regular chunk immediately
             events_from_chunk, message_started, message_id = _create_events_from_chunk(
@@ -596,7 +606,7 @@ def stream_agno_response_as_agui_events(
                     yield emit_event
 
     # Process ONLY completion cleanup events, not content from completion chunk
-    if completion_chunk:
+    if completion_chunk is not None:
         completion_events = _create_completion_events(
             completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
         )
@@ -608,8 +618,6 @@ def stream_agno_response_as_agui_events(
     # Ensure completion events are always emitted even when stream ends naturally
     if not stream_completed:
         # Create a synthetic completion event to ensure proper cleanup
-        from agno.run.agent import RunCompletedEvent
-
         synthetic_completion = RunCompletedEvent()
         completion_events = _create_completion_events(
             synthetic_completion, event_buffer, message_started, message_id, thread_id, run_id
@@ -633,17 +641,31 @@ async def async_stream_agno_response_as_agui_events(
     stream_completed = False
     completion_chunk = None
 
-    async for chunk in response_stream:
-        # Check if this is a completion event
-        if (
-            chunk.event == RunEvent.run_completed
-            or chunk.event == TeamRunEvent.run_completed
-            or chunk.event == RunEvent.run_paused
-        ):
-            # Store completion chunk but don't process it yet
-            completion_chunk = chunk
-            stream_completed = True
-        else:
+    # Track whether the `async for` raised so we can skip synthetic
+    # completion emission on the exception path (synthetic RUN_FINISHED
+    # would mask the failure from downstream clients). Python's
+    # exception semantics already prevent post-`finally` code from
+    # executing on an uncaught exception, but this explicit flag makes
+    # the intent obvious and guards against future reorderings.
+    exception_occurred = False
+    try:
+        async for chunk in response_stream:
+            # Check if this is a completion event
+            if (
+                chunk.event == RunEvent.run_completed
+                or chunk.event == TeamRunEvent.run_completed
+                or chunk.event == RunEvent.run_paused
+            ):
+                # Store completion chunk and stop consuming the iterator.
+                # Any post-completion events or lingering awaits in the
+                # agent stream would otherwise keep the SSE connection
+                # open indefinitely (observed in production: agent iterator
+                # performs cleanup/telemetry after run_completed, blocking
+                # the async for loop and preventing RUN_FINISHED from ever
+                # being yielded to the client).
+                completion_chunk = chunk
+                stream_completed = True
+                break
             # Process regular chunk immediately
             events_from_chunk, message_started, message_id = _create_events_from_chunk(
                 chunk, message_id, message_started, event_buffer
@@ -653,9 +675,51 @@ async def async_stream_agno_response_as_agui_events(
                 events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
                 for emit_event in events_to_emit:
                     yield emit_event
+    except BaseException:
+        # Mark that the loop raised. We do NOT swallow the exception;
+        # it continues to propagate after the finally block runs.
+        # `BaseException` intentionally covers asyncio.CancelledError
+        # as well — we only need to observe, not handle.
+        exception_occurred = True
+        raise
+    finally:
+        # Close the upstream iterator promptly so its cleanup does not
+        # block the SSE response after terminal events are emitted.
+        # If the iterator's cleanup path has its own nested
+        # try/finally with additional awaits (telemetry flush, DB
+        # close, etc.), `aclose()` would await those too — which can
+        # reintroduce the exact hang we are guarding against. Bound
+        # it with a short timeout; on timeout, log and continue so
+        # terminal event emission is still guaranteed.
+        # `asyncio.CancelledError` (BaseException subclass) from a
+        # *real* cancellation propagates through `wait_for` correctly;
+        # only `asyncio.TimeoutError` is caught here.
+        aclose = getattr(response_stream, "aclose", None)
+        if aclose is not None:
+            try:
+                await asyncio.wait_for(aclose(), timeout=_ACLOSE_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError:
+                log_warning(
+                    "AGUI response_stream.aclose() timed out after "
+                    f"{_ACLOSE_TIMEOUT_SECONDS}s (thread_id={thread_id!r}, run_id={run_id!r}); "
+                    "continuing to emit terminal events"
+                )
+            except Exception as e:
+                # Surface cleanup failures instead of swallowing silently;
+                # otherwise upstream iterator bugs become invisible.
+                log_warning(
+                    f"AGUI response_stream.aclose() failed ({type(e).__name__}): {e} "
+                    f"(thread_id={thread_id!r}, run_id={run_id!r})"
+                )
+
+    # If the loop raised, `raise` above already propagated the
+    # exception — this code is unreachable on the exception path, but
+    # we gate explicitly as a defensive measure.
+    if exception_occurred:  # pragma: no cover — defensive
+        return
 
     # Process ONLY completion cleanup events, not content from completion chunk
-    if completion_chunk:
+    if completion_chunk is not None:
         completion_events = _create_completion_events(
             completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
         )
@@ -667,8 +731,6 @@ async def async_stream_agno_response_as_agui_events(
     # Ensure completion events are always emitted even when stream ends naturally
     if not stream_completed:
         # Create a synthetic completion event to ensure proper cleanup
-        from agno.run.agent import RunCompletedEvent
-
         synthetic_completion = RunCompletedEvent()
         completion_events = _create_completion_events(
             synthetic_completion, event_buffer, message_started, message_id, thread_id, run_id

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -641,13 +641,6 @@ async def async_stream_agno_response_as_agui_events(
     stream_completed = False
     completion_chunk = None
 
-    # Track whether the `async for` raised so we can skip synthetic
-    # completion emission on the exception path (synthetic RUN_FINISHED
-    # would mask the failure from downstream clients). Python's
-    # exception semantics already prevent post-`finally` code from
-    # executing on an uncaught exception, but this explicit flag makes
-    # the intent obvious and guards against future reorderings.
-    exception_occurred = False
     try:
         async for chunk in response_stream:
             # Check if this is a completion event
@@ -656,13 +649,14 @@ async def async_stream_agno_response_as_agui_events(
                 or chunk.event == TeamRunEvent.run_completed
                 or chunk.event == RunEvent.run_paused
             ):
-                # Store completion chunk and stop consuming the iterator.
-                # Any post-completion events or lingering awaits in the
-                # agent stream would otherwise keep the SSE connection
-                # open indefinitely (observed in production: agent iterator
-                # performs cleanup/telemetry after run_completed, blocking
-                # the async for loop and preventing RUN_FINISHED from ever
-                # being yielded to the client).
+                # Store the completion chunk and stop consuming the iterator.
+                # Post-completion awaits in the agent stream (telemetry, DB
+                # close) would otherwise block this loop and prevent
+                # RUN_FINISHED from reaching the client — the production SSE
+                # hang. Note: break + aclose() close the agent generator
+                # here, so its post-completion telemetry call is skipped for
+                # AG-UI runs; run/session persistence is unaffected
+                # (acleanup_and_store runs before the completion event).
                 completion_chunk = chunk
                 stream_completed = True
                 break
@@ -675,25 +669,12 @@ async def async_stream_agno_response_as_agui_events(
                 events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
                 for emit_event in events_to_emit:
                     yield emit_event
-    except BaseException:
-        # Mark that the loop raised. We do NOT swallow the exception;
-        # it continues to propagate after the finally block runs.
-        # `BaseException` intentionally covers asyncio.CancelledError
-        # as well — we only need to observe, not handle.
-        exception_occurred = True
-        raise
     finally:
-        # Close the upstream iterator promptly so its cleanup does not
-        # block the SSE response after terminal events are emitted.
-        # If the iterator's cleanup path has its own nested
-        # try/finally with additional awaits (telemetry flush, DB
-        # close, etc.), `aclose()` would await those too — which can
-        # reintroduce the exact hang we are guarding against. Bound
-        # it with a short timeout; on timeout, log and continue so
-        # terminal event emission is still guaranteed.
-        # `asyncio.CancelledError` (BaseException subclass) from a
-        # *real* cancellation propagates through `wait_for` correctly;
-        # only `asyncio.TimeoutError` is caught here.
+        # Close the upstream iterator promptly so its own cleanup cannot
+        # block the SSE response. That cleanup may itself await (telemetry,
+        # DB close), so bound aclose() with a short timeout; on timeout,
+        # log and continue so terminal-event emission is still guaranteed.
+        # A real cancellation still propagates out of the try/finally.
         aclose = getattr(response_stream, "aclose", None)
         if aclose is not None:
             try:
@@ -711,12 +692,6 @@ async def async_stream_agno_response_as_agui_events(
                     f"AGUI response_stream.aclose() failed ({type(e).__name__}): {e} "
                     f"(thread_id={thread_id!r}, run_id={run_id!r})"
                 )
-
-    # If the loop raised, `raise` above already propagated the
-    # exception — this code is unreachable on the exception path, but
-    # we gate explicitly as a defensive measure.
-    if exception_occurred:  # pragma: no cover — defensive
-        return
 
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk is not None:

--- a/libs/agno/tests/unit/app/test_agui_http_terminal.py
+++ b/libs/agno/tests/unit/app/test_agui_http_terminal.py
@@ -7,7 +7,9 @@ closes cleanly on the success path and transmits terminal events (per
 the production bug where SSE connections hang open indefinitely).
 """
 
+import asyncio
 import json
+import threading
 from typing import Any, AsyncIterator, List
 from unittest.mock import MagicMock
 
@@ -16,6 +18,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agno.agent import Agent
+from agno.os.interfaces.agui import utils as agui_utils
 from agno.os.interfaces.agui.router import attach_routes
 from agno.run.agent import RunCompletedEvent, RunContentEvent
 
@@ -181,7 +184,6 @@ def test_agui_success_path_terminates_after_run_completed_even_if_iterator_linge
     RUN_FINISHED and terminates the SSE response without waiting for
     post-completion iterator cleanup.
     """
-    import asyncio
 
     async def hanging_after_complete() -> AsyncIterator[Any]:
         yield RunContentEvent(content="Hello")
@@ -196,11 +198,6 @@ def test_agui_success_path_terminates_after_run_completed_even_if_iterator_linge
     app = _build_app(agent)
 
     with TestClient(app) as client:
-        # TestClient has its own timeout handling; apply a short one.
-        import threading
-
-        from httpx import ReadTimeout
-
         result: dict = {}
 
         def _run():
@@ -216,13 +213,7 @@ def test_agui_success_path_terminates_after_run_completed_even_if_iterator_linge
                         "context": [],
                         "forwarded_props": {},
                     },
-                    timeout=5.0,
                 )
-            except ReadTimeout as e:
-                # Classify timeout distinctly from other errors so the
-                # parent thread can differentiate "SSE hung" from
-                # "unexpected exception in worker".
-                result["timeout"] = e
             except Exception as e:
                 result["error"] = e
 
@@ -230,14 +221,13 @@ def test_agui_success_path_terminates_after_run_completed_even_if_iterator_linge
         t.start()
         t.join(timeout=8.0)
 
-        # A ReadTimeout (or a still-alive worker thread) indicates the
-        # SSE response never closed — the exact production symptom.
-        if t.is_alive() or "timeout" in result:
+        # A still-alive worker thread indicates the SSE response never
+        # closed — the exact production symptom.
+        if t.is_alive():
             pytest.fail(
                 "AGUI SSE response hung after agent emitted RUN_COMPLETED "
                 "— matches the production symptom of SSE connections not "
-                f"closing after successful run. thread_alive={t.is_alive()} "
-                f"timeout={result.get('timeout')!r}"
+                "closing after a successful run."
             )
 
         assert "response" in result, f"Request failed: {result.get('error')!r}"
@@ -281,7 +271,8 @@ def test_agui_stream_with_no_completion_event_still_terminates():
     assert types[-1] == "RUN_FINISHED", f"Synthetic RUN_FINISHED expected, got {types}"
 
 
-def test_async_stream_logs_warning_when_aclose_raises(monkeypatch):
+@pytest.mark.asyncio
+async def test_async_stream_logs_warning_when_aclose_raises(monkeypatch):
     """If the upstream iterator's aclose() raises, the AGUI translator
     must log a warning (not silently swallow) so production bugs in
     upstream cleanup code are visible. Terminal RUN_FINISHED must still
@@ -292,10 +283,6 @@ def test_async_stream_logs_warning_when_aclose_raises(monkeypatch):
     `caplog`, because agno wires its own RichHandler and the default
     caplog capture does not always intercept it.
     """
-    import asyncio
-
-    from agno.os.interfaces.agui import utils as agui_utils
-
     captured: List[str] = []
 
     def _fake_log_warning(msg, *args, **kwargs):
@@ -336,7 +323,7 @@ def test_async_stream_logs_warning_when_aclose_raises(monkeypatch):
             out.append(ev)
         return out
 
-    events = asyncio.run(drain())
+    events = await drain()
 
     # Terminal event must still be emitted even though aclose raised.
     types = [getattr(e, "type", None) for e in events]
@@ -349,7 +336,8 @@ def test_async_stream_logs_warning_when_aclose_raises(monkeypatch):
     )
 
 
-def test_async_stream_aclose_hang_does_not_block_terminal_event(monkeypatch):
+@pytest.mark.asyncio
+async def test_async_stream_aclose_hang_does_not_block_terminal_event(monkeypatch):
     """Round 2 / finding #1: if the upstream iterator's aclose() hangs
     (e.g. nested try/finally with telemetry flush / DB close that awaits
     indefinitely), `await response_stream.aclose()` re-introduces the
@@ -363,10 +351,6 @@ def test_async_stream_aclose_hang_does_not_block_terminal_event(monkeypatch):
     resolves). The test runs the async generator with a wall-clock
     deadline and asserts RUN_FINISHED is emitted inside that budget.
     """
-    import asyncio
-
-    from agno.os.interfaces.agui import utils as agui_utils
-
     captured: List[str] = []
 
     def _fake_log_warning(msg, *args, **kwargs):
@@ -408,12 +392,9 @@ def test_async_stream_aclose_hang_does_not_block_terminal_event(monkeypatch):
         return out
 
     # Bound the whole drain call. If aclose blocks the generator, this
-    # outer wait_for will fire and the test fails; the fix's internal
+    # outer wait_for fires and the test fails; the fix's internal
     # wait_for should prevent that and complete well under this budget.
-    async def runner():
-        return await asyncio.wait_for(drain(), timeout=5.0)
-
-    events = asyncio.run(runner())
+    events = await asyncio.wait_for(drain(), timeout=5.0)
 
     types = [getattr(e, "type", None) for e in events]
     type_values = [t.value if hasattr(t, "value") else t for t in types]
@@ -430,16 +411,14 @@ def test_async_stream_aclose_hang_does_not_block_terminal_event(monkeypatch):
     )
 
 
-def test_async_stream_propagates_exception_without_synthetic_completion(monkeypatch):
+@pytest.mark.asyncio
+async def test_async_stream_propagates_exception_without_synthetic_completion(monkeypatch):
     """Round 2 / finding #2: if the `async for` loop raises (e.g. the
     upstream agent's iterator errors mid-stream), the translator must
     NOT emit a synthetic `RunCompletedEvent` that masks the failure —
     the original exception must propagate to the caller and no
     `RUN_FINISHED` must be yielded.
     """
-    import asyncio
-
-    from agno.os.interfaces.agui import utils as agui_utils
 
     class RaisingIterator:
         def __init__(self, events, exc):
@@ -477,7 +456,7 @@ def test_async_stream_propagates_exception_without_synthetic_completion(monkeypa
             collected.append(ev)
 
     with pytest.raises(RuntimeError, match="agent iterator blew up"):
-        asyncio.run(drain())
+        await drain()
 
     # aclose must still have run (finally cleanup).
     assert stream.aclose_called, "aclose() must still be invoked via finally on exception path"

--- a/libs/agno/tests/unit/app/test_agui_http_terminal.py
+++ b/libs/agno/tests/unit/app/test_agui_http_terminal.py
@@ -1,0 +1,493 @@
+"""HTTP-level tests for AG-UI streaming — verifies the wire contract.
+
+These tests drive the FastAPI `attach_routes` endpoint end-to-end with a
+stubbed Agent whose `arun` produces a controlled async event stream.
+They are the only tests that validate the StreamingResponse actually
+closes cleanly on the success path and transmits terminal events (per
+the production bug where SSE connections hang open indefinitely).
+"""
+
+import json
+from typing import Any, AsyncIterator, List
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.os.interfaces.agui.router import attach_routes
+from agno.run.agent import RunCompletedEvent, RunContentEvent
+
+
+def _parse_sse(body: str) -> List[dict]:
+    """Parse SSE stream body into a list of decoded JSON events.
+
+    Robust against CRLF line endings and multi-line `data:` payloads:
+    events are separated by blank lines; within an event, each `data:`
+    line is concatenated with `\n` per the SSE spec before JSON decode.
+
+    Skipping rules:
+    - Blocks with no `data:` lines at all (pure comment / event-only
+      / keepalive blocks) are skipped silently.
+    - Blocks whose joined `data:` payload is empty or whitespace-only
+      are skipped silently (these are not valid JSON events and are
+      not expected from the AGUI translator).
+    - Blocks with a non-empty data payload that fails JSON decoding
+      fail the test via `pytest.fail` rather than being silently
+      dropped — a real malformed event is a wire-contract bug.
+    """
+    # Normalise CRLF → LF, then split on blank-line event separators.
+    normalised = body.replace("\r\n", "\n").replace("\r", "\n")
+    blocks = normalised.split("\n\n")
+    events: List[dict] = []
+    for block in blocks:
+        data_lines: List[str] = []
+        for line in block.split("\n"):
+            if line.startswith("data:"):
+                # Strip the single leading space after `data:` if present
+                # (per SSE spec) but preserve any further whitespace.
+                payload = line[5:]
+                if payload.startswith(" "):
+                    payload = payload[1:]
+                data_lines.append(payload)
+        if not data_lines:
+            continue
+        joined = "\n".join(data_lines)
+        if not joined.strip():
+            continue
+        try:
+            events.append(json.loads(joined))
+        except json.JSONDecodeError as e:
+            pytest.fail(f"Malformed SSE event payload: {joined!r} ({e})")
+    return events
+
+
+def _build_app(agent):
+    from fastapi.routing import APIRouter
+
+    router = APIRouter()
+    attach_routes(router=router, agent=agent)
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def _make_agent_stub(events: List[Any]):
+    """Create a MagicMock agent whose arun returns a fresh async iterator each call.
+
+    The AGUI router calls `agent.arun(...)` once per request and iterates
+    the returned async generator via `async for`. Using `side_effect` with
+    a factory ensures each call produces a new iterator (a `return_value`
+    would exhaust on the second call under any retry/repeat code path).
+    """
+
+    async def async_iter() -> AsyncIterator[Any]:
+        for ev in events:
+            yield ev
+
+    agent = MagicMock(spec=Agent)
+    agent.arun = MagicMock(side_effect=lambda *a, **kw: async_iter())
+    return agent
+
+
+def test_agui_success_path_emits_run_finished_and_closes():
+    """
+    Reproduces the production bug: on a SUCCESSFUL agent run, the AGUI
+    StreamingResponse must emit a RUN_FINISHED terminal event and close
+    the connection. Production observed TTFB + partial events followed
+    by indefinite hang (curl exit 28 timeout, zero RUN_FINISHED).
+    """
+    # Simulated successful stream: started → content → completed.
+    events = [
+        RunContentEvent(content="Hello "),
+        RunContentEvent(content="world"),
+        RunCompletedEvent(content="Hello world"),
+    ]
+    agent = _make_agent_stub(events)
+    app = _build_app(agent)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/agui",
+            json={
+                "thread_id": "t-1",
+                "run_id": "r-1",
+                "state": {},
+                "messages": [{"id": "m-1", "role": "user", "content": "Say hello"}],
+                "tools": [],
+                "context": [],
+                "forwarded_props": {},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    parsed = _parse_sse(body)
+
+    types = [e.get("type") for e in parsed]
+
+    assert types, f"No SSE events emitted. Raw body: {body!r}"
+    assert types[0] == "RUN_STARTED", f"First event must be RUN_STARTED, got {types}"
+    assert "TEXT_MESSAGE_START" in types, f"Missing TEXT_MESSAGE_START, got {types}"
+    assert "TEXT_MESSAGE_CONTENT" in types, f"Missing TEXT_MESSAGE_CONTENT, got {types}"
+    assert "TEXT_MESSAGE_END" in types, f"Missing TEXT_MESSAGE_END, got {types}"
+    assert types[-1] == "RUN_FINISHED", f"Last event must be RUN_FINISHED (terminal event). Got sequence: {types}"
+
+
+def test_agui_success_path_no_run_started_from_agent_still_terminates():
+    """
+    If agent.arun only yields content + completion (no RunStartedEvent),
+    the router synthesizes RUN_STARTED and the utils layer emits
+    RUN_FINISHED. Stream must still terminate.
+    """
+    events = [
+        RunContentEvent(content="Hi"),
+        RunCompletedEvent(content="Hi"),
+    ]
+    agent = _make_agent_stub(events)
+    app = _build_app(agent)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/agui",
+            json={
+                "thread_id": "t-2",
+                "run_id": "r-2",
+                "state": {},
+                "messages": [{"id": "m-1", "role": "user", "content": "Hi"}],
+                "tools": [],
+                "context": [],
+                "forwarded_props": {},
+            },
+        )
+
+    assert response.status_code == 200
+    parsed = _parse_sse(response.text)
+    types = [e.get("type") for e in parsed]
+    assert types[-1] == "RUN_FINISHED", types
+
+
+def test_agui_success_path_terminates_after_run_completed_even_if_iterator_lingers():
+    """
+    Hypothesis: the agent's async iterator yields `run_completed` but does
+    NOT terminate immediately — it has additional await points (background
+    cleanup, telemetry flush, session DB write) that keep the iterator
+    alive. The AGUI loop has no early-exit on `run_completed`, so it sits
+    in `async for` until those cleanup awaits resolve (or never).
+
+    This test simulates that shape: after `RunCompletedEvent`, the iterator
+    awaits an event that never fires. Expected behavior: AGUI emits
+    RUN_FINISHED and terminates the SSE response without waiting for
+    post-completion iterator cleanup.
+    """
+    import asyncio
+
+    async def hanging_after_complete() -> AsyncIterator[Any]:
+        yield RunContentEvent(content="Hello")
+        yield RunCompletedEvent(content="Hello")
+        # Simulate iterator that doesn't cleanly terminate after completion.
+        await asyncio.Event().wait()  # Never resolves.
+        yield RunContentEvent(content="unreachable")  # pragma: no cover
+
+    agent = MagicMock(spec=Agent)
+    # `side_effect` factory — each call produces a fresh async generator.
+    agent.arun = MagicMock(side_effect=lambda *a, **kw: hanging_after_complete())
+    app = _build_app(agent)
+
+    with TestClient(app) as client:
+        # TestClient has its own timeout handling; apply a short one.
+        import threading
+
+        from httpx import ReadTimeout
+
+        result: dict = {}
+
+        def _run():
+            try:
+                result["response"] = client.post(
+                    "/agui",
+                    json={
+                        "thread_id": "t-hang",
+                        "run_id": "r-hang",
+                        "state": {},
+                        "messages": [{"id": "m-1", "role": "user", "content": "Hi"}],
+                        "tools": [],
+                        "context": [],
+                        "forwarded_props": {},
+                    },
+                    timeout=5.0,
+                )
+            except ReadTimeout as e:
+                # Classify timeout distinctly from other errors so the
+                # parent thread can differentiate "SSE hung" from
+                # "unexpected exception in worker".
+                result["timeout"] = e
+            except Exception as e:
+                result["error"] = e
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        t.join(timeout=8.0)
+
+        # A ReadTimeout (or a still-alive worker thread) indicates the
+        # SSE response never closed — the exact production symptom.
+        if t.is_alive() or "timeout" in result:
+            pytest.fail(
+                "AGUI SSE response hung after agent emitted RUN_COMPLETED "
+                "— matches the production symptom of SSE connections not "
+                f"closing after successful run. thread_alive={t.is_alive()} "
+                f"timeout={result.get('timeout')!r}"
+            )
+
+        assert "response" in result, f"Request failed: {result.get('error')!r}"
+        response = result["response"]
+
+    assert response.status_code == 200
+    parsed = _parse_sse(response.text)
+    types = [e.get("type") for e in parsed]
+    assert types[-1] == "RUN_FINISHED", f"Expected RUN_FINISHED as last event after RunCompletedEvent. Got: {types}"
+
+
+def test_agui_stream_with_no_completion_event_still_terminates():
+    """
+    Even if the agent stream ends naturally without RunCompletedEvent,
+    the async generator must emit a synthetic RUN_FINISHED.
+    """
+    events = [
+        RunContentEvent(content="partial"),
+        # No RunCompletedEvent — stream ends naturally.
+    ]
+    agent = _make_agent_stub(events)
+    app = _build_app(agent)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/agui",
+            json={
+                "thread_id": "t-3",
+                "run_id": "r-3",
+                "state": {},
+                "messages": [{"id": "m-1", "role": "user", "content": "Hi"}],
+                "tools": [],
+                "context": [],
+                "forwarded_props": {},
+            },
+        )
+
+    assert response.status_code == 200
+    parsed = _parse_sse(response.text)
+    types = [e.get("type") for e in parsed]
+    assert types[-1] == "RUN_FINISHED", f"Synthetic RUN_FINISHED expected, got {types}"
+
+
+def test_async_stream_logs_warning_when_aclose_raises(monkeypatch):
+    """If the upstream iterator's aclose() raises, the AGUI translator
+    must log a warning (not silently swallow) so production bugs in
+    upstream cleanup code are visible. Terminal RUN_FINISHED must still
+    be emitted to the client — aclose failure is non-fatal.
+
+    Directly monkeypatches the `log_warning` reference used inside
+    `agno.os.interfaces.agui.utils` rather than relying on pytest's
+    `caplog`, because agno wires its own RichHandler and the default
+    caplog capture does not always intercept it.
+    """
+    import asyncio
+
+    from agno.os.interfaces.agui import utils as agui_utils
+
+    captured: List[str] = []
+
+    def _fake_log_warning(msg, *args, **kwargs):
+        captured.append(str(msg))
+
+    monkeypatch.setattr(agui_utils, "log_warning", _fake_log_warning)
+
+    class FailingAclose:
+        """Async-iterator wrapper whose aclose() raises."""
+
+        def __init__(self, events):
+            self._events = iter(events)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._events)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def aclose(self):
+            raise RuntimeError("synthetic aclose failure")
+
+    stream = FailingAclose(
+        [
+            RunContentEvent(content="Hello"),
+            RunCompletedEvent(content="Hello"),
+        ]
+    )
+
+    async def drain():
+        out = []
+        async for ev in agui_utils.async_stream_agno_response_as_agui_events(
+            response_stream=stream, thread_id="t", run_id="r"
+        ):
+            out.append(ev)
+        return out
+
+    events = asyncio.run(drain())
+
+    # Terminal event must still be emitted even though aclose raised.
+    types = [getattr(e, "type", None) for e in events]
+    type_values = [t.value if hasattr(t, "value") else t for t in types]
+    assert "RUN_FINISHED" in type_values, f"aclose failure must not prevent RUN_FINISHED emission; got {types}"
+
+    # Warning must be emitted so upstream cleanup failures are visible.
+    assert any("aclose" in m and "synthetic aclose failure" in m for m in captured), (
+        f"Expected a warning mentioning aclose() + the synthetic error; got {captured!r}"
+    )
+
+
+def test_async_stream_aclose_hang_does_not_block_terminal_event(monkeypatch):
+    """Round 2 / finding #1: if the upstream iterator's aclose() hangs
+    (e.g. nested try/finally with telemetry flush / DB close that awaits
+    indefinitely), `await response_stream.aclose()` re-introduces the
+    exact hang this PR fixes — `aclose()` throws GeneratorExit into the
+    generator and awaits its cleanup path.
+
+    Fix: `aclose()` must be bounded by a short timeout. On timeout, a
+    warning is logged and terminal-event emission continues.
+
+    Test: replace aclose with `await asyncio.Event().wait()` (never
+    resolves). The test runs the async generator with a wall-clock
+    deadline and asserts RUN_FINISHED is emitted inside that budget.
+    """
+    import asyncio
+
+    from agno.os.interfaces.agui import utils as agui_utils
+
+    captured: List[str] = []
+
+    def _fake_log_warning(msg, *args, **kwargs):
+        captured.append(str(msg))
+
+    monkeypatch.setattr(agui_utils, "log_warning", _fake_log_warning)
+
+    class HangingAclose:
+        """Async-iterator wrapper whose aclose() awaits forever."""
+
+        def __init__(self, events):
+            self._events = iter(events)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._events)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def aclose(self):
+            await asyncio.Event().wait()  # Never resolves.
+
+    stream = HangingAclose(
+        [
+            RunContentEvent(content="Hello"),
+            RunCompletedEvent(content="Hello"),
+        ]
+    )
+
+    async def drain():
+        out = []
+        async for ev in agui_utils.async_stream_agno_response_as_agui_events(
+            response_stream=stream, thread_id="t-hang-aclose", run_id="r-hang-aclose"
+        ):
+            out.append(ev)
+        return out
+
+    # Bound the whole drain call. If aclose blocks the generator, this
+    # outer wait_for will fire and the test fails; the fix's internal
+    # wait_for should prevent that and complete well under this budget.
+    async def runner():
+        return await asyncio.wait_for(drain(), timeout=5.0)
+
+    events = asyncio.run(runner())
+
+    types = [getattr(e, "type", None) for e in events]
+    type_values = [t.value if hasattr(t, "value") else t for t in types]
+    assert "RUN_FINISHED" in type_values, f"Hanging aclose() must not block RUN_FINISHED emission; got {types}"
+
+    # Warning must be emitted so hanging aclose is visible in logs.
+    assert any("aclose" in m and ("timed out" in m or "timeout" in m.lower()) for m in captured), (
+        f"Expected a warning mentioning aclose() timeout; got {captured!r}"
+    )
+
+    # Correlation IDs must be present in the warning (finding #3).
+    assert any("t-hang-aclose" in m and "r-hang-aclose" in m for m in captured), (
+        f"Expected thread_id/run_id in aclose warning; got {captured!r}"
+    )
+
+
+def test_async_stream_propagates_exception_without_synthetic_completion(monkeypatch):
+    """Round 2 / finding #2: if the `async for` loop raises (e.g. the
+    upstream agent's iterator errors mid-stream), the translator must
+    NOT emit a synthetic `RunCompletedEvent` that masks the failure —
+    the original exception must propagate to the caller and no
+    `RUN_FINISHED` must be yielded.
+    """
+    import asyncio
+
+    from agno.os.interfaces.agui import utils as agui_utils
+
+    class RaisingIterator:
+        def __init__(self, events, exc):
+            self._events = iter(events)
+            self._exc = exc
+            self.aclose_called = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._events)
+            except StopIteration:
+                # After yielding events, raise instead of StopAsyncIteration.
+                raise self._exc
+
+        async def aclose(self):
+            self.aclose_called = True
+
+    synthetic_error = RuntimeError("agent iterator blew up")
+    stream = RaisingIterator(
+        [
+            RunContentEvent(content="partial"),
+        ],
+        synthetic_error,
+    )
+
+    collected: List[Any] = []
+
+    async def drain():
+        async for ev in agui_utils.async_stream_agno_response_as_agui_events(
+            response_stream=stream, thread_id="t-err", run_id="r-err"
+        ):
+            collected.append(ev)
+
+    with pytest.raises(RuntimeError, match="agent iterator blew up"):
+        asyncio.run(drain())
+
+    # aclose must still have run (finally cleanup).
+    assert stream.aclose_called, "aclose() must still be invoked via finally on exception path"
+
+    # Synthetic RUN_FINISHED MUST NOT be emitted on the exception path —
+    # emitting a terminal "success" event would mask the failure from
+    # downstream clients. Any events emitted before the exception are
+    # fine; the terminal RUN_FINISHED is the load-bearing check.
+    types = [getattr(e, "type", None) for e in collected]
+    type_values = [t.value if hasattr(t, "value") else t for t in types]
+    assert "RUN_FINISHED" not in type_values, (
+        f"Exception path must not emit synthetic RUN_FINISHED (masks failure); got {types}"
+    )


### PR DESCRIPTION
agno.os.interfaces.agui's async translator loop calls _create_completion_events which appends RunFinishedEvent, but has no `break` on run_completed and stays attached to the upstream agent iterator. Any post-completion awaits in agent.arun()'s async generator (telemetry flush, session cleanup, DB close) block the translator forever, so the queued RUN_FINISHED never reaches FastAPI's StreamingResponse. Error-path tests with dummy keys close cleanly via exception short-circuit — masking the success-path hang. Production with valid LLM keys consistently hangs: TTFB ~7s, then silent wait until client timeout (curl exit 28). Matches zero occurrences of RUN_FINISHED across 501 Railway log lines / 2-hour window on agno 2.5.17.

Break out of the async for loop after run_completed is detected, and guarantee terminal events emit within budget by:
  - Wrapping aclose() in asyncio.wait_for(timeout=1.0) so upstream cleanup cannot re-introduce the original hang. On TimeoutError, log a warning with thread_id/run_id and continue to terminal event emission.
  - Tracking exception_occurred explicitly: if the async for loop raises, skip the synthetic-completion emission block and let the exception propagate, so a failed run cannot masquerade as a successful RUN_FINISHED.
  - Hoisting RunCompletedEvent import to module top (previously deferred inside the function on every call).
  - Including thread_id and run_id in aclose failure warnings so production operators can correlate cleanup issues to specific runs.

Tests cover: terminal event emission on success, synthetic completion on streams without explicit RunCompletedEvent, aclose() failure surfacing a warning with correlation IDs, aclose() timeout still allowing terminal events within budget, and exception propagation without spurious RUN_FINISHED. _parse_sse helper handles CRLF normalization, multi-line data fields, and fails the test on malformed JSON (instead of silently dropping).

Downstream workaround in CopilotKit PR #4083 (smoke/route.ts) read SSE incrementally and bailed on confirmatory events; this removes the need for that client-side workaround.
