### PR TITLE
fix: keep streaming active with output_schema + parse_response

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -64,6 +64,7 @@ from agno.utils.reasoning import (
     update_run_output_with_reasoning,
 )
 from agno.utils.string import parse_response_dict_str, parse_response_model_str
+from agno.utils.structured_output import finalize_streamed_structured_output
 
 ###########################################################################
 # Reasoning
@@ -956,35 +957,6 @@ def convert_response_to_structured_format(
                 log_warning("Something went wrong. Run response content is not a string")
 
 
-def _finalize_streamed_structured_output(
-    agent: Agent,
-    run_response: RunOutput,
-    model_response: ModelResponse,
-    output_schema: Optional[Union[Type[BaseModel], Dict]],
-    should_parse_structured_output: bool,
-    stream_events: bool,
-    run_context: Optional[RunContext] = None,
-) -> Iterator[RunOutputEvent]:
-    if not should_parse_structured_output or model_response.content is None:
-        return
-
-    convert_response_to_structured_format(agent, model_response, run_context=run_context)
-    content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
-    run_response.content = model_response.content
-    run_response.content_type = content_type
-    if stream_events:
-        yield handle_event(  # type: ignore
-            create_run_output_content_event(
-                from_run_response=run_response,
-                content=run_response.content,
-                content_type=content_type,
-            ),
-            run_response,
-            events_to_skip=agent.events_to_skip,  # type: ignore
-            store_events=agent.store_events,
-        )
-
-
 # ---------------------------------------------------------------------------
 # Run response update
 # ---------------------------------------------------------------------------
@@ -1181,14 +1153,25 @@ def handle_model_response_stream(
             run_context=run_context,
         )
 
-    yield from _finalize_streamed_structured_output(
-        agent=agent,
-        run_response=run_response,
-        model_response=model_response,
+    yield from finalize_streamed_structured_output(
+        content_getter=lambda: model_response.content,
         output_schema=output_schema,
         should_parse_structured_output=should_parse_structured_output,
+        convert_fn=lambda: convert_response_to_structured_format(agent, model_response, run_context=run_context),
+        set_content_fn=lambda content: setattr(run_response, "content", content),
+        set_content_type_fn=lambda ct: setattr(run_response, "content_type", ct),
         stream_events=stream_events,
-        run_context=run_context,
+        build_event_fn=lambda content, ct: create_run_output_content_event(
+            from_run_response=run_response,
+            content=content,
+            content_type=ct,
+        ),
+        emit_fn=lambda payload: handle_event(  # type: ignore
+            payload,
+            run_response,
+            events_to_skip=agent.events_to_skip,  # type: ignore
+            store_events=agent.store_events,
+        ),
     )
 
     # Update RunOutput
@@ -1344,14 +1327,25 @@ async def ahandle_model_response_stream(
         ):
             yield event
 
-    for event in _finalize_streamed_structured_output(
-        agent=agent,
-        run_response=run_response,
-        model_response=model_response,
+    for event in finalize_streamed_structured_output(
+        content_getter=lambda: model_response.content,
         output_schema=output_schema,
         should_parse_structured_output=should_parse_structured_output,
+        convert_fn=lambda: convert_response_to_structured_format(agent, model_response, run_context=run_context),
+        set_content_fn=lambda content: setattr(run_response, "content", content),
+        set_content_type_fn=lambda ct: setattr(run_response, "content_type", ct),
         stream_events=stream_events,
-        run_context=run_context,
+        build_event_fn=lambda content, ct: create_run_output_content_event(
+            from_run_response=run_response,
+            content=content,
+            content_type=ct,
+        ),
+        emit_fn=lambda payload: handle_event(  # type: ignore
+            payload,
+            run_response,
+            events_to_skip=agent.events_to_skip,  # type: ignore
+            store_events=agent.store_events,
+        ),
     ):
         yield event
 

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1058,10 +1058,9 @@ def handle_model_response_stream(
     output_schema = run_context.output_schema if run_context else None
     should_parse_structured_output = output_schema is not None and agent.parse_response and agent.parser_model is None
 
+    # Keep model-level streaming enabled even when parse_response=True so that
+    # long-running responses still emit incremental output.
     stream_model_response = True
-    if should_parse_structured_output:
-        log_debug("Response model set, model response is not streamed.")
-        stream_model_response = False
 
     for model_response_event in call_model_stream_with_fallback(
         agent.model,
@@ -1147,11 +1146,29 @@ def handle_model_response_stream(
             model_response=model_response,
             model_response_event=model_response_event,
             reasoning_state=reasoning_state,
-            parse_structured_output=should_parse_structured_output,
+            parse_structured_output=False,
             stream_events=stream_events,
             session_state=session_state,
             run_context=run_context,
         )
+
+    # Parse final accumulated content once streaming completes.
+    if should_parse_structured_output and model_response.content is not None:
+        convert_response_to_structured_format(agent, model_response, run_context=run_context)
+        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
+        run_response.content = model_response.content
+        run_response.content_type = content_type
+        if stream_events:
+            yield handle_event(  # type: ignore
+                create_run_output_content_event(
+                    from_run_response=run_response,
+                    content=run_response.content,
+                    content_type=content_type,
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,  # type: ignore
+                store_events=agent.store_events,
+            )
 
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput
@@ -1209,10 +1226,9 @@ async def ahandle_model_response_stream(
     output_schema = run_context.output_schema if run_context else None
     should_parse_structured_output = output_schema is not None and agent.parse_response and agent.parser_model is None
 
+    # Keep model-level streaming enabled even when parse_response=True so that
+    # long-running responses still emit incremental output.
     stream_model_response = True
-    if should_parse_structured_output:
-        log_debug("Response model set, model response is not streamed.")
-        stream_model_response = False
 
     model_response_stream = acall_model_stream_with_fallback(
         agent.model,
@@ -1300,12 +1316,30 @@ async def ahandle_model_response_stream(
             model_response=model_response,
             model_response_event=model_response_event,
             reasoning_state=reasoning_state,
-            parse_structured_output=should_parse_structured_output,
+            parse_structured_output=False,
             stream_events=stream_events,
             session_state=session_state,
             run_context=run_context,
         ):
             yield event
+
+    # Parse final accumulated content once streaming completes.
+    if should_parse_structured_output and model_response.content is not None:
+        convert_response_to_structured_format(agent, model_response, run_context=run_context)
+        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
+        run_response.content = model_response.content
+        run_response.content_type = content_type
+        if stream_events:
+            yield handle_event(  # type: ignore
+                create_run_output_content_event(
+                    from_run_response=run_response,
+                    content=run_response.content,
+                    content_type=content_type,
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,  # type: ignore
+                store_events=agent.store_events,
+            )
 
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -956,6 +956,35 @@ def convert_response_to_structured_format(
                 log_warning("Something went wrong. Run response content is not a string")
 
 
+def _finalize_streamed_structured_output(
+    agent: Agent,
+    run_response: RunOutput,
+    model_response: ModelResponse,
+    output_schema: Optional[Union[Type[BaseModel], Dict]],
+    should_parse_structured_output: bool,
+    stream_events: bool,
+    run_context: Optional[RunContext] = None,
+) -> Iterator[RunOutputEvent]:
+    if not should_parse_structured_output or model_response.content is None:
+        return
+
+    convert_response_to_structured_format(agent, model_response, run_context=run_context)
+    content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
+    run_response.content = model_response.content
+    run_response.content_type = content_type
+    if stream_events:
+        yield handle_event(  # type: ignore
+            create_run_output_content_event(
+                from_run_response=run_response,
+                content=run_response.content,
+                content_type=content_type,
+            ),
+            run_response,
+            events_to_skip=agent.events_to_skip,  # type: ignore
+            store_events=agent.store_events,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Run response update
 # ---------------------------------------------------------------------------
@@ -1152,23 +1181,15 @@ def handle_model_response_stream(
             run_context=run_context,
         )
 
-    # Parse final accumulated content once streaming completes.
-    if should_parse_structured_output and model_response.content is not None:
-        convert_response_to_structured_format(agent, model_response, run_context=run_context)
-        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
-        run_response.content = model_response.content
-        run_response.content_type = content_type
-        if stream_events:
-            yield handle_event(  # type: ignore
-                create_run_output_content_event(
-                    from_run_response=run_response,
-                    content=run_response.content,
-                    content_type=content_type,
-                ),
-                run_response,
-                events_to_skip=agent.events_to_skip,  # type: ignore
-                store_events=agent.store_events,
-            )
+    yield from _finalize_streamed_structured_output(
+        agent=agent,
+        run_response=run_response,
+        model_response=model_response,
+        output_schema=output_schema,
+        should_parse_structured_output=should_parse_structured_output,
+        stream_events=stream_events,
+        run_context=run_context,
+    )
 
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput
@@ -1323,23 +1344,16 @@ async def ahandle_model_response_stream(
         ):
             yield event
 
-    # Parse final accumulated content once streaming completes.
-    if should_parse_structured_output and model_response.content is not None:
-        convert_response_to_structured_format(agent, model_response, run_context=run_context)
-        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
-        run_response.content = model_response.content
-        run_response.content_type = content_type
-        if stream_events:
-            yield handle_event(  # type: ignore
-                create_run_output_content_event(
-                    from_run_response=run_response,
-                    content=run_response.content,
-                    content_type=content_type,
-                ),
-                run_response,
-                events_to_skip=agent.events_to_skip,  # type: ignore
-                store_events=agent.store_events,
-            )
+    for event in _finalize_streamed_structured_output(
+        agent=agent,
+        run_response=run_response,
+        model_response=model_response,
+        output_schema=output_schema,
+        should_parse_structured_output=should_parse_structured_output,
+        stream_events=stream_events,
+        run_context=run_context,
+    ):
+        yield event
 
     # Update RunOutput
     # Build a list of messages that should be added to the RunOutput

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1035,22 +1035,15 @@ def _handle_model_response_stream(
             run_context=run_context,
         )
 
-    # Parse final accumulated content once streaming completes.
-    if should_parse_structured_output and full_model_response.content is not None:
-        _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
-        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
-        run_response.content_type = content_type
-        if stream_events:
-            yield handle_event(  # type: ignore
-                create_team_run_output_content_event(
-                    from_run_response=run_response,
-                    content=full_model_response.content,
-                    content_type=content_type,
-                ),
-                run_response,
-                events_to_skip=team.events_to_skip,
-                store_events=team.store_events,
-            )
+    yield from _finalize_streamed_structured_output(
+        team=team,
+        run_response=run_response,
+        full_model_response=full_model_response,
+        output_schema=output_schema,
+        should_parse_structured_output=should_parse_structured_output,
+        stream_events=stream_events,
+        run_context=run_context,
+    )
 
     # 3. Update TeamRunOutput
     if full_model_response.content is not None:
@@ -1207,22 +1200,16 @@ async def _ahandle_model_response_stream(
         ):
             yield event
 
-    # Parse final accumulated content once streaming completes.
-    if should_parse_structured_output and full_model_response.content is not None:
-        _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
-        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
-        run_response.content_type = content_type
-        if stream_events:
-            yield handle_event(  # type: ignore
-                create_team_run_output_content_event(
-                    from_run_response=run_response,
-                    content=full_model_response.content,
-                    content_type=content_type,
-                ),
-                run_response,
-                events_to_skip=team.events_to_skip,
-                store_events=team.store_events,
-            )
+    for event in _finalize_streamed_structured_output(
+        team=team,
+        run_response=run_response,
+        full_model_response=full_model_response,
+        output_schema=output_schema,
+        should_parse_structured_output=should_parse_structured_output,
+        stream_events=stream_events,
+        run_context=run_context,
+    ):
+        yield event
 
     # Update TeamRunOutput
     if full_model_response.content is not None:
@@ -1596,6 +1583,34 @@ def _handle_model_response_chunk(
 # ---------------------------------------------------------------------------
 # Structured format conversion (moved from _hooks.py)
 # ---------------------------------------------------------------------------
+
+
+def _finalize_streamed_structured_output(
+    team: Team,
+    run_response: TeamRunOutput,
+    full_model_response: ModelResponse,
+    output_schema: Optional[Union[Type[BaseModel], Dict]],
+    should_parse_structured_output: bool,
+    stream_events: bool,
+    run_context: Optional[RunContext] = None,
+) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent]]:
+    if not should_parse_structured_output or full_model_response.content is None:
+        return
+
+    _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
+    content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
+    run_response.content_type = content_type
+    if stream_events:
+        yield handle_event(  # type: ignore
+            create_team_run_output_content_event(
+                from_run_response=run_response,
+                content=full_model_response.content,
+                content_type=content_type,
+            ),
+            run_response,
+            events_to_skip=team.events_to_skip,
+            store_events=team.store_events,
+        )
 
 
 def _convert_response_to_structured_format(

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -65,6 +65,7 @@ from agno.utils.reasoning import (
     update_run_output_with_reasoning,
 )
 from agno.utils.string import parse_response_dict_str, parse_response_model_str
+from agno.utils.structured_output import finalize_streamed_structured_output
 
 if TYPE_CHECKING:
     from agno.reasoning.manager import ReasoningEvent
@@ -1035,14 +1036,24 @@ def _handle_model_response_stream(
             run_context=run_context,
         )
 
-    yield from _finalize_streamed_structured_output(
-        team=team,
-        run_response=run_response,
-        full_model_response=full_model_response,
+    yield from finalize_streamed_structured_output(
+        content_getter=lambda: full_model_response.content,
         output_schema=output_schema,
         should_parse_structured_output=should_parse_structured_output,
+        convert_fn=lambda: _convert_response_to_structured_format(team, full_model_response, run_context=run_context),
+        set_content_type_fn=lambda ct: setattr(run_response, "content_type", ct),
         stream_events=stream_events,
-        run_context=run_context,
+        build_event_fn=lambda content, ct: create_team_run_output_content_event(
+            from_run_response=run_response,
+            content=content,
+            content_type=ct,
+        ),
+        emit_fn=lambda payload: handle_event(  # type: ignore
+            payload,
+            run_response,
+            events_to_skip=team.events_to_skip,
+            store_events=team.store_events,
+        ),
     )
 
     # 3. Update TeamRunOutput
@@ -1200,14 +1211,24 @@ async def _ahandle_model_response_stream(
         ):
             yield event
 
-    for event in _finalize_streamed_structured_output(
-        team=team,
-        run_response=run_response,
-        full_model_response=full_model_response,
+    for event in finalize_streamed_structured_output(
+        content_getter=lambda: full_model_response.content,
         output_schema=output_schema,
         should_parse_structured_output=should_parse_structured_output,
+        convert_fn=lambda: _convert_response_to_structured_format(team, full_model_response, run_context=run_context),
+        set_content_type_fn=lambda ct: setattr(run_response, "content_type", ct),
         stream_events=stream_events,
-        run_context=run_context,
+        build_event_fn=lambda content, ct: create_team_run_output_content_event(
+            from_run_response=run_response,
+            content=content,
+            content_type=ct,
+        ),
+        emit_fn=lambda payload: handle_event(  # type: ignore
+            payload,
+            run_response,
+            events_to_skip=team.events_to_skip,
+            store_events=team.store_events,
+        ),
     ):
         yield event
 
@@ -1583,34 +1604,6 @@ def _handle_model_response_chunk(
 # ---------------------------------------------------------------------------
 # Structured format conversion (moved from _hooks.py)
 # ---------------------------------------------------------------------------
-
-
-def _finalize_streamed_structured_output(
-    team: Team,
-    run_response: TeamRunOutput,
-    full_model_response: ModelResponse,
-    output_schema: Optional[Union[Type[BaseModel], Dict]],
-    should_parse_structured_output: bool,
-    stream_events: bool,
-    run_context: Optional[RunContext] = None,
-) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent]]:
-    if not should_parse_structured_output or full_model_response.content is None:
-        return
-
-    _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
-    content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
-    run_response.content_type = content_type
-    if stream_events:
-        yield handle_event(  # type: ignore
-            create_team_run_output_content_event(
-                from_run_response=run_response,
-                content=full_model_response.content,
-                content_type=content_type,
-            ),
-            run_response,
-            events_to_skip=team.events_to_skip,
-            store_events=team.store_events,
-        )
 
 
 def _convert_response_to_structured_format(

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -940,10 +940,9 @@ def _handle_model_response_stream(
     output_schema = run_context.output_schema if run_context else None
     should_parse_structured_output = output_schema is not None and team.parse_response and team.parser_model is None
 
+    # Keep model-level streaming enabled even when parse_response=True so that
+    # long-running responses still emit incremental output.
     stream_model_response = True
-    if should_parse_structured_output:
-        log_debug("Response model set, model response is not streamed.")
-        stream_model_response = False
 
     full_model_response = ModelResponse()
     for model_response_event in call_model_stream_with_fallback(
@@ -1031,10 +1030,27 @@ def _handle_model_response_stream(
             model_response_event=model_response_event,
             reasoning_state=reasoning_state,
             stream_events=stream_events,
-            parse_structured_output=should_parse_structured_output,
+            parse_structured_output=False,
             session_state=session_state,
             run_context=run_context,
         )
+
+    # Parse final accumulated content once streaming completes.
+    if should_parse_structured_output and full_model_response.content is not None:
+        _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
+        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
+        run_response.content_type = content_type
+        if stream_events:
+            yield handle_event(  # type: ignore
+                create_team_run_output_content_event(
+                    from_run_response=run_response,
+                    content=full_model_response.content,
+                    content_type=content_type,
+                ),
+                run_response,
+                events_to_skip=team.events_to_skip,
+                store_events=team.store_events,
+            )
 
     # 3. Update TeamRunOutput
     if full_model_response.content is not None:
@@ -1094,10 +1110,9 @@ async def _ahandle_model_response_stream(
     output_schema = run_context.output_schema if run_context else None
     should_parse_structured_output = output_schema is not None and team.parse_response and team.parser_model is None
 
+    # Keep model-level streaming enabled even when parse_response=True so that
+    # long-running responses still emit incremental output.
     stream_model_response = True
-    if should_parse_structured_output:
-        log_debug("Response model set, model response is not streamed.")
-        stream_model_response = False
 
     full_model_response = ModelResponse()
     model_stream = acall_model_stream_with_fallback(
@@ -1186,11 +1201,28 @@ async def _ahandle_model_response_stream(
             model_response_event=model_response_event,
             reasoning_state=reasoning_state,
             stream_events=stream_events,
-            parse_structured_output=should_parse_structured_output,
+            parse_structured_output=False,
             session_state=session_state,
             run_context=run_context,
         ):
             yield event
+
+    # Parse final accumulated content once streaming completes.
+    if should_parse_structured_output and full_model_response.content is not None:
+        _convert_response_to_structured_format(team, full_model_response, run_context=run_context)
+        content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__  # type: ignore
+        run_response.content_type = content_type
+        if stream_events:
+            yield handle_event(  # type: ignore
+                create_team_run_output_content_event(
+                    from_run_response=run_response,
+                    content=full_model_response.content,
+                    content_type=content_type,
+                ),
+                run_response,
+                events_to_skip=team.events_to_skip,
+                store_events=team.store_events,
+            )
 
     # Update TeamRunOutput
     if full_model_response.content is not None:

--- a/libs/agno/agno/utils/structured_output.py
+++ b/libs/agno/agno/utils/structured_output.py
@@ -1,0 +1,34 @@
+from typing import Any, Callable, Dict, Iterator, Optional, Type, Union
+
+from pydantic import BaseModel
+
+
+def finalize_streamed_structured_output(
+    *,
+    content_getter: Callable[[], Any],
+    output_schema: Optional[Union[Type[BaseModel], Dict]],
+    should_parse_structured_output: bool,
+    convert_fn: Callable[[], None],
+    set_content_fn: Optional[Callable[[Any], None]] = None,
+    set_content_type_fn: Optional[Callable[[str], None]] = None,
+    stream_events: bool = False,
+    build_event_fn: Optional[Callable[[Any, str], Any]] = None,
+    emit_fn: Optional[Callable[[Any], Any]] = None,
+) -> Iterator[Any]:
+    """Finalize streamed structured output and optionally yield one emitted event."""
+    content = content_getter()
+    if not should_parse_structured_output or content is None or output_schema is None:
+        return
+
+    convert_fn()
+    parsed_content = content_getter()
+    content_type = "dict" if isinstance(output_schema, dict) else output_schema.__name__
+
+    if set_content_fn is not None:
+        set_content_fn(parsed_content)
+    if set_content_type_fn is not None:
+        set_content_type_fn(content_type)
+
+    if stream_events and build_event_fn is not None and emit_fn is not None:
+        event_payload = build_event_fn(parsed_content, content_type)
+        yield emit_fn(event_payload)

--- a/libs/agno/tests/unit/agent/test_streaming_output_schema_parse_response.py
+++ b/libs/agno/tests/unit/agent/test_streaming_output_schema_parse_response.py
@@ -1,0 +1,104 @@
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunCompletedEvent, RunContentEvent
+
+
+class ItemsSchema(BaseModel):
+    items: list[str]
+
+
+class MockStreamingSchemaModel(Model):
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.invoke_calls = 0
+        self.invoke_stream_calls = 0
+        self.ainvoke_calls = 0
+        self.ainvoke_stream_calls = 0
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        self.invoke_calls += 1
+        return ModelResponse(content='{"items":["a","b"]}', role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        self.ainvoke_calls += 1
+        return ModelResponse(content='{"items":["a","b"]}', role="assistant", response_usage=MessageMetrics())
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        self.invoke_stream_calls += 1
+        yield ModelResponse(content='{"items":["a",', role="assistant")
+        yield ModelResponse(content='"b"]}', role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        self.ainvoke_stream_calls += 1
+        yield ModelResponse(content='{"items":["a",', role="assistant")
+        yield ModelResponse(content='"b"]}', role="assistant", response_usage=MessageMetrics())
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return ModelResponse(content='{"items":["a","b"]}', role="assistant", response_usage=MessageMetrics())
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse(content=response.content, role="assistant")
+
+
+def test_streaming_remains_enabled_with_output_schema_and_parse_response():
+    model = MockStreamingSchemaModel()
+    agent = Agent(model=model, output_schema=ItemsSchema, parse_response=True)
+
+    content_events = 0
+    completed_event = None
+    for event in agent.run("Return items", stream=True, stream_events=True):
+        if isinstance(event, RunContentEvent) and isinstance(event.content, str):
+            content_events += 1
+        if isinstance(event, RunCompletedEvent):
+            completed_event = event
+
+    assert model.invoke_stream_calls > 0
+    assert model.invoke_calls == 0
+    assert content_events > 0
+    assert completed_event is not None
+    assert isinstance(completed_event.content, ItemsSchema)
+    assert completed_event.content.items == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_remains_enabled_with_output_schema_and_parse_response():
+    model = MockStreamingSchemaModel()
+    agent = Agent(model=model, output_schema=ItemsSchema, parse_response=True)
+
+    content_events = 0
+    completed_event = None
+    async for event in agent.arun("Return items", stream=True, stream_events=True):
+        if isinstance(event, RunContentEvent) and isinstance(event.content, str):
+            content_events += 1
+        if isinstance(event, RunCompletedEvent):
+            completed_event = event
+
+    assert model.ainvoke_stream_calls > 0
+    assert model.ainvoke_calls == 0
+    assert content_events > 0
+    assert completed_event is not None
+    assert isinstance(completed_event.content, ItemsSchema)
+    assert completed_event.content.items == ["a", "b"]

--- a/libs/agno/tests/unit/team/test_streaming_output_schema_parse_response.py
+++ b/libs/agno/tests/unit/team/test_streaming_output_schema_parse_response.py
@@ -1,0 +1,104 @@
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.team import RunCompletedEvent, RunContentEvent
+from agno.team.team import Team
+
+
+class ItemsSchema(BaseModel):
+    items: list[str]
+
+
+class MockStreamingSchemaModel(Model):
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.invoke_calls = 0
+        self.invoke_stream_calls = 0
+        self.ainvoke_calls = 0
+        self.ainvoke_stream_calls = 0
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        self.invoke_calls += 1
+        return ModelResponse(content='{"items":["a","b"]}', role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        self.ainvoke_calls += 1
+        return ModelResponse(content='{"items":["a","b"]}', role="assistant", response_usage=MessageMetrics())
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        self.invoke_stream_calls += 1
+        yield ModelResponse(content='{"items":["a",', role="assistant")
+        yield ModelResponse(content='"b"]}', role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        self.ainvoke_stream_calls += 1
+        yield ModelResponse(content='{"items":["a",', role="assistant")
+        yield ModelResponse(content='"b"]}', role="assistant", response_usage=MessageMetrics())
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return ModelResponse(content='{"items":["a","b"]}', role="assistant", response_usage=MessageMetrics())
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse(content=response.content, role="assistant")
+
+
+def test_team_streaming_remains_enabled_with_output_schema_and_parse_response():
+    model = MockStreamingSchemaModel()
+    team = Team(model=model, members=[], output_schema=ItemsSchema, parse_response=True)
+
+    content_events = 0
+    completed_event = None
+    for event in team.run("Return items", stream=True, stream_events=True):
+        if isinstance(event, RunContentEvent) and isinstance(event.content, str):
+            content_events += 1
+        if isinstance(event, RunCompletedEvent):
+            completed_event = event
+
+    assert model.invoke_stream_calls > 0
+    assert model.invoke_calls == 0
+    assert content_events > 0
+    assert completed_event is not None
+    assert isinstance(completed_event.content, ItemsSchema)
+    assert completed_event.content.items == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_team_async_streaming_remains_enabled_with_output_schema_and_parse_response():
+    model = MockStreamingSchemaModel()
+    team = Team(model=model, members=[], output_schema=ItemsSchema, parse_response=True)
+
+    content_events = 0
+    completed_event = None
+    async for event in team.arun("Return items", stream=True, stream_events=True):
+        if isinstance(event, RunContentEvent) and isinstance(event.content, str):
+            content_events += 1
+        if isinstance(event, RunCompletedEvent):
+            completed_event = event
+
+    assert model.ainvoke_stream_calls > 0
+    assert model.ainvoke_calls == 0
+    assert content_events > 0
+    assert completed_event is not None
+    assert isinstance(completed_event.content, ItemsSchema)
+    assert completed_event.content.items == ["a", "b"]


### PR DESCRIPTION
**Summary**
Fixes a streaming regression where output_schema + parse_response=True could disable effective streaming in Agent/Team runs.

When stream=True, the previous logic switched model calls to non-streaming whenever structured parsing was enabled, causing long idle periods and increasing risk of gateway/proxy timeouts (e.g. 504 via Nginx/Cloudflare/LB).

**Root Cause**
In streaming handlers, Agno computed should_parse_structured_output and then set stream_model_response=False, which routed execution through a non-streaming model path despite stream=True.

Affected codepaths:

- Agent streaming response handlers
- Team streaming response handlers

**Fix**
For both Agent and Team streaming handlers:

- Keep provider/model streaming enabled (stream_model_response=True) even when:

   - output_schema is set,
   - parse_response=True,
   - parser_model is None. 

- Avoid per-chunk structured parsing.
- Parse the accumulated final content once at end-of-stream.
- Preserve final typed output (run_response.content + content_type).
- Emit final structured content event when stream_events=True.

**Why this is correct**

- Maintains continuous incremental output during long generations.
- Prevents “streaming turns silent” behavior that leads to idle timeout failures.
- Preserves schema-typed final output expected by output_schema.

**Tests**
Added regression tests for both sync and async:

- libs/agno/tests/unit/agent/test_streaming_output_schema_parse_response.py
- libs/agno/tests/unit/team/test_streaming_output_schema_parse_response.py

Coverage verifies:

- streaming path is used (invoke_stream/ainvoke_stream, not non-stream invoke/ainvoke),
- intermediate content events are emitted during generation,
- final completed output is parsed into the configured Pydantic schema.

**Validation**

- New regression tests pass.
- Ruff format/check passes on touched files.

**Release Note Entry**

- **Fixed:** Streaming no longer degrades to non-streaming when using output_schema with parse_response=True in Agent and Team runs.
- **Behavior:** stream=True now keeps underlying model streaming active while still parsing structured output at end-of-stream.
- **Impact:** Improves reliability for long-running responses behind gateways/proxies by preserving incremental output and reducing idle timeout risk.

(If applicable, issue number: #7652)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
