### PR TITLE
fix: preserve tool argument whitespace

### DIFF
--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -59,7 +59,7 @@ def get_function_call(
                     elif _v == "false":
                         clean_arguments[k] = False
                     else:
-                        clean_arguments[k] = v.strip()
+                        clean_arguments[k] = v
                 else:
                     clean_arguments[k] = v
 

--- a/libs/agno/tests/unit/utils/test_functions.py
+++ b/libs/agno/tests/unit/utils/test_functions.py
@@ -101,10 +101,11 @@ def test_get_function_call_argument(sample_functions):
     """Test argument sanitization for boolean and null values."""
     arguments = json.dumps(
         {
-            "param1": "None",
-            "param2": "True",
-            "param3": "False",
+            "param1": "  None  ",
+            "param2": " True ",
+            "param3": " False ",
             "param4": "  test  ",
+            "param5": "\n\n",
         }
     )
 
@@ -118,7 +119,8 @@ def test_get_function_call_argument(sample_functions):
         "param1": None,
         "param2": True,
         "param3": False,
-        "param4": "test",
+        "param4": "  test  ",
+        "param5": "\n\n",
     }
 
 


### PR DESCRIPTION
﻿## Summary
- preserve non-coercion string arguments exactly as the model provided them
- keep the existing `true` / `false` / `none` / `null` string coercion behavior
- add regression coverage for whitespace-only and whitespace-padded tool arguments

## To verify
- `python -m pytest libs\agno\tests\unit\utils\test_functions.py -q`
- `python -m ruff check libs\agno\agno\utils\functions.py libs\agno\tests\unit\utils\test_functions.py`
- `python -m py_compile libs\agno\agno\utils\functions.py libs\agno\tests\unit\utils\test_functions.py`
- `git diff --check`

Closes #7871
