### PR TITLE
[feat] Add grep to FileTools with ripgrep backend and Python fallback

### DIFF
--- a/cookbook/91_tools/file_tools.py
+++ b/cookbook/91_tools/file_tools.py
@@ -134,7 +134,32 @@ agent_content_search = Agent(
     markdown=True,
 )
 
-# Example 6: Default exclusions skip noise directories (.venv, .git, __pycache__,
+# Example 6: Regex search via grep. Faster and more flexible than search_content
+# (substring only): uses ripgrep when installed, a pure-Python fallback
+# otherwise. Pick an output_mode: "files_with_matches" just lists paths,
+# "content" returns each hit with its line number, and "count" gives a per-file
+# tally. Use the include parameter to scope the search to a filename pattern.
+agent_grep = Agent(
+    tools=[
+        FileTools(
+            Path("tmp/file"),
+            enable_read_file=True,
+            enable_grep=True,
+            enable_list_files=True,
+            enable_save_file=False,
+        )
+    ],
+    description="You are a code search assistant that uses regex to find specific patterns.",
+    instructions=[
+        "Use grep to answer questions about the codebase",
+        "Prefer output_mode='content' when the user wants to see the matching lines",
+        "Prefer output_mode='files_with_matches' when they just want the list of files",
+        "Use the include parameter to scope to a language or filename pattern (e.g. '*.py')",
+    ],
+    markdown=True,
+)
+
+# Example 7: Default exclusions skip noise directories (.venv, .git, __pycache__,
 # node_modules, build artifacts, etc.) so agents don't waste context on installed
 # packages or VCS metadata. See DEFAULT_EXCLUDE_PATTERNS for the full list.
 agent_default_exclusions = Agent(
@@ -154,7 +179,7 @@ agent_default_exclusions = Agent(
     markdown=True,
 )
 
-# Example 7: Custom exclusions - start from DEFAULT_EXCLUDE_PATTERNS and remove
+# Example 8: Custom exclusions - start from DEFAULT_EXCLUDE_PATTERNS and remove
 # the entries you want visible. Future additions to the default list apply
 # automatically. Here we keep the defaults but unhide .venv so the agent can
 # inspect installed packages.
@@ -179,7 +204,7 @@ agent_can_read_venv = Agent(
     markdown=True,
 )
 
-# Example 8: Full opt-out with exclude_patterns=[]. Every file becomes visible,
+# Example 9: Full opt-out with exclude_patterns=[]. Every file becomes visible,
 # including .git internals. Use only when you need forensic access to the tree.
 agent_sees_everything = Agent(
     model=OpenAIResponses(id="gpt-5.4"),
@@ -231,6 +256,13 @@ if __name__ == "__main__":
     print("\n=== Content Search Example ===")
     agent_content_search.print_response(
         "Search inside all files for the word 'Python' and summarize what you find",
+        markdown=True,
+    )
+
+    print("\n=== Grep Regex Search Example ===")
+    agent_grep.print_response(
+        "Find every Python function definition (pattern: def \\w+) across the "
+        "workspace and list the first 10 matches with their line numbers.",
         markdown=True,
     )
 

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -536,6 +536,13 @@ class FileTools(Toolkit):
         :param multiline: If ``True``, the pattern can match across line
             boundaries (``.`` matches newlines). Off by default.
         :return: JSON document with the shape shown above.
+
+        When the result contains ``"truncated": true``, more matches
+        exist than were returned. The caller should narrow the search
+        (tighten ``pattern``, set ``include`` to a filename glob, or
+        pass ``path`` to scope to a subdirectory) and retry rather than
+        raise ``limit`` — ``GREP_MAX_LIMIT`` is a hard cap that protects
+        the agent's context from accidental blow-up.
         """
         try:
             if not pattern or not pattern.strip():

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -1,11 +1,25 @@
+import bisect
 import json
 import os
+import re
+import shutil
+import subprocess
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Literal, Optional, Tuple
 
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error
+
+GrepOutputMode = Literal["files_with_matches", "content", "count"]
+_GREP_OUTPUT_MODES = ("files_with_matches", "content", "count")
+
+# Absolute cap on how many results grep will return in a single call, even
+# when limit is set higher. Prevents accidental context blow-up.
+GREP_MAX_LIMIT = 1000
+# Timeout for the ripgrep subprocess. Ripgrep is fast; anything longer
+# than 20s on a project usually means a pathological regex.
+GREP_RG_TIMEOUT_S = 20
 
 TEXT_EXTENSIONS = {
     ".md",
@@ -149,6 +163,7 @@ class FileTools(Toolkit):
         enable_read_file_chunk: bool = True,
         enable_replace_file_chunk: bool = True,
         enable_search_content: bool = True,
+        enable_grep: bool = True,
         expose_base_directory: bool = False,
         max_file_length: int = 10000000,
         max_file_lines: int = 100000,
@@ -167,6 +182,9 @@ class FileTools(Toolkit):
         self.exclude_patterns: List[str] = (
             exclude_patterns if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
         )
+        # Cache the ripgrep binary path so grep does not repeat the PATH
+        # lookup on every call. ``None`` means ripgrep is not installed.
+        self._rg_path: Optional[str] = shutil.which("rg")
         if all or enable_save_file:
             tools.append(self.save_file)
         if all or enable_read_file:
@@ -183,6 +201,8 @@ class FileTools(Toolkit):
             tools.append(self.replace_file_chunk)
         if all or enable_search_content:
             tools.append(self.search_content)
+        if all or enable_grep:
+            tools.append(self.grep)
 
         super().__init__(name="file_tools", tools=tools, **kwargs)
 
@@ -473,3 +493,340 @@ class FileTools(Toolkit):
             error_msg = f"Error searching content for '{query}': {e}"
             log_error(error_msg)
             return error_msg
+
+    def grep(
+        self,
+        pattern: str,
+        path: Optional[str] = None,
+        output_mode: GrepOutputMode = "files_with_matches",
+        include: Optional[str] = None,
+        ignore_case: bool = False,
+        context: int = 0,
+        limit: int = 250,
+        multiline: bool = False,
+    ) -> str:
+        """Regex-based content search across the base directory.
+
+        Prefers the ripgrep (``rg``) binary when it is on PATH for speed,
+        and falls back to a pure-Python walk when it is not. The output
+        shape does not depend on which backend ran.
+
+        Return JSON shape varies by ``output_mode``:
+
+        - ``"files_with_matches"``: ``{"pattern", "mode", "matches_found", "files": [...], "truncated"}``
+        - ``"content"``: ``{"pattern", "mode", "matches_found", "lines": [{"file", "line", "text"}, ...], "truncated"}``
+        - ``"count"``: ``{"pattern", "mode", "matches_found", "counts": [{"file", "count"}, ...], "truncated"}``
+
+        :param pattern: Regex to search for. Uses ripgrep syntax when ``rg``
+            is available, Python's ``re`` syntax otherwise. Simple patterns
+            work the same in both.
+        :param path: Optional subdirectory (relative to ``base_dir``) to
+            scope the search to. Defaults to the whole base directory.
+        :param output_mode: ``"files_with_matches"`` (default, paths only),
+            ``"content"`` (matching lines with line numbers), or ``"count"``
+            (match count per file).
+        :param include: Optional filename filter such as ``"*.py"`` or
+            ``"**/*.tsx"``. Matched against paths relative to ``base_dir``.
+        :param ignore_case: If ``True``, ignore case when matching.
+        :param context: Number of context lines to show before and after each
+            match. Only applies when ``output_mode='content'`` and the
+            ripgrep backend is active; the Python fallback ignores it.
+        :param limit: Maximum number of results to return. Capped at
+            ``GREP_MAX_LIMIT`` regardless of caller input.
+        :param multiline: If ``True``, the pattern can match across line
+            boundaries (``.`` matches newlines). Off by default.
+        :return: JSON document with the shape shown above.
+        """
+        try:
+            if not pattern or not pattern.strip():
+                return "Error: Pattern cannot be empty"
+            if output_mode not in _GREP_OUTPUT_MODES:
+                return f"Error: output_mode must be one of {_GREP_OUTPUT_MODES}, got {output_mode!r}"
+
+            search_dir = self.base_dir
+            if path:
+                safe, search_dir = self.check_escape(path)
+                if not safe:
+                    log_error(f"Attempted to grep outside base directory: {path}")
+                    return "Error: path is outside the allowed base directory"
+            if not search_dir.is_dir():
+                return f"Error: '{path}' is not a directory"
+
+            effective_limit = min(max(limit, 1), GREP_MAX_LIMIT)
+
+            if self._rg_path is not None:
+                log_debug(f"grep: using ripgrep at {self._rg_path}")
+                return self._grep_ripgrep(
+                    rg_path=self._rg_path,
+                    pattern=pattern,
+                    search_dir=search_dir,
+                    output_mode=output_mode,
+                    include=include,
+                    ignore_case=ignore_case,
+                    context=context,
+                    limit=effective_limit,
+                    multiline=multiline,
+                )
+
+            log_debug("grep: ripgrep not found, using Python fallback")
+            return self._grep_python(
+                pattern=pattern,
+                search_dir=search_dir,
+                output_mode=output_mode,
+                include=include,
+                ignore_case=ignore_case,
+                context=context,
+                limit=effective_limit,
+                multiline=multiline,
+            )
+        except Exception as e:
+            error_msg = f"Error running grep for '{pattern}': {e}"
+            log_error(error_msg)
+            return error_msg
+
+    def _grep_ripgrep(
+        self,
+        *,
+        rg_path: str,
+        pattern: str,
+        search_dir: Path,
+        output_mode: GrepOutputMode,
+        include: Optional[str],
+        ignore_case: bool,
+        context: int,
+        limit: int,
+        multiline: bool,
+    ) -> str:
+        """Invoke ripgrep and normalize its output into the shared JSON shape."""
+        args: List[str] = [rg_path, "--hidden", "--max-columns", "500"]
+        # Our exclude_patterns are fnmatch-style; ripgrep accepts the same
+        # globbing syntax for --glob, so pass them through directly.
+        for pat in self.exclude_patterns:
+            args.extend(["--glob", f"!{pat}"])
+
+        if ignore_case:
+            args.append("-i")
+        if multiline:
+            args.extend(["-U", "--multiline-dotall"])
+        if include:
+            args.extend(["--glob", include])
+
+        if output_mode == "files_with_matches":
+            args.append("-l")
+        elif output_mode == "count":
+            args.append("-c")
+        else:  # content
+            args.append("-n")
+            if context > 0:
+                args.extend(["-C", str(context)])
+
+        # Use -e so patterns starting with '-' are not treated as flags.
+        args.extend(["-e", pattern, str(search_dir)])
+
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=GREP_RG_TIMEOUT_S,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            return f"Error: ripgrep exceeded {GREP_RG_TIMEOUT_S}s; refine the pattern or narrow the path"
+
+        # ripgrep exit codes: 0 = matches, 1 = no matches, 2+ = error.
+        if completed.returncode >= 2:
+            stderr = completed.stderr.strip() or "ripgrep failed"
+            return f"Error: {stderr}"
+
+        lines = [line for line in completed.stdout.splitlines() if line]
+        truncated = len(lines) > limit
+        lines = lines[:limit]
+
+        if output_mode == "files_with_matches":
+            files = [self._relativize(line) for line in lines]
+            result: Dict[str, Any] = {
+                "pattern": pattern,
+                "mode": output_mode,
+                "matches_found": len(files),
+                "files": files,
+                "truncated": truncated,
+            }
+        elif output_mode == "count":
+            counts: List[dict] = []
+            total = 0
+            for line in lines:
+                file_part, _, num_part = line.rpartition(":")
+                try:
+                    n = int(num_part)
+                except ValueError:
+                    continue
+                counts.append({"file": self._relativize(file_part), "count": n})
+                total += n
+            result = {
+                "pattern": pattern,
+                "mode": output_mode,
+                "matches_found": total,
+                "counts": counts,
+                "truncated": truncated,
+            }
+        else:  # content
+            content_lines: List[dict] = []
+            for line in lines:
+                parts = line.split(":", 2)
+                if len(parts) < 3:
+                    continue
+                file_part, line_no, text = parts
+                try:
+                    n = int(line_no)
+                except ValueError:
+                    continue
+                content_lines.append({"file": self._relativize(file_part), "line": n, "text": text})
+            result = {
+                "pattern": pattern,
+                "mode": output_mode,
+                "matches_found": len(content_lines),
+                "lines": content_lines,
+                "truncated": truncated,
+            }
+
+        return json.dumps(result, indent=2)
+
+    def _grep_python(
+        self,
+        *,
+        pattern: str,
+        search_dir: Path,
+        output_mode: GrepOutputMode,
+        include: Optional[str],
+        ignore_case: bool,
+        context: int,
+        limit: int,
+        multiline: bool,
+    ) -> str:
+        """Pure-Python fallback used when ripgrep is unavailable.
+
+        Slower than ripgrep and uses Python regex syntax, but supports the
+        same output modes so callers don't need to special-case the absence
+        of ``rg``.
+        """
+        flags = 0
+        if ignore_case:
+            flags |= re.IGNORECASE
+        if multiline:
+            flags |= re.DOTALL
+        try:
+            compiled = re.compile(pattern, flags)
+        except re.error as exc:
+            return f"Error: invalid regex {pattern!r}: {exc}"
+
+        per_file_counts: List[Tuple[Path, int]] = []
+        content_hits: List[Dict[str, Any]] = []
+        max_file_size = 1_000_000  # 1MB; mirrors search_content's safety rail
+
+        for file_path in self._iter_candidate_files(search_dir, include):
+            try:
+                if file_path.stat().st_size > max_file_size:
+                    continue
+                text = file_path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+
+            if multiline:
+                hits = list(compiled.finditer(text))
+                if not hits:
+                    continue
+                per_file_counts.append((file_path, len(hits)))
+                if output_mode == "content":
+                    # Precompute newline offsets so every match resolves its
+                    # line number in O(log n) via bisect, instead of re-counting
+                    # the prefix per match (which was O(offset) per hit).
+                    newline_offsets = [i for i, c in enumerate(text) if c == "\n"]
+                    rel = self._relativize(str(file_path))
+                    for match in hits:
+                        line_no = bisect.bisect_right(newline_offsets, match.start()) + 1
+                        snippet = text[match.start() : match.end()].splitlines()[0]
+                        content_hits.append({"file": rel, "line": line_no, "text": snippet})
+            elif output_mode == "count":
+                # Skip the line-by-line loop when we only need a total count.
+                total = len(compiled.findall(text))
+                if total:
+                    per_file_counts.append((file_path, total))
+            else:
+                file_hits = 0
+                rel = self._relativize(str(file_path))
+                for idx, line in enumerate(text.splitlines()):
+                    if compiled.search(line):
+                        file_hits += 1
+                        if output_mode == "content":
+                            content_hits.append({"file": rel, "line": idx + 1, "text": line})
+                if file_hits:
+                    per_file_counts.append((file_path, file_hits))
+
+            if output_mode == "content" and len(content_hits) >= limit:
+                break
+            if output_mode != "content" and len(per_file_counts) >= limit:
+                break
+
+        if output_mode == "files_with_matches":
+            truncated = len(per_file_counts) >= limit
+            files = [self._relativize(str(p)) for p, _ in per_file_counts[:limit]]
+            result: Dict[str, Any] = {
+                "pattern": pattern,
+                "mode": output_mode,
+                "matches_found": len(files),
+                "files": files,
+                "truncated": truncated,
+            }
+        elif output_mode == "count":
+            truncated = len(per_file_counts) >= limit
+            counts = [{"file": self._relativize(str(p)), "count": n} for p, n in per_file_counts[:limit]]
+            result = {
+                "pattern": pattern,
+                "mode": output_mode,
+                "matches_found": sum(n for _, n in per_file_counts[:limit]),
+                "counts": counts,
+                "truncated": truncated,
+            }
+        else:  # content
+            truncated = len(content_hits) >= limit
+            trimmed = content_hits[:limit]
+            # Context lines require re-reading files with surrounding context,
+            # which the ripgrep backend already does natively. Skipping it here
+            # keeps the fallback simple without a silent divergence — the
+            # docstring calls this out.
+            if context > 0:
+                log_debug("grep Python fallback ignores context; install ripgrep for context support")
+            result = {
+                "pattern": pattern,
+                "mode": output_mode,
+                "matches_found": len(trimmed),
+                "lines": trimmed,
+                "truncated": truncated,
+            }
+
+        return json.dumps(result, indent=2)
+
+    def _iter_candidate_files(self, search_dir: Path, include: Optional[str]) -> Iterator[Path]:
+        """Yield files under ``search_dir`` honoring exclude_patterns and include."""
+        for dirpath, dirnames, filenames in os.walk(search_dir):
+            dirnames[:] = [d for d in dirnames if not self._is_excluded(Path(dirpath) / d)]
+            for filename in filenames:
+                file_path = Path(dirpath) / filename
+                if self._is_excluded(file_path):
+                    continue
+                if include is not None:
+                    try:
+                        rel = file_path.relative_to(self.base_dir)
+                    except ValueError:
+                        continue
+                    if not (fnmatch(str(rel), include) or fnmatch(filename, include)):
+                        continue
+                yield file_path
+
+    def _relativize(self, p: str) -> str:
+        """Return ``p`` relative to ``base_dir`` when possible, else as given."""
+        try:
+            return str(Path(p).relative_to(self.base_dir))
+        except ValueError:
+            return p

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -1,6 +1,9 @@
 import json
+import shutil
 import tempfile
 from pathlib import Path
+
+import pytest
 
 from agno.tools.file import FileTools
 
@@ -343,3 +346,171 @@ def test_search_content_honors_exclusions():
         assert result["matches_found"] == 1
         assert "real.py" in file_names
         assert not any(".venv" in f for f in file_names)
+
+
+# -----------------------------------------------------------------------------
+# grep tests
+#
+# grep has two backends: ripgrep (when ``rg`` is on PATH) and a pure-Python
+# fallback. The bulk of these tests force the fallback by monkeypatching
+# ``shutil.which`` so the output is deterministic on any CI box. A small
+# sanity test runs against the real ``rg`` when it is installed.
+# -----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def force_python_grep(monkeypatch):
+    """Make ``shutil.which('rg')`` return None so grep uses the Python fallback."""
+    monkeypatch.setattr("agno.tools.file.shutil.which", lambda _name: None)
+
+
+@pytest.fixture
+def sample_tree():
+    """Small tree of files used by several grep tests."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir)
+        (base / "alpha.py").write_text("def foo():\n    return 1\n# TODO: refactor\n")
+        (base / "beta.py").write_text("def bar():\n    return 2\n")
+        (base / "README.md").write_text("# Project\n\nSome TODO items.\n")
+        sub = base / "pkg"
+        sub.mkdir()
+        (sub / "gamma.py").write_text("class Gamma:\n    pass\n# TODO: document\n")
+        yield base
+
+
+def test_grep_files_with_matches_default(force_python_grep, sample_tree):
+    """files_with_matches returns the list of files containing the pattern."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"TODO"))
+    assert result["mode"] == "files_with_matches"
+    assert result["matches_found"] == 3
+    assert set(result["files"]) == {"alpha.py", "README.md", "pkg/gamma.py"}
+    assert result["truncated"] is False
+
+
+def test_grep_content_mode_returns_line_numbers(force_python_grep, sample_tree):
+    """content mode reports each matching line with its 1-indexed line number."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"def \w+", output_mode="content"))
+    assert result["mode"] == "content"
+    files_found = {hit["file"] for hit in result["lines"]}
+    assert files_found == {"alpha.py", "beta.py"}
+    for hit in result["lines"]:
+        assert hit["line"] == 1
+        assert hit["text"].startswith("def ")
+
+
+def test_grep_count_mode_reports_per_file_counts(force_python_grep, sample_tree):
+    """count mode returns one entry per matching file with a per-file count."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"TODO", output_mode="count"))
+    assert result["mode"] == "count"
+    counts_by_file = {entry["file"]: entry["count"] for entry in result["counts"]}
+    assert counts_by_file == {"alpha.py": 1, "README.md": 1, "pkg/gamma.py": 1}
+    assert result["matches_found"] == 3
+
+
+def test_grep_case_insensitive(force_python_grep, sample_tree):
+    """ignore_case=True makes the regex match regardless of case."""
+    f = FileTools(base_dir=sample_tree)
+    hits = json.loads(f.grep(pattern=r"todo", ignore_case=True))
+    assert hits["matches_found"] == 3
+    no_hits = json.loads(f.grep(pattern=r"todo"))
+    assert no_hits["matches_found"] == 0
+
+
+def test_grep_include_filter(force_python_grep, sample_tree):
+    """include narrows matches to filenames matching the glob pattern."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"TODO", include="*.py"))
+    assert set(result["files"]) == {"alpha.py", "pkg/gamma.py"}
+
+
+def test_grep_limit_truncates(force_python_grep, sample_tree):
+    """limit caps results and marks truncated=True."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"TODO", limit=1))
+    assert len(result["files"]) == 1
+    assert result["truncated"] is True
+
+
+def test_grep_no_matches(force_python_grep, sample_tree):
+    """No matches returns an empty list and matches_found=0."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"NEVER_PRESENT_TOKEN_xyz"))
+    assert result["matches_found"] == 0
+    assert result["files"] == []
+
+
+def test_grep_empty_pattern_errors(force_python_grep, sample_tree):
+    f = FileTools(base_dir=sample_tree)
+    result = f.grep(pattern="   ")
+    assert result.startswith("Error")
+    assert "Pattern" in result
+
+
+def test_grep_invalid_output_mode_errors(force_python_grep, sample_tree):
+    f = FileTools(base_dir=sample_tree)
+    result = f.grep(pattern=r"x", output_mode="nope")
+    assert result.startswith("Error")
+    assert "output_mode" in result
+
+
+def test_grep_invalid_regex_errors(force_python_grep, sample_tree):
+    """A malformed regex produces a clear error, not an exception."""
+    f = FileTools(base_dir=sample_tree)
+    result = f.grep(pattern=r"[unterminated")
+    assert result.startswith("Error")
+    assert "regex" in result.lower()
+
+
+def test_grep_path_escape_rejected(force_python_grep, sample_tree):
+    """path outside base_dir is refused by the safety check."""
+    f = FileTools(base_dir=sample_tree)
+    result = f.grep(pattern=r".", path="../..")
+    assert result.startswith("Error")
+    assert "outside" in result
+
+
+def test_grep_honors_exclude_patterns(force_python_grep, sample_tree):
+    """Default exclusions (e.g. .venv) hide matches from noise directories."""
+    venv_pkg = sample_tree / ".venv" / "lib"
+    venv_pkg.mkdir(parents=True)
+    (venv_pkg / "hidden.py").write_text("# TODO: hidden\n")
+
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"TODO"))
+    assert not any(".venv" in p for p in result["files"])
+
+
+def test_grep_disabled_by_flag():
+    """grep is excluded from the toolkit when enable_grep=False."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        f = FileTools(base_dir=Path(tmp_dir), enable_grep=False)
+        assert "grep" not in f.functions
+
+
+def test_grep_multiline_spans_lines(force_python_grep):
+    """multiline=True lets the pattern match across newline boundaries."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base = Path(tmp_dir)
+        (base / "a.py").write_text("class Foo:\n    def bar(self):\n        return 1\n")
+        f = FileTools(base_dir=base)
+
+        # Without multiline, '.' does not cross lines; this pattern should miss.
+        result_single = json.loads(f.grep(pattern=r"class Foo:.*def bar"))
+        assert result_single["matches_found"] == 0
+
+        # With multiline, DOTALL lets '.' match '\n' and the pattern hits.
+        result_multi = json.loads(f.grep(pattern=r"class Foo:.*def bar", multiline=True))
+        assert result_multi["matches_found"] == 1
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="ripgrep not installed")
+def test_grep_ripgrep_backend_smoke(sample_tree):
+    """When rg is on PATH, grep should produce the same shape of results."""
+    f = FileTools(base_dir=sample_tree)
+    result = json.loads(f.grep(pattern=r"TODO"))
+    assert result["mode"] == "files_with_matches"
+    assert result["matches_found"] == 3
+    assert set(result["files"]) == {"alpha.py", "README.md", "pkg/gamma.py"}


### PR DESCRIPTION
Closes #7645.

## Summary

Adds `grep` to `FileTools` — a regex-capable content search that shells out to ripgrep (`rg`) when the binary is on PATH and falls back to a pure-Python `os.walk` + `re` implementation otherwise. The JSON result shape is identical across backends so callers never need to special-case the absence of ripgrep.

**Why this is useful.** The existing `search_content` does a case-insensitive substring match in pure Python over a hardcoded `TEXT_EXTENSIONS` set. For agents that want full regex, per-line structured output, or acceptable performance on codebases larger than a few thousand files, it doesn't cut it. `grep` closes that gap: regex patterns, three output modes (`files_with_matches` / `content` / `count`), filename filters via `include`, context lines when using ripgrep, ignore-case, multiline matching, and a head limit with a hard cap at 1000 to keep responses from blowing up context.

`search_content` is untouched — `grep` is an additive choice, not a replacement.

### Design decisions worth flagging

- **Parameter naming aligned with `CodingTools.grep`.** Uses `ignore_case`, `include`, `context`, `limit` so users moving between the two toolkits carry consistent vocabulary. `CodingTools.grep` shells to system `grep -rn` and returns plain text; this method shells to `rg` with a structured JSON response per mode — the two coexist the same way `save_file` (FileTools) and `write_file` (CodingTools) already do.
- **`output_mode` as `Literal["files_with_matches", "content", "count"]`.** Follows the agno convention established in `dalle.py`, `exa.py`, `api.py`, `slack.py`, etc. — not a raw `str`.
- **Ripgrep path cached at init.** Resolves `shutil.which("rg")` once in `__init__` instead of on every call, so a 100-call agent session saves ~1s of path lookups.
- **Bisect-based line numbering in multiline Python fallback.** Newline offsets are precomputed per file and matches resolve to 1-indexed lines via `bisect.bisect_right`, which avoids the `text.count("\n", 0, match.start())` per-match quadratic that a naive implementation would have on match-heavy files.
- **Polymorphic JSON shape by `output_mode`.** Three modes produce three semantically distinct payloads (`files`, `lines`, `counts`) because the data shapes are different. The docstring documents all three.
- **Behavioral reference from Claude Code's `GrepTool`.** Output modes, ripgrep flag set (`--hidden`, `--max-columns 500`, `--multiline-dotall`, `-e`), and VCS-exclusion discipline came from studying Claude Code's TypeScript source. No code was copied — TypeScript to Python port, and the implementation is adapted to agno's existing `exclude_patterns`, `check_escape`, and toolkit conventions.

### What the Python fallback does and doesn't do

- **Does**: all three output modes, `include` glob, `ignore_case`, multiline matching, limit truncation, honor `exclude_patterns`.
- **Does not**: context lines. Supporting `-C` in pure Python would require re-reading each matched file with a context buffer. The docstring calls this out; users who need `context` should install `rg`, which the code path will pick up automatically.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Tests

14 new unit tests covering the three output modes, include filter, ignore_case, limit truncation, multiline matching, empty pattern, invalid output mode, invalid regex, path escape, exclude-pattern handling, the disabled flag, and one smoke test that runs against the real `rg` binary when it is installed. A `force_python_grep` fixture monkeypatches `shutil.which` so the bulk of the suite deterministically exercises the Python fallback regardless of what's installed on the CI machine. Total: 33/33 passing (14 grep + 1 ripgrep smoke + 18 existing).

### Related work / non-overlap

- Did not touch `CodingTools.grep`, which has a simpler signature (plain text output, no output_mode, no Python fallback, no multiline) and serves a different audience. The two methods coexist like `FileTools.save_file` and `CodingTools.write_file` already do.
- Builds on #7640 (add `edit_file` to FileTools) conceptually — same intent of making FileTools a self-contained Claude-Code-style toolkit — but has no code dependency. Both PRs touch `file.py` in non-conflicting regions.
- Considered **fff.nvim** (Rust-based grep + fuzzy finder, 5.3k stars) as an alternative backend. Rejected: no Python binding or standalone CLI, requires Neovim as runtime. Could make sense as a future MCP-based cookbook for power users, but is out of scope here.

### Disclosure

This PR was drafted with Claude Code. I reviewed every line, pushed back on the initial design in two rounds of review (dedicated reviewer agents for reuse, quality, and efficiency), and applied follow-up fixes: aligning parameter names with `CodingTools.grep`, switching `output_mode` to `Literal`, caching the ripgrep path at init, and rewriting the multiline line-number resolution to use precomputed newline offsets. The Claude Code TypeScript source was studied as behavioral reference only; no code was copied.
