### PR TITLE
fix(agui): pass context from RunAgentInput to agent.arun() and team.arun()

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -57,6 +57,7 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
             stream_events=True,
             user_id=user_id,
             session_state=session_state,
+            context=run_input.context,
             run_id=run_id,
         )
 
@@ -99,6 +100,7 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
             stream_steps=True,
             user_id=user_id,
             session_state=session_state,
+            context=input.context,
             run_id=run_id,
         )
 


### PR DESCRIPTION
Closes #7805

## Problem

`run_agent` and `run_team` in the AG-UI router receive `RunAgentInput.context` from the CopilotKit frontend (populated via `useCopilotReadable`), but neither `agent.arun()` nor `team.arun()` is called with `context=...`. The context is silently dropped, so agents respond as if no page context exists.

## Fix

Forward `run_input.context` to `agent.arun()` and `input.context` to `team.arun()` — the `arun` signatures accept `**kwargs` which are passed through to the underlying run.
