### PR TITLE
fix: truncate HITL card body to prevent silent Slack rejection

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/builders.py
+++ b/libs/agno/agno/os/interfaces/slack/builders.py
@@ -38,6 +38,7 @@ from agno.os.interfaces.slack.types import (
     block_to_dict,
     tool_args,
     tool_name,
+    truncate,
 )
 from agno.run.requirement import RunRequirement
 from agno.utils.serialize import json_serializer
@@ -184,6 +185,8 @@ def _build_confirmation_card(requirement: RunRequirement, run_id: str = "", awai
     # Format args as bullet points in body (not subtitle which truncates)
     body_lines = [f"• {k}: `{render_arg_value(v)}`" for k, v in (args or {}).items()]
     body_text = "\n".join(body_lines) if body_lines else "_(no arguments)_"
+    # Slack Block Kit section text has ~200 char limit; truncate to prevent silent card rejection
+    body_text = truncate(body_text, 200)
     return Card(
         block_id=f"rowact:{req_id}:confirmation",
         title=MarkdownTextObject(text=f"*{name}*"),
@@ -216,6 +219,8 @@ def build_confirmation_toggle_card(
 ) -> Card:
     button_value = encode_row_button_value(req_id, run_id, awaiting_ts)
     is_approved = selected == "approve"
+    # Slack Block Kit section text has ~200 char limit
+    body_text = truncate(body_text, 200)
 
     approve_btn = ButtonElement(
         action_id=ACTION_ROW_APPROVE,

--- a/libs/agno/tests/unit/os/routers/test_slack_blocks.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_blocks.py
@@ -134,6 +134,15 @@ class TestConfirmationRow:
         assert card.actions[0].confirm is None
         assert card.actions[1].confirm is None
 
+    def test_long_tool_args_truncated_to_200_chars(self):
+        # Slack Card block body has 200 char limit; exceeding causes invalid_blocks
+        long_comment = "x" * 300
+        card = build_pause_message(
+            "A1", [_make_requirement(tool_name="comment_on_issue", tool_args={"body": long_comment})]
+        )[0]
+        assert len(card.body.text) <= 200
+        assert card.body.text.endswith("…")
+
 
 # -- User-input row --
 
@@ -453,6 +462,21 @@ class TestBuildConfirmationToggleCard:
         )
         assert card.title.text == "*cancel_subscription*"
         assert card.body.text == "• customer_id: `C-42`"
+
+    def test_long_body_truncated_to_200_chars(self):
+        from agno.os.interfaces.slack.builders import build_confirmation_toggle_card
+
+        long_body = "• body: `" + "x" * 300 + "`"
+        card = build_confirmation_toggle_card(
+            req_id="r1",
+            run_id="A1",
+            awaiting_ts=None,
+            tool_name="comment_on_issue",
+            body_text=long_body,
+            selected="approve",
+        )
+        assert len(card.body.text) <= 200
+        assert card.body.text.endswith("…")
 
 
 # -- response_blocks --


### PR DESCRIPTION
## Summary

Slack Block Kit rejects **Card block** body text longer than 200 characters with `invalid_blocks` error, causing HITL approval cards to silently fail to render. When this happens, agents pause indefinitely waiting for approval that can never come.

This fix truncates the card body text using the existing `truncate()` helper (already in `types.py`) before building the card.

## Changes

- Import `truncate` from `agno.os.interfaces.slack.types`
- Apply `truncate(body_text, 200)` in `_build_confirmation_card()` 
- Apply `truncate(body_text, 200)` in `build_confirmation_toggle_card()`
- Add 2 tests verifying truncation behavior

## Root cause

Tool calls like `comment_on_issue` with 250+ character arguments cause the body text to exceed [Slack's Card block body limit of 200 chars](https://docs.slack.dev/reference/block-kit/blocks/card-block/). The card post request returns `ok: false` with `invalid_blocks` error, but this was not being detected — the agent just hangs waiting for approval.

Note: Section blocks have a 3000 char limit, but agno's HITL cards use the newer Card block type (2024) which has stricter limits.

## How it was discovered

agno-agi/coda#23 implemented a monkey-patch workaround (`coda/slack_patches.py`) to fix this. This PR moves the fix upstream where it belongs.

## Test plan

- [x] Ruff passes
- [x] 46 unit tests pass (`pytest libs/agno/tests/unit/os/routers/test_slack_blocks.py`)
- [x] Added `test_long_tool_args_truncated_to_200_chars` for `_build_confirmation_card`
- [x] Added `test_long_body_truncated_to_200_chars` for `build_confirmation_toggle_card`