### PR TITLE
feat: add per-agent chat config with description on AgentOS

### DIFF
--- a/cookbook/05_agent_os/os_config/basic.py
+++ b/cookbook/05_agent_os/os_config/basic.py
@@ -10,6 +10,7 @@ from agno.db.postgres import PostgresDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
 from agno.os.config import (
+    AgentChatConfig,
     AgentOSConfig,
     ChatConfig,
     DatabaseConfig,
@@ -69,12 +70,15 @@ agent_os = AgentOS(
     # Configuration for the AgentOS
     config=AgentOSConfig(
         chat=ChatConfig(
-            quick_prompts={
-                "marketing-agent": [
-                    "What can you do?",
-                    "How is our latest post working?",
-                    "Tell me about our active marketing campaigns",
-                ],
+            agents={
+                "marketing-agent": AgentChatConfig(
+                    description="Plans, runs and reports on marketing campaigns.",
+                    quick_prompts=[
+                        "What can you do?",
+                        "How is our latest post working?",
+                        "Tell me about our active marketing campaigns",
+                    ],
+                ),
             },
         ),
         memory=MemoryConfig(

--- a/cookbook/05_agent_os/os_config/basic.py
+++ b/cookbook/05_agent_os/os_config/basic.py
@@ -10,8 +10,8 @@ from agno.db.postgres import PostgresDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
 from agno.os.config import (
-    AgentChatConfig,
     AgentOSConfig,
+    ChatComponentConfig,
     ChatConfig,
     DatabaseConfig,
     MemoryConfig,
@@ -70,8 +70,8 @@ agent_os = AgentOS(
     # Configuration for the AgentOS
     config=AgentOSConfig(
         chat=ChatConfig(
-            agents={
-                "marketing-agent": AgentChatConfig(
+            components={
+                "marketing-agent": ChatComponentConfig(
                     description="Plans, runs and reports on marketing campaigns.",
                     quick_prompts=[
                         "What can you do?",

--- a/cookbook/05_agent_os/os_config/config.yaml
+++ b/cookbook/05_agent_os/os_config/config.yaml
@@ -1,9 +1,11 @@
 chat:
-  quick_prompts:
+  agents:
     marketing-agent:
-      - "What can you do?"
-      - "How is our latest post working?"
-      - "Tell me about our active marketing campaigns"
+      description: "Plans, runs and reports on marketing campaigns."
+      quick_prompts:
+        - "What can you do?"
+        - "How is our latest post working?"
+        - "Tell me about our active marketing campaigns"
 memory:
   dbs:
     - db_id: db-0001

--- a/cookbook/05_agent_os/os_config/config.yaml
+++ b/cookbook/05_agent_os/os_config/config.yaml
@@ -1,5 +1,5 @@
 chat:
-  agents:
+  components:
     marketing-agent:
       description: "Plans, runs and reports on marketing campaigns."
       quick_prompts:

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -128,11 +128,12 @@ class TracesConfig(TracesDomainConfig):
     dbs: Optional[List[DatabaseConfig[TracesDomainConfig]]] = None
 
 
-class AgentChatConfig(BaseModel):
-    """Per-agent (or team/workflow) UI metadata for the AgentOS Chat page.
+class ChatComponentConfig(BaseModel):
+    """Per-component (agent, team, or workflow) UI metadata for the AgentOS Chat page.
 
     These fields are UI-only metadata. ``description`` here is unrelated to
-    ``Agent.description``, which is sent to the model.
+    ``Agent.description`` / ``Team.description`` / ``Workflow.description``,
+    which are sent to the model.
     """
 
     description: Optional[str] = None
@@ -149,30 +150,30 @@ class AgentChatConfig(BaseModel):
 class ChatConfig(BaseModel):
     """Configuration for the Chat page of the AgentOS"""
 
-    agents: dict[str, AgentChatConfig] = Field(default_factory=dict)
+    components: dict[str, ChatComponentConfig] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod
     def _lift_legacy_quick_prompts(cls, data):
         """Accept the legacy ``quick_prompts={id: [...]}`` shape by lifting it
-        into ``agents[id].quick_prompts``. Explicit ``agents`` entries win."""
+        into ``components[id].quick_prompts``. Explicit ``components`` entries win."""
         if not isinstance(data, dict):
             return data
         legacy = data.pop("quick_prompts", None)
         if not legacy:
             return data
-        agents = dict(data.get("agents") or {})
+        components = dict(data.get("components") or {})
         for key, prompts in legacy.items():
-            existing = agents.get(key)
+            existing = components.get(key)
             if existing is None:
-                agents[key] = {"quick_prompts": prompts}
+                components[key] = {"quick_prompts": prompts}
             elif isinstance(existing, dict):
                 if existing.get("quick_prompts") is None:
-                    agents[key] = {**existing, "quick_prompts": prompts}
-            elif isinstance(existing, AgentChatConfig):
+                    components[key] = {**existing, "quick_prompts": prompts}
+            elif isinstance(existing, ChatComponentConfig):
                 if existing.quick_prompts is None:
                     existing.quick_prompts = prompts
-        data["agents"] = agents
+        data["components"] = components
         return data
 
 

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -156,12 +156,18 @@ class ChatConfig(BaseModel):
     @classmethod
     def _lift_legacy_quick_prompts(cls, data):
         """Accept the legacy ``quick_prompts={id: [...]}`` shape by lifting it
-        into ``components[id].quick_prompts``. Explicit ``components`` entries win."""
+        into ``components[id].quick_prompts``. Explicit ``components`` entries win.
+
+        Legacy values are merged as raw dicts so pydantic re-runs field validation
+        (including the 3-prompt cap) when rebuilding the ``ChatComponentConfig``.
+        """
         if not isinstance(data, dict):
             return data
         legacy = data.pop("quick_prompts", None)
-        if not legacy:
+        if legacy is None:
             return data
+        if not isinstance(legacy, dict):
+            raise ValueError("chat.quick_prompts must be a mapping of component id to a list of prompts")
         components = dict(data.get("components") or {})
         for key, prompts in legacy.items():
             existing = components.get(key)
@@ -172,7 +178,9 @@ class ChatConfig(BaseModel):
                     components[key] = {**existing, "quick_prompts": prompts}
             elif isinstance(existing, ChatComponentConfig):
                 if existing.quick_prompts is None:
-                    existing.quick_prompts = prompts
+                    merged = existing.model_dump()
+                    merged["quick_prompts"] = prompts
+                    components[key] = merged
         data["components"] = components
         return data
 

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -2,7 +2,7 @@
 
 from typing import Generic, List, Optional, TypeVar
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class AuthorizationConfig(BaseModel):
@@ -128,19 +128,52 @@ class TracesConfig(TracesDomainConfig):
     dbs: Optional[List[DatabaseConfig[TracesDomainConfig]]] = None
 
 
+class AgentChatConfig(BaseModel):
+    """Per-agent (or team/workflow) UI metadata for the AgentOS Chat page.
+
+    These fields are UI-only metadata. ``description`` here is unrelated to
+    ``Agent.description``, which is sent to the model.
+    """
+
+    description: Optional[str] = None
+    quick_prompts: Optional[List[str]] = None
+
+    @field_validator("quick_prompts")
+    @classmethod
+    def _limit_quick_prompts(cls, v):
+        if v is not None and len(v) > 3:
+            raise ValueError("Too many quick prompts, maximum allowed is 3")
+        return v
+
+
 class ChatConfig(BaseModel):
     """Configuration for the Chat page of the AgentOS"""
 
-    quick_prompts: dict[str, list[str]]
+    agents: dict[str, AgentChatConfig] = Field(default_factory=dict)
 
-    # Limit the number of quick prompts to 3 (per agent/team/workflow)
-    @field_validator("quick_prompts")
+    @model_validator(mode="before")
     @classmethod
-    def limit_lists(cls, v):
-        for key, lst in v.items():
-            if len(lst) > 3:
-                raise ValueError(f"Too many quick prompts for '{key}', maximum allowed is 3")
-        return v
+    def _lift_legacy_quick_prompts(cls, data):
+        """Accept the legacy ``quick_prompts={id: [...]}`` shape by lifting it
+        into ``agents[id].quick_prompts``. Explicit ``agents`` entries win."""
+        if not isinstance(data, dict):
+            return data
+        legacy = data.pop("quick_prompts", None)
+        if not legacy:
+            return data
+        agents = dict(data.get("agents") or {})
+        for key, prompts in legacy.items():
+            existing = agents.get(key)
+            if existing is None:
+                agents[key] = {"quick_prompts": prompts}
+            elif isinstance(existing, dict):
+                if existing.get("quick_prompts") is None:
+                    agents[key] = {**existing, "quick_prompts": prompts}
+            elif isinstance(existing, AgentChatConfig):
+                if existing.quick_prompts is None:
+                    existing.quick_prompts = prompts
+        data["agents"] = agents
+        return data
 
 
 class AgentOSConfig(BaseModel):


### PR DESCRIPTION
## Summary

Refactors the AgentOS Chat page config so that per-component UI metadata lives under a single per-component struct, `ChatComponentConfig`. "Component" matches the codebase's existing terminology — `ComponentType` in `os/schema.py` is defined as "agent, team, or workflow" — and the `quick_prompts` map has always been keyed by component id, not just agent id.

The first new field is `description` — purely **AgentOS UI metadata**, unrelated to `Agent.description` / `Team.description` / `Workflow.description` (which are sent to the model). Future per-component chat-page fields (icon, display name override, starter context, suggested follow-ups, etc.) have a natural home here instead of growing a new sibling map each time.

Supersedes #8108, which nested `description` *inside* `quick_prompts`. That structure didn't model the relationship correctly — `description` and `quick_prompts` are siblings under a component, not parent/child.

### Schema change (`libs/agno/agno/os/config.py`)

```python
class ChatComponentConfig(BaseModel):
    description: Optional[str] = None
    quick_prompts: Optional[List[str]] = None

class ChatConfig(BaseModel):
    components: dict[str, ChatComponentConfig] = Field(default_factory=dict)
```

A `model_validator(mode="before")` accepts the legacy `chat.quick_prompts={id: [...]}` shape (YAML or Python kwarg) and lifts it into `chat.components[id].quick_prompts`. Explicit `components` entries win over the legacy field. The 3-prompt cap is enforced on every shape.

### New YAML shape

```yaml
chat:
  components:
    marketing-agent:
      description: "Plans, runs and reports on marketing campaigns."
      quick_prompts:
        - "What can you do?"
        - "How is our latest post working?"
        - "Tell me about our active marketing campaigns"
    support-team:
      description: "Triages and routes incoming support tickets."
      quick_prompts:
        - "How many open tickets right now?"
```

Legacy YAML continues to work unchanged:
```yaml
chat:
  quick_prompts:
    marketing-agent:
      - "What can you do?"
      - "How is our latest post working?"
```

### Cookbook

`cookbook/05_agent_os/os_config/` (`basic.py` and `config.yaml`) demos the new shape with a description. The other cookbook configs (`00_quickstart`, `01_demo`, `levels_of_agentic_software`, `shopify_demo`) are deliberately left on the legacy `quick_prompts` form so backward compatibility is exercised in-tree.

## Type of change

- [x] New feature
- [x] Improvement

## Frontend impact (action required)

This is backward compatible at the **Python and YAML input** level, but the `/config` API response shape changes:

**Before**
```json
{
  "chat": {
    "quick_prompts": {
      "marketing-agent": ["p1", "p2", "p3"]
    }
  }
}
```

**After**
```json
{
  "chat": {
    "components": {
      "marketing-agent": {
        "description": "Plans, runs and reports on marketing campaigns.",
        "quick_prompts": ["p1", "p2", "p3"]
      }
    }
  }
}
```

The AgentOS frontend that reads `/config` needs to:
1. Read quick prompts from `chat.components[id].quick_prompts` instead of `chat.quick_prompts[id]`.
2. Render `chat.components[id].description` (optional, may be `null`) alongside the component on the Chat page.

The `chat.quick_prompts` field is no longer present on `ChatConfig`, so it will not appear in the serialized response. This should be coordinated with the AgentOS frontend before release.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (docstring on `ChatComponentConfig` clarifies it is UI-only metadata and applies to agents, teams, and workflows)
- [x] Examples and guides: cookbook `05_agent_os/os_config/` updated to demo the new form
- [x] Tested in clean environment (verified legacy Python kwarg, new Python form, mixed inputs with explicit entries winning, legacy YAML, new YAML, team-id usage, and the 3-prompt cap on every shape)
- [ ] Tests added/updated (no existing tests for `ChatConfig`; happy to add unit tests if desired)

### Duplicate and AI-Generated PR Check

- [x] Searched existing open PRs; supersedes #8108
- [x] Drafted with Claude Code

## Additional Notes

No migration is required for existing users — legacy `chat.quick_prompts` configs are normalized transparently to `chat.components[id].quick_prompts`. The only breaking surface is the `/config` API response shape consumed by the AgentOS frontend, detailed above.