### PR TITLE
fix: use timezone-aware cookbook timestamp

### DIFF
--- a/cookbook/02_agents/15_dependencies/dynamic_tools.py
+++ b/cookbook/02_agents/15_dependencies/dynamic_tools.py
@@ -5,7 +5,7 @@ Dynamic Tools
 Dynamic Tools.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIResponses
@@ -16,7 +16,7 @@ def get_runtime_tools(run_context: RunContext):
     """Return tools dynamically based on session state."""
 
     def get_time() -> str:
-        return datetime.utcnow().isoformat()
+        return datetime.now(timezone.utc).isoformat()
 
     def get_project() -> str:
         project = (run_context.session_state or {}).get("project", "unknown")


### PR DESCRIPTION
## Summary
- Replace `datetime.utcnow()` in the dynamic tools cookbook with `datetime.now(timezone.utc)`
- Keep the example output explicitly UTC and timezone-aware

Closes #8060

## Problem
The cookbook example returns the current time with `datetime.utcnow().isoformat()`. That produces a naive datetime and `datetime.utcnow()` is deprecated in Python 3.12.

## Before / After
Before:

```py
return datetime.utcnow().isoformat()
```

After:

```py
return datetime.now(timezone.utc).isoformat()
```

The returned timestamp now includes UTC timezone information.

## Verification
- `python -m compileall -q cookbook\02_agents\15_dependencies\dynamic_tools.py`
- `git diff --check`

This is a cookbook-only timestamp cleanup, so I did not run the full test suite.