### PR TITLE
fix: serialize MCPTools connect/close to prevent parallel BrokenResourceError

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -186,6 +186,12 @@ class MCPTools(Toolkit):
         self._session_ttl_seconds: float = 300.0  # 5 minutes TTL for MCP sessions
         self._session_lock: Optional[asyncio.Lock] = None  # Lazily created lock for session creation
 
+        # Lazily created lock serializing connect() / close() / __aenter__ / __aexit__
+        # so parallel callers (e.g. a Team delegating multiple tool calls to the same
+        # member in one turn) share a single underlying session instead of each opening
+        # their own and racing GC into anyio.BrokenResourceError.
+        self._lifecycle_lock_inst: Optional[asyncio.Lock] = None
+
         def cleanup():
             """Cancel active connections"""
             if self._connection_task and not self._connection_task.done():
@@ -204,6 +210,19 @@ class MCPTools(Toolkit):
         if self._session_lock is None:
             self._session_lock = asyncio.Lock()
         return self._session_lock
+
+    @property
+    def _lifecycle_lock(self) -> asyncio.Lock:
+        """Lock serializing ``connect()`` / ``close()`` / ``__aenter__`` / ``__aexit__``.
+
+        Lazy because constructing the lock in ``__init__`` would bind it to whichever
+        event loop happens to be running at construction time (often a different
+        loop than the one running the agent). Creating it on first use binds it to
+        the loop that actually serializes connects.
+        """
+        if self._lifecycle_lock_inst is None:
+            self._lifecycle_lock_inst = asyncio.Lock()
+        return self._lifecycle_lock_inst
 
     def _call_header_provider(
         self,
@@ -451,24 +470,32 @@ class MCPTools(Toolkit):
             return False
 
     async def connect(self, force: bool = False):
-        """Initialize a MCPTools instance and connect to the contextual MCP server"""
+        """Initialize a MCPTools instance and connect to the contextual MCP server.
 
-        if force:
-            # Clean up the session and context so we force a new connection
-            self.session = None
-            self._context = None
-            self._session_context = None
-            self._initialized = False
-            self._connection_task = None
-            self._active_contexts = []
-
-        if self._initialized:
+        Single-flight under ``_lifecycle_lock``: parallel callers share one underlying
+        session. Failures are logged but NOT re-raised so ``pre_run_hook`` can iterate
+        every MCP tool on an agent without one bad server aborting the whole run; use
+        ``async with`` (or check ``self.initialized``) if you need failures to propagate.
+        """
+        # Fast path: already initialized and no force-reconnect requested.
+        # Skipping the lock here keeps the steady-state per-run hot path cost-free.
+        if not force and self._initialized:
             return
 
-        try:
-            await self._connect()
-        except (RuntimeError, BaseException):
-            log_error(f"Failed to connect to {str(self)}")
+        async with self._lifecycle_lock:
+            if force:
+                # Direct call avoids re-acquiring the lock (would self-deadlock).
+                await self._close_locked()
+
+            # Re-check after acquiring the lock; another caller may have connected
+            # while we were waiting. This is the double-checked-locking pattern.
+            if self._initialized:
+                return
+
+            try:
+                await self._connect()
+            except (RuntimeError, BaseException):
+                log_error(f"Failed to connect to {str(self)}")
 
     async def _connect(self) -> None:
         """Connects to the MCP server and initializes the tools"""
@@ -530,8 +557,19 @@ class MCPTools(Toolkit):
         await self.initialize()
 
     async def close(self) -> None:
-        """Close the MCP connection and clean up resources"""
-        if not self._initialized:
+        """Close the MCP connection and clean up resources.
+
+        Waits for any in-flight ``connect()`` to complete before tearing down so a
+        racing ``close()`` cannot strand a session another caller is still bringing up.
+        """
+        async with self._lifecycle_lock:
+            await self._close_locked()
+
+    async def _close_locked(self) -> None:
+        """Body of :meth:`close`. Caller must hold ``_lifecycle_lock``."""
+        # Also clean up partial state from a failed connect (session_context / context
+        # entered but initialize() raised before _initialized flipped to True).
+        if not self._initialized and self._session_context is None and self._context is None:
             return
 
         import warnings
@@ -568,21 +606,23 @@ class MCPTools(Toolkit):
         self._initialized = False
 
     async def __aenter__(self) -> "MCPTools":
-        await self._connect()
+        """Enter the async context manager; raises on init failure.
+
+        Calls ``_connect()`` directly (not :meth:`connect`) so failures surface at the
+        ``async with`` boundary instead of being swallowed by ``connect()``'s
+        log-and-continue contract.
+        """
+        if self._initialized:
+            return self
+        async with self._lifecycle_lock:
+            if self._initialized:
+                return self
+            await self._connect()
         return self
 
     async def __aexit__(self, _exc_type, _exc_val, _exc_tb):
         """Exit the async context manager."""
-        if self._session_context is not None:
-            await self._session_context.__aexit__(_exc_type, _exc_val, _exc_tb)
-            self.session = None
-            self._session_context = None
-
-        if self._context is not None:
-            await self._context.__aexit__(_exc_type, _exc_val, _exc_tb)
-            self._context = None
-
-        self._initialized = False
+        await self.close()
 
     async def build_tools(self) -> None:
         """Build the tools for the MCP toolkit"""

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -769,3 +769,269 @@ async def test_parallel_calls_no_deadlock_with_timeout():
 
             assert len(results) == 3
             assert all(s is results[0] for s in results)
+
+
+# =============================================================================
+# Lifecycle lock tests (parallel connect/close race — issue #8013, related #7347)
+# =============================================================================
+
+
+def _make_concurrency_tool() -> MCPTools:
+    """MCPTools instance configured for the lifecycle-lock concurrency tests.
+
+    Uses streamable-http with explicit server_params so construction succeeds
+    without hitting any real network — every test below stubs ``_connect`` /
+    ``_close_locked`` so we exercise lock semantics in isolation.
+    """
+    from datetime import timedelta
+
+    return MCPTools(
+        url="http://example.test/mcp",
+        transport="streamable-http",
+        server_params=StreamableHTTPClientParams(
+            url="http://example.test/mcp",
+            headers=None,
+            timeout=timedelta(seconds=300),
+        ),
+        timeout_seconds=300,
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_connect_runs_underlying_connect_exactly_once(monkeypatch):
+    """Five concurrent ``connect()`` callers must share a single underlying
+    ``_connect()`` invocation. Without the lifecycle lock all five would race
+    past the ``not _initialized`` check and each open its own MCP session,
+    leaving four orphans whose backing tasks tear down their anyio streams
+    when GC'd — the ``BrokenResourceError`` the lock is here to prevent.
+    """
+    import asyncio
+
+    tool = _make_concurrency_tool()
+
+    call_count = 0
+    inflight = 0
+    max_inflight = 0
+
+    async def fake_connect(self):
+        nonlocal call_count, inflight, max_inflight
+        call_count += 1
+        inflight += 1
+        max_inflight = max(max_inflight, inflight)
+        try:
+            # Yield to the loop so any racing caller has a real chance to
+            # observe overlap if the lock were missing.
+            await asyncio.sleep(0.01)
+            self._initialized = True
+        finally:
+            inflight -= 1
+
+    monkeypatch.setattr(MCPTools, "_connect", fake_connect)
+
+    await asyncio.gather(*(tool.connect() for _ in range(5)))
+
+    assert call_count == 1, (
+        f"_connect() ran {call_count} times under parallel callers; "
+        "the lifecycle lock + double-check should serialize them to one."
+    )
+    assert max_inflight == 1, (
+        "two _connect() calls were in flight simultaneously — the lifecycle lock is not actually serializing them."
+    )
+    assert tool.initialized is True
+
+
+@pytest.mark.asyncio
+async def test_connect_fast_path_skips_lock_when_already_initialized(monkeypatch):
+    """Once initialized, ``connect()`` must not even acquire the lock — the
+    hot agent-run path calls ``connect()`` on every run and must not pay a
+    serialization cost when there is nothing to do.
+    """
+    import asyncio
+
+    tool = _make_concurrency_tool()
+
+    async def fake_connect(self):
+        self._initialized = True
+
+    monkeypatch.setattr(MCPTools, "_connect", fake_connect)
+
+    await tool.connect()
+    assert tool.initialized is True
+
+    # Hold the lifecycle lock externally to prove that the second connect()
+    # call takes the lock-free fast path. If it tries to acquire the lock,
+    # the wait_for() below times out and the test fails loudly.
+    lock = tool._lifecycle_lock  # noqa: SLF001 — white-box concurrency probe
+    assert not lock.locked()
+
+    await lock.acquire()
+    try:
+        # If the fast path is broken, this hangs until the timeout — guard
+        # with a short timeout so the test fails loudly instead of stalling.
+        await asyncio.wait_for(tool.connect(), timeout=0.1)
+    finally:
+        lock.release()
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_inflight_connect(monkeypatch):
+    """A ``close()`` racing an in-flight ``connect()`` must wait for the
+    connect to finish before tearing down. Otherwise close can strand a
+    session another caller is in the middle of bringing up.
+    """
+    import asyncio
+
+    tool = _make_concurrency_tool()
+
+    connect_started = asyncio.Event()
+    release_connect = asyncio.Event()
+    close_ran_at: list[float] = []
+
+    async def fake_connect(self):
+        connect_started.set()
+        await release_connect.wait()
+        self._initialized = True
+
+    async def fake_close_locked(self):
+        # Record observation order; assert below that this only ran after
+        # connect completed.
+        close_ran_at.append(asyncio.get_event_loop().time())
+        self._initialized = False
+
+    monkeypatch.setattr(MCPTools, "_connect", fake_connect)
+    monkeypatch.setattr(MCPTools, "_close_locked", fake_close_locked)
+
+    connect_task = asyncio.create_task(tool.connect())
+    await connect_started.wait()
+
+    close_task = asyncio.create_task(tool.close())
+
+    # Give the close task a chance to wake up and try to acquire the lock.
+    await asyncio.sleep(0.02)
+    assert not close_task.done(), (
+        "close() returned before connect() released the lock — lifecycle lock is not serializing them."
+    )
+    assert close_ran_at == [], "close body ran while connect was in flight"
+
+    # Now release connect; close should proceed.
+    release_connect.set()
+    await asyncio.wait_for(connect_task, timeout=1.0)
+    await asyncio.wait_for(close_task, timeout=1.0)
+
+    assert len(close_ran_at) == 1
+    assert tool.initialized is False
+
+
+@pytest.mark.asyncio
+async def test_connect_force_true_does_not_deadlock(monkeypatch):
+    """``connect(force=True)`` tears down the existing session before
+    reconnecting. It does so from *inside* ``_lifecycle_lock`` by calling
+    ``_close_locked()`` directly — calling the public ``close()`` here would
+    re-acquire the same lock and deadlock. This test guards against the
+    refactor regressing to the wrong call.
+    """
+    import asyncio
+
+    tool = _make_concurrency_tool()
+
+    connect_calls = 0
+    close_calls = 0
+
+    async def fake_connect(self):
+        nonlocal connect_calls
+        connect_calls += 1
+        self._initialized = True
+
+    async def fake_close_locked(self):
+        nonlocal close_calls
+        close_calls += 1
+        self._initialized = False
+
+    monkeypatch.setattr(MCPTools, "_connect", fake_connect)
+    monkeypatch.setattr(MCPTools, "_close_locked", fake_close_locked)
+
+    await tool.connect()
+    assert connect_calls == 1
+    assert close_calls == 0
+
+    # Short timeout so a self-deadlock fails loudly rather than hanging CI.
+    await asyncio.wait_for(tool.connect(force=True), timeout=1.0)
+
+    assert close_calls == 1, "force=True did not tear down the prior session"
+    assert connect_calls == 2, "force=True did not reconnect after close"
+    assert tool.initialized is True
+
+
+@pytest.mark.asyncio
+async def test_aenter_propagates_connect_failure(monkeypatch):
+    """``async with MCPTools(...) as tool:`` must raise when the underlying
+    ``_connect()`` fails (network down, 401 from MCP middleware, handshake
+    error). Going through the public ``connect()`` — whose ``try/except``
+    intentionally swallows for the ``pre_run_hook`` path — would leave the
+    caller with an uninitialized ``tool`` and a confusing ``NoneType`` error
+    on the next call instead of a clean failure at the ``async with``
+    boundary. This guards the ``__aenter__`` → ``_connect()`` (direct) wiring
+    against accidentally being refactored back to ``__aenter__`` →
+    ``connect()``.
+    """
+
+    tool = _make_concurrency_tool()
+
+    class BoomError(RuntimeError):
+        pass
+
+    async def fake_connect(self):
+        raise BoomError("simulated MCP handshake failure")
+
+    monkeypatch.setattr(MCPTools, "_connect", fake_connect)
+
+    with pytest.raises(BoomError, match="simulated MCP handshake failure"):
+        async with tool:
+            pytest.fail("entered async-with body despite _connect() failure")
+
+    assert tool.initialized is False
+    # Lock must be released even after the failure so retries / close()
+    # don't deadlock.
+    assert not tool._lifecycle_lock.locked()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_connect_method_still_swallows_failures(monkeypatch):
+    """Companion guard for the test above: the public ``connect()`` must
+    keep its log-and-continue contract so ``pre_run_hook`` can iterate
+    every MCP tool on an agent and let unrelated tools continue working
+    even if one server is down. If this regresses to re-raising,
+    ``pre_run_hook`` would abort the whole agent run on the first bad MCP.
+    """
+
+    tool = _make_concurrency_tool()
+
+    async def fake_connect(self):
+        raise RuntimeError("simulated handshake failure")
+
+    monkeypatch.setattr(MCPTools, "_connect", fake_connect)
+
+    await tool.connect()
+
+    assert tool.initialized is False
+    assert not tool._lifecycle_lock.locked()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_lock_is_lazy_and_stable():
+    """The lifecycle lock must be lazily constructed on first access and
+    return the same instance thereafter. Lazy because constructing it in
+    ``__init__`` would bind it to whichever event loop happened to be
+    running at construction time, which is often not the one running the
+    agent.
+    """
+    import asyncio
+
+    tool = _make_concurrency_tool()
+
+    assert tool._lifecycle_lock_inst is None  # noqa: SLF001
+
+    lock = tool._lifecycle_lock  # noqa: SLF001
+    assert isinstance(lock, asyncio.Lock)
+    # Subsequent access returns the same lock instance.
+    assert tool._lifecycle_lock is lock  # noqa: SLF001


### PR DESCRIPTION
## Summary

Adds a lazy `_lifecycle_lock` (asyncio.Lock) to `MCPTools` so concurrent `connect()` / `close()` callers share a single underlying session instead of each opening their own and racing GC into `anyio.BrokenResourceError`. Includes 7 unit tests pinning down the lock semantics so this can't silently regress.

(Issue number: #8016, related: #7347)

### The bug

When multiple coroutines call `MCPTools.connect()` in parallel on a shared instance (e.g. a `Team` LLM emitting several `delegate_task_to_member` calls targeting the same member in one assistant message, dispatched via `asyncio.gather`), the lifecycle is racy: every caller passes the `if self._initialized: return` early-return at the same time, each opens its own `streamablehttp_client` / `sse_client` session, and only the last winner ends up on `self.session`. The losers' anyio task-groups get GC'd mid-run, and `await session.list_tools()` on the survivor immediately raises `anyio.BrokenResourceError`.

This is distinct from the close-time race in #7347 (one run's `disconnect_mcp_tools` tearing down a session another in-flight run is still using). The connect-time race here is reproducible without `header_provider`, without per-run sessions, and without anyone calling `close()` — simply firing `await asyncio.gather(*(tool.connect() for _ in range(5)))` is enough.

The currently-open #7351 proposes ref-counting on `close()`, which addresses the close-time race but does **not** fix this connect-time race: parallel `connect()` calls would still pass the early-return together and each spin up its own session.

### The fix

Lazy `_lifecycle_lock` shared between `connect()`, `close()`, `__aenter__`, and `__aexit__`:

- **Lock-free fast path** in `connect()`: when `not force and self._initialized`, return without acquiring — keeps the steady-state per-run hot path cost-free.
- **Double-checked locking** under the lock: re-check `_initialized` after acquiring so callers that lost the race become no-ops.
- **`close()` split** into a public wrapper and `_close_locked()` body so `connect(force=True)` can tear down the existing session from inside the lock without re-acquiring (would self-deadlock).
- **`__aenter__` calls `_connect()` directly under the lock** so init failures still raise at the `async with` boundary. The public `connect()` keeps its log-and-continue contract so `pre_run_hook` can iterate every MCP tool on an agent without one bad server aborting the whole run.
- **`__aexit__` routed through `close()`** so context-manager teardown also goes through the lock.
- **`_close_locked()` also cleans up partial state** (`_session_context` / `_context` entered but `initialize()` raised), preserving the previous `__aexit__` cleanup-on-partial-failure semantics.

The lock is constructed lazily on first access (not in `__init__`) because `asyncio.Lock()` binds to the running event loop at construction time, which is often not the loop the agent will actually run on.

### Tests

7 new tests in `libs/agno/tests/unit/tools/test_mcp.py` (mocking `_connect` / `_close_locked` so they exercise lock semantics in isolation, no real MCP server needed):

1. `test_parallel_connect_runs_underlying_connect_exactly_once` — 5 concurrent `connect()` callers must produce exactly one `_connect()` invocation.
2. `test_connect_fast_path_skips_lock_when_already_initialized` — once initialized, `connect()` must take the lock-free path (verified by holding the lock externally and calling `connect()` under a 100ms timeout).
3. `test_close_waits_for_inflight_connect` — `close()` racing an in-flight `connect()` must wait for connect to finish.
4. `test_connect_force_true_does_not_deadlock` — `connect(force=True)` must call `_close_locked()` (not `close()`), guarded by a 1s timeout that fails loudly on self-deadlock.
5. `test_aenter_propagates_connect_failure` — `async with MCPTools(...)` must raise on `_connect()` failure, and the lock must be released afterwards.
6. `test_connect_method_still_swallows_failures` — public `connect()` keeps its log-and-continue contract so `pre_run_hook` doesn't abort an agent run on the first bad MCP.
7. `test_lifecycle_lock_is_lazy_and_stable` — lock is `None` until first access, stable thereafter.

```
$ ./scripts/format.sh                 # passes (only mcp.py + test_mcp.py touched)
$ ./scripts/validate.sh               # passes (pre-existing tools/sql.py mypy error unrelated)
$ pytest libs/agno/tests/unit/tools/test_mcp.py
======================== 43 passed, 5 warnings in 0.69s ========================
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — N/A, internal lifecycle fix with no API surface change
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — assisted by Cursor

#### Why this PR over #7351

#7351 adds reference counting around `close()` so the last in-flight run wins teardown. That fixes the close-time race in #7347 but not the connect-time race targeted here:

- Without a lock, parallel `connect()` callers all pass the `not _initialized` check **before** any `_ref_count` increment matters. Each opens its own `streamablehttp_client` / `sse_client` session; the losers get GC'd mid-flight regardless of ref count.
- Ref counting also leaks the existing-session cleanup on `connect(force=True)`: the upstream code currently only resets attributes (`self.session = None`, etc.) without actually exiting the context managers. This PR's `_close_locked()` call fixes that as a side effect.
- The two approaches are not mutually exclusive — a follow-up PR could layer ref counting on top of this lock if needed for more aggressive close-deferral semantics.

---

## Additional Notes

We've been running this same lock fix in our vendored fork of `MCPTools` for ~2 weeks under production parallel-team-delegation load with no recurrence of the `BrokenResourceError`. This PR is the upstream port so we can drop the fork.

Happy to address review feedback or rebase as needed.