### PR TITLE
feat: add run-checkpointing plumbing (enum, fields, settings)

### DIFF
--- a/libs/agno/agno/agent/_init.py
+++ b/libs/agno/agno/agent/_init.py
@@ -63,6 +63,25 @@ def set_telemetry(agent: Agent) -> None:
         agent.telemetry = telemetry_env.lower() == "true"
 
 
+def set_checkpoint(agent: Agent) -> None:
+    """Resolve the agent's checkpoint setting.
+
+    Constructor default is None so that OS-level inheritance can fill it. If still
+    None at first run, fall back to "runs" (today's terminal-only behavior).
+
+    "tools" is reserved for 3.0 (see ADR-006 in specs/agno/features/checkpointing/decisions.md)
+    and raises NotImplementedError if requested.
+    """
+    if agent.checkpoint is None:
+        agent.checkpoint = "runs"
+    elif agent.checkpoint == "tools":
+        raise NotImplementedError(
+            'checkpoint="tools" is reserved for the 3.0 runs-table split and not available yet. Use "steps" or "runs".'
+        )
+    elif agent.checkpoint not in ("runs", "steps"):
+        raise ValueError(f'Invalid checkpoint level: {agent.checkpoint!r}. Expected one of: "runs", "steps", "tools".')
+
+
 def set_default_model(agent: Agent) -> None:
     # Use the default Model (OpenAIResponses) if no model is provided
     if agent.model is None:
@@ -242,6 +261,7 @@ def initialize_agent(agent: Agent, debug_mode: Optional[bool] = None) -> None:
     set_debug(agent, debug_mode=debug_mode)
     set_id(agent)
     set_telemetry(agent)
+    set_checkpoint(agent)
     if agent.update_memory_on_run or agent.enable_agentic_memory or agent.memory_manager is not None:
         set_memory_manager(agent)
     if (

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -129,6 +129,14 @@ class Agent:
     # Database to use for this agent
     db: Optional[Union[BaseDb, AsyncBaseDb]] = None
 
+    # --- Checkpointing ---
+    # When to persist run state to the database. See specs/agno/features/checkpointing/.
+    #   "runs"  — default, write only at terminal states (today's behavior)
+    #   "steps" — write after each model turn (post-gather barrier)
+    #   "tools" — reserved for 3.0; raises NotImplementedError in 2.x
+    # None during construction means "fall back to OS-level setting, else 'runs'".
+    checkpoint: Optional[Literal["runs", "steps", "tools"]] = None
+
     # --- Agent History ---
     # add_history_to_context=true adds messages from the chat history to the messages list sent to the Model.
     add_history_to_context: bool = False
@@ -397,6 +405,7 @@ class Agent:
         dependencies: Optional[Dict[str, Any]] = None,
         add_dependencies_to_context: bool = False,
         db: Optional[Union[BaseDb, AsyncBaseDb]] = None,
+        checkpoint: Optional[Literal["runs", "steps", "tools"]] = None,
         memory_manager: Optional[MemoryManager] = None,
         enable_agentic_memory: bool = False,
         update_memory_on_run: bool = False,
@@ -527,6 +536,7 @@ class Agent:
         self.add_session_state_to_context = add_session_state_to_context
 
         self.db = db
+        self.checkpoint = checkpoint
 
         self.memory_manager = memory_manager
         self.enable_agentic_memory = enable_agentic_memory

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -197,6 +197,7 @@ class AgentOS:
         description: Optional[str] = None,
         version: Optional[str] = None,
         db: Optional[Union[BaseDb, AsyncBaseDb]] = None,
+        checkpoint: Optional[Literal["runs", "steps", "tools"]] = None,
         agents: Optional[List[Union[Agent, RemoteAgent, AgentProtocol, AgentFactory]]] = None,
         teams: Optional[List[Union[Team, RemoteTeam, TeamFactory]]] = None,
         workflows: Optional[List[Union[Workflow, RemoteWorkflow, WorkflowFactory]]] = None,
@@ -230,6 +231,10 @@ class AgentOS:
             description: Description of the AgentOS instance
             version: Version of the AgentOS instance
             db: Default database for the AgentOS instance. Agents, teams and workflows with no db will use this one.
+            checkpoint: Default checkpoint level for agents in this AgentOS. Agents without their own
+                checkpoint setting inherit this one. One of "runs", "steps", "tools" (see
+                specs/agno/features/checkpointing/). None means no OS-level default; each agent falls
+                back to "runs" at first-run time.
             agents: List of agents to include in the OS
             teams: List of teams to include in the OS
             workflows: List of workflows to include in the OS
@@ -290,6 +295,7 @@ class AgentOS:
         self.version = version
         self.description = description
         self.db = db
+        self.checkpoint = checkpoint
 
         self.telemetry = telemetry
         self.tracing = tracing
@@ -545,6 +551,9 @@ class AgentOS:
             # Set the default db to agents without their own
             if self.db is not None and agent.db is None:
                 agent.db = self.db
+            # Set the default checkpoint level on agents without their own
+            if self.checkpoint is not None and agent.checkpoint is None:
+                agent.checkpoint = self.checkpoint
             # Track all MCP tools to later handle their connection
             if agent.tools and isinstance(agent.tools, list):
                 for tool in agent.tools:

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -661,6 +661,15 @@ class RunOutput:
     # User control flow (HITL) requirements to continue a run when paused, in order of arrival
     requirements: Optional[list[RunRequirement]] = None
 
+    # Checkpoint coordinate: index into messages at the most recent checkpoint write.
+    # Set when checkpoint="steps" (or any future non-default level) persists mid-run state.
+    last_checkpoint_at_message_index: Optional[int] = None
+
+    # Fork lineage. Distinct from parent_run_id (which carries team-member / workflow-step
+    # parentage); see ADR-007 in specs/agno/features/checkpointing/decisions.md.
+    forked_from_run_id: Optional[str] = None
+    forked_from_message_index: Optional[int] = None
+
     # === FOREIGN KEY RELATIONSHIPS ===
     # These fields establish relationships to parent workflow/step structures
     # and should be treated as foreign keys for data integrity

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -305,3 +305,4 @@ class RunStatus(str, Enum):
     paused = "PAUSED"
     cancelled = "CANCELLED"
     error = "ERROR"
+    interrupted = "INTERRUPTED"

--- a/libs/agno/tests/unit/agent/test_checkpoint_plumbing.py
+++ b/libs/agno/tests/unit/agent/test_checkpoint_plumbing.py
@@ -1,0 +1,142 @@
+"""Unit tests for the checkpoint plumbing (PR 1 of run-checkpointing).
+
+Scope: additive plumbing only — no behavior change. Covers:
+- RunStatus.interrupted enum value
+- New optional fields on RunOutput and their dict round-trip
+- Agent constructor accepts checkpoint and resolves the None default
+- AgentOS-level checkpoint inheritance respects the agent override
+"""
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.run import RunStatus
+from agno.run.agent import RunOutput
+
+# ---------------------------------------------------------------------------
+# RunStatus enum
+# ---------------------------------------------------------------------------
+
+
+def test_run_status_interrupted_exists():
+    assert RunStatus.interrupted.value == "INTERRUPTED"
+    assert RunStatus("INTERRUPTED") is RunStatus.interrupted
+
+
+# ---------------------------------------------------------------------------
+# RunOutput new fields
+# ---------------------------------------------------------------------------
+
+
+def test_run_output_new_fields_default_to_none():
+    run = RunOutput(run_id="r1")
+    assert run.last_checkpoint_at_message_index is None
+    assert run.forked_from_run_id is None
+    assert run.forked_from_message_index is None
+
+
+def test_run_output_round_trip_with_checkpoint_fields():
+    run = RunOutput(
+        run_id="r1",
+        session_id="s1",
+        last_checkpoint_at_message_index=14,
+        forked_from_run_id="r0",
+        forked_from_message_index=10,
+    )
+
+    d = run.to_dict()
+    assert d["last_checkpoint_at_message_index"] == 14
+    assert d["forked_from_run_id"] == "r0"
+    assert d["forked_from_message_index"] == 10
+
+    restored = RunOutput.from_dict(d)
+    assert restored.last_checkpoint_at_message_index == 14
+    assert restored.forked_from_run_id == "r0"
+    assert restored.forked_from_message_index == 10
+    # parent_run_id is independent of fork lineage (ADR-007)
+    assert restored.parent_run_id is None
+
+
+def test_run_output_dict_excludes_none_checkpoint_fields():
+    run = RunOutput(run_id="r1")
+    d = run.to_dict()
+    # Optional checkpoint/fork fields should not appear when None
+    assert "last_checkpoint_at_message_index" not in d
+    assert "forked_from_run_id" not in d
+    assert "forked_from_message_index" not in d
+
+
+# ---------------------------------------------------------------------------
+# Agent.checkpoint param + None resolution
+# ---------------------------------------------------------------------------
+
+
+def test_agent_default_checkpoint_is_none_pre_init():
+    """Constructor leaves checkpoint as None so OS-level inheritance can fill it."""
+    agent = Agent(name="a")
+    assert agent.checkpoint is None
+
+
+def test_agent_initialize_resolves_none_to_runs():
+    agent = Agent(name="a")
+    agent.initialize_agent()
+    assert agent.checkpoint == "runs"
+
+
+@pytest.mark.parametrize("level", ["runs", "steps"])
+def test_agent_initialize_preserves_explicit_level(level):
+    agent = Agent(name="a", checkpoint=level)
+    agent.initialize_agent()
+    assert agent.checkpoint == level
+
+
+def test_agent_initialize_raises_on_tools_level():
+    agent = Agent(name="a", checkpoint="tools")
+    with pytest.raises(NotImplementedError):
+        agent.initialize_agent()
+
+
+def test_agent_initialize_raises_on_invalid_level():
+    agent = Agent(name="a", checkpoint="bogus")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        agent.initialize_agent()
+
+
+# ---------------------------------------------------------------------------
+# AgentOS-level inheritance
+# ---------------------------------------------------------------------------
+
+
+def test_agentos_checkpoint_propagates_when_agent_has_none():
+    agent = Agent(name="a", id="a-id")
+    assert agent.checkpoint is None
+
+    AgentOS(agents=[agent], db=InMemoryDb(), checkpoint="steps", telemetry=False)
+
+    # Inherited from OS, then resolved by initialize_agent
+    assert agent.checkpoint == "steps"
+
+
+def test_agentos_checkpoint_does_not_override_agent_setting():
+    agent = Agent(name="a", id="a-id", checkpoint="runs")
+
+    AgentOS(agents=[agent], db=InMemoryDb(), checkpoint="steps", telemetry=False)
+
+    # Agent-level wins
+    assert agent.checkpoint == "runs"
+
+
+def test_agentos_default_checkpoint_is_none():
+    os_app = AgentOS(db=InMemoryDb(), telemetry=False)
+    assert os_app.checkpoint is None
+
+
+def test_agentos_without_checkpoint_leaves_agent_at_runs_default():
+    agent = Agent(name="a", id="a-id")
+
+    AgentOS(agents=[agent], db=InMemoryDb(), telemetry=False)
+
+    # No OS-level setting → agent resolves to "runs" via initialize_agent
+    assert agent.checkpoint == "runs"


### PR DESCRIPTION
## Summary

PR 1 of 4 for the run-checkpointing feature. **Additive plumbing only — no behavior change.** Sets up the surface that PR 2 (`checkpoint=\"steps\"` writes) and PR 3 (unified `/continue`) build on.

Spec: `specs/agno/features/checkpointing/{README,design,decisions}.md`

### Changes

- **`RunStatus.interrupted`** added to the enum (`libs/agno/agno/run/base.py`).
- **`RunOutput`** gains three optional fields (`libs/agno/agno/run/agent.py`):
  - `last_checkpoint_at_message_index: Optional[int]`
  - `forked_from_run_id: Optional[str]`
  - `forked_from_message_index: Optional[int]`
  All round-trip through the existing `to_dict()` / `from_dict()`. `parent_run_id` is **not** overloaded — see ADR-007.
- **`Agent(checkpoint=...)`** constructor param with `Literal[\"runs\", \"steps\", \"tools\"]`. Defaults to `None` so OS-level inheritance can fill it; resolved to `\"runs\"` in `initialize_agent()`. `\"tools\"` is reserved for 3.0 and raises `NotImplementedError`.
- **`AgentOS(checkpoint=...)`** with OS→Agent inheritance mirroring the existing `db` pattern (agent-level wins). Team and Workflow are deferred to a follow-up PR per ADR-008.

### What's not in this PR

- No call sites write checkpoints yet — that's PR 2.
- `/continue` is unchanged — that's PR 3.
- `Team` and `Workflow` get `checkpoint` in a follow-up PR (ADR-008).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (\`./scripts/format.sh\` and \`./scripts/validate.sh\`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — _cookbook lands in PR 4 per the spec_
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — _generated with Claude Code following the spec_

---

## Additional Notes

**Tests:** 14 new tests in `libs/agno/tests/unit/agent/test_checkpoint_plumbing.py` covering the enum, dict round-trip, `None`-resolution, `\"tools\"` rejection, and OS-level inheritance with/without agent override. All pass; full `agent/`, `os/`, `run/` test sweep clean except for two pre-existing failures around lazy sqlite/postgres imports in `test_agent_config.py` (unchanged by this PR).

**Backward compatibility:** `checkpoint` is a new optional kwarg with a `None` default that resolves to today's behavior (`\"runs\"`). Existing agents and AgentOS instances are unaffected. No schema migration; all new state lives inside the existing `session.runs` JSON via `RunOutput.to_dict()`.