### PR TITLE
feat: add NotteTools toolkit for managed browser sessions

### DIFF
--- a/cookbook/91_tools/notte_tools.py
+++ b/cookbook/91_tools/notte_tools.py
@@ -1,0 +1,80 @@
+"""
+Notte Tools
+=============================
+
+Demonstrates Notte browser tools for Agno agents.
+"""
+
+from agno.agent import Agent
+from agno.tools.notte import NotteTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+# Notte Configuration
+# -------------------------------
+# These environment variables drive the NotteTools.
+# Set them in your .env file or export them in your shell.
+
+# NOTTE_API_KEY: Your API key from the Notte console
+#   - Required for authentication
+#   - Get one at https://console.notte.cc
+
+# NOTTE_API_URL: Notte API endpoint
+#   - Optional. Defaults to https://api.notte.cc.
+#   - Override only for self-hosted deployments or non-default regions.
+
+# ==================== Usage ====================
+# NotteTools automatically picks the right implementation based on context:
+# - Sync tools when using agent.run() or agent.print_response()
+# - Async tools when using agent.arun() or agent.aprint_response()
+
+agent = Agent(
+    name="Web Automation Assistant",
+    tools=[NotteTools()],
+    instructions=[
+        "You are a web automation assistant powered by Notte. You can help with:",
+        "1. Filling forms and clicking through multi-step web flows",
+        "2. Extracting clean markdown or structured data from web pages",
+        "3. Capturing screenshots of websites",
+        "4. Monitoring website changes",
+        "5. Delegating complex multi-step browsing to an autonomous browser agent when a task is too open-ended for step-by-step tool use",
+        "Note: call observe before click or fill to discover the current interactive element IDs (B1, I1, L1, ...).",
+    ],
+    markdown=True,
+)
+
+# ==================== Sync Usage ====================
+# Use this for regular scripts and synchronous execution.
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response("""
+        Visit https://quotes.toscrape.com and:
+        1. Extract the first 5 quotes and their authors
+        2. Navigate to page 2
+        3. Extract the first 5 quotes from page 2
+    """)
+
+    # ==================== Async Usage ====================
+    # Use this for FastAPI, async frameworks, or when using agent.arun().
+    # The same agent instance works for both sync and async; just use arun/aprint_response.
+
+    # import asyncio
+    #
+    #
+    # async def main():
+    #     await agent.aprint_response("""
+    #         Visit https://quotes.toscrape.com and:
+    #         1. Extract the first 5 quotes and their authors
+    #         2. Navigate to page 2
+    #         3. Extract the first 5 quotes from page 2
+    #     """)
+    #
+    #
+    # if __name__ == "__main__":
+    #     asyncio.run(main())

--- a/libs/agno/agno/tools/notte.py
+++ b/libs/agno/agno/tools/notte.py
@@ -1,0 +1,417 @@
+import asyncio
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, logger
+
+try:
+    from notte_sdk import NotteClient
+except ImportError:
+    raise ImportError("`notte-sdk` not installed. Please install using `pip install notte-sdk`")
+
+
+class NotteTools(Toolkit):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        server_url: Optional[str] = None,
+        headless: bool = True,
+        solve_captchas: bool = False,
+        proxies: bool = False,
+        browser_type: str = "chromium",
+        timeout_minutes: Optional[int] = None,
+        perception_type: str = "fast",
+        reasoning_model: Optional[str] = None,
+        max_agent_steps: int = 15,
+        enable_navigate_to: bool = True,
+        enable_screenshot: bool = True,
+        enable_get_page_content: bool = True,
+        enable_observe: bool = True,
+        enable_click: bool = True,
+        enable_fill: bool = True,
+        enable_scrape: bool = True,
+        enable_run_agent: bool = True,
+        enable_close_session: bool = True,
+        all: bool = False,
+        max_content_length: Optional[int] = 100000,
+        **kwargs,
+    ):
+        """Initialize NotteTools.
+
+        Args:
+            api_key (str, optional): Notte API key. If not provided, reads NOTTE_API_KEY env var.
+            server_url (str, optional): Custom Notte API endpoint. Only set this for self-hosted
+                deployments or non-default regions. Defaults to https://api.notte.cc.
+            headless (bool): Run the remote browser headless. Defaults to True.
+            solve_captchas (bool): Automatically solve captchas during the session. Defaults to False.
+            proxies (bool): Route the session through Notte's proxy pool. Defaults to False.
+            browser_type (str): One of "chromium", "chrome", "firefox". Defaults to "chromium".
+            timeout_minutes (int, optional): Hard timeout for the remote session in minutes.
+            perception_type (str): "fast" or "deep". Controls how aggressively Notte parses the DOM
+                into an action space. Defaults to "fast".
+            reasoning_model (str, optional): LLM identifier passed through to the Notte agent
+                (e.g. "gemini/gemini-2.5-flash"). Used by the run_agent tool only.
+            max_agent_steps (int): Default step cap for run_agent. Defaults to 15.
+            enable_navigate_to (bool): Enable the navigate_to tool. Defaults to True.
+            enable_screenshot (bool): Enable the screenshot tool. Defaults to True.
+            enable_get_page_content (bool): Enable the get_page_content tool. Defaults to True.
+            enable_observe (bool): Enable the observe tool. Defaults to True.
+            enable_click (bool): Enable the click tool. Defaults to True.
+            enable_fill (bool): Enable the fill tool. Defaults to True.
+            enable_scrape (bool): Enable the scrape tool. Defaults to True.
+            enable_run_agent (bool): Enable the run_agent tool. Defaults to True.
+            enable_close_session (bool): Enable the close_session tool. Defaults to True.
+            all (bool): Enable all tools regardless of individual flags. Defaults to False.
+            max_content_length (int, optional): Truncate page content above this many characters.
+                Defaults to 100000. Set to None for no limit.
+        """
+        self.api_key = api_key or getenv("NOTTE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "NOTTE_API_KEY is required. Please set the NOTTE_API_KEY environment variable."
+            )
+
+        self.server_url = server_url or getenv("NOTTE_API_URL")
+        self.max_content_length = max_content_length
+        self.reasoning_model = reasoning_model
+        self.max_agent_steps = max_agent_steps
+
+        self._session_kwargs: Dict[str, Any] = {
+            "headless": headless,
+            "solve_captchas": solve_captchas,
+            "proxies": proxies,
+            "browser_type": browser_type,
+            "perception_type": perception_type,
+        }
+        if timeout_minutes is not None:
+            self._session_kwargs["timeout_minutes"] = timeout_minutes
+
+        client_kwargs: Dict[str, Any] = {"api_key": self.api_key}
+        if self.server_url:
+            client_kwargs["server_url"] = self.server_url
+            log_debug(f"Using custom Notte API endpoint: {self.server_url}")
+        self.client = NotteClient(**client_kwargs)
+
+        self._session: Any = None
+
+        # Build tools lists
+        # sync tools: used by agent.run() and agent.print_response()
+        # async tools: used by agent.arun() and agent.aprint_response()
+        tools: List[Any] = []
+        async_tools: List[tuple] = []
+
+        if all or enable_navigate_to:
+            tools.append(self.navigate_to)
+            async_tools.append((self.anavigate_to, "navigate_to"))
+        if all or enable_screenshot:
+            tools.append(self.screenshot)
+            async_tools.append((self.ascreenshot, "screenshot"))
+        if all or enable_get_page_content:
+            tools.append(self.get_page_content)
+            async_tools.append((self.aget_page_content, "get_page_content"))
+        if all or enable_observe:
+            tools.append(self.observe)
+            async_tools.append((self.aobserve, "observe"))
+        if all or enable_click:
+            tools.append(self.click)
+            async_tools.append((self.aclick, "click"))
+        if all or enable_fill:
+            tools.append(self.fill)
+            async_tools.append((self.afill, "fill"))
+        if all or enable_scrape:
+            tools.append(self.scrape)
+            async_tools.append((self.ascrape, "scrape"))
+        if all or enable_run_agent:
+            tools.append(self.run_agent)
+            async_tools.append((self.arun_agent, "run_agent"))
+        if all or enable_close_session:
+            tools.append(self.close_session)
+            async_tools.append((self.aclose_session, "close_session"))
+
+        super().__init__(name="notte_tools", tools=tools, async_tools=async_tools, **kwargs)
+
+    # -- session management --
+
+    def _ensure_session(self) -> None:
+        """Ensures a remote Notte session exists, creating one if needed."""
+        if self._session is None:
+            try:
+                self._session = self.client.Session(**self._session_kwargs)
+                self._session.start()
+                log_debug(f"Started Notte session with ID: {self._session.session_id}")
+            except Exception:
+                logger.exception("Failed to start Notte session")
+                raise
+
+    def _truncate(self, content: str) -> str:
+        """Truncate content if it exceeds max_content_length."""
+        if self.max_content_length is None or len(content) <= self.max_content_length:
+            return content
+        truncated = content[: self.max_content_length]
+        return (
+            f"{truncated}\n\n[Content truncated. Original length: {len(content)} characters. "
+            f"Showing first {self.max_content_length} characters.]"
+        )
+
+    @staticmethod
+    def _normalise_id(element_id: str) -> str:
+        """Strip an optional leading '@' from a Notte element ID."""
+        if not element_id:
+            return element_id
+        return element_id.lstrip("@").strip()
+
+    # -- sync tools --
+
+    def navigate_to(self, url: str) -> str:
+        """Navigates the remote browser to a URL.
+
+        Args:
+            url (str): The URL to navigate to.
+
+        Returns:
+            JSON string with navigation status.
+        """
+        try:
+            self._ensure_session()
+            self._session.execute(type="goto", url=url)
+            return json.dumps({"status": "complete", "url": url})
+        except Exception as e:
+            logger.exception("navigate_to failed")
+            return json.dumps({"status": "error", "url": url, "message": str(e)})
+
+    def screenshot(self, path: str, full_page: bool = True) -> str:
+        """Captures a screenshot of the current page and writes it to disk.
+
+        Args:
+            path (str): Where to save the screenshot.
+            full_page (bool): Hint for full-page capture. Notte returns the rendered viewport;
+                full-page support depends on the underlying perception mode.
+
+        Returns:
+            JSON string confirming the screenshot was saved.
+        """
+        try:
+            self._ensure_session()
+            obs = self._session.observe()
+            data = obs.screenshot.bytes()
+            with open(path, "wb") as f:
+                f.write(data)
+            return json.dumps({"status": "success", "path": path})
+        except Exception as e:
+            logger.exception("screenshot failed")
+            return json.dumps({"status": "error", "path": path, "message": str(e)})
+
+    def get_page_content(self) -> str:
+        """Returns the current page content as clean markdown.
+
+        Returns:
+            Page content as markdown, truncated to max_content_length characters.
+        """
+        try:
+            self._ensure_session()
+            content = self._session.scrape(only_main_content=True)
+            return self._truncate(content if isinstance(content, str) else str(content))
+        except Exception as e:
+            logger.exception("get_page_content failed")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def observe(self, instructions: Optional[str] = None) -> str:
+        """Observes the current page and returns the available action space.
+
+        Each interactive element is given a stable ID (e.g. B1 for buttons, I1 for inputs,
+        L1 for links) that can be passed to click, fill, or other action tools.
+
+        Args:
+            instructions (str, optional): Natural-language hint to focus the observation.
+
+        Returns:
+            JSON string with url, title, and the action space listing.
+        """
+        try:
+            self._ensure_session()
+            kwargs: Dict[str, Any] = {}
+            if instructions:
+                kwargs["instructions"] = instructions
+            obs = self._session.observe(**kwargs)
+            description = obs.space.description if obs.space else ""
+            metadata = obs.metadata
+            payload = {
+                "url": getattr(metadata, "url", None),
+                "title": getattr(metadata, "title", None),
+                "action_space": self._truncate(description),
+            }
+            return json.dumps(payload)
+        except Exception as e:
+            logger.exception("observe failed")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def click(self, element_id: str) -> str:
+        """Clicks an interactive element by its Notte ID.
+
+        Args:
+            element_id (str): The element ID returned by observe (e.g. "B1", "L3").
+
+        Returns:
+            JSON string with the click status.
+        """
+        try:
+            self._ensure_session()
+            normalised = self._normalise_id(element_id)
+            result = self._session.execute(type="click", id=normalised)
+            return json.dumps({
+                "status": "success" if getattr(result, "success", True) else "failed",
+                "element_id": normalised,
+                "message": getattr(result, "message", ""),
+            })
+        except Exception as e:
+            logger.exception("click failed")
+            return json.dumps({"status": "error", "element_id": element_id, "message": str(e)})
+
+    def fill(self, element_id: str, value: str) -> str:
+        """Fills an input element by its Notte ID with the provided value.
+
+        Args:
+            element_id (str): The input ID returned by observe (e.g. "I1").
+            value (str): The text to type into the input.
+
+        Returns:
+            JSON string with the fill status.
+        """
+        try:
+            self._ensure_session()
+            normalised = self._normalise_id(element_id)
+            result = self._session.execute(type="fill", id=normalised, value=value)
+            return json.dumps({
+                "status": "success" if getattr(result, "success", True) else "failed",
+                "element_id": normalised,
+                "message": getattr(result, "message", ""),
+            })
+        except Exception as e:
+            logger.exception("fill failed")
+            return json.dumps({"status": "error", "element_id": element_id, "message": str(e)})
+
+    def scrape(self, instructions: Optional[str] = None, only_main_content: bool = True) -> str:
+        """Scrapes the current page, optionally guided by natural-language instructions.
+
+        Args:
+            instructions (str, optional): When set, Notte returns structured data extracted
+                according to the instructions. When omitted, returns the page as markdown.
+            only_main_content (bool): Strip headers, footers, and navigation when True. Defaults to True.
+
+        Returns:
+            Markdown string when no instructions are given, else a JSON string of the extracted data.
+        """
+        try:
+            self._ensure_session()
+            if instructions:
+                result = self._session.scrape(instructions=instructions)
+                data = getattr(result, "data", result)
+                if hasattr(data, "model_dump_json"):
+                    serialised = data.model_dump_json()
+                else:
+                    serialised = json.dumps(data, default=str)
+                return self._truncate(serialised)
+            content = self._session.scrape(only_main_content=only_main_content)
+            return self._truncate(content if isinstance(content, str) else str(content))
+        except Exception as e:
+            logger.exception("scrape failed")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def run_agent(
+        self,
+        task: str,
+        url: Optional[str] = None,
+        max_steps: Optional[int] = None,
+    ) -> str:
+        """Hands a multi-step task to a Notte browser agent and returns its final answer.
+
+        Use this for complex flows that would otherwise require many sequential observe and
+        act calls. The agent runs inside the same session.
+
+        Args:
+            task (str): Natural-language description of the task.
+            url (str, optional): Starting URL. If omitted, uses the current page.
+            max_steps (int, optional): Override the toolkit-level step cap.
+
+        Returns:
+            JSON string with the agent's final answer and metadata.
+        """
+        try:
+            self._ensure_session()
+            agent_kwargs: Dict[str, Any] = {
+                "session": self._session,
+                "max_steps": max_steps or self.max_agent_steps,
+            }
+            if self.reasoning_model:
+                agent_kwargs["reasoning_model"] = self.reasoning_model
+            agent = self.client.Agent(**agent_kwargs)
+            result = agent.run(task=task, url=url)
+            return json.dumps({
+                "status": "complete",
+                "answer": getattr(result, "answer", ""),
+                "agent_id": getattr(agent, "agent_id", ""),
+            })
+        except Exception as e:
+            logger.exception("run_agent failed")
+            return json.dumps({"status": "error", "task": task, "message": str(e)})
+
+    def close_session(self) -> str:
+        """Stops the current Notte session and releases remote browser resources.
+
+        Returns:
+            JSON string with the closure status.
+        """
+        try:
+            if self._session is not None:
+                self._session.stop()
+                self._session = None
+            return json.dumps({"status": "closed", "message": "Notte session stopped."})
+        except Exception as e:
+            return json.dumps({"status": "warning", "message": f"Cleanup completed with warning: {str(e)}"})
+
+    # -- async tools --
+    # Notte's SDK exposes synchronous methods. The async siblings below offload the sync work
+    # to a thread so the event loop is never blocked in async agent flows.
+
+    async def anavigate_to(self, url: str) -> str:
+        """Navigates the remote browser to a URL asynchronously."""
+        return await asyncio.to_thread(self.navigate_to, url)
+
+    async def ascreenshot(self, path: str, full_page: bool = True) -> str:
+        """Captures a screenshot of the current page asynchronously."""
+        return await asyncio.to_thread(self.screenshot, path, full_page)
+
+    async def aget_page_content(self) -> str:
+        """Returns the current page content as clean markdown asynchronously."""
+        return await asyncio.to_thread(self.get_page_content)
+
+    async def aobserve(self, instructions: Optional[str] = None) -> str:
+        """Observes the current page asynchronously."""
+        return await asyncio.to_thread(self.observe, instructions)
+
+    async def aclick(self, element_id: str) -> str:
+        """Clicks an interactive element by its Notte ID asynchronously."""
+        return await asyncio.to_thread(self.click, element_id)
+
+    async def afill(self, element_id: str, value: str) -> str:
+        """Fills an input element by its Notte ID asynchronously."""
+        return await asyncio.to_thread(self.fill, element_id, value)
+
+    async def ascrape(self, instructions: Optional[str] = None, only_main_content: bool = True) -> str:
+        """Scrapes the current page asynchronously."""
+        return await asyncio.to_thread(self.scrape, instructions, only_main_content)
+
+    async def arun_agent(
+        self,
+        task: str,
+        url: Optional[str] = None,
+        max_steps: Optional[int] = None,
+    ) -> str:
+        """Hands a multi-step task to a Notte browser agent asynchronously."""
+        return await asyncio.to_thread(self.run_agent, task, url, max_steps)
+
+    async def aclose_session(self) -> str:
+        """Stops the current Notte session asynchronously."""
+        return await asyncio.to_thread(self.close_session)

--- a/libs/agno/agno/tools/notte.py
+++ b/libs/agno/agno/tools/notte.py
@@ -33,6 +33,7 @@ class NotteTools(Toolkit):
         enable_fill: bool = True,
         enable_scrape: bool = True,
         enable_run_agent: bool = True,
+        enable_run_function: bool = True,
         enable_close_session: bool = True,
         all: bool = False,
         max_content_length: Optional[int] = 100000,
@@ -62,6 +63,7 @@ class NotteTools(Toolkit):
             enable_fill (bool): Enable the fill tool. Defaults to True.
             enable_scrape (bool): Enable the scrape tool. Defaults to True.
             enable_run_agent (bool): Enable the run_agent tool. Defaults to True.
+            enable_run_function (bool): Enable the run_function tool. Defaults to True.
             enable_close_session (bool): Enable the close_session tool. Defaults to True.
             all (bool): Enable all tools regardless of individual flags. Defaults to False.
             max_content_length (int, optional): Truncate page content above this many characters.
@@ -126,6 +128,9 @@ class NotteTools(Toolkit):
         if all or enable_run_agent:
             tools.append(self.run_agent)
             async_tools.append((self.arun_agent, "run_agent"))
+        if all or enable_run_function:
+            tools.append(self.run_function)
+            async_tools.append((self.arun_function, "run_function"))
         if all or enable_close_session:
             tools.append(self.close_session)
             async_tools.append((self.aclose_session, "close_session"))
@@ -357,6 +362,41 @@ class NotteTools(Toolkit):
             logger.exception("run_agent failed")
             return json.dumps({"status": "error", "task": task, "message": str(e)})
 
+    def run_function(
+        self,
+        function_id: str,
+        variables: Optional[Dict[str, Any]] = None,
+        version: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> str:
+        """Invokes a Notte Function (a deployable browser automation) by ID.
+
+        Notte Functions let developers pre-build a multi-step browser workflow once in
+        the Notte console (or via the SDK), then invoke it by ID with input variables.
+        Use this for repeatable automations the agent should not have to reason through
+        on every run (e.g. login flows, checkout, scheduled scrapes).
+
+        Args:
+            function_id (str): The Notte function ID.
+            variables (dict, optional): Input variables forwarded to the function.
+            version (str, optional): Pinned function version. Defaults to latest.
+            timeout (int, optional): Override the function's default timeout.
+
+        Returns:
+            JSON string with the function's run output and metadata.
+        """
+        try:
+            function = self.client.Function(function_id=function_id)
+            result = function.run(version=version, timeout=timeout, **(variables or {}))
+            if hasattr(result, "model_dump_json"):
+                payload = result.model_dump_json()
+            else:
+                payload = json.dumps(result, default=str)
+            return self._truncate(payload)
+        except Exception as e:
+            logger.exception("run_function failed")
+            return json.dumps({"status": "error", "function_id": function_id, "message": str(e)})
+
     def close_session(self) -> str:
         """Stops the current Notte session and releases remote browser resources.
 
@@ -411,6 +451,16 @@ class NotteTools(Toolkit):
     ) -> str:
         """Hands a multi-step task to a Notte browser agent asynchronously."""
         return await asyncio.to_thread(self.run_agent, task, url, max_steps)
+
+    async def arun_function(
+        self,
+        function_id: str,
+        variables: Optional[Dict[str, Any]] = None,
+        version: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ) -> str:
+        """Invokes a Notte Function by ID asynchronously."""
+        return await asyncio.to_thread(self.run_function, function_id, variables, version, timeout)
 
     async def aclose_session(self) -> str:
         """Stops the current Notte session asynchronously."""

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -136,6 +136,7 @@ mem0 = ["mem0ai"]
 memori = ["memori>=3.0.5"]
 newspaper = ["newspaper4k", "lxml_html_clean"]
 notion = ["notion-client"]
+notte = ["notte-sdk>=1.8,<2"]
 opencv = ["opencv-python"]
 parallel = ["parallel-web"]
 psycopg = ["psycopg-binary", "psycopg"]
@@ -269,6 +270,7 @@ tools = [
   "agno[webex]",
   "agno[mcp]",
   "agno[browserbase]",
+  "agno[notte]",
   "agno[agentql]",
   "agno[opencv]",
   "agno[parallel]",
@@ -526,6 +528,7 @@ module = [
   "neo4j.*",
   "nest_asyncio.*",
   "newspaper.*",
+  "notte_sdk.*",
   "numpy.*",
   "ollama.*",
   "openpyxl.*",

--- a/libs/agno/tests/unit/tools/test_notte.py
+++ b/libs/agno/tests/unit/tools/test_notte.py
@@ -1,0 +1,262 @@
+"""Unit tests for NotteTools class."""
+
+import json
+import os
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from agno.tools.notte import NotteTools
+
+TEST_API_KEY = os.environ.get("NOTTE_API_KEY", "test_api_key")
+TEST_SERVER_URL = os.environ.get("NOTTE_API_URL")
+
+
+@pytest.fixture
+def mock_notte_client():
+    """Patch the NotteClient constructor used by NotteTools."""
+    with patch("agno.tools.notte.NotteClient") as mock_client_cls:
+        mock_client = Mock()
+        mock_client_cls.return_value = mock_client
+        yield mock_client
+
+
+@pytest.fixture
+def mock_session(mock_notte_client):
+    """Wire a mock RemoteSession onto the mock client."""
+    session = Mock()
+    session.session_id = "ses_test_123"
+
+    obs = Mock()
+    obs.metadata = Mock(url="https://example.com", title="Example")
+    obs.space = Mock(description="@B1: Submit\n@I1: Search input")
+    obs.screenshot = Mock()
+    obs.screenshot.bytes = Mock(return_value=b"\x89PNG\r\n\x1a\n")
+    session.observe = Mock(return_value=obs)
+
+    exec_result = Mock(success=True, message="ok")
+    session.execute = Mock(return_value=exec_result)
+    session.scrape = Mock(return_value="# Page Markdown\n\nHello")
+    session.stop = Mock()
+    session.start = Mock()
+
+    mock_notte_client.Session = Mock(return_value=session)
+    return session
+
+
+@pytest.fixture
+def tools(mock_notte_client, mock_session):
+    """A NotteTools instance with a mocked client and session."""
+    return NotteTools(api_key=TEST_API_KEY, server_url=TEST_SERVER_URL)
+
+
+class TestInit:
+    def test_init_with_explicit_api_key(self, mock_notte_client):
+        t = NotteTools(api_key="explicit_key")
+        assert t.api_key == "explicit_key"
+
+    def test_init_reads_env_var(self, mock_notte_client, monkeypatch):
+        monkeypatch.setenv("NOTTE_API_KEY", "env_key")
+        t = NotteTools()
+        assert t.api_key == "env_key"
+
+    def test_missing_api_key_raises(self, mock_notte_client, monkeypatch):
+        monkeypatch.delenv("NOTTE_API_KEY", raising=False)
+        with pytest.raises(ValueError, match="NOTTE_API_KEY is required"):
+            NotteTools()
+
+    def test_default_tools_registered(self, tools):
+        names = {fn.__name__ for fn in tools.tools}
+        assert names == {
+            "navigate_to",
+            "screenshot",
+            "get_page_content",
+            "observe",
+            "click",
+            "fill",
+            "scrape",
+            "run_agent",
+            "close_session",
+        }
+
+    def test_individual_enable_flags(self, mock_notte_client):
+        t = NotteTools(
+            api_key=TEST_API_KEY,
+            enable_navigate_to=True,
+            enable_screenshot=False,
+            enable_get_page_content=False,
+            enable_observe=False,
+            enable_click=False,
+            enable_fill=False,
+            enable_scrape=False,
+            enable_run_agent=False,
+            enable_close_session=False,
+        )
+        assert {fn.__name__ for fn in t.tools} == {"navigate_to"}
+
+    def test_all_flag_enables_everything(self, mock_notte_client):
+        t = NotteTools(
+            api_key=TEST_API_KEY,
+            all=True,
+            enable_navigate_to=False,
+            enable_screenshot=False,
+            enable_get_page_content=False,
+            enable_observe=False,
+            enable_click=False,
+            enable_fill=False,
+            enable_scrape=False,
+            enable_run_agent=False,
+            enable_close_session=False,
+        )
+        assert len(t.tools) == 9
+
+    def test_custom_server_url_passed_through(self, mock_notte_client):
+        with patch("agno.tools.notte.NotteClient") as cls:
+            NotteTools(api_key=TEST_API_KEY, server_url="https://eu.api.notte.cc")
+            cls.assert_called_once()
+            kwargs = cls.call_args.kwargs
+            assert kwargs["server_url"] == "https://eu.api.notte.cc"
+
+
+class TestNavigateTo:
+    def test_navigate_to_starts_session_and_executes_goto(self, tools, mock_session):
+        out = tools.navigate_to("https://example.com")
+        mock_session.start.assert_called_once()
+        mock_session.execute.assert_called_once_with(type="goto", url="https://example.com")
+        assert json.loads(out) == {"status": "complete", "url": "https://example.com"}
+
+    def test_navigate_to_handles_error(self, tools, mock_session):
+        mock_session.execute.side_effect = RuntimeError("boom")
+        out = tools.navigate_to("https://example.com")
+        payload = json.loads(out)
+        assert payload["status"] == "error"
+        assert "boom" in payload["message"]
+
+
+class TestScreenshot:
+    def test_screenshot_writes_bytes_to_path(self, tools, mock_session, tmp_path):
+        target = tmp_path / "shot.png"
+        out = tools.screenshot(str(target))
+        assert json.loads(out) == {"status": "success", "path": str(target)}
+        assert target.read_bytes().startswith(b"\x89PNG")
+
+
+class TestGetPageContent:
+    def test_returns_scrape_markdown(self, tools, mock_session):
+        out = tools.get_page_content()
+        mock_session.scrape.assert_called_once_with(only_main_content=True)
+        assert "Page Markdown" in out
+
+    def test_truncates_long_content(self, mock_notte_client, mock_session):
+        mock_session.scrape.return_value = "x" * 5000
+        t = NotteTools(api_key=TEST_API_KEY, max_content_length=100)
+        out = t.get_page_content()
+        assert "Content truncated" in out
+
+
+class TestObserve:
+    def test_observe_returns_action_space(self, tools, mock_session):
+        out = tools.observe()
+        payload = json.loads(out)
+        assert payload["url"] == "https://example.com"
+        assert payload["title"] == "Example"
+        assert "@B1" in payload["action_space"]
+
+    def test_observe_passes_instructions(self, tools, mock_session):
+        tools.observe(instructions="Find the search box")
+        mock_session.observe.assert_called_with(instructions="Find the search box")
+
+
+class TestClickFill:
+    def test_click_strips_at_prefix(self, tools, mock_session):
+        out = tools.click("@B1")
+        mock_session.execute.assert_called_with(type="click", id="B1")
+        assert json.loads(out)["element_id"] == "B1"
+
+    def test_fill_passes_value(self, tools, mock_session):
+        tools.fill("I1", "hello")
+        mock_session.execute.assert_called_with(type="fill", id="I1", value="hello")
+
+
+class TestScrape:
+    def test_scrape_markdown_default(self, tools, mock_session):
+        out = tools.scrape()
+        mock_session.scrape.assert_called_with(only_main_content=True)
+        assert "Page Markdown" in out
+
+    def test_scrape_with_instructions_serialises_pydantic(self, tools, mock_session):
+        structured = MagicMock()
+        structured.data.model_dump_json.return_value = '{"items": [1, 2, 3]}'
+        mock_session.scrape.return_value = structured
+
+        out = tools.scrape(instructions="Extract list items")
+        mock_session.scrape.assert_called_with(instructions="Extract list items")
+        assert json.loads(out) == {"items": [1, 2, 3]}
+
+
+class TestRunAgent:
+    def test_run_agent_invokes_client_agent(self, tools, mock_notte_client, mock_session):
+        agent = Mock()
+        agent.agent_id = "agt_test"
+        agent.run.return_value = Mock(answer="The answer is 42.")
+        mock_notte_client.Agent = Mock(return_value=agent)
+
+        out = tools.run_agent(task="Find the price of eggs", url="https://example.com")
+        mock_notte_client.Agent.assert_called_once()
+        agent.run.assert_called_once_with(task="Find the price of eggs", url="https://example.com")
+        payload = json.loads(out)
+        assert payload["status"] == "complete"
+        assert payload["answer"] == "The answer is 42."
+        assert payload["agent_id"] == "agt_test"
+
+    def test_run_agent_respects_reasoning_model(self, mock_notte_client, mock_session):
+        t = NotteTools(api_key=TEST_API_KEY, reasoning_model="gemini/gemini-2.5-flash")
+        agent = Mock(agent_id="agt", run=Mock(return_value=Mock(answer="ok")))
+        mock_notte_client.Agent = Mock(return_value=agent)
+
+        t.run_agent(task="x")
+        kwargs = mock_notte_client.Agent.call_args.kwargs
+        assert kwargs["reasoning_model"] == "gemini/gemini-2.5-flash"
+
+
+class TestCloseSession:
+    def test_close_session_stops_and_resets(self, tools, mock_session):
+        tools._ensure_session()
+        out = tools.close_session()
+        mock_session.stop.assert_called_once()
+        assert tools._session is None
+        assert json.loads(out)["status"] == "closed"
+
+    def test_close_session_handles_no_session(self, tools):
+        out = tools.close_session()
+        assert json.loads(out)["status"] == "closed"
+
+
+@pytest.mark.asyncio
+class TestAsync:
+    async def test_anavigate_to(self, tools, mock_session):
+        out = await tools.anavigate_to("https://example.com")
+        mock_session.execute.assert_called_with(type="goto", url="https://example.com")
+        assert json.loads(out)["status"] == "complete"
+
+    async def test_aobserve(self, tools, mock_session):
+        out = await tools.aobserve()
+        assert json.loads(out)["url"] == "https://example.com"
+
+    async def test_aclick(self, tools, mock_session):
+        out = await tools.aclick("B1")
+        assert json.loads(out)["element_id"] == "B1"
+
+    async def test_afill(self, tools, mock_session):
+        await tools.afill("I1", "hello")
+        mock_session.execute.assert_called_with(type="fill", id="I1", value="hello")
+
+    async def test_ascrape(self, tools, mock_session):
+        out = await tools.ascrape()
+        assert "Page Markdown" in out
+
+    async def test_aclose_session(self, tools, mock_session):
+        tools._ensure_session()
+        out = await tools.aclose_session()
+        mock_session.stop.assert_called_once()
+        assert json.loads(out)["status"] == "closed"

--- a/libs/agno/tests/unit/tools/test_notte.py
+++ b/libs/agno/tests/unit/tools/test_notte.py
@@ -76,6 +76,7 @@ class TestInit:
             "fill",
             "scrape",
             "run_agent",
+            "run_function",
             "close_session",
         }
 
@@ -90,6 +91,7 @@ class TestInit:
             enable_fill=False,
             enable_scrape=False,
             enable_run_agent=False,
+            enable_run_function=False,
             enable_close_session=False,
         )
         assert {fn.__name__ for fn in t.tools} == {"navigate_to"}
@@ -106,9 +108,10 @@ class TestInit:
             enable_fill=False,
             enable_scrape=False,
             enable_run_agent=False,
+            enable_run_function=False,
             enable_close_session=False,
         )
-        assert len(t.tools) == 9
+        assert len(t.tools) == 10
 
     def test_custom_server_url_passed_through(self, mock_notte_client):
         with patch("agno.tools.notte.NotteClient") as cls:
@@ -217,6 +220,31 @@ class TestRunAgent:
         t.run_agent(task="x")
         kwargs = mock_notte_client.Agent.call_args.kwargs
         assert kwargs["reasoning_model"] == "gemini/gemini-2.5-flash"
+
+
+class TestRunFunction:
+    def test_run_function_invokes_client_function(self, tools, mock_notte_client):
+        run_result = MagicMock()
+        run_result.model_dump_json.return_value = '{"output": "ok", "status": "complete"}'
+        function = Mock()
+        function.run = Mock(return_value=run_result)
+        mock_notte_client.Function = Mock(return_value=function)
+
+        out = tools.run_function(function_id="fn_abc", variables={"store": "xyz"})
+        mock_notte_client.Function.assert_called_once_with(function_id="fn_abc")
+        function.run.assert_called_once_with(version=None, timeout=None, store="xyz")
+        assert json.loads(out) == {"output": "ok", "status": "complete"}
+
+    def test_run_function_handles_error(self, tools, mock_notte_client):
+        function = Mock()
+        function.run = Mock(side_effect=RuntimeError("function not found"))
+        mock_notte_client.Function = Mock(return_value=function)
+
+        out = tools.run_function(function_id="fn_missing")
+        payload = json.loads(out)
+        assert payload["status"] == "error"
+        assert payload["function_id"] == "fn_missing"
+        assert "function not found" in payload["message"]
 
 
 class TestCloseSession:


### PR DESCRIPTION
## Summary

This PR adds `NotteTools`, a new browser-automation toolkit that lets an Agno agent drive a remote browser session via [Notte](https://notte.cc), a managed browser infrastructure platform purpose-built for AI agents.

Notte sits in the same category as the existing `BrowserbaseTools`: it provides hosted browser sessions (chromium, chrome, firefox), proxy rotation, captcha solving, and a live viewer. Where Notte differs is the abstraction level. In addition to raw navigation and scraping, Notte exposes:

- `observe`, which returns a structured "action space" of interactive elements with stable IDs (`B1`, `I1`, `L1`, ...) so the LLM can target elements without selectors,
- `scrape`, which accepts natural-language extraction instructions and returns structured data,
- `run_agent`, which hands a multi-step task to a Notte browser agent that runs inside the same session,
- `run_function`, which invokes a pre-deployed Notte Function (a reusable, versioned browser automation packaged as an API endpoint) by ID.

This toolkit exposes all three on top of the four primitives that mirror `BrowserbaseTools` (`navigate_to`, `screenshot`, `get_page_content`, `close_session`), so existing Browserbase users have a drop-in path and new users can adopt the higher-level primitives directly.

## Why Notte belongs alongside Browserbase

Browserbase and Notte are both YC-backed browser-infrastructure providers focused on AI agents. They are commonly evaluated together. Adding Notte as an official toolkit gives Agno users a credible alternative and means agent authors can pick the abstraction level that fits the task: low-level CDP-style ops via Browserbase, or higher-level observe / act / agent ops via Notte.

The toolkit has no Playwright dependency. Notte's SDK does observe, execute, and scrape over its own API, so the install is a single `pip install notte-sdk`.

## What's in this PR

- `libs/agno/agno/tools/notte.py`, the `NotteTools` toolkit class. Mirrors the structural conventions of `libs/agno/agno/tools/browserbase.py`: optional-import guard, per-tool `enable_*` flags plus an `all` flag, a `_ensure_session` lazy starter, sync methods plus `a*` async siblings registered through `super().__init__(name="notte_tools", tools=..., async_tools=..., **kwargs)`. Async siblings offload the sync SDK calls via `asyncio.to_thread` so the event loop is never blocked.
- `cookbook/91_tools/notte_tools.py`, a runnable example mirroring `cookbook/91_tools/browserbase_tools.py`.
- `libs/agno/tests/unit/tools/test_notte.py`, pytest unit tests covering init, the missing-key error, per-tool enable flags, the `all` flag, every sync method (with mocked SDK), and the async variants.
- `libs/agno/pyproject.toml`, three additions: a `notte = ["notte-sdk>=1.8,<2"]` extras entry, an `"agno[notte]"` aggregate-extras entry, and a `"notte_sdk.*"` entry in the mypy ignore-missing-imports overrides list.

No edits to `libs/agno/agno/tools/__init__.py`; that file does not enumerate individual toolkits.

## Toolkit functions exposed

| Function           | Notes                                                                                                       |
| ------------------ | ----------------------------------------------------------------------------------------------------------- |
| `navigate_to`      | Mirrors the Browserbase tool of the same name.                                                              |
| `screenshot`       | Mirrors the Browserbase tool of the same name.                                                              |
| `get_page_content` | Mirrors the Browserbase tool of the same name. Returns clean markdown via Notte's scrape primitive.         |
| `observe`          | Notte-native. Returns a JSON action space of interactive element IDs.                                       |
| `click`            | Notte-native. Clicks an element by its observed ID.                                                         |
| `fill`             | Notte-native. Fills an input by its observed ID.                                                            |
| `scrape`           | Notte-native. Markdown by default, structured-data extraction when `instructions=` is provided.             |
| `run_agent`        | Notte-native. Hands a multi-step task to a Notte browser agent in the same session.                         |
| `run_function`     | Notte-native. Invokes a pre-deployed Notte Function by ID, with input variables.                            |
| `close_session`    | Mirrors the Browserbase tool of the same name.                                                              |

Each tool has an `enable_*` flag, plus a master `all=False`. Defaults match the Browserbase pattern: everything on.

## Test plan

- [ ] `pytest libs/agno/tests/unit/tools/test_notte.py` passes
- [ ] `pip install -e libs/agno[notte]` installs cleanly
- [ ] `python cookbook/91_tools/notte_tools.py` runs end-to-end against a live `NOTTE_API_KEY`
- [ ] mypy passes against the new module

## Companion docs PR

The MDX docs page and `docs.json` nav entry land separately in `agno-agi/agno-docs-v1` (see `tools/toolkits/web_scrape/notte.mdx` and the Web Scraping group in `docs.json`).

## About Notte

Notte (notte.cc) is a YC-backed browser infrastructure platform for AI agents. The SDK is open source at [github.com/nottelabs/notte](https://github.com/nottelabs/notte) and the public docs live at [docs.notte.cc](https://docs.notte.cc). Sign-up and free credits at [console.notte.cc](https://console.notte.cc).
