### PR TITLE
[feat] Expose tool_definition to tool_hooks for runtime attribute control

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -966,6 +966,8 @@ class FunctionCall(BaseModel):
             hook_args["args"] = args
         if "arguments" in signature(hook).parameters:
             hook_args["arguments"] = args
+        if "tool_definition" in signature(hook).parameters:
+            hook_args["tool_definition"] = self.function
         return hook_args
 
     def _build_nested_execution_chain(self, entrypoint_args: Dict[str, Any]):

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1121,3 +1121,98 @@ def test_tool_hook_receives_messages_via_run_context():
     # Verify it's a copy (not the same reference), so hook mutations don't affect the run
     assert captured_messages is not run_context.messages
     assert captured_messages == run_context.messages
+
+
+def test_tool_hook_receives_tool_definition():
+    """Test that tool hooks can access the Function object via tool_definition parameter.
+
+    This enables hooks to inspect or modify tool attributes (e.g., stop_after_tool_call)
+    at runtime based on execution results.
+    """
+    captured_tool_def: Optional[Function] = None
+
+    def tool_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any], tool_definition: Any):
+        nonlocal captured_tool_def
+        captured_tool_def = tool_definition
+        return function_call(**arguments)
+
+    @tool(tool_hooks=[tool_hook], stop_after_tool_call=True)
+    def test_func(param1: str) -> str:
+        return f"processed-{param1}"
+
+    test_func.process_entrypoint()
+
+    call = FunctionCall(function=test_func, arguments={"param1": "value1"})
+    result = call.execute()
+
+    assert result.status == "success"
+    assert result.result == "processed-value1"
+    assert captured_tool_def is not None
+    # tool_definition should be the Function object itself
+    assert captured_tool_def is test_func
+    assert captured_tool_def.name == "test_func"
+    assert captured_tool_def.stop_after_tool_call is True
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_receives_tool_definition_async():
+    """Test that async tool hooks can access the Function object via tool_definition parameter."""
+    captured_tool_def: Optional[Function] = None
+
+    async def tool_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any], tool_definition: Any):
+        nonlocal captured_tool_def
+        captured_tool_def = tool_definition
+        return await function_call(**arguments)
+
+    @tool(tool_hooks=[tool_hook])
+    async def test_func(param1: str) -> str:
+        return f"processed-{param1}"
+
+    test_func.process_entrypoint()
+
+    call = FunctionCall(function=test_func, arguments={"param1": "value1"})
+    result = await call.aexecute()
+
+    assert result.status == "success"
+    assert result.result == "processed-value1"
+    assert captured_tool_def is not None
+    assert captured_tool_def is test_func
+    assert captured_tool_def.name == "test_func"
+
+
+def test_tool_hook_can_modify_stop_after_tool_call():
+    """Test that a hook can dynamically toggle stop_after_tool_call via tool_definition.
+
+    Use case: a review/advisor hook that conditionally allows or blocks an agent
+    from stopping after a tool call (e.g., reject a decision and force retry).
+    """
+
+    def review_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any], tool_definition: Any):
+        if arguments.get("should_reject"):
+            # Disable stop so the agent continues (simulating advisor rejection)
+            tool_definition.stop_after_tool_call = False
+            return "REJECTED: please retry"
+        else:
+            # Approve: restore stop so the agent stops after this call
+            tool_definition.stop_after_tool_call = True
+            return function_call(**arguments)
+
+    @tool(tool_hooks=[review_hook], stop_after_tool_call=True)
+    def output_func(result: str, should_reject: bool = False) -> str:
+        return f"output-{result}"
+
+    output_func.process_entrypoint()
+
+    # First call: rejected — stop_after_tool_call should be toggled to False
+    call1 = FunctionCall(function=output_func, arguments={"result": "v1", "should_reject": True})
+    result1 = call1.execute()
+    assert result1.status == "success"
+    assert result1.result == "REJECTED: please retry"
+    assert output_func.stop_after_tool_call is False
+
+    # Second call: approved — stop_after_tool_call should be restored to True
+    call2 = FunctionCall(function=output_func, arguments={"result": "v2", "should_reject": False})
+    result2 = call2.execute()
+    assert result2.status == "success"
+    assert result2.result == "output-v2"
+    assert output_func.stop_after_tool_call is True


### PR DESCRIPTION
## Summary

Tool hooks currently cannot access the `Function` object of the tool they intercept. This makes it impossible to dynamically modify tool attributes — most notably `stop_after_tool_call` — at runtime.

This PR adds `tool_definition` parameter injection to `_build_hook_args`, enabling middleware patterns like review/advisor hooks that conditionally control agent termination after a tool call.

Fixes #7687

### Change

**2 lines added** to `FunctionCall._build_hook_args()` in `libs/agno/agno/tools/function.py`:

```python
if "tool_definition" in signature(hook).parameters:
    hook_args["tool_definition"] = self.function
```

This follows the exact same signature-based injection pattern already used for `agent`, `team`, `run_context`, `arguments`, etc. Hooks opt in by declaring a `tool_definition` parameter — fully backward-compatible.

### Motivation

A review/advisor hook that intercepts a tool with `stop_after_tool_call=True` needs to conditionally disable it when rejecting a decision (so the agent continues the loop and retries). Without access to the `Function` object, there is no way to do this within the `tool_hooks` API.

See the issue for the complete use case and code examples.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was co-authored with Claude Code. The problem was discovered during real-world development of a review/advisor middleware for an agentic search relevance system. The solution and tests were developed interactively.

---

## Additional Notes

### Tests added (3 new unit tests in `test_functions.py`)

1. **`test_tool_hook_receives_tool_definition`** — Verifies sync hooks receive the `Function` object via `tool_definition` parameter
2. **`test_tool_hook_receives_tool_definition_async`** — Same for async hooks
3. **`test_tool_hook_can_modify_stop_after_tool_call`** — End-to-end: hook dynamically toggles `stop_after_tool_call` based on reject/approve logic

All 53 tests in `test_functions.py` pass (50 existing + 3 new).

### Related

- #6652 (expose run message history to tool hooks) — same direction of giving hooks more context for middleware patterns