### PR TITLE
[fix] A2A: serialize Pydantic content in :send and final-task paths

### DIFF
--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -83,6 +83,20 @@ from agno.run.agent import (
 from agno.run.base import RunStatus
 
 
+def _stringify_content(content: Any) -> str:
+    """Stringify RunOutput/event content for an A2A TextPart.
+
+    When an agent is configured with an `output_schema`, `content` is a
+    Pydantic model instance. It must be JSON-encoded via `model_dump_json()`
+    so A2A clients can `json.loads` the TextPart text.
+    """
+    if hasattr(content, "model_dump_json"):
+        return content.model_dump_json()
+    if isinstance(content, str):
+        return content
+    return str(content)
+
+
 async def map_a2a_request_to_run_input(request_body: dict, stream: bool = True) -> RunInput:
     """Map A2A SendMessageRequest to Agno RunInput.
 
@@ -210,7 +224,7 @@ def map_run_output_to_a2a_task(run_output: Union[RunOutput, WorkflowRunOutput]) 
 
     # 1. Handle output content
     if run_output.content:
-        parts.append(Part(root=TextPart(text=str(run_output.content))))
+        parts.append(Part(root=TextPart(text=_stringify_content(run_output.content))))
 
     # 2. Handle output media
     artifacts: List[Artifact] = []
@@ -348,16 +362,7 @@ async def stream_a2a_response(
 
         # Send content events
         elif isinstance(event, (RunContentEvent, TeamRunContentEvent)) and event.content:
-            # Serialize content to str: Pydantic models (from output_schema) must be
-            # converted before str-concatenation or TextPart construction, otherwise
-            # "TypeError: can only concatenate str (not <Model>) to str" is raised.
-            raw_content = event.content
-            if hasattr(raw_content, "model_dump_json"):
-                content_str = raw_content.model_dump_json()
-            elif not isinstance(raw_content, str):
-                content_str = str(raw_content)
-            else:
-                content_str = raw_content
+            content_str = _stringify_content(event.content)
             accumulated_content += content_str
             message = A2AMessage(
                 message_id=message_id,
@@ -814,7 +819,7 @@ async def stream_a2a_response(
 
         final_parts: List[Part] = []
         if final_content:
-            final_parts.append(Part(root=TextPart(text=str(final_content))))
+            final_parts.append(Part(root=TextPart(text=_stringify_content(final_content))))
 
         # Handle all media artifacts
         artifacts: List[Artifact] = []
@@ -949,3 +954,4 @@ async def stream_a2a_response_with_error_handling(
 
         response = SendStreamingMessageSuccessResponse(id=request_id, result=failed_task)
         yield f"event: Task\ndata: {json.dumps(response.model_dump(exclude_none=True))}\n\n"
+

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -89,6 +89,9 @@ def _stringify_content(content: Any) -> str:
     When an agent is configured with an `output_schema`, `content` is a
     Pydantic model instance. It must be JSON-encoded via `model_dump_json()`
     so A2A clients can `json.loads` the TextPart text.
+
+    Note: only Pydantic v2 models (those with ``model_dump_json()``) are handled;
+    Pydantic v1 models fall through to ``str()``.
     """
     if hasattr(content, "model_dump_json"):
         return content.model_dump_json()

--- a/libs/agno/tests/unit/a2a/test_utils.py
+++ b/libs/agno/tests/unit/a2a/test_utils.py
@@ -1,0 +1,61 @@
+"""Unit tests for A2A serialization utils."""
+
+import json
+
+from pydantic import BaseModel
+
+from agno.os.interfaces.a2a.utils import _stringify_content, map_run_output_to_a2a_task
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+
+
+class _SampleModel(BaseModel):
+    query: str
+    assumptions: list[str]
+
+
+class TestStringifyContent:
+    def test_pydantic_model_is_dumped_as_json(self):
+        model = _SampleModel(query="select 1 from something", assumptions=["a", "b"])
+        result = _stringify_content(model)
+        # Round-trips through json.loads — would fail with plain str(model)
+        assert json.loads(result) == {"query": "select 1 from something", "assumptions": ["a", "b"]}
+
+    def test_string_is_passed_through(self):
+        assert _stringify_content("hello") == "hello"
+
+    def test_non_string_non_model_falls_back_to_str(self):
+        assert _stringify_content(42) == "42"
+        assert _stringify_content({"a": 1}) == "{'a': 1}"
+
+
+class TestMapRunOutputToA2ATaskJSONContent:
+    def test_pydantic_content_produces_json_text_part(self):
+        """Non-streaming :send path must emit JSON, not BaseModel.__repr__."""
+        model = _SampleModel(query="select 1 from something", assumptions=["a", "b"])
+        run_output = RunOutput(
+            run_id="run-1",
+            session_id="sess-1",
+            content=model,
+            status=RunStatus.completed,
+        )
+
+        task = map_run_output_to_a2a_task(run_output)
+
+        assert len(task.history) == 1
+        parts = task.history[0].parts
+        assert len(parts) == 1
+        text = parts[0].root.text
+        # The fix: text is valid JSON matching the model, not a Python repr.
+        assert json.loads(text) == {"query": "select 1 from something", "assumptions": ["a", "b"]}
+
+    def test_string_content_is_unchanged(self):
+        run_output = RunOutput(
+            run_id="run-1",
+            session_id="sess-1",
+            content="plain text",
+            status=RunStatus.completed,
+        )
+        task = map_run_output_to_a2a_task(run_output)
+        assert task.history[0].parts[0].root.text == "plain text"
+


### PR DESCRIPTION
## Human Summary

When an agent is configured with a Pydantic dataclass in `output_schema`, the `BaseModel.__repr__` string output is used for `TextPart.text`.  This is a string representation of the class that is not JSON serializable and causes clients that run `json.loads()` to get a decode error.  This has already been fixed for the `message:stream` path, but not for `message:send`.

## AI Summary

Follow-up to #6936 / #6850. That PR fixed the `TypeError: can only concatenate str
(not <Model>) to str` crash in the streaming `RunContentEvent` branch, but left two
sibling sites in `libs/agno/agno/os/interfaces/a2a/utils.py` that still call bare
`str(content)`:

- `map_run_output_to_a2a_task` (line 213) — the non-streaming `message:send` path.
- `stream_a2a_response` final-task construction (line 817) — the last `Task` emitted
  after streaming completes.

When an agent is configured with a Pydantic `output_schema`, these paths don't raise;
they silently put `BaseModel.__repr__` output into `TextPart.text` (single quotes,
Python-style lists, no JSON wrapping). Clients that `json.loads()` the TextPart — which
is the natural thing to do with a structured-output response — get a `JSONDecodeError`.
This matches the symptom reported separately by downstream users.

This PR:

1. Extracts the existing inline three-branch serialization into a module-level
   `_stringify_content()` helper (named to mirror the existing `stringify_input_content`
   in `agno/os/utils.py`).
2. Applies it at all three call sites: the streaming content event branch (behavior
   preserved from #6936), plus the two missed sites above (the fix).
3. Adds unit tests covering the helper and the `:send`-path `map_run_output_to_a2a_task`
   behavior for Pydantic and string content.

Fixes the residual half of #6850.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format`, `ruff check`, `ruff check --select I`)
- [x] Self-review completed
- [x] Documentation updated (helper docstring explains the bug and its history)
- [ ] Examples and guides: n/a — internal serialization fix, no user-facing API change
- [x] Tested in clean environment
- [x] Tests added/updated (5 new unit tests in `libs/agno/tests/unit/a2a/test_utils.py`)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR
      already addresses this issue. The seven related PRs (#6851, #6902, #6904, #6909,
      #6925, #7145, #7172) were all closed as duplicates of #6936, which covered only
      the streaming content-event path. None of them touch `map_run_output_to_a2a_task`
      line 213 or the final-task construction at line 817.
- [x] If a similar PR exists, I have explained above why this PR is a better approach
      (it fixes the two remaining call sites #6936 did not touch).
- [x] This PR was authored with the assistance of Claude Code. The author has reviewed
      and understands all changes, including the root cause analysis and the scoping
      decision to leave AG-UI/Slack/Telegram untouched for a follow-up.
