### PR TITLE
[feat] Add stop_after_successful_tool_call option for tools

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2090,7 +2090,10 @@ class Model(ABC):
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,
             tool_call_error=not success,
-            stop_after_tool_call=function_call.function.stop_after_tool_call,
+            stop_after_tool_call=(
+                function_call.function.stop_after_tool_call
+                or (function_call.function.stop_after_successful_tool_call and success)
+            ),
             images=images,
             videos=videos,
             audio=audios,

--- a/libs/agno/agno/tools/decorator.py
+++ b/libs/agno/agno/tools/decorator.py
@@ -66,6 +66,7 @@ def tool(
     add_instructions: bool = True,
     show_result: Optional[bool] = None,
     stop_after_tool_call: Optional[bool] = None,
+    stop_after_successful_tool_call: Optional[bool] = None,
     requires_confirmation: Optional[bool] = None,
     requires_user_input: Optional[bool] = None,
     user_input_fields: Optional[List[str]] = None,
@@ -95,6 +96,7 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
         add_instructions: bool - If True, add instructions to the system message
         show_result: Optional[bool] - If True, shows the result after function call
         stop_after_tool_call: Optional[bool] - If True, the agent will stop after the function call.
+        stop_after_successful_tool_call: Optional[bool] - If True, the agent will stop after the function call only if it succeeded. On failure, error is returned to model for retry.
         requires_confirmation: Optional[bool] - If True, the function will require user confirmation before execution
         requires_user_input: Optional[bool] - If True, the function will require user input before execution
         user_input_fields: Optional[List[str]] - List of fields that will be provided to the function as user input
@@ -133,6 +135,7 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
             "add_instructions",
             "show_result",
             "stop_after_tool_call",
+            "stop_after_successful_tool_call",
             "requires_confirmation",
             "requires_user_input",
             "user_input_fields",
@@ -275,7 +278,7 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
         }
 
         # Automatically set show_result=True if stop_after_tool_call=True (unless explicitly set to False)
-        if kwargs.get("stop_after_tool_call") is True:
+        if kwargs.get("stop_after_tool_call") is True or kwargs.get("stop_after_successful_tool_call") is True:
             if "show_result" not in kwargs or kwargs.get("show_result") is None:
                 tool_config["show_result"] = True
         function = Function(**tool_config)

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -157,6 +157,9 @@ class Function(BaseModel):
     show_result: bool = False
     # If True, the agent will stop after the function call.
     stop_after_tool_call: bool = False
+    # If True, the agent will stop after the function call ONLY if it succeeded.
+    # On failure, the error is returned to the model so it can retry.
+    stop_after_successful_tool_call: bool = False
     # Hook that runs before the function is executed.
     # If defined, can accept the FunctionCall instance as a parameter.
     pre_hook: Optional[Callable] = None

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -264,7 +264,8 @@ class Toolkit:
 
         # decorator settings take precedence, then toolkit settings
         stop_after = function.stop_after_tool_call or tool_name in self.stop_after_tool_call_tools
-        show_result = function.show_result or tool_name in self.show_result_tools or stop_after
+        stop_after_success = function.stop_after_successful_tool_call
+        show_result = function.show_result or tool_name in self.show_result_tools or stop_after or stop_after_success
         requires_confirmation = function.requires_confirmation or tool_name in self.requires_confirmation_tools
         external_execution = function.external_execution or tool_name in self.external_execution_required_tools
 
@@ -280,6 +281,7 @@ class Toolkit:
             skip_entrypoint_processing=True,  # Parameters already processed by decorator
             show_result=show_result,
             stop_after_tool_call=stop_after,
+            stop_after_successful_tool_call=stop_after_success,
             pre_hook=function.pre_hook,
             post_hook=function.post_hook,
             tool_hooks=function.tool_hooks,


### PR DESCRIPTION
## Summary

Add a new `stop_after_successful_tool_call` parameter for tools that conditionally stops the agent loop only when the tool execution succeeds. On failure, the error is returned to the model so it can self-correct and retry.

**Motivation:** When using `stop_after_tool_call=True` on "terminal" tools (e.g., a final `Output` tool that submits results), the agent stops unconditionally — even if the tool call failed due to validation errors (missing required arguments, wrong types, etc.). The model never sees the error and cannot retry, causing permanent silent failures.

This is a real problem with smaller/faster models that occasionally emit malformed tool calls (empty arguments, wrong parameter names). With `stop_after_tool_call=True`, these are unrecoverable. With `stop_after_successful_tool_call=True`, the model gets the validation error as a tool result and can self-correct on the next turn.

**Usage:**
```python
@tool(name="Output", stop_after_successful_tool_call=True)
def submit_result(answer: str, reasoning: str) -> str:
    """Submit final answer. Agent stops after successful call."""
    if not answer.strip():
        raise ValueError("answer cannot be empty")
    return json.dumps({"answer": answer, "reasoning": reasoning})
```

The two options coexist independently and are not mutually exclusive with other tools:
- `stop_after_tool_call=True` — unconditional stop (existing behavior, unchanged)
- `stop_after_successful_tool_call=True` — stop only on success, return error to model on failure (new)

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Files changed (4):**
- `libs/agno/agno/tools/function.py` — new `stop_after_successful_tool_call` field on `Function`
- `libs/agno/agno/tools/decorator.py` — `@tool` decorator accepts and validates the new param
- `libs/agno/agno/tools/toolkit.py` — propagates the field when registering decorated functions
- `libs/agno/agno/models/base.py` — core logic in `create_function_call_result`: `stop_after_tool_call = (stop_after_tool_call or (stop_after_successful_tool_call and success))`

**Backward compatible:** No existing behavior is changed. `stop_after_tool_call=True` continues to work exactly as before.

This PR was co-authored with Claude Code. The change was motivated by a production issue where DeepSeek-v4-flash occasionally calls tools with empty arguments, and `stop_after_tool_call=True` prevented the agent from recovering.