### PR TITLE
Add LLM cost change analysis to CI

### DIFF
--- a/.github/workflows/llm-costs.yml
+++ b/.github/workflows/llm-costs.yml
@@ -1,0 +1,18 @@
+name: LLM Cost Analysis
+
+on:
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cost-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: Jwrede/tokentoll@753ca4d1150c74169b52a843439049b65e256d2b  # v0.6.1


### PR DESCRIPTION
## Summary

Add [tokentoll](https://github.com/Jwrede/tokentoll) GitHub Action to analyze LLM API cost changes on pull requests.

When a PR modifies code that makes LLM API calls (model swaps, max_tokens changes, new call sites), tokentoll posts a comment showing the projected cost impact. It stays silent on PRs that don't touch LLM code.

## What it detects

tokentoll uses Python AST analysis (zero runtime dependencies) to find calls to:
- OpenAI (`chat.completions.create`, `responses.create`, `embeddings.create`)
- Anthropic (`messages.create`)
- Google GenAI (`generate_content`)
- LiteLLM (`completion`, `embedding`)
- LangChain (`ChatOpenAI`, `ChatAnthropic`, `init_chat_model`)
- Zhipu AI / GLM (`ZhipuAiClient`, `ZhipuAI`)

## Current scan of this project

## tokentoll Scan Report

| File | Line | SDK | Model | Est. Cost/Call | Monthly |
|------|------|-----|-------|---------------|---------|
| `cookbook/09_evals/performance/comparison/langgraph_instantiation.py` | 37 | langchain | gpt-4o | $0.04 | $42.21 |
| `cookbook/99_docs/index/langgraph_agent.py` | 9 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/00_quickstart/langgraph_agent.py` | 21 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_agentos.py` | 37 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_basic.py` | 18 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_session.py` | 21 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_session_agentos.py` | 42 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_time_travel.py` | 23 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_tools.py` | 45 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `cookbook/frameworks/langgraph/langgraph_tools_session.py` | 51 | langchain | gpt-5.4 | $0.48 | $481.25 |
| `libs/agno/agno/knowledge/embedder/azure_openai.py` | 111 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/azure_openai.py` | 142 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/azure_openai.py` | 193 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/openai.py` | 79 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/openai.py` | 117 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/openai.py` | 138 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/openai.py` | 179 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/vllm.py` | 128 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/vllm.py` | 177 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/vllm.py` | 197 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/knowledge/embedder/vllm.py` | 241 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/anthropic/claude.py` | 752 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 759 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 814 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 823 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 864 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 871 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 922 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/anthropic/claude.py` | 931 | anthropic | claude-sonnet-4-20250514 (default) | $0.24 | $241.50 |
| `libs/agno/agno/models/google/gemini.py` | 536 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `libs/agno/agno/models/google/gemini.py` | 594 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `libs/agno/agno/models/google/gemini.py` | 649 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `libs/agno/agno/models/google/gemini.py` | 709 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `libs/agno/agno/models/openai/chat.py` | 418 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/chat.py` | 596 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/chat.py` | 508 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/chat.py` | 683 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/responses.py` | 765 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/responses.py` | 979 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/responses.py` | 870 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/models/openai/responses.py` | 1068 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/tools/dalle.py` | 80 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/tools/models/morph.py` | 117 | openai | gpt-4o (default) | $0.04 | $40.96 |
| `libs/agno/agno/tools/nano_banana.py` | 80 | google_genai | gemini-2.0-flash (default) | $0.000869 | $0.87 |
| `libs/agno/agno/tools/openai.py` | 92 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/tools/openai.py` | 179 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/tools/openai.py` | 125 | openai | gpt-4o (default) | $0.04 | $42.21 |
| `libs/agno/agno/tools/openai.py` | 131 | openai | gpt-4o (default) | $0.04 | $42.21 |

**Total estimated monthly cost: $7363.81**

<details>
<summary>Assumptions</summary>

- 1000 calls/month per call site

</details>

*Generated by [tokentoll](https://github.com/Jwrede/tokentoll)*

## How it works

- Runs only on PRs, compares base vs head
- Posts a sticky comment (updates in place, no duplicates)
- Only comments when LLM calls are added, removed, or modified
- First run posts an initial scan (this PR) so you can see the output
- Zero runtime dependencies, ~1s scan time for most projects
- [PyPI](https://pypi.org/project/tokentoll/) | [GitHub](https://github.com/Jwrede/tokentoll)

## Changes

- Adds `.github/workflows/llm-costs.yml` (17 lines)
- No code changes, no new dependencies
