### PR TITLE
[fix] Force MCP run tools to request non-streaming output

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -104,21 +104,21 @@ def get_mcp_server(
         agent = get_agent_by_id(agent_id, os.agents)
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
-        return await agent.arun(message)  # type: ignore[misc]
+        return await agent.arun(message, stream=False)  # type: ignore[misc]
 
     @mcp.tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
     async def run_team(team_id: str, message: str) -> TeamRunOutput:
         team = get_team_by_id(team_id, os.teams)
         if team is None:
             raise Exception(f"Team {team_id} not found")
-        return await team.arun(message)  # type: ignore[misc]
+        return await team.arun(message, stream=False)  # type: ignore[misc]
 
     @mcp.tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
     async def run_workflow(workflow_id: str, message: str) -> WorkflowRunOutput:
         workflow = get_workflow_by_id(workflow_id, os.workflows)
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
-        return await workflow.arun(message)
+        return await workflow.arun(message, stream=False)
 
     # ==================== Session Management Tools ====================
 

--- a/libs/agno/tests/integration/os/test_mcp_run_tools.py
+++ b/libs/agno/tests/integration/os/test_mcp_run_tools.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agno.os import mcp as mcp_module
+
+
+class _CapturingFastMCP:
+    def __init__(self, *_args, **_kwargs):
+        self.tools = {}
+
+    def tool(self, name=None, **_kwargs):
+        def decorator(func):
+            self.tools[name or func.__name__] = func
+            return func
+
+        return decorator
+
+    def http_app(self, *_args, **_kwargs):
+        return None
+
+
+class _StreamingByDefaultRunner:
+    id = "runner"
+
+    def __init__(self, output):
+        self.output = output
+        self.calls = []
+
+    def arun(self, message, *, stream=None):
+        self.calls.append((message, stream))
+        if stream is False:
+            return self._result()
+        return self._stream()
+
+    async def _result(self):
+        return self.output
+
+    async def _stream(self):
+        yield self.output
+
+
+def _capture_mcp_tools(monkeypatch):
+    captured = {}
+
+    class CapturingFastMCP(_CapturingFastMCP):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured["server"] = self
+
+    monkeypatch.setattr(mcp_module, "FastMCP", CapturingFastMCP)
+    mcp_module.get_mcp_server(
+        SimpleNamespace(
+            name="test-os",
+            authorization=False,
+            authorization_config=None,
+            agents=[],
+            teams=[],
+            workflows=[],
+        )
+    )
+    return captured["server"].tools
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "id_arg", "lookup_name"),
+    [
+        ("run_agent", "agent_id", "get_agent_by_id"),
+        ("run_team", "team_id", "get_team_by_id"),
+        ("run_workflow", "workflow_id", "get_workflow_by_id"),
+    ],
+)
+async def test_mcp_run_tools_force_non_streaming(monkeypatch, tool_name, id_arg, lookup_name):
+    runner = _StreamingByDefaultRunner(output={"content": "done"})
+    monkeypatch.setattr(mcp_module, lookup_name, lambda *_args, **_kwargs: runner)
+
+    tools = _capture_mcp_tools(monkeypatch)
+
+    result = await tools[tool_name](**{id_arg: "runner", "message": "hello"})
+
+    assert result == {"content": "done"}
+    assert runner.calls == [("hello", False)]


### PR DESCRIPTION
## Summary

Fixes #8062.

MCP `run_agent`, `run_team`, and `run_workflow` tools now call the async runner APIs with `stream=False`. This keeps the MCP tools on the non-streaming result path even when an agent/team/workflow is configured to stream by default.

Added an integration regression test that captures the registered MCP tools and verifies each run tool passes `stream=False` instead of awaiting the default async stream iterator.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run:

- `pytest libs/agno/tests/integration/os/test_mcp_run_tools.py -q` -> `3 passed`
- `pytest libs/agno/tests/integration/os/test_register_mcp_tools.py libs/agno/tests/integration/os/test_mcp_run_tools.py -q` -> `13 passed, 1 warning`
- `ruff check libs/agno/agno/os/mcp.py libs/agno/tests/integration/os/test_mcp_run_tools.py` -> passed
- `ruff format --check libs/agno/agno/os/mcp.py libs/agno/tests/integration/os/test_mcp_run_tools.py` -> passed
- `mypy libs/agno/agno/os/mcp.py --config-file libs/agno/pyproject.toml` -> passed
- `PATH=".venv/bin:$PATH" libs/agno/scripts/validate.sh` -> `ruff check` passed, then `mypy` failed on 7 pre-existing errors outside this diff: `knowledge/embedder/jina.py`, `tools/zoom.py`, `tools/sql.py`, `tools/desi_vocal.py`, `tools/clickup.py`, `tools/calcom.py`, `tools/models/azure_openai.py`.

Duplicate search was re-run immediately before implementation with GitHub PR search for #8062 / MCP run tool streaming terms; no open or closed matching PRs were found.
