### PR TITLE
fix: populate session_state on TeamRunCompletedEvent

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -863,6 +863,11 @@ def _run_tasks_stream(
 
         raise_if_cancelled(run_response.run_id)  # type: ignore
 
+        # Ensure the streamed RunCompletedEvent carries the final session_state
+        # after all tool / member modifications (mirrors the agent populator).
+        if run_context is not None and run_context.session_state is not None:
+            run_response.session_state = run_context.session_state
+
         # Create the run completed event
         completed_event = handle_event(
             create_team_run_completed_event(from_run_response=run_response),
@@ -1636,6 +1641,11 @@ def _run_stream(
                         )
 
                 raise_if_cancelled(run_response.run_id)  # type: ignore
+                # Ensure the streamed RunCompletedEvent carries the final session_state
+                # after all tool / member modifications (mirrors the agent populator).
+                if run_context is not None and run_context.session_state is not None:
+                    run_response.session_state = run_context.session_state
+
                 # Create the run completed event
                 completed_event = handle_event(
                     create_team_run_completed_event(
@@ -2681,6 +2691,11 @@ async def _arun_tasks_stream(
                 )
 
         await araise_if_cancelled(run_response.run_id)  # type: ignore
+
+        # Ensure the streamed RunCompletedEvent carries the final session_state
+        # after all tool / member modifications (mirrors the agent populator).
+        if run_context is not None and run_context.session_state is not None:
+            run_response.session_state = run_context.session_state
 
         # Create the run completed event
         completed_event = handle_event(
@@ -3743,6 +3758,11 @@ async def _arun_stream(
                         )
 
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
+
+                # Ensure the streamed RunCompletedEvent carries the final session_state
+                # after all tool / member modifications (mirrors the agent populator).
+                if run_context is not None and run_context.session_state is not None:
+                    run_response.session_state = run_context.session_state
 
                 # Create the run completed event
                 completed_event = handle_event(
@@ -6221,6 +6241,11 @@ def _continue_run_stream(
                             store_events=team.store_events,
                         )
 
+                # Ensure the streamed RunCompletedEvent carries the final session_state
+                # after all tool / member modifications (mirrors the agent populator).
+                if run_context is not None and run_context.session_state is not None:
+                    run_response.session_state = run_context.session_state
+
                 # Completed event
                 completed_event = handle_event(
                     create_team_run_completed_event(run_response),
@@ -7197,6 +7222,11 @@ async def _acontinue_run_stream(
                             events_to_skip=team.events_to_skip,
                             store_events=team.store_events,
                         )
+
+                # Ensure the streamed RunCompletedEvent carries the final session_state
+                # after all tool / member modifications (mirrors the agent populator).
+                if run_context is not None and run_context.session_state is not None:
+                    run_response.session_state = run_context.session_state
 
                 # Completed
                 completed_event = handle_event(

--- a/libs/agno/tests/integration/teams/test_session_state.py
+++ b/libs/agno/tests/integration/teams/test_session_state.py
@@ -1,8 +1,10 @@
+import uuid
 from typing import Any, Dict, Optional
 
 from agno.agent.agent import Agent
 from agno.models.openai.chat import OpenAIChat
 from agno.run import RunContext
+from agno.run.team import TeamRunEvent
 from agno.team.team import Team
 
 
@@ -345,3 +347,49 @@ def test_add_session_state_to_context(shared_db):
     assert "'shopping_list': ['oranges']" in response.messages[0].content
 
     assert "oranges" in response.content.lower()
+
+
+async def test_session_state_in_team_run_completed_event_stream_async(shared_db):
+    """TeamRunCompletedEvent emitted over the async streaming path must carry
+    session_state reflecting the final state after tool mutations, mirroring the
+    existing agent behavior. Regression test for the case where session_state
+    was None on the team completion event because run_response.session_state
+    was never re-pointed at the run_context dict after _asetup_session
+    reassigned it inside the async flow."""
+
+    async def async_add_item(run_context: RunContext, item: str) -> str:
+        """Add an item to the shopping list (async)."""
+        run_context.session_state["shopping_list"].append(item)
+        return f"The shopping list is now {run_context.session_state['shopping_list']}"
+
+    session_id = str(uuid.uuid4())
+    team = Team(
+        db=shared_db,
+        session_id=session_id,
+        session_state={"shopping_list": ["bananas"]},
+        members=[],
+        tools=[async_add_item],
+        instructions="You help manage shopping lists. You MUST call async_add_item to add items.",
+        markdown=True,
+    )
+
+    events: Dict[str, Any] = {}
+    async for event in team.arun("Add oranges to my shopping list", stream=True, stream_events=True):
+        key = getattr(event, "event", None)
+        if key is None:
+            continue
+        events.setdefault(key, []).append(event)
+
+    assert TeamRunEvent.run_completed.value in events, "Should receive TeamRunCompleted event"
+    run_completed_event = events[TeamRunEvent.run_completed.value][0]
+
+    assert run_completed_event.session_state is not None, "TeamRunCompletedEvent should have session_state"
+    assert isinstance(run_completed_event.session_state, dict), "session_state should be a dict"
+    assert "shopping_list" in run_completed_event.session_state, "shopping_list key should be present"
+    assert "bananas" in run_completed_event.session_state.get("shopping_list", []), "Initial item should be preserved"
+    assert len(run_completed_event.session_state.get("shopping_list", [])) == 2, (
+        "Shopping list should have 2 items after tool call"
+    )
+    assert "oranges" in run_completed_event.session_state["shopping_list"], (
+        "Shopping list should contain the item added by the tool"
+    )


### PR DESCRIPTION
## Summary

Fixes #7670.

`TeamRunCompletedEvent` is emitted over streaming runs with `session_state=None`, even when tools have mutated `run_context.session_state` during the run. The agent-side `RunCompletedEvent` populates the field correctly; the team path simply never re-pointed `run_response.session_state` at the live `run_context.session_state` dict before building the event. This change mirrors the agent populator at all six team completion sites in `libs/agno/agno/team/_run.py`.

Field-level origin: #4975 added `session_state` to both `RunCompletedEvent` and `TeamRunCompletedEvent` and wired the agent populator; the equivalent team populator was never added, so the field has been silently `None` on team completion events since then.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Before / after (wire format)

Streaming a team run that mutates `session_state` via a tool:

```
# Before
TeamRunCompleted {..., "metrics": {...}, "session_state": null}

# After
TeamRunCompleted {..., "metrics": {...}, "session_state": {"shopping_list": ["bananas", "oranges"]}}
```

## Why this shape

The team path builds the completion event from `run_response` *before* anything re-points `run_response.session_state` at the live `run_context.session_state`. On the async dispatch specifically, `run_response` is created at the top of `arun_dispatch` with `session_state=run_context.session_state`, but `_asetup_session` later reassigns `run_context.session_state` to a new dict (result of `_initialize_session_state` / `_load_session_state`), so the reference captured at init is stale by the time tools mutate state. The agent path re-points `run_response.session_state` just before building `RunCompletedEvent` (see `libs/agno/agno/agent/_run.py` lines 1081, 2421, 3439, 4580). This PR inserts the same populator at the six team completion sites in `libs/agno/agno/team/_run.py`:

- `_run_tasks_stream` (line 868)
- `_run_stream` (line 1641)
- `_arun_tasks_stream` (line 2687)
- `_arun_stream` (line 3749)
- `_continue_run_stream` (line 6226)
- `_acontinue_run_stream` (line 7203)

`run_context` is a non-Optional parameter on every one of these enclosing functions, so scope was verified at each site.

## Why not consolidate into `_cleanup_and_store`

`_cleanup_and_store` already contains a populator that reads `run_context.session_state` (line 4138), but in practice `_cleanup_and_store` is called at ~50 sites throughout `_run.py` and none of them pass `run_context`, so that populator never fires today. Rather than broadening the signature change (which would ripple through many call sites and risk changing semantics for callers that depend on the current ordering), this fix stays minimal and matches the agent pattern — inline populator right before the event is built. The populator inside `_cleanup_and_store` is left untouched; addressing it is a separate concern and is flagged in the linked issue.

## Test added

`tests/integration/teams/test_session_state.py::test_session_state_in_team_run_completed_event_stream_async` — creates a team with `session_state={"shopping_list": ["bananas"]}`, runs it with `arun(..., stream=True, stream_events=True)` and a tool that appends `"oranges"` via `run_context.session_state`, then asserts the captured `TeamRunCompleted` event carries both entries in its `session_state`.

Verified locally: the test fails on unpatched `main` (`session_state is None`) and passes with the fix applied. Only an async test is included because the sync path preserves `session_state` through the completion event via a shared-reference coincidence in the sync dispatch ordering (so a sync-only regression test would pass even on broken code); the fix is still applied at all six sites defensively to guard against future refactors that could break the sync reference coincidence.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — N/A, bug fix with no new surface area
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (no similar PR found; #4975 introduced the field but the team populator was missed)
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI disclosure (per CONTRIBUTING.md §27):** This PR was drafted with Claude Code under direct human specification and review. The bug was first identified and characterized by the author; implementation (6 call-site edits, regression test, commit) was produced in-session and reviewed by the author before submission. The fix has been manually verified end-to-end locally (test fails on unpatched main, passes with fix), and format/validate scripts pass.

**Test suite scope:** I ran the targeted test suites relevant to this change locally — `tests/integration/teams/test_session_state.py`, `tests/integration/teams/test_session.py`, `tests/unit/run/test_run_events.py`, and `tests/unit/team/`. Pre-existing failures not related to this change: one `tests/unit/team/test_team_skills.py::test_system_message_contains_skills_snippet` (missing cookbook path) and `aiosqlite` import errors in the async-db integration subset — both reproduce on an unchanged `main`. The full `./scripts/test.sh` suite will be exercised by the project's CI.