### PR TITLE
[fix] honor Team add_learnings_to_context in system message

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -535,7 +535,17 @@ def get_system_message(
             "You should ALWAYS prefer information from this conversation over the past summary.\n\n"
         )
 
-    # 2.6 Trailing sections: media, additional info, tools, expected output, etc.
+    # 2.6 LearningMachine context
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = team._learning.build_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            team_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
+    # 2.7 Trailing sections: media, additional info, tools, expected output, etc.
     system_message_content += _build_trailing_sections(
         team,
         audio=audio,
@@ -756,7 +766,17 @@ async def aget_system_message(
             "You should ALWAYS prefer information from this conversation over the past summary.\n\n"
         )
 
-    # 2.6 Trailing sections: media, additional info, tools, expected output, etc.
+    # 2.6 LearningMachine context
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = await team._learning.abuild_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            team_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
+    # 2.7 Trailing sections: media, additional info, tools, expected output, etc.
     system_message_content += _build_trailing_sections(
         team,
         audio=audio,

--- a/libs/agno/tests/unit/team/test_learning_context.py
+++ b/libs/agno/tests/unit/team/test_learning_context.py
@@ -1,0 +1,166 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from typing_extensions import assert_type
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run import RunContext
+from agno.session.team import TeamSession
+from agno.team._messages import aget_system_message, get_system_message
+from agno.team.team import Team
+
+
+class _FakeModel(Model):
+    def __init__(self) -> None:
+        super().__init__(id="fake-model")
+
+    def get_instructions_for_model(self, tools=None):
+        return []
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    def invoke_stream(self, *args, **kwargs):
+        if False:
+            yield ModelResponse()
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        if False:
+            yield ModelResponse()
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:
+        return ModelResponse()
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:
+        return ModelResponse()
+
+
+def _make_team(*, add_learnings_to_context: bool = True, learning=None) -> Team:
+    team = Team(
+        name="Learning Team",
+        model=_FakeModel(),
+        members=[],
+        add_learnings_to_context=add_learnings_to_context,
+        add_session_summary_to_context=True,
+    )
+    team.set_id()
+    team._learning = learning
+    return team
+
+
+def _make_session() -> TeamSession:
+    session = TeamSession(session_id="team-session")
+    session.summary = MagicMock(summary="Summary: the user prefers bullet points.")
+    return session
+
+
+def _make_run_context() -> RunContext:
+    return RunContext(
+        run_id="run-1",
+        session_id="team-session",
+        user_id="user-1",
+        session_state={"source": "session-state"},
+    )
+
+
+def _content(message: Message) -> str:
+    content = message.content
+    assert isinstance(content, str)
+    assert_type(content, str)
+    return content
+
+
+def test_get_system_message_includes_learning_context():
+    learning = MagicMock()
+    learning.build_context.return_value = "<learning_context>\nStored preference\n</learning_context>"
+
+    message = get_system_message(
+        _make_team(learning=learning),
+        _make_session(),
+        run_context=_make_run_context(),
+        add_session_state_to_context=True,
+    )
+
+    assert message is not None
+    assert "<learning_context>\nStored preference\n</learning_context>" in _content(message)
+    learning.build_context.assert_called_once_with(
+        user_id="user-1",
+        session_id="team-session",
+        team_id="learning-team",
+    )
+
+
+@pytest.mark.asyncio
+async def test_aget_system_message_includes_learning_context():
+    learning = MagicMock()
+    learning.abuild_context = AsyncMock(return_value="<learning_context>\nAsync preference\n</learning_context>")
+
+    message = await aget_system_message(
+        _make_team(learning=learning),
+        _make_session(),
+        run_context=_make_run_context(),
+        add_session_state_to_context=True,
+    )
+
+    assert message is not None
+    assert "<learning_context>\nAsync preference\n</learning_context>" in _content(message)
+    learning.abuild_context.assert_awaited_once_with(
+        user_id="user-1",
+        session_id="team-session",
+        team_id="learning-team",
+    )
+
+
+def test_get_system_message_skips_learning_context_when_flag_disabled():
+    learning = MagicMock()
+    learning.build_context.return_value = "<learning_context>should-not-appear</learning_context>"
+
+    message = get_system_message(
+        _make_team(add_learnings_to_context=False, learning=learning),
+        _make_session(),
+        run_context=_make_run_context(),
+    )
+
+    assert message is not None
+    assert "should-not-appear" not in _content(message)
+    learning.build_context.assert_not_called()
+
+
+def test_get_system_message_skips_empty_learning_context():
+    learning = MagicMock()
+    learning.build_context.return_value = ""
+
+    message = get_system_message(
+        _make_team(learning=learning),
+        _make_session(),
+        run_context=_make_run_context(),
+    )
+
+    assert message is not None
+    assert "<learning_context>" not in _content(message)
+    learning.build_context.assert_called_once()
+
+
+def test_get_system_message_places_learning_context_before_trailing_sections():
+    learning = MagicMock()
+    learning.build_context.return_value = "<learning_context>\nOrdered preference\n</learning_context>"
+
+    message = get_system_message(
+        _make_team(learning=learning),
+        _make_session(),
+        run_context=_make_run_context(),
+        add_session_state_to_context=True,
+    )
+
+    assert message is not None
+    content = _content(message)
+    summary_index = content.index("Summary: the user prefers bullet points.")
+    learning_index = content.index("<learning_context>\nOrdered preference\n</learning_context>")
+    session_state_index = content.index("<session_state>")
+
+    assert summary_index < learning_index < session_state_index


### PR DESCRIPTION
## Summary

This fixes a Team-side wiring gap for `LearningMachine` context injection.

`Team` already exposes `learning` and `add_learnings_to_context`, and the write path works, but `libs/agno/agno/team/_messages.py` never read from `team._learning` when building the system message. As a result, learned profile/context data was stored but never injected back into later Team runs.

Closes #7595.

## What changed

- added `LearningMachine` context injection to `get_system_message()`
- added `LearningMachine` context injection to `aget_system_message()`
- placed the injected learning context after session summary and before trailing sections
- passed `user_id`, `session_id`, and `team_id` through to `build_context()` / `abuild_context()`
- added focused unit coverage for sync, async, disabled-flag, empty-context, and ordering behavior

## Root cause

`Agent` already appends learning context in its message builder, but `Team` had no equivalent read-path hook in `_messages.py`. That left `add_learnings_to_context=True` effectively inert for Team.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated (if applicable)
- [x] Ran targeted validation for changed files

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] This PR was created with AI assistance and reviewed before submission

---

## Validation

- `python -m pytest libs/agno/tests/unit/team/test_learning_context.py -q`
- `python -m ruff check libs/agno/agno/team/_messages.py libs/agno/tests/unit/team/test_learning_context.py`
- `python -m mypy libs/agno/agno/team/_messages.py libs/agno/tests/unit/team/test_learning_context.py --config-file libs/agno/pyproject.toml`
