### PR TITLE
fix: fix 400 INVALID_PARAMETER_VALUE errors

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -68,6 +68,10 @@ class OpenAIChat(Model):
     top_p: Optional[float] = None
     service_tier: Optional[str] = None  # "auto" | "default" | "flex" | "priority", defaults to "auto" when not set
     strict_output: bool = True  # When True, guarantees schema adherence for structured outputs. When False, attempts to follow schema as a guide but may occasionally deviate
+    # Some OpenAI-compatible gateways reject requests that include both
+    # response_format and tools. When True, response_format is omitted
+    # whenever tools are present.
+    omit_response_format_when_tools_present: bool = True
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
     extra_body: Optional[Any] = None
@@ -263,9 +267,26 @@ class OpenAIChat(Model):
         if self.request_params:
             request_params.update(self.request_params)
 
+        self._omit_response_format_when_tools_present(request_params)
+
         if request_params:
             log_debug(f"Calling {self.provider} with request parameters: {request_params}", log_level=2)
         return request_params
+
+    def _omit_response_format_when_tools_present(self, request_params: Dict[str, Any]) -> None:
+        if not self.omit_response_format_when_tools_present:
+            return
+        if "response_format" not in request_params:
+            return
+        if not request_params.get("tools"):
+            return
+
+        request_params.pop("response_format", None)
+        log_debug(
+            "Omitting response_format because tools are present. "
+            "Set omit_response_format_when_tools_present=False to send both fields.",
+            log_level=2,
+        )
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -298,6 +319,7 @@ class OpenAIChat(Model):
                 "extra_query": self.extra_query,
                 "extra_body": self.extra_body,
                 "service_tier": self.service_tier,
+                "omit_response_format_when_tools_present": self.omit_response_format_when_tools_present,
             }
         )
         cleaned_dict = {k: v for k, v in model_dict.items() if v is not None}

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -70,8 +70,8 @@ class OpenAIChat(Model):
     strict_output: bool = True  # When True, guarantees schema adherence for structured outputs. When False, attempts to follow schema as a guide but may occasionally deviate
     # Some OpenAI-compatible gateways reject requests that include both
     # response_format and tools. When True, response_format is omitted
-    # whenever tools are present.
-    omit_response_format_when_tools_present: bool = True
+    # whenever tools are present (opt in; most providers accept both).
+    omit_response_format_when_tools_present: bool = False
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
     extra_body: Optional[Any] = None

--- a/libs/agno/tests/unit/models/openai/test_openai_chat_response_format_tools_conflict.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_chat_response_format_tools_conflict.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel
+
+from agno.models.openai.chat import OpenAIChat
+from agno.models.openai.like import OpenAILike
+
+
+class OutputSchema(BaseModel):
+    confidence: float
+
+
+TOOLS = [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}}}]
+
+
+def test_chat_omits_response_format_when_tools_present_by_default():
+    model = OpenAIChat(id="gpt-4.1")
+    request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
+
+    assert "tools" in request_params
+    assert "response_format" not in request_params
+
+
+def test_chat_keeps_response_format_when_omit_flag_disabled():
+    model = OpenAIChat(id="gpt-4.1", omit_response_format_when_tools_present=False)
+    request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
+
+    assert "tools" in request_params
+    assert "response_format" in request_params
+
+
+def test_openailike_omits_response_format_when_tools_present():
+    model = OpenAILike(id="claude-sonnet-4-5")
+    request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
+
+    assert "tools" in request_params
+    assert "response_format" not in request_params

--- a/libs/agno/tests/unit/models/openai/test_openai_chat_response_format_tools_conflict.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_chat_response_format_tools_conflict.py
@@ -11,24 +11,24 @@ class OutputSchema(BaseModel):
 TOOLS = [{"type": "function", "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}}}]
 
 
-def test_chat_omits_response_format_when_tools_present_by_default():
+def test_chat_keeps_response_format_when_tools_present_by_default():
     model = OpenAIChat(id="gpt-4.1")
-    request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
-
-    assert "tools" in request_params
-    assert "response_format" not in request_params
-
-
-def test_chat_keeps_response_format_when_omit_flag_disabled():
-    model = OpenAIChat(id="gpt-4.1", omit_response_format_when_tools_present=False)
     request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
 
     assert "tools" in request_params
     assert "response_format" in request_params
 
 
-def test_openailike_omits_response_format_when_tools_present():
-    model = OpenAILike(id="claude-sonnet-4-5")
+def test_chat_omits_response_format_when_tools_present_opt_in():
+    model = OpenAIChat(id="gpt-4.1", omit_response_format_when_tools_present=True)
+    request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
+
+    assert "tools" in request_params
+    assert "response_format" not in request_params
+
+
+def test_openailike_omits_response_format_when_tools_present_opt_in():
+    model = OpenAILike(id="claude-sonnet-4-5", omit_response_format_when_tools_present=True)
     request_params = model.get_request_params(response_format=OutputSchema, tools=TOOLS)
 
     assert "tools" in request_params


### PR DESCRIPTION
**Summary**
This PR fixes 400 INVALID_PARAMETER_VALUE errors from OpenAI-compatible chat endpoints that reject requests containing both response_format and tools (observed with Databricks + OpenAILike + reasoning=True).

**Context**
In the current reasoning/structured-output flow, OpenAIChat.get_request_params() may emit both:

- response_format (structured output),
- tools (function/tool calling).

Some providers reject this combination even though the schema is otherwise OpenAI-compatible.

**Change**
In OpenAIChat (and therefore OpenAILike), add:

- omit_response_format_when_tools_present: bool = True (new model param)

Request-param behavior:

- If tools is non-empty and response_format exists, remove response_format before sending.
- Log a debug message indicating the omission.
- Add the new flag to to_dict() serialization.

**Compatibility Rationale**
Defaulting to omit avoids hard request failures on strict providers and restores functional tool execution for affected users. Providers that support sending both fields can opt out:

omit_response_format_when_tools_present=False

**Tradeoff / Behavioral Note**
With the default enabled, tool-enabled turns no longer request provider-enforced structured output.
This is a deliberate compatibility tradeoff to prevent invalid requests.

**Tests Added**
Unit tests cover:

1. OpenAIChat default omission when tools are present.
2. OpenAIChat opt-out preserving response_format.
3. OpenAILike inheriting omission behavior.

**Release Note (suggested)**

- **Fixed:** OpenAILike / OpenAIChat now avoid sending response_format with tools by default to support strict OpenAI-compatible gateways (e.g. Databricks) that reject this combination.
- **Added:** omit_response_format_when_tools_present option (default True) to re-enable combined behavior on providers that support it.

**Future Follow-up (optional)**
If stricter schema guarantees are needed with tool use across all providers, consider a two-phase orchestration strategy (tool turns without structured response format, final no-tool turn with structured output).

fixes #7612

## Type of change

- [*] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
