### PR TITLE
[fix] preserve reasoning_details ↔ tool_call id link in reformat_tool…

### DIFF
--- a/libs/agno/agno/utils/message.py
+++ b/libs/agno/agno/utils/message.py
@@ -228,6 +228,26 @@ def reformat_tool_call_ids(messages: List[Message], provider: str) -> List[Messa
                         tc["id"] = id_map[old_id]
                         if call_id_prefix:
                             tc["call_id"] = call_id_map.get(old_id, id_map[old_id])
+            # Also rewrite provider_data["reasoning_details"][i].id with the
+            # same id_map. Gemini 3.x (reached via OpenRouter) emits a
+            # `reasoning_details` array where each entry carries the
+            # encrypted reasoning blob plus an `id` field that references
+            # the corresponding tool_call. On the next turn Gemini validates
+            # this cross-reference server-side; if the tool_call id has been
+            # rewritten here but the reasoning_details id still points at
+            # the *original* tool_call id, Gemini sees an orphaned signature
+            # and returns either an empty body or
+            # `native_finish_reason: "MALFORMED_FUNCTION_CALL"`. Reapplying
+            # the same map keeps the link consistent without touching the
+            # encrypted `data` blob.
+            if msg_copy.provider_data:
+                rd_list = msg_copy.provider_data.get("reasoning_details")
+                if isinstance(rd_list, list):
+                    for entry in rd_list:
+                        if isinstance(entry, dict):
+                            entry_id = entry.get("id")
+                            if entry_id and entry_id in id_map:
+                                entry["id"] = id_map[entry_id]
             result.append(msg_copy)
         elif msg.role == "tool" and msg.tool_call_id and msg.tool_call_id in id_map:
             msg_copy = msg.model_copy(deep=True)

--- a/libs/agno/tests/unit/models/test_cross_model_tool_calls.py
+++ b/libs/agno/tests/unit/models/test_cross_model_tool_calls.py
@@ -123,6 +123,158 @@ class TestReformatToolCallIds:
 
 
 # ---------------------------------------------------------------------------
+# reformat_tool_call_ids — reasoning_details cross-reference (Gemini via OpenRouter)
+# ---------------------------------------------------------------------------
+
+
+class TestReformatReasoningDetailsLink:
+    """Gemini 3.x (via OpenRouter) emits ``reasoning_details`` entries whose
+    ``id`` field cross-references the tool_call ``id`` they correspond to.
+    When ``reformat_tool_call_ids`` rewrites tool_call ids to satisfy a
+    provider's prefix/length constraints, it must rewrite the matching
+    ``reasoning_details[i].id`` with the same map — otherwise Gemini sees
+    an orphaned signature on the next turn and returns
+    ``MALFORMED_FUNCTION_CALL`` / an empty body.
+    """
+
+    def _gemini_assistant(self, tool_calls, reasoning_details):
+        return Message(
+            role="assistant",
+            content="",
+            tool_calls=tool_calls,
+            provider_data={"reasoning_details": reasoning_details},
+        )
+
+    def _rd(self, tc_id, index=0, data="encrypted_blob_placeholder"):
+        return {
+            "type": "reasoning.encrypted",
+            "data": data,
+            "format": "google-gemini-v1",
+            "id": tc_id,
+            "index": index,
+        }
+
+    def test_reasoning_details_id_follows_tool_call_id(self):
+        """The cross-reference must survive an OpenAI-Chat-style remap."""
+        original_id = "tool_aggregate_project_tasks_PGIfDtr4xVoWH8JRq862"
+        msgs = [
+            self._gemini_assistant(
+                tool_calls=[_make_tool_call(original_id)],
+                reasoning_details=[self._rd(original_id, index=0, data="blob_abc")],
+            ),
+            _tool_msg(original_id),
+        ]
+        result = reformat_tool_call_ids(msgs, provider="openai_chat")
+        new_tc_id = result[0].tool_calls[0]["id"]
+        new_rd_id = result[0].provider_data["reasoning_details"][0]["id"]
+        # Tool_call rewrite happened.
+        assert new_tc_id.startswith("call_")
+        assert new_tc_id != original_id
+        # The crucial assertion — reasoning_details id tracked the rewrite.
+        assert new_rd_id == new_tc_id
+        # Tool result also tracks.
+        assert result[1].tool_call_id == new_tc_id
+        # Encrypted blob must NOT be touched.
+        assert result[0].provider_data["reasoning_details"][0]["data"] == "blob_abc"
+
+    def test_reasoning_details_parallel_tool_calls(self):
+        """Each reasoning_details entry follows its corresponding tool_call."""
+        id1 = "tool_aaaaaaaa_one"
+        id2 = "tool_bbbbbbbb_two"
+        msgs = [
+            self._gemini_assistant(
+                tool_calls=[_make_tool_call(id1), _make_tool_call(id2)],
+                reasoning_details=[
+                    self._rd(id1, index=0, data="blob1"),
+                    self._rd(id2, index=1, data="blob2"),
+                ],
+            ),
+            _tool_msg(id1),
+            _tool_msg(id2),
+        ]
+        result = reformat_tool_call_ids(msgs, provider="openai_chat")
+        tc1 = result[0].tool_calls[0]["id"]
+        tc2 = result[0].tool_calls[1]["id"]
+        rd1 = result[0].provider_data["reasoning_details"][0]["id"]
+        rd2 = result[0].provider_data["reasoning_details"][1]["id"]
+        assert tc1 != tc2  # remapped to distinct ids
+        assert tc1 == rd1  # entry 0 link preserved
+        assert tc2 == rd2  # entry 1 link preserved
+        # Blobs untouched.
+        assert result[0].provider_data["reasoning_details"][0]["data"] == "blob1"
+        assert result[0].provider_data["reasoning_details"][1]["data"] == "blob2"
+
+    def test_reasoning_details_noop_when_no_remap_needed(self):
+        """If tool_call ids already match the target prefix, reasoning_details
+        is left untouched (the early-return path)."""
+        good_id = "call_already_correct_id"
+        msgs = [
+            self._gemini_assistant(
+                tool_calls=[_make_tool_call(good_id)],
+                reasoning_details=[self._rd(good_id, data="blob_x")],
+            ),
+        ]
+        result = reformat_tool_call_ids(msgs, provider="openai_chat")
+        assert result[0].provider_data["reasoning_details"][0]["id"] == good_id
+        assert result[0].provider_data["reasoning_details"][0]["data"] == "blob_x"
+
+    def test_reasoning_details_not_mutated_in_original(self):
+        """Original message's reasoning_details must not be modified in-place."""
+        original_id = "tool_xyz_abcdefgh"
+        rd = self._rd(original_id, data="blob_orig")
+        msgs = [
+            self._gemini_assistant(
+                tool_calls=[_make_tool_call(original_id)],
+                reasoning_details=[rd],
+            ),
+            _tool_msg(original_id),
+        ]
+        reformat_tool_call_ids(msgs, provider="openai_chat")
+        # Original list is unchanged.
+        assert msgs[0].provider_data["reasoning_details"][0]["id"] == original_id
+        assert msgs[0].provider_data["reasoning_details"][0]["data"] == "blob_orig"
+        assert rd["id"] == original_id  # local reference also unchanged
+
+    def test_reasoning_details_without_tool_calls_passes_through(self):
+        """An assistant message that has reasoning_details but no tool_calls
+        is left untouched — there's no cross-reference to maintain."""
+        msgs = [
+            Message(
+                role="assistant",
+                content="just thinking out loud",
+                provider_data={"reasoning_details": [self._rd("orphan_id", data="blob_y")]},
+            ),
+        ]
+        result = reformat_tool_call_ids(msgs, provider="openai_chat")
+        # Pass-through: same object back, no rewriting attempted.
+        assert result[0].provider_data["reasoning_details"][0]["id"] == "orphan_id"
+
+    def test_reasoning_details_partial_remap_only_changes_matching_ids(self):
+        """If some tool_call ids are already valid (`call_*`) and others need
+        rewriting, only the rewritten ones should propagate to reasoning_details."""
+        good_id = "call_already_good"
+        bad_id = "tool_needs_rewrite"
+        msgs = [
+            self._gemini_assistant(
+                tool_calls=[_make_tool_call(good_id), _make_tool_call(bad_id)],
+                reasoning_details=[
+                    self._rd(good_id, index=0, data="blob_keep"),
+                    self._rd(bad_id, index=1, data="blob_swap"),
+                ],
+            ),
+        ]
+        result = reformat_tool_call_ids(msgs, provider="openai_chat")
+        # First entry untouched.
+        assert result[0].tool_calls[0]["id"] == good_id
+        assert result[0].provider_data["reasoning_details"][0]["id"] == good_id
+        # Second entry rewritten consistently on both sides.
+        new_id = result[0].tool_calls[1]["id"]
+        assert new_id.startswith("call_")
+        assert new_id != bad_id
+        assert result[0].provider_data["reasoning_details"][1]["id"] == new_id
+
+
+# ---------------------------------------------------------------------------
 # reformat_tool_call_ids — parallel tool calls
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…_call_ids

Gemini 3.x (reached via OpenRouter) emits a `reasoning_details` array on each assistant turn where every entry carries the encrypted reasoning blob plus an `id` field that cross-references the corresponding `tool_call.id`. On the next turn Gemini validates this cross-reference server-side; if the link is broken, it returns either an empty body or `native_finish_reason: "MALFORMED_FUNCTION_CALL"`.

`reformat_tool_call_ids` rewrites `tool_calls[*].id` (and tool result `tool_call_id`) to match a provider's prefix/length constraints — but until now it did NOT also rewrite `provider_data["reasoning_details"][*].id`. For OpenRouter Gemini (where the original ids look like `tool_aggregate_project_tasks_PGIfDtr4xVoWH8JRq862` and get rewritten to `call_0000…`), this leaves the `reasoning_details` entries pointing at the *original* id — Gemini sees an orphaned signature on the next turn and the run silently breaks.

This change applies the same `id_map` that rewrites `tool_calls.id` to `provider_data["reasoning_details"][*].id`. The encrypted `data` blob is never touched — only the cross-reference is repaired.

Scope is intentionally narrow:
- Only runs for assistant messages that already have `tool_calls` AND `provider_data["reasoning_details"]` populated.
- Other providers / non-Gemini routes never populate `reasoning_details` here, so this is a no-op for them.
- Existing 29 `reformat_tool_call_ids` tests continue to pass.

Adds 6 new unit tests under `TestReformatReasoningDetailsLink` covering:
- single tool call id-rebind
- parallel tool calls (each rd entry follows its corresponding tc)
- no-op when ids already correct
- input messages are not mutated in place
- assistant message with `reasoning_details` but no `tool_calls` passes through
- partial remap (only mismatched ids propagate)

Fixes #3649
Fixes #4165
Fixes #5471

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
