### PR TITLE
fix(aws): suppress false structured-output warning on Bedrock models

### DIFF
--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -49,6 +49,20 @@ class Claude(AnthropicClaude):
         self.supports_native_structured_outputs = False
         self.supports_json_schema_outputs = False
 
+    def _using_structured_outputs(
+        self,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+    ) -> bool:
+        """AWS Bedrock does not support the Anthropic native structured outputs beta
+        (``structured-outputs-2025-11-13`` header). Structured outputs are handled
+        via the JSON output prompt fallback in the agent message layer instead.
+        Override to suppress the misleading parent warning that fires when
+        ``response_format`` is passed to a model with
+        ``supports_native_structured_outputs=False``.
+        """
+        return False
+
     def _get_client_params(self) -> Dict[str, Any]:
         if self.session:
             # Use get_frozen_credentials() for an atomic snapshot so that

--- a/libs/agno/tests/unit/models/aws/test_claude_client.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_client.py
@@ -249,3 +249,54 @@ class TestSessionNullCredentials:
 
         with pytest.raises(ValueError, match="boto3 session has no credentials"):
             model._get_client_params()
+
+
+class TestStructuredOutputs:
+    """Verify that the Bedrock Claude override suppresses the spurious structured-output
+    warning that the parent AnthropicClaude emits when response_format is passed to a
+    model with supports_native_structured_outputs=False.
+    """
+
+    def test_returns_false_and_no_warning_when_response_format_given(self):
+        from pydantic import BaseModel as PydanticBaseModel
+
+        class MySchema(PydanticBaseModel):
+            answer: str
+
+        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+
+        with patch("agno.models.anthropic.claude.log_warning") as mock_warn:
+            result = model._using_structured_outputs(response_format=MySchema)
+
+        assert result is False
+        mock_warn.assert_not_called()
+
+    def test_returns_false_when_no_response_format(self):
+        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+
+        with patch("agno.models.anthropic.claude.log_warning") as mock_warn:
+            result = model._using_structured_outputs(response_format=None)
+
+        assert result is False
+        mock_warn.assert_not_called()
+
+    def test_parent_would_warn_without_override(self):
+        """Regression guard: confirm the parent path does emit a warning when
+        supports_native_structured_outputs is False and response_format is given.
+        This documents that the override is load-bearing - if the parent ever stops
+        warning, the override is harmless but the bug is gone upstream.
+        """
+        from agno.models.anthropic import Claude as AnthropicClaude
+        from pydantic import BaseModel as PydanticBaseModel
+
+        class MySchema(PydanticBaseModel):
+            answer: str
+
+        parent = AnthropicClaude(id="claude-3-sonnet-20240229")
+        parent.supports_native_structured_outputs = False
+
+        with patch("agno.models.anthropic.claude.log_warning") as mock_warn:
+            result = parent._using_structured_outputs(response_format=MySchema)
+
+        assert result is False
+        mock_warn.assert_called_once()


### PR DESCRIPTION
## Summary

AWS Bedrock Claude models emit a misleading warning when `response_format` is passed:

> Model '...' does not support structured outputs. Structured output features will not be available for this model.

This warning is wrong. Structured outputs **do work** on Bedrock via the JSON output prompt fallback in the agent message layer. The warning fires because `aws/claude.py` correctly sets `supports_native_structured_outputs = False` (Bedrock does not support the `structured-outputs-2025-11-13` beta header), but the parent `AnthropicClaude._using_structured_outputs()` treats that flag as "structured outputs are broken" and warns.

## Fix

Override `_using_structured_outputs()` in the Bedrock `Claude` subclass to return `False` without emitting the warning. This lets the JSON prompt fallback path proceed silently, which is the correct Bedrock behavior.

The flag values (`supports_native_structured_outputs = False`, `supports_json_schema_outputs = False`) are unchanged - only the spurious warning is suppressed.

## Repro



Fixes #7592