### PR TITLE
fix: raise ValueError in delete_session when called with async db

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -263,9 +263,12 @@ async def asave_session(agent: Agent, session: Union[AgentSession, TeamSession, 
 
 def delete_session(agent: Agent, session_id: str, user_id: Optional[str] = None):
     """Delete the current session and save to storage"""
+    from agno.agent import _init
+
     if agent.db is None:
         return
-
+    if _init.has_async_db(agent):
+        raise ValueError("Cannot use sync delete_session() with an async database. Use adelete_session() instead.")
     agent.db.delete_session(session_id=session_id, user_id=user_id)
 
 


### PR DESCRIPTION
## Summary

Calling the sync  with an async database silently creates an unawaited coroutine and does nothing. The  function already guards against this correctly:

```python
# save_session already raises:
if _init.has_async_db(agent):
    raise ValueError("Cannot use sync save_session() with an async database. Use asave_session() instead.")
```

But  had no such guard at line 269:

```python
def delete_session(agent, session_id, user_id=None):
    if agent.db is None:
        return
    # BUG: if db is async, this returns a coroutine that is never awaited
    agent.db.delete_session(session_id=session_id, user_id=user_id)
```

## Fix

Add the same async-db guard already used in :

```python
def delete_session(agent, session_id, user_id=None):
    from agno.agent import _init
    if agent.db is None:
        return
    if _init.has_async_db(agent):
        raise ValueError("Cannot use sync delete_session() with an async database. Use adelete_session() instead.")
    agent.db.delete_session(session_id=session_id, user_id=user_id)
```

The async path () already handles both async and sync databases correctly and is unchanged.

Fixes #7969
