### PR TITLE
fix: emit ReasoningContentDeltaEvent from main-call streaming

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1406,6 +1406,24 @@ def handle_model_response_chunk(
                     model_response.reasoning_content or ""
                 ) + model_response_event.reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
+                # Also yield a dedicated reasoning delta so consumers like
+                # AGUI / AgentOS light up the reasoning panel during
+                # streaming. Without this, models that stream reasoning
+                # from the main call (Claude w/ thinking, OpenAI o-series
+                # on Responses API, Gemini thinking, GeminiInteractions
+                # agent path) only reach the panel via the explicit
+                # ReasoningManager pre-call pattern, which doesn't fit
+                # models where reasoning is interleaved with tool calls.
+                if stream_events and model_response_event.reasoning_content:
+                    yield handle_event(  # type: ignore
+                        create_reasoning_content_delta_event(
+                            from_run_response=run_response,
+                            reasoning_content=model_response_event.reasoning_content,
+                        ),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
 
             if model_response_event.redacted_reasoning_content is not None:
                 if not model_response.reasoning_content:

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1377,6 +1377,20 @@ def _handle_model_response_chunk(
                 ) + model_response_event.reasoning_content
                 run_response.reasoning_content = full_model_response.reasoning_content
                 should_yield = True
+                # Mirror the agent fix: emit a dedicated team reasoning
+                # delta so AGUI / AgentOS light up the reasoning panel
+                # for models that stream reasoning from the main call
+                # instead of via the explicit ReasoningManager pre-call.
+                if stream_events:
+                    yield handle_event(  # type: ignore
+                        create_team_reasoning_content_delta_event(
+                            from_run_response=run_response,
+                            reasoning_content=model_response_event.reasoning_content,
+                        ),
+                        run_response,
+                        events_to_skip=team.events_to_skip,
+                        store_events=team.store_events,
+                    )
 
             if model_response_event.redacted_reasoning_content is not None:
                 if not full_model_response.reasoning_content:

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -82,6 +82,91 @@ def test_reasoning_content_delta_event_class_exists():
 
 
 # ============================================================================
+# Test handle_model_response_chunk emits ReasoningContentDeltaEvent
+# ============================================================================
+
+
+def test_handle_model_response_chunk_emits_reasoning_content_delta():
+    """When a streamed model response carries reasoning_content, the agent
+    chunk handler must yield a ReasoningContentDeltaEvent (in addition to
+    the usual RunOutputContent). This is what lets AGUI / AgentOS light up
+    the reasoning panel for models that stream reasoning from the main
+    call (Claude w/ thinking, OpenAI o-series, Gemini thinking,
+    GeminiInteractions agent path) instead of via the explicit
+    ReasoningManager pre-call pattern."""
+    from unittest.mock import MagicMock
+
+    from agno.agent._response import handle_model_response_chunk
+    from agno.models.response import ModelResponse, ModelResponseEvent
+    from agno.run.agent import ReasoningContentDeltaEvent, RunOutput
+
+    agent = MagicMock()
+    agent.events_to_skip = []
+    agent.store_events = False
+    session = MagicMock()
+    session.session_id = "session-1"
+    run_response = RunOutput(run_id="run-1", session_id="session-1", content="")
+    accumulator = ModelResponse()
+    chunk = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        reasoning_content="I'm thinking about this...",
+    )
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=accumulator,
+            model_response_event=chunk,
+            stream_events=True,
+        )
+    )
+
+    reasoning_events = [e for e in events if isinstance(e, ReasoningContentDeltaEvent)]
+    assert len(reasoning_events) == 1
+    assert reasoning_events[0].reasoning_content == "I'm thinking about this..."
+    # The accumulator and run_response should still pick up the content
+    # (existing behavior preserved).
+    assert run_response.reasoning_content == "I'm thinking about this..."
+
+
+def test_handle_model_response_chunk_skips_reasoning_event_when_not_streaming():
+    """Without stream_events, no ReasoningContentDeltaEvent is yielded -
+    keeping the accumulation-only behavior for non-streaming consumers."""
+    from unittest.mock import MagicMock
+
+    from agno.agent._response import handle_model_response_chunk
+    from agno.models.response import ModelResponse, ModelResponseEvent
+    from agno.run.agent import ReasoningContentDeltaEvent, RunOutput
+
+    agent = MagicMock()
+    agent.events_to_skip = []
+    agent.store_events = False
+    session = MagicMock()
+    session.session_id = "session-1"
+    run_response = RunOutput(run_id="run-1", session_id="session-1", content="")
+    chunk = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        reasoning_content="Thinking...",
+    )
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=ModelResponse(),
+            model_response_event=chunk,
+            stream_events=False,
+        )
+    )
+
+    assert not any(isinstance(e, ReasoningContentDeltaEvent) for e in events)
+    assert run_response.reasoning_content == "Thinking..."
+
+
+# ============================================================================
 # Test Anthropic streaming functions exist
 # ============================================================================
 


### PR DESCRIPTION
## Summary

AgentOS / AGUI light up the reasoning panel only when they see `ReasoningContentDeltaEvent` (handled at `libs/agno/agno/os/interfaces/agui/utils.py:388`). The only emission site for that event is `handle_reasoning_event` in `agent/_response.py`, which is reached via the `ReasoningManager` pre-call pattern - a two-call flow (separate reasoning agent runs before the main model call).

That pattern fits Claude/OpenAI reasoning agents fine, but **any model that streams reasoning_content from the main call drops the reasoning panel on the floor**:

- Claude with \`thinking={\"type\":\"enabled\", \"budget_tokens\": 5000}\` (verified empty in AgentOS)
- OpenAI o-series on the Responses API
- Gemini thinking (\`thinking_budget\`, \`include_thoughts\`)
- GeminiInteractions on the agent path (Antigravity / Deep Research) - reasoning interleaved with tool calls in a single call, so the two-call pattern can't apply

The chunks were already being accumulated into \`run_response.reasoning_content\` (still visible when printing the response), but the AGUI handler doesn't extract reasoning from \`RunOutputContent\` events - only from the dedicated reasoning event.

## Fix

In both \`handle_model_response_chunk\` (agent) and \`_handle_model_response_chunk\` (team), when \`model_response_event.reasoning_content\` is set during streaming, also yield a \`(Team)ReasoningContentDeltaEvent\` alongside the existing \`RunOutputContent\`. Existing accumulation into \`run_response.reasoning_content\` is unchanged.

\`\`\`python
if model_response_event.reasoning_content is not None:
    model_response.reasoning_content = (
        model_response.reasoning_content or \"\"
    ) + model_response_event.reasoning_content
    run_response.reasoning_content = model_response.reasoning_content
    if stream_events and model_response_event.reasoning_content:
        yield handle_event(
            create_reasoning_content_delta_event(
                from_run_response=run_response,
                reasoning_content=model_response_event.reasoning_content,
            ),
            ...
        )
\`\`\`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (\`./scripts/format.sh\` and \`./scripts/validate.sh\`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) - N/A
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Tests

Two regression tests added in \`libs/agno/tests/unit/reasoning/test_reasoning_streaming.py\`:
- \`test_handle_model_response_chunk_emits_reasoning_content_delta\` - asserts a \`ReasoningContentDeltaEvent\` is yielded when streaming.
- \`test_handle_model_response_chunk_skips_reasoning_event_when_not_streaming\` - asserts non-streaming consumers don't get the event (accumulation-only behavior preserved).

Full \`tests/unit/agent\`, \`tests/unit/team\`, \`tests/unit/reasoning\` sweep: 822 passed.

### Edge cases

- **\`reasoning=True\` + a model that also streams reasoning natively**: technically could emit reasoning twice (once from the pre-call, once from the main call). In practice \`reasoning=True\` is usually paired with a separate cheaper reasoning model, so the main model doesn't have thinking on. If this becomes a problem we can gate the new emission with a \"reasoning_manager isn't running\" flag.

### Related

- PR #8045 (GeminiInteractions agent path) - I investigated this gap while working on that PR and confirmed it affects Claude with extended thinking too. This fix is independent and covers all providers.