### PR TITLE
fix(team): warn when store_member_responses=False silently wipes data on paused HITL run

### DIFF
--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -198,6 +198,12 @@ def save_session(team: "Team", session: TeamSession) -> None:
             for run in session.runs:
                 if hasattr(run, "member_responses"):
                     if not team.store_member_responses:
+                        if run.member_responses and run.status == RunStatus.paused:
+                            log_warning(
+                                f"store_member_responses=False: wiping {len(run.member_responses)} "
+                                f"member_responses on paused run {run.run_id}. "
+                                "Set store_member_responses=True to preserve them for HITL resume."
+                            )
                         # Remove all member responses
                         run.member_responses = []
                     else:


### PR DESCRIPTION
## Summary

`store_member_responses` defaults to `False`. At save time, `_asave_session` wipes every run's `member_responses` list without checking whether the run is paused or whether the list is non-empty. For HITL setups this causes silent data loss: the cross-process resume fails because `member_responses` is empty in the DB, but there is no indication of why.

This PR adds a `log_warning` when a non-empty `member_responses` list is cleared on a **paused** run, giving operators a clear diagnostic:

```
WARNING store_member_responses=False: wiping 3 member_responses on paused run abc123.
Set store_member_responses=True to preserve them for HITL resume.
```

## Changes

`libs/agno/agno/team/_session.py` — one guard + `log_warning` before the existing `run.member_responses = []` line.

## What this does NOT change

- The wipe still happens (behaviour is unchanged for non-paused runs and for users who don't care about HITL).
- For paused runs, the warning is emitted but the wipe still occurs — it's a diagnostic, not a behaviour change.
- A separate PR would be needed to change the default or skip the wipe for paused runs.

## Relationship to other issues

- Pairs with #7978 (persist outer team run before pause) and #7821/#7760 (resume path fixes).
- Addresses the observability gap described in #7960.

Fixes #7960 (partial — diagnostic; full fix requires `store_member_responses=True` or default change)
