### PR TITLE
cookbook: switch data_labeling examples to model string shorthand

### DIFF
--- a/cookbook/data_labeling/_01_text_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_01_text_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _01_text_classification
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_01_text_classification/basic.py
+++ b/cookbook/data_labeling/_01_text_classification/basic.py
@@ -11,7 +11,6 @@ This example classifies short product reviews into sentiment classes.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -29,7 +28,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions="You classify product reviews by sentiment.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_01_text_classification/with_confidence.py
+++ b/cookbook/data_labeling/_01_text_classification/with_confidence.py
@@ -9,7 +9,6 @@ to route low-confidence labels to a human queue or to a stronger model.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -41,7 +40,7 @@ Classify the sentiment of the input text. Report a confidence level:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_01_text_classification/with_rationale.py
+++ b/cookbook/data_labeling/_01_text_classification/with_rationale.py
@@ -9,7 +9,6 @@ for training datasets where the reasoning trace is itself an artifact.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -39,7 +38,7 @@ words that drove your decision in the rationale.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_02_text_multilabel_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _02_text_multilabel_classification
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_02_text_multilabel_classification/basic.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/basic.py
@@ -12,7 +12,6 @@ on.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -42,7 +41,7 @@ positively or negatively - both count.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/hierarchical.py
@@ -10,7 +10,6 @@ that category. Useful when the label space is large and naturally nested
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -51,7 +50,7 @@ is actually about - not every entity mentioned in passing.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_02_text_multilabel_classification/with_confidence.py
+++ b/cookbook/data_labeling/_02_text_multilabel_classification/with_confidence.py
@@ -10,7 +10,6 @@ the training set.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -47,7 +46,7 @@ report confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_03_text_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_03_text_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _03_text_extraction
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_03_text_extraction/basic.py
+++ b/cookbook/data_labeling/_03_text_extraction/basic.py
@@ -11,7 +11,6 @@ This example extracts contact info from an email signature.
 from typing import Optional
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -41,7 +40,7 @@ not guess.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Contact,
 )

--- a/cookbook/data_labeling/_03_text_extraction/nested.py
+++ b/cookbook/data_labeling/_03_text_extraction/nested.py
@@ -11,7 +11,6 @@ This example extracts action items from a meeting transcript.
 from typing import List, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +43,7 @@ due date is not mentioned, leave it null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Meeting,
 )

--- a/cookbook/data_labeling/_03_text_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_03_text_extraction/with_confidence.py
@@ -10,7 +10,6 @@ or a stronger model.
 from typing import Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -51,7 +50,7 @@ Use exactly what the text shows. Do not normalize or paraphrase.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Contact,
 )

--- a/cookbook/data_labeling/_04_text_span_labeling/TEST_LOG.md
+++ b/cookbook/data_labeling/_04_text_span_labeling/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _04_text_span_labeling
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_04_text_span_labeling/basic.py
+++ b/cookbook/data_labeling/_04_text_span_labeling/basic.py
@@ -12,7 +12,6 @@ substring and locating it in Python is the robust pattern.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -46,7 +45,7 @@ pronouns or generic references.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Entities,
 )

--- a/cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
+++ b/cookbook/data_labeling/_04_text_span_labeling/pii_redaction.py
@@ -10,7 +10,6 @@ and its PII type; Python does the find-and-replace.
 from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -45,7 +44,7 @@ person names. Skip generic references like "the customer".
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=PIIDetection,
 )

--- a/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _05_text_pairwise_preference
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_05_text_pairwise_preference/basic.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/basic.py
@@ -9,7 +9,6 @@ data shape used to train reward models (RLHF) or do DPO fine-tuning.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -37,7 +36,7 @@ only when the two are genuinely indistinguishable in quality.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Preference,
 )

--- a/cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/with_rationale.py
@@ -10,7 +10,6 @@ own preferences to a human reviewer.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -40,7 +39,7 @@ clarity, tone, etc.).
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Preference,
 )

--- a/cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
+++ b/cookbook/data_labeling/_05_text_pairwise_preference/with_rubric.py
@@ -10,7 +10,6 @@ across many graders or many runs.
 from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +43,7 @@ indistinguishable on the rubric above.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Preference,
 )

--- a/cookbook/data_labeling/_06_image_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_06_image_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _06_image_classification
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_06_image_classification/basic.py
+++ b/cookbook/data_labeling/_06_image_classification/basic.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -28,7 +27,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions="You classify images by scene type.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_06_image_classification/multilabel.py
+++ b/cookbook/data_labeling/_06_image_classification/multilabel.py
@@ -10,7 +10,6 @@ from typing import List, Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -49,7 +48,7 @@ inferred or implied.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Tagging,
 )

--- a/cookbook/data_labeling/_07_image_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_07_image_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _07_image_extraction
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_07_image_extraction/basic.py
+++ b/cookbook/data_labeling/_07_image_extraction/basic.py
@@ -10,7 +10,6 @@ from typing import List, Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -43,7 +42,7 @@ If a field is not determinable from the image, leave it null or empty.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Scene,
 )

--- a/cookbook/data_labeling/_07_image_extraction/ocr_fields.py
+++ b/cookbook/data_labeling/_07_image_extraction/ocr_fields.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -46,7 +45,7 @@ include what is legible and leave the rest null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=SignReading,
 )

--- a/cookbook/data_labeling/_07_image_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_07_image_extraction/with_confidence.py
@@ -11,7 +11,6 @@ from typing import List, Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -58,7 +57,7 @@ confidence low.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Scene,
 )

--- a/cookbook/data_labeling/_08_image_bounding_boxes/TEST_LOG.md
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _08_image_bounding_boxes
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_08_image_bounding_boxes/basic.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/basic.py
@@ -8,7 +8,6 @@ emits normalized coordinates so the result is resolution-independent.
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -42,7 +41,7 @@ as possible without clipping the subject.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=BoundingBox,
 )

--- a/cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/multi_object.py
@@ -10,7 +10,6 @@ from typing import List
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -50,7 +49,7 @@ report a single box.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Detection,
 )

--- a/cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
+++ b/cookbook/data_labeling/_08_image_bounding_boxes/with_confidence.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Image
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -52,7 +51,7 @@ Confidence reflects both the box and the label:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=BoundingBox,
 )

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/TEST_LOG.md
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _09_image_extraction_to_vectordb
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini) + `gemini-embedding-001` (GeminiEmbedder), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash` + `gemini-embedding-001` (embedder), agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
+++ b/cookbook/data_labeling/_09_image_extraction_to_vectordb/basic.py
@@ -19,7 +19,6 @@ from agno.agent import Agent
 from agno.knowledge.document import Document
 from agno.knowledge.embedder.google import GeminiEmbedder
 from agno.media import Image
-from agno.models.google import Gemini
 from agno.vectordb.lancedb import LanceDb, SearchType
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
@@ -41,7 +40,7 @@ class ImageDescription(BaseModel):
 # Create Extraction Agent
 # ---------------------------------------------------------------------------
 extractor = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions="You describe images as structured, search-friendly metadata.",
     output_schema=ImageDescription,
 )

--- a/cookbook/data_labeling/_10_audio_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_10_audio_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _10_audio_classification
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_10_audio_classification/basic.py
+++ b/cookbook/data_labeling/_10_audio_classification/basic.py
@@ -12,7 +12,6 @@ from typing import Literal
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -30,7 +29,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions="You classify audio clips by spoken language.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_10_audio_classification/with_confidence.py
+++ b/cookbook/data_labeling/_10_audio_classification/with_confidence.py
@@ -11,7 +11,6 @@ from typing import Literal
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -43,7 +42,7 @@ Identify the language and report a confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_11_audio_transcription/TEST_LOG.md
+++ b/cookbook/data_labeling/_11_audio_transcription/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _11_audio_transcription
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_11_audio_transcription/basic.py
+++ b/cookbook/data_labeling/_11_audio_transcription/basic.py
@@ -8,7 +8,6 @@ Speech-to-text on an audio clip. The output is a flat transcript string.
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -34,7 +33,7 @@ transcript. Do not add commentary.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Transcript,
 )

--- a/cookbook/data_labeling/_11_audio_transcription/with_diarization.py
+++ b/cookbook/data_labeling/_11_audio_transcription/with_diarization.py
@@ -12,7 +12,6 @@ from typing import List
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -46,7 +45,7 @@ the whole clip: the first speaker is "Speaker A", the second is
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=DiarizedTranscript,
 )

--- a/cookbook/data_labeling/_11_audio_transcription/with_timestamps.py
+++ b/cookbook/data_labeling/_11_audio_transcription/with_timestamps.py
@@ -12,7 +12,6 @@ from typing import List
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +43,7 @@ beginning of the clip. Times should be monotonically non-decreasing.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=TimedTranscript,
 )

--- a/cookbook/data_labeling/_12_audio_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_12_audio_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _12_audio_extraction
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_12_audio_extraction/basic.py
+++ b/cookbook/data_labeling/_12_audio_extraction/basic.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -43,7 +42,7 @@ write what you can determine and leave others null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=CallSummary,
 )

--- a/cookbook/data_labeling/_12_audio_extraction/call_summary.py
+++ b/cookbook/data_labeling/_12_audio_extraction/call_summary.py
@@ -11,7 +11,6 @@ from typing import Literal, Optional
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -48,7 +47,7 @@ customer's tone, not the support agent's.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=SupportCall,
 )

--- a/cookbook/data_labeling/_12_audio_extraction/meeting_notes.py
+++ b/cookbook/data_labeling/_12_audio_extraction/meeting_notes.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 import requests
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Audio
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -50,7 +49,7 @@ audio (named by another speaker or self-introduced).
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=MeetingNotes,
 )

--- a/cookbook/data_labeling/_13_video_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_13_video_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _13_video_classification
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_13_video_classification/basic.py
+++ b/cookbook/data_labeling/_13_video_classification/basic.py
@@ -11,7 +11,6 @@ from typing import Literal
 import httpx
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Video
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -35,7 +34,7 @@ class Classification(BaseModel):
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions="You classify short video clips by dominant scene type.",
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_13_video_classification/with_confidence.py
+++ b/cookbook/data_labeling/_13_video_classification/with_confidence.py
@@ -11,7 +11,6 @@ from typing import Literal
 import httpx
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Video
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -50,7 +49,7 @@ Classify the clip and report a confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_14_video_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_14_video_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _14_video_extraction
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### action_timestamps.py
 

--- a/cookbook/data_labeling/_14_video_extraction/action_timestamps.py
+++ b/cookbook/data_labeling/_14_video_extraction/action_timestamps.py
@@ -12,7 +12,6 @@ from typing import List
 import httpx
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Video
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -45,7 +44,7 @@ filler content - only include events with a clear beginning and end.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Events,
 )

--- a/cookbook/data_labeling/_14_video_extraction/basic.py
+++ b/cookbook/data_labeling/_14_video_extraction/basic.py
@@ -12,7 +12,6 @@ from typing import List, Optional
 import httpx
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Video
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -48,7 +47,7 @@ shown, not what the clip is "about" thematically.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=VideoSummary,
 )

--- a/cookbook/data_labeling/_14_video_extraction/scene_descriptions.py
+++ b/cookbook/data_labeling/_14_video_extraction/scene_descriptions.py
@@ -12,7 +12,6 @@ from typing import List
 import httpx
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import Video
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -47,7 +46,7 @@ changes substantially. Do not invent details.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=ScenesDocument,
 )

--- a/cookbook/data_labeling/_15_document_classification/TEST_LOG.md
+++ b/cookbook/data_labeling/_15_document_classification/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _15_document_classification
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_15_document_classification/basic.py
+++ b/cookbook/data_labeling/_15_document_classification/basic.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +43,7 @@ on the document's structure and content, not on a few keywords.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_15_document_classification/with_confidence.py
+++ b/cookbook/data_labeling/_15_document_classification/with_confidence.py
@@ -10,7 +10,6 @@ from typing import Literal
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -49,7 +48,7 @@ Classify the attached PDF and report confidence:
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Classification,
 )

--- a/cookbook/data_labeling/_16_document_extraction/TEST_LOG.md
+++ b/cookbook/data_labeling/_16_document_extraction/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _16_document_extraction
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_16_document_extraction/basic.py
+++ b/cookbook/data_labeling/_16_document_extraction/basic.py
@@ -11,7 +11,6 @@ from typing import Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -41,7 +40,7 @@ the document shows. If a field is not present, leave it null.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=RecipeBook,
 )

--- a/cookbook/data_labeling/_16_document_extraction/with_confidence.py
+++ b/cookbook/data_labeling/_16_document_extraction/with_confidence.py
@@ -11,7 +11,6 @@ from typing import Literal, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.google import Gemini
 from pydantic import BaseModel
 from rich.pretty import pprint  # noqa
 
@@ -51,7 +50,7 @@ Be conservative. Mark unsure fields low.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=RecipeBook,
 )

--- a/cookbook/data_labeling/_16_document_extraction/with_line_items.py
+++ b/cookbook/data_labeling/_16_document_extraction/with_line_items.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 
 from agno.agent import Agent, RunOutput  # noqa
 from agno.media import File
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -45,7 +44,7 @@ fields null if not present. Do not invent recipes or paraphrase names.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=RecipeBook,
 )

--- a/cookbook/data_labeling/_17_llm_as_judge/TEST_LOG.md
+++ b/cookbook/data_labeling/_17_llm_as_judge/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _17_llm_as_judge
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini), agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash`, agno 2.6.9.
 
 Score schemas switched from `Literal[1, 2, 3, 4, 5]` to `int` with `ge=1, le=5`. Gemini's structured-output enforcement requires string-valued enums, not integer enums; bounded `int` keeps the same 1-5 scale and the discrete-output guarantee without the Literal incompatibility.
 

--- a/cookbook/data_labeling/_17_llm_as_judge/basic.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/basic.py
@@ -8,7 +8,6 @@ classification, just applied to (prompt, response) pairs.
 """
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -44,7 +43,7 @@ Use the full scale. Reserve 5 for genuinely excellent responses.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Score,
 )

--- a/cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/single_rubric.py
@@ -8,7 +8,6 @@ graders.
 """
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -45,7 +44,7 @@ clarity, but the overall should reflect the worst dimension.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=RubricScore,
 )

--- a/cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
+++ b/cookbook/data_labeling/_17_llm_as_judge/with_rationale.py
@@ -8,7 +8,6 @@ reward model.
 """
 
 from agno.agent import Agent, RunOutput  # noqa
-from agno.models.google import Gemini
 from pydantic import BaseModel, Field
 from rich.pretty import pprint  # noqa
 
@@ -35,7 +34,7 @@ phrase from the response when possible.
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=instructions,
     output_schema=Score,
 )

--- a/cookbook/data_labeling/_18_quality_review/TEST_LOG.md
+++ b/cookbook/data_labeling/_18_quality_review/TEST_LOG.md
@@ -1,6 +1,6 @@
 # Test Log - _18_quality_review
 
-Tested 2026-05-19 against `gemini-3.5-flash` (Gemini) for labeler A and `claude-opus-4-7` (Claude) for labeler B / reviewer / adjudicator, agno 2.6.8.
+Tested 2026-05-22 against `gemini-3.5-flash` for labeler A and `claude-opus-4-7` for labeler B / reviewer / adjudicator, agno 2.6.9.
 
 ### basic.py
 

--- a/cookbook/data_labeling/_18_quality_review/basic.py
+++ b/cookbook/data_labeling/_18_quality_review/basic.py
@@ -15,8 +15,6 @@ from typing import List, Optional
 
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
-from agno.models.anthropic import Claude
-from agno.models.google import Gemini
 from agno.workflow import Step, Workflow
 from agno.workflow.condition import Condition
 from agno.workflow.parallel import Parallel
@@ -63,21 +61,21 @@ shows. If a field is missing, leave it null. Do not guess.
 
 labeler_a = Agent(
     name="Labeler A",
-    model=Gemini(id="gemini-3.5-flash"),
+    model="google:gemini-3.5-flash",
     instructions=LABELER_INSTRUCTIONS,
     output_schema=Contact,
 )
 
 labeler_b = Agent(
     name="Labeler B",
-    model=Claude(id="claude-opus-4-7"),
+    model="anthropic:claude-opus-4-7",
     instructions=LABELER_INSTRUCTIONS,
     output_schema=Contact,
 )
 
 reviewer = Agent(
     name="Reviewer",
-    model=Claude(id="claude-opus-4-7"),
+    model="anthropic:claude-opus-4-7",
     instructions="""\
 You are given two labelers' Contact outputs. Compare them field by field.
 A field needs adjudication when both labelers report non-null but
@@ -89,7 +87,7 @@ needs_adjudication=true if any field needs adjudication.
 
 adjudicator = Agent(
     name="Adjudicator",
-    model=Claude(id="claude-opus-4-7"),
+    model="anthropic:claude-opus-4-7",
     instructions="""\
 Re-read the original input text and resolve every reported disagreement.
 Return a FinalLabel.contact populated with the correct values for all

--- a/cookbook/data_labeling/image_search/workflows/ingest.py
+++ b/cookbook/data_labeling/image_search/workflows/ingest.py
@@ -26,7 +26,6 @@ from typing import Any, Dict
 import httpx
 from agno.agent import Agent
 from agno.media import Image
-from agno.models.google import Gemini
 from agno.workflow import Step, StepInput, StepOutput, Workflow
 from db import get_db, get_knowledge
 from schemas import ImageDescription, to_searchable_text
@@ -79,7 +78,7 @@ EXTRACTOR_INSTRUCTIONS = (
 def make_extractor() -> Agent:
     return Agent(
         name="ImageLabeler",
-        model=Gemini(id=EXTRACTOR_MODEL_ID),
+        model=f"google:{EXTRACTOR_MODEL_ID}",
         instructions=EXTRACTOR_INSTRUCTIONS,
         output_schema=ImageDescription,
     )


### PR DESCRIPTION
## Summary

Replace explicit `Gemini(id=...)` / `Claude(id=...)` instantiations with the `"google:..."` / `"anthropic:..."` string-shorthand form across all `cookbook/data_labeling/` examples. Resolves to the same `Model` subclass via [`_parse_model_string`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/models/utils.py) in `agno.models.utils` — purely a style change, no behavior difference.

**Why:** drops a per-file import, matches the style already used in `cookbook/99_docs/` and `cookbook/frameworks/00_quickstart/`, and makes the data_labeling cookbooks more consistent internally.

**Scope:**
- 45 cookbook files in `cookbook/data_labeling/` updated (everything except `image_search/`)
- 1 workflow file in `cookbook/data_labeling/image_search/workflows/ingest.py` updated (kept its `EXTRACTOR_MODEL_ID` variable via f-string: `f"google:{EXTRACTOR_MODEL_ID}"`)
- `GeminiEmbedder` imports preserved where used (separate class)
- 18 `TEST_LOG.md` headers refreshed with 2026-05-22 date and agno 2.6.9

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — N/A, no API surface changed
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment — all 45 cookbooks re-run on 2026-05-22, all PASS
- [ ] Tests added/updated (if applicable) — N/A, no library code changed

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach — N/A
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — yes, generated via Claude Code, reviewed by author

---

## Additional Notes

**Validation:** `./scripts/format.sh` and `./scripts/validate.sh` are both clean for `cookbook/`. The 2 mypy errors that appear in `validate.sh` output (`libs/agno/agno/tools/sql.py:153` and `libs/agno/agno/tools/google/drive.py:431`) pre-exist on `main` and are unrelated to this PR — confirmed by running mypy on those files on a clean main checkout.

**Cookbook test runs (2026-05-22):** all 45 in-scope files pass against `gemini-3.5-flash` (and `claude-opus-4-7` for `_18_quality_review/basic.py`). Spot-checked outputs across sentiment classification, audio diarization, image bounding boxes, and the quality_review workflow — all produced correct structured results.

**Out of scope:**
- `cookbook/data_labeling/image_search/` (the workflow itself wasn't run; it needs pgvector + a full index rebuild). The model-line change in `workflows/ingest.py` is included but unverified.
- A separate, pre-existing observation: `agno[lancedb]` doesn't appear to be installed by `./scripts/demo_setup.sh`. `_09_image_extraction_to_vectordb/basic.py` needed a manual `uv pip install lancedb` before it would run. Worth a follow-up to `demo_setup.sh`.