### PR TITLE
fix(run): add team_id, team_name, member_responses to RunOutput

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -666,6 +666,11 @@ class RunOutput:
     # and should be treated as foreign keys for data integrity
     workflow_step_id: Optional[str] = None  # FK: Points to StepOutput.step_id
 
+    # Team context -- populated when this agent runs as a member of a team
+    team_id: Optional[str] = None
+    team_name: Optional[str] = None
+    member_responses: Optional[List[Any]] = None
+
     @property
     def active_requirements(self) -> list[RunRequirement]:
         if not self.requirements:


### PR DESCRIPTION
## Summary

`RunOutput` (returned by `Agent.run()`) is missing three fields that `events.py` accesses in 30+ places, each suppressed with a `# type: ignore` comment:

- `team_id`
- `team_name`
- `member_responses`

These fields exist on `TeamRunOutput` but not on `RunOutput`. Any code path that creates an agent-level `RunOutput` and then tries to read `.team_id` or `.member_responses` raises `AttributeError` at runtime; the `# type: ignore` comments hide the static-analysis warning but do nothing to prevent the runtime crash.

## Root Cause

`RunOutput` in `libs/agno/agno/run/agent.py` was never updated when those fields were added to `TeamRunOutput`. The dataclass currently ends at:

```python
workflow_step_id: Optional[str] = None  # FK: Points to StepOutput.step_id
```

## Fix

Add the three fields as `Optional` with `None` defaults immediately after `workflow_step_id`:

```python
# Team context -- populated when this agent runs as a member of a team
team_id: Optional[str] = None
team_name: Optional[str] = None
member_responses: Optional[List[Any]] = None
```

This is fully backward compatible: existing `RunOutput` objects that do not set these fields continue to work, and `events.py` can now access them without `# type: ignore` or risking `AttributeError`.

## Test Plan

- [ ] Existing unit tests pass (`pytest libs/agno/tests/`)
- [ ] `events.py` `# type: ignore` comments for these three fields can be removed
- [ ] Agent running as team member: `run_output.team_id` returns the parent team's id instead of raising `AttributeError`

Fixes #7963