### PR TITLE
fix: file upload media

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -426,6 +426,7 @@ class File(BaseModel):
             "application/json",
             "application/x-javascript",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
             "text/javascript",
             "application/x-python",
             "text/x-python",

--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -421,12 +421,24 @@ class File(BaseModel):
 
     @classmethod
     def valid_mime_types(cls) -> List[str]:
+        # NOTE: Keep this in sync with `DOCUMENT_MIME_TYPES` in agno.os.utils. Every MIME type
+        # the upload routers accept must be valid here, otherwise FileMedia construction fails
+        # and the file is silently dropped. Not all of these are accepted by every model
+        # provider (e.g. Anthropic/Gemini reject Office binary formats); those fail at the
+        # model with a provider error rather than being dropped at upload.
         return [
             "application/pdf",
             "application/json",
             "application/x-javascript",
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            # Office Open XML (modern Office formats)
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # .pptx
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # .xlsx
+            # Legacy binary Office formats
+            "application/msword",  # .doc
+            "application/vnd.ms-powerpoint",  # .ppt
+            "application/vnd.ms-excel",  # .xls
+            "application/vnd.ms-outlook",  # .msg
             "text/javascript",
             "application/x-python",
             "text/x-python",

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -719,7 +719,7 @@ class Claude(Model):
             raise ModelProviderError(
                 message=e.message, status_code=e.status_code, model_name=self.name, model_id=self.id
             ) from e
-        log_error("Unexpected error calling Claude API")
+        log_error(f"Unexpected error calling Claude API: {e}")
         raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
 
     def invoke(

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -49,6 +49,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
+    classify_upload_file,
     find_factory_by_id,
     format_sse_event,
     get_agent_by_id,
@@ -634,36 +635,15 @@ def get_agent_router(
 
         if files:
             for file in files:
-                if file.content_type in [
-                    "image/png",
-                    "image/jpeg",
-                    "image/jpg",
-                    "image/gif",
-                    "image/webp",
-                    "image/bmp",
-                    "image/tiff",
-                    "image/tif",
-                    "image/avif",
-                    "image/heic",
-                    "image/heif",
-                ]:
+                file_category = classify_upload_file(file)
+                if file_category == "image":
                     try:
                         base64_image = process_image(file)
                         base64_images.append(base64_image)
                     except Exception as e:
                         log_error(f"Error processing image {file.filename}: {str(e)}")
                         continue
-                elif file.content_type in [
-                    "audio/wav",
-                    "audio/wave",
-                    "audio/mp3",
-                    "audio/mpeg",
-                    "audio/ogg",
-                    "audio/mp4",
-                    "audio/m4a",
-                    "audio/aac",
-                    "audio/flac",
-                ]:
+                elif file_category == "audio":
                     try:
                         audio = process_audio(file)
                         base64_audios.append(audio)
@@ -672,42 +652,14 @@ def get_agent_router(
                             f"Error processing audio {file.filename} with content type {file.content_type}: {str(e)}"
                         )
                         continue
-                elif file.content_type in [
-                    "video/x-flv",
-                    "video/quicktime",
-                    "video/mpeg",
-                    "video/mpegs",
-                    "video/mpgs",
-                    "video/mpg",
-                    "video/mpg",
-                    "video/mp4",
-                    "video/webm",
-                    "video/wmv",
-                    "video/3gpp",
-                ]:
+                elif file_category == "video":
                     try:
                         base64_video = process_video(file)
                         base64_videos.append(base64_video)
                     except Exception as e:
                         log_error(f"Error processing video {file.filename}: {str(e)}")
                         continue
-                elif file.content_type in [
-                    "application/pdf",
-                    "application/json",
-                    "application/x-javascript",
-                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                    "application/vnd.ms-outlook",
-                    "text/javascript",
-                    "application/x-python",
-                    "text/x-python",
-                    "text/plain",
-                    "text/html",
-                    "text/css",
-                    "text/markdown",
-                    "text/csv",
-                    "text/xml",
-                    "text/rtf",
-                ]:
+                elif file_category == "document":
                     # Process document files
                     try:
                         input_file = process_document(file)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -45,6 +45,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
+    classify_upload_file,
     find_factory_by_id,
     format_sse_event,
     get_request_kwargs,
@@ -639,54 +640,29 @@ def get_team_router(
 
         if files:
             for file in files:
-                if file.content_type in [
-                    "image/png",
-                    "image/jpeg",
-                    "image/jpg",
-                    "image/webp",
-                    "image/heic",
-                    "image/heif",
-                ]:
+                file_category = classify_upload_file(file)
+                if file_category == "image":
                     try:
                         base64_image = process_image(file)
                         base64_images.append(base64_image)
                     except Exception:
                         logger.exception(f"Error processing image {file.filename}")
                         continue
-                elif file.content_type in ["audio/wav", "audio/mp3", "audio/mpeg"]:
+                elif file_category == "audio":
                     try:
                         base64_audio = process_audio(file)
                         base64_audios.append(base64_audio)
                     except Exception:
                         logger.exception(f"Error processing audio {file.filename}")
                         continue
-                elif file.content_type in [
-                    "video/x-flv",
-                    "video/quicktime",
-                    "video/mpeg",
-                    "video/mpegs",
-                    "video/mpgs",
-                    "video/mpg",
-                    "video/mpg",
-                    "video/mp4",
-                    "video/webm",
-                    "video/wmv",
-                    "video/3gpp",
-                ]:
+                elif file_category == "video":
                     try:
                         base64_video = process_video(file)
                         base64_videos.append(base64_video)
                     except Exception:
                         logger.exception(f"Error processing video {file.filename}")
                         continue
-                elif file.content_type in [
-                    "application/pdf",
-                    "text/csv",
-                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                    "application/vnd.ms-outlook",
-                    "text/plain",
-                    "application/json",
-                ]:
+                elif file_category == "document":
                     document_file = process_document(file)
                     if document_file is not None:
                         document_files.append(document_file)

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -500,6 +500,149 @@ def extract_input_media(run_dict: Dict[str, Any]) -> Dict[str, Any]:
     return input_media
 
 
+# Supported MIME types per media category, used to route uploaded files to the
+# correct processor. Keep these aligned with `File.valid_mime_types()` in agno.media
+# for document types.
+IMAGE_MIME_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+    "image/tiff",
+    "image/tif",
+    "image/avif",
+    "image/heic",
+    "image/heif",
+}
+
+AUDIO_MIME_TYPES = {
+    "audio/wav",
+    "audio/wave",
+    "audio/mp3",
+    "audio/mpeg",
+    "audio/ogg",
+    "audio/mp4",
+    "audio/m4a",
+    "audio/aac",
+    "audio/flac",
+}
+
+VIDEO_MIME_TYPES = {
+    "video/x-flv",
+    "video/quicktime",
+    "video/mpeg",
+    "video/mpegs",
+    "video/mpgs",
+    "video/mpg",
+    "video/mp4",
+    "video/webm",
+    "video/wmv",
+    "video/3gpp",
+}
+
+DOCUMENT_MIME_TYPES = {
+    "application/pdf",
+    "application/json",
+    "application/x-javascript",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
+    # NOTE: not all models might accept ppt or md files, like Gemini and Claude don't accept .pptx
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # .pptx
+    "application/vnd.ms-outlook",
+    "text/javascript",
+    "application/x-python",
+    "text/x-python",
+    "text/plain",
+    "text/html",
+    "text/css",
+    "text/markdown",
+    "text/csv",
+    "text/xml",
+    "text/rtf",
+}
+
+# Fallback mapping from file extension to media category. Used when the browser sends a
+# missing or ambiguous content type (e.g. `application/octet-stream` or empty for `.md`
+# and `.pptx`, which are not in every OS MIME registry).
+EXTENSION_CATEGORY: Dict[str, str] = {
+    # documents
+    "pdf": "document",
+    "json": "document",
+    "js": "document",
+    "docx": "document",
+    "pptx": "document",
+    "msg": "document",
+    "py": "document",
+    "txt": "document",
+    "html": "document",
+    "htm": "document",
+    "css": "document",
+    "md": "document",
+    "markdown": "document",
+    "csv": "document",
+    "xml": "document",
+    "rtf": "document",
+    # images
+    "png": "image",
+    "jpg": "image",
+    "jpeg": "image",
+    "gif": "image",
+    "webp": "image",
+    "bmp": "image",
+    "tiff": "image",
+    "tif": "image",
+    "avif": "image",
+    "heic": "image",
+    "heif": "image",
+    # audio
+    "wav": "audio",
+    "mp3": "audio",
+    "ogg": "audio",
+    "m4a": "audio",
+    "aac": "audio",
+    "flac": "audio",
+    # video
+    "flv": "video",
+    "mov": "video",
+    "mpeg": "video",
+    "mpg": "video",
+    "mp4": "video",
+    "webm": "video",
+    "wmv": "video",
+    "3gp": "video",
+}
+
+# Content types that are too generic to classify on their own; fall back to the
+# file extension for these.
+_AMBIGUOUS_CONTENT_TYPES = {None, "", "application/octet-stream"}
+
+
+def classify_upload_file(file: UploadFile) -> Optional[str]:
+    """Classify an uploaded file into one of: image, audio, video, document.
+
+    Routes primarily by `content_type`. When the content type is missing or too generic
+    to be useful (common for `.md` and `.pptx` uploaded from browsers), falls back to the
+    filename extension. Returns None if the file type is not supported.
+    """
+    content_type = file.content_type
+    if content_type in IMAGE_MIME_TYPES:
+        return "image"
+    if content_type in AUDIO_MIME_TYPES:
+        return "audio"
+    if content_type in VIDEO_MIME_TYPES:
+        return "video"
+    if content_type in DOCUMENT_MIME_TYPES:
+        return "document"
+
+    # Fall back to the file extension for ambiguous/missing content types.
+    if content_type in _AMBIGUOUS_CONTENT_TYPES and file.filename and "." in file.filename:
+        extension = file.filename.rsplit(".", 1)[-1].lower()
+        return EXTENSION_CATEGORY.get(extension)
+
+    return None
+
+
 def process_image(file: UploadFile) -> Image:
     content = file.file.read()
     if not content:
@@ -521,13 +664,53 @@ def process_video(file: UploadFile) -> Video:
     return Video(content=content, format=extract_format(file), mime_type=file.content_type)
 
 
+# Map document file extensions to their canonical MIME type, used to recover a valid
+# mime_type when the browser sends a missing or generic content type (e.g. `.md`).
+_DOCUMENT_EXTENSION_MIME: Dict[str, str] = {
+    "pdf": "application/pdf",
+    "json": "application/json",
+    "js": "text/javascript",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "msg": "application/vnd.ms-outlook",
+    "py": "text/x-python",
+    "txt": "text/plain",
+    "html": "text/html",
+    "htm": "text/html",
+    "css": "text/css",
+    "md": "text/markdown",
+    "markdown": "text/markdown",
+    "csv": "text/csv",
+    "xml": "text/xml",
+    "rtf": "text/rtf",
+}
+
+
+def _resolve_document_mime_type(file: UploadFile) -> Optional[str]:
+    """Resolve a valid document MIME type for an upload.
+
+    Prefers a usable `content_type`; otherwise derives it from the file extension so
+    documents with ambiguous content types (e.g. `.md` sent as octet-stream) still get a
+    mime_type accepted by `FileMedia`.
+    """
+    if file.content_type and file.content_type in DOCUMENT_MIME_TYPES:
+        return file.content_type
+    if file.filename and "." in file.filename:
+        extension = file.filename.rsplit(".", 1)[-1].lower()
+        return _DOCUMENT_EXTENSION_MIME.get(extension)
+    return file.content_type
+
+
 def process_document(file: UploadFile) -> Optional[FileMedia]:
     try:
         content = file.file.read()
         if not content:
             raise HTTPException(status_code=400, detail="Empty file")
         return FileMedia(
-            content=content, filename=file.filename, format=extract_format(file), mime_type=file.content_type
+            content=content,
+            filename=file.filename,
+            format=extract_format(file),
+            mime_type=_resolve_document_mime_type(file),
         )
     except Exception:
         logger.exception(f"Error processing document {file.filename}")

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -542,14 +542,24 @@ VIDEO_MIME_TYPES = {
     "video/3gpp",
 }
 
+# NOTE: Keep this in sync with `File.valid_mime_types()` in agno.media. Every type here must
+# be valid there, or the upload returns 200 but the file is silently dropped during FileMedia
+# construction. Office binary/OOXML formats (.doc, .docx, .ppt, .pptx, .xls, .xlsx) are accepted
+# at upload, but not all model providers support them as raw input - Anthropic and Gemini, for
+# example, 400 on PowerPoint. Those uploads succeed here and fail later with a provider error.
 DOCUMENT_MIME_TYPES = {
     "application/pdf",
     "application/json",
     "application/x-javascript",
+    # Office Open XML (modern Office formats)
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # .docx
-    # NOTE: not all models might accept ppt or md files, like Gemini and Claude don't accept .pptx
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # .pptx
-    "application/vnd.ms-outlook",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # .xlsx
+    # Legacy binary Office formats
+    "application/msword",  # .doc
+    "application/vnd.ms-powerpoint",  # .ppt
+    "application/vnd.ms-excel",  # .xls
+    "application/vnd.ms-outlook",  # .msg
     "text/javascript",
     "application/x-python",
     "text/x-python",
@@ -571,7 +581,11 @@ EXTENSION_CATEGORY: Dict[str, str] = {
     "json": "document",
     "js": "document",
     "docx": "document",
+    "doc": "document",
     "pptx": "document",
+    "ppt": "document",
+    "xlsx": "document",
+    "xls": "document",
     "msg": "document",
     "py": "document",
     "txt": "document",
@@ -671,7 +685,11 @@ _DOCUMENT_EXTENSION_MIME: Dict[str, str] = {
     "json": "application/json",
     "js": "text/javascript",
     "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "doc": "application/msword",
     "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "ppt": "application/vnd.ms-powerpoint",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "xls": "application/vnd.ms-excel",
     "msg": "application/vnd.ms-outlook",
     "py": "text/x-python",
     "txt": "text/plain",
@@ -702,19 +720,18 @@ def _resolve_document_mime_type(file: UploadFile) -> Optional[str]:
 
 
 def process_document(file: UploadFile) -> Optional[FileMedia]:
-    try:
-        content = file.file.read()
-        if not content:
-            raise HTTPException(status_code=400, detail="Empty file")
-        return FileMedia(
-            content=content,
-            filename=file.filename,
-            format=extract_format(file),
-            mime_type=_resolve_document_mime_type(file),
-        )
-    except Exception:
-        logger.exception(f"Error processing document {file.filename}")
-        return None
+    content = file.file.read()
+    if not content:
+        raise HTTPException(status_code=400, detail="Empty file")
+    # FileMedia construction validates the mime_type against File.valid_mime_types(). Every
+    # type in DOCUMENT_MIME_TYPES must also be valid there, otherwise the file is silently
+    # dropped here (the upload still returns 200). The unit tests assert the two stay in sync.
+    return FileMedia(
+        content=content,
+        filename=file.filename,
+        format=extract_format(file),
+        mime_type=_resolve_document_mime_type(file),
+    )
 
 
 def extract_format(file: UploadFile) -> Optional[str]:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -318,7 +318,9 @@ def _format_file_for_message(file: File, enable_citations: bool = True) -> Optio
                     "type": "document",
                     "source": {
                         "type": "text",
-                        "media_type": media_type,
+                        # Anthropic's text document source only accepts "text/plain". Other
+                        # text/* subtypes (markdown, csv, html, ...) are sent as plain text.
+                        "media_type": "text/plain",
                         "data": raw_bytes.decode("utf-8", errors="replace"),
                     },
                 }
@@ -345,7 +347,9 @@ def _format_file_for_message(file: File, enable_citations: bool = True) -> Optio
                 "type": "document",
                 "source": {
                     "type": "text",
-                    "media_type": media_type,
+                    # Anthropic's text document source only accepts "text/plain". Other
+                    # text/* subtypes (markdown, csv, html, ...) are sent as plain text.
+                    "media_type": "text/plain",
                     "data": file.content.decode("utf-8", errors="replace"),
                 },
             }

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -1,8 +1,17 @@
 """Unit tests for OS utility functions."""
 
+import io
 from datetime import datetime, timezone
+from typing import Optional
 
-from agno.os.utils import to_utc_datetime
+import pytest
+from starlette.datastructures import Headers, UploadFile
+
+from agno.os.utils import (
+    classify_upload_file,
+    process_document,
+    to_utc_datetime,
+)
 
 
 def test_returns_none_for_none_input():
@@ -89,3 +98,75 @@ def test_handles_negative_timestamp():
     assert result.year == 1969
     assert result.month == 12
     assert result.day == 31
+
+
+def _make_upload_file(filename: str, content_type: Optional[str], data: bytes = b"content") -> UploadFile:
+    """Build an UploadFile mirroring what Starlette passes the routers from a multipart upload."""
+    headers = Headers({"content-type": content_type}) if content_type is not None else Headers({})
+    return UploadFile(filename=filename, file=io.BytesIO(data), headers=headers)
+
+
+class TestClassifyUploadFile:
+    """Tests for classify_upload_file, including the extension fallback for ambiguous content types."""
+
+    @pytest.mark.parametrize(
+        "content_type, filename, expected",
+        [
+            # Images / audio / video route by content type.
+            ("image/png", "img.png", "image"),
+            ("audio/wav", "clip.wav", "audio"),
+            ("video/mp4", "movie.mp4", "video"),
+            # Documents route by content type.
+            ("application/pdf", "doc.pdf", "document"),
+            ("text/markdown", "notes.md", "document"),
+            (
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "deck.pptx",
+                "document",
+            ),
+        ],
+    )
+    def test_routes_known_content_types(self, content_type, filename, expected):
+        assert classify_upload_file(_make_upload_file(filename, content_type)) == expected
+
+    @pytest.mark.parametrize("content_type", ["application/octet-stream", "", None])
+    def test_markdown_falls_back_to_extension(self, content_type):
+        """Browsers often send .md as octet-stream/empty rather than text/markdown."""
+        assert classify_upload_file(_make_upload_file("notes.md", content_type)) == "document"
+        assert classify_upload_file(_make_upload_file("README.markdown", content_type)) == "document"
+
+    @pytest.mark.parametrize("content_type", ["application/octet-stream", "", None])
+    def test_pptx_falls_back_to_extension(self, content_type):
+        assert classify_upload_file(_make_upload_file("deck.pptx", content_type)) == "document"
+
+    def test_unsupported_type_returns_none(self):
+        """Genuinely unsupported files must still be rejected (router raises 400)."""
+        assert classify_upload_file(_make_upload_file("archive.zip", "application/zip")) is None
+        assert classify_upload_file(_make_upload_file("mystery.xyz", "application/octet-stream")) is None
+        assert classify_upload_file(_make_upload_file("noext", "application/octet-stream")) is None
+
+    def test_specific_content_type_not_overridden_by_extension(self):
+        """A recognised content type is trusted even if the extension disagrees."""
+        # An image content type with a misleading .txt name is still an image.
+        assert classify_upload_file(_make_upload_file("photo.txt", "image/png")) == "image"
+
+
+class TestProcessDocumentMimeResolution:
+    """process_document must build a FileMedia with a mime_type accepted by File.valid_mime_types()."""
+
+    def test_markdown_with_octet_stream_gets_valid_mime(self):
+        result = process_document(_make_upload_file("notes.md", "application/octet-stream", b"# Title"))
+        assert result is not None
+        assert result.mime_type == "text/markdown"
+        assert result.format == "md"
+
+    def test_pptx_with_octet_stream_gets_valid_mime(self):
+        result = process_document(_make_upload_file("deck.pptx", "application/octet-stream", b"PK\x03\x04binary"))
+        assert result is not None
+        assert result.mime_type == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        assert result.format == "pptx"
+
+    def test_known_content_type_is_preserved(self):
+        result = process_document(_make_upload_file("doc.pdf", "application/pdf", b"%PDF-1.4"))
+        assert result is not None
+        assert result.mime_type == "application/pdf"

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -7,7 +7,9 @@ from typing import Optional
 import pytest
 from starlette.datastructures import Headers, UploadFile
 
+from agno.media import File
 from agno.os.utils import (
+    DOCUMENT_MIME_TYPES,
     classify_upload_file,
     process_document,
     to_utc_datetime,
@@ -106,6 +108,30 @@ def _make_upload_file(filename: str, content_type: Optional[str], data: bytes = 
     return UploadFile(filename=filename, file=io.BytesIO(data), headers=headers)
 
 
+# Single source of truth for the document formats the API accepts: (extension, canonical MIME).
+# Every entry must classify as "document" and produce a FileMedia accepted by File.valid_mime_types().
+DOCUMENT_FORMATS = [
+    ("doc.pdf", "application/pdf"),
+    ("data.json", "application/json"),
+    ("script.js", "text/javascript"),
+    ("report.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+    ("report.doc", "application/msword"),
+    ("deck.pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+    ("deck.ppt", "application/vnd.ms-powerpoint"),
+    ("sheet.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    ("sheet.xls", "application/vnd.ms-excel"),
+    ("email.msg", "application/vnd.ms-outlook"),
+    ("module.py", "text/x-python"),
+    ("readme.txt", "text/plain"),
+    ("page.html", "text/html"),
+    ("style.css", "text/css"),
+    ("notes.md", "text/markdown"),
+    ("data.csv", "text/csv"),
+    ("feed.xml", "text/xml"),
+    ("doc.rtf", "text/rtf"),
+]
+
+
 class TestClassifyUploadFile:
     """Tests for classify_upload_file, including the extension fallback for ambiguous content types."""
 
@@ -116,28 +142,23 @@ class TestClassifyUploadFile:
             ("image/png", "img.png", "image"),
             ("audio/wav", "clip.wav", "audio"),
             ("video/mp4", "movie.mp4", "video"),
-            # Documents route by content type.
-            ("application/pdf", "doc.pdf", "document"),
-            ("text/markdown", "notes.md", "document"),
-            (
-                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                "deck.pptx",
-                "document",
-            ),
         ],
     )
-    def test_routes_known_content_types(self, content_type, filename, expected):
+    def test_routes_known_media_content_types(self, content_type, filename, expected):
         assert classify_upload_file(_make_upload_file(filename, content_type)) == expected
 
-    @pytest.mark.parametrize("content_type", ["application/octet-stream", "", None])
-    def test_markdown_falls_back_to_extension(self, content_type):
-        """Browsers often send .md as octet-stream/empty rather than text/markdown."""
-        assert classify_upload_file(_make_upload_file("notes.md", content_type)) == "document"
-        assert classify_upload_file(_make_upload_file("README.markdown", content_type)) == "document"
+    @pytest.mark.parametrize("filename, content_type", DOCUMENT_FORMATS)
+    def test_all_document_content_types_route_to_document(self, filename, content_type):
+        assert classify_upload_file(_make_upload_file(filename, content_type)) == "document"
 
-    @pytest.mark.parametrize("content_type", ["application/octet-stream", "", None])
-    def test_pptx_falls_back_to_extension(self, content_type):
-        assert classify_upload_file(_make_upload_file("deck.pptx", content_type)) == "document"
+    @pytest.mark.parametrize("filename, _content_type", DOCUMENT_FORMATS)
+    @pytest.mark.parametrize("ambiguous", ["application/octet-stream", "", None])
+    def test_documents_fall_back_to_extension(self, filename, _content_type, ambiguous):
+        """Browsers often send documents (e.g. .md, .pptx) as octet-stream/empty rather than the real MIME."""
+        assert classify_upload_file(_make_upload_file(filename, ambiguous)) == "document"
+
+    def test_markdown_alternate_extension(self):
+        assert classify_upload_file(_make_upload_file("README.markdown", "application/octet-stream")) == "document"
 
     def test_unsupported_type_returns_none(self):
         """Genuinely unsupported files must still be rejected (router raises 400)."""
@@ -151,22 +172,44 @@ class TestClassifyUploadFile:
         assert classify_upload_file(_make_upload_file("photo.txt", "image/png")) == "image"
 
 
-class TestProcessDocumentMimeResolution:
+class TestProcessDocument:
     """process_document must build a FileMedia with a mime_type accepted by File.valid_mime_types()."""
 
-    def test_markdown_with_octet_stream_gets_valid_mime(self):
-        result = process_document(_make_upload_file("notes.md", "application/octet-stream", b"# Title"))
+    @pytest.mark.parametrize("filename, content_type", DOCUMENT_FORMATS)
+    def test_known_content_type_is_preserved(self, filename, content_type):
+        result = process_document(_make_upload_file(filename, content_type, b"data"))
         assert result is not None
-        assert result.mime_type == "text/markdown"
-        assert result.format == "md"
+        assert result.mime_type == content_type
 
-    def test_pptx_with_octet_stream_gets_valid_mime(self):
-        result = process_document(_make_upload_file("deck.pptx", "application/octet-stream", b"PK\x03\x04binary"))
+    @pytest.mark.parametrize("filename, content_type", DOCUMENT_FORMATS)
+    def test_octet_stream_recovers_mime_from_extension(self, filename, content_type):
+        """When the browser sends a generic content type, mime_type is recovered from the extension."""
+        result = process_document(_make_upload_file(filename, "application/octet-stream", b"data"))
         assert result is not None
-        assert result.mime_type == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-        assert result.format == "pptx"
+        assert result.mime_type == content_type
+        assert result.format == filename.rsplit(".", 1)[-1]
 
-    def test_known_content_type_is_preserved(self):
-        result = process_document(_make_upload_file("doc.pdf", "application/pdf", b"%PDF-1.4"))
-        assert result is not None
-        assert result.mime_type == "application/pdf"
+    def test_empty_file_raises(self):
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            process_document(_make_upload_file("notes.md", "text/markdown", b""))
+        assert exc_info.value.status_code == 400
+
+
+class TestDocumentMimeTypesConsistency:
+    """Guards the invariant that broke .msg: every accepted document type must be valid for FileMedia."""
+
+    @pytest.mark.parametrize("mime_type", sorted(DOCUMENT_MIME_TYPES))
+    def test_every_document_mime_type_is_valid_for_filemedia(self, mime_type):
+        """If a type is in DOCUMENT_MIME_TYPES but not File.valid_mime_types(), uploads of that type
+        return 200 but the file is silently dropped during FileMedia construction."""
+        assert mime_type in File.valid_mime_types(), (
+            f"{mime_type} is accepted by the upload routers but rejected by File.valid_mime_types(), "
+            "so the file would be silently dropped. Add it to File.valid_mime_types()."
+        )
+
+    def test_constructing_filemedia_with_each_document_mime_type_succeeds(self):
+        for mime_type in DOCUMENT_MIME_TYPES:
+            # Should not raise.
+            File(content=b"data", mime_type=mime_type)

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -16,7 +16,8 @@ class TestFormatFileForMessage:
 
         assert result["type"] == "document"
         assert result["source"]["type"] == "text"
-        assert result["source"]["media_type"] == "text/csv"
+        # Anthropic's text document source only accepts "text/plain" as the media_type.
+        assert result["source"]["media_type"] == "text/plain"
         assert result["source"]["data"] == csv_content
         assert result["citations"] == {"enabled": True}
 
@@ -38,7 +39,7 @@ class TestFormatFileForMessage:
         result = _format_file_for_message(File(content=raw, mime_type="text/csv"))
 
         assert result["source"]["type"] == "text"
-        assert result["source"]["media_type"] == "text/csv"
+        assert result["source"]["media_type"] == "text/plain"
         assert result["source"]["data"] == "col1,col2\na,b"
 
     def test_bytes_content_pdf_returns_base64_source(self):
@@ -66,7 +67,16 @@ class TestFormatFileForMessage:
 
     @pytest.mark.parametrize(
         "mime_type",
-        ["text/plain", "text/html", "text/xml", "text/javascript", "application/json", "application/x-python"],
+        [
+            "text/plain",
+            "text/html",
+            "text/xml",
+            "text/javascript",
+            "text/markdown",
+            "text/csv",
+            "application/json",
+            "application/x-python",
+        ],
     )
     def test_all_text_mimes_route_to_text_source(self, mime_type):
         raw = b"some text content"
@@ -74,7 +84,9 @@ class TestFormatFileForMessage:
         result = _format_file_for_message(File(content=raw, mime_type=mime_type))
 
         assert result["source"]["type"] == "text"
-        assert result["source"]["media_type"] == mime_type
+        # Regardless of the original text subtype, Anthropic only accepts "text/plain"
+        # for a text document source, so all of these must be normalised to it.
+        assert result["source"]["media_type"] == "text/plain"
 
     def test_text_data_is_not_base64_encoded(self, tmp_path):
         """Regression: old code base64-encoded before checking MIME, sending gibberish as text."""


### PR DESCRIPTION
## Summary

Fixes `.md` and `.pptx` uploads failing with `"Unsupported file type"` on the agent/team run endpoints, plus a related Anthropic error for text documents.

Root causes:

- Browsers send `.md/.pptx` with a missing or generic content type (`application/octet-stream`), so the routers' `content_type`-only check rejected them even though `text/markdown` was whitelisted.
- Anthropic's text document source only accepts `media_type: "text/plain"`, but we were forwarding the real subtype (text/markdown, text/csv, ...), causing a 400.

FE PR: https://github.com/agno-agi/agno-os/pull/1046

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
