### PR TITLE
[feat] Add edit_file to FileTools with read-before-edit guard

### DIFF
--- a/cookbook/91_tools/file_tools.py
+++ b/cookbook/91_tools/file_tools.py
@@ -134,7 +134,32 @@ agent_content_search = Agent(
     markdown=True,
 )
 
-# Example 6: Default exclusions skip noise directories (.venv, .git, __pycache__,
+# Example 6: String-based edits via edit_file. The agent must read a file fully
+# before editing it (the toolkit tracks this), and if the file changes on disk
+# between the read and the edit, the edit is rejected — the agent has to
+# re-read. This mirrors the read-before-edit discipline of modern coding
+# agents. Pass replace_all=True to rewrite every occurrence; otherwise the
+# match must be unique so the agent adds surrounding context to disambiguate.
+agent_editor = Agent(
+    tools=[
+        FileTools(
+            Path("tmp/file"),
+            enable_read_file=True,
+            enable_edit_file=True,
+            enable_save_file=True,
+            enable_list_files=True,
+        )
+    ],
+    description="You are a precise file editor that applies targeted string replacements.",
+    instructions=[
+        "Always read a file before editing it",
+        "When editing, choose old_text with enough surrounding context to be unique",
+        "Prefer edit_file over rewriting the whole file",
+    ],
+    markdown=True,
+)
+
+# Example 7: Default exclusions skip noise directories (.venv, .git, __pycache__,
 # node_modules, build artifacts, etc.) so agents don't waste context on installed
 # packages or VCS metadata. See DEFAULT_EXCLUDE_PATTERNS for the full list.
 agent_default_exclusions = Agent(
@@ -154,7 +179,7 @@ agent_default_exclusions = Agent(
     markdown=True,
 )
 
-# Example 7: Custom exclusions - start from DEFAULT_EXCLUDE_PATTERNS and remove
+# Example 8: Custom exclusions - start from DEFAULT_EXCLUDE_PATTERNS and remove
 # the entries you want visible. Future additions to the default list apply
 # automatically. Here we keep the defaults but unhide .venv so the agent can
 # inspect installed packages.
@@ -179,7 +204,7 @@ agent_can_read_venv = Agent(
     markdown=True,
 )
 
-# Example 8: Full opt-out with exclude_patterns=[]. Every file becomes visible,
+# Example 9: Full opt-out with exclude_patterns=[]. Every file becomes visible,
 # including .git internals. Use only when you need forensic access to the tree.
 agent_sees_everything = Agent(
     model=OpenAIResponses(id="gpt-5.4"),
@@ -231,6 +256,13 @@ if __name__ == "__main__":
     print("\n=== Content Search Example ===")
     agent_content_search.print_response(
         "Search inside all files for the word 'Python' and summarize what you find",
+        markdown=True,
+    )
+
+    print("\n=== Targeted Edit Example ===")
+    agent_editor.print_response(
+        "Read 'python_guide.txt', then replace the phrase 'best practices' with "
+        "'core principles' in it. Confirm the change.",
         markdown=True,
     )
 

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -1,11 +1,24 @@
 import json
 import os
+from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error
+
+
+@dataclass
+class _ReadState:
+    """Tracks the last-observed mtime of a file and whether the agent saw it
+    in full. ``edit_file`` uses both: staleness is detected via mtime, and
+    partial reads are rejected because the agent may pick an ``old_text``
+    that exists only in unseen lines."""
+
+    mtime_ns: int
+    is_partial: bool
+
 
 TEXT_EXTENSIONS = {
     ".md",
@@ -149,6 +162,7 @@ class FileTools(Toolkit):
         enable_read_file_chunk: bool = True,
         enable_replace_file_chunk: bool = True,
         enable_search_content: bool = True,
+        enable_edit_file: bool = True,
         expose_base_directory: bool = False,
         max_file_length: int = 10000000,
         max_file_lines: int = 100000,
@@ -167,6 +181,7 @@ class FileTools(Toolkit):
         self.exclude_patterns: List[str] = (
             exclude_patterns if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
         )
+        self._read_state: Dict[Path, _ReadState] = {}
         if all or enable_save_file:
             tools.append(self.save_file)
         if all or enable_read_file:
@@ -183,8 +198,15 @@ class FileTools(Toolkit):
             tools.append(self.replace_file_chunk)
         if all or enable_search_content:
             tools.append(self.search_content)
+        if all or enable_edit_file:
+            tools.append(self.edit_file)
 
         super().__init__(name="file_tools", tools=tools, **kwargs)
+
+    def _record_read(self, path: Path, is_partial: bool) -> None:
+        """Cache the current mtime of ``path`` so ``edit_file`` can detect
+        external modifications between reads and edits."""
+        self._read_state[path] = _ReadState(mtime_ns=path.stat().st_mtime_ns, is_partial=is_partial)
 
     def _is_excluded(self, path: Path) -> bool:
         """Return True if any component of ``path`` (relative to ``base_dir``) matches an exclude pattern."""
@@ -228,6 +250,7 @@ class FileTools(Toolkit):
             if file_path.exists() and not overwrite:
                 return f"File {file_name} already exists"
             file_path.write_text(contents, encoding=encoding)
+            self._record_read(file_path, is_partial=False)
             log_debug(f"Saved: {file_path}")
             return str(file_name)
         except Exception as e:
@@ -252,6 +275,7 @@ class FileTools(Toolkit):
                 return "Error reading file"
             contents = file_path.read_text(encoding=encoding)
             lines = contents.split(self.line_separator)
+            self._record_read(file_path, is_partial=True)
             return self.line_separator.join(lines[start_line : end_line + 1])
         except Exception as e:
             log_error(f"Error reading file: {str(e)}")
@@ -307,6 +331,7 @@ class FileTools(Toolkit):
             if len(contents.split(self.line_separator)) > self.max_file_lines:
                 return "Error reading file: file too long. Use read_file_chunk instead"
 
+            self._record_read(file_path, is_partial=False)
             return str(contents)
         except Exception as e:
             log_error(f"Error reading file: {str(e)}")
@@ -473,3 +498,87 @@ class FileTools(Toolkit):
             error_msg = f"Error searching content for '{query}': {e}"
             log_error(error_msg)
             return error_msg
+
+    def edit_file(
+        self,
+        file_name: str,
+        old_text: str,
+        new_text: str,
+        replace_all: bool = False,
+        encoding: str = "utf-8",
+    ) -> str:
+        """Edit a file by replacing ``old_text`` with ``new_text``.
+
+        The file must have been fully read via ``read_file`` (or just written
+        via ``save_file``) before it can be edited. If its mtime has changed
+        since then, the edit is rejected so the agent re-reads the current
+        contents before retrying.
+
+        ``old_text`` must match exactly one location unless ``replace_all``
+        is ``True``. Passing an empty ``old_text`` on a non-existent file
+        creates it with ``new_text`` as its contents.
+
+        :param file_name: Path (relative to ``base_dir``) of the file to edit.
+        :param old_text: Exact text to replace. Empty string + missing file => create.
+        :param new_text: Replacement text. Must differ from ``old_text``.
+        :param replace_all: Replace every occurrence instead of requiring a unique match.
+        :param encoding: File encoding, defaults to utf-8.
+        :return: A short success message, or an ``Error: ...`` string.
+        """
+        try:
+            if old_text == new_text:
+                return "Error editing file: old_text and new_text are identical"
+
+            safe, file_path = self.check_escape(file_name)
+            if not safe:
+                log_error(f"Attempted to edit file: {file_name}")
+                return "Error editing file"
+
+            if not file_path.exists():
+                if old_text == "":
+                    file_path.parent.mkdir(parents=True, exist_ok=True)
+                    file_path.write_text(new_text, encoding=encoding)
+                    self._record_read(file_path, is_partial=False)
+                    log_debug(f"Created file via edit_file: {file_path}")
+                    return f"Created {file_name}"
+                return (
+                    f"Error editing file: {file_name} does not exist. "
+                    "To create it, pass old_text='' with the new contents in new_text."
+                )
+
+            cached = self._read_state.get(file_path)
+            if cached is None:
+                return (
+                    f"Error editing file: {file_name} has not been read yet. "
+                    "Call read_file first so the agent sees the current contents."
+                )
+            if cached.is_partial:
+                return (
+                    f"Error editing file: {file_name} was only partially read via read_file_chunk. "
+                    "Call read_file for the full contents before editing."
+                )
+            if file_path.stat().st_mtime_ns != cached.mtime_ns:
+                return (
+                    f"Error editing file: {file_name} has been modified since last read. "
+                    "Call read_file again before editing."
+                )
+
+            contents = file_path.read_text(encoding=encoding)
+            count = contents.count(old_text)
+            if count == 0:
+                return f"Error editing file: old_text not found in {file_name}"
+            if count > 1 and not replace_all:
+                return (
+                    f"Error editing file: old_text matches {count} locations in {file_name}. "
+                    "Add surrounding context to make the match unique, or pass replace_all=True."
+                )
+
+            replacements = count if replace_all else 1
+            new_contents = contents.replace(old_text, new_text, replacements)
+            file_path.write_text(new_contents, encoding=encoding)
+            self._record_read(file_path, is_partial=False)
+            log_debug(f"Edited {file_path} ({replacements} replacement{'s' if replacements != 1 else ''})")
+            return f"Edited {file_name} ({replacements} replacement{'s' if replacements != 1 else ''})"
+        except Exception as e:
+            log_error(f"Error editing file: {str(e)}")
+            return f"Error editing file: {e}"

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -14,7 +14,14 @@ class _ReadState:
     """Tracks the last-observed mtime of a file and whether the agent saw it
     in full. ``edit_file`` uses both: staleness is detected via mtime, and
     partial reads are rejected because the agent may pick an ``old_text``
-    that exists only in unseen lines."""
+    that exists only in unseen lines.
+
+    mtime is stored in nanoseconds because filesystems with coarse mtime
+    granularity (HFS+ with 1s precision, some network mounts, older ext4)
+    can produce identical mtime values for two writes within the same tick,
+    letting a real change slip past the staleness check. Nanosecond precision
+    widens the detection window on Linux/modern macOS (APFS) — do not
+    downgrade this to seconds without replacing it with a content hash."""
 
     mtime_ns: int
     is_partial: bool

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -1,4 +1,5 @@
 import json
+import os
 import tempfile
 from pathlib import Path
 
@@ -343,3 +344,150 @@ def test_search_content_honors_exclusions():
         assert result["matches_found"] == 1
         assert "real.py" in file_names
         assert not any(".venv" in f for f in file_names)
+
+
+def test_edit_file_basic():
+    """edit_file replaces an occurrence after a prior read."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="hello world\n", file_name="a.txt")
+        f.read_file(file_name="a.txt")
+
+        result = f.edit_file(file_name="a.txt", old_text="world", new_text="agno")
+        assert "Edited a.txt" in result
+        assert (base_dir / "a.txt").read_text() == "hello agno\n"
+
+
+def test_edit_file_requires_prior_read():
+    """edit_file refuses when the file has not been read first."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        (base_dir / "a.txt").write_text("hello world\n")
+        f = FileTools(base_dir=base_dir)
+
+        result = f.edit_file(file_name="a.txt", old_text="world", new_text="agno")
+        assert result.startswith("Error editing file")
+        assert "has not been read yet" in result
+        assert (base_dir / "a.txt").read_text() == "hello world\n"
+
+
+def test_edit_file_rejects_partial_read():
+    """edit_file refuses after read_file_chunk (agent only saw a slice)."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="line0\nline1\nline2\nline3\n", file_name="a.txt")
+        f.read_file_chunk(file_name="a.txt", start_line=0, end_line=1)
+
+        result = f.edit_file(file_name="a.txt", old_text="line0", new_text="LINE0")
+        assert result.startswith("Error editing file")
+        assert "partially read" in result
+
+
+def test_edit_file_no_match_errors():
+    """edit_file errors clearly when old_text is absent."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="hello world\n", file_name="a.txt")
+        f.read_file(file_name="a.txt")
+
+        result = f.edit_file(file_name="a.txt", old_text="missing", new_text="x")
+        assert result.startswith("Error editing file")
+        assert "old_text not found" in result
+
+
+def test_edit_file_multiple_matches_without_replace_all():
+    """edit_file rejects ambiguous matches when replace_all is False."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="foo\nfoo\nfoo\n", file_name="a.txt")
+        f.read_file(file_name="a.txt")
+
+        result = f.edit_file(file_name="a.txt", old_text="foo", new_text="bar")
+        assert result.startswith("Error editing file")
+        assert "matches 3 locations" in result
+        assert (base_dir / "a.txt").read_text() == "foo\nfoo\nfoo\n"
+
+
+def test_edit_file_replace_all():
+    """replace_all=True replaces every occurrence."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="foo\nfoo\nfoo\n", file_name="a.txt")
+        f.read_file(file_name="a.txt")
+
+        result = f.edit_file(file_name="a.txt", old_text="foo", new_text="bar", replace_all=True)
+        assert "3 replacements" in result
+        assert (base_dir / "a.txt").read_text() == "bar\nbar\nbar\n"
+
+
+def test_edit_file_identical_strings_rejected():
+    """edit_file rejects no-op edits where old_text == new_text."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="hello\n", file_name="a.txt")
+        f.read_file(file_name="a.txt")
+
+        result = f.edit_file(file_name="a.txt", old_text="hello", new_text="hello")
+        assert result.startswith("Error editing file")
+        assert "identical" in result
+
+
+def test_edit_file_creates_on_empty_old_text():
+    """Passing old_text='' for a missing file creates it."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+
+        result = f.edit_file(file_name="new/nested.txt", old_text="", new_text="fresh content")
+        assert result == "Created new/nested.txt"
+        assert (base_dir / "new" / "nested.txt").read_text() == "fresh content"
+
+        # And it now has state, so a subsequent edit works without an explicit read.
+        result2 = f.edit_file(file_name="new/nested.txt", old_text="fresh", new_text="updated")
+        assert "Edited" in result2
+        assert (base_dir / "new" / "nested.txt").read_text() == "updated content"
+
+
+def test_edit_file_rejects_stale_mtime():
+    """edit_file refuses when the file was modified externally after the read."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="hello\n", file_name="a.txt")
+        f.read_file(file_name="a.txt")
+
+        # Simulate an external modification with a different mtime.
+        path = base_dir / "a.txt"
+        path.write_text("hello world\n")
+        stat = path.stat()
+        os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+
+        result = f.edit_file(file_name="a.txt", old_text="hello", new_text="hi")
+        assert result.startswith("Error editing file")
+        assert "modified since last read" in result
+
+
+def test_edit_file_save_populates_state():
+    """save_file alone is enough to unlock edit_file — no explicit read needed."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir)
+        f.save_file(contents="alpha\n", file_name="a.txt")
+
+        result = f.edit_file(file_name="a.txt", old_text="alpha", new_text="beta")
+        assert "Edited a.txt" in result
+        assert (base_dir / "a.txt").read_text() == "beta\n"
+
+
+def test_edit_file_disabled_by_flag():
+    """edit_file is excluded from the toolkit when enable_edit_file=False."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        f = FileTools(base_dir=base_dir, enable_edit_file=False)
+        assert "edit_file" not in f.functions


### PR DESCRIPTION
Closes #7644.

## Summary

Adds `edit_file` to `FileTools` for literal string-based edits with a read-before-edit guard. The method replaces `old_text` with `new_text` in a file the agent has previously read, rejects the edit if the file has been modified on disk since that read (mtime mismatch), refuses to run when the agent only saw the file via `read_file_chunk`, and enforces a unique match unless `replace_all=True`. An empty `old_text` on a missing file creates it.

**Why this is useful.** `save_file` requires the agent to reproduce the entire file on every change — expensive in tokens and easy to regress. `replace_file_chunk` is line-number-based, which LLMs are bad at. `edit_file` matches on literal text, which is robust, cheap, and the dominant pattern in modern coding agents (Claude Code, Cursor, Aider). Naming and parameter vocabulary are aligned with the existing `CodingTools.edit_file` (`old_text`/`new_text`) so users moving between the two toolkits carry a consistent mental model.

Internally, the toolkit now tracks the last-observed mtime of each file it reads or writes in a small `_ReadState` cache. `read_file`, `read_file_chunk`, and `save_file` populate it; `edit_file` consults it before touching disk.

No existing behaviour changes. `search_content`, `replace_file_chunk`, and the rest of `FileTools` are untouched.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Design decisions worth flagging

- **`enable_edit_file` defaults to `True`.** Matches the convention of the rest of `FileTools`: destructive ops (`enable_delete_file`) are opt-in at `False`, everything else is on by default. `edit_file` is strictly safer than `save_file` (which is `True`) because of the read-before-edit and staleness guards, so making it opt-out would invert the safety/default relationship.
- **Parameter naming aligned with `CodingTools.edit_file`.** Uses `old_text`/`new_text` (not `old_string`/`new_string`) to match the vocabulary already in the codebase. `file_name` (not `file_path`) matches the rest of `FileTools`.
- **`_ReadState` as `@dataclass`.** Consistent with existing internal-state patterns in the repo (`_ToolRef` in `slack/events.py`, `_MediaResult` in `whatsapp/helpers.py`). Not a `NamedTuple` because the two fields (`mtime_ns`, `is_partial`) have distinct semantics and tend to evolve independently.
- **`old_text=''` on a missing file creates it.** Matches Claude Code's `Edit` semantics. Rejected on an existing file (the error message tells the agent to use the non-empty path or a different API).

### Related work / non-overlap

- Did not touch `CodingTools.edit_file`, which has a simpler signature (no `replace_all`, no staleness check) and serves the coding-agent toolkit. The two methods coexist the same way `save_file`/`write_file` and `read_file`/`read_file` already coexist between the two toolkits.
- Did not touch `replace_file_chunk`. Deprecating it in favour of `edit_file` might make sense long-term but is out of scope here.
- Potential follow-up: upgrade `search_content` to regex + ripgrep backend (Grep-style). Tracked mentally, not opened as an issue yet.

### Disclosure

This PR was drafted with Claude Code. I reviewed every line, wrote the design spec myself, challenged the agent on naming/convention choices (which is why the parameter rename from `old_string`/`new_string` to `old_text`/`new_text` happened), ran `./scripts/format.sh` and the unit test suite locally, and confirmed `ruff check` + `mypy` are clean. Test coverage is 11 new cases exercising the happy path and every guard (not-read, partial-read, stale mtime, no match, ambiguous match, identical strings, creation, save-unlocks-edit, disabled-flag).