### PR TITLE
cookbook: add pgvector prefix_match example and improved comments

### DIFF
--- a/cookbook/07_knowledge/04_advanced/06_prefix_search.py
+++ b/cookbook/07_knowledge/04_advanced/06_prefix_search.py
@@ -1,0 +1,111 @@
+"""
+Prefix Search: Help Center with search-as-you-type
+===================================================
+Real-world use case: A help center where users search for articles
+while typing, getting instant results for partial words.
+
+Example: User types "auth" and immediately sees articles about
+"authentication", "authorization", "authenticator app", etc.
+
+Without prefix_match: User must type complete words to get matches.
+With prefix_match=True: Partial words match, enabling typeahead search.
+"""
+
+from agno.knowledge.document import Document
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.vectordb.pgvector import PgVector
+from agno.vectordb.search import SearchType
+
+# ---------------------------------------------------------------------------
+# Setup: Help Center knowledge base with prefix matching
+# ---------------------------------------------------------------------------
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+
+# Help center with prefix search enabled for typeahead
+help_center = PgVector(
+    table_name="help_center_articles",
+    db_url=db_url,
+    search_type=SearchType.hybrid,
+    prefix_match=True,  # enables search-as-you-type
+    embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+)
+
+# Same database without prefix matching (for comparison)
+help_center_standard = PgVector(
+    table_name="help_center_articles",
+    db_url=db_url,
+    search_type=SearchType.hybrid,
+    prefix_match=False,  # default - exact word match only
+    embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+)
+
+# ---------------------------------------------------------------------------
+# Sample help articles
+# ---------------------------------------------------------------------------
+
+help_articles = [
+    Document(
+        name="auth-setup",
+        content="Setting up authentication: Configure two-factor authentication (2FA) "
+        "using an authenticator app like Google Authenticator or Authy.",
+    ),
+    Document(
+        name="auth-troubleshoot",
+        content="Authentication troubleshooting: Common issues with login, "
+        "password reset, and authentication token expiration.",
+    ),
+    Document(
+        name="authorization",
+        content="Authorization and permissions: How to configure role-based access "
+        "control (RBAC) and manage user authorization levels.",
+    ),
+    Document(
+        name="api-keys",
+        content="API key management: Generate, rotate, and revoke API keys "
+        "for programmatic access to your account.",
+    ),
+    Document(
+        name="billing",
+        content="Billing and payments: Update payment methods, view invoices, "
+        "and manage your subscription plan.",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Demo: Simulate user typing "auth" in search box
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Setup
+    help_center.create()
+    help_center.upsert(documents=help_articles, content_hash="v1")
+
+    print("=" * 60)
+    print("Help Center Search Demo")
+    print("=" * 60)
+
+    # Simulate user typing progressively
+    search_queries = ["au", "auth", "authent"]
+
+    for query in search_queries:
+        print(f"\nUser types: '{query}'")
+        print("-" * 40)
+
+        # Without prefix matching
+        print("Standard search (prefix_match=False):")
+        results = help_center_standard.search(query, limit=2)
+        for doc in results:
+            score = doc.meta_data.get("similarity_score", 0)
+            print(f"  [{score:.2f}] {doc.name}: {doc.content[:40]}...")
+
+        # With prefix matching
+        print("\nTypeahead search (prefix_match=True):")
+        results = help_center.search(query, limit=2)
+        for doc in results:
+            score = doc.meta_data.get("similarity_score", 0)
+            print(f"  [{score:.2f}] {doc.name}: {doc.content[:40]}...")
+
+    print("\n" + "=" * 60)
+    print("prefix_match=True finds 'authentication' when user types 'auth'")
+    print("=" * 60)

--- a/cookbook/07_knowledge/04_advanced/README.md
+++ b/cookbook/07_knowledge/04_advanced/README.md
@@ -5,8 +5,9 @@ Advanced knowledge patterns for power users and custom integrations.
 ## Prerequisites
 
 1. Run Qdrant: `./cookbook/scripts/run_qdrant.sh`
-2. Set `OPENAI_API_KEY` environment variable
-3. For Graph RAG: `pip install lightrag-agno`
+2. Run PgVector (for prefix search): `./cookbook/scripts/run_pgvector.sh`
+3. Set `OPENAI_API_KEY` environment variable
+4. For Graph RAG: `pip install lightrag-agno`
 
 ## Examples
 
@@ -17,6 +18,7 @@ Advanced knowledge patterns for power users and custom integrations.
 | [03_graph_rag.py](./03_graph_rag.py) | LightRAG knowledge graph integration |
 | [04_knowledge_tools.py](./04_knowledge_tools.py) | KnowledgeTools: think, search, analyze |
 | [05_knowledge_protocol.py](./05_knowledge_protocol.py) | Custom KnowledgeProtocol implementation |
+| [06_prefix_search.py](./06_prefix_search.py) | PgVector prefix matching for search-as-you-type |
 
 ## Running
 

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -1090,19 +1090,24 @@ class PgVector(VectorDb):
                 self.table.c.usage,
             ]
 
-            # Build the text search vector
+            # === TEXT SEARCH COMPONENT ===
+            # Hybrid search combines: (1) text/keyword matching + (2) vector similarity
+
+            # ts_vector: convert document content into searchable tokens
+            # Example: "The quick fox" -> 'fox':3 'quick':2 (stems words, removes stopwords)
             ts_vector = func.to_tsvector(self.content_language, self.table.c.content)
-            # Build the ts_query — routes through to_tsquery with :* per token
-            # when prefix_match is on, websearch_to_tsquery otherwise.
+
+            # ts_query: convert user's search query into a search pattern
+            # Routes through to_tsquery with :* per token when prefix_match is on,
+            # websearch_to_tsquery otherwise
             ts_query = self._build_ts_query(query)
             if ts_query is None:
-                # Prefix mode with no usable tokens (e.g. empty query): fall back
-                # to an empty tsquery literal that ranks 0 everywhere, so hybrid
-                # scoring degrades to pure vector ranking. Using the literal cast
-                # avoids depending on to_tsquery's tolerance for empty input.
+                # No usable tokens (e.g. query was "!@#$" or empty)
+                # Fall back to empty tsquery so text_rank=0, letting vector search drive results
                 ts_query = literal_column("''::tsquery")
-            # Compute the text rank, normalized to [0, 1] range
-            # ts_rank_cd returns small values (0.0-0.1), so we normalize using x/(x+k)
+
+            # text_rank: score how well document matches the query (0.0 to 1.0)
+            # ts_rank_cd returns small values (0.0-0.1), normalize with x/(x+k) formula
             raw_text_rank = func.ts_rank_cd(ts_vector, ts_query)
             text_rank = raw_text_rank / (raw_text_rank + 0.1)
 

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -940,26 +940,28 @@ class PgVector(VectorDb):
         """
         Build the tsquery expression for keyword / hybrid search.
 
-        When ``prefix_match`` is False (default) we use
-        ``websearch_to_tsquery``, which accepts free-form natural language
-        and supports AND/OR/quoted-phrases/-negation. When ``prefix_match``
-        is True we tokenize on word boundaries and build a ``to_tsquery``
-        expression with ``:*`` per token — that lets a partial query like
-        ``"ani"`` match the ``anim`` lexeme that ``"animal"`` lemmatizes
-        into.
+        Args:
+            query (str): The search query string.
 
-        Returns ``None`` for a query that doesn't yield any usable tokens
-        in prefix mode (caller should treat as "no FTS hit").
+        Returns:
+            A SQLAlchemy func expression for the tsquery, or None if prefix_match=True
+            and the query yields no usable tokens (caller should treat as "no FTS hit").
         """
+        # Default mode: use websearch_to_tsquery for natural language queries
+        # Supports AND/OR/phrases but does not support prefix matching
         if not self.prefix_match:
             return func.websearch_to_tsquery(self.content_language, bindparam("query", value=query))
 
-        # to_tsquery is stricter than websearch_to_tsquery: it doesn't
-        # tolerate punctuation or operators in the input. Tokenize on
-        # word boundaries, append :* per token, AND them.
+        # Prefix mode: use to_tsquery with :* suffix for partial word matching
+        # Example: "ani" becomes "ani:*" which matches "animal", "animation", etc.
+
+        # Extract word tokens only — to_tsquery errors on punctuation like & | -
         tokens = re.findall(r"\w+", query)
         if not tokens:
             return None
+
+        # Build tsquery string: join tokens with & (AND) and append :* for prefix match
+        # Example: ["wild", "san"] becomes "wild:* & san:*"
         prefix_query = " & ".join(f"{t}:*" for t in tokens)
         return func.to_tsquery(self.content_language, bindparam("query", value=prefix_query))
 
@@ -1090,17 +1092,24 @@ class PgVector(VectorDb):
                 self.table.c.usage,
             ]
 
-            # Build the text search vector
+            # === TEXT SEARCH COMPONENT ===
+            # Hybrid search combines: (1) text/keyword matching + (2) vector similarity
+            # This section builds the text search part
+
+            # ts_vector: convert document content into searchable tokens
+            # Example: "The quick fox" -> 'fox':3 'quick':2 (stems words, removes stopwords)
             ts_vector = func.to_tsvector(self.content_language, self.table.c.content)
-            # Build the ts_query — routes through to_tsquery with :* per token
-            # when prefix_match is on, websearch_to_tsquery otherwise.
+
+            # ts_query: convert user's search query into a search pattern
+            # Uses _build_ts_query which picks the right PostgreSQL function based on prefix_match
             ts_query = self._build_ts_query(query)
             if ts_query is None:
-                # Prefix mode with no usable tokens (e.g. empty query): fall back
-                # to pure vector search by building a tsquery that never matches.
+                # No usable tokens (e.g. query was "!@#$" or empty)
+                # Use empty tsquery so text_rank=0, letting vector search handle results alone
                 ts_query = func.to_tsquery(self.content_language, bindparam("query", value=""))
-            # Compute the text rank, normalized to [0, 1] range
-            # ts_rank_cd returns small values (0.0-0.1), so we normalize using x/(x+k)
+
+            # text_rank: score how well document matches the query (0.0 to 1.0)
+            # ts_rank_cd returns small values (0.0-0.1), normalize with x/(x+k) formula
             raw_text_rank = func.ts_rank_cd(ts_vector, ts_query)
             text_rank = raw_text_rank / (raw_text_rank + 0.1)
 

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -1204,7 +1204,6 @@ def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, moc
     """
     from pgvector.sqlalchemy import Vector as RealVector
     from sqlalchemy import Column, MetaData, String, Table
-    from sqlalchemy.dialects import postgresql
 
     metadata = MetaData()
     real_table = Table(

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -1128,3 +1128,43 @@ def test_keyword_search_returns_empty_on_no_usable_tokens(mock_engine, mock_embe
         assert results == []
         # Session was never opened — we short-circuited before any DB work.
         db.Session.assert_not_called()
+
+
+def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, mock_embedder):
+    """hybrid_search uses empty tsquery fallback when prefix_match strips all tokens.
+
+    Unlike keyword_search which returns [], hybrid_search still runs because
+    the vector similarity branch can return results even without text matches.
+    """
+    with (
+        patch("agno.vectordb.pgvector.pgvector.inspect"),
+        patch("agno.vectordb.pgvector.pgvector.scoped_session") as mock_scoped_session,
+        patch("agno.vectordb.pgvector.pgvector.Vector"),
+        patch.object(PgVector, "get_table", return_value=MagicMock()),
+    ):
+        db = PgVector(
+            table_name="test_hybrid_fallback",
+            db_engine=mock_engine,
+            embedder=mock_embedder,
+            prefix_match=True,
+        )
+
+        # Mock the session to return empty results
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.begin.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.begin.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.execute.return_value.fetchall.return_value = []
+        mock_scoped_session.return_value.return_value = mock_session
+
+        # Mock embedder to return a valid embedding
+        mock_embedder.get_embedding.return_value = [0.1] * 1024
+
+        # Query with no usable tokens — should still call embedder and run query
+        results = db.hybrid_search("!@#$")
+
+        # Embedder was called — vector search still runs
+        mock_embedder.get_embedding.assert_called_once_with("!@#$")
+        # Results returned (empty in this mock, but query executed)
+        assert results == []

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -1192,3 +1192,64 @@ def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine, mo
     sql = captured.get("sql", "")
     assert "''::tsquery" in sql, f"expected empty tsquery literal in SQL, got: {sql}"
     assert "to_tsquery(" not in sql, f"fallback should not call to_tsquery, got: {sql}"
+
+
+def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, mock_embedder):
+    """hybrid_search still computes embeddings when prefix_match strips all tokens.
+
+    Unlike keyword_search which returns [] immediately, hybrid_search proceeds
+    because the vector similarity branch can return results even without text matches.
+    This test verifies the embedder is called (vector path runs) even when the
+    text search component has no usable tokens.
+    """
+    from pgvector.sqlalchemy import Vector as RealVector
+    from sqlalchemy import Column, MetaData, String, Table
+    from sqlalchemy.dialects import postgresql
+
+    metadata = MetaData()
+    real_table = Table(
+        "test_hybrid_vector_fallback",
+        metadata,
+        Column("id", String, primary_key=True),
+        Column("name", String),
+        Column("meta_data", String),
+        Column("content", String),
+        Column("embedding", RealVector(3)),
+        Column("usage", String),
+    )
+
+    with (
+        patch("agno.vectordb.pgvector.pgvector.inspect"),
+        patch("agno.vectordb.pgvector.pgvector.scoped_session"),
+        patch.object(PgVector, "get_table", return_value=real_table),
+    ):
+        db = PgVector(
+            table_name="test_hybrid_vector_fallback",
+            db_engine=mock_engine,
+            embedder=mock_embedder,
+            prefix_match=True,
+        )
+
+        mock_embedder.get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+        class _SessionCtx:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return False
+
+            def begin(self_inner):
+                return self_inner
+
+            def execute(self_inner, stmt):
+                result = MagicMock()
+                result.fetchall.return_value = []
+                return result
+
+        db.Session = MagicMock(return_value=_SessionCtx())
+        results = db.hybrid_search("!@#$")
+
+        # Embedder was called — vector search still runs even with no text tokens
+        mock_embedder.get_embedding.assert_called_once_with("!@#$")
+        assert results == []

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -1194,7 +1194,7 @@ def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine, mo
     assert "to_tsquery(" not in sql, f"fallback should not call to_tsquery, got: {sql}"
 
 
-def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, mock_embedder):
+def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine):
     """hybrid_search still computes embeddings when prefix_match strips all tokens.
 
     Unlike keyword_search which returns [] immediately, hybrid_search proceeds
@@ -1204,6 +1204,10 @@ def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, moc
     """
     from pgvector.sqlalchemy import Vector as RealVector
     from sqlalchemy import Column, MetaData, String, Table
+
+    # Create a local embedder mock to avoid mutating the session-scoped fixture
+    local_embedder = MagicMock()
+    local_embedder.get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     metadata = MetaData()
     real_table = Table(
@@ -1225,11 +1229,9 @@ def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, moc
         db = PgVector(
             table_name="test_hybrid_vector_fallback",
             db_engine=mock_engine,
-            embedder=mock_embedder,
+            embedder=local_embedder,
             prefix_match=True,
         )
-
-        mock_embedder.get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
         class _SessionCtx:
             def __enter__(self_inner):
@@ -1250,5 +1252,5 @@ def test_hybrid_search_falls_back_to_vector_on_no_usable_tokens(mock_engine, moc
         results = db.hybrid_search("!@#$")
 
         # Embedder was called — vector search still runs even with no text tokens
-        mock_embedder.get_embedding.assert_called_once_with("!@#$")
+        local_embedder.get_embedding.assert_called_once_with("!@#$")
         assert results == []

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -1130,7 +1130,7 @@ def test_keyword_search_returns_empty_on_no_usable_tokens(mock_engine, mock_embe
         db.Session.assert_not_called()
 
 
-def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine, mock_embedder):
+def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine):
     """When prefix_match strips all tokens, hybrid_search falls back to ``''::tsquery``.
 
     Verified by compiling the SELECT statement that hybrid_search hands to the
@@ -1140,6 +1140,10 @@ def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine, mo
     from pgvector.sqlalchemy import Vector as RealVector
     from sqlalchemy import Column, MetaData, String, Table
     from sqlalchemy.dialects import postgresql
+
+    # Create a local embedder mock to avoid mutating the session-scoped fixture
+    local_embedder = MagicMock()
+    local_embedder.get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     # Build a real Table so SQLAlchemy can compile the SELECT hybrid_search produces.
     metadata = MetaData()
@@ -1162,11 +1166,9 @@ def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine, mo
         db = PgVector(
             table_name="test_hybrid_empty",
             db_engine=mock_engine,
-            embedder=mock_embedder,
+            embedder=local_embedder,
             prefix_match=True,
         )
-
-        mock_embedder.get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
         captured = {}
 


### PR DESCRIPTION
## Summary

Follow-up to #8048 (prefix_match fix). Adds documentation and testing improvements:

- **Cookbook** (`cookbook/07_knowledge/04_advanced/06_prefix_search.py`): Real-world help center typeahead demo showing `prefix_match=True` vs `False` — user types "au" and gets articles about "authentication"
- **Improved comments** in `_build_ts_query()` with Args/Returns format and explanation of text search component in `hybrid_search()`
- **Test coverage** for `hybrid_search` empty-token fallback path (when prefix_match strips all tokens, vector search still runs)

## Type of change

- [x] Documentation / cookbook
- [x] Test coverage improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Cookbook tested locally with PgVector

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated — assisted by Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)