### PR TITLE
docs: fix storage README links

### DIFF
--- a/cookbook/06_storage/README.md
+++ b/cookbook/06_storage/README.md
@@ -35,20 +35,20 @@ agent = Agent(
 ## Supported Databases
 
 - [`postgres`](postgres/) - PostgreSQL relational database integration
-- [`sqllite`](sqllite/) - SQLite lightweight database integration
+- [`sqlite`](sqlite/) - SQLite lightweight database integration
 - [`mongo`](mongo/) - MongoDB document database integration
 - [`mysql`](mysql/) - MySQL relational database integration
 - [`redis`](redis/) - Redis in-memory data structure store integration
 - [`singlestore`](singlestore/) - SingleStore distributed SQL database integration
 - [`firestore`](firestore/) - Google Cloud Firestore NoSQL database integration
 - [`dynamodb`](dynamodb/) - AWS DynamoDB NoSQL database integration
-- [`json`](json/) - JSON file-based storage integration
+- [`json_db`](json_db/) - JSON file-based storage integration
 - [`gcs`](gcs/) - Google Cloud Storage JSON blob integration
 - [`in_memory`](in_memory/) - In-memory storage with optional persistence hooks
 
 ## Session Management
 
-- [`00_in_memory_session_storage.py`](00_in_memory_session_storage.py) - Basic session handling
+- [`in_memory_storage_for_agent.py`](in_memory/in_memory_storage_for_agent.py) - Basic session handling
 - [`01_persistent_session_storage.py`](01_persistent_session_storage.py) - Database persistence
 - [`02_session_summary.py`](02_session_summary.py) - Session summarization
 - [`03_chat_history.py`](03_chat_history.py) - Chat history management


### PR DESCRIPTION
## Summary

Fix broken links in `cookbook/06_storage/README.md` by correcting the SQLite and JSON directory paths and pointing the in-memory example entry to an existing file.

Closes #8090

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Docs-only change. I did not run format or validation scripts for these README link fixes.