### PR TITLE
security: fix SSRF in WebTools.expand_url and url_validation

### DIFF
--- a/libs/agno/agno/knowledge/reader/utils/url_validation.py
+++ b/libs/agno/agno/knowledge/reader/utils/url_validation.py
@@ -1,3 +1,5 @@
+import ipaddress
+import socket
 from typing import Any, Callable, List, Optional
 from urllib.parse import urlparse
 
@@ -14,71 +16,102 @@ def validate_allowed_hosts(allowed_hosts: Optional[List[str]]) -> Optional[List[
     return [host.lower() for host in allowed_hosts]
 
 
-def is_host_allowed(url: str, allowed_hosts: Optional[List[str]]) -> bool:
-    """Return True if the URL's hostname is permitted by the allowlist.
+_BLOCKED_IPV4 = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("0.0.0.0/8"),
+]
 
-    When ``allowed_hosts`` is ``None``, all hosts are allowed.
-    When set, only URLs whose hostname matches an entry are allowed
-    matching is case-insensitive and exact (no implicit subdomains).
+_BLOCKED_IPV6 = [
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _resolves_to_private(hostname: str, port: int = 80) -> bool:
+    """Return True if hostname resolves to a private/reserved IP (SSRF protection)."""
+    try:
+        infos = socket.getaddrinfo(hostname, port)
+    except socket.gaierror:
+        return True  # can't resolve → block
+    for _family, _, _, _, sockaddr in infos:
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+            if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+                addr = addr.ipv4_mapped
+            nets = _BLOCKED_IPV4 if isinstance(addr, ipaddress.IPv4Address) else _BLOCKED_IPV6
+            if any(addr in net for net in nets):
+                return True
+        except ValueError:
+            return True
+    return False
+
+
+def is_host_allowed(url: str, allowed_hosts: Optional[List[str]]) -> bool:
+    """Return True if the URL's hostname is permitted.
+
+    Always blocks private/reserved IP ranges to prevent SSRF regardless of
+    the ``allowed_hosts`` setting. When ``allowed_hosts`` is additionally set,
+    restricts to only those hostnames.
 
     Args:
         url: The URL to check.
-        allowed_hosts: Allowlist of hostnames (matched case-insensitively),
-            or ``None`` for permissive.
+        allowed_hosts: Allowlist of hostnames (case-insensitive exact match),
+            or ``None`` to allow any *public* host.
 
     Returns:
-        ``True`` if the URL's host is permitted, ``False`` otherwise.
+        ``True`` if the URL's host is permitted and resolves to a public IP.
     """
-    if allowed_hosts is None:
-        return True
-    host = urlparse(url).hostname
+    parsed = urlparse(url)
+    host = parsed.hostname
     if not host:
         return False
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    if _resolves_to_private(host, port):
+        return False
+
+    if allowed_hosts is None:
+        return True
+
     host_lower = host.lower()
     return any(host_lower == entry.lower() for entry in allowed_hosts)
 
 
-def make_redirect_guard(allowed_hosts: Optional[List[str]]) -> Optional[Callable[[Any], None]]:
-    """Build a *sync* httpx request event-hook that refuses redirects to disallowed hosts.
+def make_redirect_guard(allowed_hosts: Optional[List[str]]) -> Callable[[Any], None]:
+    """Build a *sync* httpx request event-hook that blocks unsafe redirects.
 
-    Use this with ``httpx.Client``. For ``httpx.AsyncClient`` use
-    :func:`make_async_redirect_guard` — httpx enforces that AsyncClient hooks be
-    coroutines, so the two cannot share a single implementation.
+    Always blocks redirects to private/reserved IP ranges (SSRF prevention).
+    When ``allowed_hosts`` is set, also restricts to those hostnames.
 
-    httpx invokes the ``request`` event hook for every outbound request including
-    those issued by 3xx redirect-following. Pair this with ``follow_redirects=True``
-    so legitimate same-host redirects work, while cross-host redirects to addresses
-    outside the allowlist raise an error before the request is sent.
-
-    Returns ``None`` when ``allowed_hosts`` is ``None`` so callers can omit the hook
-    entirely in the permissive default case.
+    Use this with ``httpx.Client(event_hooks={"request": [guard]})``.
+    For ``httpx.AsyncClient`` use :func:`make_async_redirect_guard`.
     """
-    if allowed_hosts is None:
-        return None
-
     def _guard(request: Any) -> None:
         if not is_host_allowed(str(request.url), allowed_hosts):
             import httpx
 
-            raise httpx.RequestError(f"Host not in allowed_hosts: {request.url.host}", request=request)
+            raise httpx.RequestError(
+                f"Redirect to disallowed host blocked: {request.url.host}", request=request
+            )
 
     return _guard
 
 
-def make_async_redirect_guard(allowed_hosts: Optional[List[str]]) -> Optional[Callable[[Any], Any]]:
-    """Async counterpart to :func:`make_redirect_guard` for use with ``httpx.AsyncClient``.
-
-    httpx awaits AsyncClient event hooks, so they must be ``async def`` callables —
-    the sync version blows up with "object NoneType can't be used in 'await' expression"
-    when handed to an AsyncClient.
-    """
-    if allowed_hosts is None:
-        return None
+def make_async_redirect_guard(allowed_hosts: Optional[List[str]]) -> Callable[[Any], Any]:
+    """Async counterpart to :func:`make_redirect_guard` for use with ``httpx.AsyncClient``."""
 
     async def _guard(request: Any) -> None:
         if not is_host_allowed(str(request.url), allowed_hosts):
             import httpx
 
-            raise httpx.RequestError(f"Host not in allowed_hosts: {request.url.host}", request=request)
+            raise httpx.RequestError(
+                f"Redirect to disallowed host blocked: {request.url.host}", request=request
+            )
 
     return _guard

--- a/libs/agno/agno/tools/webtools.py
+++ b/libs/agno/agno/tools/webtools.py
@@ -1,7 +1,57 @@
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
 import httpx
 
 from agno.tools import Toolkit
 from agno.utils.log import logger
+
+
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("0.0.0.0/8"),
+]
+
+_BLOCKED_IPV6_NETWORKS = [
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+]
+
+
+def _is_safe_url(url: str) -> tuple[bool, str]:
+    """Return (is_safe, reason). Blocks private/reserved IP ranges."""
+    try:
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            return False, f"scheme '{parsed.scheme}' not allowed"
+        if not parsed.hostname:
+            return False, "missing hostname"
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        infos = socket.getaddrinfo(parsed.hostname, port)
+    except socket.gaierror:
+        return False, f"cannot resolve '{parsed.hostname}'"
+    except Exception as exc:
+        return False, str(exc)
+
+    for _family, _, _, _, sockaddr in infos:
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+            if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+                addr = addr.ipv4_mapped
+            nets = _BLOCKED_NETWORKS if isinstance(addr, ipaddress.IPv4Address) else _BLOCKED_IPV6_NETWORKS
+            if any(addr in net for net in nets):
+                return False, f"resolves to private/reserved IP {addr}"
+        except ValueError:
+            return False, f"invalid address '{sockaddr[0]}'"
+
+    return True, ""
 
 
 class WebTools(Toolkit):
@@ -27,19 +77,35 @@ class WebTools(Toolkit):
     def expand_url(self, url: str) -> str:
         """
         Expands a shortened URL to its final destination using HTTP HEAD requests with retries.
+        Only public URLs are followed; requests to private/internal addresses are blocked.
 
         :param url: The URL to expand.
 
         :return: The final destination URL if successful; otherwise, returns the original URL.
         """
+        safe, reason = _is_safe_url(url)
+        if not safe:
+            logger.warning(f"expand_url: blocked {url!r}: {reason}")
+            return url
+
         timeout = 5
+        current_url = url
         for attempt in range(1, self.retries + 1):
             try:
-                response = httpx.head(url, follow_redirects=True, timeout=timeout)
-                final_url = response.url
-                logger.info(f"expand_url: {url} expanded to {final_url} on attempt {attempt}")
-                return str(final_url)
+                response = httpx.head(current_url, follow_redirects=False, timeout=timeout)
+                if response.is_redirect:
+                    location = response.headers.get("location", "")
+                    if not location:
+                        return current_url
+                    safe, reason = _is_safe_url(location)
+                    if not safe:
+                        logger.warning(f"expand_url: redirect to {location!r} blocked: {reason}")
+                        return current_url
+                    current_url = location
+                    continue
+                logger.info(f"expand_url: {url} expanded to {current_url} on attempt {attempt}")
+                return current_url
             except Exception:
-                logger.exception(f"Error expanding URL {url} on attempt {attempt}")
+                logger.exception(f"Error expanding URL {current_url} on attempt {attempt}")
 
         return url

--- a/libs/agno/tests/unit/tools/test_llms_txt.py
+++ b/libs/agno/tests/unit/tools/test_llms_txt.py
@@ -548,10 +548,16 @@ def test_knowledge_error_handling(tools_with_knowledge):
 # ============================================================================
 
 
-def test_reader_allowed_hosts_default_none():
+def test_reader_allowed_hosts_default_none_blocks_private():
+    """With allowed_hosts=None, private/reserved IPs must still be blocked (SSRF prevention)."""
     reader = LLMsTxtReader()
     assert reader.allowed_hosts is None
-    assert is_host_allowed("http://anything.example/path", reader.allowed_hosts) is True
+    with patch("agno.knowledge.reader.utils.url_validation.socket.getaddrinfo",
+               return_value=[(None, None, None, None, ("169.254.169.254", 80))]):
+        assert is_host_allowed("http://metadata.internal/", reader.allowed_hosts) is False
+    with patch("agno.knowledge.reader.utils.url_validation.socket.getaddrinfo",
+               return_value=[(None, None, None, None, ("93.184.216.34", 80))]):
+        assert is_host_allowed("http://example.com/path", reader.allowed_hosts) is True
 
 
 def test_reader_allowed_hosts_normalizes_case():
@@ -611,15 +617,25 @@ def test_reader_fetch_url_uses_event_hook_when_allowlisted():
     assert get_kwargs.get("follow_redirects") is True
 
 
-def test_reader_fetch_url_uses_fetch_with_retry_when_no_allowlist():
-    """Without an allowlist the existing retry helper is still used unchanged."""
+def test_reader_fetch_url_uses_event_hook_when_no_allowlist():
+    """Without an allowlist, the redirect guard is still active (blocks private IPs)."""
     reader = LLMsTxtReader()
     response = _mock_httpx_response("Doc content", "text/plain")
 
-    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry", return_value=response) as mock_fetch:
-        reader.fetch_url("https://example.com/page")
+    mock_client = MagicMock()
+    mock_client.__enter__.return_value = mock_client
+    mock_client.get.return_value = response
 
-    mock_fetch.assert_called_once()
+    with (
+        patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry") as mock_fetch,
+        patch("agno.knowledge.reader.llms_txt_reader.httpx.Client", return_value=mock_client),
+        patch("agno.knowledge.reader.utils.url_validation.socket.getaddrinfo",
+              return_value=[(None, None, None, None, ("93.184.216.34", 80))]),
+    ):
+        result = reader.fetch_url("https://example.com/page")
+
+    assert result == "Doc content"
+    mock_fetch.assert_not_called()  # guard path is always used now
 
 
 def test_reader_fetch_url_returns_none_when_redirect_target_disallowed():

--- a/libs/agno/tests/unit/tools/test_webtools.py
+++ b/libs/agno/tests/unit/tools/test_webtools.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from agno.tools.webtools import WebTools
+from agno.tools.webtools import WebTools, _is_safe_url
 
 
 @pytest.fixture
@@ -13,19 +13,105 @@ def web_tools():
     return WebTools(retries=3)
 
 
+# ---------------------------------------------------------------------------
+# _is_safe_url unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_safe_url_blocks_loopback():
+    with patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("127.0.0.1", 80))]):
+        safe, reason = _is_safe_url("http://localhost/admin")
+    assert not safe
+    assert "private" in reason
+
+
+def test_is_safe_url_blocks_link_local():
+    with patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("169.254.169.254", 80))]):
+        safe, reason = _is_safe_url("http://metadata.internal/")
+    assert not safe
+    assert "private" in reason
+
+
+def test_is_safe_url_blocks_private_rfc1918():
+    for ip in ("10.0.0.1", "172.16.0.1", "192.168.1.1"):
+        with patch("socket.getaddrinfo", return_value=[(None, None, None, None, (ip, 80))]):
+            safe, reason = _is_safe_url(f"http://{ip}/secret")
+        assert not safe, f"{ip} should be blocked"
+
+
+def test_is_safe_url_blocks_file_scheme():
+    safe, reason = _is_safe_url("file:///etc/passwd")
+    assert not safe
+    assert "scheme" in reason
+
+
+def test_is_safe_url_allows_public_ip():
+    with patch("socket.getaddrinfo", return_value=[(None, None, None, None, ("93.184.216.34", 80))]):
+        safe, reason = _is_safe_url("http://example.com/page")
+    assert safe
+    assert reason == ""
+
+
+# ---------------------------------------------------------------------------
+# expand_url integration tests
+# ---------------------------------------------------------------------------
+
+
 def test_expand_url_success(web_tools):
-    """Test successful expansion of a URL."""
-    mock_url = "https://tinyurl.com/k2fkfxra."
+    """Test successful expansion of a public URL."""
+    mock_url = "https://tinyurl.com/k2fkfxra"
     final_url = "https://github.com/agno-agi/agno"
 
     mock_response = Mock()
+    mock_response.is_redirect = False
     mock_response.url = final_url
 
-    with patch("httpx.head", return_value=mock_response) as mock_head:
+    with (
+        patch("agno.tools.webtools._is_safe_url", return_value=(True, "")),
+        patch("httpx.head", return_value=mock_response) as mock_head,
+    ):
         result = web_tools.expand_url(mock_url)
 
     assert result == final_url
-    mock_head.assert_called_once_with(mock_url, follow_redirects=True, timeout=5)
+    # redirects are now followed manually (follow_redirects=False for security)
+    mock_head.assert_called_once_with(mock_url, follow_redirects=False, timeout=5)
+
+
+def test_expand_url_blocks_private_ip(web_tools):
+    """expand_url must refuse to probe private/internal addresses."""
+    with patch("agno.tools.webtools._is_safe_url", return_value=(False, "resolves to private/reserved IP 127.0.0.1")):
+        result = web_tools.expand_url("http://localhost/admin")
+    assert result == "http://localhost/admin"
+
+
+def test_expand_url_blocks_metadata_endpoint(web_tools):
+    """expand_url must not reach cloud metadata endpoints."""
+    with patch(
+        "agno.tools.webtools._is_safe_url",
+        return_value=(False, "resolves to private/reserved IP 169.254.169.254"),
+    ):
+        result = web_tools.expand_url("http://169.254.169.254/latest/meta-data/")
+    assert result == "http://169.254.169.254/latest/meta-data/"
+
+
+def test_expand_url_blocks_redirect_to_private(web_tools):
+    """expand_url must not follow redirects that lead to internal addresses."""
+    redirect_response = Mock()
+    redirect_response.is_redirect = True
+    redirect_response.headers = {"location": "http://10.0.0.1/internal"}
+
+    def safe_side_effect(url):
+        if "evil.com" in url:
+            return (True, "")
+        return (False, "resolves to private/reserved IP 10.0.0.1")
+
+    with (
+        patch("agno.tools.webtools._is_safe_url", side_effect=safe_side_effect),
+        patch("httpx.head", return_value=redirect_response),
+    ):
+        result = web_tools.expand_url("http://evil.com/redirect")
+
+    assert result == "http://evil.com/redirect"
 
 
 def test_toolkit_registration(web_tools):


### PR DESCRIPTION
fixes #7950

## Summary

Fix two SSRF vulnerabilities that allow agents (or prompt injection) to make the server fetch internal network addresses.

### WebTools.expand_url

**Before:** `httpx.head(url, follow_redirects=True)` with no URL validation — any internal address reachable, redirects to private IPs followed automatically.

**After:** `_is_safe_url()` resolves hostname to IP before the request and blocks RFC 1918, loopback (127.x), and link-local (169.254.x) ranges. Redirects are followed manually with per-hop validation to prevent redirect-chain bypass.

### url_validation.py (LLMsTxtTools)

**Before:** `is_host_allowed(url, None)` returned `True` for every URL (SSRF via default `allowed_hosts=None`). `make_redirect_guard(None)` returned `None`, disabling redirect validation entirely.

**After:** `is_host_allowed` always resolves hostname and checks against blocked IP ranges regardless of `allowed_hosts`. Guards are always returned — the unguarded `fetch_with_retry` path no longer exists.

## Attack scenario

An agent given `LLMsTxtTools()` or `WebTools()` with default settings could be prompted (via prompt injection in a document) to call:
- `read_llms_txt_url("http://internal-service/secret")` → server makes GET, returns full body
- `expand_url("http://169.254.169.254/latest/meta-data/")` → server probes cloud metadata

## Test plan

- [x] `test_is_safe_url_blocks_loopback` — 127.x blocked
- [x] `test_is_safe_url_blocks_link_local` — 169.254.x blocked
- [x] `test_is_safe_url_blocks_private_rfc1918` — 10.x, 172.16.x, 192.168.x blocked
- [x] `test_expand_url_blocks_private_ip` — returns original URL unchanged for internal targets
- [x] `test_expand_url_blocks_redirect_to_private` — redirect chain to internal IP stopped
- [x] `test_reader_allowed_hosts_default_none_blocks_private` — private IPs blocked even with `allowed_hosts=None`
- [x] `test_reader_fetch_url_uses_event_hook_when_no_allowlist` — guard always active