### PR TITLE
feat: encapsulate sub-team members from parent team leader

### DIFF
--- a/cookbook/03_teams/01_quickstart/nested_team_encapsulation.py
+++ b/cookbook/03_teams/01_quickstart/nested_team_encapsulation.py
@@ -1,0 +1,79 @@
+"""
+Nested Team Encapsulation
+==========================
+
+When a Team contains another Team as a member, by default the parent team's
+leader sees the full nested member tree in its system prompt and can delegate
+directly to grandchild agents — bypassing the sub-team's own leader.
+
+Set `expose_sub_team_members=False` on the parent team to treat sub-teams as
+opaque capabilities. The sub-team appears to the parent as a single unit; the
+sub-team's leader handles its own internal delegation.
+
+This example prints the top team's `<team_members>` content under both settings
+so the difference is visible without hitting a model.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+
+
+def build_top_team(expose_sub_team_members: bool) -> Team:
+    research_agent = Agent(
+        name="Research Agent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        role="Gather references and source material",
+    )
+    analysis_agent = Agent(
+        name="Analysis Agent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        role="Extract key findings and implications",
+    )
+    research_team = Team(
+        name="Research Team",
+        description="Handles gathering and analyzing evidence",
+        members=[research_agent, analysis_agent],
+        model=OpenAIResponses(id="gpt-5.4"),
+    )
+
+    writing_agent = Agent(
+        name="Writing Agent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        role="Draft polished narrative output",
+    )
+    editing_agent = Agent(
+        name="Editing Agent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        role="Improve clarity and structure",
+    )
+    writing_team = Team(
+        name="Writing Team",
+        description="Handles drafting and editing the final piece",
+        members=[writing_agent, editing_agent],
+        model=OpenAIResponses(id="gpt-5.4"),
+    )
+
+    return Team(
+        name="Program Team",
+        members=[research_team, writing_team],
+        model=OpenAIResponses(id="gpt-5.4"),
+        expose_sub_team_members=expose_sub_team_members,
+    )
+
+
+if __name__ == "__main__":
+    print("--- expose_sub_team_members=True (default: nested members visible) ---")
+    open_top = build_top_team(expose_sub_team_members=True)
+    print(open_top.get_members_system_message_content())
+
+    print("--- expose_sub_team_members=False (sub-teams as opaque capabilities) ---")
+    closed_top = build_top_team(expose_sub_team_members=False)
+    print(closed_top.get_members_system_message_content())
+
+    # With encapsulation on, the top team must delegate to the sub-team
+    # (e.g. member_id="research-team"), and the sub-team's leader decides
+    # which of its own members to use. Trying to delegate directly to a
+    # grandchild like "research-agent" from the top team is rejected.
+    print("--- find 'research-agent' from the closed top team ---")
+    print(closed_top._find_member_by_id("research-agent"))

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -549,7 +549,8 @@ def _get_delegate_task_function(
         # Find the member agent using the helper function
         result = _find_member_by_id(team, member_id, run_context=run_context)
         if result is None:
-            yield f"Member with ID {member_id} not found in the team or any subteams. Please choose the correct member from the list of members:\n\n{team.get_members_system_message_content(indent=0, run_context=run_context)}"
+            scope = "the team or any subteams" if team.expose_sub_team_members else "the team"
+            yield f"Member with ID {member_id} not found in {scope}. Please choose the correct member from the list of members:\n\n{team.get_members_system_message_content(indent=0, run_context=run_context)}"
             return
 
         _, member_agent = result
@@ -689,7 +690,8 @@ def _get_delegate_task_function(
         # Find the member agent using the helper function
         result = _find_member_by_id(team, member_id, run_context=run_context)
         if result is None:
-            yield f"Member with ID {member_id} not found in the team or any subteams. Please choose the correct member from the list of members:\n\n{team.get_members_system_message_content(indent=0, run_context=run_context, async_mode=True)}"
+            scope = "the team or any subteams" if team.expose_sub_team_members else "the team"
+            yield f"Member with ID {member_id} not found in {scope}. Please choose the correct member from the list of members:\n\n{team.get_members_system_message_content(indent=0, run_context=run_context, async_mode=True)}"
             return
 
         _, member_agent = result

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -102,6 +102,7 @@ def __init__(
     timezone_identifier: Optional[str] = None,
     add_name_to_context: bool = False,
     add_member_tools_to_context: bool = False,
+    expose_sub_team_members: bool = True,
     system_message: Optional[Union[str, Callable, Message]] = None,
     system_message_role: str = "system",
     introduction: Optional[str] = None,
@@ -274,6 +275,7 @@ def __init__(
     team.add_name_to_context = add_name_to_context
     team.timezone_identifier = timezone_identifier
     team.add_member_tools_to_context = add_member_tools_to_context
+    team.expose_sub_team_members = expose_sub_team_members
     team.system_message = system_message
     team.system_message_role = system_message_role
     team.introduction = introduction

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -92,7 +92,10 @@ def get_members_system_message_content(
             content += f'{pad}<member id="{member_id}" name="{member.name}" type="team">\n'
             if member.description is not None:
                 content += f"{pad}  Description: {member.description}\n"
-            if member.members is not None:
+            # Only expand a sub-team's members into this team's prompt when this team is
+            # configured to see through sub-teams. Otherwise the sub-team is treated as
+            # an opaque capability — its leader handles delegation to its own members.
+            if team.expose_sub_team_members and member.members is not None:
                 content += member.get_members_system_message_content(
                     indent=indent + 2, run_context=run_context, async_mode=async_mode
                 )

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -504,6 +504,8 @@ def to_dict(team: "Team") -> Dict[str, Any]:
         config["add_name_to_context"] = team.add_name_to_context
     if team.add_member_tools_to_context:
         config["add_member_tools_to_context"] = team.add_member_tools_to_context
+    if not team.expose_sub_team_members:  # default is True
+        config["expose_sub_team_members"] = team.expose_sub_team_members
     if not team.resolve_in_context:  # default is True
         config["resolve_in_context"] = team.resolve_in_context
 
@@ -913,6 +915,7 @@ def from_dict(
             timezone_identifier=config.get("timezone_identifier"),
             add_name_to_context=config.get("add_name_to_context", False),
             add_member_tools_to_context=config.get("add_member_tools_to_context", False),
+            expose_sub_team_members=config.get("expose_sub_team_members", True),
             resolve_in_context=config.get("resolve_in_context", True),
             # --- Database settings ---
             db=config.get("db"),

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -483,7 +483,12 @@ def _determine_team_member_interactions(
 def _find_member_by_id(
     team: "Team", member_id: str, run_context: Optional["RunContext"] = None
 ) -> Optional[Tuple[int, Union[Agent, "Team"]]]:
-    """Find a member (agent or team) by its URL-safe ID, searching recursively.
+    """Find a member (agent or team) by its URL-safe ID.
+
+    Searches `team`'s direct members. Recursion into sub-teams is gated by
+    `team.expose_sub_team_members`: when False, sub-teams are opaque and their
+    descendants are not discoverable from this team — the caller must delegate
+    to the sub-team itself, which then resolves its own members.
 
     Args:
         team: The team to search in.
@@ -508,8 +513,8 @@ def _find_member_by_id(
         if url_safe_member_id == member_id:
             return i, member
 
-        # If this member is a team, search its members recursively
-        if isinstance(member, Team):
+        # Only descend into sub-teams when this team exposes nested members.
+        if isinstance(member, Team) and team.expose_sub_team_members:
             result = member._find_member_by_id(member_id, run_context=run_context)
             if result is not None:
                 return result

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -175,6 +175,13 @@ class Team:
     add_name_to_context: bool = False
     # If True, add the tools available to team members to the context
     add_member_tools_to_context: bool = False
+    # If True (default), sub-teams are transparent: the team leader sees the full nested
+    # member tree in its system prompt and can delegate directly to grandchild members.
+    # If False, sub-teams are opaque capabilities: only the sub-team itself is visible to
+    # the parent, and delegation must target the sub-team (its leader then delegates to
+    # its own members). Encapsulation preserves the sub-team's own orchestration, reduces
+    # prompt size, and avoids the leader picking a grandchild over the sub-team as a whole.
+    expose_sub_team_members: bool = True
 
     # Provide the system message as a string or function
     system_message: Optional[Union[str, Callable, Message]] = None
@@ -468,6 +475,7 @@ class Team:
         timezone_identifier: Optional[str] = None,
         add_name_to_context: bool = False,
         add_member_tools_to_context: bool = False,
+        expose_sub_team_members: bool = True,
         system_message: Optional[Union[str, Callable, Message]] = None,
         system_message_role: str = "system",
         introduction: Optional[str] = None,
@@ -590,6 +598,7 @@ class Team:
             timezone_identifier=timezone_identifier,
             add_name_to_context=add_name_to_context,
             add_member_tools_to_context=add_member_tools_to_context,
+            expose_sub_team_members=expose_sub_team_members,
             system_message=system_message,
             system_message_role=system_message_role,
             introduction=introduction,

--- a/libs/agno/tests/unit/team/test_nested_team_encapsulation.py
+++ b/libs/agno/tests/unit/team/test_nested_team_encapsulation.py
@@ -1,0 +1,126 @@
+"""Tests for `Team.expose_sub_team_members`.
+
+When a team contains a sub-team, the parent leader has historically seen the
+sub-team's full member tree in its system prompt and could delegate directly
+to grandchild agents, bypassing the sub-team's own leader. `expose_sub_team_members`
+lets a team opt into treating sub-teams as opaque capabilities.
+"""
+
+from agno.agent import Agent
+from agno.run import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team.team import Team
+
+
+def _build_nested_team(expose_sub_team_members: bool) -> Team:
+    grandchild_a = Agent(name="Agent A", role="Worker A")
+    grandchild_b = Agent(name="Agent B", role="Worker B")
+    sub_team = Team(
+        name="Sub Team",
+        description="Handles sub things",
+        members=[grandchild_a, grandchild_b],
+    )
+    top_team = Team(
+        name="Top Team",
+        members=[sub_team],
+        expose_sub_team_members=expose_sub_team_members,
+    )
+    return top_team
+
+
+def test_expose_sub_team_members_default_is_true():
+    team = Team(name="T", members=[])
+    assert team.expose_sub_team_members is True
+
+
+def test_prompt_exposes_nested_members_when_flag_true():
+    top_team = _build_nested_team(expose_sub_team_members=True)
+    content = top_team.get_members_system_message_content()
+
+    assert 'id="sub-team"' in content
+    assert 'type="team"' in content
+    # Grandchildren are visible to the top team leader.
+    assert 'id="agent-a"' in content
+    assert 'id="agent-b"' in content
+    assert "Role: Worker A" in content
+
+
+def test_prompt_hides_nested_members_when_flag_false():
+    top_team = _build_nested_team(expose_sub_team_members=False)
+    content = top_team.get_members_system_message_content()
+
+    # Sub-team itself is still visible as an opaque capability.
+    assert 'id="sub-team"' in content
+    assert 'type="team"' in content
+    assert "Description: Handles sub things" in content
+
+    # But its members must not leak into the top team's prompt.
+    assert 'id="agent-a"' not in content
+    assert 'id="agent-b"' not in content
+    assert "Worker A" not in content
+    assert "Worker B" not in content
+
+
+def test_sub_team_prompt_still_exposes_its_own_members_when_flag_false_on_top():
+    """Opting out on the top team must not change the sub-team's own prompt."""
+    top_team = _build_nested_team(expose_sub_team_members=False)
+    sub_team = top_team.members[0]
+    assert isinstance(sub_team, Team)
+
+    sub_content = sub_team.get_members_system_message_content()
+    assert 'id="agent-a"' in sub_content
+    assert 'id="agent-b"' in sub_content
+
+
+def test_find_member_by_id_finds_grandchild_when_flag_true():
+    top_team = _build_nested_team(expose_sub_team_members=True)
+    result = top_team._find_member_by_id("agent-a")
+    assert result is not None
+    _, member = result
+    assert isinstance(member, Agent)
+    assert member.name == "Agent A"
+
+
+def test_find_member_by_id_does_not_find_grandchild_when_flag_false():
+    top_team = _build_nested_team(expose_sub_team_members=False)
+    assert top_team._find_member_by_id("agent-a") is None
+    assert top_team._find_member_by_id("agent-b") is None
+
+
+def test_find_member_by_id_still_finds_direct_sub_team_when_flag_false():
+    top_team = _build_nested_team(expose_sub_team_members=False)
+    result = top_team._find_member_by_id("sub-team")
+    assert result is not None
+    _, member = result
+    assert isinstance(member, Team)
+    assert member.name == "Sub Team"
+
+
+def test_delegate_to_grandchild_is_rejected_when_flag_false():
+    top_team = _build_nested_team(expose_sub_team_members=False)
+
+    function = top_team._get_delegate_task_function(
+        session=TeamSession(session_id="test-session"),
+        run_response=TeamRunOutput(content="Hello, world!"),
+        run_context=RunContext(session_state={}, run_id="test-run", session_id="test-session"),
+        team_run_context={},
+    )
+    response = list(function.entrypoint(member_id="agent-a", task="do something"))
+    text = response[0]
+    assert "Member with ID agent-a not found in the team" in text
+    # The scope phrasing should reflect that sub-teams are opaque.
+    assert "any subteams" not in text
+
+
+def test_delegate_error_mentions_subteams_when_flag_true():
+    top_team = _build_nested_team(expose_sub_team_members=True)
+
+    function = top_team._get_delegate_task_function(
+        session=TeamSession(session_id="test-session"),
+        run_response=TeamRunOutput(content="Hello, world!"),
+        run_context=RunContext(session_state={}, run_id="test-run", session_id="test-session"),
+        team_run_context={},
+    )
+    response = list(function.entrypoint(member_id="wrong-agent", task="do something"))
+    assert "Member with ID wrong-agent not found in the team or any subteams" in response[0]


### PR DESCRIPTION
Closes #7690

## Summary

Adds `Team.expose_sub_team_members` (default `True`, backwards-compatible) that gates whether a parent team leader can see and address the members of nested sub-teams directly.

**Motivation.** When a `Team` contains another `Team` as a member, today the parent leader sees the full nested member tree in its system prompt and can call `delegate_task_to_member` directly on a grandchild, bypassing the sub-team's own leader. This breaks encapsulation: the sub-team's instructions, member-interaction context, and synthesis step are all skipped; the prompt bloats in deep hierarchies; and the leader frequently picks a grandchild over the sub-team as a unit.

**Behavior when `expose_sub_team_members=False`:**
- `get_members_system_message_content` no longer recurses into sub-team members; sub-teams render as opaque `<member type="team">` blocks.
- `_find_member_by_id` no longer descends into sub-teams, so `delegate_task_to_member` can only target direct members. The sub-team's leader resolves its own members via its own (independently configured) flag.
- `delegate_task_to_member`'s not-found error message scope follows the flag (`"in the team"` vs `"in the team or any subteams"`).

**HITL routing is unchanged:** `_find_member_route_by_id` still calls into each sub-team's own `_find_member_by_id`, which follows that sub-team's own flag, so resuming a paused nested member continues to work.

The field is only serialized when non-default to avoid touching existing snapshots.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: cookbook example added (`cookbook/03_teams/01_quickstart/nested_team_encapsulation.py`)
- [x] Tested in clean environment
- [x] Tests added (`libs/agno/tests/unit/team/test_nested_team_encapsulation.py`, 9 cases)

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests; no other PR addresses this
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated

## Additional Notes

- Default is `True`, so existing teams behave exactly as before.
- The flag is per-team, so a parent and its sub-team can be configured independently (the cookbook example demonstrates this).
- Tests cover: default value, prompt content with flag on/off, sub-team's own prompt unaffected by parent's flag, member resolution with flag on/off, direct sub-team still resolvable, delegation rejection, and error-message scoping.