### PR TITLE
fix(pgvector): use literal empty tsquery for hybrid_search fallback

### DIFF
--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -14,7 +14,7 @@ try:
     from sqlalchemy.orm import Session, scoped_session, sessionmaker
     from sqlalchemy.schema import Column, Index, MetaData, Table
     from sqlalchemy.sql.elements import ColumnElement
-    from sqlalchemy.sql.expression import bindparam, desc, func, select, text
+    from sqlalchemy.sql.expression import bindparam, desc, func, literal_column, select, text
     from sqlalchemy.types import DateTime, Integer, String
 
 except ImportError:
@@ -1097,8 +1097,10 @@ class PgVector(VectorDb):
             ts_query = self._build_ts_query(query)
             if ts_query is None:
                 # Prefix mode with no usable tokens (e.g. empty query): fall back
-                # to pure vector search by building a tsquery that never matches.
-                ts_query = func.to_tsquery(self.content_language, bindparam("query", value=""))
+                # to an empty tsquery literal that ranks 0 everywhere, so hybrid
+                # scoring degrades to pure vector ranking. Using the literal cast
+                # avoids depending on to_tsquery's tolerance for empty input.
+                ts_query = literal_column("''::tsquery")
             # Compute the text rank, normalized to [0, 1] range
             # ts_rank_cd returns small values (0.0-0.1), so we normalize using x/(x+k)
             raw_text_rank = func.ts_rank_cd(ts_vector, ts_query)

--- a/libs/agno/tests/unit/vectordb/test_pgvector.py
+++ b/libs/agno/tests/unit/vectordb/test_pgvector.py
@@ -1128,3 +1128,67 @@ def test_keyword_search_returns_empty_on_no_usable_tokens(mock_engine, mock_embe
         assert results == []
         # Session was never opened — we short-circuited before any DB work.
         db.Session.assert_not_called()
+
+
+def test_hybrid_search_empty_token_fallback_uses_tsquery_literal(mock_engine, mock_embedder):
+    """When prefix_match strips all tokens, hybrid_search falls back to ``''::tsquery``.
+
+    Verified by compiling the SELECT statement that hybrid_search hands to the
+    session — the literal cast sidesteps any ``to_tsquery`` parser strictness
+    around empty input.
+    """
+    from pgvector.sqlalchemy import Vector as RealVector
+    from sqlalchemy import Column, MetaData, String, Table
+    from sqlalchemy.dialects import postgresql
+
+    # Build a real Table so SQLAlchemy can compile the SELECT hybrid_search produces.
+    metadata = MetaData()
+    real_table = Table(
+        "test_hybrid_empty",
+        metadata,
+        Column("id", String, primary_key=True),
+        Column("name", String),
+        Column("meta_data", String),
+        Column("content", String),
+        Column("embedding", RealVector(3)),
+        Column("usage", String),
+    )
+
+    with (
+        patch("agno.vectordb.pgvector.pgvector.inspect"),
+        patch("agno.vectordb.pgvector.pgvector.scoped_session"),
+        patch.object(PgVector, "get_table", return_value=real_table),
+    ):
+        db = PgVector(
+            table_name="test_hybrid_empty",
+            db_engine=mock_engine,
+            embedder=mock_embedder,
+            prefix_match=True,
+        )
+
+        mock_embedder.get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+        captured = {}
+
+        class _SessionCtx:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, *exc):
+                return False
+
+            def begin(self_inner):
+                return self_inner
+
+            def execute(self_inner, stmt):
+                captured["sql"] = str(stmt.compile(dialect=postgresql.dialect()))
+                result = MagicMock()
+                result.fetchall.return_value = []
+                return result
+
+        db.Session = MagicMock(return_value=_SessionCtx())
+        db.hybrid_search("!@#$")
+
+    sql = captured.get("sql", "")
+    assert "''::tsquery" in sql, f"expected empty tsquery literal in SQL, got: {sql}"
+    assert "to_tsquery(" not in sql, f"fallback should not call to_tsquery, got: {sql}"


### PR DESCRIPTION
## Summary

Follow-up to #8048. The hybrid_search fallback for prefix-mode queries with no usable tokens (empty/symbol-only input) previously built `to_tsquery(language, '')`, which depends on the tsquery parser tolerating empty input. That is undocumented behavior and can shift between Postgres versions and text-search configurations.

Replace the fallback with a literal `''::tsquery` cast via `literal_column`. This is guaranteed to be a valid, never-matching tsquery regardless of parser strictness. `ts_rank_cd` returns 0 against an empty tsquery, so hybrid scoring degrades cleanly to pure vector ranking — same intended behavior as before, but without the parser-tolerance dependency.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments)
- [ ] Examples and guides: N/A — internal SQL construction change, no API surface impact
- [x] Tested in clean environment
- [x] Tests added/updated — see below

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated — assisted by Claude Code

---

## Implementation

`libs/agno/agno/vectordb/pgvector/pgvector.py`:

- Import `literal_column` from `sqlalchemy.sql.expression`.
- In `hybrid_search`, replace the `func.to_tsquery(language, bindparam('query', value=''))` fallback with `literal_column(\"''::tsquery\")`.

## Tests

New unit test `test_hybrid_search_empty_token_fallback_uses_tsquery_literal` in `libs/agno/tests/unit/vectordb/test_pgvector.py`:

- Builds a real SQLAlchemy `Table` (with a real `pgvector` `Vector` column) so the full hybrid_search SELECT compiles.
- Calls `hybrid_search('!@#$')` (prefix_match=True, tokens get stripped → fallback path).
- Asserts the compiled SQL contains `''::tsquery` and does **not** call `to_tsquery(`.

All 59 tests in the file pass:

```
libs/agno/tests/unit/vectordb/test_pgvector.py ........................................... [100%]
59 passed
```

## Behavior

Before: `to_tsquery('english', '')` — relies on parser accepting empty input.
After: `''::tsquery` — explicit empty tsquery literal, parser-agnostic.

Net behavior at runtime is identical when the parser does tolerate empty input (which it does in current Postgres); the change just makes the fallback robust to stricter configs and future versions.