### PR TITLE
feat: prefix delegate_task_to_member results with member_id in history

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2083,9 +2083,21 @@ class Model(ABC):
             audios = function_execution_result.audios
             files = function_execution_result.files
 
+        # Prefix delegate_task_to_member results with member_id for history readability
+        content: Optional[Union[List[Any], str]] = output if success else function_call.error
+        if (
+            success
+            and function_call.function.name == "delegate_task_to_member"
+            and isinstance(output, str)
+            and function_call.arguments
+        ):
+            member_id = function_call.arguments.get("member_id")
+            if member_id and output and not output.lstrip().startswith(f"[{member_id}]"):
+                content = f"[{member_id}]: {output}"
+
         return Message(
             role=self.tool_message_role,
-            content=output if success else function_call.error,
+            content=content,
             tool_call_id=function_call.call_id,
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2084,7 +2084,7 @@ class Model(ABC):
             files = function_execution_result.files
 
         # Prefix delegate_task_to_member results with member_id for history readability
-        content: Optional[Union[List[Any], str]] = output if success else function_call.error
+        content = output if success else function_call.error
         if (
             success
             and function_call.function.name == "delegate_task_to_member"

--- a/libs/agno/tests/unit/models/test_delegate_member_attribution.py
+++ b/libs/agno/tests/unit/models/test_delegate_member_attribution.py
@@ -1,0 +1,180 @@
+import pytest
+
+from agno.models.openai import OpenAIChat
+from agno.tools.function import Function, FunctionCall
+
+
+class TestDelegateMemberAttribution:
+    @pytest.fixture
+    def model(self):
+        return OpenAIChat(id="gpt-5-mini")
+
+    @pytest.fixture
+    def delegate_function(self):
+        def delegate_task_to_member(member_id: str, task: str) -> str:
+            return "Mock response"
+
+        return Function.from_callable(delegate_task_to_member)
+
+    @pytest.fixture
+    def regular_function(self):
+        def get_weather(city: str) -> str:
+            return "Sunny"
+
+        return Function.from_callable(get_weather)
+
+    def test_delegate_result_prefixed_with_member_id(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="The analysis shows positive trends.",
+        )
+
+        assert result.content == "[analyst-agent]: The analysis shows positive trends."
+        assert result.role == "tool"
+        assert result.tool_name == "delegate_task_to_member"
+
+    def test_delegate_result_not_double_prefixed(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="[analyst-agent]: Already prefixed content",
+        )
+
+        assert result.content == "[analyst-agent]: Already prefixed content"
+
+    def test_delegate_result_handles_whitespace_prefix(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="  [analyst-agent]: Content with leading spaces",
+        )
+
+        assert result.content == "  [analyst-agent]: Content with leading spaces"
+
+    def test_delegate_result_error_not_prefixed(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+        function_call.error = "Member not found"
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=False,
+            output="Some output that should be ignored",
+        )
+
+        assert result.content == "Member not found"
+        assert result.tool_call_error is True
+
+    def test_delegate_result_empty_output_not_prefixed(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="",
+        )
+
+        assert result.content == ""
+
+    def test_delegate_result_none_output_not_prefixed(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output=None,
+        )
+
+        assert result.content is None
+
+    def test_delegate_result_missing_member_id_not_prefixed(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="The analysis shows positive trends.",
+        )
+
+        assert result.content == "The analysis shows positive trends."
+
+    def test_regular_tool_result_not_prefixed(self, model, regular_function):
+        function_call = FunctionCall(
+            call_id="call_456",
+            function=regular_function,
+            arguments={"city": "Tokyo"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="Sunny, 25 degrees",
+        )
+
+        assert result.content == "Sunny, 25 degrees"
+        assert result.tool_name == "get_weather"
+
+    def test_delegate_result_list_output_not_prefixed(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output=["item1", "item2"],
+        )
+
+        assert result.content == ["item1", "item2"]
+
+    def test_delegate_result_preserves_tool_args(self, model, delegate_function):
+        function_call = FunctionCall(
+            call_id="call_123",
+            function=delegate_function,
+            arguments={"member_id": "analyst-agent", "task": "Analyze the data"},
+        )
+
+        result = model.create_function_call_result(
+            function_call=function_call,
+            success=True,
+            output="Analysis complete.",
+        )
+
+        assert result.tool_args == {"member_id": "analyst-agent", "task": "Analyze the data"}
+        assert result.tool_call_id == "call_123"


### PR DESCRIPTION
## Summary

- Prefix `delegate_task_to_member` tool results with `[member_id]:` in stored history
- Improves debuggability of multi-turn team conversations
- Member's own `RunOutput.content` remains unchanged

**Before:**
```
Message(role="tool", content="The analysis shows positive trends.")
```

**After:**
```
Message(role="tool", content="[analyst-agent]: The analysis shows positive trends.")
```

## Motivation

In multi-turn team orchestration, delegated outputs get mixed into regular tool history with no indication of which member produced them. This makes it difficult to:
- Debug team behavior
- Analyze routing quality  
- Understand role specialization

The fix applies to the single chokepoint `create_function_call_result()` which covers all execution paths (sync, async, streaming, non-streaming).

## How Member ID Resolution Works

The `member_id` used for prefixing comes from `get_member_id()` which has a built-in fallback chain:

| Agent Config | Prefix Result |
|--------------|---------------|
| `Agent(id="x", name="Analyst")` | `[x]: ...` (explicit id preferred) |
| `Agent(name="Bull Analyst")` | `[bull-analyst]: ...` (name → URL-safe) |
| `Agent(id="agent-007")` | `[agent-007]: ...` (id used) |

Priority order:
1. If `member.id` is set → use it
2. If `member.name` is set → convert to URL-safe string
3. Otherwise → no prefix (graceful fallback)

## Why Two Places Have Member Info (Not Duplicate)

| Context | Where Used | Format | Purpose |
|---------|------------|--------|---------|
| **Intra-run** | `<member_interaction_context>` XML in task prompt | `Member: {name}` | Share context between delegations in same run |
| **Inter-run** | Tool result Messages in session storage | `[member_id]: content` | Multi-turn conversation history (**this PR**) |

The existing `get_team_member_interactions_str()` provides member attribution for intra-run context sharing. This PR fills the gap for **inter-run session history**.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Format and validate: `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Unit tests added for prefix logic and edge cases
- [x] Verified with team cookbooks (basic_coordination, multi-turn with history)
- [x] Multi-turn test confirms LLM correctly interprets prefixed history

## Test Results

10 unit tests covering:
- Normal prefixing works
- Already-prefixed content not double-prefixed (idempotent)
- Error results bypass prefixing
- Empty/None output handled gracefully
- Missing member_id → no prefix (graceful fallback)
- Non-delegate tools unaffected
- List output (non-string) bypasses prefixing
- tool_args preserved correctly

## Related Issues

Closes #7716 (section 3: "Team delegate results do not identify the member clearly in conversation history")
Related: #6141 (AGUI cannot distinguish between agent and team messages)