### PR TITLE
refactor: move resolved approval from typed field to metadata bag

### DIFF
--- a/cookbook/02_agents/11_approvals/TEST_LOG.md
+++ b/cookbook/02_agents/11_approvals/TEST_LOG.md
@@ -41,6 +41,15 @@
 
 ---
 
+### approval_post_hook.py
+
+**Status:** PASS
+**Tier:** untagged
+**Description:** Demonstrates a post-hook reading the resolved approval record from run_output.metadata["approval"] after the admin/API resolution path (db.update_approval -> continue_run without requirements).
+**Result:** Completed successfully. Audit hook fires with approval_id, status, resolved_by, resolved_at populated from the DB record.
+
+---
+
 ### approval_team.py
 
 **Status:** FAIL

--- a/cookbook/02_agents/11_approvals/approval_post_hook.py
+++ b/cookbook/02_agents/11_approvals/approval_post_hook.py
@@ -85,8 +85,11 @@ if __name__ == "__main__":
     print(f"  Resolved by: {resolved['resolved_by']}")
 
     print("\n--- Step 3: Continuing run (post-hook should see resolution) ---")
-    run = agent.continue_run(run_id=run.run_id, requirements=run.requirements)
-    assert not run.is_paused, "Expected run to complete"
+    # Calling continue_run with run_id and NO requirements triggers the admin/API
+    # resolution path: check_and_apply_approval_resolution reads the resolved
+    # record from the DB and attaches it to run_response.metadata["approval"].
+    run = agent.continue_run(run_id=run.run_id)
+    assert not run.is_paused, f"Expected run to complete, got {run.status}"
 
     print("\n--- Step 4: Verifying metadata exposed on RunOutput ---")
     assert run.metadata is not None, "Expected metadata to be populated"

--- a/cookbook/02_agents/11_approvals/approval_post_hook.py
+++ b/cookbook/02_agents/11_approvals/approval_post_hook.py
@@ -1,0 +1,100 @@
+"""
+Approval Post Hook
+=============================
+
+Demonstrates the post-hook reading the resolved approval record from
+run_output.metadata["approval"] after a paused run resumes via DB resolution.
+
+Use case: audit/observability hooks that need to know WHO resolved the
+approval and WHEN, not just whether the tool was allowed to run.
+"""
+
+import os
+import time
+
+from agno.agent import Agent
+from agno.approval import approval
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.run.agent import RunOutput
+from agno.tools import tool
+
+DB_FILE = "tmp/approval_post_hook.db"
+
+
+@approval
+@tool(requires_confirmation=True)
+def delete_user_data(user_id: str) -> str:
+    """Permanently delete all data for a user. This is irreversible.
+
+    Args:
+        user_id (str): The user ID whose data should be deleted.
+    """
+    return f"All data for user {user_id} has been permanently deleted."
+
+
+def audit_resolved_approval(run_output: RunOutput) -> None:
+    """Post-hook: log audit trail using the resolved approval record."""
+    if not run_output.metadata:
+        return
+
+    approval_record = run_output.metadata.get("approval")
+    if approval_record is None:
+        return
+
+    print("[audit-hook] tool gated by approval:")
+    print(f"  approval_id: {approval_record['id']}")
+    print(f"  status:      {approval_record['status']}")
+    print(f"  resolved_by: {approval_record.get('resolved_by')}")
+    print(f"  resolved_at: {approval_record.get('resolved_at')}")
+
+
+if __name__ == "__main__":
+    if os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+    os.makedirs("tmp", exist_ok=True)
+
+    db = SqliteDb(
+        db_file=DB_FILE, session_table="agent_sessions", approvals_table="approvals"
+    )
+    agent = Agent(
+        name="Admin Agent",
+        model=OpenAIResponses(id="gpt-5-mini"),
+        tools=[delete_user_data],
+        post_hooks=[audit_resolved_approval],
+        db=db,
+    )
+
+    print("--- Step 1: Running agent (expects pause) ---")
+    run = agent.run("Delete all data for user U-12345")
+    assert run.is_paused, f"Expected paused, got {run.status}"
+    print(f"Paused. Run ID: {run.run_id}")
+
+    print("\n--- Step 2: Resolving approval in DB (admin/API path) ---")
+    pending, _ = db.get_approvals(run_id=run.run_id, status="pending")
+    assert len(pending) == 1
+    approval_id = pending[0]["id"]
+    resolved = db.update_approval(
+        approval_id,
+        expected_status="pending",
+        status="approved",
+        resolved_by="admin@example.com",
+        resolved_at=int(time.time()),
+    )
+    assert resolved is not None
+    print(f"  Resolved by: {resolved['resolved_by']}")
+
+    print("\n--- Step 3: Continuing run (post-hook should see resolution) ---")
+    run = agent.continue_run(run_id=run.run_id, requirements=run.requirements)
+    assert not run.is_paused, "Expected run to complete"
+
+    print("\n--- Step 4: Verifying metadata exposed on RunOutput ---")
+    assert run.metadata is not None, "Expected metadata to be populated"
+    assert "approval" in run.metadata, "Expected metadata['approval'] to be set"
+    assert run.metadata["approval"]["resolved_by"] == "admin@example.com"
+    print(f"  metadata['approval'] status: {run.metadata['approval']['status']}")
+    print(
+        f"  metadata['approval'] resolved_by: {run.metadata['approval']['resolved_by']}"
+    )
+
+    print("\n--- All checks passed! ---")

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -652,9 +652,6 @@ class RunOutput:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
 
-    # Resolved approval record exposed to post-hooks after a paused run resumes; None otherwise.
-    resolved_approval: Optional[Dict[str, Any]] = None
-
     created_at: int = field(default_factory=lambda: int(time()))
 
     events: Optional[List[RunOutputEvent]] = None

--- a/libs/agno/agno/run/approval.py
+++ b/libs/agno/agno/run/approval.py
@@ -438,6 +438,13 @@ def _collect_all_approval_tools(run_response: Any) -> List[Any]:
     return result
 
 
+def _attach_resolved_approval(run_response: Any, approval: Dict[str, Any]) -> None:
+    """Expose the resolved approval record to post-hooks via run_response.metadata["approval"]."""
+    if run_response.metadata is None:
+        run_response.metadata = {}
+    run_response.metadata["approval"] = approval
+
+
 def check_and_apply_approval_resolution(db: Any, run_id: str, run_response: Any) -> None:
     """Gate: if any tool has approval_type='required', verify the approval is resolved before continuing.
 
@@ -472,9 +479,7 @@ def check_and_apply_approval_resolution(db: Any, run_id: str, run_response: Any)
     resolution_data = approval.get("resolution_data")
     _apply_approval_to_tools(all_approval_tools, status, resolution_data)
 
-    # Expose the resolved approval record to post-hooks via a typed attribute
-    # on RunOutput / TeamRunOutput.
-    run_response.resolved_approval = approval
+    _attach_resolved_approval(run_response, approval)
 
 
 async def acheck_and_apply_approval_resolution(db: Any, run_id: str, run_response: Any) -> None:
@@ -505,9 +510,7 @@ async def acheck_and_apply_approval_resolution(db: Any, run_id: str, run_respons
     resolution_data = approval.get("resolution_data")
     _apply_approval_to_tools(all_approval_tools, status, resolution_data)
 
-    # Expose the resolved approval record to post-hooks via a typed attribute
-    # on RunOutput / TeamRunOutput.
-    run_response.resolved_approval = approval
+    _attach_resolved_approval(run_response, approval)
 
 
 async def acreate_audit_approval(

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -761,9 +761,6 @@ class TeamRunOutput:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
 
-    # Resolved approval record exposed to post-hooks after a paused run resumes; None otherwise.
-    resolved_approval: Optional[Dict[str, Any]] = None
-
     references: Optional[List[MessageReferences]] = None
     additional_input: Optional[List[Message]] = None
     reasoning_steps: Optional[List[ReasoningStep]] = None

--- a/libs/agno/tests/unit/run/test_approval.py
+++ b/libs/agno/tests/unit/run/test_approval.py
@@ -53,6 +53,7 @@ class FakeRunResponse:
     session_id: Optional[str] = "sess-456"
     tools: Optional[list] = None
     requirements: Optional[list] = None
+    metadata: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -521,6 +522,27 @@ class TestCheckAndApplyApprovalResolution:
         check_and_apply_approval_resolution(db=db, run_id="r1", run_response=rr)
         assert t.confirmed is False
 
+    def test_attaches_resolved_approval_to_metadata(self):
+        approval = {"status": "approved", "resolution_data": None, "resolved_by": "alice", "resolved_at": 1700000000}
+        db = MagicMock()
+        db.get_approvals.return_value = ([approval], 1)
+        rr = FakeRunResponse(tools=[FakeToolExecution(approval_type="required", requires_confirmation=True)])
+        check_and_apply_approval_resolution(db=db, run_id="r1", run_response=rr)
+        assert rr.metadata is not None
+        assert rr.metadata["approval"] == approval
+
+    def test_preserves_existing_metadata(self):
+        approval = {"status": "approved", "resolution_data": None}
+        db = MagicMock()
+        db.get_approvals.return_value = ([approval], 1)
+        rr = FakeRunResponse(
+            tools=[FakeToolExecution(approval_type="required", requires_confirmation=True)],
+            metadata={"existing": "value"},
+        )
+        check_and_apply_approval_resolution(db=db, run_id="r1", run_response=rr)
+        assert rr.metadata["existing"] == "value"
+        assert rr.metadata["approval"] == approval
+
 
 # =============================================================================
 # acheck_and_apply_approval_resolution (async)
@@ -566,3 +588,13 @@ class TestAsyncCheckAndApplyApprovalResolution:
         rr = FakeRunResponse(tools=[t])
         await acheck_and_apply_approval_resolution(db=db, run_id="r1", run_response=rr)
         assert t.confirmed is True
+
+    @pytest.mark.asyncio
+    async def test_attaches_resolved_approval_to_metadata(self):
+        approval = {"status": "approved", "resolution_data": None, "resolved_by": "alice"}
+        db = MagicMock()
+        db.get_approvals = AsyncMock(return_value=([approval], 1))
+        rr = FakeRunResponse(tools=[FakeToolExecution(approval_type="required", requires_confirmation=True)])
+        await acheck_and_apply_approval_resolution(db=db, run_id="r1", run_response=rr)
+        assert rr.metadata is not None
+        assert rr.metadata["approval"] == approval


### PR DESCRIPTION
## Summary

Follow-up to #7366. Moves the resolved approval record from a top-level `resolved_approval` field on `RunOutput` / `TeamRunOutput` into `run_response.metadata["approval"]`. Same data, same lifecycle, smaller core schema. Needs to land before the next release so the typed field never enters the public API surface and this stays a non-breaking change.

**Why:**
- `metadata` is already the contextual-augmentation surface on run outputs. Promoting `resolved_approval` to a top-level field added permanent dataclass surface for a flow that only populates on the narrow HITL-resume path.
- The original v1 of #7366 used `metadata["_approval"]`. The underscore prefix was the real smell, not the use of `metadata`. As soon as the key is just `metadata["approval"]`, the "private key in a public dict" issue goes away.
- A typed `Optional[Dict[str, Any]]` doesn't give IDE completion for the contents anyway, so the discoverability win over `metadata["approval"]` is one hop.
- `WorkflowRunOutput` is out of scope for the current approval flow but already has a `metadata` field. If approvals ever extend to workflows, the metadata approach works uniformly across all three output types without forcing the field onto a third dataclass.

**Changes:**
- Drop `resolved_approval` from `RunOutput` (`libs/agno/agno/run/agent.py`) and `TeamRunOutput` (`libs/agno/agno/run/team.py`).
- Replace direct attribute assignment in `check_and_apply_approval_resolution` and `acheck_and_apply_approval_resolution` with a shared `_attach_resolved_approval` helper that writes to `run_response.metadata["approval"]`, initializing `metadata` if `None` and preserving any existing keys.
- Add unit tests: metadata is populated on resolution, existing metadata is preserved (sync + async).
- Add cookbook `cookbook/02_agents/11_approvals/approval_post_hook.py` showing a post-hook reading the resolved approval for audit logging.

## Type of change

- [x] Improvement
- [ ] Breaking change (only if this lands after #7366 ships in a release)

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Migration:** any user code reading `run_output.resolved_approval` should switch to `run_output.metadata.get("approval")`. The typed field has not shipped in a release yet, so no deprecation period is needed if this merges before cutting one.