### PR TITLE
fix: use running loop in youtube reader

### DIFF
--- a/libs/agno/agno/knowledge/reader/youtube_reader.py
+++ b/libs/agno/agno/knowledge/reader/youtube_reader.py
@@ -79,4 +79,4 @@ class YouTubeReader(Reader):
             return []
 
     async def async_read(self, url: str) -> List[Document]:
-        return await asyncio.get_event_loop().run_in_executor(None, self.read, url)
+        return await asyncio.get_running_loop().run_in_executor(None, self.read, url)


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `YouTubeReader.async_read()`

Closes #8077

## Problem
`async_read()` already executes inside a coroutine, but it currently relies on `asyncio.get_event_loop()` before offloading the sync `read()` call to an executor. `get_event_loop()` has legacy event-loop policy behavior, while `get_running_loop()` directly returns the loop currently running the coroutine.

## Before / After
Before:

```py
await asyncio.get_event_loop().run_in_executor(None, self.read, url)
```

After:

```py
await asyncio.get_running_loop().run_in_executor(None, self.read, url)
```

## Verification
- `python -m compileall -q libs\agno\agno\knowledge\reader\youtube_reader.py`
- `git diff --check`

This is a one-line async API cleanup, so I did not run the full test suite.