### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop() in embedders

### DIFF
--- a/libs/agno/agno/knowledge/embedder/fastembed.py
+++ b/libs/agno/agno/knowledge/embedder/fastembed.py
@@ -55,7 +55,7 @@ class FastEmbedEmbedder(Embedder):
         """Async version using thread executor for CPU-bound operations."""
         import asyncio
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         # Run the CPU-bound operation in a thread executor
         return await loop.run_in_executor(None, self.get_embedding, text)
 
@@ -63,6 +63,6 @@ class FastEmbedEmbedder(Embedder):
         """Async version using thread executor for CPU-bound operations."""
         import asyncio
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         # Run the CPU-bound operation in a thread executor
         return await loop.run_in_executor(None, self.get_embedding_and_usage, text)

--- a/libs/agno/agno/knowledge/embedder/sentence_transformer.py
+++ b/libs/agno/agno/knowledge/embedder/sentence_transformer.py
@@ -51,7 +51,7 @@ class SentenceTransformerEmbedder(Embedder):
         """Async version using thread executor for CPU-bound operations."""
         import asyncio
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         # Run the CPU-bound operation in a thread executor
         return await loop.run_in_executor(None, self.get_embedding, text)
 
@@ -59,5 +59,5 @@ class SentenceTransformerEmbedder(Embedder):
         """Async version using thread executor for CPU-bound operations."""
         import asyncio
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self.get_embedding_and_usage, text)

--- a/libs/agno/agno/knowledge/embedder/vllm.py
+++ b/libs/agno/agno/knowledge/embedder/vllm.py
@@ -181,7 +181,7 @@ class VLLMEmbedder(Embedder):
                 return []
         else:
             # Local mode: use thread executor for CPU-bound operations
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             return await loop.run_in_executor(None, self.get_embedding, text)
 
     async def async_get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
@@ -204,7 +204,7 @@ class VLLMEmbedder(Embedder):
         else:
             # Local mode: use thread executor for CPU-bound operations
             try:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 return await loop.run_in_executor(None, self.get_embedding_and_usage, text)
             except Exception as e:
                 log_warning(f"Error in async local embedding: {str(e)}")


### PR DESCRIPTION
## Summary

Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in three embedder modules (6 occurrences total).

## Motivation

`asyncio.get_event_loop()` was deprecated in Python 3.10 ([docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop)). When called inside an `async def` method — which is the case for all six call sites — `asyncio.get_running_loop()` is the correct modern API. It:

1. Avoids the `DeprecationWarning` emitted in Python 3.10+
2. Is semantically precise — these methods can only be called from a running loop
3. Fails fast with `RuntimeError` if accidentally called outside an async context, rather than silently creating a new loop

## Changes

| File | Occurrences |
|------|-------------|
| `libs/agno/agno/knowledge/embedder/fastembed.py` | 2 (`async_get_embedding`, `async_get_embedding_and_usage`) |
| `libs/agno/agno/knowledge/embedder/sentence_transformer.py` | 2 (`async_get_embedding`, `async_get_embedding_and_usage`) |
| `libs/agno/agno/knowledge/embedder/vllm.py` | 2 (`async_get_embedding`, `async_get_embedding_and_usage` — local mode branch) |

## Not changed

- `tracing/exporter.py` — intentionally handles both running and non-running loop contexts (`loop.is_running()` branch + `asyncio.run()` fallback), so `get_event_loop()` is appropriate there.
- `knowledge/reader/youtube_reader.py` — already addressed by #8078.

## Testing

- All three files pass `py_compile` syntax check.
- No behavioral change: in an `async def` method, `get_event_loop()` and `get_running_loop()` return the same loop object. The only difference is the deprecation warning is eliminated.

Closes: N/A (no open issue — discovered via codebase grep)