### PR TITLE
feat: add agent description to AgentOS quick prompts

### DIFF
--- a/cookbook/05_agent_os/os_config/basic.py
+++ b/cookbook/05_agent_os/os_config/basic.py
@@ -15,6 +15,7 @@ from agno.os.config import (
     DatabaseConfig,
     MemoryConfig,
     MemoryDomainConfig,
+    QuickPromptsConfig,
 )
 from agno.team import Team
 from agno.workflow.step import Step
@@ -70,11 +71,14 @@ agent_os = AgentOS(
     config=AgentOSConfig(
         chat=ChatConfig(
             quick_prompts={
-                "marketing-agent": [
-                    "What can you do?",
-                    "How is our latest post working?",
-                    "Tell me about our active marketing campaigns",
-                ],
+                "marketing-agent": QuickPromptsConfig(
+                    description="Plans, runs and reports on marketing campaigns.",
+                    prompts=[
+                        "What can you do?",
+                        "How is our latest post working?",
+                        "Tell me about our active marketing campaigns",
+                    ],
+                ),
             },
         ),
         memory=MemoryConfig(

--- a/cookbook/05_agent_os/os_config/config.yaml
+++ b/cookbook/05_agent_os/os_config/config.yaml
@@ -1,9 +1,11 @@
 chat:
   quick_prompts:
     marketing-agent:
-      - "What can you do?"
-      - "How is our latest post working?"
-      - "Tell me about our active marketing campaigns"
+      description: "Plans, runs and reports on marketing campaigns."
+      prompts:
+        - "What can you do?"
+        - "How is our latest post working?"
+        - "Tell me about our active marketing campaigns"
 memory:
   dbs:
     - db_id: db-0001

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -1,6 +1,6 @@
 """Schemas related to the AgentOS configuration"""
 
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, field_validator
 
@@ -128,19 +128,46 @@ class TracesConfig(TracesDomainConfig):
     dbs: Optional[List[DatabaseConfig[TracesDomainConfig]]] = None
 
 
+class QuickPromptsConfig(BaseModel):
+    """Quick prompts configuration for a single agent/team/workflow on the Chat page.
+
+    The ``description`` is AgentOS-only UI metadata shown alongside the quick prompts.
+    It is unrelated to ``Agent.description``, which is sent to the model.
+    """
+
+    description: Optional[str] = None
+    prompts: List[str]
+
+
 class ChatConfig(BaseModel):
     """Configuration for the Chat page of the AgentOS"""
 
-    quick_prompts: dict[str, list[str]]
+    quick_prompts: dict[str, QuickPromptsConfig]
 
-    # Limit the number of quick prompts to 3 (per agent/team/workflow)
-    @field_validator("quick_prompts")
+    # Accept legacy list[str] form and normalize to QuickPromptsConfig. Also enforce
+    # the max of 3 prompts per agent/team/workflow.
+    @field_validator("quick_prompts", mode="before")
     @classmethod
-    def limit_lists(cls, v):
-        for key, lst in v.items():
-            if len(lst) > 3:
+    def normalize_and_limit(cls, v):
+        if not isinstance(v, dict):
+            return v
+        normalized: dict[str, Union[QuickPromptsConfig, dict, list]] = {}
+        for key, value in v.items():
+            if isinstance(value, list):
+                entry = QuickPromptsConfig(prompts=value)
+            elif isinstance(value, QuickPromptsConfig):
+                entry = value
+            elif isinstance(value, dict):
+                entry = QuickPromptsConfig(**value)
+            else:
+                raise ValueError(
+                    f"Invalid quick_prompts value for '{key}': expected list of strings or "
+                    f"a mapping with 'prompts' (and optional 'description')"
+                )
+            if len(entry.prompts) > 3:
                 raise ValueError(f"Too many quick prompts for '{key}', maximum allowed is 3")
-        return v
+            normalized[key] = entry
+        return normalized
 
 
 class AgentOSConfig(BaseModel):


### PR DESCRIPTION
## Summary

Adds an optional `description` field to the AgentOS quick prompts configuration so the Chat page can show a short blurb alongside each agent's quick prompts.

The description is **AgentOS UI metadata only** — unrelated to `Agent.description`, which is sent to the model.

### Schema change

`libs/agno/agno/os/config.py`:
- New `QuickPromptsConfig` model with `description: Optional[str]` and `prompts: List[str]`
- `ChatConfig.quick_prompts` is now `dict[str, QuickPromptsConfig]`
- A `mode="before"` validator normalizes the legacy `list[str]` shape to `QuickPromptsConfig(prompts=...)` and accepts plain dicts (the form YAML parses to)
- The max-3-prompts cap is enforced on every shape

### YAML — new optional form

```yaml
chat:
  quick_prompts:
    marketing-agent:
      description: "Plans, runs and reports on marketing campaigns."
      prompts:
        - "What can you do?"
        - "How is our latest post working?"
        - "Tell me about our active marketing campaigns"
```

The legacy form continues to work unchanged:

```yaml
chat:
  quick_prompts:
    marketing-agent:
      - "What can you do?"
      - "How is our latest post working?"
```

### Cookbook

`cookbook/05_agent_os/os_config/` (both `basic.py` and `config.yaml`) is updated to demo the new form with a description. Other cookbook configs (`00_quickstart`, `01_demo`, `levels_of_agentic_software`, `shopify_demo`) are deliberately left on the legacy `list[str]` form so backward compatibility is exercised in-tree.

## Type of change

- [x] New feature
- [x] Improvement

## Frontend impact (action required)

This is backward compatible at the **Python and YAML input** level, but the `/config` API response shape changes for `chat.quick_prompts`. Because the validator normalizes internally, the serialized response always uses the new struct now:

**Before**
```json
{
  "chat": {
    "quick_prompts": {
      "marketing-agent": ["p1", "p2", "p3"]
    }
  }
}
```

**After**
```json
{
  "chat": {
    "quick_prompts": {
      "marketing-agent": {
        "description": "Plans, runs and reports on marketing campaigns.",
        "prompts": ["p1", "p2", "p3"]
      }
    }
  }
}
```

The AgentOS frontend that reads `/config` needs to:
1. Read `entry.prompts` instead of treating the value as an array
2. Render `entry.description` (optional, may be `null`) alongside the quick prompts on the Chat page

This should be coordinated with the AgentOS frontend before release.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (docstrings on `QuickPromptsConfig` clarify it is UI-only metadata)
- [x] Examples and guides: cookbook `05_agent_os/os_config/` updated to demo the new form
- [x] Tested in clean environment (verified legacy `list[str]`, new `QuickPromptsConfig` instance, dict-from-YAML, and the 3-prompt cap on every shape)
- [ ] Tests added/updated (no existing tests for `ChatConfig`; happy to add unit tests if desired)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed no other PR already addresses this
- [x] Check if this PR was entirely AI-generated (drafted with Claude Code)

## Additional Notes

No migration is required for existing users — legacy `list[str]` configs are normalized transparently. The only breaking surface is the `/config` API response shape consumed by the frontend, detailed above.