### PR TITLE
cookbook: add AG-UI multimodal input example (agent_with_media)

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/README.md
+++ b/cookbook/05_agent_os/interfaces/agui/README.md
@@ -3,6 +3,7 @@
 Examples for `interfaces/agui` in AgentOS.
 
 ## Files
+- `agent_with_media.py` — Agent With Media - Accept multimodal user input (image, audio, video, document).
 - `agent_with_silent_tools.py` — Silent External Tools - Suppress verbose messages in frontends.
 - `agent_with_tools.py` — Agent With Tools.
 - `basic.py` — Basic.

--- a/cookbook/05_agent_os/interfaces/agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/interfaces/agui/TEST_LOG.md
@@ -2,6 +2,16 @@
 
 > Tests not yet run. Run each file and update this log.
 
+### agent_with_media.py
+
+**Status:** PASS
+
+**Description:** Agent With Media - AG-UI agent (Google Gemini) that accepts multimodal user input.
+
+**Result:** AgentOS boots with the AG-UI interface; /config returns 200. Media sent through POST /agui reaches the Gemini agent, which describes it accurately - verified with an image via CLI and interactively in a browser. Multimodal input path verified end-to-end.
+
+---
+
 ### agent_with_silent_tools.py
 
 **Status:** PENDING

--- a/cookbook/05_agent_os/interfaces/agui/agent_with_media.py
+++ b/cookbook/05_agent_os/interfaces/agui/agent_with_media.py
@@ -1,0 +1,53 @@
+"""
+Agent With Media
+================
+
+Demonstrates an AG-UI agent that accepts multimodal user input.
+
+The agent uses Google Gemini, which can analyze images, audio, video, and
+documents. When a user attaches a file in an AG-UI frontend, the AG-UI
+interface forwards it to the agent as the matching media type and the agent
+answers questions about it.
+
+Setup: Set the GOOGLE_API_KEY environment variable.
+"""
+
+from agno.agent.agent import Agent
+from agno.models.google import Gemini
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+media_agent = Agent(
+    name="Media Agent",
+    model=Gemini(id="gemini-flash-latest"),
+    instructions="Analyze any image, audio, video, or document the user sends and answer their question about it.",
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+# Setup your AgentOS app
+agent_os = AgentOS(
+    agents=[media_agent],
+    interfaces=[AGUI(agent=media_agent)],
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """Run your AgentOS.
+
+    You can see the configuration and available apps at:
+    http://localhost:9001/config
+
+    Use Port 9001 to configure the Dojo endpoint, then attach an image,
+    audio, video, or document in the frontend.
+    """
+    agent_os.serve(app="agent_with_media:app", port=9001, reload=True)


### PR DESCRIPTION
## Summary

Adds `cookbook/05_agent_os/interfaces/agui/agent_with_media.py` — an AG-UI agent (Google Gemini) that accepts multimodal user input (image / audio / video / document). Registers it in the agui cookbook README and TEST_LOG.

AG-UI was the only `interfaces/` cookbook with no media example — `telegram/` and `whatsapp/` both ship `agent_with_media.py`. This closes that gap.

## Depends on #7937 

This example exercises the multimodal AG-UI **input** path added in #7937. Without #7937, AG-UI drops user-attached media (#7928), so the example only works on top of #7937. Opened as a draft for that reason.

## Type of change

- [x] New cookbook example

## Testing

- `ruff check` and `ruff format` pass.
- Verified on #7937's branch: AgentOS boots; an image sent through `POST /agui` reaches the Gemini agent, which describes it accurately. Logged in the cookbook `TEST_LOG.md`.
