### PR TITLE
[cookbook] Fix Google Calendar spelling

### DIFF
--- a/cookbook/91_tools/googlecalendar_tools.py
+++ b/cookbook/91_tools/googlecalendar_tools.py
@@ -1,7 +1,7 @@
 """
 Steps to get the Google OAuth Credentials (Reference : https://developers.google.com/calendar/api/quickstart/python)
 
-1. Enable Google Calender API
+1. Enable Google Calendar API
     - Go To https://console.cloud.google.com/apis/enableflow?apiid=calendar-json.googleapis.com
     - Select Project and Enable The API
 
@@ -15,7 +15,7 @@ Steps to get the Google OAuth Credentials (Reference : https://developers.google
 
 5. Select Scope
     - Click on Add or Remove Scope
-    - Search for Google Calender API (Make Sure you've enabled Google calender API otherwise scopes wont be visible)
+    - Search for Google Calendar API (Make Sure you've enabled Google calendar API otherwise scopes wont be visible)
     - Select Scopes Accordingly
         - From the dropdown check on /auth/calendar scope
     - Save and Continue
@@ -36,8 +36,8 @@ Steps to get the Google OAuth Credentials (Reference : https://developers.google
     - Select Application Type as Desktop app
     - Download JSON
 
-8. Using Google Calender Tool
-    - Pass the Path of downloaded credentials as credentials_path to Google Calender tool
+8. Using Google Calendar Tool
+    - Pass the Path of downloaded credentials as credentials_path to Google Calendar tool
 """
 
 from agno.agent import Agent


### PR DESCRIPTION
﻿## Summary

Fixes the spelling of "Google Calendar" in the Google Calendar cookbook setup instructions.

Closes #8046

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: cookbook documentation typo

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed:

- `rg -n -i "\\bcalender\\b" . --glob '!**/.git/**' --glob '!**/.venv/**' --glob '!**/node_modules/**'`
- `python -m compileall -q cookbook/91_tools/googlecalendar_tools.py`
- `git diff --check`

I did not run `./scripts/format.sh` or `./scripts/validate.sh` locally because `uv` and `ruff` are not installed in this environment. This PR only updates user-facing text in a cookbook docstring.

This PR was prepared with Codex assistance and the diff/validation were reviewed before submission.
