### PR TITLE
fix: make async session name generation non-blocking

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -383,6 +383,41 @@ async def aset_session_name(
     )
 
 
+def _get_session_name_messages(agent: Agent, session: AgentSession) -> List[Message]:
+    gen_session_name_prompt = "Conversation\n"
+
+    messages_for_generating_session_name = session.get_messages()
+
+    for message in messages_for_generating_session_name:
+        gen_session_name_prompt += f"{message.role.upper()}: {message.content}\n"
+
+    gen_session_name_prompt += "\n\nConversation Name: "
+
+    system_message = Message(
+        role=agent.system_message_role,
+        content="Please provide a suitable name for this conversation in maximum 5 words. "
+        "Remember, do not exceed 5 words.",
+    )
+    user_message = Message(role=agent.user_message_role, content=gen_session_name_prompt)
+    return [system_message, user_message]
+
+
+def _parse_generated_session_name(content: Optional[str], max_retries: int, attempt: int) -> Optional[str]:
+    if content is None:
+        if attempt >= max_retries:
+            return "New Session"
+        log_error("Generated name is None. Trying again.")
+        return None
+
+    if len(content.split()) > 5:
+        if attempt >= max_retries:
+            return " ".join(content.split()[:5])
+        log_error("Generated name is too long. It should be less than 5 words. Trying again.")
+        return None
+
+    return content.replace('"', "").strip()
+
+
 def generate_session_name(agent: Agent, session: AgentSession, max_retries: int = 3, _attempt: int = 0) -> str:
     """
     Generate a name for the session using the first 6 messages from the memory
@@ -399,38 +434,35 @@ def generate_session_name(agent: Agent, session: AgentSession, max_retries: int 
     if agent.model is None:
         raise Exception("Model not set")
 
-    gen_session_name_prompt = "Conversation\n"
-
-    messages_for_generating_session_name = session.get_messages()
-
-    for message in messages_for_generating_session_name:
-        gen_session_name_prompt += f"{message.role.upper()}: {message.content}\n"
-
-    gen_session_name_prompt += "\n\nConversation Name: "
-
-    system_message = Message(
-        role=agent.system_message_role,
-        content="Please provide a suitable name for this conversation in maximum 5 words. "
-        "Remember, do not exceed 5 words.",
-    )
-    user_message = Message(role=agent.user_message_role, content=gen_session_name_prompt)
-    generate_name_messages = [system_message, user_message]
-
     # Generate name
-    generated_name = agent.model.response(messages=generate_name_messages)
-    content = generated_name.content
-    if content is None:
-        if _attempt >= max_retries:
-            return "New Session"
-        log_error("Generated name is None. Trying again.")
+    generated_name = agent.model.response(messages=_get_session_name_messages(agent, session))
+    session_name = _parse_generated_session_name(generated_name.content, max_retries=max_retries, attempt=_attempt)
+    if session_name is None:
         return generate_session_name(agent, session=session, max_retries=max_retries, _attempt=_attempt + 1)
+    return session_name
 
-    if len(content.split()) > 5:
-        if _attempt >= max_retries:
-            return " ".join(content.split()[:5])
-        log_error("Generated name is too long. It should be less than 5 words. Trying again.")
-        return generate_session_name(agent, session=session, max_retries=max_retries, _attempt=_attempt + 1)
-    return content.replace('"', "").strip()
+
+async def agenerate_session_name(agent: Agent, session: AgentSession, max_retries: int = 3, _attempt: int = 0) -> str:
+    """
+    Generate a name for the session using the first 6 messages from the memory asynchronously
+
+    Args:
+        agent: The Agent instance.
+        session (AgentSession): The session to generate a name for.
+        max_retries: Maximum number of retries if generation fails.
+        _attempt: Current attempt number (used internally for recursion).
+    Returns:
+        str: The generated session name.
+    """
+
+    if agent.model is None:
+        raise Exception("Model not set")
+
+    generated_name = await agent.model.aresponse(messages=_get_session_name_messages(agent, session))
+    session_name = _parse_generated_session_name(generated_name.content, max_retries=max_retries, attempt=_attempt)
+    if session_name is None:
+        return await agenerate_session_name(agent, session=session, max_retries=max_retries, _attempt=_attempt + 1)
+    return session_name
 
 
 def get_session_name(agent: Agent, session_id: Optional[str] = None) -> str:

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -981,6 +981,9 @@ class Agent:
     def generate_session_name(self, session: AgentSession) -> str:
         return _session.generate_session_name(self, session=session)
 
+    async def agenerate_session_name(self, session: AgentSession) -> str:
+        return await _session.agenerate_session_name(self, session=session)
+
     def get_session_name(self, session_id: Optional[str] = None) -> str:
         return _session.get_session_name(self, session_id=session_id)
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -33,7 +33,7 @@ from agno.utils.agent import (
     set_session_name_util,
     update_session_state_util,
 )
-from agno.utils.log import log_debug, log_warning
+from agno.utils.log import log_debug, log_error, log_warning
 
 # ---------------------------------------------------------------------------
 # Session read / write
@@ -247,21 +247,7 @@ async def asave_session(team: "Team", session: TeamSession) -> None:
 # ---------------------------------------------------------------------------
 
 
-def generate_session_name(team: "Team", session: TeamSession, _retries: int = 0) -> str:
-    """
-    Generate a name for the team session
-
-    Args:
-        session: The TeamSession to generate a name for.
-        _retries: Internal retry counter (do not set manually).
-    Returns:
-        str: The generated session name.
-    """
-    max_retries = 3
-
-    if team.model is None:
-        raise Exception("Model not set")
-
+def _get_session_name_messages(team: "Team", session: TeamSession) -> List[Message]:
     gen_session_name_prompt = "Team Conversation\n"
 
     # Get team session messages for generating the name
@@ -278,32 +264,72 @@ def generate_session_name(team: "Team", session: TeamSession, _retries: int = 0)
         "Remember, do not exceed 5 words.",
     )
     user_message = Message(role="user", content=gen_session_name_prompt)
-    generate_name_messages = [system_message, user_message]
+    return [system_message, user_message]
 
-    # Generate name
-    generated_name = team.model.response(messages=generate_name_messages)
-    content = generated_name.content
+
+def _parse_generated_session_name(content: Optional[str], retries: int, max_retries: int) -> Optional[str]:
     if content is None:
-        if _retries < max_retries:
-            from agno.utils.log import log_error
-
+        if retries < max_retries:
             log_error("Generated name is None. Trying again.")
-            return generate_session_name(team, session=session, _retries=_retries + 1)
-        from agno.utils.log import log_error
+            return None
 
         log_error("Generated name is None after max retries. Using fallback.")
         return "Team Session"
-    if len(content.split()) > 15:
-        if _retries < max_retries:
-            from agno.utils.log import log_error
 
+    if len(content.split()) > 15:
+        if retries < max_retries:
             log_error("Generated name is too long. Trying again.")
-            return generate_session_name(team, session=session, _retries=_retries + 1)
-        from agno.utils.log import log_error
+            return None
 
         log_error("Generated name is too long after max retries. Using fallback.")
         return "Team Session"
+
     return content.replace('"', "").strip()
+
+
+def generate_session_name(team: "Team", session: TeamSession, _retries: int = 0) -> str:
+    """
+    Generate a name for the team session
+
+    Args:
+        session: The TeamSession to generate a name for.
+        _retries: Internal retry counter (do not set manually).
+    Returns:
+        str: The generated session name.
+    """
+    max_retries = 3
+
+    if team.model is None:
+        raise Exception("Model not set")
+
+    # Generate name
+    generated_name = team.model.response(messages=_get_session_name_messages(team, session))
+    session_name = _parse_generated_session_name(generated_name.content, retries=_retries, max_retries=max_retries)
+    if session_name is None:
+        return generate_session_name(team, session=session, _retries=_retries + 1)
+    return session_name
+
+
+async def agenerate_session_name(team: "Team", session: TeamSession, _retries: int = 0) -> str:
+    """
+    Generate a name for the team session asynchronously
+
+    Args:
+        session: The TeamSession to generate a name for.
+        _retries: Internal retry counter (do not set manually).
+    Returns:
+        str: The generated session name.
+    """
+    max_retries = 3
+
+    if team.model is None:
+        raise Exception("Model not set")
+
+    generated_name = await team.model.aresponse(messages=_get_session_name_messages(team, session))
+    session_name = _parse_generated_session_name(generated_name.content, retries=_retries, max_retries=max_retries)
+    if session_name is None:
+        return await agenerate_session_name(team, session=session, _retries=_retries + 1)
+    return session_name
 
 
 def set_session_name(

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1560,6 +1560,9 @@ class Team:
     def generate_session_name(self, session: TeamSession) -> str:
         return _session.generate_session_name(self, session=session)
 
+    async def agenerate_session_name(self, session: TeamSession) -> str:
+        return await _session.agenerate_session_name(self, session=session)
+
     def set_session_name(
         self, session_id: Optional[str] = None, autogenerate: bool = False, session_name: Optional[str] = None
     ) -> TeamSession:

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -746,7 +746,7 @@ async def aset_session_name_util(
 
     # -*- Generate name for session
     if autogenerate:
-        session_name = entity.generate_session_name(session=session)  # type: ignore
+        session_name = await entity.agenerate_session_name(session=session)  # type: ignore
         log_debug(f"Generated Session Name: {session_name}")
     elif session_name is None:
         raise Exception("No session name provided")

--- a/libs/agno/tests/unit/agent/test_session_name.py
+++ b/libs/agno/tests/unit/agent/test_session_name.py
@@ -1,0 +1,48 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from agno.agent.agent import Agent
+from agno.models.response import ModelResponse
+from agno.session import AgentSession
+from agno.utils.agent import aset_session_name_util
+
+
+async def test_agent_agenerate_session_name_uses_async_model_response():
+    agent = Agent(id="session-name-agent")
+    agent.model = MagicMock()
+    agent.model.response = MagicMock(side_effect=AssertionError("sync response should not be called"))
+    agent.model.aresponse = AsyncMock(return_value=ModelResponse(content='"Async Session Name"'))
+
+    session_name = await agent.agenerate_session_name(session=AgentSession(session_id="session-1", runs=[]))
+
+    assert session_name == "Async Session Name"
+    agent.model.response.assert_not_called()
+    agent.model.aresponse.assert_awaited_once()
+
+
+async def test_aset_session_name_util_autogenerate_uses_async_generator():
+    class AsyncSessionNameEntity:
+        db = None
+
+        def __init__(self):
+            self.session = AgentSession(session_id="session-1", session_data={})
+            self.saved_session = None
+
+        async def aget_session(self, session_id: str):
+            assert session_id == self.session.session_id
+            return self.session
+
+        async def asave_session(self, session: AgentSession):
+            self.saved_session = session
+
+        def generate_session_name(self, session: AgentSession):
+            raise AssertionError("sync generator should not be called")
+
+        async def agenerate_session_name(self, session: AgentSession):
+            return "Generated Async Name"
+
+    entity = AsyncSessionNameEntity()
+
+    session = await aset_session_name_util(entity, session_id="session-1", autogenerate=True)  # type: ignore[arg-type]
+
+    assert session.session_data == {"session_name": "Generated Async Name"}
+    assert entity.saved_session is session

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -12,12 +12,13 @@ Tests cover:
 """
 
 from typing import Any, Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agno.agent.agent import Agent
 from agno.db.base import BaseDb, ComponentType
+from agno.models.response import ModelResponse
 from agno.registry import Registry
 from agno.session import TeamSession
 from agno.team.team import Team, get_team_by_id, get_teams
@@ -760,6 +761,19 @@ class TestTeamSessionNaming:
 
         assert session_name == "Team Session"
         assert team.model.response.call_count == 4
+
+    async def test_agenerate_session_name_uses_async_model_response(self):
+        """Test async session naming does not call the sync model response path."""
+        team = Team(id="session-name-team", members=[])
+        team.model = MagicMock()
+        team.model.response = MagicMock(side_effect=AssertionError("sync response should not be called"))
+        team.model.aresponse = AsyncMock(return_value=ModelResponse(content='"Async Team Name"'))
+
+        session_name = await team.agenerate_session_name(session=TeamSession(session_id="session-1", runs=[]))
+
+        assert session_name == "Async Team Name"
+        team.model.response.assert_not_called()
+        team.model.aresponse.assert_awaited_once()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add async Agent/Team session-name generation paths that call `model.aresponse()`.
- Route `aset_session_name(..., autogenerate=True)` through the async generator so async request handlers do not block on `model.response()`.
- Add regression coverage for Agent, Team, and the shared async utility path.

Fixes #7719

## Tests
- `uv run --no-sync pytest tests/unit/agent/test_session_name.py tests/unit/team/test_team_config.py::TestTeamSessionNaming`
- `uv run --no-sync ruff check agno/agent/_session.py agno/team/_session.py agno/utils/agent.py agno/agent/agent.py agno/team/team.py tests/unit/agent/test_session_name.py tests/unit/team/test_team_config.py`
- `uv run --no-sync ruff format --check agno/agent/_session.py agno/team/_session.py agno/utils/agent.py agno/agent/agent.py agno/team/team.py tests/unit/agent/test_session_name.py tests/unit/team/test_team_config.py`
- `git diff --check`