### PR TITLE
[feat] OAuth M2M flow with `client_credentials` support

### DIFF
--- a/cookbook/91_tools/mcp/oauth/README.md
+++ b/cookbook/91_tools/mcp/oauth/README.md
@@ -1,0 +1,36 @@
+# mcp/oauth
+
+Demonstrates native OAuth2.1 `client_credentials` authentication for `MCPTools`.
+
+## Overview
+
+`MCPTools` now accepts an `oauth` parameter. When provided, it internally creates
+a `ClientCredentialsOAuthProvider` (from the MCP Python SDK) and handles OIDC
+discovery, token acquisition, caching, and refresh automatically.
+
+## Usage
+
+```python
+from agno.tools.mcp import MCPTools, OAuthConfig
+
+async with MCPTools(
+    url="http://your-mcp-server/mcp",
+    transport="streamable-http",
+    oauth=OAuthConfig(
+        client_id="your-client-id",
+        client_secret="your-client-secret",
+        # scopes="read write",  # optional
+    ),
+) as mcp_tools:
+    agent = Agent(tools=[mcp_tools], ...)
+```
+
+## Running the example
+
+```bash
+# Terminal 1 — start the mock server
+.venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
+
+# Terminal 2 — run the agent
+.venvs/demo/bin/python cookbook/91_tools/mcp/oauth/client.py
+```

--- a/cookbook/91_tools/mcp/oauth/README.md
+++ b/cookbook/91_tools/mcp/oauth/README.md
@@ -34,3 +34,8 @@ async with MCPTools(
 # Terminal 2 — run the agent
 .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/client.py
 ```
+
+> Disclaimer: The current OAuthConfig only supports `client_credentials` flow
+> with in-memory token storage.
+> Future versions may expand to support other flows like `authorization_code`,
+> `private_key_jwt` and persistent storage.

--- a/cookbook/91_tools/mcp/oauth/README.md
+++ b/cookbook/91_tools/mcp/oauth/README.md
@@ -1,20 +1,80 @@
 # mcp/oauth
 
-Demonstrates native OAuth2.1 `client_credentials` authentication for `MCPTools`.
+Native OAuth2.1 `client_credentials` authentication for `MCPTools` against a
+real OAuth-protected MCP server.
 
-## Overview
+## How it works
 
-`MCPTools` now accepts an `oauth` parameter. When provided, it internally creates
-a `ClientCredentialsOAuthProvider` (from the MCP Python SDK) and handles OIDC
-discovery, token acquisition, caching, and refresh automatically.
+- **`server.py`** — FastMCP server protected by `RemoteAuthProvider` +
+  `JWTVerifier`. It validates incoming bearer tokens against an external OIDC
+  provider's JWKS endpoint and advertises that provider via
+  protected-resource metadata.
+- **`client.py`** — Agno agent using `MCPTools(oauth=OAuthConfig(...))`. The
+  MCP SDK's `ClientCredentialsOAuthProvider` discovers the authorization
+  server from the protected-resource metadata, fetches an access token via
+  `client_credentials`, and injects `Authorization: Bearer <token>` on every
+  request.
 
-## Usage
+## Requirements
+
+Any standards-compliant OIDC provider (Keycloak, Auth0, Okta, Authentik,
+Zitadel, ...) configured with:
+
+- A `client_credentials`-capable client (confidential client with service
+  accounts / machine-to-machine grant enabled).
+- An `aud` claim on issued access tokens that the MCP server can validate
+  against (configure via an audience mapper or scope on most providers).
+- A publicly reachable JWKS endpoint (`/.well-known/jwks.json` or the
+  provider-specific equivalent) and discovery document.
+
+You will need:
+
+- Issuer URL (e.g. `https://auth.example.com` or `https://.../realms/<name>`)
+- JWKS URI
+- Expected audience value
+- Client ID and client secret
+
+> **Why `RemoteAuthProvider` and not `OIDCProxy`?** FastMCP's `OIDCProxy` is a
+> Dynamic Client Registration (DCR) shim in front of providers that don't
+> support DCR (Auth0, Okta, Google, Azure) and is designed for the interactive
+> `authorization_code` flow. The `client_credentials` grant uses
+> pre-registered credentials and never performs DCR, so the lighter
+> `RemoteAuthProvider` (JWT validation + protected-resource metadata) is the
+> right fit for M2M scenarios regardless of whether the upstream provider
+> supports DCR.
+
+## Running
+
+Configure both pieces via environment variables and run them in separate
+terminals.
+
+```bash
+# server.py — what the MCP server expects
+export OIDC_ISSUER="https://auth.example.com"
+export OIDC_JWKS_URI="https://auth.example.com/.well-known/jwks.json"
+export OIDC_AUDIENCE="mcp-server"
+export MCP_BASE_URL="http://localhost:9000"
+
+.venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
+```
+
+```bash
+# client.py — what the Agno agent uses
+export MCP_URL="http://localhost:9000/mcp"
+export OAUTH_CLIENT_ID="your-client-id"
+export OAUTH_CLIENT_SECRET="your-client-secret"
+export OPENAI_API_KEY="sk-..."  # used by the agent's model
+
+.venvs/demo/bin/python cookbook/91_tools/mcp/oauth/client.py
+```
+
+## Using it in your own code
 
 ```python
 from agno.tools.mcp import MCPTools, OAuthConfig
 
 async with MCPTools(
-    url="http://your-mcp-server/mcp",
+    url="https://your-mcp-server/mcp",
     transport="streamable-http",
     oauth=OAuthConfig(
         client_id="your-client-id",
@@ -25,17 +85,7 @@ async with MCPTools(
     agent = Agent(tools=[mcp_tools], ...)
 ```
 
-## Running the example
-
-```bash
-# Terminal 1 — start the mock server
-.venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
-
-# Terminal 2 — run the agent
-.venvs/demo/bin/python cookbook/91_tools/mcp/oauth/client.py
-```
-
-> Disclaimer: The current OAuthConfig only supports `client_credentials` flow
-> with in-memory token storage.
-> Future versions may expand to support other flows like `authorization_code`,
-> `private_key_jwt` and persistent storage.
+> **Note:** `OAuthConfig` currently supports only the `client_credentials`
+> (M2M) grant with in-memory token storage. Other grants
+> (e.g. `authorization_code`, `private_key_jwt`) and persistent storage may
+> be added in future versions.

--- a/cookbook/91_tools/mcp/oauth/TEST_LOG.md
+++ b/cookbook/91_tools/mcp/oauth/TEST_LOG.md
@@ -1,42 +1,11 @@
-# TEST_LOG
+# Test Log
 
-### client.py
+### Pending
 
-**Status:** PARTIAL
+**Status:** NOT RUN
 
-**Description:** Agent connecting to an OAuth-protected MCP server using `OAuthConfig`. The cookbook server (`server.py`) is a mock FastMCP instance that validates a static bearer token inside the `get_secret_data` tool — it is not a real OAuth authorization server (no `.well-known/oauth-authorization-server`, no token endpoint, no transport-level 401 challenge).
+**Description:** Tests for this cookbook directory have not been executed yet in this workspace.
 
-**Result:** The MCPTools session connected successfully with `OAuthConfig(client_id="demo-client-id", client_secret="demo-client-secret")` attached and the tool list was discovered:
-
-```
-Connected. Available tools: ['get_secret_data', 'ping']
-```
-
-Verifications:
-
-- `OAuthConfig` is accepted by `MCPTools.__init__` and propagated into the underlying provider construction (see `libs/agno/agno/tools/mcp/oauth.py::create_oauth_provider`).
-- `ClientCredentialsOAuthProvider` is instantiated and registered as the MCP transport's auth provider — the MCP session initialized over `streamable-http` without errors.
-- The server received `POST /mcp` (initialize), `POST /mcp` (notifications), `GET /mcp`, `POST /mcp` (tools/list), `DELETE /mcp` (session close) and returned 200/202 to all of them.
-
-Where it stopped:
-
-1. The OAuth **token-fetch path was not exercised end-to-end**. The mock server does not return a `401 Unauthorized` with a `WWW-Authenticate: Bearer ...` challenge at the transport layer (it only checks the bearer token inside the `get_secret_data` tool body). The MCP SDK's `ClientCredentialsOAuthProvider` only triggers OIDC discovery + client-credentials token exchange in response to a 401 challenge — none was issued, so no `/.well-known/...` or token-endpoint requests were observed in the server log. This is the limitation the plan anticipated: a real OAuth-protected MCP server (e.g., one wrapped with FastMCP's `OIDCProxy`) is required to exercise the full flow.
-2. The agent's LLM call failed because `OPENAI_API_KEY` is not set in this environment:
-
-   ```
-   ERROR    Model authentication error from OpenAI API: OPENAI_API_KEY not set.
-            Please set the OPENAI_API_KEY environment variable.
-   ERROR    Error in Agent run: OPENAI_API_KEY not set. Please set the
-            OPENAI_API_KEY environment variable.
-   ```
-
-   This is unrelated to OAuth — it blocks the LLM from calling the tool, which is what would have caused the mock server to return its "Unauthorized: invalid token 'demo-access-token'" string (since the static token does not match what a real client_credentials grant against the mock would produce anyway).
-
-Conclusion: the OAuth **wiring** in `MCPTools` is verified — `OAuthConfig` is accepted, the provider is constructed and attached to the MCP transport, and the MCP session establishes cleanly. The **token-exchange** itself was not observed because the cookbook's mock server does not issue 401 challenges and is not a real authorization server. End-to-end verification requires a real OAuth-protected MCP server.
-
-**Environment:**
-- demo venv: `.venvs/demo` (created via `./scripts/demo_setup.sh`; `fastmcp` was installed afterwards into the venv as it is not part of `agno[demo]`)
-- OPENAI_API_KEY: not set
-- Server: `cookbook/91_tools/mcp/oauth/server.py`, run via an inline wrapper on port **18000** because port 8000 was occupied by an unrelated local service on this machine. The cookbook source files were not modified; the wrapper imported `mcp` from `server.py` and called `mcp.run(transport="streamable-http", port=18000)`. The client was invoked with `url="http://localhost:18000/mcp"`.
+**Result:** Add individual run results after executing examples.
 
 ---

--- a/cookbook/91_tools/mcp/oauth/TEST_LOG.md
+++ b/cookbook/91_tools/mcp/oauth/TEST_LOG.md
@@ -1,0 +1,11 @@
+# TEST_LOG
+
+### client.py
+
+**Status:** UNTESTED
+
+**Description:** Agent connecting to an OAuth-protected MCP server using OAuthConfig.
+
+**Result:** Not yet tested — fill in after running.
+
+---

--- a/cookbook/91_tools/mcp/oauth/TEST_LOG.md
+++ b/cookbook/91_tools/mcp/oauth/TEST_LOG.md
@@ -2,10 +2,41 @@
 
 ### client.py
 
-**Status:** UNTESTED
+**Status:** PARTIAL
 
-**Description:** Agent connecting to an OAuth-protected MCP server using OAuthConfig.
+**Description:** Agent connecting to an OAuth-protected MCP server using `OAuthConfig`. The cookbook server (`server.py`) is a mock FastMCP instance that validates a static bearer token inside the `get_secret_data` tool — it is not a real OAuth authorization server (no `.well-known/oauth-authorization-server`, no token endpoint, no transport-level 401 challenge).
 
-**Result:** Not yet tested — fill in after running.
+**Result:** The MCPTools session connected successfully with `OAuthConfig(client_id="demo-client-id", client_secret="demo-client-secret")` attached and the tool list was discovered:
+
+```
+Connected. Available tools: ['get_secret_data', 'ping']
+```
+
+Verifications:
+
+- `OAuthConfig` is accepted by `MCPTools.__init__` and propagated into the underlying provider construction (see `libs/agno/agno/tools/mcp/oauth.py::create_oauth_provider`).
+- `ClientCredentialsOAuthProvider` is instantiated and registered as the MCP transport's auth provider — the MCP session initialized over `streamable-http` without errors.
+- The server received `POST /mcp` (initialize), `POST /mcp` (notifications), `GET /mcp`, `POST /mcp` (tools/list), `DELETE /mcp` (session close) and returned 200/202 to all of them.
+
+Where it stopped:
+
+1. The OAuth **token-fetch path was not exercised end-to-end**. The mock server does not return a `401 Unauthorized` with a `WWW-Authenticate: Bearer ...` challenge at the transport layer (it only checks the bearer token inside the `get_secret_data` tool body). The MCP SDK's `ClientCredentialsOAuthProvider` only triggers OIDC discovery + client-credentials token exchange in response to a 401 challenge — none was issued, so no `/.well-known/...` or token-endpoint requests were observed in the server log. This is the limitation the plan anticipated: a real OAuth-protected MCP server (e.g., one wrapped with FastMCP's `OIDCProxy`) is required to exercise the full flow.
+2. The agent's LLM call failed because `OPENAI_API_KEY` is not set in this environment:
+
+   ```
+   ERROR    Model authentication error from OpenAI API: OPENAI_API_KEY not set.
+            Please set the OPENAI_API_KEY environment variable.
+   ERROR    Error in Agent run: OPENAI_API_KEY not set. Please set the
+            OPENAI_API_KEY environment variable.
+   ```
+
+   This is unrelated to OAuth — it blocks the LLM from calling the tool, which is what would have caused the mock server to return its "Unauthorized: invalid token 'demo-access-token'" string (since the static token does not match what a real client_credentials grant against the mock would produce anyway).
+
+Conclusion: the OAuth **wiring** in `MCPTools` is verified — `OAuthConfig` is accepted, the provider is constructed and attached to the MCP transport, and the MCP session establishes cleanly. The **token-exchange** itself was not observed because the cookbook's mock server does not issue 401 challenges and is not a real authorization server. End-to-end verification requires a real OAuth-protected MCP server.
+
+**Environment:**
+- demo venv: `.venvs/demo` (created via `./scripts/demo_setup.sh`; `fastmcp` was installed afterwards into the venv as it is not part of `agno[demo]`)
+- OPENAI_API_KEY: not set
+- Server: `cookbook/91_tools/mcp/oauth/server.py`, run via an inline wrapper on port **18000** because port 8000 was occupied by an unrelated local service on this machine. The cookbook source files were not modified; the wrapper imported `mcp` from `server.py` and called `mcp.run(transport="streamable-http", port=18000)`. The client was invoked with `url="http://localhost:18000/mcp"`.
 
 ---

--- a/cookbook/91_tools/mcp/oauth/client.py
+++ b/cookbook/91_tools/mcp/oauth/client.py
@@ -1,45 +1,50 @@
-"""Agent with MCPTools using native OAuth2.1 client_credentials flow.
+"""Agno agent connecting to an OAuth-protected MCP server via OAuthConfig.
 
-This example shows how to connect an Agno agent to an OAuth-protected MCP server
-without any manual token management.
+`MCPTools(oauth=...)` performs OIDC discovery from the MCP server's
+protected-resource metadata, fetches a `client_credentials` access token, and
+injects `Authorization: Bearer <token>` on every request — all transparently.
+
+Defaults match the preconfigured client (`mcp-client` / `mcp-client-secret`) in
+the Keycloak realm at `~/code/tools/keycloak`. Override via env vars to point
+at any other OIDC provider:
+
+    MCP_URL              MCP server URL (e.g. https://api.example.com/mcp)
+    OAUTH_CLIENT_ID      client_credentials client ID
+    OAUTH_CLIENT_SECRET  client_credentials client secret
 
 Prerequisites:
-    1. Start the server:   .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
-    2. Run this client:    .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/client.py
-
-The OAuthConfig instructs MCPTools to:
-    1. Perform OIDC discovery on the MCP server URL
-    2. Acquire a client_credentials access token
-    3. Inject Authorization: Bearer <token> on every request
-    4. Refresh the token transparently when it expires
+    1. OIDC provider running and reachable
+    2. Protected MCP server running:
+         .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
+    3. OPENAI_API_KEY set (the agent uses an OpenAI model)
 """
 
 import asyncio
+import os
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIResponses
 from agno.tools.mcp import MCPTools, OAuthConfig
 
+MCP_URL = os.environ.get("MCP_URL", "http://localhost:9000/mcp")
+CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID", "mcp-client")
+CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET", "mcp-client-secret")
+
 
 async def main():
-    oauth_config = OAuthConfig(
-        client_id="demo-client-id",
-        client_secret="demo-client-secret",
-    )
-
     async with MCPTools(
-        url="http://localhost:8000/mcp",
+        url=MCP_URL,
         transport="streamable-http",
-        oauth=oauth_config,
+        oauth=OAuthConfig(
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        ),
     ) as mcp_tools:
-        print(f"Connected. Available tools: {list(mcp_tools.functions.keys())}")
-
         agent = Agent(
             model=OpenAIResponses(id="gpt-5.4"),
             tools=[mcp_tools],
             markdown=False,
         )
-
         await agent.aprint_response(
             "Fetch the secret data using the get_secret_data tool."
         )

--- a/cookbook/91_tools/mcp/oauth/client.py
+++ b/cookbook/91_tools/mcp/oauth/client.py
@@ -1,0 +1,47 @@
+"""Agent with MCPTools using native OAuth2.1 client_credentials flow.
+
+This example shows how to connect an Agno agent to an OAuth-protected MCP server
+without any manual token management.
+
+Prerequisites:
+    1. Start the server:   .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
+    2. Run this client:    .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/client.py
+
+The OAuthConfig instructs MCPTools to:
+    1. Perform OIDC discovery on the MCP server URL
+    2. Acquire a client_credentials access token
+    3. Inject Authorization: Bearer <token> on every request
+    4. Refresh the token transparently when it expires
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.mcp import MCPTools, OAuthConfig
+
+
+async def main():
+    oauth_config = OAuthConfig(
+        client_id="demo-client-id",
+        client_secret="demo-client-secret",
+    )
+
+    async with MCPTools(
+        url="http://localhost:8000/mcp",
+        transport="streamable-http",
+        oauth=oauth_config,
+    ) as mcp_tools:
+        print(f"Connected. Available tools: {list(mcp_tools.functions.keys())}")
+
+        agent = Agent(
+            model=OpenAIResponses(id="gpt-5.4"),
+            tools=[mcp_tools],
+            markdown=False,
+        )
+
+        await agent.aprint_response("Fetch the secret data using the get_secret_data tool.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/91_tools/mcp/oauth/client.py
+++ b/cookbook/91_tools/mcp/oauth/client.py
@@ -40,7 +40,9 @@ async def main():
             markdown=False,
         )
 
-        await agent.aprint_response("Fetch the secret data using the get_secret_data tool.")
+        await agent.aprint_response(
+            "Fetch the secret data using the get_secret_data tool."
+        )
 
 
 if __name__ == "__main__":

--- a/cookbook/91_tools/mcp/oauth/server.py
+++ b/cookbook/91_tools/mcp/oauth/server.py
@@ -1,39 +1,62 @@
-"""OAuth-protected MCP server (mock for cookbook demonstration).
+"""OAuth-protected MCP server using FastMCP's RemoteAuthProvider + JWTVerifier.
 
-In production, use FastMCP's OIDCProxy to protect your MCP server with a real
-OAuth2 authorization server. This mock validates a static bearer token so the
-cookbook runs without external infrastructure.
+This is the canonical FastMCP pattern: an external OIDC provider (Keycloak,
+Auth0, Okta, Authentik, ...) issues access tokens, and the MCP server validates
+each incoming bearer token against the provider's JWKS endpoint. The server
+publishes protected-resource metadata pointing at the provider, which is what
+the MCP client uses to discover the token endpoint.
 
-Run this first:
+Configuration is taken from environment variables so the same script works
+against any provider. Defaults match the preconfigured Keycloak realm at
+`~/code/tools/keycloak`:
+
+    OIDC_ISSUER     authorization-server issuer URL
+    OIDC_JWKS_URI   JWKS endpoint (defaults to issuer + Keycloak path)
+    OIDC_AUDIENCE   expected `aud` claim in access tokens
+    MCP_BASE_URL    public base URL of this MCP server
+
+Run:
     .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
 """
 
+import os
+
 from fastmcp import FastMCP
-from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.auth import RemoteAuthProvider
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+from pydantic import AnyHttpUrl
 
-EXPECTED_TOKEN = "demo-access-token"
+ISSUER = os.environ.get("OIDC_ISSUER", "http://localhost:8080/realms/mcp-demo")
+JWKS_URI = os.environ.get("OIDC_JWKS_URI", f"{ISSUER}/protocol/openid-connect/certs")
+AUDIENCE = os.environ.get("OIDC_AUDIENCE", "mcp-server")
+BASE_URL = os.environ.get("MCP_BASE_URL", "http://localhost:9000")
 
-mcp = FastMCP("OAuth Protected Server")
+token_verifier = JWTVerifier(
+    jwks_uri=JWKS_URI,
+    issuer=ISSUER,
+    audience=AUDIENCE,
+)
+
+auth = RemoteAuthProvider(
+    token_verifier=token_verifier,
+    authorization_servers=[AnyHttpUrl(ISSUER)],
+    base_url=BASE_URL,
+)
+
+mcp = FastMCP(name="OAuth Protected Server", auth=auth)
 
 
 @mcp.tool
 async def get_secret_data() -> str:
-    """Return sensitive data — only accessible with a valid bearer token."""
-    request = get_http_request()
-    auth_header = request.headers.get("authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return "Unauthorized: missing bearer token"
-    token = auth_header.removeprefix("Bearer ")
-    if token != EXPECTED_TOKEN:
-        return f"Unauthorized: invalid token '{token}'"
+    """Return sensitive data. Only reachable with a valid bearer token."""
     return "Secret data: the answer is 42"
 
 
 @mcp.tool
 async def ping() -> str:
-    """Health check tool."""
+    """Health check."""
     return "pong"
 
 
 if __name__ == "__main__":
-    mcp.run(transport="streamable-http", port=8000)
+    mcp.run(transport="streamable-http", port=9000)

--- a/cookbook/91_tools/mcp/oauth/server.py
+++ b/cookbook/91_tools/mcp/oauth/server.py
@@ -1,0 +1,39 @@
+"""OAuth-protected MCP server (mock for cookbook demonstration).
+
+In production, use FastMCP's OIDCProxy to protect your MCP server with a real
+OAuth2 authorization server. This mock validates a static bearer token so the
+cookbook runs without external infrastructure.
+
+Run this first:
+    .venvs/demo/bin/python cookbook/91_tools/mcp/oauth/server.py
+"""
+
+from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_http_request
+
+EXPECTED_TOKEN = "demo-access-token"
+
+mcp = FastMCP("OAuth Protected Server")
+
+
+@mcp.tool
+async def get_secret_data() -> str:
+    """Return sensitive data — only accessible with a valid bearer token."""
+    request = get_http_request()
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return "Unauthorized: missing bearer token"
+    token = auth_header.removeprefix("Bearer ")
+    if token != EXPECTED_TOKEN:
+        return f"Unauthorized: invalid token '{token}'"
+    return "Secret data: the answer is 42"
+
+
+@mcp.tool
+async def ping() -> str:
+    """Health check tool."""
+    return "pong"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http", port=8000)

--- a/libs/agno/agno/tools/mcp/__init__.py
+++ b/libs/agno/agno/tools/mcp/__init__.py
@@ -1,10 +1,12 @@
 from agno.tools.mcp.mcp import MCPTools
 from agno.tools.mcp.multi_mcp import MultiMCPTools
+from agno.tools.mcp.oauth import OAuthConfig
 from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
 
 __all__ = [
     "MCPTools",
     "MultiMCPTools",
+    "OAuthConfig",
     "StreamableHTTPClientParams",
     "SSEClientParams",
 ]

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -510,6 +510,7 @@ class MCPTools(Toolkit):
         # Create OAuth provider if configured
         if self._oauth_config is not None:
             from agno.tools.mcp.oauth import create_oauth_provider
+
             server_url = self.url or (
                 self.server_params.url if self.server_params is not None else None  # type: ignore
             )

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from agno.agent import Agent
     from agno.run import RunContext
     from agno.team.team import Team
+    from agno.tools.mcp.oauth import OAuthConfig
 
 try:
     from mcp import ClientSession, StdioServerParameters
@@ -53,6 +54,7 @@ class MCPTools(Toolkit):
         refresh_connection: bool = False,
         tool_name_prefix: Optional[str] = None,
         header_provider: Optional[Callable[..., dict[str, Any]]] = None,
+        oauth: Optional["OAuthConfig"] = None,
         **kwargs,
     ):
         """
@@ -74,6 +76,9 @@ class MCPTools(Toolkit):
             header_provider: Optional function to generate dynamic HTTP headers.
                 Only relevant with HTTP transports (Streamable HTTP or SSE).
                 Creates a new session per agent run with dynamic headers merged into connection config.
+            oauth: Optional OAuth client_credentials configuration. When provided, MCPTools will
+                obtain access tokens from the OAuth server and attach them to outgoing MCP
+                requests. Only relevant with HTTP transports (Streamable HTTP or SSE).
         """
         # Extract these before super().__init__() to bypass early validation
         # (tools aren't available until build_tools() is called)
@@ -148,6 +153,21 @@ class MCPTools(Toolkit):
                 )
             log_debug("Dynamic header support enabled for MCP tools")
             self.header_provider = header_provider
+
+        self._oauth_provider = None
+        if oauth is not None:
+            if self.transport not in ["sse", "streamable-http"]:
+                raise ValueError(
+                    f"oauth is not supported with '{self.transport}' transport. "
+                    "Use 'sse' or 'streamable-http' transport instead."
+                )
+            if session is not None:
+                log_warning("oauth is ignored when a pre-built session is provided")
+                self._oauth_config = None
+            else:
+                self._oauth_config = oauth
+        else:
+            self._oauth_config = None
 
         self.timeout_seconds = timeout_seconds
         self.session: Optional[ClientSession] = session
@@ -349,7 +369,7 @@ class MCPTools(Toolkit):
                 existing_headers = sse_params.get("headers") or {}
                 sse_params["headers"] = {**existing_headers, **dynamic_headers}
 
-                context = sse_client(**sse_params)  # type: ignore
+                context = sse_client(**sse_params, auth=self._oauth_provider)  # type: ignore
                 client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
 
             elif self.transport == "streamable-http":
@@ -361,7 +381,7 @@ class MCPTools(Toolkit):
                 existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
 
-                context = streamablehttp_client(**streamable_http_params)  # type: ignore
+                context = streamablehttp_client(**streamable_http_params, auth=self._oauth_provider)  # type: ignore
                 params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
                 if isinstance(params_timeout, timedelta):
                     params_timeout = int(params_timeout.total_seconds())
@@ -487,6 +507,15 @@ class MCPTools(Toolkit):
         if self.header_provider:
             init_headers = self._call_header_provider()
 
+        # Create OAuth provider if configured
+        if self._oauth_config is not None:
+            from agno.tools.mcp.oauth import create_oauth_provider
+            server_url = self.url or (
+                self.server_params.url if self.server_params is not None else None  # type: ignore
+            )
+            if server_url:
+                self._oauth_provider = create_oauth_provider(self._oauth_config, server_url)
+
         # Create a new studio session
         if self.transport == "sse":
             sse_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
@@ -495,7 +524,7 @@ class MCPTools(Toolkit):
             if init_headers:
                 existing_headers = sse_params.get("headers") or {}
                 sse_params["headers"] = {**existing_headers, **init_headers}
-            self._context = sse_client(**sse_params)  # type: ignore
+            self._context = sse_client(**sse_params, auth=self._oauth_provider)  # type: ignore
             client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
 
         # Create a new streamable HTTP session
@@ -506,7 +535,7 @@ class MCPTools(Toolkit):
             if init_headers:
                 existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **init_headers}
-            self._context = streamablehttp_client(**streamable_http_params)  # type: ignore
+            self._context = streamablehttp_client(**streamable_http_params, auth=self._oauth_provider)  # type: ignore
             params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
             if isinstance(params_timeout, timedelta):
                 params_timeout = int(params_timeout.total_seconds())

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -13,6 +13,8 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.mcp import get_entrypoint_for_tool, prepare_command
 
 if TYPE_CHECKING:
+    from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
     from agno.agent import Agent
     from agno.run import RunContext
     from agno.team.team import Team
@@ -25,6 +27,8 @@ try:
     from mcp.client.streamable_http import streamablehttp_client
 except (ImportError, ModuleNotFoundError):
     raise ImportError("`mcp` not installed. Please install using `pip install mcp`")
+
+_HTTP_TRANSPORTS: frozenset[str] = frozenset({"sse", "streamable-http"})
 
 
 class MCPTools(Toolkit):
@@ -146,7 +150,7 @@ class MCPTools(Toolkit):
 
         self.header_provider = None
         if header_provider is not None:
-            if self.transport not in ["sse", "streamable-http"]:
+            if self.transport not in _HTTP_TRANSPORTS:
                 raise ValueError(
                     f"header_provider is not supported with '{self.transport}' transport. "
                     "Use 'sse' or 'streamable-http' transport instead."
@@ -154,20 +158,16 @@ class MCPTools(Toolkit):
             log_debug("Dynamic header support enabled for MCP tools")
             self.header_provider = header_provider
 
-        self._oauth_provider: Optional[Any] = None
+        self._oauth_provider: Optional["ClientCredentialsOAuthProvider"] = None
         if oauth is not None:
-            if self.transport not in ["sse", "streamable-http"]:
+            if self.transport not in _HTTP_TRANSPORTS:
                 raise ValueError(
                     f"oauth is not supported with '{self.transport}' transport. "
                     "Use 'sse' or 'streamable-http' transport instead."
                 )
             if session is not None:
                 log_warning("oauth is ignored when a pre-built session is provided")
-                self._oauth_config = None
-            else:
-                self._oauth_config = oauth
-        else:
-            self._oauth_config = None
+                oauth = None
 
         self.timeout_seconds = timeout_seconds
         self.session: Optional[ClientSession] = session
@@ -175,6 +175,13 @@ class MCPTools(Toolkit):
             server_params
         )
         self.url = url
+
+        if oauth is not None:
+            _server_url = url or (server_params.url if server_params is not None else None)
+            if _server_url:
+                from agno.tools.mcp.oauth import create_oauth_provider
+
+                self._oauth_provider = create_oauth_provider(oauth, _server_url)
 
         # Merge provided env with system env
         if env is not None:
@@ -185,7 +192,7 @@ class MCPTools(Toolkit):
         else:
             env = get_default_environment()
 
-        if command is not None and transport not in ["sse", "streamable-http"]:
+        if command is not None and transport not in _HTTP_TRANSPORTS:
             parts = prepare_command(command)
             cmd = parts[0]
             arguments = parts[1:] if len(parts) > 1 else []
@@ -507,17 +514,7 @@ class MCPTools(Toolkit):
         if self.header_provider:
             init_headers = self._call_header_provider()
 
-        # Create OAuth provider if configured
-        if self._oauth_config is not None:
-            from agno.tools.mcp.oauth import create_oauth_provider
-
-            server_url = self.url or (
-                self.server_params.url if self.server_params is not None else None  # type: ignore
-            )
-            if server_url:
-                self._oauth_provider = create_oauth_provider(self._oauth_config, server_url)
-
-        # Create a new studio session
+        # Create a new server session
         if self.transport == "sse":
             sse_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
             if "url" not in sse_params:

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -154,7 +154,7 @@ class MCPTools(Toolkit):
             log_debug("Dynamic header support enabled for MCP tools")
             self.header_provider = header_provider
 
-        self._oauth_provider = None
+        self._oauth_provider: Optional[Any] = None
         if oauth is not None:
             if self.transport not in ["sse", "streamable-http"]:
                 raise ValueError(

--- a/libs/agno/agno/tools/mcp/oauth.py
+++ b/libs/agno/agno/tools/mcp/oauth.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Optional
+
+if TYPE_CHECKING:
+    from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+
+@dataclass
+class OAuthConfig:
+    """OAuth2.1 client credentials configuration for MCPTools.
+
+    Enables native M2M authentication against OAuth-protected MCP servers
+    without external token management.
+    """
+
+    client_id: str
+    client_secret: str
+    scopes: Optional[str] = None
+    token_endpoint_auth_method: Literal["client_secret_basic", "client_secret_post"] = field(
+        default="client_secret_basic"
+    )
+
+
+class InMemoryTokenStorage:
+    """In-memory implementation of the MCP SDK TokenStorage protocol.
+
+    Tokens are cached for the lifetime of the MCPTools instance.
+    The ClientCredentialsOAuthProvider handles refresh automatically.
+    """
+
+    def __init__(self) -> None:
+        self._tokens: Optional["OAuthToken"] = None
+        self._client_info: Optional["OAuthClientInformationFull"] = None
+
+    async def get_tokens(self) -> Optional["OAuthToken"]:
+        return self._tokens
+
+    async def set_tokens(self, tokens: "OAuthToken") -> None:
+        self._tokens = tokens
+
+    async def get_client_info(self) -> Optional["OAuthClientInformationFull"]:
+        return self._client_info
+
+    async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
+        self._client_info = client_info
+
+
+def create_oauth_provider(config: OAuthConfig, server_url: str) -> "ClientCredentialsOAuthProvider":
+    """Create a ClientCredentialsOAuthProvider from an OAuthConfig.
+
+    Internal factory — not part of the public API.
+    """
+    from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
+    storage = InMemoryTokenStorage()
+    return ClientCredentialsOAuthProvider(
+        server_url=server_url,
+        storage=storage,
+        client_id=config.client_id,
+        client_secret=config.client_secret,
+        token_endpoint_auth_method=config.token_endpoint_auth_method,
+        scopes=config.scopes,
+    )

--- a/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
@@ -1,0 +1,80 @@
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# InMemoryTokenStorage tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_in_memory_token_storage_tokens_start_none():
+    from agno.tools.mcp.oauth import InMemoryTokenStorage
+    storage = InMemoryTokenStorage()
+    assert await storage.get_tokens() is None
+
+
+@pytest.mark.asyncio
+async def test_in_memory_token_storage_roundtrip_tokens():
+    from agno.tools.mcp.oauth import InMemoryTokenStorage
+    from mcp.shared.auth import OAuthToken
+    storage = InMemoryTokenStorage()
+    token = OAuthToken(access_token="tok", token_type="bearer")
+    await storage.set_tokens(token)
+    result = await storage.get_tokens()
+    assert result is not None
+    assert result.access_token == "tok"
+
+
+@pytest.mark.asyncio
+async def test_in_memory_token_storage_client_info_starts_none():
+    from agno.tools.mcp.oauth import InMemoryTokenStorage
+    storage = InMemoryTokenStorage()
+    assert await storage.get_client_info() is None
+
+
+@pytest.mark.asyncio
+async def test_in_memory_token_storage_roundtrip_client_info():
+    from agno.tools.mcp.oauth import InMemoryTokenStorage
+    from mcp.shared.auth import OAuthClientInformationFull
+    storage = InMemoryTokenStorage()
+    info = OAuthClientInformationFull(client_id="cid", client_secret="sec", redirect_uris=None)
+    await storage.set_client_info(info)
+    result = await storage.get_client_info()
+    assert result is not None
+    assert result.client_id == "cid"
+
+
+# ---------------------------------------------------------------------------
+# OAuthConfig tests
+# ---------------------------------------------------------------------------
+
+def test_oauth_config_defaults():
+    from agno.tools.mcp.oauth import OAuthConfig
+    cfg = OAuthConfig(client_id="id", client_secret="secret")
+    assert cfg.client_id == "id"
+    assert cfg.client_secret == "secret"
+    assert cfg.scopes is None
+    assert cfg.token_endpoint_auth_method == "client_secret_basic"
+
+
+def test_oauth_config_custom_values():
+    from agno.tools.mcp.oauth import OAuthConfig
+    cfg = OAuthConfig(
+        client_id="id",
+        client_secret="secret",
+        scopes="read write",
+        token_endpoint_auth_method="client_secret_post",
+    )
+    assert cfg.scopes == "read write"
+    assert cfg.token_endpoint_auth_method == "client_secret_post"
+
+
+# ---------------------------------------------------------------------------
+# create_oauth_provider tests
+# ---------------------------------------------------------------------------
+
+def test_create_oauth_provider_returns_provider():
+    from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+    from agno.tools.mcp.oauth import OAuthConfig, create_oauth_provider
+    cfg = OAuthConfig(client_id="cid", client_secret="secret")
+    provider = create_oauth_provider(cfg, "http://localhost:8000/mcp")
+    assert isinstance(provider, ClientCredentialsOAuthProvider)

--- a/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
@@ -1,21 +1,24 @@
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # InMemoryTokenStorage tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_in_memory_token_storage_tokens_start_none():
     from agno.tools.mcp.oauth import InMemoryTokenStorage
+
     storage = InMemoryTokenStorage()
     assert await storage.get_tokens() is None
 
 
 @pytest.mark.asyncio
 async def test_in_memory_token_storage_roundtrip_tokens():
-    from agno.tools.mcp.oauth import InMemoryTokenStorage
     from mcp.shared.auth import OAuthToken
+
+    from agno.tools.mcp.oauth import InMemoryTokenStorage
+
     storage = InMemoryTokenStorage()
     token = OAuthToken(access_token="tok", token_type="bearer")
     await storage.set_tokens(token)
@@ -27,14 +30,17 @@ async def test_in_memory_token_storage_roundtrip_tokens():
 @pytest.mark.asyncio
 async def test_in_memory_token_storage_client_info_starts_none():
     from agno.tools.mcp.oauth import InMemoryTokenStorage
+
     storage = InMemoryTokenStorage()
     assert await storage.get_client_info() is None
 
 
 @pytest.mark.asyncio
 async def test_in_memory_token_storage_roundtrip_client_info():
-    from agno.tools.mcp.oauth import InMemoryTokenStorage
     from mcp.shared.auth import OAuthClientInformationFull
+
+    from agno.tools.mcp.oauth import InMemoryTokenStorage
+
     storage = InMemoryTokenStorage()
     info = OAuthClientInformationFull(client_id="cid", client_secret="sec", redirect_uris=None)
     await storage.set_client_info(info)
@@ -47,8 +53,10 @@ async def test_in_memory_token_storage_roundtrip_client_info():
 # OAuthConfig tests
 # ---------------------------------------------------------------------------
 
+
 def test_oauth_config_defaults():
     from agno.tools.mcp.oauth import OAuthConfig
+
     cfg = OAuthConfig(client_id="id", client_secret="secret")
     assert cfg.client_id == "id"
     assert cfg.client_secret == "secret"
@@ -58,6 +66,7 @@ def test_oauth_config_defaults():
 
 def test_oauth_config_custom_values():
     from agno.tools.mcp.oauth import OAuthConfig
+
     cfg = OAuthConfig(
         client_id="id",
         client_secret="secret",
@@ -72,9 +81,12 @@ def test_oauth_config_custom_values():
 # create_oauth_provider tests
 # ---------------------------------------------------------------------------
 
+
 def test_create_oauth_provider_returns_provider():
     from mcp.client.auth.extensions.client_credentials import ClientCredentialsOAuthProvider
+
     from agno.tools.mcp.oauth import OAuthConfig, create_oauth_provider
+
     cfg = OAuthConfig(client_id="cid", client_secret="secret")
     provider = create_oauth_provider(cfg, "http://localhost:8000/mcp")
     assert isinstance(provider, ClientCredentialsOAuthProvider)
@@ -84,10 +96,13 @@ def test_create_oauth_provider_returns_provider():
 # MCPTools oauth parameter tests
 # ---------------------------------------------------------------------------
 
+
 def test_mcptools_oauth_raises_for_stdio():
+    import pytest
+
     from agno.tools.mcp import MCPTools
     from agno.tools.mcp.oauth import OAuthConfig
-    import pytest
+
     with pytest.raises(ValueError, match="oauth.*stdio"):
         MCPTools(
             command="npx -y @modelcontextprotocol/server-everything",
@@ -99,6 +114,7 @@ def test_mcptools_oauth_raises_for_stdio():
 def test_mcptools_oauth_warns_when_session_provided(caplog):
     import logging
     from unittest.mock import MagicMock
+
     from agno.tools.mcp import MCPTools
     from agno.tools.mcp.oauth import OAuthConfig
 
@@ -138,7 +154,8 @@ def test_mcptools_oauth_warns_when_session_provided(caplog):
 
 @pytest.mark.asyncio
 async def test_mcptools_connect_passes_auth_to_streamable_http():
-    from unittest.mock import AsyncMock, MagicMock, patch
+    from unittest.mock import AsyncMock, patch
+
     from agno.tools.mcp import MCPTools
     from agno.tools.mcp.oauth import OAuthConfig
 
@@ -162,9 +179,11 @@ async def test_mcptools_connect_passes_auth_to_streamable_http():
     mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
 
-    with patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=mock_transport_ctx) as mock_http, \
-         patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx), \
-         patch.object(mcp, "initialize", new_callable=AsyncMock):
+    with (
+        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=mock_transport_ctx) as mock_http,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx),
+        patch.object(mcp, "initialize", new_callable=AsyncMock),
+    ):
         await mcp._connect()
 
     call_kwargs = mock_http.call_args.kwargs
@@ -175,6 +194,7 @@ async def test_mcptools_connect_passes_auth_to_streamable_http():
 @pytest.mark.asyncio
 async def test_mcptools_connect_passes_auth_to_sse():
     from unittest.mock import AsyncMock, patch
+
     from agno.tools.mcp import MCPTools
     from agno.tools.mcp.oauth import OAuthConfig
 
@@ -198,9 +218,11 @@ async def test_mcptools_connect_passes_auth_to_sse():
     mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
 
-    with patch("agno.tools.mcp.mcp.sse_client", return_value=mock_transport_ctx) as mock_sse, \
-         patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx), \
-         patch.object(mcp, "initialize", new_callable=AsyncMock):
+    with (
+        patch("agno.tools.mcp.mcp.sse_client", return_value=mock_transport_ctx) as mock_sse,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx),
+        patch.object(mcp, "initialize", new_callable=AsyncMock),
+    ):
         await mcp._connect()
 
     call_kwargs = mock_sse.call_args.kwargs

--- a/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
@@ -78,3 +78,131 @@ def test_create_oauth_provider_returns_provider():
     cfg = OAuthConfig(client_id="cid", client_secret="secret")
     provider = create_oauth_provider(cfg, "http://localhost:8000/mcp")
     assert isinstance(provider, ClientCredentialsOAuthProvider)
+
+
+# ---------------------------------------------------------------------------
+# MCPTools oauth parameter tests
+# ---------------------------------------------------------------------------
+
+def test_mcptools_oauth_raises_for_stdio():
+    from agno.tools.mcp import MCPTools
+    from agno.tools.mcp.oauth import OAuthConfig
+    import pytest
+    with pytest.raises(ValueError, match="oauth.*stdio"):
+        MCPTools(
+            command="npx -y @modelcontextprotocol/server-everything",
+            transport="stdio",
+            oauth=OAuthConfig(client_id="id", client_secret="secret"),
+        )
+
+
+def test_mcptools_oauth_warns_when_session_provided(caplog):
+    import logging
+    from unittest.mock import MagicMock
+    from agno.tools.mcp import MCPTools
+    from agno.tools.mcp.oauth import OAuthConfig
+
+    # Agno's logger has propagate=False, so pytest's caplog cannot see its
+    # records. Capture warnings via a dedicated handler attached to "agno".
+    records: list[logging.LogRecord] = []
+
+    class _Recorder(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    # Other tests may switch the active agno logger via use_team_logger /
+    # use_workflow_logger. Attach to every known agno logger to be safe.
+    agno_loggers = [
+        logging.getLogger("agno"),
+        logging.getLogger("agno-team"),
+        logging.getLogger("agno-workflow"),
+    ]
+    handler = _Recorder(level=logging.WARNING)
+    for lg in agno_loggers:
+        lg.addHandler(handler)
+    try:
+        mock_session = MagicMock()
+        mcp = MCPTools(
+            url="http://localhost:8000/mcp",
+            transport="streamable-http",
+            session=mock_session,
+            oauth=OAuthConfig(client_id="id", client_secret="secret"),
+        )
+    finally:
+        for lg in agno_loggers:
+            lg.removeHandler(handler)
+
+    assert mcp._oauth_provider is None
+    assert any("oauth" in r.getMessage().lower() for r in records)
+
+
+@pytest.mark.asyncio
+async def test_mcptools_connect_passes_auth_to_streamable_http():
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from agno.tools.mcp import MCPTools
+    from agno.tools.mcp.oauth import OAuthConfig
+
+    mcp = MCPTools(
+        url="http://localhost:8000/mcp",
+        transport="streamable-http",
+        oauth=OAuthConfig(client_id="id", client_secret="secret"),
+    )
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+
+    mock_read = AsyncMock()
+    mock_write = AsyncMock()
+
+    mock_transport_ctx = AsyncMock()
+    mock_transport_ctx.__aenter__ = AsyncMock(return_value=(mock_read, mock_write, None))
+    mock_transport_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=mock_transport_ctx) as mock_http, \
+         patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx), \
+         patch.object(mcp, "initialize", new_callable=AsyncMock):
+        await mcp._connect()
+
+    call_kwargs = mock_http.call_args.kwargs
+    assert "auth" in call_kwargs
+    assert call_kwargs["auth"] is not None
+
+
+@pytest.mark.asyncio
+async def test_mcptools_connect_passes_auth_to_sse():
+    from unittest.mock import AsyncMock, patch
+    from agno.tools.mcp import MCPTools
+    from agno.tools.mcp.oauth import OAuthConfig
+
+    mcp = MCPTools(
+        url="http://localhost:8000/mcp",
+        transport="sse",
+        oauth=OAuthConfig(client_id="id", client_secret="secret"),
+    )
+
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+
+    mock_read = AsyncMock()
+    mock_write = AsyncMock()
+
+    mock_transport_ctx = AsyncMock()
+    mock_transport_ctx.__aenter__ = AsyncMock(return_value=(mock_read, mock_write))
+    mock_transport_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("agno.tools.mcp.mcp.sse_client", return_value=mock_transport_ctx) as mock_sse, \
+         patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx), \
+         patch.object(mcp, "initialize", new_callable=AsyncMock):
+        await mcp._connect()
+
+    call_kwargs = mock_sse.call_args.kwargs
+    assert "auth" in call_kwargs
+    assert call_kwargs["auth"] is not None

--- a/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
+++ b/libs/agno/tests/unit/tools/mcp/test_mcp_oauth.py
@@ -228,3 +228,61 @@ async def test_mcptools_connect_passes_auth_to_sse():
     call_kwargs = mock_sse.call_args.kwargs
     assert "auth" in call_kwargs
     assert call_kwargs["auth"] is not None
+
+
+@pytest.mark.asyncio
+async def test_mcptools_get_session_for_run_passes_auth_with_header_provider():
+    """Coexistence: when both oauth and header_provider are configured,
+    the per-run session creation in get_session_for_run() must still pass
+    auth=self._oauth_provider to the transport client."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from agno.tools.mcp import MCPTools
+    from agno.tools.mcp.oauth import OAuthConfig
+
+    def headers():
+        return {"X-Custom": "value"}
+
+    mcp = MCPTools(
+        url="http://localhost:8000/mcp",
+        transport="streamable-http",
+        oauth=OAuthConfig(client_id="id", client_secret="secret"),
+        header_provider=headers,
+    )
+    # Pre-seed the provider as _connect would have done
+    sentinel = MagicMock(name="oauth_provider_sentinel")
+    mcp._oauth_provider = sentinel
+
+    # Build a mocked transport context
+    mock_session = AsyncMock()
+    mock_session.initialize = AsyncMock()
+    mock_session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+
+    mock_read = AsyncMock()
+    mock_write = AsyncMock()
+
+    mock_transport_ctx = AsyncMock()
+    mock_transport_ctx.__aenter__ = AsyncMock(return_value=(mock_read, mock_write, None))
+    mock_transport_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session_ctx = AsyncMock()
+    mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    run_context = MagicMock()
+    run_context.run_id = "test-run-id"
+
+    with (
+        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=mock_transport_ctx) as mock_http,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=mock_session_ctx),
+    ):
+        try:
+            await mcp.get_session_for_run(run_context=run_context, agent=MagicMock())
+        except Exception:
+            # We only care that the transport was called with auth=
+            pass
+
+    assert mock_http.called, "streamablehttp_client should have been called"
+    call_kwargs = mock_http.call_args.kwargs
+    assert "auth" in call_kwargs
+    assert call_kwargs["auth"] is sentinel


### PR DESCRIPTION
## Summary

Adds native OAuth 2.1 `client_credentials` (M2M) authentication to `MCPTools` via a new `oauth` parameter, eliminating the need for callers to manage tokens manually.

**Key changes:**

- **`agno/tools/mcp/oauth.py`** (new): `OAuthConfig` dataclass for credential configuration; `InMemoryTokenStorage` implementing the MCP SDK `TokenStorage` protocol; `create_oauth_provider` factory wiring them to `ClientCredentialsOAuthProvider`.
- **`agno/tools/mcp/mcp.py`**: `MCPTools.__init__` accepts `oauth: Optional[OAuthConfig]`. The provider is created eagerly in `__init__` (so tokens survive reconnects) and passed as `auth=` to both `sse_client` and `streamablehttp_client`, in both the long-lived `_connect` path and the per-run `get_session_for_run` path. A module-level `_HTTP_TRANSPORTS` constant replaces repeated string-literal transport checks throughout the file.
- **`agno/tools/mcp/__init__.py`**: `OAuthConfig` re-exported for ergonomic import.
- **Tests**: 12 unit tests covering `InMemoryTokenStorage`, `OAuthConfig`, `create_oauth_provider`, and `MCPTools` integration (stdio guard, session warning, SSE/streamable-http auth propagation, `header_provider` coexistence).
- **Cookbook** (`cookbook/91_tools/mcp/oauth/`): `server.py` — FastMCP server using `RemoteAuthProvider` + `JWTVerifier`; `client.py` — Agno agent using `MCPTools(oauth=OAuthConfig(...))` against it.

Usage:
```python
from agno.tools.mcp import MCPTools, OAuthConfig

async with MCPTools(
    url="https://your-mcp-server/mcp",
    transport="streamable-http",
    oauth=OAuthConfig(client_id="...", client_secret="..."),
) as mcp_tools:
    agent = Agent(tools=[mcp_tools], ...)
```

Closes issue https://github.com/agno-agi/agno/issues/7309

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
