### PR TITLE
[fix] Enable native structured outputs on Bedrock Claude for supported models

### DIFF
--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -1,13 +1,12 @@
 from dataclasses import dataclass
 from os import getenv
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Optional
 
 import httpx
-from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
-from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model
+from agno.utils.log import log_warning
+from agno.utils.models.claude import supports_bedrock_structured_outputs
 
 try:
     from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
@@ -42,12 +41,8 @@ class Claude(AnthropicClaude):
     client: Optional[AnthropicBedrock] = None  # type: ignore
     async_client: Optional[AsyncAnthropicBedrock] = None  # type: ignore
 
-    def __post_init__(self):
-        """Validate model configuration after initialization"""
-        super().__post_init__()
-        # Overwrite output schema support for AWS Bedrock Claude
-        self.supports_native_structured_outputs = False
-        self.supports_json_schema_outputs = False
+    def _supports_structured_outputs(self) -> bool:
+        return supports_bedrock_structured_outputs(self.id)
 
     def _get_client_params(self) -> Dict[str, Any]:
         if self.session:
@@ -175,85 +170,3 @@ class Claude(AnthropicClaude):
         if not self.session:
             self.async_client = async_client
         return async_client
-
-    def get_request_params(
-        self,
-        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
-        tools: Optional[List[Dict[str, Any]]] = None,
-    ) -> Dict[str, Any]:
-        """
-        Generate keyword arguments for API requests.
-
-        Returns:
-            Dict[str, Any]: The keyword arguments for API requests.
-        """
-        # Validate thinking support if thinking is enabled
-        if self.thinking:
-            self._validate_thinking_support()
-
-        _request_params: Dict[str, Any] = {}
-        if self.max_tokens:
-            _request_params["max_tokens"] = self.max_tokens
-        if self.thinking:
-            _request_params["thinking"] = self.thinking
-        if self.output_config:
-            _request_params["output_config"] = self.output_config
-        if self.temperature is not None:
-            _request_params["temperature"] = self.temperature
-        if self.stop_sequences:
-            _request_params["stop_sequences"] = self.stop_sequences
-        if self.top_p is not None:
-            _request_params["top_p"] = self.top_p
-        if self.top_k is not None:
-            _request_params["top_k"] = self.top_k
-        if self.timeout:
-            _request_params["timeout"] = self.timeout
-
-        # Build betas list - include existing betas and add new one if needed
-        betas_list = list(self.betas) if self.betas else []
-
-        # Include betas if any are present
-        if betas_list:
-            _request_params["betas"] = betas_list
-
-        if self.request_params:
-            _request_params.update(self.request_params)
-
-        if _request_params:
-            log_debug(f"Calling {self.provider} with request parameters: {_request_params}", log_level=2)
-        return _request_params
-
-    def _prepare_request_kwargs(
-        self,
-        system_message: str,
-        tools: Optional[List[Dict[str, Any]]] = None,
-        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
-        messages: Optional[List[Any]] = None,
-    ) -> Dict[str, Any]:
-        """
-        Prepare the request keyword arguments for the API call.
-
-        Args:
-            system_message (str): The concatenated system messages.
-            tools: Optional list of tools
-            response_format: Optional response format (Pydantic model or dict)
-            messages: Optional list of Message objects for the conversation.
-
-        Returns:
-            Dict[str, Any]: The request keyword arguments.
-        """
-        # Pass response_format and tools to get_request_params for beta header handling
-        request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
-        system = self._build_system(system_message)
-        if system:
-            request_kwargs["system"] = system
-
-        # Format tools (this will handle strict mode)
-        if tools:
-            request_kwargs["tools"] = format_tools_for_model(tools)
-
-        self._apply_cache_tools(request_kwargs)
-
-        if request_kwargs:
-            log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)
-        return request_kwargs

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -37,17 +37,30 @@ _PREFILL_SUPPORTED_ALIASES = {
     "claude-haiku-4",
 }
 
+# Claude families with GA native structured outputs on Amazon Bedrock's InvokeModel
+# path (per Anthropic docs + live verification). Support is NOT monotonic with version
+# (Opus 4.1 and 4.7 are unsupported here while 4.5/4.6 work), so this is an explicit
+# allowlist: unlisted ids fall back to prompt-injection rather than 400ing.
+_BEDROCK_STRUCTURED_OUTPUT_PREFIXES = (
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+)
 
-def supports_prefill(model_id: str) -> bool:
-    """Return True if the given model ID supports assistant message prefill.
+
+def base_claude_id(model_id: str) -> str:
+    """Strip provider decoration from a Claude model ID, returning the base Anthropic ID.
 
     Handles provider-specific ID formats:
       - Anthropic direct:  "claude-sonnet-4-5-20250929"
       - Bedrock:           "us.anthropic.claude-sonnet-4-6-v1:0"
+      - Bedrock ARN:       "arn:...:inference-profile/us.anthropic.claude-...-v1:0"
       - Vertex AI:         "claude-sonnet-4@20250514"
       - LiteLLM:           "anthropic/claude-sonnet-4-6"
     """
-    # Strip LiteLLM provider prefix (e.g. "anthropic/claude-sonnet-4-6")
+    # Strip LiteLLM provider prefix / Bedrock ARN path (e.g. "anthropic/claude-sonnet-4-6")
     core_id = model_id.split("/")[-1] if "/" in model_id else model_id
     # Strip Bedrock prefix (e.g. "us.anthropic.claude-sonnet-4-6-v1:0")
     core_id = core_id.split("anthropic.")[-1] if "anthropic." in core_id else core_id
@@ -57,10 +70,22 @@ def supports_prefill(model_id: str) -> bool:
     if ":0" in core_id:
         core_id = core_id.split("-v")[0] if "-v" in core_id else core_id.split(":")[0]
 
+    return core_id
+
+
+def supports_prefill(model_id: str) -> bool:
+    """Return True if the given model ID supports assistant message prefill."""
+    core_id = base_claude_id(model_id)
+
     if not core_id.startswith("claude"):
         return True  # Non-Claude models are unaffected — don't inject trailing messages
 
     return core_id in _PREFILL_SUPPORTED_ALIASES or core_id.startswith(_PREFILL_SUPPORTED_PREFIXES)
+
+
+def supports_bedrock_structured_outputs(model_id: str) -> bool:
+    """Return True if the Bedrock-hosted Claude model supports native structured outputs."""
+    return base_claude_id(model_id).startswith(_BEDROCK_STRUCTURED_OUTPUT_PREFIXES)
 
 
 @dataclass

--- a/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
+++ b/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
@@ -249,6 +249,47 @@ class TestSupportsPrefillHelper:
         assert supports_prefill("gemini-2.0-flash") is True
 
 
+class TestBaseClaudeId:
+    """Tests for the shared base_claude_id() normalizer."""
+
+    @pytest.mark.parametrize(
+        "model_id,expected",
+        [
+            # Anthropic direct — returned unchanged
+            ("claude-sonnet-4-5-20250929", "claude-sonnet-4-5-20250929"),
+            ("claude-sonnet-4", "claude-sonnet-4"),
+            # Bedrock region prefixes + version suffix
+            ("global.anthropic.claude-sonnet-4-5-20250929-v1:0", "claude-sonnet-4-5-20250929"),
+            ("us.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5-20251001"),
+            ("eu.anthropic.claude-sonnet-4-5-20250929-v1:0", "claude-sonnet-4-5-20250929"),
+            ("apac.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5-20251001"),
+            # Bedrock without region prefix
+            ("anthropic.claude-3-5-sonnet-20240620-v1:0", "claude-3-5-sonnet-20240620"),
+            # Bedrock inference-profile ARN
+            (
+                "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "claude-3-5-sonnet-20240620",
+            ),
+            # Bedrock foundation-model ARN
+            (
+                "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "claude-sonnet-4-5-20250929",
+            ),
+            # Vertex AI version suffix
+            ("claude-sonnet-4@20250514", "claude-sonnet-4"),
+            # LiteLLM provider prefix
+            ("anthropic/claude-sonnet-4-6", "claude-sonnet-4-6"),
+            # Edge cases — returned unchanged, no crash
+            ("", ""),
+            ("gpt-5.4", "gpt-5.4"),
+        ],
+    )
+    def test_normalization(self, model_id, expected):
+        from agno.utils.models.claude import base_claude_id
+
+        assert base_claude_id(model_id) == expected
+
+
 class TestAutoDetection:
     """Tests for automatic append_trailing_user_message detection."""
 

--- a/libs/agno/tests/unit/models/aws/test_claude_structured_outputs.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_structured_outputs.py
@@ -1,0 +1,134 @@
+"""Unit tests for native structured-output support on AWS Bedrock Claude.
+
+Bedrock-hosted Claude models support Anthropic's native structured outputs
+(`output_format` + the `structured-outputs-2025-11-13` beta header) on the same
+model generations as the direct Anthropic API. These tests pin that the Bedrock
+subclass:
+  - reports `supports_native_structured_outputs` correctly per model id, and
+  - actually emits `output_format` and the beta header in outgoing requests.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+pytest.importorskip("anthropic")
+pytest.importorskip("boto3")
+
+from agno.models.aws.claude import Claude as AwsClaude
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+class TestBedrockStructuredOutputSupportFlag:
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            # Confirmed supported via live Bedrock calls
+            "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "global.anthropic.claude-sonnet-4-6",
+            "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
+            "global.anthropic.claude-opus-4-5-20251101-v1:0",
+            "global.anthropic.claude-opus-4-6-v1",
+            "claude-sonnet-4-5-20250929",  # plain Anthropic id — normalization is a no-op
+        ],
+    )
+    def test_supported_models_enable_structured_outputs(self, model_id):
+        model = AwsClaude(id=model_id, aws_access_key="k", aws_secret_key="s", aws_region="us-east-1")
+        assert model.supports_native_structured_outputs is True
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "anthropic.claude-3-haiku-20240307-v1:0",
+            "us.anthropic.claude-sonnet-4-20250514-v1:0",  # legacy Sonnet 4
+            "us.anthropic.claude-opus-4-20250514-v1:0",  # legacy Opus 4
+            # available on Bedrock but reject output_format with a 400
+            "us.anthropic.claude-opus-4-1-20250805-v1:0",
+            "global.anthropic.claude-opus-4-7",
+            # full inference-profile ARN of a legacy (Claude 3) model
+            "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+        ],
+    )
+    def test_unsupported_models_disable_structured_outputs(self, model_id):
+        model = AwsClaude(id=model_id, aws_access_key="k", aws_secret_key="s", aws_region="us-east-1")
+        assert model.supports_native_structured_outputs is False
+
+
+@pytest.fixture
+def model():
+    return AwsClaude(
+        id="global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        aws_access_key="k",
+        aws_secret_key="s",
+        aws_region="us-east-1",
+    )
+
+
+class TestBedrockStructuredOutputRequestParams:
+    def test_beta_header_added_with_response_format(self, model):
+        params = model.get_request_params(response_format=_Person)
+        assert "structured-outputs-2025-11-13" in params.get("betas", [])
+
+    def test_no_beta_header_without_response_format(self, model):
+        params = model.get_request_params()
+        assert "structured-outputs-2025-11-13" not in params.get("betas", [])
+
+    def test_output_format_built_in_request_kwargs(self, model):
+        kwargs = model._prepare_request_kwargs("system prompt", response_format=_Person)
+        assert "output_format" in kwargs
+        assert kwargs["output_format"]["type"] == "json_schema"
+
+    def test_no_output_format_without_response_format(self, model):
+        kwargs = model._prepare_request_kwargs("system prompt")
+        assert "output_format" not in kwargs
+
+    def test_unsupported_model_omits_output_format(self):
+        model = AwsClaude(
+            id="anthropic.claude-3-5-sonnet-20240620-v1:0",
+            aws_access_key="k",
+            aws_secret_key="s",
+            aws_region="us-east-1",
+        )
+        kwargs = model._prepare_request_kwargs("system prompt", response_format=_Person)
+        assert "output_format" not in kwargs
+        assert "structured-outputs-2025-11-13" not in kwargs.get("betas", [])
+
+
+class TestSupportsBedrockStructuredOutputsHelper:
+    """Direct tests for the shared supports_bedrock_structured_outputs() predicate."""
+
+    @pytest.mark.parametrize(
+        "base_id",
+        [
+            "claude-sonnet-4-5-20250929",
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-5-20251101",
+            "claude-opus-4-6-v1",
+        ],
+    )
+    def test_supported_families(self, base_id):
+        from agno.utils.models.claude import supports_bedrock_structured_outputs
+
+        assert supports_bedrock_structured_outputs(base_id) is True
+
+    @pytest.mark.parametrize(
+        "base_id",
+        [
+            "claude-opus-4-1-20250805",  # available on Bedrock but rejects output_format
+            "claude-opus-4-7",  # InvokeModel path unsupported
+            "claude-sonnet-4-20250514",  # legacy Sonnet 4
+            "claude-3-5-sonnet-20240620",
+            "gpt-5.4",  # non-Claude
+            "",
+        ],
+    )
+    def test_unsupported_or_unknown(self, base_id):
+        from agno.utils.models.claude import supports_bedrock_structured_outputs
+
+        assert supports_bedrock_structured_outputs(base_id) is False


### PR DESCRIPTION
## Summary

`agno.models.aws.Claude` (the Bedrock wrapper around Anthropic's AnthropicBedrock SDK) never enforced native structured outputs, even on models that support them. It hardcoded `supports_native_structured_outputs = False` and overrode `get_request_params` / `_prepare_request_kwargs` to strip the `output_format` parameter and the `structured-outputs-2025-11-13` beta header. As a result, agents with an `output_schema` only asked the model in the prompt to return matching JSON.

This PR makes the following changes:
* Removes the Bedrock-specific `get_request_params` / `_prepare_request_kwargs` overrides so the parent AnthropicClaude builds and sends `output_format` + the beta header (the actual enforcement fix).
* Replaces the inherited "supported unless denylisted" predicate with an explicit Bedrock allowlist, because support on Bedrock's `InvokeModel` path is not monotonic with version. For example, `Opus 4.5` and `Opus 4.6` support structured outputs, but `Opus 4.1` (older) and `Opus 4.7` (newer) reject `output_format` with a 400 error. A denylist fails open and would regress those models from silent prompt-injection to a hard 400; the allowlist fails safe (unknown/new ids fall back to prompt-injection).
* Adds shared `base_claude_id()` and `supports_bedrock_structured_outputs()` utility functions, mirroring the existing `supports_prefill()` pattern.

Fixes:  https://github.com/agno-agi/agno/issues/8119

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

https://github.com/agno-agi/agno/pull/7641 is related to this PR and addresses the same false "does not support structured outputs" warning by suppressing it while leaving `supports_native_structured_outputs = False`, on the assumption Bedrock can't enforce schemas natively.