### PR TITLE
fix: share session_state with default reasoning sub-agent

### DIFF
--- a/libs/agno/agno/reasoning/manager.py
+++ b/libs/agno/agno/reasoning/manager.py
@@ -827,10 +827,15 @@ class ReasoningManager:
 
         log_debug("Starting Reasoning", center=True, symbol="=")
 
+        parent_session_state = self.config.run_context.session_state if self.config.run_context else None
+
         while next_action == NextAction.CONTINUE and step_count < self.config.max_steps:
             log_debug(f"Step {step_count}", center=True, symbol="=")
             try:
-                reasoning_agent_response: RunOutput = reasoning_agent.run(input=run_messages.get_input_messages())
+                reasoning_agent_response: RunOutput = reasoning_agent.run(
+                    input=run_messages.get_input_messages(),
+                    session_state=parent_session_state,
+                )
 
                 # Accumulate reasoning model metrics
                 if self.config.run_metrics is not None:
@@ -939,12 +944,15 @@ class ReasoningManager:
 
         log_debug("Starting Reasoning", center=True, symbol="=")
 
+        parent_session_state = self.config.run_context.session_state if self.config.run_context else None
+
         while next_action == NextAction.CONTINUE and step_count < self.config.max_steps:
             log_debug(f"Step {step_count}", center=True, symbol="=")
             step_count += 1
             try:
                 reasoning_agent_response: RunOutput = await reasoning_agent.arun(  # type: ignore[misc]
-                    input=run_messages.get_input_messages()
+                    input=run_messages.get_input_messages(),
+                    session_state=parent_session_state,
                 )
 
                 # Accumulate reasoning model metrics

--- a/libs/agno/tests/unit/reasoning/test_reasoning_session_state.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_session_state.py
@@ -1,0 +1,129 @@
+"""Regression tests for default-reasoning session_state propagation.
+
+Bug: ``ReasoningManager`` builds the default Chain-of-Thought sub-agent with
+``db=None`` and only seeds ``session_state`` via the constructor. When that
+sub-agent runs, ``read_or_create_session`` deepcopies ``agent.session_state``
+into a fresh ``session_data`` dict and ``load_session_state`` overwrites the
+run's ``session_state`` with that copy — so any tool calls fired inside the
+sub-agent mutate an isolated dict and the parent run never sees the writes.
+
+Passing ``session_state=parent_state`` on the sub-agent's ``run``/``arun`` call
+preserves dict identity end-to-end (``load_session_state`` mutates in place
+via ``clear``/``update``), so tool writes land on the parent's dict.
+"""
+
+from typing import Any, List, Optional
+
+import pytest
+
+from agno.models.message import Message
+from agno.reasoning.manager import ReasoningConfig, ReasoningManager
+from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
+from agno.run.agent import RunOutput
+from agno.run.base import RunContext
+from agno.run.messages import RunMessages
+
+
+class _FakeReasoningAgent:
+    """Stub stand-in for the default reasoning sub-agent.
+
+    Captures the kwargs passed to ``run``/``arun`` and returns a final-answer
+    ``RunOutput`` so the manager loop terminates after one step.
+    """
+
+    def __init__(self) -> None:
+        self.run_calls: List[dict] = []
+        self.arun_calls: List[dict] = []
+        self.output_schema = ReasoningSteps
+
+    def _final_answer_output(self) -> RunOutput:
+        steps = ReasoningSteps(
+            reasoning_steps=[
+                ReasoningStep(
+                    title="done",
+                    action="finish",
+                    result="ok",
+                    reasoning="done",
+                    next_action=NextAction.FINAL_ANSWER,
+                    confidence=1.0,
+                )
+            ]
+        )
+        return RunOutput(
+            run_id="r-1",
+            agent_id="a-1",
+            content=steps,
+            messages=[Message(role="assistant", content="done")],
+        )
+
+    def run(self, **kwargs: Any) -> RunOutput:
+        self.run_calls.append(kwargs)
+        return self._final_answer_output()
+
+    async def arun(self, **kwargs: Any) -> RunOutput:
+        self.arun_calls.append(kwargs)
+        return self._final_answer_output()
+
+
+def _build_manager(
+    fake_agent: _FakeReasoningAgent,
+    session_state: Optional[dict],
+) -> ReasoningManager:
+    run_context = RunContext(run_id="r-1", session_id="s-1", session_state=session_state)
+    config = ReasoningConfig(run_context=run_context)
+    manager = ReasoningManager(config)
+    # Bypass the real sub-agent construction so we don't need a model.
+    manager._get_default_reasoning_agent = lambda model: fake_agent  # type: ignore[assignment, method-assign]
+    return manager
+
+
+def _drain(it: Any) -> None:
+    for _ in it:
+        pass
+
+
+async def _adrain(it: Any) -> None:
+    async for _ in it:
+        pass
+
+
+def test_run_default_reasoning_passes_parent_session_state() -> None:
+    """Sync: the sub-agent must receive the parent's session_state by reference."""
+    parent_state: dict = {"existing_key": "existing_value"}
+    fake = _FakeReasoningAgent()
+    manager = _build_manager(fake, parent_state)
+
+    _drain(manager.run_default_reasoning(model=None, run_messages=RunMessages()))  # type: ignore[arg-type]
+
+    assert len(fake.run_calls) == 1
+    kwargs = fake.run_calls[0]
+    assert "session_state" in kwargs
+    assert kwargs["session_state"] is parent_state
+
+
+@pytest.mark.asyncio
+async def test_arun_default_reasoning_passes_parent_session_state() -> None:
+    """Async: the sub-agent must receive the parent's session_state by reference."""
+    parent_state: dict = {"existing_key": "existing_value"}
+    fake = _FakeReasoningAgent()
+    manager = _build_manager(fake, parent_state)
+
+    await _adrain(manager.arun_default_reasoning(model=None, run_messages=RunMessages()))  # type: ignore[arg-type]
+
+    assert len(fake.arun_calls) == 1
+    kwargs = fake.arun_calls[0]
+    assert "session_state" in kwargs
+    assert kwargs["session_state"] is parent_state
+
+
+def test_run_default_reasoning_without_run_context_passes_none() -> None:
+    """When no run_context is configured, session_state must be None (not crash)."""
+    fake = _FakeReasoningAgent()
+    config = ReasoningConfig(run_context=None)
+    manager = ReasoningManager(config)
+    manager._get_default_reasoning_agent = lambda model: fake  # type: ignore[assignment, method-assign]
+
+    _drain(manager.run_default_reasoning(model=None, run_messages=RunMessages()))  # type: ignore[arg-type]
+
+    assert len(fake.run_calls) == 1
+    assert fake.run_calls[0]["session_state"] is None


### PR DESCRIPTION
## Summary

When `reasoning=True` and the active model is not a native reasoning model, `ReasoningManager` falls back to default Chain-of-Thought and constructs a sub-agent via `get_default_reasoning_agent`. That sub-agent is built with `db=None`, so its `run()` falls into the no-DB branch of `read_or_create_session`, which deepcopies `agent.session_state` into a fresh `session_data` dict. `load_session_state` then clears + updates the run's `session_state` with that copy, isolating it from the parent.

As a result, any tool calls fired during reasoning mutate a throwaway dict and the parent run never observes the writes, all stay empty post-run even though the sub-agent clearly invoked the tools.

**Fix:** pass the parent's `session_state` explicitly on the sub-agent's `run`/`arun` call. `load_session_state` mutates its argument in place via `clear()` + `update()`, so dict identity is preserved end-to-end and tool writes land on the parent's dict.

Fixes #7990

### Reproducer

```python
from agno.agent import Agent
from agno.models.openai import OpenAIResponses
from agno.run.base import RunContext


def mark_done(token: str, run_context: RunContext) -> str:
    """Stamp session_state['marker'] with token."""
    if run_context.session_state is not None:
        print("Setting marker to", token)
        run_context.session_state["marker"] = token
    return f"marked: {token}"


agent = Agent(
    model=OpenAIResponses(id="gpt-5.4-mini"),  # not native-reasoning -> default CoT
    tools=[mark_done],
    session_state={},
    reasoning=True,
)

response = agent.run(
    "Call the `mark_done` tool exactly once with token='hello'. "
    "Then write a one-sentence confirmation."
)

print("marker on response.session_state:", response.session_state.get("marker"))
```

**Before this PR**

```
Setting marker to hello
marker on response.session_state: None
```

The sub-agent definitely called `mark_done` (visible in the print), but the write went to a deepcopied throwaway dict that was discarded when the sub-agent's run returned. The parent dict and the post-run `response.session_state` were untouched.

**After this PR**

```
Setting marker to hello
marker on response.session_state: hello
```

The sub-agent now receives the parent's dict by identity, so `mark_done`'s write lands where the parent reads it back from.



Files touched:
- `libs/agno/agno/reasoning/manager.py` — both sync and async default-CoT call sites now forward `run_context.session_state`.
- `libs/agno/tests/unit/reasoning/test_reasoning_session_state.py` — three regression tests (sync, async, no-run_context) verify the kwarg is forwarded by reference.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

