### PR TITLE
fix: quote variables in dev_setup.sh

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -21,29 +21,29 @@ print_heading "Development setup..."
 
 print_heading "Removing virtual env"
 print_info "rm -rf ${VENV_DIR}"
-rm -rf ${VENV_DIR}
+rm -rf "${VENV_DIR}"
 
 print_heading "Creating virtual env"
 print_info "VIRTUAL_ENV=${VENV_DIR} uv venv --python 3.12"
-VIRTUAL_ENV=${VENV_DIR} uv venv --python 3.12
+VIRTUAL_ENV="${VENV_DIR}" uv venv --python 3.12
 
 print_heading "Installing agno"
 print_info "VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_DIR}/requirements.txt"
-VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_DIR}/requirements.txt
+VIRTUAL_ENV="${VENV_DIR}" uv pip install -r "${AGNO_DIR}/requirements.txt"
 
 print_heading "Installing agno in editable mode with dev dependencies"
-VIRTUAL_ENV=${VENV_DIR} uv pip install -U -e ${AGNO_DIR}[dev]
+VIRTUAL_ENV="${VENV_DIR}" uv pip install -U -e "${AGNO_DIR}[dev]"
 #TODO: Improve the dev setup to handle conflicts which results in missing dependencies
 
 print_heading "Installing agno-infra"
 print_info "VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_INFRA_DIR}/requirements.txt"
-VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_INFRA_DIR}/requirements.txt
+VIRTUAL_ENV="${VENV_DIR}" uv pip install -r "${AGNO_INFRA_DIR}/requirements.txt"
 
 print_heading "Installing agno-infra in editable mode with dev dependencies"
-VIRTUAL_ENV=${VENV_DIR} uv pip install -e ${AGNO_INFRA_DIR}[dev]
+VIRTUAL_ENV="${VENV_DIR}" uv pip install -e "${AGNO_INFRA_DIR}[dev]"
 
 print_heading "uv pip list"
-VIRTUAL_ENV=${VENV_DIR} uv pip list
+VIRTUAL_ENV="${VENV_DIR}" uv pip list
 
 print_heading "Development setup complete"
 print_heading "Activate venv using: source .venv/bin/activate"


### PR DESCRIPTION
## Summary
- Quotes all unquoted variable expansions in `scripts/dev_setup.sh`

## Problem
Variables like `${VENV_DIR}`, `${AGNO_DIR}`, and `${AGNO_INFRA_DIR}` are used unquoted throughout the script. If the repo is cloned to a path containing spaces (e.g. `~/My Projects/agno/`), word splitting causes `rm -rf`, `uv pip install`, and other commands to operate on wrong paths.

The script already uses proper quoting for `CURR_DIR` and `REPO_ROOT` at the top — this change applies the same defensive style to the remaining variables.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)