### PR TITLE
fix: avoid kwarg collision when MCP tools have `team`/`agent`/`run_context` params

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -907,6 +907,17 @@ class FunctionCall(BaseModel):
         if "fc" in sig.parameters:
             entrypoint_args["fc"] = self
 
+        # Underscore-prefixed variants are used by internal wrappers (e.g. the
+        # MCP `call_tool` entrypoint) so framework objects can be injected
+        # without colliding with user-facing tool arguments that happen to be
+        # named "agent", "team", "run_context".
+        if "_agent" in sig.parameters:
+            entrypoint_args["_agent"] = self.function._agent
+        if "_team" in sig.parameters:
+            entrypoint_args["_team"] = self.function._team
+        if "_run_context" in sig.parameters:
+            entrypoint_args["_run_context"] = self.function._run_context
+
         # Check if the entrypoint has media arguments
         if "images" in sig.parameters:
             entrypoint_args["images"] = self.function._images

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -907,16 +907,15 @@ class FunctionCall(BaseModel):
         if "fc" in sig.parameters:
             entrypoint_args["fc"] = self
 
-        # Underscore-prefixed variants are used by internal wrappers (e.g. the
-        # MCP `call_tool` entrypoint) so framework objects can be injected
-        # without colliding with user-facing tool arguments that happen to be
-        # named "agent", "team", "run_context".
-        if "_agent" in sig.parameters:
-            entrypoint_args["_agent"] = self.function._agent
-        if "_team" in sig.parameters:
-            entrypoint_args["_team"] = self.function._team
-        if "_run_context" in sig.parameters:
-            entrypoint_args["_run_context"] = self.function._run_context
+        # `_agno_`-prefixed variants are used by internal wrappers so framework
+        # objects can be injected without colliding with user-facing tool
+        # arguments that happen to be named "agent", "team" and "run_context".
+        if "_agno_agent" in sig.parameters:
+            entrypoint_args["_agno_agent"] = self.function._agent
+        if "_agno_team" in sig.parameters:
+            entrypoint_args["_agno_team"] = self.function._team
+        if "_agno_run_context" in sig.parameters:
+            entrypoint_args["_agno_run_context"] = self.function._run_context
 
         # Check if the entrypoint has media arguments
         if "images" in sig.parameters:

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -45,14 +45,14 @@ def get_entrypoint_for_tool(
 
     async def call_tool(
         tool_name: str,
-        _run_context: Optional["RunContext"] = None,
-        _agent: Optional["Agent"] = None,
-        _team: Optional["Team"] = None,
+        _agno_run_context: Optional["RunContext"] = None,
+        _agno_agent: Optional["Agent"] = None,
+        _agno_team: Optional["Team"] = None,
         **kwargs,
     ) -> ToolResult:
-        # Framework-injected params use leading underscores (_run_context,
-        # _agent, _team) so they do not collide with MCP tool arguments
-        # named "run_context", "agent", "team".
+        # Framework-injected params use the `_agno_` prefix so they cannot
+        # collide with MCP tool arguments named "run_context", "agent" and
+        # "team".
 
         # Execute the MCP tool call
         try:
@@ -66,11 +66,14 @@ def get_entrypoint_for_tool(
                 # For MultiMCPTools, pass server_idx; for MCPTools, only pass run_context
                 if isinstance(mcp_tools_instance, MultiMCPTools):
                     active_session = await mcp_tools_instance.get_session_for_run(
-                        run_context=_run_context, server_idx=server_idx, agent=_agent, team=_team
+                        run_context=_agno_run_context,
+                        server_idx=server_idx,
+                        agent=_agno_agent,
+                        team=_agno_team,
                     )
                 else:
                     active_session = await mcp_tools_instance.get_session_for_run(
-                        run_context=_run_context, agent=_agent, team=_team
+                        run_context=_agno_run_context, agent=_agno_agent, team=_agno_team
                     )
             else:
                 active_session = session

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -45,11 +45,15 @@ def get_entrypoint_for_tool(
 
     async def call_tool(
         tool_name: str,
-        run_context: Optional["RunContext"] = None,
-        agent: Optional["Agent"] = None,
-        team: Optional["Team"] = None,
+        _run_context: Optional["RunContext"] = None,
+        _agent: Optional["Agent"] = None,
+        _team: Optional["Team"] = None,
         **kwargs,
     ) -> ToolResult:
+        # Framework-injected params use leading underscores (_run_context,
+        # _agent, _team) so they do not collide with MCP tool arguments
+        # named "run_context", "agent", "team".
+
         # Execute the MCP tool call
         try:
             # Get the appropriate session for this run
@@ -62,11 +66,11 @@ def get_entrypoint_for_tool(
                 # For MultiMCPTools, pass server_idx; for MCPTools, only pass run_context
                 if isinstance(mcp_tools_instance, MultiMCPTools):
                     active_session = await mcp_tools_instance.get_session_for_run(
-                        run_context=run_context, server_idx=server_idx, agent=agent, team=team
+                        run_context=_run_context, server_idx=server_idx, agent=_agent, team=_team
                     )
                 else:
                     active_session = await mcp_tools_instance.get_session_for_run(
-                        run_context=run_context, agent=agent, team=team
+                        run_context=_run_context, agent=_agent, team=_team
                     )
             else:
                 active_session = session

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -2,8 +2,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agno.tools.function import Function, FunctionCall
 from agno.tools.mcp import MCPTools, MultiMCPTools
 from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+from agno.utils.mcp import get_entrypoint_for_tool
 
 
 class _AsyncContextManager:
@@ -769,3 +771,96 @@ async def test_parallel_calls_no_deadlock_with_timeout():
 
             assert len(results) == 3
             assert all(s is results[0] for s in results)
+
+
+# =============================================================================
+# Tool-argument-name collision tests
+# =============================================================================
+
+
+def _make_mcp_tool_mock(name: str):
+    """Build a minimal mock that quacks like mcp.types.Tool."""
+    tool = MagicMock()
+    tool.name = name
+    return tool
+
+
+def _make_session_returning(content_text: str):
+    """Build a mock ClientSession whose call_tool returns a TextContent result."""
+    from mcp.types import TextContent
+
+    result = MagicMock()
+    result.isError = False
+    result.content = [TextContent(type="text", text=content_text)]
+
+    session = AsyncMock()
+    session.send_ping = AsyncMock()
+    session.call_tool = AsyncMock(return_value=result)
+    return session
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_with_team_argument_does_not_collide():
+    """An MCP tool with a 'team' parameter must not collide with
+    the framework's auto-injected `team` kwarg."""
+    tool = _make_mcp_tool_mock("save_issue")
+    session = _make_session_returning("issue saved")
+
+    entrypoint = get_entrypoint_for_tool(tool, session)
+
+    fn = Function(name="save_issue", entrypoint=entrypoint)
+    fn._team = MagicMock(name="agno-team-instance")
+
+    fc = FunctionCall(function=fn, arguments={"title": "Bug", "team": "Engineering"})
+
+    result = await fc.aexecute()
+
+    assert result.status == "success", f"Expected success, got error: {result.error}"
+    session.call_tool.assert_awaited_once()
+    called_name, called_kwargs = session.call_tool.await_args.args
+    assert called_name == "save_issue"
+    assert called_kwargs == {"title": "Bug", "team": "Engineering"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_with_agent_argument_does_not_collide():
+    """An MCP tool with an 'agent' parameter must not collide
+    with the framework's auto-injected `agent` kwarg."""
+    tool = _make_mcp_tool_mock("assign_task")
+    session = _make_session_returning("task assigned")
+
+    entrypoint = get_entrypoint_for_tool(tool, session)
+
+    fn = Function(name="assign_task", entrypoint=entrypoint)
+    fn._agent = MagicMock(name="agno-agent-instance")
+
+    fc = FunctionCall(function=fn, arguments={"task": "Fix bug", "agent": "alice"})
+
+    result = await fc.aexecute()
+
+    assert result.status == "success", f"Expected success, got error: {result.error}"
+    called_name, called_kwargs = session.call_tool.await_args.args
+    assert called_name == "assign_task"
+    assert called_kwargs == {"task": "Fix bug", "agent": "alice"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_with_run_context_argument_does_not_collide():
+    """An MCP tool with a 'run_context' parameter must not collide
+    with the framework's auto-injected `run_context` kwarg."""
+    tool = _make_mcp_tool_mock("log_event")
+    session = _make_session_returning("logged")
+
+    entrypoint = get_entrypoint_for_tool(tool, session)
+
+    fn = Function(name="log_event", entrypoint=entrypoint)
+    fn._run_context = MagicMock(name="agno-run-context")
+
+    fc = FunctionCall(function=fn, arguments={"event": "click", "run_context": "from-llm"})
+
+    result = await fc.aexecute()
+
+    assert result.status == "success", f"Expected success, got error: {result.error}"
+    called_name, called_kwargs = session.call_tool.await_args.args
+    assert called_name == "log_event"
+    assert called_kwargs == {"event": "click", "run_context": "from-llm"}


### PR DESCRIPTION
## Summary

`MCPTools` crashed with `TypeError: got multiple values for keyword argument 'team'` whenever an MCP server exposed a tool whose own arguments are named `team`, `agent`, or `run_context`.

Closes https://github.com/agno-agi/agno/issues/6760

## Fix

- Rename `call_tool` parameters from `run_context / agent / team` to `_run_context / _agent / _team`. The wrapper kwargs catches the LLM supplied arguments cleanly, with no overlap.
- `_build_entrypoint_args` injects into the underscored names when present. User facing tool keep using `agent / team / run_context` exactly as before, only internal wrappers opt into the underscored variants.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
