### PR TITLE
[feat] Add Wolfram Alpha computational knowledge tool

### DIFF
--- a/cookbook/91_tools/wolfram_alpha_tools.py
+++ b/cookbook/91_tools/wolfram_alpha_tools.py
@@ -1,0 +1,12 @@
+"""Run: pip install wolframalpha agno"""
+
+from agno.agent import Agent
+from agno.tools.wolfram_alpha import WolframAlphaTools
+
+agent = Agent(
+    tools=[WolframAlphaTools()],
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    agent.print_response("What is the integral of x^3 from 0 to 10?")

--- a/libs/agno/agno/tools/wolfram_alpha.py
+++ b/libs/agno/agno/tools/wolfram_alpha.py
@@ -1,0 +1,150 @@
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from os import getenv
+from typing import Any, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+try:
+    import wolframalpha
+except ImportError:
+    raise ImportError("`wolframalpha` not installed. Please install using `pip install wolframalpha`")
+
+
+class WolframAlphaTools(Toolkit):
+    def __init__(
+        self,
+        app_id: Optional[str] = None,
+        max_pods: int = 10,
+        include_pod_ids: Optional[List[str]] = None,
+        enable_query: bool = True,
+        enable_short_answer: bool = True,
+        enable_conversational: bool = False,
+        all: bool = False,
+        **kwargs: Any,
+    ):
+        self.app_id = app_id or getenv("WOLFRAM_ALPHA_APP_ID")
+        if not self.app_id:
+            raise ValueError(
+                "Wolfram Alpha App ID not provided. "
+                "Set WOLFRAM_ALPHA_APP_ID environment variable or pass app_id parameter. "
+                "Get one at https://developer.wolframalpha.com/"
+            )
+
+        self.client = wolframalpha.Client(self.app_id)
+        self.max_pods = max_pods
+        self.include_pod_ids = include_pod_ids
+
+        tools: List[Any] = []
+        if all or enable_query:
+            tools.append(self.query)
+        if all or enable_short_answer:
+            tools.append(self.short_answer)
+        if all or enable_conversational:
+            tools.append(self.conversational_query)
+
+        super().__init__(name="wolfram_alpha_tools", tools=tools, **kwargs)
+
+    def query(self, input_query: str) -> str:
+        """Query Wolfram Alpha and return structured pod results.
+
+        Args:
+            input_query: Natural language or mathematical expression.
+
+        Returns:
+            str: JSON with pods containing computed results.
+        """
+        try:
+            res = self.client.query(input_query)
+
+            if not hasattr(res, "pods") or res.pods is None:
+                return json.dumps({"success": False, "error": "No results found.", "query": input_query})
+
+            pods = []
+            pod_count = 0
+            for pod in res.pods:
+                if pod_count >= self.max_pods:
+                    break
+                if self.include_pod_ids and pod.id not in self.include_pod_ids:
+                    continue
+
+                texts = []
+                if hasattr(pod, "subpods"):
+                    for subpod in pod.subpods:
+                        if hasattr(subpod, "plaintext") and subpod.plaintext:
+                            texts.append(subpod.plaintext)
+                elif hasattr(pod, "text") and pod.text:
+                    texts.append(pod.text)
+
+                if texts:
+                    pods.append({"title": pod.title, "id": pod.id, "text": "\n".join(texts)})
+                    pod_count += 1
+
+            if not pods:
+                return json.dumps({"success": False, "error": "No text results produced.", "query": input_query})
+
+            return json.dumps({"success": True, "query": input_query, "num_pods": len(pods), "pods": pods})
+
+        except Exception as e:
+            logger.exception(f"Error querying Wolfram Alpha: {input_query}")
+            return json.dumps({"success": False, "error": str(e), "query": input_query})
+
+    def short_answer(self, input_query: str) -> str:
+        """Get a single-line answer from Wolfram Alpha Short Answers API.
+
+        Args:
+            input_query: Natural language question.
+
+        Returns:
+            str: JSON with the answer string.
+        """
+        try:
+            encoded_query = urllib.parse.quote_plus(input_query)
+            url = f"https://api.wolframalpha.com/v1/result?appid={self.app_id}&i={encoded_query}"
+
+            with urllib.request.urlopen(url, timeout=10) as response:
+                answer = response.read().decode("utf-8")
+
+            return json.dumps({"success": True, "query": input_query, "answer": answer})
+
+        except urllib.error.HTTPError as e:
+            error_msg = "Query not understood" if e.code == 501 else str(e)
+            return json.dumps({"success": False, "query": input_query, "error": error_msg})
+        except Exception as e:
+            logger.exception(f"Error getting short answer: {input_query}")
+            return json.dumps({"success": False, "error": str(e), "query": input_query})
+
+    def conversational_query(self, input_query: str, conversation_id: Optional[str] = None) -> str:
+        """Query Wolfram Alpha Conversational API. Supports follow-up questions.
+
+        Args:
+            input_query: Natural language question.
+            conversation_id: ID from previous response to continue conversation.
+
+        Returns:
+            str: JSON with answer and conversation_id for follow-ups.
+        """
+        try:
+            encoded_query = urllib.parse.quote_plus(input_query)
+            url = f"https://api.wolframalpha.com/v1/conversation.jsp?appid={self.app_id}&i={encoded_query}"
+            if conversation_id:
+                url += f"&conversationid={conversation_id}"
+
+            with urllib.request.urlopen(url, timeout=10) as response:
+                result = json.loads(response.read().decode("utf-8"))
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "query": input_query,
+                    "answer": result.get("result", ""),
+                    "conversation_id": result.get("conversationID", ""),
+                }
+            )
+
+        except Exception as e:
+            logger.exception(f"Error in conversational query: {input_query}")
+            return json.dumps({"success": False, "error": str(e), "query": input_query})

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -586,6 +586,7 @@ module = [
   "surrealdb.*",
   "trafilatura.*",
   "xlrd.*",
-  "celpy.*"
+  "celpy.*",
+  "wolframalpha.*"
 ]
 ignore_missing_imports = true

--- a/libs/agno/tests/unit/tools/test_wolfram_alpha.py
+++ b/libs/agno/tests/unit/tools/test_wolfram_alpha.py
@@ -1,0 +1,343 @@
+"""Unit tests for WolframAlphaTools class."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock wolframalpha before importing our module
+mock_wolframalpha = MagicMock()
+sys.modules["wolframalpha"] = mock_wolframalpha
+
+
+@pytest.fixture
+def mock_client():
+    """Create a mock Wolfram Alpha client."""
+    mock_client_instance = MagicMock()
+    mock_wolframalpha.Client.return_value = mock_client_instance
+    return mock_client_instance
+
+
+@pytest.fixture
+def wolfram_tools(mock_client):
+    """Create a WolframAlphaTools instance with mocked client."""
+    with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-app-id"}):
+        from agno.tools.wolfram_alpha import WolframAlphaTools
+
+        tools = WolframAlphaTools()
+        tools.client = mock_client
+        return tools
+
+
+class TestWolframAlphaToolsInitialization:
+    """Tests for WolframAlphaTools initialization."""
+
+    def test_initialization_with_env_var(self, mock_client):
+        """Test initialization using environment variable."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools()
+            assert tools.app_id == "test-id"
+
+    def test_initialization_with_explicit_app_id(self, mock_client):
+        """Test initialization with explicit app_id parameter."""
+        with patch.dict("os.environ", {}, clear=True):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(app_id="explicit-id")
+            assert tools.app_id == "explicit-id"
+
+    def test_initialization_without_app_id_raises(self, mock_client):
+        """Test that missing app_id raises ValueError."""
+        with patch.dict("os.environ", {}, clear=True):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            with pytest.raises(ValueError, match="Wolfram Alpha App ID not provided"):
+                WolframAlphaTools()
+
+    def test_default_tools_registered(self, wolfram_tools):
+        """Test that query and short_answer are registered by default."""
+        function_names = list(wolfram_tools.functions.keys())
+        assert "query" in function_names
+        assert "short_answer" in function_names
+        assert "conversational_query" not in function_names
+
+    def test_all_tools_registered(self, mock_client):
+        """Test that all=True registers all tools."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(all=True)
+            function_names = list(tools.functions.keys())
+            assert "query" in function_names
+            assert "short_answer" in function_names
+            assert "conversational_query" in function_names
+
+    def test_selective_tool_enablement(self, mock_client):
+        """Test enabling only specific tools."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(
+                enable_query=False,
+                enable_short_answer=True,
+                enable_conversational=True,
+            )
+            function_names = list(tools.functions.keys())
+            assert "query" not in function_names
+            assert "short_answer" in function_names
+            assert "conversational_query" in function_names
+
+
+class TestWolframAlphaQuery:
+    """Tests for the query method."""
+
+    def test_successful_query(self, wolfram_tools, mock_client):
+        """Test a successful full query with pods."""
+        # Create mock pods
+        mock_subpod = MagicMock()
+        mock_subpod.plaintext = "125/3"
+
+        mock_pod = MagicMock()
+        mock_pod.title = "Result"
+        mock_pod.id = "Result"
+        mock_pod.subpods = [mock_subpod]
+
+        mock_input_pod = MagicMock()
+        mock_input_pod.title = "Input"
+        mock_input_pod.id = "Input"
+        mock_input_subpod = MagicMock()
+        mock_input_subpod.plaintext = "integral_0^5 x^2 dx"
+        mock_input_pod.subpods = [mock_input_subpod]
+
+        mock_result = MagicMock()
+        mock_result.pods = [mock_input_pod, mock_pod]
+        mock_client.query.return_value = mock_result
+
+        result = wolfram_tools.query("integrate x^2 from 0 to 5")
+        parsed = json.loads(result)
+
+        assert parsed["success"] is True
+        assert parsed["num_pods"] == 2
+        assert parsed["pods"][1]["title"] == "Result"
+        assert parsed["pods"][1]["text"] == "125/3"
+
+    def test_query_no_results(self, wolfram_tools, mock_client):
+        """Test query that returns no results."""
+        mock_result = MagicMock()
+        mock_result.pods = None
+        mock_client.query.return_value = mock_result
+
+        result = wolfram_tools.query("asdfghjkl nonsense")
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "No results found" in parsed["error"]
+
+    def test_query_empty_pods(self, wolfram_tools, mock_client):
+        """Test query that returns pods with no text content."""
+        mock_pod = MagicMock()
+        mock_pod.title = "Image"
+        mock_pod.id = "Image"
+        mock_pod.subpods = []
+        mock_pod.text = None
+
+        mock_result = MagicMock()
+        mock_result.pods = [mock_pod]
+        # Make hasattr work correctly
+        type(mock_pod).subpods = []
+        mock_client.query.return_value = mock_result
+
+        result = wolfram_tools.query("plot x^2")
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "No text results" in parsed["error"]
+
+    def test_query_with_max_pods_limit(self, mock_client):
+        """Test that max_pods limits the number of returned pods."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(max_pods=2)
+            tools.client = mock_client
+
+            # Create 5 mock pods
+            pods = []
+            for i in range(5):
+                mock_subpod = MagicMock()
+                mock_subpod.plaintext = f"Result {i}"
+                mock_pod = MagicMock()
+                mock_pod.title = f"Pod {i}"
+                mock_pod.id = f"Pod{i}"
+                mock_pod.subpods = [mock_subpod]
+                pods.append(mock_pod)
+
+            mock_result = MagicMock()
+            mock_result.pods = pods
+            mock_client.query.return_value = mock_result
+
+            result = tools.query("test query")
+            parsed = json.loads(result)
+
+            assert parsed["success"] is True
+            assert parsed["num_pods"] == 2
+
+    def test_query_with_pod_id_filter(self, mock_client):
+        """Test filtering pods by ID."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(include_pod_ids=["Result"])
+            tools.client = mock_client
+
+            mock_input_subpod = MagicMock()
+            mock_input_subpod.plaintext = "x^2"
+            mock_input_pod = MagicMock()
+            mock_input_pod.title = "Input"
+            mock_input_pod.id = "Input"
+            mock_input_pod.subpods = [mock_input_subpod]
+
+            mock_result_subpod = MagicMock()
+            mock_result_subpod.plaintext = "42"
+            mock_result_pod = MagicMock()
+            mock_result_pod.title = "Result"
+            mock_result_pod.id = "Result"
+            mock_result_pod.subpods = [mock_result_subpod]
+
+            mock_response = MagicMock()
+            mock_response.pods = [mock_input_pod, mock_result_pod]
+            mock_client.query.return_value = mock_response
+
+            result = tools.query("test")
+            parsed = json.loads(result)
+
+            assert parsed["success"] is True
+            assert parsed["num_pods"] == 1
+            assert parsed["pods"][0]["id"] == "Result"
+
+    def test_query_exception_handling(self, wolfram_tools, mock_client):
+        """Test that exceptions are caught and returned as JSON errors."""
+        mock_client.query.side_effect = Exception("API timeout")
+
+        result = wolfram_tools.query("test query")
+        parsed = json.loads(result)
+
+        assert parsed["success"] is False
+        assert "API timeout" in parsed["error"]
+
+
+class TestWolframAlphaShortAnswer:
+    """Tests for the short_answer method."""
+
+    def test_successful_short_answer(self, wolfram_tools):
+        """Test a successful short answer query."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"384,400 kilometers"
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_response):
+            result = wolfram_tools.short_answer("distance from Earth to Moon")
+            parsed = json.loads(result)
+
+            assert parsed["success"] is True
+            assert parsed["answer"] == "384,400 kilometers"
+
+    def test_short_answer_query_not_understood(self, wolfram_tools):
+        """Test short answer with unrecognized query."""
+        import urllib.error
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.HTTPError(url="", code=501, msg="", hdrs=None, fp=None),
+        ):
+            result = wolfram_tools.short_answer("asdfghjkl")
+            parsed = json.loads(result)
+
+            assert parsed["success"] is False
+            assert "not understood" in parsed["error"]
+
+    def test_short_answer_exception_handling(self, wolfram_tools):
+        """Test that network errors are handled gracefully."""
+        with patch("urllib.request.urlopen", side_effect=Exception("Network error")):
+            result = wolfram_tools.short_answer("test")
+            parsed = json.loads(result)
+
+            assert parsed["success"] is False
+            assert "Network error" in parsed["error"]
+
+
+class TestWolframAlphaConversational:
+    """Tests for the conversational_query method."""
+
+    def test_successful_conversational_query(self, mock_client):
+        """Test a successful conversational query."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(all=True)
+
+            response_data = json.dumps(
+                {
+                    "result": "The population of France is approximately 67 million.",
+                    "conversationID": "conv-123",
+                }
+            ).encode("utf-8")
+
+            mock_response = MagicMock()
+            mock_response.read.return_value = response_data
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch("urllib.request.urlopen", return_value=mock_response):
+                result = tools.conversational_query("population of France")
+                parsed = json.loads(result)
+
+                assert parsed["success"] is True
+                assert "67 million" in parsed["answer"]
+                assert parsed["conversation_id"] == "conv-123"
+
+    def test_conversational_follow_up(self, mock_client):
+        """Test a follow-up conversational query with conversation_id."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(all=True)
+
+            response_data = json.dumps(
+                {
+                    "result": "Germany has approximately 83 million people.",
+                    "conversationID": "conv-123",
+                }
+            ).encode("utf-8")
+
+            mock_response = MagicMock()
+            mock_response.read.return_value = response_data
+            mock_response.__enter__ = MagicMock(return_value=mock_response)
+            mock_response.__exit__ = MagicMock(return_value=False)
+
+            with patch("urllib.request.urlopen", return_value=mock_response) as mock_urlopen:
+                result = tools.conversational_query("what about Germany?", conversation_id="conv-123")
+                parsed = json.loads(result)
+
+                assert parsed["success"] is True
+                # Verify conversation_id was included in the URL
+                call_url = mock_urlopen.call_args[0][0]
+                assert "conversationid=conv-123" in call_url
+
+    def test_conversational_exception_handling(self, mock_client):
+        """Test that exceptions in conversational mode are handled."""
+        with patch.dict("os.environ", {"WOLFRAM_ALPHA_APP_ID": "test-id"}):
+            from agno.tools.wolfram_alpha import WolframAlphaTools
+
+            tools = WolframAlphaTools(all=True)
+
+            with patch("urllib.request.urlopen", side_effect=Exception("Timeout")):
+                result = tools.conversational_query("test")
+                parsed = json.loads(result)
+
+                assert parsed["success"] is False
+                assert "Timeout" in parsed["error"]


### PR DESCRIPTION
Fixes #7942

Add WolframAlphaTools toolkit for precise mathematical computation, scientific data lookups, unit conversions, and factual queries via the Wolfram Alpha API.

## Changes

- libs/agno/agno/tools/wolfram_alpha.py - Tool implementation
- cookbook/91_tools/wolfram_alpha_tools.py - Cookbook recipe
- libs/agno/tests/unit/tools/test_wolfram_alpha.py - 18 unit tests
- libs/agno/pyproject.toml - Added wolframalpha to mypy overrides

## Tools

| Tool | Purpose |
|------|---------|
| query | Full computational results with structured pods |
| short_answer | Single-line factual answers |
| conversational_query | Multi-turn follow-up queries |

## Testing

pytest libs/agno/tests/unit/tools/test_wolfram_alpha.py - 18 tests passing, no network calls.