### PR TITLE
[fix] Inject run_context for decorated Toolkit tools

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -581,14 +581,14 @@ class Function(BaseModel):
             return func
 
         # Don't wrap functions with framework-injected parameters
-        # These parameters (agent, team) are
+        # These parameters (agent, team, run_context) are
         # injected by the framework at runtime and shouldn't be validated by Pydantic
         sig = signature(func)
-        framework_params = {"agent", "team"}
+        framework_params = {"agent", "team", "run_context"}
         if framework_params & set(sig.parameters.keys()):
             return func
 
-        # Also skip validation when parameter types include Agent or Team,
+        # Also skip validation when parameter types include Agent, Team, or RunContext,
         # even if the parameter name differs (e.g. my_agent: Agent).
         # validate_call uses get_type_hints() which fails to resolve types
         # from Agent/Team class hierarchies (like BaseDb) in the user's module globals.
@@ -597,7 +597,7 @@ class Function(BaseModel):
             from agno.agent.agent import Agent
             from agno.team.team import Team
 
-            framework_types = (Agent, Team)
+            framework_types = (Agent, Team, RunContext)
             for hint in hints.values():
                 if isinstance(hint, type) and issubclass(hint, framework_types):
                     return func

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -246,6 +246,7 @@ class Toolkit:
 
                     bound.__name__ = getattr(func, "__name__", tool_name)
                     bound.__doc__ = getattr(func, "__doc__", None)
+                    bound.__wrapped__ = func  # type: ignore[attr-defined]
                     return bound
             else:
 
@@ -255,6 +256,7 @@ class Toolkit:
 
                     bound.__name__ = getattr(func, "__name__", tool_name)
                     bound.__doc__ = getattr(func, "__doc__", None)
+                    bound.__wrapped__ = func  # type: ignore[attr-defined]
                     return bound
 
             bound_method = make_bound_method(original_func, self)

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -3,7 +3,7 @@
 import pytest
 
 from agno.tools import Toolkit, tool
-from agno.tools.function import Function
+from agno.tools.function import Function, FunctionCall
 
 
 def example_func(a: int, b: int) -> int:
@@ -368,7 +368,7 @@ class TestToolDecoratorOnClassMethods:
             def __init__(self):
                 super().__init__(name="test_toolkit", tools=[self.update_state])
 
-            @tool()
+            @tool(name="update_tool_state")
             def update_state(self, key: str, value: str, run_context: RunContext) -> str:
                 """Update session state via run_context."""
                 if run_context.session_state is None:
@@ -377,12 +377,21 @@ class TestToolDecoratorOnClassMethods:
                 return f"Set {key}={value}"
 
         toolkit = MyToolkit()
-        func = toolkit.functions["update_state"]
+        func = toolkit.functions["update_tool_state"]
 
         # run_context should be excluded from parameters
         assert "run_context" not in func.parameters.get("properties", {})
         assert "key" in func.parameters.get("properties", {})
         assert "value" in func.parameters.get("properties", {})
+
+        run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+        func._run_context = run_context
+
+        result = FunctionCall(function=func, arguments={"key": "theme", "value": "dark"}).execute()
+
+        assert result.status == "success"
+        assert result.result == "Set theme=dark"
+        assert run_context.session_state == {"theme": "dark"}
 
     def test_tool_decorator_multiple_methods(self):
         """Test multiple @tool decorated methods in same toolkit."""


### PR DESCRIPTION
## Summary

Fixes #7889.

Decorated `Toolkit` methods that declare `run_context: RunContext` were failing at execution time because the Toolkit binding wrapper hid the original method signature from Agno's framework-argument injection. When the decorated method had also been wrapped by Pydantic validation, the call failed with `Missing required argument: run_context`.

This PR:
- skips `validate_call` wrapping for functions that need framework-injected `run_context`, matching the existing `agent` and `team` behavior
- preserves `__wrapped__` on Toolkit-bound decorated methods so `inspect.signature()` can still detect `run_context`
- extends the Toolkit decorator regression test to execute the `FunctionCall` path with a custom `@tool(name=...)`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed:
- Reproduced the original failure locally before the patch using a `Toolkit` method decorated with `@tool(name=...)` and `run_context: RunContext`.
- Re-ran the same reproduction after the patch; it returned `success` and updated `run_context.session_state`.
- `.venv/bin/pytest libs/agno/tests/unit/tools/test_toolkit.py::TestToolDecoratorOnClassMethods::test_tool_decorator_with_run_context libs/agno/tests/unit/tools/test_functions.py::test_user_input_with_run_context_execution -q` passed.
- `.venv/bin/pytest libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_functions.py -q` passed: 97 passed, 1 existing deprecation warning.
- `.venv/bin/ruff format libs/agno/agno/tools/function.py libs/agno/agno/tools/toolkit.py libs/agno/tests/unit/tools/test_toolkit.py` left files unchanged.
- `.venv/bin/ruff check libs/agno/agno/tools/function.py libs/agno/agno/tools/toolkit.py libs/agno/tests/unit/tools/test_toolkit.py` passed.
- `git diff --check` passed.
- `PATH="$PWD/.venv/bin:$PATH" ./libs/agno/scripts/validate.sh` passed `ruff check`; full-package `mypy` was attempted twice in the fresh checkout but did not complete after several minutes. The first attempt surfaced a missing optional `cryptography` dependency, which I installed before the second attempt.
