### PR TITLE
fix: persist team-member AgentSession on HITL pause to enable cross-process resume

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -221,12 +221,20 @@ def save_session(agent: Agent, session: Union[AgentSession, TeamSession, Workflo
 
     if _init.has_async_db(agent):
         raise ValueError("Cannot use sync save_session() with an async database. Use asave_session() instead.")
+    # Paused team-member sessions must be persisted so acontinue_run() can locate
+    # the run from a fresh process on HITL resume.
+    _has_paused_run = any(
+        getattr(run, "status", None) == RunStatus.paused
+        for run in (session.runs or [])
+    )
+
     # If the agent is a member of a team, do not save the session to the database
+    # unless a run is paused (HITL pending).
     if (
         agent.db is not None
-        and agent.team_id is None
+        and (agent.team_id is None or _has_paused_run)
         and agent.workflow_id is None
-        and session.session_data is not None
+        and (session.session_data is not None or _has_paused_run)
     ):
         if session.session_data is not None and isinstance(session.session_data.get("session_state"), dict):
             session.session_data["session_state"].pop("current_session_id", None)
@@ -243,12 +251,20 @@ async def asave_session(agent: Agent, session: Union[AgentSession, TeamSession, 
     """
     from agno.agent import _init, _storage
 
+    # Paused team-member sessions must be persisted so acontinue_run() can locate
+    # the run from a fresh process on HITL resume.
+    _has_paused_run = any(
+        getattr(run, "status", None) == RunStatus.paused
+        for run in (session.runs or [])
+    )
+
     # If the agent is a member of a team, do not save the session to the database
+    # unless a run is paused (HITL pending).
     if (
         agent.db is not None
-        and agent.team_id is None
+        and (agent.team_id is None or _has_paused_run)
         and agent.workflow_id is None
-        and session.session_data is not None
+        and (session.session_data is not None or _has_paused_run)
     ):
         if session.session_data is not None and isinstance(session.session_data.get("session_state"), dict):
             session.session_data["session_state"].pop("current_session_id", None)


### PR DESCRIPTION
## Summary

Fixes #7959.

When `agent.team_id` is set, `save_session` and `asave_session` silently skip the DB write — this is intentional for the normal case (the team manages the session). But it breaks HITL resume across processes: after a nested sub-team member's run is paused waiting for confirmation, `acontinue_run(run_id=...)` does a DB lookup for that `AgentSession` row. The row was never written, so the lookup fails and agno falls back to a fake `"Task completed (no final output)"` string, causing the outer leader to synthesise a false success.

## Root Cause

`libs/agno/agno/agent/_session.py`:

```python
# BEFORE — team members always skipped
if (
    agent.db is not None
    and agent.team_id is None       # <-- blocks all team members
    and agent.workflow_id is None
    and session.session_data is not None
):
```

## Fix

Add `_has_paused_run` detection before the guard in both `save_session` and `asave_session`. When any run in `session.runs` has `RunStatus.paused`, the `team_id` guard is lifted and the `AgentSession` is written to DB.

```python
_has_paused_run = any(
    getattr(run, "status", None) == RunStatus.paused
    for run in (session.runs or [])
)

if (
    agent.db is not None
    and (agent.team_id is None or _has_paused_run)   # lift guard for paused runs
    and agent.workflow_id is None
    and (session.session_data is not None or _has_paused_run)
):
```

This is minimal: non-paused team-member sessions are still skipped exactly as before.

## Test plan

- [ ] Standalone agent HITL pause/resume: existing behaviour unchanged
- [ ] Team member agent HITL pause: `AgentSession` row now written to DB with `RunStatus.paused`
- [ ] Fresh-process `acontinue_run(run_id=member_run_id)` finds the session and resumes correctly
- [ ] Non-paused team member runs: no new DB writes (condition still blocks them)
