### PR TITLE
fix: add timeout to HTTP requests in tool integrations

### DIFF
--- a/libs/agno/agno/tools/bitbucket.py
+++ b/libs/agno/agno/tools/bitbucket.py
@@ -74,7 +74,7 @@ class BitbucketTools(Toolkit):
         data: Optional[Dict[str, Any]] = None,
     ) -> Union[str, Dict[str, Any]]:
         url = f"{self.base_url}{endpoint}"
-        response = requests.request(method, url, headers=self.headers, json=data, params=params)
+        response = requests.request(method, url, headers=self.headers, json=data, params=params, timeout=10)
         response.raise_for_status()
         encoding_type = response.headers.get("Content-Type", "application/json")
         if encoding_type.startswith("application/json"):

--- a/libs/agno/agno/tools/desi_vocal.py
+++ b/libs/agno/agno/tools/desi_vocal.py
@@ -44,7 +44,7 @@ class DesiVocalTools(Toolkit):
         """
         try:
             url = "https://prod-api2.desivocal.com/dv/api/v0/tts_api/voices"
-            response = requests.get(url)
+            response = requests.get(url, timeout=10)
             response.raise_for_status()
 
             voices_data = response.json()

--- a/libs/agno/agno/tools/openweather.py
+++ b/libs/agno/agno/tools/openweather.py
@@ -70,7 +70,7 @@ class OpenWeatherTools(Toolkit):
         """
         try:
             params["appid"] = self.api_key
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=10)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/libs/agno/agno/tools/serper.py
+++ b/libs/agno/agno/tools/serper.py
@@ -88,7 +88,7 @@ class SerperTools(Toolkit):
             payload = json.dumps(params)
 
             log_debug(f"Making request to {url} with params: {params}")
-            response = requests.request("POST", url, headers=headers, data=payload)
+            response = requests.request("POST", url, headers=headers, data=payload, timeout=10)
             response.raise_for_status()
 
             log_debug(f"Successfully received response from {endpoint} endpoint")

--- a/libs/agno/agno/tools/zendesk.py
+++ b/libs/agno/agno/tools/zendesk.py
@@ -73,7 +73,7 @@ class ZendeskTools(Toolkit):
         auth = (self.username, self.password)
         url = f"https://{self.company_name}.zendesk.com/api/v2/help_center/articles/search.json?query={search_string}"
         try:
-            response = requests.get(url, auth=auth)
+            response = requests.get(url, auth=auth, timeout=10)
             response.raise_for_status()
             clean = re.compile("<.*?>")
             articles = [re.sub(clean, "", article["body"]) for article in response.json()["results"]]


### PR DESCRIPTION
## Summary
- Adds a 10-second timeout to outbound HTTP requests in 5 tool integrations that were missing it

## Problem
Several tool integrations (`openweather`, `serper`, `zendesk`, `desi_vocal`, `bitbucket`) make `requests.get()` / `requests.request()` calls without a `timeout` parameter. If a remote API becomes unresponsive, the calling agent hangs indefinitely with no feedback — no exception, no retry, just a blocked thread.

## Changes
| File | Method | Fix |
|------|--------|-----|
| `tools/openweather.py` | `_make_request` | `timeout=10` |
| `tools/serper.py` | `search` | `timeout=10` |
| `tools/zendesk.py` | `search_articles` | `timeout=10` |
| `tools/desi_vocal.py` | `get_voices` | `timeout=10` |
| `tools/bitbucket.py` | `_make_request` | `timeout=10` |

All existing callers already wrap these in try/except, so `requests.exceptions.ReadTimeout` / `ConnectTimeout` will propagate as expected.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed the changes
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)