### PR TITLE
chore: Release v2.6.9

### DIFF
--- a/cookbook/05_agent_os/google/gemini_3/data_labeling.py
+++ b/cookbook/05_agent_os/google/gemini_3/data_labeling.py
@@ -22,8 +22,8 @@ from typing import List, Literal, Optional
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
-from agno.tools.youtube import YouTubeTools
 from agno.os import AgentOS
+from agno.tools.youtube import YouTubeTools
 from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -125,27 +125,6 @@ _RESULT_DELTA_TYPES = (
 )
 
 
-def _summarize_thought(text: str, max_chars: int = 120) -> str:
-    """Collapse a multi-line ThoughtSummary into a single short log line.
-
-    Gemini's thought summaries usually start with a markdown heading
-    (`**Title**`) followed by paragraphs. Prefer the heading; fall back to
-    the first non-empty line. Truncate to keep terminal output readable.
-    """
-    text = text.strip()
-    if not text:
-        return ""
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        # Strip a leading "**Title**" marker if present.
-        if line.startswith("**") and line.endswith("**") and len(line) > 4:
-            line = line[2:-2].strip()
-        return line if len(line) <= max_chars else line[: max_chars - 1] + "…"
-    return ""
-
-
 @dataclass
 class GeminiInteractions(Model):
     """

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.6.8"
+version = "2.6.9"
 description = "The programming language for agentic software."
 requires-python = ">=3.7,<4"
 readme = "README.md"

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -1082,22 +1082,6 @@ class TestParseInteractionResponse:
         assert response.content == "Here is my answer."
         assert response.provider_data["thought_signature"] == "sig123"
 
-    def test_parse_thought_logs_summary_title(self):
-        """Each ThoughtStep should produce a Server-side reasoning: log line
-        with the summary title extracted (mirrors tool-call logging)."""
-        model = self._make_model()
-
-        mock_interaction = MagicMock()
-        mock_interaction.id = "interactions/thought-log"
-        mock_interaction.steps = [
-            self._make_thought_step("**Clarifying User Intent**\n\nThe request is vague..."),
-        ]
-        mock_interaction.usage = None
-
-        with patch("agno.models.google.gemini_interactions.log_info") as mock_log:
-            model._parse_provider_response(mock_interaction)
-        mock_log.assert_called_once_with("Server-side reasoning: Clarifying User Intent")
-
     def test_summarize_thought_truncates_and_strips_heading(self):
         from agno.models.google.gemini_interactions import _summarize_thought
 
@@ -1517,9 +1501,8 @@ class TestInvokeStream:
         )
         assert any(r.role == "assistant" for r in responses)
 
-    def test_invoke_stream_logs_reasoning_and_merges_thought_signature(self):
-        """Streaming should log each DeltaThoughtSummary's title and merge
-        thought_signature into provider_data without clobbering siblings."""
+    def test_invoke_stream_merges_thought_signature(self):
+        """thought_signature must merge into provider_data without clobbering siblings."""
         from agno.models.google.gemini_interactions import (
             DeltaThoughtSignature,
             DeltaThoughtSummary,
@@ -1552,11 +1535,7 @@ class TestInvokeStream:
 
         mock_client.interactions.create.return_value = iter([summary_evt, sig_evt])
 
-        with patch("agno.models.google.gemini_interactions.log_info") as mock_log:
-            responses = list(model.invoke_stream([Message(role="user", content="hi")], Message(role="assistant")))
-        mock_log.assert_any_call("Server-side reasoning: Clarifying User Intent")
-        # provider_data on the signature chunk must include thought_signature
-        # without clobbering keys (the merge regression we fixed).
+        responses = list(model.invoke_stream([Message(role="user", content="hi")], Message(role="assistant")))
         sig_responses = [r for r in responses if r.provider_data and "thought_signature" in r.provider_data]
         assert sig_responses
         assert sig_responses[0].provider_data["thought_signature"] == "sig-abc"

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -1082,18 +1082,6 @@ class TestParseInteractionResponse:
         assert response.content == "Here is my answer."
         assert response.provider_data["thought_signature"] == "sig123"
 
-    def test_summarize_thought_truncates_and_strips_heading(self):
-        from agno.models.google.gemini_interactions import _summarize_thought
-
-        assert _summarize_thought("**Locating Initial Data**\n\nbody") == "Locating Initial Data"
-        # No heading: first non-empty line wins.
-        assert _summarize_thought("\n\nLet me think\n\nMore...") == "Let me think"
-        # Long line is truncated with ellipsis.
-        long = "x" * 300
-        out = _summarize_thought(long, max_chars=50)
-        assert len(out) == 50
-        assert out.endswith("…")
-
     def test_parse_usage_metrics(self):
         model = self._make_model()
 


### PR DESCRIPTION
# Changelog

## New Features:

- **Approvals - Resolved Approval in Post-Hooks:** Post-hooks and observability integrations can now read the full resolved approval record (`resolved_by`, `resolved_at`, etc.) via `run_response.metadata["approval"]`. Previously only `status` and `resolution_data` were exposed. Lives in `metadata` so it works uniformly across `RunOutput` / `TeamRunOutput` / future `WorkflowRunOutput`. (#7366, #8032)

## Improvements:

- **PgVector - prefix_match=True actually works:** `PgVector(prefix_match=True)` was a silent no-op - it appended `*` then routed through `websearch_to_tsquery`, which ignores wildcards. Now routes through `to_tsquery('tok:*')` with proper tokenization, so partial queries like `"ani"` FTS-match `"animal"` as documented. New cookbook `cookbook/07_knowledge/04_advanced/06_prefix_search.py` shows the help-center typeahead use case. (#8048, #8051, #8052)
- **PgVector - empty-tsquery fallback robustness:** Replaced the `to_tsquery(language, '')` fallback with a literal `''::tsquery` cast so behavior no longer depends on the parser tolerating empty input. (#8053)
- **Claude variants - temperature/top_p/top_k = 0 honored:** Anthropic, AWS, and VertexAI Claude variants were silently dropping `0.0` values due to bare truthiness checks. Switched to `is not None` so deterministic output works as intended. (#8009, fixes #8004)
- **Calendar & Gmail context providers - clean instruction layering:** Trimmed `DEFAULT_READ_INSTRUCTIONS` / `DEFAULT_WRITE_INSTRUCTIONS` from 157 lines to 27 by removing content already supplied by the toolkit-side instructions. Provider now owns role + safety; toolkit owns the technical reference. (#7982)
- **decision_log - drop deprecated `datetime.utcnow()`:** Replaced with `datetime.now(timezone.utc)` to clear the Python 3.12 deprecation warning. (Closes #8030)
- **Chonkie:** Bumped to `>=1.6.7` to pick up the upstream language auto-detection fix; removed the temporary test workarounds from #7904. (#8012)

## Bug Fixes:

- **GeminiInteractions - server-side tool calls leaking onto the agent path:** On the agent path (Antigravity, Deep Research), `FunctionCallStep`s describe tools the autonomous loop runs inside the server-managed sandbox. Previously we surfaced them as local `tool_calls`, leading to `Function <name> not found` and follow-up `400 invalid_request` errors. Gated the `FunctionCallStep` branch on `self.agent is None` for both streaming and non-streaming. Model path with user-declared tools is unchanged. (#8045)
- **Claude (Anthropic / AWS / VertexAI) - `temperature=0` silently dropped:** See Improvements. Every prior release silently fell back to API defaults (~1.0) when callers explicitly set `0`. (#8009, fixes #8004)
