### PR TITLE
LanceDb add refresh_sync_connect

### DIFF
--- a/libs/agno/agno/vectordb/lancedb/lance_db.py
+++ b/libs/agno/agno/vectordb/lancedb/lance_db.py
@@ -42,6 +42,7 @@ class LanceDb(VectorDb):
         use_tantivy: Whether to use Tantivy for full text search.
         on_bad_vectors: What to do if the vector is bad. One of "error", "drop", "fill", "null".
         fill_value: The value to fill the vector with if on_bad_vectors is "fill".
+        refresh_sync_connect: Whether to refresh sync connection to see async changes (not needed for cloud)
     """
 
     def __init__(
@@ -64,6 +65,7 @@ class LanceDb(VectorDb):
         use_tantivy: bool = True,
         on_bad_vectors: Optional[str] = None,  # One of "error", "drop", "fill", "null".
         fill_value: Optional[float] = None,  # Only used if on_bad_vectors is "fill"
+        refresh_sync_connect: bool = False,
     ):
         # Dynamic ID generation based on unique identifiers
         if id is None:
@@ -162,6 +164,7 @@ class LanceDb(VectorDb):
         self.fill_value: Optional[float] = fill_value
         self.fts_index_exists = False
         self.use_tantivy = use_tantivy
+        self.refresh_sync_connect = refresh_sync_connect
 
         if self.use_tantivy and (self.search_type in [SearchType.keyword, SearchType.hybrid]):
             try:
@@ -294,7 +297,8 @@ class LanceDb(VectorDb):
             log_info("API key found, creating table in remote LanceDB")
             tbl = self.connection.create_table(name=self.table_name, schema=schema, mode="overwrite")  # type: ignore
         else:
-            tbl = self.connection.create_table(name=self.table_name, schema=schema, mode="overwrite", exist_ok=True)  # type: ignore
+            tbl = self.connection.create_table(name=self.table_name, schema=schema, mode="overwrite",
+                                               exist_ok=True)  # type: ignore
         return tbl  # type: ignore
 
     def insert(self, content_hash: str, documents: List[Document], filters: Optional[Dict[str, Any]] = None) -> None:
@@ -504,6 +508,10 @@ class LanceDb(VectorDb):
             log_error("Table not initialized")
             return []
 
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         results = None
 
         if isinstance(filters, list):
@@ -583,6 +591,10 @@ class LanceDb(VectorDb):
     def vector_search(
         self, query: str, limit: int = 5, filters: Optional[Union[Dict[str, Any], List[FilterExpr]]] = None
     ) -> Optional[List[Dict[str, Any]]]:
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         query_embedding = self.embedder.get_embedding(query)
         if query_embedding is None:
             log_error(f"Error getting embedding for Query: {query}")
@@ -605,6 +617,10 @@ class LanceDb(VectorDb):
     def hybrid_search(
         self, query: str, limit: int = 5, filters: Optional[Union[Dict[str, Any], List[FilterExpr]]] = None
     ) -> List[Dict[str, Any]]:
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         query_embedding = self.embedder.get_embedding(query)
         if query_embedding is None:
             log_error(f"Error getting embedding for Query: {query}")
@@ -636,6 +652,10 @@ class LanceDb(VectorDb):
     def keyword_search(
         self, query: str, limit: int = 5, filters: Optional[Union[Dict[str, Any], List[FilterExpr]]] = None
     ) -> List[Dict[str, Any]]:
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         if self.table is None:
             log_error("Table not initialized. Please create the table first")
             return []
@@ -718,6 +738,10 @@ class LanceDb(VectorDb):
         return 0
 
     def get_count(self) -> int:
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         # If we have data in the async table but sync table isn't available, try to get count from async table
         if self.async_table is not None:
             try:
@@ -749,6 +773,10 @@ class LanceDb(VectorDb):
 
     def name_exists(self, name: str) -> bool:
         """Check if a document with the given name exists in the database"""
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         if self.table is None:
             return False
 
@@ -768,6 +796,10 @@ class LanceDb(VectorDb):
 
     def id_exists(self, id: str) -> bool:
         """Check if a document with the given ID exists in the database"""
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         if self.table is None:
             log_error("Table not initialized")
             return False
@@ -926,6 +958,10 @@ class LanceDb(VectorDb):
 
     def content_hash_exists(self, content_hash: str) -> bool:
         """Check if documents with the given content hash exist."""
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         if self.table is None:
             log_error("Table not initialized")
             return False
@@ -953,6 +989,10 @@ class LanceDb(VectorDb):
             content_id (str): The content ID to update
             metadata (Dict[str, Any]): The metadata to update
         """
+        # Refresh sync connection if enabled
+        if self.refresh_sync_connect:
+            self._refresh_sync_connection()
+
         import json
 
         try:

--- a/libs/agno/tests/unit/vectordb/test_lancedb.py
+++ b/libs/agno/tests/unit/vectordb/test_lancedb.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from typing import List
+from unittest.mock import patch
 
 import pytest
 
@@ -567,3 +568,158 @@ def test_search_deduplicates_preserves_unique(lance_db):
     contents = [doc.content for doc in results]
     assert len(contents) == len(set(contents))
     assert len(contents) == 3
+
+
+def test_refresh_sync_connect_default_value(mock_embedder):
+    """Test that refresh_sync_connect defaults to False."""
+    db = LanceDb(uri=TEST_PATH, table_name="test_refresh_default", embedder=mock_embedder)
+    assert db.refresh_sync_connect is False
+    db.drop()
+    if os.path.exists(TEST_PATH):
+        shutil.rmtree(TEST_PATH)
+
+
+def test_refresh_sync_connect_true_value(mock_embedder):
+    """Test that refresh_sync_connect can be set to True."""
+    db = LanceDb(
+        uri=TEST_PATH, table_name="test_refresh_true", embedder=mock_embedder, refresh_sync_connect=True
+    )
+    assert db.refresh_sync_connect is True
+    db.drop()
+    if os.path.exists(TEST_PATH):
+        shutil.rmtree(TEST_PATH)
+
+
+def test_refresh_sync_connect_called_in_search(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during search when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.search("coconut", limit=2)
+        # search() calls _refresh_sync_connection() at least once
+        # (may be called multiple times by search() and its sub-methods)
+        mock_refresh.assert_called()
+
+
+def test_refresh_sync_connect_not_called_when_false(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is NOT called during search when refresh_sync_connect is False."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = False
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.search("coconut", limit=2)
+        mock_refresh.assert_not_called()
+
+
+def test_refresh_sync_connect_called_in_vector_search(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during vector_search when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.vector_search("coconut", limit=2)
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_keyword_search(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during keyword_search when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.search_type = SearchType.keyword
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.keyword_search("curry", limit=2)
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_hybrid_search(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during hybrid_search when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.search_type = SearchType.hybrid
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.hybrid_search("soup", limit=2)
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_get_count(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during get_count when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.get_count()
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_name_exists(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during name_exists when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=[sample_documents[0]], content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.name_exists("tom_kha")
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_id_exists(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during id_exists when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=[sample_documents[0]], content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.id_exists("test_id")
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_content_hash_exists(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during content_hash_exists when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.content_hash_exists("test_hash")
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connect_called_in_update_metadata(lance_db, sample_documents):
+    """Test that _refresh_sync_connection is called during update_metadata when refresh_sync_connect is True."""
+    from unittest.mock import patch
+
+    sample_documents[0].content_id = "doc_1"
+    lance_db.insert(documents=[sample_documents[0]], content_hash="test_hash")
+    lance_db.refresh_sync_connect = True
+
+    with patch.object(lance_db, "_refresh_sync_connection") as mock_refresh:
+        lance_db.update_metadata("doc_1", {"updated": True})
+        mock_refresh.assert_called_once()
+
+
+def test_refresh_sync_connection_reopens_table(lance_db, sample_documents):
+    """Test that _refresh_sync_connection reopens the table to see changes."""
+    lance_db.insert(documents=sample_documents, content_hash="test_hash")
+
+    # Mock the open_table method to verify it's called
+    with patch.object(lance_db.connection, "open_table") as mock_open:
+        lance_db._refresh_sync_connection()
+        mock_open.assert_called_once_with(lance_db.table_name)


### PR DESCRIPTION
## Summary

different processes use a single lancedb,the latest data cannot be selected

## Type of change

- Bug fix
-  New feature

---

## Checklist

Tested in clean environment
