### PR TITLE
fix: propagate tool_executions through base.py and emit streaming events

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1158,6 +1158,10 @@ class Model(ABC):
             model_response.provider_data = provider_response.provider_data
         if provider_response.response_usage is not None:
             model_response.response_usage = provider_response.response_usage
+        if provider_response.tool_executions:
+            if model_response.tool_executions is None:
+                model_response.tool_executions = []
+            model_response.tool_executions.extend(provider_response.tool_executions)
 
     async def _aprocess_model_response(
         self,
@@ -1221,6 +1225,10 @@ class Model(ABC):
             model_response.provider_data = provider_response.provider_data
         if provider_response.response_usage is not None:
             model_response.response_usage = provider_response.response_usage
+        if provider_response.tool_executions:
+            if model_response.tool_executions is None:
+                model_response.tool_executions = []
+            model_response.tool_executions.extend(provider_response.tool_executions)
 
     def _populate_assistant_message(
         self,

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -23,7 +23,7 @@ from agno.models.base import Model
 from agno.models.google.utils import media_to_content_item
 from agno.models.message import Citations, Message, UrlCitation
 from agno.models.metrics import MessageMetrics
-from agno.models.response import ModelResponse, ToolExecution
+from agno.models.response import ModelResponse, ModelResponseEvent, ToolExecution
 from agno.run.agent import RunOutput
 from agno.utils.gemini import inject_agno_client_header
 from agno.utils.log import log_debug, log_error, log_info, log_warning
@@ -1143,6 +1143,7 @@ class GeminiInteractions(Model):
                             tool_call_error=bool(is_error) if is_error is not None else None,
                         )
                     )
+                    model_response.event = ModelResponseEvent.tool_call_completed.value
                     args_repr = json.dumps(pending_call["tool_args"]) if pending_call["tool_args"] else ""
                     log_info(f"Server-side tool call: {pending_call['tool_name']}({args_repr})")
 


### PR DESCRIPTION
## Summary
- Propagate `tool_executions` from provider response through `base._process_model_response()` to reach `run_response.tools`
- Set `ModelResponseEvent.tool_call_completed` in streaming path so `agent/_response.py` handles UI display correctly

## Problem
The original PR (#8045) creates `ToolExecution` records in the Gemini parser for server-side tool calls (Antigravity/Deep Research), but:
1. `base._process_model_response()` didn't copy `tool_executions` to the accumulated response
2. Streaming path didn't set the event type, so `agent/_response.py` didn't route them to the UI

Result: `response.tools = []` and AgentOS UI showed no tool activity despite tool calls completing.

## Changes

### libs/agno/agno/models/base.py
Added propagation in both sync and async `_process_model_response()`:
```python
if provider_response.tool_executions:
    if model_response.tool_executions is None:
        model_response.tool_executions = []
    model_response.tool_executions.extend(provider_response.tool_executions)
```

### libs/agno/agno/models/google/gemini_interactions.py
- Added `ModelResponseEvent` to import
- Set `model_response.event = ModelResponseEvent.tool_call_completed.value` when emitting completed server-side tool executions

## Test plan
- [x] Tested via API: `response.tools` now populated with `ToolExecution` records
- [x] Tested on AgentOS UI: Tool calls show in chat interface with "1 TOOL CALLED" badge
- [x] Verified multiple tool types: `list_files`, `google_search` (multiple calls per query)