### PR TITLE
fix: team cancellation to **cascade** to currently-running member agent runs.

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -60,7 +60,6 @@ from agno.utils.team import (
 )
 from agno.utils.timer import Timer
 
-
 # ---------------------------------------------------------------------------
 # Team → Member run_id mapping for cascade cancellation
 # Maps team_run_id to a set of member_run_ids so that cancelling a team run

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 import asyncio
 import contextlib
 import json
+import threading
 from copy import copy
 from typing import (
     Any,
@@ -18,9 +19,11 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Set,
     Union,
     cast,
 )
+from uuid import uuid4
 
 from pydantic import BaseModel
 
@@ -56,6 +59,33 @@ from agno.utils.team import (
     format_member_agent_task,
 )
 from agno.utils.timer import Timer
+
+
+# ---------------------------------------------------------------------------
+# Team → Member run_id mapping for cascade cancellation
+# Maps team_run_id to a set of member_run_ids so that cancelling a team run
+# also cancels all in-flight member runs.
+# ---------------------------------------------------------------------------
+_child_runs_lock = threading.Lock()
+_child_runs: Dict[str, Set[str]] = {}
+
+
+def _register_child_run(team_run_id: str, member_run_id: str) -> None:
+    """Record that a member run belongs to a team run."""
+    with _child_runs_lock:
+        _child_runs.setdefault(team_run_id, set()).add(member_run_id)
+
+
+def _unregister_team_run(team_run_id: str) -> None:
+    """Remove the mapping when a team run finishes (success, error, or cancel)."""
+    with _child_runs_lock:
+        _child_runs.pop(team_run_id, None)
+
+
+def get_child_run_ids(team_run_id: str) -> Set[str]:
+    """Get the set of member run_ids for a team run (for cascade cancel)."""
+    with _child_runs_lock:
+        return set(_child_runs.get(team_run_id, set()))
 
 
 def _get_update_user_memory_function(team: "Team", user_id: Optional[str] = None, async_mode: bool = False) -> Function:
@@ -561,6 +591,8 @@ def _get_delegate_task_function(
         member_session_state_copy = copy(run_context.session_state)
 
         if stream:
+            member_run_id = str(uuid4())
+            _register_child_run(run_response.run_id, member_run_id)  # type: ignore[arg-type]
             member_agent_run_response_stream = member_agent.run(
                 input=member_agent_task if not history else history,
                 user_id=user_id,
@@ -581,6 +613,7 @@ def _get_delegate_task_function(
                 knowledge_filters=run_context.knowledge_filters
                 if not member_agent.knowledge_filters and member_agent.knowledge
                 else None,
+                run_id=member_run_id,
                 yield_run_output=True,
             )
             member_agent_run_response = None
@@ -599,6 +632,8 @@ def _get_delegate_task_function(
                 )
                 yield member_agent_run_output_event  # type: ignore
         else:
+            member_run_id = str(uuid4())
+            _register_child_run(run_response.run_id, member_run_id)  # type: ignore[arg-type]
             member_agent_run_response = member_agent.run(  # type: ignore
                 input=member_agent_task if not history else history,  # type: ignore
                 user_id=user_id,
@@ -618,6 +653,7 @@ def _get_delegate_task_function(
                 knowledge_filters=run_context.knowledge_filters
                 if not member_agent.knowledge_filters and member_agent.knowledge
                 else None,
+                run_id=member_run_id,
             )
 
             check_if_run_cancelled(member_agent_run_response)  # type: ignore
@@ -830,6 +866,8 @@ def _get_delegate_task_function(
 
             member_session_state_copy = copy(run_context.session_state)
             if stream:
+                member_run_id = str(uuid4())
+                _register_child_run(run_response.run_id, member_run_id)  # type: ignore[arg-type]
                 member_agent_run_response_stream = member_agent.run(
                     input=member_agent_task if not history else history,
                     user_id=user_id,
@@ -850,6 +888,7 @@ def _get_delegate_task_function(
                     add_dependencies_to_context=add_dependencies_to_context,
                     add_session_state_to_context=add_session_state_to_context,
                     metadata=run_context.metadata,
+                    run_id=member_run_id,
                     yield_run_output=True,
                 )
                 member_agent_run_response = None
@@ -869,6 +908,8 @@ def _get_delegate_task_function(
                     yield member_agent_run_response_chunk  # type: ignore
 
             else:
+                member_run_id = str(uuid4())
+                _register_child_run(run_response.run_id, member_run_id)  # type: ignore[arg-type]
                 member_agent_run_response = member_agent.run(  # type: ignore
                     input=member_agent_task if not history else history,
                     user_id=user_id,
@@ -888,6 +929,7 @@ def _get_delegate_task_function(
                     add_dependencies_to_context=add_dependencies_to_context,
                     add_session_state_to_context=add_session_state_to_context,
                     metadata=run_context.metadata,
+                    run_id=member_run_id,
                 )
 
                 check_if_run_cancelled(member_agent_run_response)  # type: ignore

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -101,7 +101,7 @@ if TYPE_CHECKING:
 
 
 def cancel_run(run_id: str) -> bool:
-    """Cancel a running team execution.
+    """Cancel a running team execution and cascade to all member runs.
 
     Args:
         run_id (str): The run_id to cancel.
@@ -109,11 +109,25 @@ def cancel_run(run_id: str) -> bool:
     Returns:
         bool: True if the run was found and marked for cancellation, False otherwise.
     """
-    return cancel_run_global(run_id)
+    from agno.team._default_tools import get_child_run_ids, _unregister_team_run
+
+    # Cancel the team run itself
+    result = cancel_run_global(run_id)
+
+    # Cascade: cancel all member runs that belong to this team run
+    child_ids = get_child_run_ids(run_id)
+    for child_id in child_ids:
+        cancel_run_global(child_id)
+        log_info(f"Cancelled member run {child_id} (cascade from team run {run_id})")
+
+    # Clean up the mapping
+    _unregister_team_run(run_id)
+
+    return result
 
 
 async def acancel_run(run_id: str) -> bool:
-    """Cancel a running team execution.
+    """Cancel a running team execution and cascade to all member runs.
 
     Args:
         run_id (str): The run_id to cancel.
@@ -121,7 +135,21 @@ async def acancel_run(run_id: str) -> bool:
     Returns:
         bool: True if the run was found and marked for cancellation, False otherwise.
     """
-    return await acancel_run_global(run_id)
+    from agno.team._default_tools import get_child_run_ids, _unregister_team_run
+
+    # Cancel the team run itself
+    result = await acancel_run_global(run_id)
+
+    # Cascade: cancel all member runs that belong to this team run
+    child_ids = get_child_run_ids(run_id)
+    for child_id in child_ids:
+        await acancel_run_global(child_id)
+        log_info(f"Cancelled member run {child_id} (cascade from team run {run_id})")
+
+    # Clean up the mapping
+    _unregister_team_run(run_id)
+
+    return result
 
 
 async def _asetup_session(
@@ -4124,7 +4152,12 @@ def _cleanup_and_store(
     import copy
 
     from agno.run.approval import update_approval_run_status
+    from agno.team._default_tools import _unregister_team_run
     from agno.team._session import update_session_metrics
+
+    # Clean up the team→member run_id mapping
+    if run_response.run_id:
+        _unregister_team_run(run_response.run_id)
 
     # Scrub a shallow copy for storage — the original run_response is never
     # mutated so the caller always sees generated media regardless of store_media.
@@ -4170,7 +4203,12 @@ async def _acleanup_and_store(
     import copy
 
     from agno.run.approval import aupdate_approval_run_status
+    from agno.team._default_tools import _unregister_team_run
     from agno.team._session import update_session_metrics
+
+    # Clean up the team→member run_id mapping
+    if run_response.run_id:
+        _unregister_team_run(run_response.run_id)
 
     # Scrub a shallow copy for storage — the original run_response is never
     # mutated so the caller always sees generated media regardless of store_media.

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -109,7 +109,7 @@ def cancel_run(run_id: str) -> bool:
     Returns:
         bool: True if the run was found and marked for cancellation, False otherwise.
     """
-    from agno.team._default_tools import get_child_run_ids, _unregister_team_run
+    from agno.team._default_tools import _unregister_team_run, get_child_run_ids
 
     # Cancel the team run itself
     result = cancel_run_global(run_id)
@@ -135,7 +135,7 @@ async def acancel_run(run_id: str) -> bool:
     Returns:
         bool: True if the run was found and marked for cancellation, False otherwise.
     """
-    from agno.team._default_tools import get_child_run_ids, _unregister_team_run
+    from agno.team._default_tools import _unregister_team_run, get_child_run_ids
 
     # Cancel the team run itself
     result = await acancel_run_global(run_id)

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -531,11 +531,13 @@ class SlackTools(Toolkit):
                     if not (ch_id and ch_name):
                         continue
                     self._cache_channel(_ResolvedChannel(id=ch_id, name=ch_name))
-                    channels.append({
-                        "id": ch_id,
-                        "name": ch_name,
-                        "is_private": ch.get("is_private", False),
-                    })
+                    channels.append(
+                        {
+                            "id": ch_id,
+                            "name": ch_name,
+                            "is_private": ch.get("is_private", False),
+                        }
+                    )
                 cursor = (response.get("response_metadata") or {}).get("next_cursor")
                 if not cursor:
                     break

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -531,13 +531,11 @@ class SlackTools(Toolkit):
                     if not (ch_id and ch_name):
                         continue
                     self._cache_channel(_ResolvedChannel(id=ch_id, name=ch_name))
-                    channels.append(
-                        {
-                            "id": ch_id,
-                            "name": ch_name,
-                            "is_private": ch.get("is_private", False),
-                        }
-                    )
+                    channels.append({
+                        "id": ch_id,
+                        "name": ch_name,
+                        "is_private": ch.get("is_private", False),
+                    })
                 cursor = (response.get("response_metadata") or {}).get("next_cursor")
                 if not cursor:
                     break

--- a/libs/agno/tests/unit/team/test_team_cascade_cancel.py
+++ b/libs/agno/tests/unit/team/test_team_cascade_cancel.py
@@ -1,0 +1,214 @@
+"""Unit tests for team cascade cancellation.
+
+Tests cover the child run mapping and cascade cancel behaviour:
+1. _register_child_run / get_child_run_ids / _unregister_team_run
+2. cancel_run cascades to all registered member runs
+3. acancel_run cascades to all registered member runs
+4. Thread-safety of the mapping
+5. Cleanup on all exit paths (cancel, normal completion, unregister)
+6. Edge cases (empty mapping, double unregister, non-existent keys)
+"""
+
+import asyncio
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from agno.team._default_tools import (
+    _child_runs,
+    _child_runs_lock,
+    _register_child_run,
+    _unregister_team_run,
+    get_child_run_ids,
+)
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def clean_child_runs():
+    """Ensure _child_runs is empty before and after each test."""
+    with _child_runs_lock:
+        _child_runs.clear()
+    yield
+    with _child_runs_lock:
+        _child_runs.clear()
+
+
+# ============================================================================
+# Unit tests: child run mapping
+# ============================================================================
+
+
+class TestChildRunMapping:
+    """Tests for _register_child_run, get_child_run_ids, _unregister_team_run."""
+
+    def test_register_single_child(self):
+        _register_child_run("team-1", "member-1")
+        assert get_child_run_ids("team-1") == {"member-1"}
+
+    def test_register_multiple_children(self):
+        _register_child_run("team-1", "member-1")
+        _register_child_run("team-1", "member-2")
+        _register_child_run("team-1", "member-3")
+        assert get_child_run_ids("team-1") == {"member-1", "member-2", "member-3"}
+
+    def test_register_multiple_teams(self):
+        _register_child_run("team-1", "member-a")
+        _register_child_run("team-2", "member-b")
+        assert get_child_run_ids("team-1") == {"member-a"}
+        assert get_child_run_ids("team-2") == {"member-b"}
+
+    def test_get_child_run_ids_returns_copy(self):
+        """get_child_run_ids should return a copy, not a reference."""
+        _register_child_run("team-1", "member-1")
+        ids = get_child_run_ids("team-1")
+        ids.add("member-hacked")
+        # Original should not be modified
+        assert get_child_run_ids("team-1") == {"member-1"}
+
+    def test_get_child_run_ids_empty(self):
+        assert get_child_run_ids("nonexistent") == set()
+
+    def test_unregister_team_run(self):
+        _register_child_run("team-1", "member-1")
+        _unregister_team_run("team-1")
+        assert get_child_run_ids("team-1") == set()
+
+    def test_unregister_nonexistent_team(self):
+        """Should not raise on non-existent key."""
+        _unregister_team_run("nonexistent")  # no error
+
+    def test_double_unregister(self):
+        _register_child_run("team-1", "member-1")
+        _unregister_team_run("team-1")
+        _unregister_team_run("team-1")  # no error
+        assert get_child_run_ids("team-1") == set()
+
+    def test_unregister_one_team_does_not_affect_other(self):
+        _register_child_run("team-1", "member-a")
+        _register_child_run("team-2", "member-b")
+        _unregister_team_run("team-1")
+        assert get_child_run_ids("team-1") == set()
+        assert get_child_run_ids("team-2") == {"member-b"}
+
+    def test_duplicate_register_same_child(self):
+        """Registering the same child twice should not create duplicates."""
+        _register_child_run("team-1", "member-1")
+        _register_child_run("team-1", "member-1")
+        assert get_child_run_ids("team-1") == {"member-1"}
+
+
+# ============================================================================
+# Unit tests: thread safety
+# ============================================================================
+
+
+class TestThreadSafety:
+    """Tests for concurrent access to _child_runs."""
+
+    def test_concurrent_registrations(self):
+        """Many threads registering children for the same team should not lose any."""
+        n = 100
+        barrier = threading.Barrier(n)
+
+        def register(i):
+            barrier.wait()
+            _register_child_run("team-1", f"member-{i}")
+
+        threads = [threading.Thread(target=register, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        ids = get_child_run_ids("team-1")
+        assert len(ids) == n
+        for i in range(n):
+            assert f"member-{i}" in ids
+
+
+# ============================================================================
+# Unit tests: cancel_run cascade
+# ============================================================================
+
+
+class TestCancelRunCascade:
+    """Tests for team._run.cancel_run cascade behaviour."""
+
+    @patch("agno.team._run.cancel_run_global")
+    def test_cancel_run_cascades_to_children(self, mock_cancel_global):
+        """cancel_run should call cancel_run_global for team + all member runs."""
+        from agno.team._run import cancel_run
+
+        mock_cancel_global.return_value = True
+
+        # Register some children
+        _register_child_run("team-1", "member-1")
+        _register_child_run("team-1", "member-2")
+
+        result = cancel_run("team-1")
+
+        assert result is True
+        # Should have been called 3 times: team + 2 members
+        assert mock_cancel_global.call_count == 3
+        called_ids = {call.args[0] for call in mock_cancel_global.call_args_list}
+        assert called_ids == {"team-1", "member-1", "member-2"}
+
+    @patch("agno.team._run.cancel_run_global")
+    def test_cancel_run_cleans_up_mapping(self, mock_cancel_global):
+        """cancel_run should unregister the team run after cascading."""
+        from agno.team._run import cancel_run
+
+        mock_cancel_global.return_value = True
+        _register_child_run("team-1", "member-1")
+
+        cancel_run("team-1")
+
+        assert get_child_run_ids("team-1") == set()
+
+    @patch("agno.team._run.cancel_run_global")
+    def test_cancel_run_no_children(self, mock_cancel_global):
+        """cancel_run with no children should only cancel the team itself."""
+        from agno.team._run import cancel_run
+
+        mock_cancel_global.return_value = False
+
+        result = cancel_run("team-no-children")
+
+        assert result is False
+        assert mock_cancel_global.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("agno.team._run.acancel_run_global")
+    async def test_acancel_run_cascades_to_children(self, mock_acancel_global):
+        """acancel_run should cascade to all member runs."""
+        from agno.team._run import acancel_run
+
+        mock_acancel_global.return_value = True
+
+        _register_child_run("team-1", "member-1")
+        _register_child_run("team-1", "member-2")
+
+        result = await acancel_run("team-1")
+
+        assert result is True
+        assert mock_acancel_global.call_count == 3
+        called_ids = {call.args[0] for call in mock_acancel_global.call_args_list}
+        assert called_ids == {"team-1", "member-1", "member-2"}
+
+    @pytest.mark.asyncio
+    @patch("agno.team._run.acancel_run_global")
+    async def test_acancel_run_cleans_up_mapping(self, mock_acancel_global):
+        """acancel_run should unregister the team run after cascading."""
+        from agno.team._run import acancel_run
+
+        mock_acancel_global.return_value = True
+        _register_child_run("team-1", "member-1")
+
+        await acancel_run("team-1")
+
+        assert get_child_run_ids("team-1") == set()


### PR DESCRIPTION
## Summary

(Fixes #7730)

Fix team cancellation to **cascade** to currently-running member agent runs.

**Problem:** When a team run is cancelled via `cancel_run(team_run_id)`, only the team-level execution is interrupted. Member agents that are currently running continue to completion because they generate their own `run_id` via `uuid4()` — the team's `cancelled_runs` entry does not match the member's `run_id`, so `raise_if_cancelled()` inside the member agent never detects the cancellation.

**Reproduction on upstream/main (v2.6.3):**

```python
# Start team run in background, pre-set run_id
t = threading.Thread(target=lambda: team.run(input="...", run_id="team-001", stream=False))
t.start()

# Wait for member to start, then cancel
time.sleep(8)
team.cancel_run("team-001")
t.join()
```

**Actual output on upstream/main:**

```
Run[0]: RunOutput,     status=COMPLETED, content_len=12498, run_id=54e914cc-...  ← member kept running!
Run[1]: TeamRunOutput, status=CANCELLED, content_len=35,    run_id=team-001
```

**With this fix:**

```
INFO Run team-002 marked for cancellation
INFO Run 01220370-... marked for cancellation                          ← cascade!
INFO Cancelled member run 01220370-... (cascade from team run team-002)
INFO Run 01220370-... was cancelled during streaming                   ← member stopped!
```

**Solution:** Pre-generate a unique `member_run_id` for each member delegation and maintain a **parent→child mapping** (`_child_runs: Dict[str, Set[str]]`). When the team is cancelled, `cancel_run()` cascades to all registered member runs.

### Cascade Cancel Flow

```
cancel_run("team-123")
  → cancel_run_global("team-123")           ← mark team cancelled
  → cancel_run_global("member-456")          ← cascade: mark member_a cancelled
  → cancel_run_global("member-789")          ← cascade: mark member_b cancelled
  → _unregister_team_run("team-123")         ← clean up mapping
  → member raise_if_cancelled("member-456")  ← detects cancellation → raises → stops
```

### Files Changed

| File | Change |
|------|--------|
| `agno/team/_default_tools.py` | Add `_child_runs` mapping + helpers (`_register_child_run`, `_unregister_team_run`, `get_child_run_ids`); pre-generate `member_run_id` and pass `run_id=` to all 4 `member.run()` call sites |
| `agno/team/_run.py` | `cancel_run()` / `acancel_run()` cascade to child runs via `get_child_run_ids()`; `_cleanup_and_store()` / `_acleanup_and_store()` clean up the mapping on normal completion |

### Key Design Decisions

1. **Pre-generated member_run_id**: Each member gets a unique ID (`uuid4()`), avoiding conflicts with team storage/cleanup.
2. **Thread-safe mapping**: `_child_runs` protected by `threading.Lock` for safe concurrent access.
3. **Cleanup on all paths**: Mapping is cleaned up in `cancel_run()` (cancel path) and `_cleanup_and_store()` (normal/error path).
4. **No changes to Agent code**: The fix is entirely within Team-layer code.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Why run_id cannot be shared

Sharing the team's `run_id` with member runs causes conflicts:

| Mechanism | Conflict |
|-----------|----------|
| `session.upsert_run()` | Member `RunOutput` overwrites team `TeamRunOutput` (same run_id) |
| `cleanup_run()` | Member finishing first deletes team's cancellation tracking |
| `parent_run_id` | Creates circular reference (parent == self) |

### Scenario Coverage

| Scenario | Before | After |
|----------|--------|-------|
| Member not yet started, team cancelled | ❌ Member still starts | ✅ Member cancelled before start |
| Member currently running, team cancelled | ❌ Member runs to completion | ✅ Member detects cancellation at next checkpoint |
| Member already completed, team cancelled | ✅ No issue | ✅ No issue |
| Multiple members, cancel mid-broadcast | ❌ All continue | ✅ All running members stopped |
