### PR TITLE
fix(gemini): apply timeout after client_params merge and handle HttpOptions object

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -187,14 +187,24 @@ class Gemini(Model):
 
         client_params = {k: v for k, v in client_params.items() if v is not None}
 
-        if self.timeout is not None:
-            http_options = client_params.get("http_options", {})
-            if isinstance(http_options, dict):
-                http_options["timeout"] = int(self.timeout * 1000)
-                client_params["http_options"] = http_options
-
         if self.client_params:
             client_params.update(self.client_params)
+
+        if self.timeout is not None:
+            # Normalize http_options to a dict so we can safely merge the timeout.
+            # client_params may supply http_options as either a plain dict or an
+            # HttpOptions object; both are normalised here to avoid silently
+            # skipping the timeout when the object form is used.
+            http_options = client_params.get("http_options", {})
+            if hasattr(http_options, "model_dump"):
+                # HttpOptions (or any pydantic model) → plain dict
+                http_options = http_options.model_dump(exclude_none=True)
+            elif not isinstance(http_options, dict):
+                http_options = {}
+            # Only inject timeout when the caller has not already set one
+            if "timeout" not in http_options:
+                http_options["timeout"] = int(self.timeout * 1000)
+            client_params["http_options"] = http_options
 
         self.client = genai.Client(**client_params)
         return self.client

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -200,6 +200,10 @@ class Gemini(Model):
                 # HttpOptions (or any pydantic model) → plain dict
                 http_options = http_options.model_dump(exclude_none=True)
             elif not isinstance(http_options, dict):
+                log_warning(
+                    f"Unrecognized http_options type {type(http_options).__name__!r} in client_params; "
+                    "falling back to empty dict. Use a plain dict or HttpOptions object instead."
+                )
                 http_options = {}
             # Only inject timeout when the caller has not already set one
             if "timeout" not in http_options:

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -268,6 +268,21 @@ class TestGeminiTimeout:
             _, kwargs = mock_client_cls.call_args
             assert kwargs["http_options"]["timeout"] == 1500
 
+    def test_timeout_does_not_override_client_params_http_options(self):
+        """Test that client_params http_options take precedence over timeout."""
+        model = Gemini(
+            api_key="test-key",
+            timeout=30.0,
+            client_params={"http_options": {"timeout": 60000}},
+        )
+
+        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
+            model.get_client()
+
+            _, kwargs = mock_client_cls.call_args
+            # Caller's explicit timeout in client_params wins over self.timeout
+            assert kwargs["http_options"]["timeout"] == 60000
+
 
     def test_timeout_with_vertexai(self):
         """Test that timeout works correctly in Vertex AI mode."""

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -268,20 +268,6 @@ class TestGeminiTimeout:
             _, kwargs = mock_client_cls.call_args
             assert kwargs["http_options"]["timeout"] == 1500
 
-    def test_timeout_does_not_override_client_params_http_options(self):
-        """Test that client_params http_options take precedence over timeout."""
-        model = Gemini(
-            api_key="test-key",
-            timeout=30.0,
-            client_params={"http_options": {"timeout": 60000}},
-        )
-
-        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
-            model.get_client()
-
-            _, kwargs = mock_client_cls.call_args
-            # client_params is applied after timeout, so it should override
-            assert kwargs["http_options"]["timeout"] == 60000
 
     def test_timeout_with_vertexai(self):
         """Test that timeout works correctly in Vertex AI mode."""
@@ -298,6 +284,72 @@ class TestGeminiTimeout:
             _, kwargs = mock_client_cls.call_args
             assert kwargs["http_options"]["timeout"] == 10000
             assert kwargs["vertexai"] is True
+
+    def test_timeout_survives_client_params_update(self):
+        """Regression test for #7599: timeout must be applied AFTER client_params.update()
+        so that extra client_params keys don't silently overwrite http_options."""
+        model = Gemini(
+            api_key="test-key",
+            timeout=5.0,
+            # client_params carries an unrelated key — must not clobber timeout
+            client_params={"some_other_param": "value"},
+        )
+
+        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
+            model.get_client()
+
+            _, kwargs = mock_client_cls.call_args
+            assert "http_options" in kwargs
+            assert kwargs["http_options"]["timeout"] == 5000
+
+    def test_timeout_with_http_options_object_in_client_params(self):
+        """Regression test for #7599: when client_params supplies http_options as an
+        HttpOptions-like object (not a plain dict), timeout must still be injected."""
+
+        class FakeHttpOptions:
+            """Minimal stand-in for google.genai.types.HttpOptions."""
+
+            def __init__(self, **kw):
+                self._data = kw
+
+            def model_dump(self, exclude_none=False):
+                if exclude_none:
+                    return {k: v for k, v in self._data.items() if v is not None}
+                return dict(self._data)
+
+        model = Gemini(
+            api_key="test-key",
+            timeout=7.0,
+            client_params={"http_options": FakeHttpOptions(some_option="value")},
+        )
+
+        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
+            model.get_client()
+
+            _, kwargs = mock_client_cls.call_args
+            http_opts = kwargs["http_options"]
+            # Timeout must be present even though http_options was an object
+            assert isinstance(http_opts, dict)
+            assert http_opts["timeout"] == 7000
+            # Pre-existing options must be preserved
+            assert http_opts["some_option"] == "value"
+
+    def test_explicit_timeout_in_client_params_http_options_takes_precedence(self):
+        """When the user explicitly sets a timeout inside client_params http_options,
+        that value must not be overwritten by self.timeout."""
+        model = Gemini(
+            api_key="test-key",
+            timeout=30.0,
+            client_params={"http_options": {"timeout": 60000}},
+        )
+
+        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
+            model.get_client()
+
+            _, kwargs = mock_client_cls.call_args
+            # client_params explicit timeout wins over self.timeout
+            assert kwargs["http_options"]["timeout"] == 60000
+
 
 
 def test_parallel_search_requires_vertexai():


### PR DESCRIPTION
## Description

Fixes two bugs in `Gemini.get_client()` that caused `self.timeout` to be silently ignored when `client_params` is provided.

Fixes #7599

---

## Root Cause

### Bug 1 — Wrong order: timeout was applied before `client_params.update()`

```python
# BEFORE (broken)
if self.timeout is not None:
    http_options = client_params.get("http_options", {})
    if isinstance(http_options, dict):
        http_options["timeout"] = int(self.timeout * 1000)
        client_params["http_options"] = http_options  # ← set here

if self.client_params:
    client_params.update(self.client_params)  # ← overwrites http_options entirely
```

Any `http_options` key inside `client_params` would overwrite the injected timeout, causing requests to fall back to the underlying client default (e.g. 120 seconds) regardless of what the user set.

### Bug 2 — Type guard: `HttpOptions` object silently skipped

```python
# BEFORE (broken)
if isinstance(http_options, dict):   # fails for HttpOptions(...) objects → timeout skipped
    http_options["timeout"] = int(self.timeout * 1000)
```

When a user passes `http_options=HttpOptions(some_option="value")` inside `client_params`, the `isinstance(dict)` guard evaluates to `False` and timeout injection is silently skipped with no warning or error.

---

## Fix

```python
# AFTER (fixed)
if self.client_params:
    client_params.update(self.client_params)  # merge first

if self.timeout is not None:
    http_options = client_params.get("http_options", {})
    if hasattr(http_options, "model_dump"):
        # HttpOptions (or any pydantic model) → normalise to plain dict
        http_options = http_options.model_dump(exclude_none=True)
    elif not isinstance(http_options, dict):
        http_options = {}
    # Only inject timeout when the caller has not already set one
    if "timeout" not in http_options:
        http_options["timeout"] = int(self.timeout * 1000)
    client_params["http_options"] = http_options
```

Changes:
- Move timeout injection **after** `client_params.update()` so all user params are fully merged first.
- Normalize `http_options` to a plain dict via `model_dump(exclude_none=True)` when it is an `HttpOptions` / pydantic object, preserving any other options the user set.
- Only inject `self.timeout` when the caller has **not** already set a `timeout` key, so explicit user overrides are respected.

---

## Tests

Added 3 regression tests to the existing `TestGeminiTimeout` class in `tests/unit/models/google/test_gemini.py`:

| Test | What it covers |
|------|----------------|
| `test_timeout_survives_client_params_update` | Bug 1 — timeout is present even when `client_params` carries unrelated keys |
| `test_timeout_with_http_options_object_in_client_params` | Bug 2 — `HttpOptions`-like object is normalized; timeout is injected and existing options preserved |
| `test_explicit_timeout_in_client_params_http_options_takes_precedence` | User's explicit `timeout` inside `client_params` http_options is not overwritten |

All **7 tests** in `TestGeminiTimeout` pass.

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests added / updated
