### PR TITLE
fix: Qdrant.upsert_available must return True

### DIFF
--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -513,8 +513,33 @@ class Qdrant(VectorDb):
     async def async_upsert(
         self, content_hash: str, documents: List[Document], filters: Optional[Dict[str, Any]] = None
     ) -> None:
-        """Upsert documents asynchronously."""
+        """Upsert documents asynchronously.
+
+        Mirrors the sync ``upsert`` behaviour: if any points with the same
+        ``content_hash`` already exist, delete them first so the collection
+        ends up with exactly the new set of points instead of accumulating
+        duplicates from successive ingests.
+        """
         log_debug("Redirecting the async request to async_insert")
+        if self.async_client:
+            try:
+                filter_condition = models.Filter(
+                    must=[models.FieldCondition(key="content_hash", match=models.MatchValue(value=content_hash))]
+                )
+                count_result = await self.async_client.count(
+                    collection_name=self.collection, count_filter=filter_condition, exact=True
+                )
+                if count_result.count > 0:
+                    log_info(
+                        f"Deleting {count_result.count} existing points with content_hash: {content_hash} before upsert"
+                    )
+                    await self.async_client.delete(
+                        collection_name=self.collection,
+                        points_selector=filter_condition,
+                        wait=True,
+                    )
+            except Exception as e:
+                log_info(f"Error deleting existing points with content_hash {content_hash}: {e}")
         await self.async_insert(content_hash=content_hash, documents=documents, filters=filters)
 
     def search(

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -522,24 +522,22 @@ class Qdrant(VectorDb):
         """
         log_debug("Redirecting the async request to async_insert")
         if self.async_client:
-            try:
-                filter_condition = models.Filter(
-                    must=[models.FieldCondition(key="content_hash", match=models.MatchValue(value=content_hash))]
+            # Let delete errors propagate: inserting after a failed dedup would stack new points on top of old ones.
+            filter_condition = models.Filter(
+                must=[models.FieldCondition(key="content_hash", match=models.MatchValue(value=content_hash))]
+            )
+            count_result = await self.async_client.count(
+                collection_name=self.collection, count_filter=filter_condition, exact=True
+            )
+            if count_result.count > 0:
+                log_info(
+                    f"Deleting {count_result.count} existing points with content_hash: {content_hash} before upsert"
                 )
-                count_result = await self.async_client.count(
-                    collection_name=self.collection, count_filter=filter_condition, exact=True
+                await self.async_client.delete(
+                    collection_name=self.collection,
+                    points_selector=filter_condition,
+                    wait=True,
                 )
-                if count_result.count > 0:
-                    log_info(
-                        f"Deleting {count_result.count} existing points with content_hash: {content_hash} before upsert"
-                    )
-                    await self.async_client.delete(
-                        collection_name=self.collection,
-                        points_selector=filter_condition,
-                        wait=True,
-                    )
-            except Exception as e:
-                log_info(f"Error deleting existing points with content_hash {content_hash}: {e}")
         await self.async_insert(content_hash=content_hash, documents=documents, filters=filters)
 
     def search(

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -493,6 +493,10 @@ class Qdrant(VectorDb):
             await self.async_client.upsert(collection_name=self.collection, wait=False, points=points)
         log_debug(f"Upserted {len(points)} documents asynchronously")
 
+    def upsert_available(self) -> bool:
+        """Check if upsert is available in Qdrant."""
+        return True
+
     def upsert(self, content_hash: str, documents: List[Document], filters: Optional[Dict[str, Any]] = None) -> None:
         """
         Upsert documents into the database.

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -566,6 +566,10 @@ class Qdrant(VectorDb):
             await self.async_client.upsert(collection_name=self.collection, wait=False, points=points)
         log_debug(f"Upserted {len(points)} documents asynchronously")
 
+    def upsert_available(self) -> bool:
+        """Check if upsert is available in Qdrant."""
+        return True
+
     def upsert(
         self,
         content_hash: str,

--- a/libs/agno/tests/unit/vectordb/test_qdrantdb.py
+++ b/libs/agno/tests/unit/vectordb/test_qdrantdb.py
@@ -155,6 +155,15 @@ def test_upsert_documents(qdrant_db, sample_documents, mock_qdrant_client):
         mock_insert.assert_called_once()
 
 
+def test_upsert_available(qdrant_db):
+    """Qdrant supports upsert, so upsert_available must report True.
+
+    The VectorDb base class defaults to False; Qdrant overrides it because
+    both upsert / async_upsert are implemented.
+    """
+    assert qdrant_db.upsert_available() is True
+
+
 def test_search(qdrant_db, mock_qdrant_client):
     """Test search functionality"""
     # Set up mock embedding
@@ -540,3 +549,71 @@ async def test_concurrent_async_searches_no_blocking(tracking_embedder):
     # All should use async embedder
     assert tracking_embedder.async_call_count == 5, "async_get_embedding should be called 5 times"
     assert tracking_embedder.sync_call_count == 0, "sync get_embedding should NOT be called"
+
+
+@pytest.mark.asyncio
+async def test_async_upsert_deletes_existing_points_before_insert(mock_embedder, sample_documents):
+    """async_upsert must clear points sharing the content_hash before re-inserting.
+
+    This mirrors the sync upsert path: point ids fold in each chunk's own id, so a
+    re-upsert into fewer chunks would strand the surplus points unless the prior
+    ones are cleared first. The clear must stay scoped to the writing owner.
+    """
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    calls: List[str] = []
+
+    with (
+        patch.object(db, "content_hash_exists", return_value=True) as mock_exists,
+        patch.object(db, "_delete_by_content_hash", side_effect=lambda *a, **k: calls.append("delete")) as mock_delete,
+        patch.object(
+            db, "async_insert", new_callable=AsyncMock, side_effect=lambda **k: calls.append("insert")
+        ) as mock_async_insert,
+    ):
+        await db.async_upsert(content_hash="hash_a", documents=sample_documents, user_id="alice")
+
+    # Guard and delete resolve the same bucket: same content_hash, same owner
+    assert mock_exists.call_args.args == ("hash_a", "alice")
+    assert mock_delete.call_args.args == ("hash_a", "alice")
+
+    # Deleted the stale points first, then delegated to async_insert for the fresh chunks
+    assert calls == ["delete", "insert"]
+    assert mock_async_insert.await_args.kwargs["content_hash"] == "hash_a"
+    assert mock_async_insert.await_args.kwargs["user_id"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_async_upsert_skips_delete_when_no_existing_points(mock_embedder, sample_documents):
+    """async_upsert must not issue a delete when no points share the content_hash."""
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+
+    with (
+        patch.object(db, "content_hash_exists", return_value=False) as mock_exists,
+        patch.object(db, "_delete_by_content_hash") as mock_delete,
+        patch.object(db, "async_insert", new_callable=AsyncMock) as mock_async_insert,
+    ):
+        await db.async_upsert(content_hash="hash_a", documents=sample_documents)
+
+    mock_exists.assert_called_once()
+    mock_delete.assert_not_called()
+    mock_async_insert.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_upsert_propagates_delete_errors_without_inserting(mock_embedder, sample_documents):
+    """A failed dedup-delete must propagate and the insert must be skipped.
+
+    If the error were swallowed, fresh chunks would be stacked on top of the
+    stale ones the delete failed to remove, producing exactly the duplicate
+    accumulation that upsert is meant to prevent.
+    """
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+
+    with (
+        patch.object(db, "content_hash_exists", return_value=True),
+        patch.object(db, "_delete_by_content_hash", side_effect=RuntimeError("qdrant delete failed")),
+        patch.object(db, "async_insert", new_callable=AsyncMock) as mock_async_insert,
+    ):
+        with pytest.raises(RuntimeError, match="qdrant delete failed"):
+            await db.async_upsert(content_hash="hash_a", documents=sample_documents)
+
+    mock_async_insert.assert_not_called()


### PR DESCRIPTION
## Problem — `Qdrant.upsert_available()` returns `False`

`Qdrant` inherits `upsert_available()` from the `VectorDb` abstract base class, which returns `False`. But Qdrant does support upsert: `Qdrant.upsert` / `Qdrant.async_upsert` are both fully implemented, they dedup by `content_hash` before delegating to `insert` / `async_insert`, and `insert` itself calls `qdrant_client.QdrantClient.upsert(...)` directly.

`Knowledge` gates the upsert path on this method in six places (`libs/agno/agno/knowledge/knowledge.py`), all of the shape:

```python
if self.vector_db.upsert_available() and upsert:
```

So on Qdrant every one of those flows silently falls back to `insert`. A re-ingest of already-known content appends a fresh set of points instead of replacing the prior ones — the `upsert` implementation that exists is simply never reached.

Of the 20 `VectorDb` implementations, 15 already override `upsert_available()`. Among the five that don't, `langchaindb` and `llamaindex` are correct to report `False` — their `upsert` raises `NotImplementedError`. Qdrant's does not; it works. This is the same oversight fixed for ChromaDB in #1698 / #1699.

Fixes #7728

## Changes

1. `libs/agno/agno/vectordb/qdrant/qdrant.py` — override `upsert_available()` to return `True` (4 lines).
2. `libs/agno/tests/unit/vectordb/test_qdrantdb.py` — four tests:
   - `test_upsert_available` — the override itself.
   - `test_async_upsert_deletes_existing_points_before_insert` — the async dedup clears the prior points *before* inserting, and the guard (`content_hash_exists`) and the delete (`_delete_by_content_hash`) resolve the same bucket, i.e. same `content_hash` **and** same `user_id`.
   - `test_async_upsert_skips_delete_when_no_existing_points` — no delete is issued when nothing shares the hash.
   - `test_async_upsert_propagates_delete_errors_without_inserting` — a failed dedup-delete propagates and the insert is skipped. If it were swallowed, fresh chunks would stack on top of the stale ones the delete failed to remove, producing exactly the duplicate accumulation upsert exists to prevent.

### Why the async tests are here

Earlier revisions of this PR also *implemented* the `async_upsert` dedup, because `async_upsert` was a bare alias for `async_insert` at the time. v3.0 (#8210) landed that implementation upstream, so on rebase those commits were dropped — the code is already in `main` and there is nothing left to change there.

The tests are kept, because that behaviour is currently unguarded: `TestUpsertDedupScope` in `test_qdrant_user_isolation.py` covers the sync re-upsert path thoroughly, but nothing exercises the async one. Since this PR is what routes `Knowledge`'s async flows onto `async_upsert` in the first place, the async path is worth pinning down here.

## Verification

- `pytest libs/agno/tests/unit/vectordb/test_qdrantdb.py libs/agno/tests/unit/vectordb/test_qdrant_user_isolation.py` — all green (24 + 23).
- Mutation-checked, not just run: deleting the `upsert_available` override and the two dedup lines in `async_upsert` fails exactly the four new tests and nothing else. They guard behaviour rather than passing incidentally.
- `ruff format --check` and `ruff check` clean on both touched files. `mypy` reports no new findings on the added lines.

## Out of scope

`cassandra` looks like the same oversight — a real dedup-ing `upsert` behind an un-overridden `upsert_available()` — but it has no linked issue and no test coverage here, so it is left alone.
