### PR TITLE
feat: Add support for Excel and PowerPoint file types 

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -673,6 +673,8 @@ def get_agent_router(
                     "application/x-javascript",
                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                     "application/vnd.ms-outlook",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
                     "text/javascript",
                     "application/x-python",
                     "text/x-python",

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -661,6 +661,8 @@ def get_team_router(
                     "text/csv",
                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
                     "application/vnd.ms-outlook",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
                     "text/plain",
                     "application/json",
                 ]:


### PR DESCRIPTION
## Summary
Add missing MIME types to the accepted document types in the agent and team run routes (/agents/{agent_id}/runs and /teams/{team_id}/runs).
Fixes #7330
The following formats returned 400 Unsupported file type despite being common in enterprise workflows:

Format
MIME type
.xlsx (Excel)
application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
.pptx (PowerPoint)
application/vnd.openxmlformats-officedocument.presentationml.presentation

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

## Additional Notes
Changes are minimal (two lines each) in:
• libs/agno/agno/os/routers/agents/router.py
• libs/agno/agno/os/routers/teams/router.py