### PR TITLE
[fix] Sanitize member HITL continuation results

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5222,12 +5222,27 @@ async def _aroute_requirements_to_members_stream(
             req._member_run_response = None
 
 
+_INTERNAL_MEMBER_RESULT_MARKERS = (
+    "member with id",
+    "could not route requirement",
+    "task completed (no final output)",
+    "streaming did not yield a final runoutput",
+    "requires human input before continuing",
+)
+
+
+def _is_internal_member_result(member_result: str) -> bool:
+    normalized_result = member_result.lower()
+    return any(marker in normalized_result for marker in _INTERNAL_MEMBER_RESULT_MARKERS)
+
+
 def _build_continuation_message(member_results: List[str]) -> str:
     """Build a user message from member results to feed back into the team model."""
-    if not member_results:
+    user_facing_results = [result for result in member_results if not _is_internal_member_result(result)]
+    if not user_facing_results:
         return "The delegated task has been completed."
     parts = ["Member results after human-in-the-loop resolution:"]
-    parts.extend(member_results)
+    parts.extend(user_facing_results)
     return "\n".join(parts)
 
 

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -366,6 +366,35 @@ class TestBuildContinuationMessage:
         assert "Result 1" in msg
         assert "Result 2" in msg
 
+    def test_filters_internal_member_results(self):
+        from agno.team._run import _build_continuation_message
+
+        msg = _build_continuation_message(
+            [
+                "[send_message]: Could not route requirement - member not found",
+                "[Telegram Agent]: message_id: 166",
+            ]
+        )
+
+        assert "Telegram Agent" in msg
+        assert "message_id: 166" in msg
+        assert "Could not route requirement" not in msg
+        assert "member not found" not in msg
+
+    def test_all_internal_member_results_get_generic_message(self):
+        from agno.team._run import _build_continuation_message
+
+        msg = _build_continuation_message(
+            [
+                "[send_message]: Member with ID send_message not found in the team or any subteams",
+                "[Sender]: Task completed (no final output)",
+            ]
+        )
+
+        assert msg == "The delegated task has been completed."
+        assert "Member with ID" not in msg
+        assert "Task completed (no final output)" not in msg
+
 
 # ===========================================================================
 # 6. Chained HITL: newly propagated requirements are preserved
@@ -798,6 +827,30 @@ class TestPrepareMemberHitlContinuation:
         _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
 
         assert "Done" in tool.result
+
+    def test_sanitizes_internal_member_results_in_tool_message(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(
+            run_response,
+            run_messages,
+            [
+                "[send_message]: Member with ID send_message not found in the team or any subteams",
+                "[Telegram Agent]: message_id: 166",
+            ],
+        )
+
+        assert "message_id: 166" in tool.result
+        assert "Member with ID" not in tool.result
+        assert "Member with ID" not in run_messages.messages[0].content
 
     def test_resets_run_state(self):
         from agno.team._run import _prepare_member_hitl_continuation


### PR DESCRIPTION
## Summary

Fixes #7966.

- Filters internal member HITL routing/status strings from continuation messages before they are written back to the delegate tool result and run message.
- Preserves real member output in the continuation message and falls back to the existing generic completion message when every collected member result is internal.

(If applicable, issue number: #7966)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Duplicate check: searched open PRs for `#7966` and HITL continuation/member-result terms before opening this PR.

Targeted validation run locally:

- `uv run --no-project --with pytest --with pytest-asyncio --with docstring-parser --with gitpython --with 'httpx[http2]' --with packaging --with pydantic-settings --with pydantic --with python-dotenv --with python-multipart --with pyyaml --with rich --with typer --with typing-extensions --with sqlalchemy --with aiosqlite --with greenlet python -m pytest libs/agno/tests/unit/team/test_continue_run_requirements.py -q`
- `uv run --no-project --with ruff ruff format --check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py`
- `uv run --no-project --with ruff ruff check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py`

Full project scripts were not run because project-level `uv run --project libs/agno ...` dependency resolution currently fails before tests are invoked due conflicting optional dependency constraints around `httpx`.
