### PR TITLE
fix: emit followup suggestions as CustomEvent in AGUI stream

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -292,6 +292,23 @@ def on_reasoning_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     return events
 
 
+def on_followups_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Surface generated followup suggestions to the frontend.
+
+    Without a handler this event falls through to on_unknown_event and is emitted
+    as an opaque RawEvent, which no AG-UI client renders. A named CustomEvent
+    gives frontends a stable contract to hook onto.
+
+    Registered under the agent event name only: _normalize_event strips the
+    "Team" prefix, so TeamFollowupsCompleted resolves to this same handler.
+    """
+    followups = getattr(chunk, "followups", None)
+    if not followups:
+        return []
+
+    return [CustomEvent(name="followups", value={"suggestions": followups})]
+
+
 def on_custom_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     try:
         custom_event_name = chunk.__class__.__name__
@@ -425,6 +442,7 @@ HANDLERS: Dict[str, EventHandler] = {
     RunEvent.reasoning_step.value: on_reasoning_step,
     RunEvent.reasoning_completed.value: on_reasoning_completed,
     RunEvent.custom_event.value: on_custom_event,
+    RunEvent.followups_completed.value: on_followups_completed,
 }
 
 # Terminal events that trigger completion handling

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -2152,3 +2152,82 @@ def test_extract_context_preserves_none_value():
     item = MagicMock(description="empty", value=None)
     result = extract_context([item])
     assert result == {"empty": None}
+
+
+@pytest.mark.asyncio
+async def test_followups_completed_emits_custom_event():
+    """FollowupsCompleted must surface as a CustomEvent named 'followups' before RUN_FINISHED.
+
+    Regression guard: the agui handler registry had no entry for this event, so
+    generated followup suggestions reached the client as an opaque RawEvent that
+    no frontend renders.
+    """
+    from agno.run.agent import FollowupsCompletedEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "Looking for a house"
+        yield text
+        yield FollowupsCompletedEvent(followups=["budget?", "location?", "size?"])
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    followups = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followups) == 1, f"expected 1 followups CustomEvent, got {len(followups)}"
+    assert followups[0].value == {"suggestions": ["budget?", "location?", "size?"]}
+
+    types = [e.type for e in events]
+    assert types.index(EventType.CUSTOM) < types.index(EventType.RUN_FINISHED), (
+        "followups CustomEvent must precede RUN_FINISHED so the client can render it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_followups_completed_empty_emits_nothing():
+    """None or empty followups must not emit a CustomEvent.
+
+    Guards the truthy check so an empty payload does not clutter the stream.
+    """
+    from agno.run.agent import FollowupsCompletedEvent
+
+    async def mock_stream():
+        yield FollowupsCompletedEvent(followups=None)
+        yield FollowupsCompletedEvent(followups=[])
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    assert [e for e in events if e.type == EventType.CUSTOM] == []
+
+
+@pytest.mark.asyncio
+async def test_team_followups_completed_uses_same_handler():
+    """TeamFollowupsCompleted normalizes to the agent handler, so teams behave identically."""
+    from agno.run.team import FollowupsCompletedEvent as TeamFollowupsCompletedEvent
+
+    async def mock_stream():
+        yield TeamFollowupsCompletedEvent(followups=["next step?"])
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    followups = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followups) == 1
+    assert followups[0].value == {"suggestions": ["next step?"]}


### PR DESCRIPTION
## Summary

Fixes #7398.

When an agent is configured with `followups=True`, the run loop yields `FollowupsStartedEvent` and `FollowupsCompletedEvent` before `run_completed`. These events reach the AGUI event processing loop in `stream_agno_response_as_agui_events` and `async_stream_agno_response_as_agui_events`, but `_create_events_from_chunk` had no handler for either event and silently dropped both.

## Root cause

```python
# utils.py - _create_events_from_chunk
# No branch handled RunEvent.followups_completed or RunEvent.followups_started
# → events were processed, produced empty events_to_emit, and were discarded
```

## Fix

Add an `isinstance` branch for `FollowupsCompletedEvent` in `_create_events_from_chunk` that emits a `CustomEvent` with `name="followups"` and `value={"suggestions": [...]}`:

```python
elif isinstance(chunk, FollowupsCompletedEvent):
    if chunk.followups:
        custom_event = CustomEvent(name="followups", value={"suggestions": chunk.followups})
        events_to_emit.append(custom_event)
```

The `FollowupsStartedEvent` carries no data, so it does not need its own AGUI event — only the completed event with the actual suggestions is emitted.

## Tests

Added 3 unit tests in `libs/agno/tests/unit/app/test_agui_app.py`:

- `test_followups_completed_emits_custom_event` — non-empty followups produce a `CUSTOM` event with `name="followups"` and a `suggestions` array, ordered before `RUN_FINISHED`.
- `test_followups_completed_empty_skipped` — `followups=None` and `followups=[]` produce no `CUSTOM` event (guards the truthy check).
- `test_followups_started_is_noop` — `FollowupsStartedEvent` produces no `CUSTOM` event (sibling guard).

## Manual verification

1. Configure an agent with `followups=True` and `num_followups=3`.
2. Hit the AGUI endpoint with a user message.
3. Before this fix: no followup events appear in the event stream.
4. After this fix: a `CustomEvent` with `name="followups"` arrives before `RUN_FINISHED`, containing `{"suggestions": [...]}`.