### PR TITLE
docs: fix newsletter link typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Read the full guide [here](https://docs.agno.com/coding-agents).
 ## Community
 
 - [X](https://x.com/AgnoAgi): follow for releases and demos
-- [Newsletter](https://www.agno.com/the-agno-loop-newsleter): monthly updates on what's shipping
+- [Newsletter](https://www.agno.com/the-agno-loop-newsletter): monthly updates on what's shipping
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Fix the newsletter URL typo in the root README so the Community section points to the correct page.

Closes #8089

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Docs-only change. I did not run format or validation scripts for this one-line README link fix.