### PR TITLE
[fix] Add parser_model guard to continue_run_dispatch and acontinue_run_dispatch

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -2989,7 +2989,7 @@ def continue_run_dispatch(
 
     # Prepare arguments for the model
     set_default_model(agent)
-    response_format = get_response_format(agent, run_context=run_context)
+    response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
     agent.model = cast(Model, agent.model)
 
     processed_tools = agent.get_tools(
@@ -3673,7 +3673,7 @@ def acontinue_run_dispatch(  # type: ignore
         metadata_provided=metadata is not None,
     )
 
-    response_format = get_response_format(agent, run_context=run_context)
+    response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
 
     if background:
         if not agent.db:

--- a/libs/agno/tests/unit/agent/test_run_regressions.py
+++ b/libs/agno/tests/unit/agent/test_run_regressions.py
@@ -1108,3 +1108,84 @@ def test_continue_run_dispatch_syncs_requirements_with_updated_tools(monkeypatch
     assert rr.requirements[0].tool_execution is new_tool, (
         "Requirement should reference the updated ToolExecution object, not the stale one from the session."
     )
+
+
+def test_continue_run_dispatch_skips_response_format_when_parser_model_set(monkeypatch: pytest.MonkeyPatch):
+    """Regression for #8101: continue_run_dispatch must pass response_format=None
+    when agent.parser_model is set, mirroring run_dispatch's guard."""
+    agent = _make_precedence_test_agent()
+    agent.parser_model = object()  # truthy non-None sentinel
+    _patch_continue_dispatch_dependencies(agent, monkeypatch)
+
+    # Override get_response_format to return a non-None sentinel that should be
+    # discarded by the parser_model guard.
+    monkeypatch.setattr(_response, "get_response_format", lambda agent, run_context=None: {"type": "json_object"})
+
+    captured: dict[str, Any] = {}
+
+    def fake_continue_run_impl(
+        agent: Agent,
+        run_response,
+        run_messages,
+        run_context,
+        tools,
+        user_id: Optional[str] = None,
+        session=None,
+        response_format: Optional[Any] = None,
+        debug_mode: Optional[bool] = None,
+        background_tasks: Optional[Any] = None,
+        **kwargs: Any,
+    ):
+        captured["response_format"] = response_format
+        return run_response
+
+    monkeypatch.setattr(_run, "_continue_run", fake_continue_run_impl)
+
+    _run.continue_run_dispatch(
+        agent=agent,
+        run_response=RunOutput(run_id="cont-parser-1", session_id="session-1", messages=[]),
+        stream=False,
+    )
+
+    assert captured["response_format"] is None
+
+
+@pytest.mark.asyncio
+async def test_acontinue_run_dispatch_skips_response_format_when_parser_model_set(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression for #8101: acontinue_run_dispatch must pass response_format=None
+    when agent.parser_model is set, mirroring arun_dispatch's guard."""
+    agent = _make_precedence_test_agent()
+    agent.parser_model = object()
+    monkeypatch.setattr(agent, "initialize_agent", lambda debug_mode=None: None)
+    monkeypatch.setattr(_response, "get_response_format", lambda agent, run_context=None: {"type": "json_object"})
+
+    captured: dict[str, Any] = {}
+
+    async def fake_acontinue_run(
+        agent: Agent,
+        session_id: str,
+        run_context,
+        run_response: Optional[RunOutput] = None,
+        updated_tools=None,
+        requirements=None,
+        run_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        response_format: Optional[Any] = None,
+        debug_mode: Optional[bool] = None,
+        background_tasks: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> RunOutput:
+        captured["response_format"] = response_format
+        return run_response if run_response is not None else RunOutput(run_id=run_id, session_id=session_id)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(_run, "_acontinue_run", fake_acontinue_run)
+
+    await _run.acontinue_run_dispatch(
+        agent=agent,
+        run_response=RunOutput(run_id="acont-parser-1", session_id="session-1", messages=[]),
+        stream=False,
+    )
+
+    assert captured["response_format"] is None


### PR DESCRIPTION
## Summary

`continue_run_dispatch` and `acontinue_run_dispatch` were missing the `parser_model` guard that already exists in `run_dispatch`/`arun_dispatch`. When `parser_model` is set, `response_format` should be `None` to avoid passing `{"type": "json_object"}` to the model on continue iterations. This caused streaming to break on providers that don't support `json_object` in streaming continue mode (e.g. Bedrock Claude).

fixes #8101

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The fix mirrors the existing one-line guard in `run_dispatch`/`arun_dispatch`:

```python
response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
```

Applied to both `continue_run_dispatch` (line ~2992) and `acontinue_run_dispatch` (line ~3676) in `libs/agno/agno/agent/_run.py`.

Two regression tests added (sync + async) verifying `response_format` is `None` when `parser_model` is set on continue dispatchers. All 29 existing regression tests continue to pass.