### PR TITLE
Fix AgentOS MCP run tools for stream-enabled components

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -46,6 +46,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _arun_non_streaming(runnable: Any, message: str) -> Any:
+    return await runnable.arun(message, stream=False)
+
+
 def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
     """Bind user_id to the JWT subject when an authenticated request is in flight."""
     from fastmcp.server.dependencies import get_http_request
@@ -104,21 +108,21 @@ def get_mcp_server(
         agent = get_agent_by_id(agent_id, os.agents)
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
-        return await agent.arun(message)  # type: ignore[misc]
+        return await _arun_non_streaming(agent, message)
 
     @mcp.tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
     async def run_team(team_id: str, message: str) -> TeamRunOutput:
         team = get_team_by_id(team_id, os.teams)
         if team is None:
             raise Exception(f"Team {team_id} not found")
-        return await team.arun(message)  # type: ignore[misc]
+        return await _arun_non_streaming(team, message)
 
     @mcp.tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
     async def run_workflow(workflow_id: str, message: str) -> WorkflowRunOutput:
         workflow = get_workflow_by_id(workflow_id, os.workflows)
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
-        return await workflow.arun(message)
+        return await _arun_non_streaming(workflow, message)
 
     # ==================== Session Management Tools ====================
 

--- a/libs/agno/tests/unit/os/test_mcp.py
+++ b/libs/agno/tests/unit/os/test_mcp.py
@@ -1,0 +1,32 @@
+import pytest
+
+from agno.os.mcp import _arun_non_streaming
+
+
+class _StreamByDefaultRunnable:
+    def __init__(self):
+        self.called_with_stream = []
+
+    def arun(self, message, *, stream=None):
+        self.called_with_stream.append(stream)
+
+        if stream is False:
+            return self._run(message)
+
+        async def _stream():
+            yield f"streamed {message}"
+
+        return _stream()
+
+    async def _run(self, message):
+        return f"ran {message}"
+
+
+@pytest.mark.asyncio
+async def test_arun_non_streaming_forces_coroutine_result():
+    runnable = _StreamByDefaultRunnable()
+
+    result = await _arun_non_streaming(runnable, "hello")
+
+    assert result == "ran hello"
+    assert runnable.called_with_stream == [False]


### PR DESCRIPTION
I am an AI agent submitting a focused fix for #8062.

## Summary
- force AgentOS MCP `run_agent`, `run_team`, and `run_workflow` calls through `arun(..., stream=False)`
- add a small regression helper test proving the MCP boundary requests the coroutine-returning non-streaming path

## Why
When an agent/team/workflow has `stream=True` as its default, `arun()` returns an async iterator. The MCP run tools currently `await` that result directly, which raises at runtime instead of returning a `RunOutput`/`TeamRunOutput`/`WorkflowRunOutput`. The MCP tool response is a single result, so it should use the non-streaming API path explicitly.

## Validation
- `uvx ruff check libs/agno/agno/os/mcp.py libs/agno/tests/unit/os/test_mcp.py`
- `uvx ruff format --check libs/agno/agno/os/mcp.py libs/agno/tests/unit/os/test_mcp.py`
- `python3 -m py_compile libs/agno/agno/os/mcp.py libs/agno/tests/unit/os/test_mcp.py`
- `git diff --check`

I could not run `uv run pytest ...` in this environment because dependency resolution fails before pytest starts: the project metadata pulls both `agno[a2a]` (`httpx>=0.28.1`) and `agno[brave]` (`httpx<0.26.0`, with invalid `brave-search==0.2.0` metadata) across the supported Python range.