### PR TITLE
feat: add google-interactions provider to model string parser

### DIFF
--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -84,6 +84,11 @@ def _get_model_class(model_id: str, model_provider: str) -> Model:
 
         return Gemini(id=model_id)
 
+    elif model_provider == "google-interactions":
+        from agno.models.google import GeminiInteractions
+
+        return GeminiInteractions(id=model_id)
+
     elif model_provider == "groq":
         from agno.models.groq import Groq
 


### PR DESCRIPTION
## Summary

Register `GeminiInteractions` in `_get_model_class` (`libs/agno/agno/models/utils.py`) so it can be instantiated via the string-shorthand form, e.g. `"google-interactions:gemini-3.5-flash"`.

Follows the same provider-variant convention already used for `openai-chat` / `openai-responses` and `aws-claude` / `azure-foundry-claude`. Without this, only `Gemini` was reachable via shorthand and `GeminiInteractions` required an explicit `from agno.models.google import GeminiInteractions` + instantiation.

Related: #8080 (cookbook switch to string shorthand) — surfaced that the `GeminiInteractions` path wasn't wired up.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — N/A
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — N/A
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable) — no existing tests for `_get_model_class`; follows the pattern of every other provider entry

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach — N/A
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — generated via Claude Code, reviewed by author

---

## Additional Notes

Provider key choice: `google-interactions` mirrors `openai-chat` / `openai-responses` (provider-variant). Considered `google:gemini-...` defaulting to `GeminiInteractions` in the future, but kept `google` mapped to `Gemini` to avoid a silent behavior change for existing users.