### PR TITLE
fix: align BaseDb subclass signatures with base contract

### DIFF
--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -270,11 +270,11 @@ class RedisDb(BaseDb):
             log_error(f"Error getting all records for {table_type}: {str(e)}")
             return []
 
-    def get_latest_schema_version(self):
+    def get_latest_schema_version(self, table_name: str):
         """Get the latest version of the database schema."""
         pass
 
-    def upsert_schema_version(self, version: str) -> None:
+    def upsert_schema_version(self, table_name: str, version: str) -> None:
         """Upsert the schema version into the database."""
         pass
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3272,6 +3272,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         component_type: Optional[ComponentType] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        current_version: Optional[int] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -2877,12 +2877,14 @@ class SqliteDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         parent_span_id: Optional[str] = None,
+        limit: Optional[int] = 1000,
     ) -> List:
         """Get spans matching the provided filters.
 
         Args:
             trace_id: Filter by trace ID.
             parent_span_id: Filter by parent span ID.
+            limit: Maximum number of spans to return.
 
         Returns:
             List[Span]: List of matching spans.
@@ -2902,6 +2904,9 @@ class SqliteDb(BaseDb):
                     stmt = stmt.where(table.c.trace_id == trace_id)
                 if parent_span_id:
                     stmt = stmt.where(table.c.parent_span_id == parent_span_id)
+
+                if limit:
+                    stmt = stmt.limit(limit)
 
                 results = sess.execute(stmt).fetchall()
                 return [Span.from_dict(dict(row._mapping)) for row in results]
@@ -4136,12 +4141,14 @@ class SqliteDb(BaseDb):
         self,
         component_id: str,
         version: Optional[int] = None,
+        label: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Load a component with its full resolved graph.
 
         Args:
             component_id: The component ID.
             version: Specific version or None for current.
+            label: Optional label (not yet implemented in SQLite).
 
         Returns:
             Dictionary with component, config, links, and resolved children.


### PR DESCRIPTION
## Summary

Fixes signature drift between `BaseDb`/`AsyncBaseDb` and concrete backends (`RedisDb`, `SqliteDb`, `AsyncSqliteDb`) as reported in #7762.

### Changes

**RedisDb:**
- `get_latest_schema_version`: add `table_name` param
- `upsert_schema_version`: add `table_name` param

**SqliteDb:**
- `get_spans`: add `limit` param (also implements the limit logic)
- `load_component_graph`: add `label` param

**AsyncSqliteDb:**
- `upsert_component`: add `current_version` param

### Not included

- `filter_expr` param for Redis trace methods — not added because it's not implemented in other non-SQLAlchemy backends either (DynamoDB, MongoDB, JsonDb, etc.). Adding it would just create silent failures.
- `get_all_memory_topics(user_id)` — already fixed in #7490
- `get_trace(agent_id, session_id, user_id)` — BaseDb was redesigned, these params no longer exist

### Why it matters

These changes prevent `TypeError: got an unexpected keyword argument` when AgentOS routers call backend methods with parameters the backends don't accept.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted and validated: `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Existing tests pass

Closes #7762