### PR TITLE
fix: preserve CSV row boundaries in async reader

### DIFF
--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -169,7 +169,7 @@ class CSVReader(Reader):
 
             if total_rows <= 10:
                 # Small files: single document
-                csv_content = " ".join(", ".join(stringify_cell_value(cell) for cell in row) for row in rows)
+                csv_content = "\n".join(", ".join(stringify_cell_value(cell) for cell in row) for row in rows)
                 documents = [
                     Document(
                         name=csv_name,
@@ -186,7 +186,7 @@ class CSVReader(Reader):
                 async def _process_page(page_number: int, page_rows: List[List[str]]) -> Document:
                     """Process a page of rows into a document."""
                     start_row = (page_number - 1) * page_size + 1
-                    page_content = " ".join(", ".join(stringify_cell_value(cell) for cell in row) for row in page_rows)
+                    page_content = "\n".join(", ".join(stringify_cell_value(cell) for cell in row) for row in page_rows)
 
                     return Document(
                         name=csv_name,

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -137,10 +137,13 @@ def test_read_with_chunking(csv_reader, csv_file):
 async def test_async_read_path(csv_reader, csv_file):
     documents = await csv_reader.async_read(csv_file)
 
-    assert len(documents) == 1
+    assert len(documents) == 4
     assert documents[0].name == "test"
     assert documents[0].id.endswith("_1")
-    assert documents[0].content == "name, age, city John, 30, New York Jane, 25, San Francisco Bob, 40, Chicago"
+    assert documents[0].content == "name, age, city"
+    assert documents[1].content == "John, 30, New York"
+    assert documents[2].content == "Jane, 25, San Francisco"
+    assert documents[3].content == "Bob, 40, Chicago"
 
 
 @pytest.fixture
@@ -167,7 +170,7 @@ row10,39,City10"""
 async def test_async_read_multi_page_csv(csv_reader, multi_page_csv_file):
     documents = await csv_reader.async_read(multi_page_csv_file, page_size=5)
 
-    assert len(documents) == 3
+    assert len(documents) == 11
 
     # Check first page
     assert documents[0].name == "multi_page"
@@ -175,18 +178,24 @@ async def test_async_read_multi_page_csv(csv_reader, multi_page_csv_file):
     assert documents[0].meta_data["page"] == 1
     assert documents[0].meta_data["start_row"] == 1
     assert documents[0].meta_data["rows"] == 5
+    assert documents[0].meta_data["row_number"] == 1
+    assert documents[0].content == "name, age, city"
 
     # Check second page
-    assert documents[1].id is not None and isinstance(documents[1].id, str)
-    assert documents[1].meta_data["page"] == 2
-    assert documents[1].meta_data["start_row"] == 6
-    assert documents[1].meta_data["rows"] == 5
+    assert documents[5].id is not None and isinstance(documents[5].id, str)
+    assert documents[5].meta_data["page"] == 2
+    assert documents[5].meta_data["start_row"] == 6
+    assert documents[5].meta_data["rows"] == 5
+    assert documents[5].meta_data["row_number"] == 1
+    assert documents[5].content == "row5, 34, City5"
 
     # Check third page
-    assert documents[2].id is not None and isinstance(documents[2].id, str)
-    assert documents[2].meta_data["page"] == 3
-    assert documents[2].meta_data["start_row"] == 11
-    assert documents[2].meta_data["rows"] == 1
+    assert documents[10].id is not None and isinstance(documents[10].id, str)
+    assert documents[10].meta_data["page"] == 3
+    assert documents[10].meta_data["start_row"] == 11
+    assert documents[10].meta_data["rows"] == 1
+    assert documents[10].meta_data["row_number"] == 1
+    assert documents[10].content == "row10, 39, City10"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Make CSVReader.async_read join rows with newlines, matching the synchronous read path.
- Keep paginated async reads row-boundary preserving before RowChunking runs.
- Update CSV reader tests to assert async reads produce row chunks instead of flattened text.

Fixes #8023

## To verify
- python -m py_compile libs\agno\agno\knowledge\reader\csv_reader.py libs\agno\tests\unit\reader\test_csv_reader.py
- python -m pytest libs\agno\tests\unit\reader\test_csv_reader.py -q
- python -m ruff check libs\agno\agno\knowledge\reader\csv_reader.py libs\agno\tests\unit\reader\test_csv_reader.py
- python -m ruff format --check libs\agno\agno\knowledge\reader\csv_reader.py libs\agno\tests\unit\reader\test_csv_reader.py
- git diff --check origin/main...HEAD