### PR TITLE
fix: Addressing the race

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 from functools import partial
 from importlib.metadata import version
@@ -772,6 +773,51 @@ class FunctionCall(BaseModel):
     # Error while parsing arguments or running the function.
     error: Optional[str] = None
 
+    class _ReentrantAsyncLock:
+        """Task-reentrant async lock for nested async tool hooks."""
+
+        def __init__(self) -> None:
+            self._lock = asyncio.Lock()
+            self._owner: Optional[asyncio.Task[Any]] = None
+            self._depth = 0
+
+        async def acquire(self) -> None:
+            current_task = asyncio.current_task()
+            if current_task is None:
+                await self._lock.acquire()
+                self._owner = None
+                self._depth = 1
+                return
+
+            if self._owner is current_task:
+                self._depth += 1
+                return
+
+            await self._lock.acquire()
+            self._owner = current_task
+            self._depth = 1
+
+        def release(self) -> None:
+            current_task = asyncio.current_task()
+            if self._owner is not None and self._owner is not current_task:
+                raise RuntimeError("ReentrantAsyncLock released by non-owner task")
+
+            if self._depth <= 0:
+                raise RuntimeError("ReentrantAsyncLock released too many times")
+
+            self._depth -= 1
+            if self._depth == 0:
+                self._owner = None
+                self._lock.release()
+
+    @staticmethod
+    def _get_or_create_async_messages_lock(run_context: RunContext) -> "_ReentrantAsyncLock":
+        lock = getattr(run_context, "_messages_swap_lock", None)
+        if lock is None:
+            lock = FunctionCall._ReentrantAsyncLock()
+            setattr(run_context, "_messages_swap_lock", lock)
+        return lock
+
     def get_call_str(self) -> str:
         """Returns a string representation of the function call."""
         import shutil
@@ -822,12 +868,17 @@ class FunctionCall(BaseModel):
         """Async variant of _safe_hook_call."""
         rc = self.function._run_context
         if rc is not None and rc.messages is not None:
-            live_ref = rc.messages
-            rc.messages = list(live_ref)
+            lock = self._get_or_create_async_messages_lock(rc)
+            await lock.acquire()
             try:
-                return await hook(**hook_args)
+                live_ref = rc.messages
+                rc.messages = list(live_ref)
+                try:
+                    return await hook(**hook_args)
+                finally:
+                    rc.messages = live_ref
             finally:
-                rc.messages = live_ref
+                lock.release()
         else:
             return await hook(**hook_args)
 

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Callable, Dict, List, Optional
 
 import pytest
@@ -638,6 +639,63 @@ async def test_function_call_async_with_tool_hooks():
     assert hook_calls[0][1] == "test_func"
     assert hook_calls[1][0] == "after"
     assert hook_calls[1][2] == "processed-value1"
+
+
+@pytest.mark.asyncio
+async def test_async_pre_hook_parallel_calls_restore_live_messages_reference():
+    """Parallel async hooks should not leave run_context.messages stale."""
+    observed_ids: List[int] = []
+
+    async def pre_hook(run_context: RunContext):
+        observed_ids.append(id(run_context.messages))
+        await asyncio.sleep(0.01)
+
+    async def test_func(param1: str) -> str:
+        return f"processed-{param1}"
+
+    run_context = RunContext(run_id="test-run", session_id="test-session")
+    run_context.messages = [
+        Message(role="user", content="first"),
+        Message(role="assistant", content="second"),
+    ]
+    original_messages_ref = run_context.messages
+
+    func = Function(name="test_func", entrypoint=test_func, pre_hook=pre_hook)
+    func._run_context = run_context
+
+    call_1 = FunctionCall(function=func, arguments={"param1": "value1"})
+    call_2 = FunctionCall(function=func, arguments={"param1": "value2"})
+
+    result_1, result_2 = await asyncio.gather(call_1.aexecute(), call_2.aexecute())
+
+    assert result_1.status == "success"
+    assert result_2.status == "success"
+    assert run_context.messages is original_messages_ref
+    assert len(observed_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_tool_hooks_with_multiple_layers_do_not_deadlock():
+    """Nested async tool hooks should execute without deadlocking."""
+
+    async def outer_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        await asyncio.sleep(0.001)
+        return await function_call(**arguments)
+
+    async def inner_hook(function_name: str, function_call: Callable, arguments: Dict[str, Any]):
+        await asyncio.sleep(0.001)
+        return await function_call(**arguments)
+
+    @tool(tool_hooks=[outer_hook, inner_hook])
+    async def test_func(param1: str) -> str:
+        return f"processed-{param1}"
+
+    test_func.process_entrypoint()
+    call = FunctionCall(function=test_func, arguments={"param1": "value1"})
+
+    result = await asyncio.wait_for(call.aexecute(), timeout=1.0)
+    assert result.status == "success"
+    assert result.result == "processed-value1"
 
 
 def test_tool_decorator_basic():


### PR DESCRIPTION
**What I changed**

- Updated libs/agno/agno/tools/function.py:

  -     Added a small task-reentrant async lock (_ReentrantAsyncLock) scoped to each RunContext.
  -     FunctionCall._safe_hook_call_async(...) now:

    -     acquires that per-RunContext reentrant lock,
    -     performs the existing swap-to-shallow-copy,
    -     awaits the hook,
    -     restores the original run_context.messages,
    -     releases the lock.

  -     This prevents cross-task interleaving during asyncio.gather while still allowing nested async hook chains in the same task (no deadlock).

**Why this fixes the bug**

- Parallel tool calls sharing the same run_context can no longer race to overwrite run_context.messages restores.
- Last-writer-wins corruption is eliminated.
- run_context.messages remains correctly restored to the live list after each async hook call.
- Nested hook execution (outer hook awaiting inner hook path) still works due to reentrancy.

**Tests added**

- In libs/agno/tests/unit/tools/test_functions.py:

  - test_async_pre_hook_parallel_calls_restore_live_messages_reference
   
    - runs two async FunctionCall.aexecute() in parallel on the same RunContext
    - verifies run_context.messages still points to the original live list after both complete.
  - test_async_tool_hooks_with_multiple_layers_do_not_deadlock
  
    - uses two async tool_hooks wrapping each other
    - verifies async nested hook execution completes (no deadlock).

(If applicable, issue number: #7851)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
