### PR TITLE
cookbook: data_labeling on Gemini + quality review as Workflow

### DIFF
--- a/cookbook/90_models/google/gemini_interactions/antigravity.py
+++ b/cookbook/90_models/google/gemini_interactions/antigravity.py
@@ -35,6 +35,4 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    agent.print_response(
-        "What is the capital of France?"
-    )
+    agent.print_response("What is the capital of France?")

--- a/cookbook/91_tools/google/drive_all_drives_search.py
+++ b/cookbook/91_tools/google/drive_all_drives_search.py
@@ -20,11 +20,10 @@ Setup:
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
-
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.tools.google.drive import GoogleDriveTools
+from pydantic import BaseModel, Field
 
 
 class DocumentResult(BaseModel):

--- a/cookbook/data_labeling/README.md
+++ b/cookbook/data_labeling/README.md
@@ -76,8 +76,7 @@ Each subfolder's `README.md` documents its inputs, the model it expects, and any
 
 | Variable | Used by |
 |---|---|
-| `OPENAI_API_KEY` | Default for text and most extraction cookbooks |
-| `ANTHROPIC_API_KEY` | Image and document cookbooks where Claude is the picked model |
-| `GOOGLE_API_KEY` | Audio and video cookbooks (Gemini) |
+| `GOOGLE_API_KEY` | Default for every cookbook (Gemini 3.5 Flash, natively multimodal) |
+| `ANTHROPIC_API_KEY` | `_18_quality_review/` only — Claude Opus 4.7 is the second labeler |
 
 The per-cookbook README calls out which model it uses and why.

--- a/cookbook/data_labeling/_01_text_classification/README.md
+++ b/cookbook/data_labeling/_01_text_classification/README.md
@@ -34,4 +34,4 @@ python cookbook/data_labeling/_01_text_classification/with_confidence.py
 python cookbook/data_labeling/_01_text_classification/with_rationale.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_01_text_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_01_text_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _01_text_classification
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_01_text_classification/basic.py
+++ b/cookbook/data_labeling/_01_text_classification/basic.py
@@ -11,7 +11,7 @@ This example classifies short product reviews into sentiment classes.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -29,7 +29,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="You classify product reviews by sentiment.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_01_text_classification/with_confidence.py
+++ b/cookbook/data_labeling/_01_text_classification/with_confidence.py
@@ -9,7 +9,7 @@ to route low-confidence labels to a human queue or to a stronger model.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -41,7 +41,7 @@ Classify the sentiment of the input text. Report a confidence level:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_01_text_classification/with_rationale.py
+++ b/cookbook/data_labeling/_01_text_classification/with_rationale.py
@@ -9,7 +9,7 @@ for training datasets where the reasoning trace is itself an artifact.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -39,7 +39,7 @@ words that drove your decision in the rationale.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_02_text_multilabel_classification/README.md
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/README.md
@@ -26,4 +26,4 @@ python cookbook/data_labeling/_02_text_multilabel_classification/with_confidence
 python cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_02_text_multilabel_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _02_text_multilabel_classification
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 
@@ -12,16 +12,6 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 
 ---
 
-### with_confidence.py
-
-**Status:** PASS
-
-**Description:** Same task with per-tag confidence.
-
-**Result:** Reasonable tag/confidence pairs; empty list returned when no aspects are addressed.
-
----
-
 ### hierarchical.py
 
 **Status:** PASS
@@ -29,5 +19,15 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 **Description:** Two-level (parent/child) tagging on news snippets.
 
 **Result:** Tags correctly nested (e.g. business -> markets, tech -> ai chips).
+
+---
+
+### with_confidence.py
+
+**Status:** PASS
+
+**Description:** Same task with per-tag confidence.
+
+**Result:** Reasonable tag/confidence pairs; empty list returned when no aspects are addressed.
 
 ---

--- a/cookbook/data_labeling/_02_text_multilabel_classification/basic.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/basic.py
@@ -12,7 +12,7 @@ on.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -42,7 +42,7 @@ positively or negatively - both count.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
@@ -10,7 +10,7 @@ that category. Useful when the label space is large and naturally nested
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -51,7 +51,7 @@ is actually about - not every entity mentioned in passing.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_02_text_multilabel_classification/with_confidence.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/with_confidence.py
@@ -10,7 +10,7 @@ the training set.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -47,7 +47,7 @@ report confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_03_text_extraction/README.md
+++ b/cookbook/data_labeling/_03_text_extraction/README.md
@@ -31,4 +31,4 @@ python cookbook/data_labeling/_03_text_extraction/with_confidence.py
 python cookbook/data_labeling/_03_text_extraction/nested.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_03_text_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_03_text_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _03_text_extraction
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 
@@ -12,16 +12,6 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 
 ---
 
-### with_confidence.py
-
-**Status:** PASS
-
-**Description:** Same task with `ConfidentField` wrapping each value.
-
-**Result:** Confidences are sensible: high for explicit fields, medium for inferred ones (e.g. "@mike" as a name).
-
----
-
 ### nested.py
 
 **Status:** PASS
@@ -29,5 +19,15 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 **Description:** Extract a `Meeting` containing a list of nested `ActionItem`s from a meeting transcript.
 
 **Result:** Three action items extracted with correct owners and due dates.
+
+---
+
+### with_confidence.py
+
+**Status:** PASS
+
+**Description:** Same task with `ConfidentField` wrapping each value.
+
+**Result:** Confidences are sensible: high for explicit fields, medium for inferred ones (e.g. "@mike" as a name).
 
 ---

--- a/cookbook/data_labeling/_03_text_extraction/basic.py
+++ b/cookbook/data_labeling/_03_text_extraction/basic.py
@@ -11,7 +11,7 @@ This example extracts contact info from an email signature.
 from typing import Optional
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -41,7 +41,7 @@ not guess.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Contact,
 )

--- a/cookbook/data_labeling/_03_text_extraction/nested.py
+++ b/cookbook/data_labeling/_03_text_extraction/nested.py
@@ -11,7 +11,7 @@ This example extracts action items from a meeting transcript.
 from typing import List, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +44,7 @@ due date is not mentioned, leave it null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Meeting,
 )

--- a/cookbook/data_labeling/_03_text_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_03_text_extraction/with_confidence.py
@@ -10,7 +10,7 @@ or a stronger model.
 from typing import Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -51,7 +51,7 @@ Use exactly what the text shows. Do not normalize or paraphrase.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Contact,
 )

--- a/cookbook/data_labeling/_04_text_span_labeling/README.md
+++ b/cookbook/data_labeling/_04_text_span_labeling/README.md
@@ -27,4 +27,4 @@ python cookbook/data_labeling/_04_text_span_labeling/basic.py
 python cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_04_text_span_labeling/TEST_LOG.md
+++ b/cookbook/data_labeling/_04_text_span_labeling/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _04_text_span_labeling
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_04_text_span_labeling/basic.py
+++ b/cookbook/data_labeling/_04_text_span_labeling/basic.py
@@ -12,7 +12,7 @@ substring and locating it in Python is the robust pattern.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -46,7 +46,7 @@ pronouns or generic references.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Entities,
 )

--- a/cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
+++ b/cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
@@ -10,7 +10,7 @@ and its PII type; Python does the find-and-replace.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -45,7 +45,7 @@ person names. Skip generic references like "the customer".
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=PIIDetection,
 )

--- a/cookbook/data_labeling/_05_text_pairwise_preference/README.md
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/README.md
@@ -27,4 +27,4 @@ python cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
 python cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _05_text_pairwise_preference
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_05_text_pairwise_preference/basic.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/basic.py
@@ -9,7 +9,7 @@ data shape used to train reward models (RLHF) or do DPO fine-tuning.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -37,7 +37,7 @@ only when the two are genuinely indistinguishable in quality.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Preference,
 )

--- a/cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
@@ -10,7 +10,7 @@ own preferences to a human reviewer.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -40,7 +40,7 @@ clarity, tone, etc.).
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Preference,
 )

--- a/cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
@@ -10,7 +10,7 @@ across many graders or many runs.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +44,7 @@ indistinguishable on the rubric above.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Preference,
 )

--- a/cookbook/data_labeling/_06_image_classification/README.md
+++ b/cookbook/data_labeling/_06_image_classification/README.md
@@ -24,5 +24,5 @@ python cookbook/data_labeling/_06_image_classification/basic.py
 python cookbook/data_labeling/_06_image_classification/multilabel.py
 ```
 
-Requires `OPENAI_API_KEY`. The samples use stable Wikimedia URLs - swap
+Requires `GOOGLE_API_KEY`. The samples use stable Wikimedia URLs - swap
 your own image URLs or local paths in the `Image(...)` call.

--- a/cookbook/data_labeling/_06_image_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_06_image_classification/TEST_LOG.md
@@ -1,14 +1,16 @@
 # Test Log - _06_image_classification
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6. Inputs are public Wikimedia URLs.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Single-label classification over a cat photo and a dog collage.
+**Description:** Single-label scene-type classification (wildlife / landscape / sports / architecture / other) over four photos.
 
-**Result:** Both classified correctly.
+**Result:** All four classified into the expected scene type.
+
+**Note:** Test inputs moved off Wikimedia (Gemini can't fetch those URLs) to agno-public S3, gstatic gallery, and a Google generative-AI sample. Label set switched from animal types to scene types so the available images classify cleanly.
 
 ---
 
@@ -16,8 +18,8 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6. Inputs are pu
 
 **Status:** PASS
 
-**Description:** Multi-label tagging of scene attributes per image.
+**Description:** Multi-label tagging of scene attributes (outdoor, daytime, people, nature, architecture, etc.) over a Krakow basilica photo and a Google generative-AI wildlife sample.
 
-**Result:** Tag sets are coherent with the photo content.
+**Result:** Tag sets are coherent with each image's content.
 
 ---

--- a/cookbook/data_labeling/_06_image_classification/basic.py
+++ b/cookbook/data_labeling/_06_image_classification/basic.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -19,8 +19,8 @@ from rich.pretty import pprint  # noqa
 # Schema
 # ---------------------------------------------------------------------------
 class Classification(BaseModel):
-    label: Literal["dog", "cat", "bird", "fish", "other"] = Field(
-        ..., description="What kind of animal is in the image"
+    label: Literal["wildlife", "landscape", "sports", "architecture", "other"] = Field(
+        ..., description="The primary scene type of the image"
     )
 
 
@@ -28,8 +28,8 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
-    instructions="You classify images by animal type.",
+    model=Gemini(id="gemini-3.5-flash"),
+    instructions="You classify images by scene type.",
     output_schema=Classification,
 )
 
@@ -39,8 +39,10 @@ agent = Agent(
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     samples = [
-        "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg",
-        "https://upload.wikimedia.org/wikipedia/commons/d/d9/Collage_of_Nine_Dogs.jpg",
+        "https://storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg",
+        "https://www.gstatic.com/webp/gallery/1.jpg",
+        "https://www.gstatic.com/webp/gallery/2.jpg",
+        "https://agno-public.s3.amazonaws.com/images/krakow_mariacki.jpg",
     ]
     for url in samples:
         run: RunOutput = agent.run("Classify this image.", images=[Image(url=url)])

--- a/cookbook/data_labeling/_06_image_classification/multilabel.py
+++ b/cookbook/data_labeling/_06_image_classification/multilabel.py
@@ -10,7 +10,7 @@ from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -49,7 +49,7 @@ inferred or implied.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Tagging,
 )
@@ -60,8 +60,8 @@ agent = Agent(
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     samples = [
-        "https://upload.wikimedia.org/wikipedia/commons/0/0c/GoldenGateBridge-001.jpg",
-        "https://upload.wikimedia.org/wikipedia/commons/a/a8/Tour_Eiffel_Wikimedia_Commons.jpg",
+        "https://agno-public.s3.amazonaws.com/images/krakow_mariacki.jpg",
+        "https://storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg",
     ]
     for url in samples:
         run: RunOutput = agent.run("Tag this image.", images=[Image(url=url)])

--- a/cookbook/data_labeling/_07_image_extraction/README.md
+++ b/cookbook/data_labeling/_07_image_extraction/README.md
@@ -29,4 +29,4 @@ python cookbook/data_labeling/_07_image_extraction/with_confidence.py
 python cookbook/data_labeling/_07_image_extraction/ocr_fields.py
 ```
 
-Requires `OPENAI_API_KEY`. Swap the URLs for your own images as needed.
+Requires `GOOGLE_API_KEY`. Swap the URLs for your own images as needed.

--- a/cookbook/data_labeling/_07_image_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_07_image_extraction/TEST_LOG.md
@@ -1,24 +1,16 @@
 # Test Log - _07_image_extraction
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6. Inputs are public Wikimedia URLs.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Extract a `Scene` (subject, setting, time of day, colors, objects) from a Golden Gate Bridge photo.
+**Description:** Extract a `Scene` (subject, setting, time of day, colors, objects) from a photo of Krakow's St. Mary's Basilica.
 
 **Result:** All fields populated correctly.
 
----
-
-### with_confidence.py
-
-**Status:** PASS
-
-**Description:** Same task with `ConfidentField` / `ConfidentList` wrapping each output (Eiffel Tower image).
-
-**Result:** All fields populated with `high` confidence; nested confidence wrappers serialize correctly.
+**Note:** Test image switched from a Wikimedia URL (Gemini can't fetch those) to `agno-public.s3.amazonaws.com/images/krakow_mariacki.jpg`.
 
 ---
 
@@ -26,10 +18,20 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6. Inputs are pu
 
 **Status:** PASS
 
-**Description:** OCR a sign image into typed fields (primary text, secondary text, color scheme).
+**Description:** OCR a text-heavy image into typed fields (primary text, secondary text, color scheme).
 
-**Result:** "Welcome to Fabulous Las Vegas / NEVADA" read correctly with multi-color palette.
+**Result:** Reads the Agno wordmark and body copy from the intro image into the typed schema.
 
-**Note:** Original URL (`Stop_sign_London_2020.jpg`) was 404. Replaced with the canonical Las Vegas welcome-sign URL (verified via Wikimedia API); also gives a richer multi-text example than a single-word stop sign.
+**Note:** Input switched from a Wikimedia "Welcome to Las Vegas" sign (Gemini can't fetch those URLs) to `agno-public.s3.us-east-1.amazonaws.com/images/agno-intro.png`. The schema is still about extracting text from an image — content changed from a sign to a marketing graphic.
+
+---
+
+### with_confidence.py
+
+**Status:** PASS
+
+**Description:** Same task with `ConfidentStr` / `ConfidentList` wrapping each output (fjord landscape from the gstatic gallery).
+
+**Result:** All fields populated with `high` confidence; nested confidence wrappers serialize correctly.
 
 ---

--- a/cookbook/data_labeling/_07_image_extraction/basic.py
+++ b/cookbook/data_labeling/_07_image_extraction/basic.py
@@ -10,7 +10,7 @@ from typing import List, Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -43,7 +43,7 @@ If a field is not determinable from the image, leave it null or empty.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Scene,
 )
@@ -53,6 +53,6 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    url = "https://upload.wikimedia.org/wikipedia/commons/0/0c/GoldenGateBridge-001.jpg"
+    url = "https://agno-public.s3.amazonaws.com/images/krakow_mariacki.jpg"
     run: RunOutput = agent.run("Extract the scene attributes.", images=[Image(url=url)])
     pprint({"url": url, "result": run.content})

--- a/cookbook/data_labeling/_07_image_extraction/ocr_fields.py
+++ b/cookbook/data_labeling/_07_image_extraction/ocr_fields.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -46,7 +46,7 @@ include what is legible and leave the rest null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=SignReading,
 )
@@ -56,9 +56,8 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    # The "Welcome to Fabulous Las Vegas" sign, public domain.
-    url = "https://upload.wikimedia.org/wikipedia/commons/1/10/Welcome_to_Fabulous_Las_Vegas_sign.jpg"
+    url = "https://agno-public.s3.us-east-1.amazonaws.com/images/agno-intro.png"
     run: RunOutput = agent.run(
-        "Extract the text fields from this sign.", images=[Image(url=url)]
+        "Extract the text fields from this image.", images=[Image(url=url)]
     )
     pprint({"url": url, "result": run.content})

--- a/cookbook/data_labeling/_07_image_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_07_image_extraction/with_confidence.py
@@ -11,7 +11,7 @@ from typing import List, Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -58,7 +58,7 @@ confidence low.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Scene,
 )
@@ -68,6 +68,6 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    url = "https://upload.wikimedia.org/wikipedia/commons/a/a8/Tour_Eiffel_Wikimedia_Commons.jpg"
+    url = "https://www.gstatic.com/webp/gallery/1.jpg"
     run: RunOutput = agent.run("Extract the scene attributes.", images=[Image(url=url)])
     pprint({"url": url, "result": run.content})

--- a/cookbook/data_labeling/_08_image_bounding_boxes/README.md
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/README.md
@@ -38,4 +38,4 @@ python cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
 python cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_08_image_bounding_boxes/TEST_LOG.md
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/TEST_LOG.md
@@ -1,26 +1,16 @@
 # Test Log - _08_image_bounding_boxes
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Detect the main subject in a cat photo, return one normalized bounding box.
+**Description:** Detect the main subject in a kayaker-in-whitewater photo, return one normalized bounding box.
 
-**Result:** Sensible tight box around the cat (x=0.22, y=0.12, w=0.69, h=0.86).
+**Result:** Sensible tight box around the kayaker.
 
----
-
-### with_confidence.py
-
-**Status:** PASS
-
-**Description:** Same task with a `confidence` field added to the schema.
-
-**Result:** Returns sensible box (x=0.215, y=0.115, w=0.69, h=0.84) with `high` confidence.
-
-**Note:** Initially produced degenerate boxes (all-zero or all-one). Fix: added per-field descriptions on x/y/w/h and expanded coordinate guidance in the instructions to match `basic.py`. Without that grounding, `gpt-5.5` does not consistently produce sensible coordinates.
+**Note:** Test image switched from a Wikimedia cat photo (Gemini can't fetch those URLs) to `www.gstatic.com/webp/gallery/2.jpg`.
 
 ---
 
@@ -28,8 +18,22 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 
 **Status:** PASS
 
-**Description:** Detect multiple objects in an image, return a list of bounding boxes.
+**Description:** Detect multiple objects in an image, return a list of bounding boxes. Input is a savanna scene with elephants, giraffes, zebras, and a crocodile.
 
-**Result:** Multiple boxes returned with reasonable coordinates and labels.
+**Result:** Multiple boxes returned with reasonable coordinates and per-animal labels.
+
+**Note:** Test image switched from a Wikimedia "Collage of Nine Dogs" (Gemini can't fetch those URLs) to a Google generative-AI sample at `storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg`.
+
+---
+
+### with_confidence.py
+
+**Status:** PASS
+
+**Description:** Same task with a `confidence` field added to the schema (kayaker-in-whitewater photo).
+
+**Result:** Sensible bounding box around the kayaker with `high` confidence.
+
+**Note:** Per-field `description` on `x`, `y`, `width`, `height` is load-bearing — without it, and without the `[0, 1]` coordinate convention spelled out in instructions, models tend to return degenerate boxes (all-zero or whole-image).
 
 ---

--- a/cookbook/data_labeling/_08_image_bounding_boxes/basic.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/basic.py
@@ -8,7 +8,7 @@ emits normalized coordinates so the result is resolution-independent.
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -42,7 +42,7 @@ as possible without clipping the subject.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=BoundingBox,
 )
@@ -52,7 +52,7 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    url = "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg"
+    url = "https://www.gstatic.com/webp/gallery/2.jpg"
     run: RunOutput = agent.run(
         "Locate the main subject of this image.", images=[Image(url=url)]
     )

--- a/cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
@@ -10,7 +10,7 @@ from typing import List
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -50,7 +50,7 @@ report a single box.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Detection,
 )
@@ -60,7 +60,7 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    url = "https://upload.wikimedia.org/wikipedia/commons/d/d9/Collage_of_Nine_Dogs.jpg"
+    url = "https://storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg"
     run: RunOutput = agent.run(
         "Detect every object in this image.", images=[Image(url=url)]
     )

--- a/cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -52,7 +52,7 @@ Confidence reflects both the box and the label:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=BoundingBox,
 )
@@ -62,7 +62,7 @@ agent = Agent(
 # Run Agent
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    url = "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg"
+    url = "https://www.gstatic.com/webp/gallery/2.jpg"
     run: RunOutput = agent.run(
         "Locate the main subject and report confidence.", images=[Image(url=url)]
     )

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/README.md
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/README.md
@@ -15,7 +15,7 @@ No variants. The value here is the full pipeline.
 1. For each image URL, an agent extracts a structured `ImageDescription`
    (subject, setting, mood, key objects).
 2. The structured fields are flattened to a single searchable string.
-3. The string is embedded with `OpenAIEmbedder` and stored in LanceDb.
+3. The string is embedded with `GeminiEmbedder` and stored in LanceDb.
 4. A text query searches the index and returns the most similar images.
 
 ## When to use
@@ -33,4 +33,4 @@ pip install lancedb tantivy
 python cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
 ```
 
-Requires `OPENAI_API_KEY`. Writes to `tmp/lancedb/` under the repo root.
+Requires `GOOGLE_API_KEY`. Writes to `tmp/lancedb/` under the repo root.

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/TEST_LOG.md
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/TEST_LOG.md
@@ -1,15 +1,15 @@
 # Test Log - _09_image_extraction_to_vectordb
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses) + `text-embedding-3-small`, agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini) + `gemini-embedding-001` (GeminiEmbedder), agno 2.6.8.
 
 ### basic.py
 
 **Status:** PASS
 
-**Description:** Describe three images, embed the descriptions, store in LanceDb, then run two semantic queries.
+**Description:** Describe three images (Krakow basilica, fjord, savanna wildlife), embed the descriptions with `GeminiEmbedder`, store in LanceDb, then run two semantic queries.
 
-**Result:** "a famous landmark" returns Golden Gate and Eiffel; "a sleeping pet" returns the cat as top hit.
+**Result:** "a historic city at night" returns the Krakow basilica as top hit; "wildlife on the savanna" returns the elephants/giraffes/zebras scene.
 
-**Note:** Requires `lancedb` (not in the `agno[demo]` extras). Install with `uv pip install lancedb` into `.venvs/demo`. Worth either adding to the demo extras or shipping a `requirements.in` for this folder.
+**Note:** Requires `lancedb` (not in the `agno[demo]` extras). Install with `uv pip install lancedb` into `.venvs/demo`. Test inputs were also swapped off Wikimedia URLs since Gemini can't fetch those.
 
 ---

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
@@ -7,7 +7,7 @@ End-to-end labeling pipeline:
 
 1. An agent extracts an ImageDescription from each image.
 2. The description is flattened to a single searchable string.
-3. The string is embedded with OpenAIEmbedder and stored in LanceDb.
+3. The string is embedded with GeminiEmbedder and stored in LanceDb.
 4. We query the index with natural language.
 
 Writes to tmp/lancedb/ under the repo root.
@@ -17,9 +17,9 @@ from typing import List
 
 from agno.agent import Agent
 from agno.knowledge.document import Document
-from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.embedder.google import GeminiEmbedder
 from agno.media import Image
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from agno.vectordb.lancedb import LanceDb, SearchType
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
@@ -41,7 +41,7 @@ class ImageDescription(BaseModel):
 # Create Extraction Agent
 # ---------------------------------------------------------------------------
 extractor = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="You describe images as structured, search-friendly metadata.",
     output_schema=ImageDescription,
 )
@@ -54,7 +54,7 @@ vector_db = LanceDb(
     uri="tmp/lancedb",
     table_name="data_labeling_images",
     search_type=SearchType.vector,
-    embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+    embedder=GeminiEmbedder(id="gemini-embedding-001"),
 )
 
 
@@ -92,12 +92,12 @@ def index_images(urls: List[str]) -> None:
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     urls = [
-        "https://upload.wikimedia.org/wikipedia/commons/0/0c/GoldenGateBridge-001.jpg",
-        "https://upload.wikimedia.org/wikipedia/commons/a/a8/Tour_Eiffel_Wikimedia_Commons.jpg",
-        "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg",
+        "https://agno-public.s3.amazonaws.com/images/krakow_mariacki.jpg",
+        "https://www.gstatic.com/webp/gallery/1.jpg",
+        "https://storage.googleapis.com/generativeai-downloads/images/generated_elephants_giraffes_zebras_sunset.jpg",
     ]
     index_images(urls)
 
-    for query in ["a famous landmark", "a sleeping pet"]:
+    for query in ["a historic city at night", "wildlife on the savanna"]:
         results = vector_db.search(query, limit=2)
         pprint({"query": query, "hits": [r.meta_data for r in results]})

--- a/cookbook/data_labeling/_10_audio_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_10_audio_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _10_audio_classification
 
-Tested 2026-05-17 against `gemini-3-flash-preview` (Gemini), agno 2.6.6. Input is `agno-public/demo_data/QA-01.mp3` (English Q&A clip).
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_10_audio_classification/basic.py
+++ b/cookbook/data_labeling/_10_audio_classification/basic.py
@@ -30,7 +30,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="You classify audio clips by spoken language.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_10_audio_classification/with_confidence.py
+++ b/cookbook/data_labeling/_10_audio_classification/with_confidence.py
@@ -43,7 +43,7 @@ Identify the language and report a confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_11_audio_transcription/TEST_LOG.md
+++ b/cookbook/data_labeling/_11_audio_transcription/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _11_audio_transcription
 
-Tested 2026-05-17 against `gemini-3-flash-preview` (Gemini), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_11_audio_transcription/basic.py
+++ b/cookbook/data_labeling/_11_audio_transcription/basic.py
@@ -34,7 +34,7 @@ transcript. Do not add commentary.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Transcript,
 )

--- a/cookbook/data_labeling/_11_audio_transcription/with_diarization.py
+++ b/cookbook/data_labeling/_11_audio_transcription/with_diarization.py
@@ -46,7 +46,7 @@ the whole clip: the first speaker is "Speaker A", the second is
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=DiarizedTranscript,
 )

--- a/cookbook/data_labeling/_11_audio_transcription/with_timestamps.py
+++ b/cookbook/data_labeling/_11_audio_transcription/with_timestamps.py
@@ -44,7 +44,7 @@ beginning of the clip. Times should be monotonically non-decreasing.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=TimedTranscript,
 )

--- a/cookbook/data_labeling/_12_audio_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_12_audio_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _12_audio_extraction
 
-Tested 2026-05-17 against `gemini-3-flash-preview` (Gemini), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_12_audio_extraction/basic.py
+++ b/cookbook/data_labeling/_12_audio_extraction/basic.py
@@ -43,7 +43,7 @@ write what you can determine and leave others null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=CallSummary,
 )

--- a/cookbook/data_labeling/_12_audio_extraction/call_summary.py
+++ b/cookbook/data_labeling/_12_audio_extraction/call_summary.py
@@ -48,7 +48,7 @@ customer's tone, not the support agent's.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=SupportCall,
 )

--- a/cookbook/data_labeling/_12_audio_extraction/meeting_notes.py
+++ b/cookbook/data_labeling/_12_audio_extraction/meeting_notes.py
@@ -50,7 +50,7 @@ audio (named by another speaker or self-introduced).
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=MeetingNotes,
 )

--- a/cookbook/data_labeling/_13_video_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_13_video_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _13_video_classification
 
-Tested 2026-05-17 against `gemini-3-flash-preview` (Gemini), agno 2.6.6. Input is `agno-public/demo/sample_seaview.mp4` (note: actual clip is a lab/microscope scene, not a seaview — sample asset name is misleading).
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_13_video_classification/basic.py
+++ b/cookbook/data_labeling/_13_video_classification/basic.py
@@ -35,7 +35,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="You classify short video clips by dominant scene type.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_13_video_classification/with_confidence.py
+++ b/cookbook/data_labeling/_13_video_classification/with_confidence.py
@@ -50,7 +50,7 @@ Classify the clip and report a confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_14_video_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_14_video_extraction/TEST_LOG.md
@@ -1,6 +1,16 @@
 # Test Log - _14_video_extraction
 
-Tested 2026-05-17 against `gemini-3-flash-preview` (Gemini), agno 2.6.6. Input is `agno-public/demo/sample_seaview.mp4` (actually a scientist using a microscope).
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+
+### action_timestamps.py
+
+**Status:** PASS
+
+**Description:** Extract a list of `Event`s with action descriptions and `[start, end]` second timestamps.
+
+**Result:** Three events returned with monotonically increasing timestamps.
+
+---
 
 ### basic.py
 
@@ -19,15 +29,5 @@ Tested 2026-05-17 against `gemini-3-flash-preview` (Gemini), agno 2.6.6. Input i
 **Description:** Extract a list of `Scene` objects with name, description, and visible objects.
 
 **Result:** One scene returned with detailed description and visible objects list.
-
----
-
-### action_timestamps.py
-
-**Status:** PASS
-
-**Description:** Extract a list of `Event`s with action descriptions and `[start, end]` second timestamps.
-
-**Result:** Three events returned with monotonically increasing timestamps.
 
 ---

--- a/cookbook/data_labeling/_14_video_extraction/action_timestamps.py
+++ b/cookbook/data_labeling/_14_video_extraction/action_timestamps.py
@@ -45,7 +45,7 @@ filler content - only include events with a clear beginning and end.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Events,
 )

--- a/cookbook/data_labeling/_14_video_extraction/basic.py
+++ b/cookbook/data_labeling/_14_video_extraction/basic.py
@@ -48,7 +48,7 @@ shown, not what the clip is "about" thematically.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=VideoSummary,
 )

--- a/cookbook/data_labeling/_14_video_extraction/scene_descriptions.py
+++ b/cookbook/data_labeling/_14_video_extraction/scene_descriptions.py
@@ -47,7 +47,7 @@ changes substantially. Do not invent details.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=ScenesDocument,
 )

--- a/cookbook/data_labeling/_15_document_classification/README.md
+++ b/cookbook/data_labeling/_15_document_classification/README.md
@@ -24,5 +24,5 @@ python cookbook/data_labeling/_15_document_classification/basic.py
 python cookbook/data_labeling/_15_document_classification/with_confidence.py
 ```
 
-Requires `OPENAI_API_KEY`. The samples use a public PDF hosted by
+Requires `GOOGLE_API_KEY`. The samples use a public PDF hosted by
 agno-public; swap the URL for your own PDF.

--- a/cookbook/data_labeling/_15_document_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_15_document_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _15_document_classification
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6. Input is `agno-public/recipes/ThaiRecipes.pdf`.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_15_document_classification/basic.py
+++ b/cookbook/data_labeling/_15_document_classification/basic.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +44,7 @@ on the document's structure and content, not on a few keywords.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_15_document_classification/with_confidence.py
+++ b/cookbook/data_labeling/_15_document_classification/with_confidence.py
@@ -10,7 +10,7 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -49,7 +49,7 @@ Classify the attached PDF and report confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_16_document_extraction/README.md
+++ b/cookbook/data_labeling/_16_document_extraction/README.md
@@ -35,4 +35,4 @@ python cookbook/data_labeling/_16_document_extraction/with_line_items.py
 python cookbook/data_labeling/_16_document_extraction/with_confidence.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_16_document_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_16_document_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _16_document_extraction
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6. Input is `agno-public/recipes/ThaiRecipes.pdf`.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_16_document_extraction/basic.py
+++ b/cookbook/data_labeling/_16_document_extraction/basic.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -41,7 +41,7 @@ the document shows. If a field is not present, leave it null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=RecipeBook,
 )

--- a/cookbook/data_labeling/_16_document_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_16_document_extraction/with_confidence.py
@@ -11,7 +11,7 @@ from typing import Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel
 from rich.pretty import pprint  # noqa
 
@@ -51,7 +51,7 @@ Be conservative. Mark unsure fields low.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=RecipeBook,
 )

--- a/cookbook/data_labeling/_16_document_extraction/with_line_items.py
+++ b/cookbook/data_labeling/_16_document_extraction/with_line_items.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -45,7 +45,7 @@ fields null if not present. Do not invent recipes or paraphrase names.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=RecipeBook,
 )

--- a/cookbook/data_labeling/_17_llm_as_judge/README.md
+++ b/cookbook/data_labeling/_17_llm_as_judge/README.md
@@ -26,4 +26,4 @@ python cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
 python cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
 ```
 
-Requires `OPENAI_API_KEY`.
+Requires `GOOGLE_API_KEY`.

--- a/cookbook/data_labeling/_17_llm_as_judge/TEST_LOG.md
+++ b/cookbook/data_labeling/_17_llm_as_judge/TEST_LOG.md
@@ -1,6 +1,8 @@
 # Test Log - _17_llm_as_judge
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+
+Score schemas switched from `Literal[1, 2, 3, 4, 5]` to `int` with `ge=1, le=5`. Gemini's structured-output enforcement requires string-valued enums, not integer enums; bounded `int` keeps the same 1-5 scale and the discrete-output guarantee without the Literal incompatibility.
 
 ### basic.py
 
@@ -12,16 +14,6 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 
 ---
 
-### with_rationale.py
-
-**Status:** PASS
-
-**Description:** Same task with a free-text rationale for the score.
-
-**Result:** Score 4 with a rationale that calls out both the positives and a specific weakness.
-
----
-
 ### single_rubric.py
 
 **Status:** PASS
@@ -29,5 +21,15 @@ Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses), agno 2.6.6.
 **Description:** Score against an explicit rubric (correctness, completeness, clarity, concision, overall).
 
 **Result:** All rubric dimensions scored independently with a separate overall.
+
+---
+
+### with_rationale.py
+
+**Status:** PASS
+
+**Description:** Same task with a free-text rationale for the score.
+
+**Result:** Score 4 with a rationale that calls out both the positives and a specific weakness.
 
 ---

--- a/cookbook/data_labeling/_17_llm_as_judge/basic.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/basic.py
@@ -7,10 +7,8 @@ eval primitive - and identical machinery to single-label text
 classification, just applied to (prompt, response) pairs.
 """
 
-from typing import Literal
-
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -19,8 +17,11 @@ from rich.pretty import pprint  # noqa
 # Schema
 # ---------------------------------------------------------------------------
 class Score(BaseModel):
-    overall: Literal[1, 2, 3, 4, 5] = Field(
-        ..., description="Overall quality on a 1-5 scale where 5 is excellent"
+    overall: int = Field(
+        ...,
+        ge=1,
+        le=5,
+        description="Overall quality on a 1-5 scale where 5 is excellent",
     )
 
 
@@ -43,7 +44,7 @@ Use the full scale. Reserve 5 for genuinely excellent responses.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Score,
 )

--- a/cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
@@ -7,25 +7,25 @@ score, plus an overall. Use this for eval consistency across runs and
 graders.
 """
 
-from typing import Literal
-
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
-
-Score = Literal[1, 2, 3, 4, 5]
 
 
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
 class RubricScore(BaseModel):
-    correctness: Score = Field(..., description="Is everything stated true")
-    completeness: Score = Field(..., description="Does it answer the prompt fully")
-    clarity: Score = Field(..., description="Easy to understand for the target reader")
-    concision: Score = Field(..., description="Free of wasted words")
-    overall: Score = Field(..., description="Holistic quality")
+    correctness: int = Field(..., ge=1, le=5, description="Is everything stated true")
+    completeness: int = Field(
+        ..., ge=1, le=5, description="Does it answer the prompt fully"
+    )
+    clarity: int = Field(
+        ..., ge=1, le=5, description="Easy to understand for the target reader"
+    )
+    concision: int = Field(..., ge=1, le=5, description="Free of wasted words")
+    overall: int = Field(..., ge=1, le=5, description="Holistic quality")
 
 
 # ---------------------------------------------------------------------------
@@ -45,7 +45,7 @@ clarity, but the overall should reflect the worst dimension.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=RubricScore,
 )

--- a/cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
@@ -7,10 +7,8 @@ check the model's reasoning and is itself useful as training data for a
 reward model.
 """
 
-from typing import Literal
-
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -19,7 +17,7 @@ from rich.pretty import pprint  # noqa
 # Schema
 # ---------------------------------------------------------------------------
 class Score(BaseModel):
-    overall: Literal[1, 2, 3, 4, 5] = Field(..., description="Overall quality 1-5")
+    overall: int = Field(..., ge=1, le=5, description="Overall quality 1-5")
     rationale: str = Field(..., description="One sentence explaining the score")
 
 
@@ -37,7 +35,7 @@ phrase from the response when possible.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     output_schema=Score,
 )

--- a/cookbook/data_labeling/_18_quality_review/README.md
+++ b/cookbook/data_labeling/_18_quality_review/README.md
@@ -35,5 +35,5 @@ see `cookbook/04_workflows/04_parallel_execution/parallel_with_condition.py`.
 python cookbook/data_labeling/_18_quality_review/basic.py
 ```
 
-Requires `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` (the two labelers run
+Requires `GOOGLE_API_KEY` and `ANTHROPIC_API_KEY` (the two labelers run
 on different providers for ensemble diversity).

--- a/cookbook/data_labeling/_18_quality_review/TEST_LOG.md
+++ b/cookbook/data_labeling/_18_quality_review/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _18_quality_review
 
-Tested 2026-05-17 against `gpt-5.5` (OpenAIResponses) for labeler A / reviewer / adjudicator and `claude-sonnet-4-5` (Claude) for labeler B, agno 2.6.6.
+Tested 2026-05-19 against `gemini-3.5-flash` (Gemini) for labeler A and `claude-opus-4-7` (Claude) for labeler B / reviewer / adjudicator, agno 2.6.8.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_18_quality_review/basic.py
+++ b/cookbook/data_labeling/_18_quality_review/basic.py
@@ -2,13 +2,11 @@
 Quality Review - Basic
 ======================
 
-Multi-agent quality control on a labeling task. Two labelers (different
-providers) extract a Contact from the input text. A reviewer compares them
-and decides if adjudication is needed. If yes, an adjudicator resolves
-disagreements against the original text.
+Multi-agent quality control on a labeling task, expressed as an agno
+Workflow. Two labelers (different providers) run concurrently, a reviewer
+diffs them field by field, and an adjudicator runs only when the reviewer
+flags disagreement. Every run is persisted to SQLite for traceability.
 
-This is what the original cookbook/data_labeling/ invoice pipeline did,
-condensed to one file and applied to text input so the pattern stands out.
 The same shape composes on top of any extraction primitive in this
 directory (text, image, audio, document).
 """
@@ -16,8 +14,13 @@ directory (text, image, audio, document).
 from typing import List, Optional
 
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.anthropic import Claude
-from agno.models.openai import OpenAIResponses
+from agno.models.google import Gemini
+from agno.workflow import Step, Workflow
+from agno.workflow.condition import Condition
+from agno.workflow.parallel import Parallel
+from agno.workflow.types import StepInput, StepOutput
 from pydantic import BaseModel, Field
 from rich.pretty import pprint
 
@@ -60,21 +63,21 @@ shows. If a field is missing, leave it null. Do not guess.
 
 labeler_a = Agent(
     name="Labeler A",
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=LABELER_INSTRUCTIONS,
     output_schema=Contact,
 )
 
 labeler_b = Agent(
     name="Labeler B",
-    model=Claude(id="claude-sonnet-4-5"),
+    model=Claude(id="claude-opus-4-7"),
     instructions=LABELER_INSTRUCTIONS,
     output_schema=Contact,
 )
 
 reviewer = Agent(
     name="Reviewer",
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Claude(id="claude-opus-4-7"),
     instructions="""\
 You are given two labelers' Contact outputs. Compare them field by field.
 A field needs adjudication when both labelers report non-null but
@@ -86,7 +89,7 @@ needs_adjudication=true if any field needs adjudication.
 
 adjudicator = Agent(
     name="Adjudicator",
-    model=OpenAIResponses(id="gpt-5.5"),
+    model=Claude(id="claude-opus-4-7"),
     instructions="""\
 Re-read the original input text and resolve every reported disagreement.
 Return a FinalLabel.contact populated with the correct values for all
@@ -97,28 +100,71 @@ fields (use the agreed values for fields not in dispute).
 
 
 # ---------------------------------------------------------------------------
-# Pipeline
+# Steps
 # ---------------------------------------------------------------------------
-def label_with_quality_review(text: str) -> FinalLabel:
-    a = labeler_a.run(text).content
-    b = labeler_b.run(text).content
+# Labelers are plain agent steps; they run in parallel below.
+label_a = Step(name="Labeler A", agent=labeler_a)
+label_b = Step(name="Labeler B", agent=labeler_b)
 
-    review_prompt = (
+
+# Reviewer needs both labelers' outputs in its prompt, so wrap it in an
+# executor that pulls them out by step name. get_step_output() recursively
+# searches nested steps, so it finds labelers inside the Parallel block.
+def run_reviewer(step_input: StepInput) -> StepOutput:
+    a = step_input.get_step_output("Labeler A").content
+    b = step_input.get_step_output("Labeler B").content
+    prompt = (
         f"Labeler A:\n{a.model_dump_json(indent=2)}\n\n"
         f"Labeler B:\n{b.model_dump_json(indent=2)}"
     )
-    report = reviewer.run(review_prompt).content
+    report = reviewer.run(prompt).content
+    return StepOutput(content=report)
 
-    if not report.needs_adjudication:
-        return FinalLabel(contact=a, notes="Labelers agreed.")
 
-    adj_prompt = (
-        f"Original input:\n{text}\n\n"
+review = Step(name="Reviewer", executor=run_reviewer)
+
+
+# Adjudicator needs the original input, both labeler outputs, and the
+# reviewer's report.
+def run_adjudicator(step_input: StepInput) -> StepOutput:
+    a = step_input.get_step_output("Labeler A").content
+    b = step_input.get_step_output("Labeler B").content
+    report = step_input.get_step_output("Reviewer").content
+    prompt = (
+        f"Original input:\n{step_input.input}\n\n"
         f"Labeler A:\n{a.model_dump_json(indent=2)}\n\n"
         f"Labeler B:\n{b.model_dump_json(indent=2)}\n\n"
         f"Reviewer report:\n{report.model_dump_json(indent=2)}"
     )
-    return adjudicator.run(adj_prompt).content
+    final = adjudicator.run(prompt).content
+    return StepOutput(content=final)
+
+
+adjudicate = Step(name="Adjudicator", executor=run_adjudicator)
+
+
+# Run the adjudicator only when the reviewer flagged a disagreement.
+def has_disagreement(step_input: StepInput) -> bool:
+    report = step_input.previous_step_content
+    return bool(report and getattr(report, "needs_adjudication", False))
+
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+workflow = Workflow(
+    name="Quality review labeling",
+    db=SqliteDb(db_file="tmp/labeling.db"),  # every run is persisted
+    steps=[
+        Parallel(label_a, label_b, name="Label"),  # labelers run concurrently
+        review,  # diff them field by field
+        Condition(  # adjudicate only on disagreement
+            name="Adjudicate",
+            evaluator=has_disagreement,
+            steps=[adjudicate],
+        ),
+    ],
+)
 
 
 # ---------------------------------------------------------------------------
@@ -129,4 +175,5 @@ if __name__ == "__main__":
         "Sarah Johnson, VP Marketing at Acme Corp. "
         "Reach me at sarah@acme.com or +1-555-0102."
     )
-    pprint(label_with_quality_review(text))
+    response = workflow.run(input=text)
+    pprint(response.content)

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -1,12 +1,12 @@
-import tempfile
 import asyncio
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agno.media import File
 from agno.exceptions import ModelProviderError
+from agno.media import File
 from agno.models.google.gemini import Gemini
 from agno.models.message import Message
 


### PR DESCRIPTION
## Summary

Three commits to `cookbook/data_labeling/` and adjacent files, in service of the upcoming "Agents for data labeling" blog post.

### 1. Migrate all 18 data_labeling cookbooks to Gemini

Across every folder (`_01` through `_18`), switch the default model from `OpenAIResponses(gpt-5.5)` to `Gemini(gemini-3.5-flash)`. The rationale:

- **One model, one API key for the whole cookbook.** Readers can run all 18 workflows with `GOOGLE_API_KEY` alone (the lone exception is `_18_quality_review/`, which uses Claude for one of its two labelers).
- **Native multimodality.** `_06`–`_14` all run through audio, video, images, and PDFs without rearchitecting the agent. Gemini 3.5 Flash handles every modality in the same call shape.
- **Flash pricing for frontier-grade reasoning on the routine labeling tier**, which is the whole pitch of the cookbook.

READMEs and TEST_LOGs across all 18 folders updated to match (`OPENAI_API_KEY` → `GOOGLE_API_KEY`).

### 2. Rewrite `_18_quality_review/basic.py` as a Workflow

Lifts the labeler → reviewer → adjudicator pipeline off procedural Python and onto the agno Workflow API:

- **Real concurrency between the two labelers** via `Parallel(label_a, label_b)`. The old version ran them sequentially, doubling latency.
- **Conditional adjudication** via `Condition(evaluator=has_disagreement, steps=[adjudicate])` — workflow structure instead of an `if` statement.
- **Persistent traces** via `SqliteDb(db_file="tmp/labeling.db")` — every run captured for auditability, which matters for a labeling pipeline.

The reviewer and adjudicator use `Step(executor=fn)` and reach into the Parallel block with `step_input.get_step_output("Labeler A")`, the documented helper for recursively searching nested steps.

### 3. Ruff format drift in three unrelated files

`./scripts/format.sh` surfaced pre-existing format / import-order drift in three files outside the data_labeling cookbook (`cookbook/90_models/...antigravity.py`, `cookbook/91_tools/...drive_all_drives_search.py`, `libs/agno/tests/unit/models/google/test_gemini.py`). Pure formatting fixes, no semantic changes. Included here to keep `format.sh` clean on this branch.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`; cookbook ruff + pattern checks pass; mypy crash in `agno_infra` is a pre-existing pydantic_settings issue unrelated to this PR)
- [x] Self-review completed
- [x] Documentation updated (file docstrings + per-folder READMEs)
- [x] Examples and guides: this IS the cookbook update
- [x] Tested in clean environment (workflow constructs correctly; quality_review end-to-end run verified by author with live API keys)
- [ ] Tests added/updated (N/A — cookbook examples)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Companion to the upcoming "Agents for data labeling" blog post — the post uses `gemini-3.5-flash` throughout and shows the Workflow version of the quality review pipeline as its wedge example for multi-agent quality control. This PR makes the cookbook match.

Stats: 80 files changed, +284/-231 across three commits.