### PR TITLE
[feat] Add Connected App (OAuth 2.0) auth to SalesforceTools

### DIFF
--- a/cookbook/91_tools/salesforce_tools.py
+++ b/cookbook/91_tools/salesforce_tools.py
@@ -6,19 +6,32 @@ Prerequisites:
     2. Get a Salesforce org:
        - Sign up free at https://developer.salesforce.com/signup
        - Verify your email and set a password
-    3. Get your security token:
-       - Log into Salesforce > click avatar (top right) > Settings
-       - Left sidebar: "Reset My Security Token" > click "Reset Security Token"
-       - Token will be emailed to you
-    4. Set environment variables:
-       ```
-       export SALESFORCE_USERNAME=you@example.com
-       export SALESFORCE_PASSWORD=your-password
-       export SALESFORCE_SECURITY_TOKEN=token-from-email
-       export SALESFORCE_DOMAIN=login
-       ```
+    3. Authenticate (pick one option):
 
-    If you get "SOAP API login() is disabled", use session-based auth instead:
+    **Option A: Username / Password**
+       - Get your security token:
+         Log into Salesforce > click avatar (top right) > Settings
+         > "Reset My Security Token" > token will be emailed to you
+       - Set environment variables:
+         ```
+         export SALESFORCE_USERNAME=you@example.com
+         export SALESFORCE_PASSWORD=your-password
+         export SALESFORCE_SECURITY_TOKEN=token-from-email
+         export SALESFORCE_DOMAIN=login
+         ```
+
+    **Option B: Connected App (OAuth 2.0 Client Credentials)**
+       - Create a Connected App in Salesforce Setup > App Manager
+       - Enable OAuth Settings and Client Credentials Flow
+       - Set environment variables:
+         ```
+         export SALESFORCE_CONSUMER_KEY=your-consumer-key
+         export SALESFORCE_CONSUMER_SECRET=your-consumer-secret
+         export SALESFORCE_DOMAIN=your-org.my  # optional, for custom domains
+         ```
+
+    **Option C: Session / Instance URL**
+       Use when SOAP API login is disabled (default in newer Developer Edition orgs):
        ```python
        SalesforceTools(
            instance_url="https://your-org.my.salesforce.com",

--- a/libs/agno/agno/tools/salesforce.py
+++ b/libs/agno/agno/tools/salesforce.py
@@ -8,11 +8,14 @@ Requirements:
     ``pip install simple-salesforce``
 
 Authentication (pick one):
-    **Username / Password** — set SALESFORCE_USERNAME, SALESFORCE_PASSWORD,
-    SALESFORCE_SECURITY_TOKEN, and optionally SALESFORCE_DOMAIN env vars.
-
     **Session / Instance URL** — pass ``instance_url`` and ``session_id`` directly.
     Use this when SOAP API login is disabled (default in newer Developer Edition orgs).
+
+    **Connected App (OAuth 2.0 Client Credentials)** — set SALESFORCE_CONSUMER_KEY
+    and SALESFORCE_CONSUMER_SECRET. Optionally set SALESFORCE_DOMAIN for custom domains.
+
+    **Username / Password** — set SALESFORCE_USERNAME, SALESFORCE_PASSWORD,
+    SALESFORCE_SECURITY_TOKEN, and optionally SALESFORCE_DOMAIN env vars.
 """
 
 import json
@@ -55,6 +58,8 @@ class SalesforceTools(Toolkit):
         domain: Optional[str] = None,
         instance_url: Optional[str] = None,
         session_id: Optional[str] = None,
+        consumer_key: Optional[str] = None,
+        consumer_secret: Optional[str] = None,
         max_records: int = 200,
         max_fields: int = 100,
         enable_list_objects: bool = True,
@@ -79,9 +84,23 @@ class SalesforceTools(Toolkit):
         password = password or getenv("SALESFORCE_PASSWORD")
         security_token = security_token or getenv("SALESFORCE_SECURITY_TOKEN")
         domain = domain or getenv("SALESFORCE_DOMAIN", "login")
+        consumer_key = consumer_key or getenv("SALESFORCE_CONSUMER_KEY")
+        consumer_secret = consumer_secret or getenv("SALESFORCE_CONSUMER_SECRET")
 
         if instance_url and session_id:
             self.sf = Salesforce(instance_url=instance_url, session_id=session_id)
+        elif consumer_key and consumer_secret:
+            cc_kwargs: Dict[str, Any] = {
+                "consumer_key": consumer_key,
+                "consumer_secret": consumer_secret,
+            }
+            if username:
+                cc_kwargs["username"] = username
+            if password:
+                cc_kwargs["password"] = password
+            if domain != "login":
+                cc_kwargs["domain"] = domain
+            self.sf = Salesforce(**cc_kwargs)
         elif username and password:
             self.sf = Salesforce(
                 username=username,
@@ -91,9 +110,11 @@ class SalesforceTools(Toolkit):
             )
         else:
             raise ValueError(
-                "Salesforce credentials not configured. "
-                "Set SALESFORCE_USERNAME, SALESFORCE_PASSWORD, and SALESFORCE_SECURITY_TOKEN "
-                "or pass instance_url and session_id."
+                "Salesforce credentials not configured. Provide one of:\n"
+                "  1. instance_url + session_id\n"
+                "  2. consumer_key + consumer_secret (Connected App OAuth 2.0)\n"
+                "  3. username + password + security_token\n"
+                "All values can be set via SALESFORCE_* environment variables."
             )
 
         tools: List[Any] = []
@@ -122,6 +143,8 @@ class SalesforceTools(Toolkit):
         """List all available Salesforce objects in the org."""
         try:
             describe = self.sf.describe()
+            if not describe:
+                return json.dumps({"total": 0, "returned": 0, "objects": []})
             objects = [
                 {
                     "name": obj.get("name", ""),

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -545,6 +545,7 @@ module = [
   "sentence_transformers.*",
   "serpapi.*",
   "setuptools.*",
+  "simple_salesforce.*",
   "simplejson.*",
   "slack_sdk.*",
   "spider.*",

--- a/libs/agno/tests/unit/tools/test_salesforce.py
+++ b/libs/agno/tests/unit/tools/test_salesforce.py
@@ -164,6 +164,68 @@ class TestSalesforceInit:
         assert "delete_record" not in fn_names
         assert "get_report" not in fn_names
 
+    def test_init_oauth2_client_credentials(self, mock_sf_client):
+        from agno.tools.salesforce import Salesforce
+
+        tools = SalesforceTools(
+            consumer_key="test-consumer-key",
+            consumer_secret="test-consumer-secret",
+        )
+        assert tools.sf is not None
+        Salesforce.assert_called_with(
+            consumer_key="test-consumer-key",
+            consumer_secret="test-consumer-secret",
+        )
+
+    def test_init_oauth2_with_env_variables(self, mock_sf_client):
+        with patch.dict(
+            "os.environ",
+            {
+                "SALESFORCE_CONSUMER_KEY": "env-consumer-key",
+                "SALESFORCE_CONSUMER_SECRET": "env-consumer-secret",
+            },
+        ):
+            tools = SalesforceTools()
+            assert tools.sf is not None
+            from agno.tools.salesforce import Salesforce
+
+            Salesforce.assert_called_with(
+                consumer_key="env-consumer-key",
+                consumer_secret="env-consumer-secret",
+            )
+
+    def test_init_oauth2_with_custom_domain(self, mock_sf_client):
+        from agno.tools.salesforce import Salesforce
+
+        tools = SalesforceTools(
+            consumer_key="test-key",
+            consumer_secret="test-secret",
+            domain="myorg.my",
+        )
+        assert tools.sf is not None
+        Salesforce.assert_called_with(
+            consumer_key="test-key",
+            consumer_secret="test-secret",
+            domain="myorg.my",
+        )
+
+    def test_init_oauth2_with_username_password(self, mock_sf_client):
+        from agno.tools.salesforce import Salesforce
+
+        tools = SalesforceTools(
+            consumer_key="test-key",
+            consumer_secret="test-secret",
+            username="user@example.com",
+            password="pass123",
+        )
+        assert tools.sf is not None
+        Salesforce.assert_called_with(
+            consumer_key="test-key",
+            consumer_secret="test-secret",
+            username="user@example.com",
+            password="pass123",
+        )
+
     def test_tool_registration_selective(self, mock_sf_client):
         tools = SalesforceTools(
             username="test@example.com",


### PR DESCRIPTION
Closes #7774

## Summary

Add OAuth 2.0 Client Credentials authentication to SalesforceTools, enabling headless server-to-server flows via Salesforce Connected Apps without requiring username/password.

Auth priority is now:
1. Session ID + Instance URL
2. Connected App Client Credentials (new)
3. Username + Password + Security Token

### Changes
- Add consumer_key, consumer_secret params to __init__ with SALESFORCE_CONSUMER_KEY / SALESFORCE_CONSUMER_SECRET env var fallbacks
- Add OAuth 2.0 client credentials auth path
- Update error message and module docstring to document all three auth options
- Update cookbook example docs with all three auth options
- Add simple_salesforce to mypy overrides in pyproject.toml
- Add None guard on sf.describe() to fix mypy validation
- Add 4 unit tests for OAuth 2.0 auth (33 total tests pass)

### Usage

```bash
export SALESFORCE_CONSUMER_KEY=your-connected-app-consumer-key
export SALESFORCE_CONSUMER_SECRET=your-connected-app-consumer-secret
```

```python
from agno.tools.salesforce import SalesforceTools

# Credentials from env vars
agent = Agent(tools=[SalesforceTools()])

# Or pass explicitly
agent = Agent(tools=[SalesforceTools(
    consumer_key="your-key",
    consumer_secret="your-secret",
)])
```

## Type of change

- [x] New feature

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (ruff + mypy both pass clean)
- [x] Self-review completed
- [x] Documentation updated
- [x] Examples and guides updated
- [x] Tested in clean environment
- [x] Tests added/updated (4 new OAuth 2.0 tests, 33 total pass)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

## Additional Notes

All 33 unit tests pass (29 existing + 4 new). No existing behavior changed — the new auth method is additive and only activates when consumer_key + consumer_secret are provided. mypy passes with zero errors.