### PR TITLE
fix: preserve CSV row boundaries in async reader

### DIFF
--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -169,7 +169,7 @@ class CSVReader(Reader):
 
             if total_rows <= 10:
                 # Small files: single document
-                csv_content = " ".join(", ".join(stringify_cell_value(cell) for cell in row) for row in rows)
+                csv_content = "\n".join(", ".join(stringify_cell_value(cell) for cell in row) for row in rows)
                 documents = [
                     Document(
                         name=csv_name,
@@ -186,7 +186,7 @@ class CSVReader(Reader):
                 async def _process_page(page_number: int, page_rows: List[List[str]]) -> Document:
                     """Process a page of rows into a document."""
                     start_row = (page_number - 1) * page_size + 1
-                    page_content = " ".join(", ".join(stringify_cell_value(cell) for cell in row) for row in page_rows)
+                    page_content = "\n".join(", ".join(stringify_cell_value(cell) for cell in row) for row in page_rows)
 
                     return Document(
                         name=csv_name,

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -137,10 +137,16 @@ def test_read_with_chunking(csv_reader, csv_file):
 async def test_async_read_path(csv_reader, csv_file):
     documents = await csv_reader.async_read(csv_file)
 
-    assert len(documents) == 1
+    assert len(documents) == 4
     assert documents[0].name == "test"
     assert documents[0].id.endswith("_1")
-    assert documents[0].content == "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago"
+    assert [document.content for document in documents] == [
+        "name, age, city",
+        "John, 30, New York",
+        "Jane, 25, San Francisco",
+        "Bob, 40, Chicago",
+    ]
+    assert [document.meta_data["row_number"] for document in documents] == [1, 2, 3, 4]
 
 
 @pytest.fixture
@@ -167,7 +173,20 @@ row10,39,City10"""
 async def test_async_read_multi_page_csv(csv_reader, multi_page_csv_file):
     documents = await csv_reader.async_read(multi_page_csv_file, page_size=5)
 
-    assert len(documents) == 3
+    assert len(documents) == 11
+    assert [document.content for document in documents] == [
+        "name, age, city",
+        "row1, 30, City1",
+        "row2, 31, City2",
+        "row3, 32, City3",
+        "row4, 33, City4",
+        "row5, 34, City5",
+        "row6, 35, City6",
+        "row7, 36, City7",
+        "row8, 37, City8",
+        "row9, 38, City9",
+        "row10, 39, City10",
+    ]
 
     # Check first page
     assert documents[0].name == "multi_page"
@@ -177,16 +196,16 @@ async def test_async_read_multi_page_csv(csv_reader, multi_page_csv_file):
     assert documents[0].meta_data["rows"] == 5
 
     # Check second page
-    assert documents[1].id is not None and isinstance(documents[1].id, str)
-    assert documents[1].meta_data["page"] == 2
-    assert documents[1].meta_data["start_row"] == 6
-    assert documents[1].meta_data["rows"] == 5
+    assert documents[5].id is not None and isinstance(documents[5].id, str)
+    assert documents[5].meta_data["page"] == 2
+    assert documents[5].meta_data["start_row"] == 6
+    assert documents[5].meta_data["rows"] == 5
 
     # Check third page
-    assert documents[2].id is not None and isinstance(documents[2].id, str)
-    assert documents[2].meta_data["page"] == 3
-    assert documents[2].meta_data["start_row"] == 11
-    assert documents[2].meta_data["rows"] == 1
+    assert documents[10].id is not None and isinstance(documents[10].id, str)
+    assert documents[10].meta_data["page"] == 3
+    assert documents[10].meta_data["start_row"] == 11
+    assert documents[10].meta_data["rows"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Preserve CSV row boundaries in `CSVReader.async_read()` by joining async row content with newlines in both the small-file and paginated paths, matching `CSVReader.read()`.

This keeps the default `RowChunking()` behavior row-aware for async CSV ingestion and prevents flattened rows from becoming oversized embedding inputs.

Issue number: #8023

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed on Windows with the repository's batch scripts/equivalent changed-file format checks:

- `python -m pytest libs/agno/tests/unit/reader/test_csv_reader.py -q`
- `ruff format libs/agno/agno/knowledge/reader/csv_reader.py libs/agno/tests/unit/reader/test_csv_reader.py`
- `ruff check --select I --fix libs/agno/agno/knowledge/reader/csv_reader.py libs/agno/tests/unit/reader/test_csv_reader.py`
- `libs/agno/scripts/validate.bat`

Duplicate check performed with open PR searches for `CSVReader async_read` and `CSVReader async_read RowChunking`; no existing open PR matched this fix.

Docs/examples are not updated because this is an internal correctness fix for existing CSV reader behavior, with no public API change.