### PR TITLE
fix followup system prompt in  _response.py

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1725,6 +1725,7 @@ def _build_followup_messages(
 
     system_prompt = (
         "Based on the user's message and the assistant's response below, generate follow-up suggestions. "
+        "The output MUST be a JSON object with a single key 'suggestions' containing a list of strings. "
         "Each suggestion should be a short action-oriented prompt (5-10 words). "
         "Cover different angles: dig deeper, practical next step, or alternative perspective."
     )


### PR DESCRIPTION
When you set followups=True , Agno makes a secondary LLM request to generate follow-up questions. To ensure the follow-ups are parsed correctly, Agno tells the API to return a structured JSON object ( response_format={"type": "json_object"} ).

However, OpenAI-Compatible APIs strictly enforce a rule: If you request json_object format, your prompt MUST contain the word "json" somewhere in the text.

Without "json" in the text, the following error occurs:

```txt
ERROR    API status error from OpenAI API: Error code: 400 - {'error': {'message': "Prompt must contain the word 'json' in PS 
ERROR    API status error from OpenAI API: Error code: 400 - {'error': {'message': "Prompt must contain the word 'json' in some form to use
         'response_format' of type 'json_object'.", 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
```

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
