### PR TITLE
fix: force non-streaming AgentOS MCP runs

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -235,7 +235,9 @@ def build_mcp_server(
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await agent.arun(message, user_id=user_id, session_id=session_id)  # type: ignore[misc]
+        # Force non-streaming: MCP returns a single final output, but the component default may be
+        # stream=True, in which case arun() returns an AsyncIterator and awaiting it raises (see #8062).
+        return await agent.arun(message, user_id=user_id, session_id=session_id, stream=False)  # type: ignore[misc]
 
     @register_builtin_tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
     async def run_team(
@@ -248,7 +250,7 @@ def build_mcp_server(
         if team is None:
             raise Exception(f"Team {team_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await team.arun(message, user_id=user_id, session_id=session_id)  # type: ignore[misc]
+        return await team.arun(message, user_id=user_id, session_id=session_id, stream=False)  # type: ignore[misc]
 
     @register_builtin_tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
     async def run_workflow(
@@ -261,7 +263,7 @@ def build_mcp_server(
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await workflow.arun(message, user_id=user_id, session_id=session_id)
+        return await workflow.arun(message, user_id=user_id, session_id=session_id, stream=False)
 
     # ==================== Session Management Tools ====================
 

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -73,6 +73,7 @@ def _stub_arun(component, run_output):
         captured["message"] = message
         captured["user_id"] = kwargs.get("user_id")
         captured["session_id"] = kwargs.get("session_id")
+        captured["stream"] = kwargs.get("stream")
         return run_output
 
     component.arun = fake_arun  # type: ignore[method-assign]
@@ -241,6 +242,8 @@ async def test_run_agent_threads_resolved_identity(monkeypatch):
     assert captured["message"] == "hi"
     assert captured["user_id"] == "jwt-alice"
     assert captured["session_id"] == "s-1"
+    # Regression for #8062: MCP must force non-streaming so awaiting arun() never hits an AsyncIterator.
+    assert captured["stream"] is False
 
 
 async def test_run_team_threads_resolved_identity(monkeypatch):
@@ -254,6 +257,7 @@ async def test_run_team_threads_resolved_identity(monkeypatch):
 
     assert captured["user_id"] == "jwt-alice"
     assert captured["session_id"] == "s-2"
+    assert captured["stream"] is False
 
 
 async def test_run_workflow_threads_resolved_identity(monkeypatch):
@@ -267,6 +271,7 @@ async def test_run_workflow_threads_resolved_identity(monkeypatch):
 
     assert captured["user_id"] == "jwt-alice"
     assert captured["session_id"] == "s-3"
+    assert captured["stream"] is False
 
 
 # ==================== Identity in custom tools ====================


### PR DESCRIPTION
﻿## Summary
- make AgentOS MCP run tools call agents, teams, and workflows with `stream=False`
- add regression coverage for components whose default run mode would otherwise stream

Fixes #8062.

## Why
`run_agent`, `run_team`, and `run_workflow` return one final output through MCP. When the underlying component default is `stream=True`, `arun()` returns an async iterator, so awaiting it raises at runtime.

## Tests
- `python -m py_compile libs\agno\agno\os\mcp.py libs\agno\tests\unit\os\test_mcp.py`
- `python -m pytest libs\agno\tests\unit\os\test_mcp.py -q`
- `python -m ruff check libs\agno\agno\os\mcp.py libs\agno\tests\unit\os\test_mcp.py`
- `python -m ruff format --check libs\agno\agno\os\mcp.py libs\agno\tests\unit\os\test_mcp.py`
