### PR TITLE
fix: recover member HITL runs from team session

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4799,6 +4799,33 @@ def _has_team_level_requirements(requirements: List[Any]) -> bool:
     return any(getattr(req, "member_agent_id", None) is None for req in requirements)
 
 
+def _resolve_member_run_output(
+    reqs: Sequence[Any],
+    run_response: TeamRunOutput,
+    session: TeamSession,
+) -> Optional[Union[RunOutput, TeamRunOutput]]:
+    """Find a member run needed to resume a delegated HITL requirement."""
+    if not reqs:
+        return None
+
+    member_run_output = getattr(reqs[0], "_member_run_response", None)
+    if member_run_output is not None:
+        return member_run_output
+
+    member_run_id = getattr(reqs[0], "member_run_id", None)
+    if member_run_id is None:
+        return None
+
+    for member_response in run_response.member_responses or []:
+        if getattr(member_response, "run_id", None) == member_run_id:
+            return member_response
+
+    if session.runs:
+        return session.get_run(member_run_id)
+
+    return None
+
+
 def _route_requirements_to_members(
     team: "Team",
     run_response: TeamRunOutput,
@@ -4834,22 +4861,7 @@ def _route_requirements_to_members(
 
         _, member = route_result
 
-        # Get the member's paused RunOutput from the requirement.
-        # This is stored by _propagate_member_pause and avoids needing a
-        # session/DB lookup (which fails without a database since
-        # initialize_team clears the cached session).
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
-
-        # If _member_run_response is not available (e.g., API flow where it's lost during
-        # JSON serialization), try to find the member's run from run_response.member_responses.
-        # This requires store_member_responses=True on the team.
-        if member_run_output is None:
-            member_run_id = reqs[0].member_run_id if reqs else None
-            if member_run_id and run_response.member_responses:
-                for mr in run_response.member_responses:
-                    if getattr(mr, "run_id", None) == member_run_id:
-                        member_run_output = mr
-                        break
+        member_run_output = _resolve_member_run_output(reqs, run_response, session)
 
         if member_run_output is not None:
             # Update requirements and tool executions on the member's run output
@@ -4933,15 +4945,7 @@ def _route_requirements_to_members_stream(
 
         _, member = route_result
 
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
-
-        if member_run_output is None:
-            member_run_id = reqs[0].member_run_id if reqs else None
-            if member_run_id and run_response.member_responses:
-                for mr in run_response.member_responses:
-                    if getattr(mr, "run_id", None) == member_run_id:
-                        member_run_output = mr
-                        break
+        member_run_output = _resolve_member_run_output(reqs, run_response, session)
 
         if member_run_output is not None:
             member_run_output.requirements = reqs
@@ -5037,19 +5041,7 @@ async def _aroute_requirements_to_members(
             return f"[{member_id}]: Could not route requirement — member not found"
 
         _, member = route_result
-        # Get the member's paused RunOutput from the requirement
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
-
-        # If _member_run_response is not available (e.g., API flow where it's lost during
-        # JSON serialization), try to find the member's run from run_response.member_responses.
-        # This requires store_member_responses=True on the team.
-        if member_run_output is None:
-            member_run_id = reqs[0].member_run_id if reqs else None
-            if member_run_id and run_response.member_responses:
-                for mr in run_response.member_responses:
-                    if getattr(mr, "run_id", None) == member_run_id:
-                        member_run_output = mr
-                        break
+        member_run_output = _resolve_member_run_output(reqs, run_response, session)
 
         if member_run_output is not None:
             member_run_output.requirements = reqs
@@ -5143,15 +5135,7 @@ async def _aroute_requirements_to_members_stream(
 
         _, member = route_result
 
-        member_run_output = getattr(reqs[0], "_member_run_response", None)
-
-        if member_run_output is None:
-            member_run_id = reqs[0].member_run_id if reqs else None
-            if member_run_id and run_response.member_responses:
-                for mr in run_response.member_responses:
-                    if getattr(mr, "run_id", None) == member_run_id:
-                        member_run_output = mr
-                        break
+        member_run_output = _resolve_member_run_output(reqs, run_response, session)
 
         if member_run_output is not None:
             member_run_output.requirements = reqs

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -578,6 +578,58 @@ class TestMemberRunResponseCleanup:
         assert run_response.requirements[0]._member_run_response is member_run_response
 
 
+class TestMemberRunOutputResolution:
+    """Verify member HITL resume can recover runs after in-memory state is lost."""
+
+    def test_prefers_in_memory_member_run_response(self):
+        from agno.run.agent import RunOutput
+        from agno.session import TeamSession
+        from agno.team._run import _resolve_member_run_output
+
+        req = _make_requirement(requires_confirmation=True)
+        req.member_run_id = "member-run-1"
+        in_memory_run = RunOutput(run_id="member-run-1", session_id="session-1")
+        req._member_run_response = in_memory_run
+
+        run_response = TeamRunOutput(run_id="team-run-1", session_id="session-1")
+        session = TeamSession(
+            session_id="session-1",
+            runs=[RunOutput(run_id="member-run-1", session_id="session-1")],
+        )
+
+        assert _resolve_member_run_output([req], run_response, session) is in_memory_run
+
+    def test_falls_back_to_member_responses(self):
+        from agno.run.agent import RunOutput
+        from agno.session import TeamSession
+        from agno.team._run import _resolve_member_run_output
+
+        req = _make_requirement(requires_confirmation=True)
+        req.member_run_id = "member-run-1"
+        member_response = RunOutput(run_id="member-run-1", session_id="session-1")
+        run_response = TeamRunOutput(
+            run_id="team-run-1",
+            session_id="session-1",
+            member_responses=[member_response],
+        )
+        session = TeamSession(session_id="session-1", runs=[])
+
+        assert _resolve_member_run_output([req], run_response, session) is member_response
+
+    def test_falls_back_to_persisted_team_session_run(self):
+        from agno.run.agent import RunOutput
+        from agno.session import TeamSession
+        from agno.team._run import _resolve_member_run_output
+
+        req = _make_requirement(requires_confirmation=True)
+        req.member_run_id = "member-run-1"
+        persisted_member_run = RunOutput(run_id="member-run-1", session_id="session-1")
+        run_response = TeamRunOutput(run_id="team-run-1", session_id="session-1")
+        session = TeamSession(session_id="session-1", runs=[persisted_member_run])
+
+        assert _resolve_member_run_output([req], run_response, session) is persisted_member_run
+
+
 # ===========================================================================
 # 10. Unresolved team-level requirements guard
 # ===========================================================================


### PR DESCRIPTION
## Summary
- resolve delegated member HITL runs from the persisted team session when in-memory references are gone
- reuse the same resolver across sync, streaming, async, and async-streaming continue paths
- add unit coverage for in-memory, member_responses, and persisted session fallback

Fixes #7717

## Tests
- `.test-venv/bin/python -m pytest tests/unit/team/test_continue_run_requirements.py -q`
- `.test-venv/bin/python -m ruff check agno/team/_run.py tests/unit/team/test_continue_run_requirements.py`
- `.test-venv/bin/python -m ruff format --check agno/team/_run.py tests/unit/team/test_continue_run_requirements.py`

## AI assistance
- Drafted with AI assistance and reviewed locally before submission.