### PR TITLE
cookbook: agent dependency-injection examples (7 new patterns)

### DIFF
--- a/cookbook/02_agents/15_dependencies/01_static_dependencies.py
+++ b/cookbook/02_agents/15_dependencies/01_static_dependencies.py
@@ -1,0 +1,32 @@
+"""
+Static Dependencies
+=============================
+
+Inject plain values (no callables) as dependencies. Useful for tenant config,
+feature flags, and request-scoped settings that do not need to be computed.
+
+Pitfall: dependencies are read once per run; mutating the dict after the
+agent is created has no effect on in-flight runs.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    dependencies={
+        "tenant_name": "acme-inc",
+        "feature_flags": {"new_ui": True, "beta_search": False},
+        "max_results": 10,
+    },
+    add_dependencies_to_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response("Summarize my configuration. Which feature flags are enabled?")

--- a/cookbook/02_agents/15_dependencies/02_callable_dependencies.py
+++ b/cookbook/02_agents/15_dependencies/02_callable_dependencies.py
@@ -1,0 +1,49 @@
+"""
+Callable Dependencies
+=============================
+
+Inject functions as dependencies. Each callable is invoked once at the start
+of every run, so the agent always sees fresh data without you needing to
+pass it explicitly.
+
+Pitfall: callables run once per run, not per turn or per tool call. For
+truly dynamic per-tool-call data, fetch it inside the tool instead.
+"""
+
+from datetime import datetime
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+
+def get_current_time() -> str:
+    return datetime.now().isoformat()
+
+
+def get_active_users() -> list[dict]:
+    # Pretend this is a database query that runs at the start of every run
+    return [
+        {"id": 1, "name": "Alice", "role": "admin"},
+        {"id": 2, "name": "Bob", "role": "viewer"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    dependencies={
+        "current_time": get_current_time,
+        "active_users": get_active_users,
+    },
+    add_dependencies_to_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "What time is it now and who is currently active in the system?"
+    )

--- a/cookbook/02_agents/15_dependencies/03_async_dependencies.py
+++ b/cookbook/02_agents/15_dependencies/03_async_dependencies.py
@@ -1,0 +1,52 @@
+"""
+Async Dependencies
+=============================
+
+Inject async resolvers. The framework awaits async callables automatically
+so you can use `httpx.AsyncClient`, async DB drivers, or any awaitable.
+
+Pitfall: only `arun` and `aprint_response` will await async dependencies
+cleanly. Calling sync `run` with async dependencies logs a warning and
+skips them.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+
+async def fetch_user_profile() -> dict:
+    # Simulate an async DB or HTTP fetch
+    await asyncio.sleep(0.1)
+    return {
+        "name": "Alice",
+        "tier": "enterprise",
+        "region": "us-west-2",
+    }
+
+
+async def fetch_quotas() -> dict:
+    await asyncio.sleep(0.1)
+    return {"monthly_tokens": 100_000, "used": 12_345}
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    dependencies={
+        "user_profile": fetch_user_profile,
+        "quotas": fetch_quotas,
+    },
+    add_dependencies_to_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    asyncio.run(
+        agent.aprint_response("Greet me by name and tell me my remaining token quota.")
+    )

--- a/cookbook/02_agents/15_dependencies/04_template_strings_in_instructions.py
+++ b/cookbook/02_agents/15_dependencies/04_template_strings_in_instructions.py
@@ -1,0 +1,50 @@
+"""
+Template Strings In Instructions
+=============================
+
+Dependency values are substituted into instructions, system messages, and
+additional context using `{key}` syntax. The agent resolves these at run
+start when `resolve_in_context` is True (the default).
+
+This avoids the need for `add_dependencies_to_context=True` when you only
+want a couple of values placed in specific spots — the templating is more
+precise.
+
+Pitfall: keys that don't exist in dependencies or session_state raise an
+error. Only reference keys you know are populated.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+
+def get_user_profile() -> dict:
+    return {
+        "name": "Alex Chen",
+        "role": "Senior Data Scientist",
+        "team": "Recommendations",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    dependencies={
+        "user_profile": get_user_profile,
+        "tone": "concise",
+    },
+    instructions=[
+        "You are responding to {user_profile}.",
+        "Always use a {tone} tone.",
+    ],
+    # Default is True; shown explicitly here for clarity
+    resolve_in_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response("What should I focus on this week?")

--- a/cookbook/02_agents/15_dependencies/05_run_level_overrides.py
+++ b/cookbook/02_agents/15_dependencies/05_run_level_overrides.py
@@ -1,0 +1,40 @@
+"""
+Run Level Overrides
+=============================
+
+Dependencies merge: class-level dependencies provide defaults, and
+`agent.run(dependencies=...)` overrides them per-run. Run-level wins on
+key conflicts; non-conflicting keys merge.
+
+Pitfall: this is a SHALLOW merge. Nested dicts at the same key are
+replaced wholesale, not deep-merged.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    dependencies={
+        "tenant": "acme-inc",
+        "tone": "professional",
+        "max_results": 10,
+    },
+    add_dependencies_to_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=== Run 1: defaults from class-level dependencies ===")
+    agent.print_response("Which configuration values are you using?")
+
+    print("\n=== Run 2: override 'tone' and add new key 'audience' ===")
+    agent.print_response(
+        "Which configuration values are you using?",
+        dependencies={"tone": "casual", "audience": "engineers"},
+    )

--- a/cookbook/02_agents/15_dependencies/06_runtime_aware_dependencies.py
+++ b/cookbook/02_agents/15_dependencies/06_runtime_aware_dependencies.py
@@ -1,0 +1,65 @@
+"""
+Runtime-Aware Dependencies
+=============================
+
+Dependency resolvers can opt into the agent and run context by declaring
+`agent` and/or `run_context` parameters. The framework inspects the
+signature and passes them in automatically.
+
+This is the cleanest way to fetch user-specific data from the resolver:
+read `run_context.user_id` or `run_context.session_id` to drive the
+lookup, and the rest of the agent pipeline sees the resolved value.
+
+Pitfall: parameter names matter — only `agent` and `run_context` are
+injected. Other names are ignored.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.run import RunContext
+
+USER_PROFILES = {
+    "user_alice": {"name": "Alice", "tier": "enterprise"},
+    "user_bob": {"name": "Bob", "tier": "free"},
+}
+
+
+def get_user_profile(run_context: RunContext) -> dict:
+    user_id = run_context.user_id or "unknown"
+    return USER_PROFILES.get(user_id, {"name": "Unknown", "tier": "guest"})
+
+
+def describe_session(run_context: RunContext, agent: Agent) -> str:
+    return f"agent={agent.name}, session={run_context.session_id}"
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    name="ProfileAware",
+    model=OpenAIResponses(id="gpt-5.4"),
+    dependencies={
+        "user_profile": get_user_profile,
+        "session_info": describe_session,
+    },
+    add_dependencies_to_context=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=== Run as user_alice ===")
+    agent.print_response(
+        "Greet me by name and mention my tier.",
+        user_id="user_alice",
+        session_id="alice_session",
+    )
+
+    print("\n=== Run as user_bob ===")
+    agent.print_response(
+        "Greet me by name and mention my tier.",
+        user_id="user_bob",
+        session_id="bob_session",
+    )

--- a/cookbook/02_agents/15_dependencies/07_dependencies_with_memory.py
+++ b/cookbook/02_agents/15_dependencies/07_dependencies_with_memory.py
@@ -1,0 +1,75 @@
+"""
+Dependencies With Memory
+=============================
+
+Realistic personalisation flow: a dependency fetches user-specific profile
+data per-run, and persistent memory accumulates user-specific facts across
+runs. Combined, you get an agent that knows who the user is from your
+application data AND remembers what they have told it.
+
+This pattern is the foundation for multi-tenant, personalised agents.
+
+Pitfall: dependencies do NOT persist. They resolve per-run from your
+application state (DB, cache, request). Memory persists in `db`.
+"""
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.models.openai import OpenAIResponses
+from agno.run import RunContext
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+USER_PROFILES = {
+    "user_alice": {
+        "name": "Alice",
+        "tenant": "acme",
+        "preferences": ["concise replies", "code examples"],
+    },
+    "user_bob": {
+        "name": "Bob",
+        "tenant": "globex",
+        "preferences": ["detailed explanations"],
+    },
+}
+
+
+def get_user_profile(run_context: RunContext) -> dict:
+    return USER_PROFILES.get(run_context.user_id or "", {"name": "Unknown"})
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+db = InMemoryDb()
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    db=db,
+    enable_user_memories=True,
+    add_memories_to_context=True,
+    dependencies={"user_profile": get_user_profile},
+    instructions=[
+        "You are responding to {user_profile}.",
+        "Match the user's stated preferences when responding.",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=== Run 1: alice introduces a fact about herself ===")
+    agent.print_response(
+        "Hi! I'm working on a recommendation engine in Rust this quarter.",
+        user_id="user_alice",
+        session_id="alice_session_1",
+    )
+
+    print("\n=== Run 2: same user, new session — profile dep + memory carry over ===")
+    agent.print_response(
+        "What was I working on, and what language am I using?",
+        user_id="user_alice",
+        session_id="alice_session_2",
+    )

--- a/cookbook/02_agents/15_dependencies/README.md
+++ b/cookbook/02_agents/15_dependencies/README.md
@@ -1,16 +1,35 @@
-# dependencies
+# 15_dependencies
 
-Examples for runtime dependency injection and dynamic runtime inputs.
+Dependency injection for agents. Inject configuration, user-specific data, or
+runtime resources into the agent context, into tools, and into instructions
+via template strings.
 
 ## Files
-- `dependencies_in_context.py` - Demonstrates dependencies in context.
-- `dependencies_in_tools.py` - Demonstrates dependencies in tools.
-- `dynamic_tools.py` - Demonstrates dynamic tools.
+
+Numbered files form a progression from simplest to most advanced. The
+unnumbered files are kept as alternative entry points.
+
+| File | What it shows |
+|------|---------------|
+| `01_static_dependencies.py` | Plain dict values — config, feature flags, tenant settings |
+| `02_callable_dependencies.py` | Sync callables resolved once per run |
+| `03_async_dependencies.py` | Async resolvers awaited via `arun` / `aprint_response` |
+| `04_template_strings_in_instructions.py` | `{key}` substitution into instructions and system messages |
+| `05_run_level_overrides.py` | Class-level defaults vs `agent.run(dependencies=...)` precedence |
+| `06_runtime_aware_dependencies.py` | Resolvers that read `agent` and `run_context` (e.g. `user_id`) |
+| `07_dependencies_with_memory.py` | Personalised flow combining dependencies with persistent memory |
+| `dependencies_in_context.py` | Original example: `add_dependencies_to_context=True` with HackerNews |
+| `dependencies_in_tools.py` | Read `run_context.dependencies` from inside a tool |
+| `dynamic_tools.py` | Return a list of tools from a callable factory |
 
 ## Prerequisites
+
 - Load environment variables with `direnv allow` (including `OPENAI_API_KEY`).
-- Create the demo environment with `./scripts/demo_setup.sh`, then run cookbooks with `.venvs/demo/bin/python`.
-- Some examples require optional local services (for example pgvector) or provider-specific API keys.
+- Create the demo environment with `./scripts/demo_setup.sh`, then run cookbooks
+  with `.venvs/demo/bin/python`.
 
 ## Run
-- `.venvs/demo/bin/python cookbook/02_agents/<directory>/<file>.py`
+
+```bash
+.venvs/demo/bin/python cookbook/02_agents/15_dependencies/<file>.py
+```

--- a/cookbook/02_agents/15_dependencies/TEST_LOG.md
+++ b/cookbook/02_agents/15_dependencies/TEST_LOG.md
@@ -1,33 +1,86 @@
 # Test Log -- 15_dependencies
 
-**Tested:** 2026-02-13
-**Environment:** .venvs/demo/bin/python, pgvector: running
+**Tested:** 2026-04-28
+**Environment:** .venvs/demo/bin/python (gpt-5.4)
+
+---
+
+### 01_static_dependencies.py
+
+**Status:** PASS
+**Description:** Plain dict values as dependencies; verified the agent receives feature flags and tenant config in context.
+**Result:** Completed successfully in ~3s.
+
+---
+
+### 02_callable_dependencies.py
+
+**Status:** PASS
+**Description:** Sync callables resolved once per run; current_time and active_users injected.
+**Result:** Completed successfully in ~3s.
+
+---
+
+### 03_async_dependencies.py
+
+**Status:** PASS
+**Description:** Async dependency resolvers awaited via `aprint_response`.
+**Result:** Completed successfully in ~3s.
+
+---
+
+### 04_template_strings_in_instructions.py
+
+**Status:** PASS
+**Description:** `{user_profile}` and `{tone}` substituted into instructions; agent matched stated tone.
+**Result:** Completed successfully in ~9s.
+
+---
+
+### 05_run_level_overrides.py
+
+**Status:** PASS
+**Description:** Class-level defaults override-able per-run; second run shows different tone and added audience key.
+**Result:** Completed successfully in ~6s.
+
+---
+
+### 06_runtime_aware_dependencies.py
+
+**Status:** PASS
+**Description:** Resolvers read `run_context.user_id` and `agent.name`; profile differs by user.
+**Result:** Completed successfully in ~4s.
+
+---
+
+### 07_dependencies_with_memory.py
+
+**Status:** PASS
+**Description:** Combined dependencies (per-run profile) with persistent user memory across two sessions.
+**Result:** Completed successfully in ~10s.
 
 ---
 
 ### dependencies_in_context.py
 
 **Status:** PASS
-**Tier:** untagged
-**Description:** Demonstrates dependencies in context. Ran successfully and produced expected output.
-**Result:** Completed successfully in 19s.
+**Description:** Demonstrates dependencies in context (HackerNews summary).
+**Result:** Ran successfully after gpt-5.4 model update.
 
 ---
 
 ### dependencies_in_tools.py
 
 **Status:** PASS
-**Tier:** untagged
-**Description:** Demonstrates dependencies in tools. Ran successfully and produced expected output.
-**Result:** Completed successfully in 11s.
+**Description:** Demonstrates dependencies accessed inside a tool via `run_context.dependencies`.
+**Result:** Ran successfully after gpt-5.4 model update.
 
 ---
 
 ### dynamic_tools.py
 
 **Status:** PASS
-**Tier:** untagged
-**Description:** Demonstrates dynamic tools. Ran successfully and produced expected output.
-**Result:** Completed successfully in 3s.
+**Description:** Demonstrates a callable tools factory (note: this is a tools example placed here for now).
+**Result:** Ran successfully after gpt-5.4 model update.
 
 ---

--- a/cookbook/02_agents/15_dependencies/dependencies_in_context.py
+++ b/cookbook/02_agents/15_dependencies/dependencies_in_context.py
@@ -43,7 +43,7 @@ def get_top_hackernews_stories(num_stories: int = 5) -> str:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.2"),
+    model=OpenAIResponses(id="gpt-5.4"),
     # Each function in the dependencies is resolved when the agent is run,
     # think of it as dependency injection for Agents
     dependencies={"top_hackernews_stories": get_top_hackernews_stories},

--- a/cookbook/02_agents/15_dependencies/dependencies_in_tools.py
+++ b/cookbook/02_agents/15_dependencies/dependencies_in_tools.py
@@ -72,7 +72,7 @@ def analyze_user(user_id: str, run_context: RunContext) -> str:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.2"),
+    model=OpenAIResponses(id="gpt-5.4"),
     tools=[analyze_user],
     name="User Analysis Agent",
     description="An agent specialized in analyzing users using integrated data sources.",

--- a/cookbook/02_agents/15_dependencies/dynamic_tools.py
+++ b/cookbook/02_agents/15_dependencies/dynamic_tools.py
@@ -30,7 +30,7 @@ def get_runtime_tools(run_context: RunContext):
 # ---------------------------------------------------------------------------
 agent = Agent(
     name="Dynamic Tools Agent",
-    model=OpenAIResponses(id="gpt-5.2"),
+    model=OpenAIResponses(id="gpt-5.4"),
     tools=get_runtime_tools,
 )
 

--- a/cookbook/02_agents/README.md
+++ b/cookbook/02_agents/README.md
@@ -20,10 +20,10 @@ Practical examples for building agents with Agno, organized by feature area.
 | 12 | [12_multimodal](./12_multimodal/) | Image, audio, video processing | 10 |
 | 13 | [13_reasoning](./13_reasoning/) | Multi-step reasoning, reasoning models | 2 |
 | 14 | [14_advanced](./14_advanced/) | Caching, compression, events, retries, concurrency, culture | 20 |
-| 15 | [15_dependencies](./15_dependencies/) | Dependency injection in tools and context | 3 |
+| 15 | [15_dependencies](./15_dependencies/) | Dependency injection in tools and context | 10 |
 | 16 | [16_skills](./16_skills/) | Agent skills with scripts and reference docs | 1 |
 
-**Total: 111 files across 16 directories**
+**Total: 118 files across 16 directories**
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Expands `cookbook/02_agents/15_dependencies/` from 3 examples to 10, walking
through Agent dependency injection from simplest to most realistic. The
existing examples were thin and did not surface several capabilities the
framework already supports — template-string substitution, async resolvers,
runtime-aware callables, run-level overrides, and personalisation flows.

This is **Phase 1 of a multi-phase cookbook expansion**. Subsequent phases
will mirror the work for Teams (`17_dependencies/`) and Workflows (a new
`09_dependencies/` folder), then fill smaller parameter and method gaps
across Agent / Team / Workflow.

### What's new

7 progressive examples in `cookbook/02_agents/15_dependencies/`:

| # | File | Pattern |
|---|------|---------|
| 1 | `01_static_dependencies.py` | Plain dict values — config, feature flags |
| 2 | `02_callable_dependencies.py` | Sync callables resolved once per run |
| 3 | `03_async_dependencies.py` | Async resolvers awaited via `aprint_response` |
| 4 | `04_template_strings_in_instructions.py` | `{key}` substitution + `resolve_in_context` |
| 5 | `05_run_level_overrides.py` | Class-level vs run-level merge (shallow) |
| 6 | `06_runtime_aware_dependencies.py` | Resolvers reading `agent` / `run_context` (e.g. `user_id`) |
| 7 | `07_dependencies_with_memory.py` | Personalised flow combining deps with persistent memory |

Plus:
- The 3 existing files (`dependencies_in_context.py`, `dependencies_in_tools.py`,
  `dynamic_tools.py`) bumped from `gpt-5.2` to `gpt-5.4` (framework default).
- README rewritten with a file table and progression notes.
- TEST_LOG.md refreshed with current results.
- Parent `cookbook/02_agents/README.md` file count updated (3 → 10, total 111 → 118).

## Type of change

- [x] New feature
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment — every new file runs to exit 0 with `OPENAI_API_KEY` loaded
- [ ] Tests added/updated (if applicable) — N/A, cookbook examples

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this
- [x] If a similar PR exists, I have explained below why this PR is a better approach — N/A
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — yes, generated with Claude Code under direct human review per phase

## Additional Notes

**Validation performed**

- `cookbook/scripts/check_cookbook_pattern.py --base-dir cookbook/02_agents/15_dependencies --recursive` → 0 violations across all 10 files.
- `ruff format` + `ruff check` clean.
- Each new file run with real API calls — all exit 0.
- The 3 existing files re-run after the model bump — all still exit 0.

**Implementation note**

The originally planned `07_caching_callables.py` was dropped after discovering
that `cache_callables` only applies to `tools`, `knowledge`, and `members`
resolvers — NOT to `dependencies`. Verified at
`libs/agno/agno/utils/callables.py` (look for `resolve_callable_*`) vs
`libs/agno/agno/agent/_run.py:resolve_run_dependencies` which has no caching
path. Replaced with `06_runtime_aware_dependencies.py` which surfaces a
unique-to-deps capability: resolvers can opt into `agent` and `run_context`
kwargs by parameter name.

**`dynamic_tools.py` placement**

This file remains in `15_dependencies/` for now. It's really a tools example
(returning a tool list from a callable factory), not a dependency-injection
example. Flagged for a possible future move to `04_tools/` — left alone in
this PR to keep scope tight.