### PR TITLE
fix(team): stop route history from replaying answered delegations

### DIFF
--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Union
 
@@ -10,6 +11,21 @@ from agno.run.agent import RunOutput, RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.summary import SessionSummary
 from agno.utils.log import log_debug, log_warning
+
+
+def _coerce_run_content_for_history(content: Any) -> Optional[Union[List[Any], str]]:
+    if content is None:
+        return None
+    if isinstance(content, str):
+        return content if content.strip() else None
+    if isinstance(content, list):
+        return content or None
+    if isinstance(content, BaseModel):
+        return content.model_dump_json()
+    try:
+        return json.dumps(content, ensure_ascii=False)
+    except TypeError:
+        return str(content)
 
 
 @dataclass
@@ -121,6 +137,7 @@ class TeamSession:
         skip_statuses: Optional[List[RunStatus]] = None,
         skip_history_messages: bool = True,
         skip_member_messages: bool = True,
+        include_run_response_content: bool = False,
     ) -> List[Message]:
         """Returns the messages belonging to the session that fit the given criteria.
 
@@ -133,6 +150,8 @@ class TeamSession:
             skip_statuses: Skip messages with these statuses.
             skip_history_messages: Skip messages that were tagged as history in previous runs.
             skip_member_messages: Skip messages created by members of the team.
+            include_run_response_content: Include the visible run output as an assistant message when it is not
+                already represented by a stored assistant message.
 
         Returns:
             A list of Messages belonging to the session.
@@ -150,6 +169,32 @@ class TeamSession:
             if skip_roles and message.role in skip_roles:
                 return True
             return False
+
+        def _has_visible_assistant_response(messages: List[Message]) -> bool:
+            return any(
+                message.role == "assistant" and not message.tool_calls and message.content not in (None, "")
+                for message in messages
+            )
+
+        def _append_run_response_content_if_needed(
+            run_response: Union[TeamRunOutput, RunOutput], messages: List[Message]
+        ) -> None:
+            if not include_run_response_content:
+                return
+            if skip_roles and "assistant" in skip_roles:
+                return
+            if getattr(run_response, "status", None) != RunStatus.completed:
+                return
+
+            content = _coerce_run_content_for_history(getattr(run_response, "content", None))
+            if content is None:
+                return
+            if not any(message.role == "user" for message in messages):
+                return
+            if _has_visible_assistant_response(messages):
+                return
+
+            messages.append(Message(role="assistant", content=content))
 
         if member_ids is not None and skip_member_messages:
             log_debug("Member IDs to filter by were provided. The skip_member_messages flag will be ignored.")
@@ -209,6 +254,7 @@ class TeamSession:
                 if not run_response or not run_response.messages:
                     continue
 
+                run_messages: List[Message] = []
                 for message in run_response.messages or []:
                     if _should_skip_message(message, skip_roles, skip_history_messages):
                         continue
@@ -218,7 +264,10 @@ class TeamSession:
                         if system_message is None:
                             system_message = message
                     else:
-                        messages_from_history.append(message)
+                        run_messages.append(message)
+
+                _append_run_response_content_if_needed(run_response, run_messages)
+                messages_from_history.extend(run_messages)
 
             if system_message:
                 if limit <= 1:
@@ -241,6 +290,7 @@ class TeamSession:
                 if not (run_response and run_response.messages):
                     continue
 
+                run_messages = []
                 for message in run_response.messages or []:
                     if _should_skip_message(message, skip_roles, skip_history_messages):
                         continue
@@ -249,9 +299,12 @@ class TeamSession:
                         # Only add the system message once
                         if system_message is None:
                             system_message = message
-                            messages_from_history.append(system_message)
+                            run_messages.append(system_message)
                     else:
-                        messages_from_history.append(message)
+                        run_messages.append(message)
+
+                _append_run_response_content_if_needed(run_response, run_messages)
+                messages_from_history.extend(run_messages)
 
         log_debug(f"Getting messages from previous runs: {len(messages_from_history)}")
         return messages_from_history

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -896,6 +896,7 @@ def _get_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            include_run_response_content=True,
         )
 
         if len(history) > 0:
@@ -1030,6 +1031,7 @@ async def _aget_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            include_run_response_content=True,
         )
 
         if len(history) > 0:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4417,6 +4417,7 @@ def _get_continue_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            include_run_response_content=True,
         )
 
         if len(history) > 0:

--- a/libs/agno/tests/unit/team/test_route_history_context.py
+++ b/libs/agno/tests/unit/team/test_route_history_context.py
@@ -1,0 +1,255 @@
+from typing import Any, AsyncIterator, Iterator, Optional
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.run.base import RunContext, RunStatus
+from agno.run.team import TeamRunOutput
+from agno.session import TeamSession
+from agno.team._messages import _aget_run_messages, _get_run_messages
+from agno.team.team import Team, TeamMode
+from agno.utils.agent import scrub_tool_results_from_run_output
+
+
+class MockModel(Model):
+    def __init__(self):
+        super().__init__(id="test-model", name="test-model", provider="test")
+
+    def get_instructions_for_model(self, *args: Any, **kwargs: Any) -> Optional[list[str]]:
+        return None
+
+    def get_system_message_for_model(self, *args: Any, **kwargs: Any) -> Optional[Message]:
+        return None
+
+    async def aget_instructions_for_model(self, *args: Any, **kwargs: Any) -> Optional[list[str]]:
+        return None
+
+    async def aget_system_message_for_model(self, *args: Any, **kwargs: Any) -> Optional[Message]:
+        return None
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        raise NotImplementedError
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        raise NotImplementedError
+
+
+def _delegated_route_run(*, content: str = "math_agent answered: 4", final_assistant: Optional[str] = None):
+    messages = [
+        Message(role="user", content="Q1: what is 2+2?"),
+        Message(
+            role="assistant",
+            tool_calls=[
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "delegate_task_to_member",
+                        "arguments": '{"member_id": "math_agent", "task": "Q1: what is 2+2?"}',
+                    },
+                }
+            ],
+        ),
+        Message(role="tool", content=content, tool_call_id="call-1"),
+    ]
+    if final_assistant is not None:
+        messages.append(Message(role="assistant", content=final_assistant))
+
+    return TeamRunOutput(
+        run_id="run-1",
+        team_id="brain-team",
+        status=RunStatus.completed,
+        content=content,
+        messages=messages,
+    )
+
+
+def _team(**kwargs: Any) -> Team:
+    return Team(
+        id="brain-team",
+        name="brain-team",
+        model=MockModel(),
+        members=[],
+        mode=TeamMode.route,
+        add_history_to_context=True,
+        num_history_runs=2,
+        **kwargs,
+    )
+
+
+def _session(previous_run: TeamRunOutput) -> TeamSession:
+    return TeamSession(session_id="session-1", team_id="brain-team", runs=[previous_run])
+
+
+def _history_messages(messages: list[Message]) -> list[Message]:
+    return [message for message in messages if message.from_history]
+
+
+def test_route_history_keeps_completed_turn_when_tool_messages_are_not_stored():
+    previous_run = _delegated_route_run(content="math_agent answered: 4")
+    scrub_tool_results_from_run_output(previous_run)
+
+    run_messages = _get_run_messages(
+        _team(store_tool_messages=False),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [
+        ("user", "Q1: what is 2+2?"),
+        ("assistant", "math_agent answered: 4"),
+    ]
+    assert all(message.role != "tool" for message in history)
+    assert all(not message.tool_calls for message in history)
+
+
+def test_route_history_keeps_completed_turn_when_tool_calls_are_filtered_out():
+    previous_run = _delegated_route_run(content="math_agent answered: 4")
+
+    run_messages = _get_run_messages(
+        _team(max_tool_calls_from_history=0),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [
+        ("user", "Q1: what is 2+2?"),
+        ("assistant", "math_agent answered: 4"),
+    ]
+    assert all(message.role != "tool" for message in history)
+    assert all(not message.tool_calls for message in history)
+
+
+def test_route_history_does_not_duplicate_existing_assistant_answer():
+    previous_run = _delegated_route_run(content="The answer is 4.", final_assistant="The answer is 4.")
+    scrub_tool_results_from_run_output(previous_run)
+
+    run_messages = _get_run_messages(
+        _team(store_tool_messages=False),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [
+        ("user", "Q1: what is 2+2?"),
+        ("assistant", "The answer is 4."),
+    ]
+
+
+def test_route_history_does_not_override_existing_visible_assistant_answer():
+    previous_run = TeamRunOutput(
+        run_id="run-1",
+        team_id="brain-team",
+        status=RunStatus.completed,
+        content="different serialized run output",
+        messages=[
+            Message(role="user", content="Q1: what is 2+2?"),
+            Message(role="assistant", content="The answer is 4."),
+        ],
+    )
+
+    run_messages = _get_run_messages(
+        _team(store_tool_messages=False),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [
+        ("user", "Q1: what is 2+2?"),
+        ("assistant", "The answer is 4."),
+    ]
+
+
+def test_route_history_does_not_synthesize_content_for_unfinished_runs():
+    previous_run = TeamRunOutput(
+        run_id="run-1",
+        team_id="brain-team",
+        status=RunStatus.running,
+        content="partial delegated answer",
+        messages=[Message(role="user", content="Q1: what is 2+2?")],
+    )
+
+    run_messages = _get_run_messages(
+        _team(store_tool_messages=False),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [("user", "Q1: what is 2+2?")]
+
+
+def test_route_history_does_not_synthesize_empty_run_content():
+    previous_run = TeamRunOutput(
+        run_id="run-1",
+        team_id="brain-team",
+        status=RunStatus.completed,
+        content=[],
+        messages=[Message(role="user", content="Q1: what is 2+2?")],
+    )
+
+    run_messages = _get_run_messages(
+        _team(store_tool_messages=False),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [("user", "Q1: what is 2+2?")]
+
+
+@pytest.mark.asyncio
+async def test_async_route_history_matches_sync_behavior_when_tool_messages_are_not_stored():
+    previous_run = _delegated_route_run(content="math_agent answered: 4")
+    scrub_tool_results_from_run_output(previous_run)
+
+    run_messages = await _aget_run_messages(
+        _team(store_tool_messages=False),
+        run_response=TeamRunOutput(run_id="run-2", team_id="brain-team", status=RunStatus.running),
+        run_context=RunContext(run_id="run-2", session_id="session-1"),
+        session=_session(previous_run),
+        input_message="Q2: what is Newton's second law?",
+        add_history_to_context=True,
+    )
+
+    history = _history_messages(run_messages.messages)
+    assert [(message.role, message.content) for message in history] == [
+        ("user", "Q1: what is 2+2?"),
+        ("assistant", "math_agent answered: 4"),
+    ]


### PR DESCRIPTION
## Summary

This fixes route-mode team history when delegated tool messages are hidden or filtered out.

Previously, a completed delegated route turn could enter the next model context as only the historical user request, without the visible answer that was returned to the caller. On the next turn, the route model could treat that old request as still unresolved and delegate or answer the wrong question.

## Motivation

In route mode, delegated member output is often surfaced as the run response content. If `store_tool_messages=False` scrubs tool results, or `max_tool_calls_from_history=0` filters the tool-call chain out of history, the stored message list may lose the only assistant-side representation of the completed turn.

That makes the history shape misleading:

```text
history:
  user: previous question
current:
  user: new question
```

The previous turn was actually completed, so the history passed to the next model should preserve that as a completed user/assistant exchange.

## Changes

- Adds an opt-in history path that can include the visible `run_response.content` as an assistant message when a completed run has a user message but no visible assistant response after filtering.
- Enables that path for team run-message construction, including sync, async, and continue-run history.
- Keeps the fallback narrow:
  - only applies to completed runs
  - does not run when assistant messages are skipped
  - does not duplicate an existing visible assistant answer
  - does not override an existing assistant answer
  - ignores empty run content

## Test Plan

```bash
libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/team/test_route_history_context.py libs/agno/tests/unit/team/test_get_messages_dedup.py libs/agno/tests/unit/team/test_team_mode.py -q
```

Result: `34 passed in 0.27s`

```bash
libs/agno/.venv/bin/ruff check libs/agno/agno/session/team.py libs/agno/agno/team/_messages.py libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_route_history_context.py
```

Result: `All checks passed!`

```bash
libs/agno/.venv/bin/ruff format --check libs/agno/agno/session/team.py libs/agno/agno/team/_messages.py libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_route_history_context.py
```

Result: `4 files already formatted`

```bash
git diff --check
```

Result: passed with no whitespace errors.

## Risk

The behavioral change is intentionally scoped to history construction. Raw `TeamSession.get_messages()` behavior remains unchanged unless callers opt in with `include_run_response_content=True`.

The fallback only synthesizes an assistant history message when the filtered run would otherwise contain a user message without any visible assistant response. That preserves the completed-turn shape for route delegation while avoiding duplicate or stale assistant messages.

## Related Issue

Fixes #7971
