### PR TITLE
cookbook: swap image_search from ChromaDb to PgVector

### DIFF
--- a/cookbook/data_labeling/image_search/README.md
+++ b/cookbook/data_labeling/image_search/README.md
@@ -37,10 +37,12 @@ call. The only custom Python is the labeling agent and the ingest loop.
    cards with the image, caption, subjects, scene, visual style, and tag
    chips.
 
-3. **Search** — the UI hits `POST /knowledge/search`. The query is
-   embedded with `GeminiEmbedder`, matched against the stored description
-   vectors, and the top hits come back with their full metadata for
-   rendering.
+3. **Search** — the UI hits `POST /knowledge/search` with
+   `search_type=hybrid`. PgVector combines vector similarity (cosine
+   over `GeminiEmbedder` vectors) with PostgreSQL full-text search
+   (`to_tsvector` + `websearch_to_tsquery`) into one fused score, so
+   `car` matches `cars` via stemming without dragging in `carnivore`.
+   The top hits come back with their full metadata for rendering.
 
 4. **Reindex** — the UI's Reindex button hits the workflow endpoint with
    `background=true`, polls the run for status, and refreshes the gallery
@@ -62,8 +64,8 @@ cookbook/data_labeling/image_search/
 ├── workflows/
 │   └── ingest.py             extractor agent + Step + Workflow
 ├── public/
-│   └── index.html            single-file UI (Tailwind + Alpine + Lucide + PhotoSwipe — all CDN)
-└── data/                     gitignored: chroma + sqlite live here
+│   └── index.html            single-file UI (Tailwind + Alpine + Lucide — all CDN)
+└── data/                     gitignored, kept for future local artifacts
 ```
 
 ## Get started
@@ -81,7 +83,17 @@ source .venvs/image_search/bin/activate
 uv pip install -r cookbook/data_labeling/image_search/requirements.txt
 ```
 
-### 3. Set your API key
+### 3. Start pgvector
+
+```bash
+./cookbook/scripts/run_pgvector.sh
+```
+
+That brings up `agnohq/pgvector:18` on port 5532 with database `ai` and
+credentials `ai/ai` — which is what [`settings.py`](settings.py) expects
+out of the box. Point `DB_URL` at your own instance if you'd rather.
+
+### 4. Set your API key
 
 ```bash
 export GOOGLE_API_KEY="..."
@@ -90,7 +102,7 @@ export GOOGLE_API_KEY="..."
 The demo uses `gemini-3.5-flash` for vision + structured output and
 `gemini-embedding-001` for embeddings.
 
-### 4. Serve
+### 5. Serve
 
 ```bash
 fastapi dev cookbook/data_labeling/image_search/run.py --port 7777
@@ -131,5 +143,5 @@ This is demo-grade. For production:
 - CloudFront in front of the bucket for cold-load latency.
 - Background worker pool for ingest at real scale; the in-process Workflow
   is fine up to maybe a few thousand items.
-- Migrate ChromaDb to managed Chroma or pgvector once you outgrow local
-  persistence.
+- Move from the local Docker pgvector to a managed Postgres (RDS,
+  Supabase, etc.) once you outgrow a laptop.

--- a/cookbook/data_labeling/image_search/TEST_LOG.md
+++ b/cookbook/data_labeling/image_search/TEST_LOG.md
@@ -127,3 +127,65 @@ Fetch URLs and field mappings are unchanged, so the curl-equivalence
 verification above still applies. Interactive features (lightbox click,
 reindex polling, tab switching) should be re-smoked against a live server
 before relying on them.
+
+---
+
+### PgVector swap (2026-05-22)
+
+**Status:** PASS
+
+The cookbook was migrated from `ChromaDb` + `SqliteDb` to `PgVector` +
+`PostgresDb` against `agnohq/pgvector:18` (the image
+`cookbook/scripts/run_pgvector.sh` brings up on port 5532). The swap
+deletes two client-side workarounds that were papering over storage-layer
+weirdness in the previous stack:
+
+- `asArray()` in [`public/index.html`](public/index.html): pgvector
+  preserves JSONB arrays as native arrays in both
+  `/knowledge/content.metadata` and `/knowledge/search.meta_data`. No
+  more string ↔ array reconciliation.
+- The frontend "trust real keyword hits, not substring noise" heuristic
+  is no longer needed. PgVector's keyword branch runs
+  `to_tsvector(english, content)` + `websearch_to_tsquery(english,
+  query)`, so `car` no longer false-matches `carnivore` or `streetcar` —
+  the English Snowball stemmer lemmatizes both query and document into
+  lexemes (`car`, `cars` → `car`; `carnivore` → `carnivor`).
+
+**Reindex:** 38/38 indexed in ~10s. No "agent returned str" issues
+recurred (the per-worker Agent construction from Fix 2 still applies).
+
+**Query battery** — `MIN_SCORE_RATIO=0.5`, `SCORE_FLOOR=0.30`. PgVector's
+hybrid score = `0.5 * cosine_similarity + 0.5 * ts_rank`. A pure vector
+match tops out at ~0.5; anything above that is FTS-boosted.
+
+| Query        | Best   | Shown | Below | Verdict                                              |
+|--------------|--------|-------|-------|------------------------------------------------------|
+| `animal`     | 0.525  | 5     | 7     | bulldog, leopard, bear, coyote, highland cow         |
+| `anim`       | 0.488  | 6     | 6     | same set as `animal`, stemmer makes them equivalent  |
+| `anima`      | 0.243  | 0     | 12    | tsquery `anima` ≠ lexeme `anim` — tucked under tray  |
+| `wildlife`   | 0.532  | 5     | 7     | coyote, bear, leopard, tiger cub, pelican            |
+| `mountain`   | 0.696  | 8     | 4     | valleys, peaks, lakes — all mountain scenes          |
+| `coffee`     | 0.710  | 1     | 11    | just the macro beans — laptop-in-cafe correctly demoted to 0.27 |
+| `car`        | 0.240  | 0     | 12    | no FTS hits — leopard `carnivore` is gone (stemmer)  |
+| `night city` | 0.259  | 0     | 12    | vector-only candidates (Milan dusk, NYC) shown via tray |
+| `asdf`       | 0.223  | 0     | 12    | correctly tucked under tray                          |
+
+**Observations:**
+
+- `SCORE_FLOOR = 0.30` cleanly separates "real FTS match" (scores >0.45)
+  from "vector noise" (scores 0.20–0.27). The relative cutoff
+  (`best * MIN_SCORE_RATIO`) only kicks in inside the strong-match tier,
+  so `coffee` correctly returns one bullseye instead of dragging in the
+  laptop-in-cafe image.
+- Search-as-you-type has a quirk: `anim` matches because the lexeme is
+  `anim`, but `anima` doesn't because the stemmer treats it as a
+  different word. The 250ms debounce + AbortController + tray-fallback
+  UX (`Show 12 below threshold`) gives an honest "no high-confidence
+  match" experience instead of pretending.
+- `prefix_match=True` was tried and reverted: it appends `*` to query
+  terms, but agno passes the query through `websearch_to_tsquery`, which
+  doesn't honor `:*` / `*` operators — it's a silent no-op.
+
+**Endpoints:** unchanged surface — `/knowledge/content`,
+`/knowledge/search`, `/workflows/image-ingest/runs` all behave the same
+shape-wise. Just the underlying storage moved.

--- a/cookbook/data_labeling/image_search/db.py
+++ b/cookbook/data_labeling/image_search/db.py
@@ -1,35 +1,43 @@
 """
 Shared Storage and Knowledge
 
-SqliteDb is used by:
+PostgresDb is used by:
   - Knowledge.contents_db (gallery list, content metadata, status)
   - Workflow.db          (background runs for the Reindex button)
+
+PgVector is used as the vector store. We pick Postgres for both layers
+so:
+  - Keyword search is real lexical FTS (to_tsvector + websearch_to_tsquery)
+    instead of substring matching — "car" matches "cars" via stemming
+    without bringing in "carnivore" or "streetcar".
+  - List metadata (tags, subjects) round-trips through JSONB as native
+    arrays, not JSON-encoded strings.
 
 Knowledge is used by:
   - The ingest workflow's executor (writes)
   - AgentOS's /knowledge/* routes (reads)
 """
 
-from agno.db.sqlite import SqliteDb
+from agno.db.postgres import PostgresDb
 from agno.knowledge.embedder.google import GeminiEmbedder
 from agno.knowledge.knowledge import Knowledge
-from agno.vectordb.chroma import ChromaDb
+from agno.vectordb.pgvector import PgVector, SearchType
 from settings import (
-    CHROMA_COLLECTION,
-    CHROMA_PATH,
+    DB_URL,
     EMBEDDER_MODEL_ID,
     KNOWLEDGE_NAME,
-    SQLITE_PATH,
+    KNOWLEDGE_TABLE,
+    VECTOR_TABLE,
 )
 
-_db: SqliteDb | None = None
+_db: PostgresDb | None = None
 _knowledge: Knowledge | None = None
 
 
-def get_db() -> SqliteDb:
+def get_db() -> PostgresDb:
     global _db
     if _db is None:
-        _db = SqliteDb(db_file=str(SQLITE_PATH))
+        _db = PostgresDb(db_url=DB_URL, knowledge_table=KNOWLEDGE_TABLE)
     return _db
 
 
@@ -39,10 +47,10 @@ def get_knowledge() -> Knowledge:
         _knowledge = Knowledge(
             name=KNOWLEDGE_NAME,
             contents_db=get_db(),
-            vector_db=ChromaDb(
-                collection=CHROMA_COLLECTION,
-                persistent_client=True,
-                path=str(CHROMA_PATH),
+            vector_db=PgVector(
+                db_url=DB_URL,
+                table_name=VECTOR_TABLE,
+                search_type=SearchType.hybrid,
                 embedder=GeminiEmbedder(id=EMBEDDER_MODEL_ID),
             ),
         )

--- a/cookbook/data_labeling/image_search/public/index.html
+++ b/cookbook/data_labeling/image_search/public/index.html
@@ -59,17 +59,21 @@
 
     <!-- Search view -->
     <section x-show="tab === 'search'">
-      <form @submit.prevent="runSearch()" class="relative mb-4">
-        <span class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400">
-          <i data-lucide="search" class="w-5 h-5"></i>
-        </span>
-        <input x-model="query" @input.debounce.250ms="runSearch()" type="search" autofocus
-               autocomplete="off" data-1p-ignore data-lpignore="true" data-form-type="other"
-               placeholder="Try: a historic city at night, wildlife on the savanna, latte art ..."
-               class="w-full pl-12 pr-12 py-3 text-base rounded-lg border border-slate-300 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-900 focus:border-slate-900 transition-shadow" />
-        <span x-show="searching" class="absolute right-4 top-1/2 -translate-y-1/2 text-slate-400">
-          <i data-lucide="loader-2" class="w-5 h-5 animate-spin"></i>
-        </span>
+      <form @submit.prevent="runSearch()" class="flex gap-2 mb-4">
+        <div class="relative flex-1">
+          <span class="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400">
+            <i data-lucide="search" class="w-5 h-5"></i>
+          </span>
+          <input x-model="query" type="search" autofocus
+                 autocomplete="off" data-1p-ignore data-lpignore="true" data-form-type="other"
+                 placeholder="Try: a historic city at night, wildlife on the savanna, latte art ..."
+                 class="w-full pl-12 pr-4 py-3 text-base rounded-lg border border-slate-300 bg-white shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-900 focus:border-slate-900 transition-shadow" />
+        </div>
+        <button type="submit" :disabled="searching"
+                class="inline-flex items-center gap-2 px-5 py-3 text-sm font-medium rounded-lg bg-slate-900 text-white shadow-sm hover:bg-slate-700 disabled:bg-slate-400 disabled:cursor-not-allowed">
+          <i :data-lucide="searching ? 'loader-2' : 'search'" :class="searching && 'animate-spin'" class="w-4 h-4"></i>
+          <span x-text="searching ? 'Searching…' : 'Search'"></span>
+        </button>
       </form>
       <div class="flex items-center justify-between text-xs text-slate-500 mb-4 min-h-[1.25rem]">
         <p x-text="searchMeta"></p>
@@ -114,7 +118,7 @@
             </div>
           </a>
         </template>
-        <div x-show="!searching && searchMeta && searchResults.length === 0"
+        <div x-show="!searching && searchMeta && searchResults.length === 0 && filteredOut.length === 0"
              class="col-span-full text-sm text-slate-500 py-12 text-center">
           No matches. Try a different query.
         </div>
@@ -286,6 +290,7 @@
         init() {
           this.refreshCounter();
           this.$nextTick(() => lucide.createIcons());
+          this.$watch('searching', () => this.$nextTick(() => lucide.createIcons()));
           this.$watch('showFiltered', () => this.$nextTick(() => lucide.createIcons()));
           this.$watch('activeItem', () => this.$nextTick(() => lucide.createIcons()));
         },
@@ -335,14 +340,17 @@
           this.searchMeta = `"${q}" — searching…`;
           const t0 = performance.now();
           try {
-            const r = await fetch('/knowledge/search', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ query: q, max_results: 12, search_type: 'hybrid' }),
-              signal,
-            });
-            const j = await r.json();
+            // Gemini's embedding endpoint flakes with a transient 503 every now
+            // and then; agno's pgvector adapter swallows the failure and returns
+            // []. Retry once with a brief backoff before giving up.
+            let j = await this._search(q, signal);
             if (signal.aborted) return;
+            if ((j.data || []).length === 0) {
+              await new Promise(r => setTimeout(r, 400));
+              if (signal.aborted) return;
+              j = await this._search(q, signal);
+              if (signal.aborted) return;
+            }
             const dt = Math.round(performance.now() - t0);
             const all = (j.data || []).map(d => ({
               url:          d.meta_data?.url,
@@ -368,6 +376,10 @@
             }
             this.searchResults = primary;
             this.filteredOut = secondary;
+            // Auto-reveal the below-threshold tier when there's nothing else
+            // to show — beats a bare "0 results" with a hidden tray.
+            if (primary.length === 0 && secondary.length > 0) this.showFiltered = true;
+            else if (primary.length > 0) this.showFiltered = false;
             const n = this.searchResults.length;
             this.searchMeta = `"${q}" · ${n} result${n === 1 ? '' : 's'} in ${dt}ms`;
           } catch (e) {
@@ -376,6 +388,16 @@
           } finally {
             if (!signal.aborted) this.searching = false;
           }
+        },
+
+        async _search(q, signal) {
+          const r = await fetch('/knowledge/search', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ query: q, max_results: 12, search_type: 'hybrid' }),
+            signal,
+          });
+          return await r.json();
         },
 
         async loadGallery() {

--- a/cookbook/data_labeling/image_search/public/index.html
+++ b/cookbook/data_labeling/image_search/public/index.html
@@ -122,7 +122,7 @@
 
       <!-- Below-threshold reveal -->
       <div x-show="showFiltered && filteredOut.length" x-transition class="mt-8 pt-6 border-t border-slate-200">
-        <p class="text-xs text-slate-500 mb-3" x-text="`Below the ${Math.round(MIN_SCORE_RATIO * 100)}% relative-score cutoff — lower-confidence matches.`"></p>
+        <p class="text-xs text-slate-500 mb-3">Below the relevance cutoff — vector-only candidates without a real FTS match.</p>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 opacity-70">
           <template x-for="hit in filteredOut" :key="hit.url">
             <a :href="hit.url" @click="onCardClick($event, hit)" target="_blank" rel="noreferrer"
@@ -249,25 +249,21 @@
   </div>
 
   <script>
-    // Drop hits whose hybrid score is below this fraction of the best hit's
-    // score. Hybrid RRF gives a bimodal distribution when keyword matches
-    // exist (good hits ~2x the vector-only tail), so a relative cutoff cleanly
-    // separates them. When all scores cluster together (no keyword wins),
-    // nothing is filtered.
+    // PgVector's hybrid score = vector_score_weight * cosine_similarity +
+    // text_rank_weight * ts_rank. Defaults put a perfect vector hit at 0.5;
+    // a real FTS hit pushes scores past 0.5. Anything below ~0.30 is
+    // vector-only on a tangentially related image — noise for a literal
+    // query like "car" that has no FTS match.
+    const SCORE_FLOOR = 0.30;
+    // Within the "real match" tier, also drop hits below this fraction of
+    // the top score so a query with one bullseye doesn't drag in
+    // medium-confidence tail (e.g. "coffee" → coffee beans, drop everything
+    // else that scored mid-range).
     const MIN_SCORE_RATIO = 0.5;
-
-    // ChromaDb stringifies list metadata, so /knowledge/search hits come back
-    // with tags/subjects as JSON strings. /knowledge/content (SQLite) returns
-    // real arrays. Normalize both paths through this.
-    function asArray(v) {
-      if (Array.isArray(v)) return v;
-      if (typeof v !== 'string') return [];
-      try { const p = JSON.parse(v); return Array.isArray(p) ? p : []; }
-      catch { return []; }
-    }
 
     function imageSearch() {
       return {
+        SCORE_FLOOR,
         MIN_SCORE_RATIO,
         tab: 'search',
         query: '',
@@ -351,16 +347,27 @@
             const all = (j.data || []).map(d => ({
               url:          d.meta_data?.url,
               caption:      d.meta_data?.caption,
-              subjects:     asArray(d.meta_data?.subjects),
+              subjects:     d.meta_data?.subjects || [],
               scene:        d.meta_data?.scene,
               visual_style: d.meta_data?.visual_style,
-              tags:         asArray(d.meta_data?.tags),
-              score:        d.meta_data?.rrf_score,
+              tags:         d.meta_data?.tags || [],
+              score:        d.meta_data?.similarity_score,
             }));
             const best = Math.max(0, ...all.map(h => h.score || 0));
-            const cutoff = best * MIN_SCORE_RATIO;
-            this.searchResults = all.filter(h => h.score == null || h.score >= cutoff);
-            this.filteredOut = all.filter(h => h.score != null && h.score < cutoff);
+            // No high-confidence match at all → tuck everything under
+            // "below threshold" instead of showing low-score vector noise.
+            // Otherwise apply the relative ratio against the best hit.
+            let primary, secondary;
+            if (best < SCORE_FLOOR) {
+              primary = [];
+              secondary = all;
+            } else {
+              const cutoff = Math.max(SCORE_FLOOR, best * MIN_SCORE_RATIO);
+              primary = all.filter(h => h.score == null || h.score >= cutoff);
+              secondary = all.filter(h => h.score != null && h.score < cutoff);
+            }
+            this.searchResults = primary;
+            this.filteredOut = secondary;
             const n = this.searchResults.length;
             this.searchMeta = `"${q}" · ${n} result${n === 1 ? '' : 's'} in ${dt}ms`;
           } catch (e) {
@@ -380,10 +387,10 @@
             this.galleryItems = (j.data || []).map(c => ({
               url:          c.metadata?.url,
               caption:      c.metadata?.caption,
-              subjects:     asArray(c.metadata?.subjects),
+              subjects:     c.metadata?.subjects || [],
               scene:        c.metadata?.scene,
               visual_style: c.metadata?.visual_style,
-              tags:         asArray(c.metadata?.tags),
+              tags:         c.metadata?.tags || [],
             }));
             this.galleryMeta = `${j.meta.total_count} image${j.meta.total_count === 1 ? '' : 's'}`;
           } catch (e) {

--- a/cookbook/data_labeling/image_search/public/index.html
+++ b/cookbook/data_labeling/image_search/public/index.html
@@ -71,16 +71,19 @@
         </div>
         <button type="submit" :disabled="searching"
                 class="inline-flex items-center gap-2 px-5 py-3 text-sm font-medium rounded-lg bg-slate-900 text-white shadow-sm hover:bg-slate-700 disabled:bg-slate-400 disabled:cursor-not-allowed">
-          <i :data-lucide="searching ? 'loader-2' : 'search'" :class="searching && 'animate-spin'" class="w-4 h-4"></i>
+          <i x-show="!searching" data-lucide="search" class="w-4 h-4"></i>
+          <i x-show="searching" data-lucide="loader-2" class="w-4 h-4 animate-spin"></i>
           <span x-text="searching ? 'Searching…' : 'Search'"></span>
         </button>
       </form>
       <div class="flex items-center justify-between text-xs text-slate-500 mb-4 min-h-[1.25rem]">
         <p x-text="searchMeta"></p>
-        <button x-show="filteredOut.length" @click="showFiltered = !showFiltered"
+        <button x-show="filteredOut.length && searchResults.length > 0"
+                @click="showFiltered = !showFiltered"
                 class="inline-flex items-center gap-1 text-slate-500 hover:text-slate-900 underline-offset-4 hover:underline">
-          <span x-text="(showFiltered ? 'Hide' : 'Show') + ' ' + filteredOut.length + ' below threshold'"></span>
-          <i :data-lucide="showFiltered ? 'chevron-up' : 'chevron-down'" class="w-3.5 h-3.5"></i>
+          <span x-text="(showFiltered ? 'Hide' : 'Show') + ' ' + filteredOut.length + ' weaker match' + (filteredOut.length === 1 ? '' : 'es')"></span>
+          <i x-show="!showFiltered" data-lucide="chevron-down" class="w-3.5 h-3.5"></i>
+          <i x-show="showFiltered" data-lucide="chevron-up" class="w-3.5 h-3.5"></i>
         </button>
       </div>
 
@@ -126,7 +129,8 @@
 
       <!-- Below-threshold reveal -->
       <div x-show="showFiltered && filteredOut.length" x-transition class="mt-8 pt-6 border-t border-slate-200">
-        <p class="text-xs text-slate-500 mb-3">Below the relevance cutoff — vector-only candidates without a real FTS match.</p>
+        <p class="text-xs text-slate-500 mb-3"
+           x-text="searchResults.length === 0 ? 'No exact match — showing the closest vector-similarity candidates.' : 'Weaker matches — vector similarity only, no text-search overlap.'"></p>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 opacity-70">
           <template x-for="hit in filteredOut" :key="hit.url">
             <a :href="hit.url" @click="onCardClick($event, hit)" target="_blank" rel="noreferrer"
@@ -380,8 +384,12 @@
             // to show — beats a bare "0 results" with a hidden tray.
             if (primary.length === 0 && secondary.length > 0) this.showFiltered = true;
             else if (primary.length > 0) this.showFiltered = false;
-            const n = this.searchResults.length;
-            this.searchMeta = `"${q}" · ${n} result${n === 1 ? '' : 's'} in ${dt}ms`;
+            const n = primary.length;
+            if (n === 0 && secondary.length > 0) {
+              this.searchMeta = `"${q}" · no exact match · showing ${secondary.length} closest in ${dt}ms`;
+            } else {
+              this.searchMeta = `"${q}" · ${n} result${n === 1 ? '' : 's'} in ${dt}ms`;
+            }
           } catch (e) {
             if (e.name === 'AbortError') return;
             this.searchMeta = `Search failed: ${e.message}`;

--- a/cookbook/data_labeling/image_search/requirements.in
+++ b/cookbook/data_labeling/image_search/requirements.in
@@ -1,8 +1,9 @@
 agno[os]
-chromadb
 fastapi[standard]
 google-genai
 httpx
+pgvector
+psycopg[binary]
 pydantic
 rich
 sqlalchemy

--- a/cookbook/data_labeling/image_search/requirements.txt
+++ b/cookbook/data_labeling/image_search/requirements.txt
@@ -2,12 +2,6 @@
 #    ./generate_requirements.sh
 agno==2.6.8
     # via -r cookbook/data_labeling/image_search/requirements.in
-aiohappyeyeballs==2.6.2
-    # via aiohttp
-aiohttp==3.13.5
-    # via kubernetes
-aiosignal==1.4.0
-    # via aiohttp
 annotated-doc==0.0.4
     # via
     #   fastapi
@@ -20,28 +14,16 @@ anyio==4.13.0
     #   httpx
     #   starlette
     #   watchfiles
-attrs==26.1.0
-    # via
-    #   aiohttp
-    #   jsonschema
-    #   referencing
-bcrypt==5.0.0
-    # via chromadb
-build==1.5.0
-    # via chromadb
 certifi==2026.5.20
     # via
     #   httpcore
     #   httpx
-    #   kubernetes
     #   requests
     #   sentry-sdk
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.7
     # via requests
-chromadb==1.5.9
-    # via -r cookbook/data_labeling/image_search/requirements.in
 click==8.4.0
     # via
     #   rich-toolkit
@@ -57,8 +39,6 @@ dnspython==2.8.0
     # via email-validator
 docstring-parser==0.18.0
     # via agno
-durationpy==0.10
-    # via kubernetes
 email-validator==2.3.0
     # via
     #   fastapi
@@ -75,16 +55,6 @@ fastar==0.11.0
     # via
     #   fastapi
     #   fastapi-cloud-cli
-filelock==3.29.0
-    # via huggingface-hub
-flatbuffers==25.12.19
-    # via onnxruntime
-frozenlist==1.8.0
-    # via
-    #   aiohttp
-    #   aiosignal
-fsspec==2026.4.0
-    # via huggingface-hub
 gitdb==4.0.12
     # via gitpython
 gitpython==3.1.50
@@ -93,12 +63,6 @@ google-auth==2.53.0
     # via google-genai
 google-genai==2.5.0
     # via -r cookbook/data_labeling/image_search/requirements.in
-googleapis-common-protos==1.75.0
-    # via opentelemetry-exporter-otlp-proto-grpc
-grpcio==1.80.0
-    # via
-    #   chromadb
-    #   opentelemetry-exporter-otlp-proto-grpc
 h11==0.16.0
     # via
     #   agno
@@ -106,8 +70,6 @@ h11==0.16.0
     #   uvicorn
 h2==4.3.0
     # via httpx
-hf-xet==1.5.0
-    # via huggingface-hub
 hpack==4.1.0
     # via h2
 httpcore==1.0.9
@@ -118,13 +80,9 @@ httpx==0.28.1
     # via
     #   -r cookbook/data_labeling/image_search/requirements.in
     #   agno
-    #   chromadb
     #   fastapi
     #   fastapi-cloud-cli
     #   google-genai
-    #   huggingface-hub
-huggingface-hub==1.15.0
-    # via tokenizers
 hyperframe==6.1.0
     # via h2
 idna==3.15
@@ -133,37 +91,16 @@ idna==3.15
     #   email-validator
     #   httpx
     #   requests
-    #   yarl
-importlib-resources==7.1.0
-    # via chromadb
 jinja2==3.1.6
     # via fastapi
-jsonschema==4.26.0
-    # via chromadb
-jsonschema-specifications==2025.9.1
-    # via jsonschema
-kubernetes==36.0.0
-    # via chromadb
 markdown-it-py==4.2.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-mmh3==5.2.1
-    # via chromadb
-multidict==6.7.1
-    # via
-    #   aiohttp
-    #   yarl
 numpy==2.4.6
-    # via
-    #   chromadb
-    #   onnxruntime
-oauthlib==3.3.1
-    # via requests-oauthlib
-onnxruntime==1.26.0
-    # via chromadb
+    # via pgvector
 openinference-instrumentation==0.1.51
     # via openinference-instrumentation-agno
 openinference-instrumentation-agno==0.1.34
@@ -174,67 +111,42 @@ openinference-semantic-conventions==0.1.29
     #   openinference-instrumentation-agno
 opentelemetry-api==1.42.0
     # via
-    #   chromadb
     #   openinference-instrumentation
     #   openinference-instrumentation-agno
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp-proto-common==1.42.0
-    # via opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-exporter-otlp-proto-grpc==1.42.0
-    # via chromadb
 opentelemetry-instrumentation==0.63b0
     # via openinference-instrumentation-agno
-opentelemetry-proto==1.42.0
-    # via
-    #   opentelemetry-exporter-otlp-proto-common
-    #   opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-sdk==1.42.0
     # via
     #   agno
-    #   chromadb
     #   openinference-instrumentation
-    #   opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-semantic-conventions==0.63b0
     # via
     #   openinference-instrumentation-agno
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
-orjson==3.11.9
-    # via chromadb
-overrides==7.7.0
-    # via chromadb
 packaging==26.2
     # via
     #   agno
-    #   build
-    #   huggingface-hub
-    #   onnxruntime
     #   opentelemetry-instrumentation
-propcache==0.5.2
-    # via
-    #   aiohttp
-    #   yarl
-protobuf==6.33.6
-    # via
-    #   googleapis-common-protos
-    #   onnxruntime
-    #   opentelemetry-proto
+pgvector==0.4.2
+    # via -r cookbook/data_labeling/image_search/requirements.in
+psycopg==3.3.4
+    # via -r cookbook/data_labeling/image_search/requirements.in
+psycopg-binary==3.3.4
+    # via psycopg
 pyasn1==0.6.3
     # via pyasn1-modules
 pyasn1-modules==0.4.2
     # via google-auth
-pybase64==1.4.3
-    # via chromadb
 pycparser==3.0
     # via cffi
 pydantic==2.13.4
     # via
     #   -r cookbook/data_labeling/image_search/requirements.in
     #   agno
-    #   chromadb
     #   fastapi
     #   fastapi-cloud-cli
     #   google-genai
@@ -247,20 +159,13 @@ pydantic-extra-types==2.11.1
 pydantic-settings==2.14.1
     # via
     #   agno
-    #   chromadb
     #   fastapi
 pygments==2.20.0
     # via rich
 pyjwt==2.12.1
     # via agno
-pypika==0.51.1
-    # via chromadb
-pyproject-hooks==1.2.0
-    # via build
 python-dateutil==2.9.0.post0
-    # via
-    #   croniter
-    #   kubernetes
+    # via croniter
 python-dotenv==1.2.2
     # via
     #   agno
@@ -275,27 +180,15 @@ pytz==2026.2
 pyyaml==6.0.3
     # via
     #   agno
-    #   chromadb
-    #   huggingface-hub
-    #   kubernetes
     #   uvicorn
-referencing==0.37.0
-    # via
-    #   jsonschema
-    #   jsonschema-specifications
 requests==2.34.2
     # via
     #   google-auth
     #   google-genai
-    #   kubernetes
-    #   requests-oauthlib
-requests-oauthlib==2.0.0
-    # via kubernetes
 rich==15.0.0
     # via
     #   -r cookbook/data_labeling/image_search/requirements.in
     #   agno
-    #   chromadb
     #   rich-toolkit
     #   typer
 rich-toolkit==0.19.9
@@ -304,18 +197,12 @@ rich-toolkit==0.19.9
     #   fastapi-cloud-cli
 rignore==0.7.6
     # via fastapi-cloud-cli
-rpds-py==0.30.0
-    # via
-    #   jsonschema
-    #   referencing
 sentry-sdk==2.60.0
     # via fastapi-cloud-cli
 shellingham==1.5.4
     # via typer
 six==1.17.0
-    # via
-    #   kubernetes
-    #   python-dateutil
+    # via python-dateutil
 smmap==5.0.3
     # via gitdb
 sniffio==1.3.1
@@ -327,41 +214,26 @@ sqlalchemy==2.0.49
 starlette==1.0.0
     # via fastapi
 tenacity==9.1.4
-    # via
-    #   chromadb
-    #   google-genai
-tokenizers==0.23.1
-    # via chromadb
-tqdm==4.67.3
-    # via
-    #   chromadb
-    #   huggingface-hub
+    # via google-genai
 typer==0.25.1
     # via
     #   agno
-    #   chromadb
     #   fastapi-cli
     #   fastapi-cloud-cli
-    #   huggingface-hub
 typing-extensions==4.15.0
     # via
     #   agno
-    #   aiosignal
     #   anyio
-    #   chromadb
     #   fastapi
     #   google-genai
-    #   grpcio
-    #   huggingface-hub
     #   openinference-instrumentation-agno
     #   opentelemetry-api
-    #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   psycopg
     #   pydantic
     #   pydantic-core
     #   pydantic-extra-types
-    #   referencing
     #   rich-toolkit
     #   sqlalchemy
     #   starlette
@@ -373,13 +245,11 @@ typing-inspection==0.4.2
     #   pydantic-settings
 urllib3==2.7.0
     # via
-    #   kubernetes
     #   requests
     #   sentry-sdk
 uvicorn==0.47.0
     # via
     #   agno
-    #   chromadb
     #   fastapi
     #   fastapi-cli
     #   fastapi-cloud-cli
@@ -387,8 +257,6 @@ uvloop==0.22.1
     # via uvicorn
 watchfiles==1.2.0
     # via uvicorn
-websocket-client==1.9.0
-    # via kubernetes
 websockets==16.0
     # via
     #   google-genai
@@ -398,5 +266,3 @@ wrapt==2.2.0
     #   openinference-instrumentation
     #   openinference-instrumentation-agno
     #   opentelemetry-instrumentation
-yarl==1.24.2
-    # via aiohttp

--- a/cookbook/data_labeling/image_search/settings.py
+++ b/cookbook/data_labeling/image_search/settings.py
@@ -2,28 +2,28 @@
 Settings for the image_search demo.
 
 Centralized so the rest of the code can stay short. Holds the image set
-(swap-in target for an S3 list later), tmp paths, and ingest tunables.
+(swap-in target for an S3 list later), Postgres URL, and ingest tunables.
 """
 
+import os
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
-
-# Data dir (gitignored). Holds the SQLite file and the Chroma collection.
-DATA_DIR = HERE / "data"
-DATA_DIR.mkdir(parents=True, exist_ok=True)
-
-SQLITE_PATH = DATA_DIR / "image_search.db"
-CHROMA_PATH = DATA_DIR / "chroma"
 PUBLIC_DIR = HERE / "public"
 
 # Models. Same family as the rest of the data_labeling cookbooks.
 EXTRACTOR_MODEL_ID = "gemini-3.5-flash"
 EMBEDDER_MODEL_ID = "gemini-embedding-001"
 
-# Vector + contents DB names.
+# Postgres + pgvector. Matches the credentials baked into
+# cookbook/scripts/run_pgvector.sh — override with DB_URL if you run your
+# own instance.
+DB_URL = os.getenv("DB_URL", "postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+# Vector + contents table names.
 KNOWLEDGE_NAME = "image_library"
-CHROMA_COLLECTION = "image_library"
+VECTOR_TABLE = "image_library_vectors"
+KNOWLEDGE_TABLE = "image_library_contents"
 
 # How many URLs to process concurrently inside the ingest workflow. Each
 # in-flight URL holds an httpx fetch + a Gemini vision call + an embedding


### PR DESCRIPTION
## Summary

Follow-up to #8035. Swaps the [`image_search`](../tree/ab/image-search-pgvector/cookbook/data_labeling/image_search) demo from `ChromaDb` + `SqliteDb` to `PgVector` + `PostgresDb` against the existing `agnohq/pgvector:18` container brought up by [`cookbook/scripts/run_pgvector.sh`](../tree/main/cookbook/scripts/run_pgvector.sh).

The original demo was patching two storage-layer bugs in the frontend:

- `tags` / `subjects` arrived as JSON-encoded strings from `/knowledge/search.meta_data` but as native arrays from `/knowledge/content.metadata` — ChromaDb stringifies list values, SQLite doesn't. The UI carried an `asArray()` helper to reconcile.
- ChromaDb's hybrid keyword branch uses `LIKE '%query%'` substring match, so `car` false-matched `carnivore` and `streetcar`. The UI had a `realKeywordHit()` heuristic (revert in this branch) to throw those out.

Both are storage-layer concerns, not UI concerns. PgVector handles them correctly out of the box: `to_tsvector(english, content)` + `websearch_to_tsquery(english, query)` with the English Snowball stemmer for keyword search, and JSONB metadata that round-trips as native lists. Both workarounds were deleted.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (README setup section, TEST_LOG addendum)
- [x] Examples and guides: this IS the cookbook example
- [x] Tested in clean environment — fresh ingest into pgvector, full query battery in TEST_LOG
- [ ] Tests added/updated — N/A, demo cookbook

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated — assisted by Claude Code

---

## Additional Notes

**What changed:**

- `requirements.in`: `-chromadb`, `+pgvector`, `+psycopg[binary]`
- `settings.py`: `CHROMA_PATH` / `SQLITE_PATH` → `DB_URL` (defaults to the `run_pgvector.sh` creds; override with `DB_URL` env var)
- `db.py`: `PostgresDb` + `PgVector(search_type=SearchType.hybrid)`
- `public/index.html`: deleted `asArray()` and the substring-keyword heuristic; score field renamed from `meta_data.rrf_score` → `meta_data.similarity_score`
- `public/index.html`: replaced the bare relative-score cutoff with `SCORE_FLOOR=0.30` + `MIN_SCORE_RATIO=0.5`. PgVector's hybrid score = `0.5 * cosine + 0.5 * ts_rank` (with default weights), so a perfect vector match alone caps at 0.5; anything below ~0.3 is vector-only noise. Queries without a real FTS hit fall through to the existing "Show N below threshold" tray rather than rendering misleading top matches
- `README.md`: setup adds a "start pgvector" step
- `TEST_LOG.md`: addendum captures the reindex + query battery against the new backend

**Search quality (full table in TEST_LOG):**

| Query        | Top score | Shown | Behaviour                                        |
|--------------|-----------|-------|--------------------------------------------------|
| `wildlife`   | 0.532     | 5     | coyote, bear, leopard, tiger cub, pelican        |
| `mountain`   | 0.696     | 8     | all mountain scenes                              |
| `coffee`     | 0.710     | 1     | just the macro beans                             |
| `car`        | 0.240     | 0     | no FTS hits — leopard `carnivore` gone (stemmer) |
| `anima`      | 0.243     | 0     | tsquery `anima` ≠ lexeme `anim`                  |
| `night city` | 0.259     | 0     | vector-only candidates → tray                    |

**`prefix_match=True` dead-end.** PgVector exposes a `prefix_match` constructor flag that appends `*` to each query term — but it routes through `websearch_to_tsquery`, which doesn't honour `:*` / `*` operators, so the flag is a silent no-op. Tried it, reverted it, documented in TEST_LOG so the next person doesn't repeat the experiment. A future improvement on the agno side could route `prefix_match=True` through `to_tsquery('term:*')` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)