### PR TITLE
feat: add InvisiblePlaywrightTools toolkit

### DIFF
--- a/cookbook/91_tools/invisible_playwright_tools.py
+++ b/cookbook/91_tools/invisible_playwright_tools.py
@@ -1,0 +1,80 @@
+"""
+InvisiblePlaywrightTools - Firefox-based stealth browser
+
+Useful when sites behind bot protection return
+empty content or 403 from FirecrawlTools / Crawl4aiTools / ScrapegraphTools.
+
+Backend: patched Firefox 150 binary (feder-cr/invisible_firefox, MPL-2.0,
+same license as Firefox upstream). Fingerprint patches at the C++ source
+code level so there are no JS shims to detect.
+
+Prerequisites:
+- pip install git+https://github.com/feder-cr/invisible_playwright.git
+- python -m invisible_playwright fetch
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.invisible_playwright import InvisiblePlaywrightTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Example 1: scrape one URL through stealth Firefox
+agent_scrape = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[InvisiblePlaywrightTools()],
+    description="You are a web reader that uses a stealth Firefox to read sites that block standard scrapers.",
+    instructions=[
+        "Use scrape_url to read the requested page.",
+        "Summarise what you find concisely.",
+    ],
+    markdown=True,
+)
+
+# Example 2: crawl a domain (multi-page) and search the web
+agent_full = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[
+        InvisiblePlaywrightTools(
+            all=True,
+            seed=42,
+            max_pages=5,
+            max_depth=2,
+            search_engine="duckduckgo",
+            num_results=5,
+        )
+    ],
+    description="You are a research agent with stealth browsing.",
+    instructions=[
+        "Use search_web to discover relevant pages.",
+        "Use crawl_site to follow links within a single domain.",
+        "Use scrape_url for a single targeted page.",
+    ],
+    markdown=True,
+)
+
+# Example 3: scrape behind a proxy with deterministic fingerprint
+agent_proxy = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[
+        InvisiblePlaywrightTools(
+            seed=42,
+            proxy={
+                "server": "socks5://proxy.example.com:1080",
+                "username": "user",
+                "password": "pass",
+            },
+            locale="en-US",
+            timezone="America/New_York",
+        )
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent_scrape.print_response("Read https://bot.sannysoft.com and tell me which automation checks pass.")

--- a/libs/agno/agno/tools/invisible_playwright.py
+++ b/libs/agno/agno/tools/invisible_playwright.py
@@ -1,0 +1,462 @@
+"""InvisiblePlaywrightTools toolkit.
+
+Firefox-based stealth browser toolkit, parallel to FirecrawlTools,
+Crawl4aiTools, ScrapegraphTools. Wraps invisible_playwright, which drives
+a patched Firefox 150 binary (feder-cr/invisible_firefox, MPL-2.0, same
+license as Firefox upstream). Fingerprint patches at the C++ source code
+level so there are no JS shims to detect.
+
+Useful for sites where the existing Firecrawl, Crawl4ai, or Scrapegraph
+toolkits hit bot-protection walls.
+
+Tracking discussion: #8128
+Related open issues: #7943 (Playwright tool), #7104,
+#6997.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin, urlparse
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error
+
+try:
+    from invisible_playwright import InvisiblePlaywright
+    from invisible_playwright.async_api import InvisiblePlaywright as AsyncInvisiblePlaywright
+except ImportError:
+    raise ImportError(
+        "`invisible_playwright` not installed. "
+        "Install with `pip install git+https://github.com/feder-cr/invisible_playwright.git` and run "
+        "`python -m invisible_playwright fetch` to download the patched Firefox binary."
+    )
+
+
+class InvisiblePlaywrightTools(Toolkit):
+    """Firefox-based stealth browser toolkit.
+
+    Args:
+        enable_scrape: Enable single-page scrape. Default True.
+        enable_crawl: Enable multi-page crawl within a domain. Default False.
+        enable_search: Enable search engine query. Default False.
+        all: Enable all tools. Overrides individual flags. Default False.
+        seed: Integer seed for deterministic fingerprint across runs.
+            Same seed produces identical fingerprint.
+        headless: When True, render on a hidden virtual display so the
+            browser stays in real headed mode without showing windows.
+            Default True.
+        proxy: Proxy dict ({"server": "...", "username": "...", "password": "..."}).
+        locale: BCP-47 locale tag (e.g. "en-US"). Default "en-US".
+        timezone: IANA timezone (e.g. "America/New_York"). Empty means host tz.
+        max_pages: Default cap on pages per crawl. Default 10.
+        max_depth: Default link-depth cap for crawl. Default 2.
+        search_engine: Default search engine for search_web ("duckduckgo" or "bing").
+            Default "duckduckgo" (no captcha pre-screen on the HTML endpoint).
+        num_results: Default number of search results returned. Default 5.
+        max_length: Truncate scrape/crawl output beyond this length. Default 5000.
+            Set to None to disable truncation.
+    """
+
+    def __init__(
+        self,
+        enable_scrape: bool = True,
+        enable_crawl: bool = False,
+        enable_search: bool = False,
+        all: bool = False,
+        seed: Optional[int] = None,
+        headless: bool = True,
+        proxy: Optional[Dict[str, str]] = None,
+        locale: str = "en-US",
+        timezone: str = "",
+        max_pages: int = 10,
+        max_depth: int = 2,
+        search_engine: str = "duckduckgo",
+        num_results: int = 5,
+        max_length: Optional[int] = 5000,
+        **kwargs,
+    ):
+        tools: List[Any] = []
+        async_tools: List[Any] = []
+        if all or enable_scrape:
+            tools.append(self.scrape_url)
+            async_tools.append((self.ascrape_url, "scrape_url"))
+        if all or enable_crawl:
+            tools.append(self.crawl_site)
+            async_tools.append((self.acrawl_site, "crawl_site"))
+        if all or enable_search:
+            tools.append(self.search_web)
+            async_tools.append((self.asearch_web, "search_web"))
+
+        super().__init__(
+            name="invisible_playwright_tools",
+            tools=tools,
+            async_tools=async_tools,
+            **kwargs,
+        )
+
+        self._seed = seed
+        self._headless = headless
+        self._proxy = proxy
+        self._locale = locale
+        self._timezone = timezone
+        self._max_pages = max_pages
+        self._max_depth = max_depth
+        self._search_engine = search_engine.lower()
+        self._num_results = num_results
+        self._max_length = max_length
+
+    def _launch(self) -> InvisiblePlaywright:
+        """Build a fresh sync InvisiblePlaywright context manager."""
+        return InvisiblePlaywright(
+            seed=self._seed,
+            headless=self._headless,
+            proxy=self._proxy,
+            locale=self._locale,
+            timezone=self._timezone,
+        )
+
+    def _alaunch(self) -> AsyncInvisiblePlaywright:
+        """Build a fresh async InvisiblePlaywright context manager."""
+        return AsyncInvisiblePlaywright(
+            seed=self._seed,
+            headless=self._headless,
+            proxy=self._proxy,
+            locale=self._locale,
+            timezone=self._timezone,
+        )
+
+    def _truncate(self, text: str) -> str:
+        if self._max_length and len(text) > self._max_length:
+            return text[: self._max_length] + "..."
+        return text
+
+    @staticmethod
+    def _collect_results(
+        page,
+        result_selector: str,
+        title_selector: str,
+        snippet_selector: str,
+        limit: int,
+    ) -> List[Dict[str, str]]:
+        """Extract search result items via sync Playwright element methods only.
+
+        Avoids in-page eval so CSP-restricted SERPs (DuckDuckGo, others)
+        don't reject the extraction.
+        """
+        items: List[Dict[str, str]] = []
+        for el in page.query_selector_all(result_selector)[:limit]:
+            title_el = el.query_selector(title_selector)
+            snippet_el = el.query_selector(snippet_selector)
+            items.append(
+                {
+                    "title": (title_el.inner_text() if title_el else "").strip(),
+                    "url": (title_el.get_attribute("href") if title_el else "") or "",
+                    "snippet": (snippet_el.inner_text() if snippet_el else "").strip(),
+                }
+            )
+        return items
+
+    @staticmethod
+    async def _acollect_results(
+        page,
+        result_selector: str,
+        title_selector: str,
+        snippet_selector: str,
+        limit: int,
+    ) -> List[Dict[str, str]]:
+        """Async variant of _collect_results. Same CSP-safe element-walk pattern."""
+        items: List[Dict[str, str]] = []
+        elements = await page.query_selector_all(result_selector)
+        for el in elements[:limit]:
+            title_el = await el.query_selector(title_selector)
+            snippet_el = await el.query_selector(snippet_selector)
+            title_text = (await title_el.inner_text()) if title_el else ""
+            url = (await title_el.get_attribute("href")) if title_el else ""
+            snippet_text = (await snippet_el.inner_text()) if snippet_el else ""
+            items.append(
+                {
+                    "title": title_text.strip(),
+                    "url": url or "",
+                    "snippet": snippet_text.strip(),
+                }
+            )
+        return items
+
+    def scrape_url(self, url: str, wait_for_selector: Optional[str] = None) -> str:
+        """Fetch the rendered HTML of a URL using a patched stealth Firefox.
+
+        Use when sites behind bot protection return
+        empty content or 403 from the standard Firecrawl/Crawl4ai/Scrapegraph
+        toolkits.
+
+        Args:
+            url: The URL to fetch.
+            wait_for_selector: Optional CSS selector to wait for before
+                returning. Useful for JS-rendered pages.
+
+        Returns:
+            The page HTML, truncated to max_length if set.
+        """
+        if not url:
+            return "Error: No URL provided"
+        try:
+            with self._launch() as browser:
+                page = browser.new_page()
+                page.goto(url)
+                if wait_for_selector:
+                    page.wait_for_selector(wait_for_selector)
+                content = page.content()
+                return self._truncate(content)
+        except Exception as e:
+            log_error(f"InvisiblePlaywrightTools.scrape_url failed for {url}: {e}")
+            return f"Error fetching {url}: {e}"
+
+    def crawl_site(
+        self,
+        url: str,
+        max_pages: Optional[int] = None,
+        max_depth: Optional[int] = None,
+    ) -> str:
+        """Crawl multiple pages from a starting URL, staying within the same domain.
+
+        Breadth-first traversal capped by max_pages and max_depth. Reuses one
+        browser session across all pages for efficiency.
+
+        Args:
+            url: The starting URL.
+            max_pages: Override default page cap.
+            max_depth: Override default depth cap.
+
+        Returns:
+            JSON object mapping each visited URL to its truncated HTML.
+        """
+        if not url:
+            return "Error: No URL provided"
+        page_cap = max_pages or self._max_pages
+        depth_cap = max_depth or self._max_depth
+        origin = urlparse(url).netloc
+        seen: set = {url}
+        results: Dict[str, str] = {}
+        queue: List = [(url, 0)]
+        try:
+            with self._launch() as browser:
+                page = browser.new_page()
+                while queue and len(results) < page_cap:
+                    current, depth = queue.pop(0)
+                    try:
+                        page.goto(current)
+                        html = page.content()
+                        results[current] = self._truncate(html)
+                        log_debug(f"crawl_site: visited {current} ({len(results)}/{page_cap})")
+                    except Exception as inner:
+                        results[current] = f"Error: {inner}"
+                        continue
+                    if depth >= depth_cap:
+                        continue
+                    # query_selector_all + get_attribute avoids in-page eval() which
+                    # some sites block via CSP (e.g. DuckDuckGo).
+                    anchors = page.query_selector_all("a[href]")
+                    for anchor in anchors:
+                        href = anchor.get_attribute("href") or ""
+                        if not href:
+                            continue
+                        # resolve relative links against the current page url
+                        if href.startswith(("/", "?", "#")):
+                            href = urljoin(current, href)
+                        if href in seen:
+                            continue
+                        if urlparse(href).netloc != origin:
+                            continue
+                        seen.add(href)
+                        queue.append((href, depth + 1))
+            return json.dumps(results)
+        except Exception as e:
+            log_error(f"InvisiblePlaywrightTools.crawl_site failed for {url}: {e}")
+            return f"Error crawling {url}: {e}"
+
+    def search_web(self, query: str, num_results: Optional[int] = None) -> str:
+        """Run a search engine query through stealth Firefox and return results.
+
+        Defaults to DuckDuckGo HTML endpoint (no captcha pre-screen). Other
+        supported engine: "bing". Google is intentionally not supported because
+        the SERP HTML is volatile and captcha-walled even for real users.
+
+        Args:
+            query: The search query.
+            num_results: Override default result count.
+
+        Returns:
+            JSON list of result objects with `title`, `url`, `snippet` fields.
+        """
+        if not query:
+            return "Error: No query provided"
+        n = num_results or self._num_results
+        engine = self._search_engine
+        try:
+            with self._launch() as browser:
+                page = browser.new_page()
+                if engine == "duckduckgo":
+                    page.goto(f"https://duckduckgo.com/html/?q={query}")
+                    page.wait_for_selector(".result__title a", timeout=10000)
+                    items = self._collect_results(
+                        page,
+                        result_selector=".result",
+                        title_selector=".result__title a",
+                        snippet_selector=".result__snippet",
+                        limit=n,
+                    )
+                elif engine == "bing":
+                    page.goto(f"https://www.bing.com/search?q={query}")
+                    page.wait_for_selector("li.b_algo", timeout=10000)
+                    items = self._collect_results(
+                        page,
+                        result_selector="li.b_algo",
+                        title_selector="h2 a",
+                        snippet_selector=".b_caption p",
+                        limit=n,
+                    )
+                else:
+                    return f"Error: unsupported search engine '{engine}'. Use 'duckduckgo' or 'bing'."
+                return json.dumps(items)
+        except Exception as e:
+            log_error(f"InvisiblePlaywrightTools.search_web failed for {query!r}: {e}")
+            return f"Error searching for {query!r}: {e}"
+
+    # ------------------------------------------------------------------ #
+    # Async surface (mirrors the sync methods above 1:1).                #
+    # Pattern modelled on BrowserbaseTools (a-prefixed parallel methods) #
+    # per maintainer guidance on PR #8129.                               #
+    # ------------------------------------------------------------------ #
+
+    async def ascrape_url(self, url: str, wait_for_selector: Optional[str] = None) -> str:
+        """Async: fetch the rendered HTML of a URL using a patched stealth Firefox.
+
+        See scrape_url for behaviour. Use this from async agents / asyncio
+        event loops where the sync variant would block.
+
+        Args:
+            url: The URL to fetch.
+            wait_for_selector: Optional CSS selector to wait for before
+                returning. Useful for JS-rendered pages.
+
+        Returns:
+            The page HTML, truncated to max_length if set.
+        """
+        if not url:
+            return "Error: No URL provided"
+        try:
+            async with self._alaunch() as browser:
+                page = await browser.new_page()
+                await page.goto(url)
+                if wait_for_selector:
+                    await page.wait_for_selector(wait_for_selector)
+                content = await page.content()
+                return self._truncate(content)
+        except Exception as e:
+            log_error(f"InvisiblePlaywrightTools.ascrape_url failed for {url}: {e}")
+            return f"Error fetching {url}: {e}"
+
+    async def acrawl_site(
+        self,
+        url: str,
+        max_pages: Optional[int] = None,
+        max_depth: Optional[int] = None,
+    ) -> str:
+        """Async: crawl multiple pages from a starting URL, staying within the same domain.
+
+        See crawl_site for behaviour.
+
+        Args:
+            url: The starting URL.
+            max_pages: Override default page cap.
+            max_depth: Override default depth cap.
+
+        Returns:
+            JSON object mapping each visited URL to its truncated HTML.
+        """
+        if not url:
+            return "Error: No URL provided"
+        page_cap = max_pages or self._max_pages
+        depth_cap = max_depth or self._max_depth
+        origin = urlparse(url).netloc
+        seen: set = {url}
+        results: Dict[str, str] = {}
+        queue: List = [(url, 0)]
+        try:
+            async with self._alaunch() as browser:
+                page = await browser.new_page()
+                while queue and len(results) < page_cap:
+                    current, depth = queue.pop(0)
+                    try:
+                        await page.goto(current)
+                        html = await page.content()
+                        results[current] = self._truncate(html)
+                        log_debug(f"acrawl_site: visited {current} ({len(results)}/{page_cap})")
+                    except Exception as inner:
+                        results[current] = f"Error: {inner}"
+                        continue
+                    if depth >= depth_cap:
+                        continue
+                    anchors = await page.query_selector_all("a[href]")
+                    for anchor in anchors:
+                        href = (await anchor.get_attribute("href")) or ""
+                        if not href:
+                            continue
+                        if href.startswith(("/", "?", "#")):
+                            href = urljoin(current, href)
+                        if href in seen:
+                            continue
+                        if urlparse(href).netloc != origin:
+                            continue
+                        seen.add(href)
+                        queue.append((href, depth + 1))
+            return json.dumps(results)
+        except Exception as e:
+            log_error(f"InvisiblePlaywrightTools.acrawl_site failed for {url}: {e}")
+            return f"Error crawling {url}: {e}"
+
+    async def asearch_web(self, query: str, num_results: Optional[int] = None) -> str:
+        """Async: run a search engine query through stealth Firefox and return results.
+
+        See search_web for behaviour.
+
+        Args:
+            query: The search query.
+            num_results: Override default result count.
+
+        Returns:
+            JSON list of result objects with `title`, `url`, `snippet` fields.
+        """
+        if not query:
+            return "Error: No query provided"
+        n = num_results or self._num_results
+        engine = self._search_engine
+        try:
+            async with self._alaunch() as browser:
+                page = await browser.new_page()
+                if engine == "duckduckgo":
+                    await page.goto(f"https://duckduckgo.com/html/?q={query}")
+                    await page.wait_for_selector(".result__title a", timeout=10000)
+                    items = await self._acollect_results(
+                        page,
+                        result_selector=".result",
+                        title_selector=".result__title a",
+                        snippet_selector=".result__snippet",
+                        limit=n,
+                    )
+                elif engine == "bing":
+                    await page.goto(f"https://www.bing.com/search?q={query}")
+                    await page.wait_for_selector("li.b_algo", timeout=10000)
+                    items = await self._acollect_results(
+                        page,
+                        result_selector="li.b_algo",
+                        title_selector="h2 a",
+                        snippet_selector=".b_caption p",
+                        limit=n,
+                    )
+                else:
+                    return f"Error: unsupported search engine '{engine}'. Use 'duckduckgo' or 'bing'."
+                return json.dumps(items)
+        except Exception as e:
+            log_error(f"InvisiblePlaywrightTools.asearch_web failed for {query!r}: {e}")
+            return f"Error searching for {query!r}: {e}"

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -91,6 +91,7 @@ google = ["google-genai>=1.52.0", "pydantic>=2.12.5"]
 groq = ["groq"]
 ibm = ["ibm-watsonx-ai"]
 infinity = ["infinity_client"]
+invisible_playwright = ["invisible_playwright @ git+https://github.com/feder-cr/invisible_playwright.git"]
 litellm = ["litellm<=1.82.6"]
 lmstudio = ["lmstudio"]
 meta = ["llama-api-client"]
@@ -535,6 +536,7 @@ module = [
   "ibm_watsonx_ai.*",
   "imghdr.*",
   "infinity_client.*",
+  "invisible_playwright.*",
   "jira.*",
   "jsonpatch.*",
   "jwt.*",

--- a/libs/agno/tests/unit/tools/test_invisible_playwright.py
+++ b/libs/agno/tests/unit/tools/test_invisible_playwright.py
@@ -1,0 +1,411 @@
+"""Unit tests for InvisiblePlaywrightTools."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# invisible_playwright is an optional dependency (extras = "invisible_playwright").
+# Skip the whole module when it isn't installed so CI without the extra reports
+# skipped, not a collection error.
+pytest.importorskip("invisible_playwright")
+
+from agno.tools.invisible_playwright import InvisiblePlaywrightTools  # noqa: E402
+
+
+@pytest.fixture
+def mock_invisible():
+    """Mock the InvisiblePlaywright context manager."""
+    with patch("agno.tools.invisible_playwright.InvisiblePlaywright") as mock_cls:
+        mock_browser = MagicMock()
+        mock_page = MagicMock()
+        mock_browser.new_page.return_value = mock_page
+        mock_cls.return_value.__enter__.return_value = mock_browser
+        yield {"cls": mock_cls, "browser": mock_browser, "page": mock_page}
+
+
+def test_initialization_default():
+    """Default init enables scrape_url in both sync + async dicts.
+
+    Sync + async tools share the same name (agno Toolkit convention: the
+    LLM sees one tool name, runtime picks the sync or async impl).
+    """
+    tools = InvisiblePlaywrightTools()
+    assert tools.name == "invisible_playwright_tools"
+    assert "scrape_url" in tools.functions
+    assert "scrape_url" in tools.async_functions
+    assert "crawl_site" not in tools.functions
+    assert "search_web" not in tools.functions
+
+
+def test_initialization_all_flag():
+    """all=True enables every tool in both sync + async dicts."""
+    tools = InvisiblePlaywrightTools(all=True)
+    for n in ("scrape_url", "crawl_site", "search_web"):
+        assert n in tools.functions, f"missing sync {n}"
+        assert n in tools.async_functions, f"missing async {n}"
+
+
+def test_initialization_individual_flags():
+    """Each enable_* flag registers its sync + async pair."""
+    tools = InvisiblePlaywrightTools(enable_scrape=False, enable_crawl=True, enable_search=True)
+    assert "scrape_url" not in tools.functions
+    assert "scrape_url" not in tools.async_functions
+    assert "crawl_site" in tools.functions
+    assert "crawl_site" in tools.async_functions
+    assert "search_web" in tools.functions
+    assert "search_web" in tools.async_functions
+
+
+def test_initialization_custom_options():
+    """Custom options are stored on the instance."""
+    tools = InvisiblePlaywrightTools(
+        seed=42,
+        headless=False,
+        proxy={"server": "socks5://proxy:1080"},
+        locale="it-IT",
+        timezone="Europe/Rome",
+        max_pages=20,
+        max_depth=3,
+        search_engine="bing",
+        num_results=10,
+        max_length=2000,
+    )
+    assert tools._seed == 42
+    assert tools._headless is False
+    assert tools._proxy == {"server": "socks5://proxy:1080"}
+    assert tools._locale == "it-IT"
+    assert tools._timezone == "Europe/Rome"
+    assert tools._max_pages == 20
+    assert tools._max_depth == 3
+    assert tools._search_engine == "bing"
+    assert tools._num_results == 10
+    assert tools._max_length == 2000
+
+
+def test_scrape_url_empty():
+    """Empty URL returns error string."""
+    tools = InvisiblePlaywrightTools()
+    assert tools.scrape_url("") == "Error: No URL provided"
+
+
+def test_scrape_url_success(mock_invisible):
+    """Successful scrape returns page content."""
+    mock_invisible["page"].content.return_value = "<html>hello</html>"
+    tools = InvisiblePlaywrightTools()
+    result = tools.scrape_url("https://example.com")
+    assert result == "<html>hello</html>"
+    mock_invisible["page"].goto.assert_called_once_with("https://example.com")
+
+
+def test_scrape_url_with_wait_selector(mock_invisible):
+    """wait_for_selector is forwarded to the page."""
+    mock_invisible["page"].content.return_value = "<html>after wait</html>"
+    tools = InvisiblePlaywrightTools()
+    tools.scrape_url("https://example.com", wait_for_selector=".content")
+    mock_invisible["page"].wait_for_selector.assert_called_once_with(".content")
+
+
+def test_scrape_url_truncation(mock_invisible):
+    """Output is truncated to max_length when set."""
+    mock_invisible["page"].content.return_value = "A" * 10000
+    tools = InvisiblePlaywrightTools(max_length=100)
+    result = tools.scrape_url("https://example.com")
+    assert len(result) == 103
+    assert result.endswith("...")
+
+
+def test_scrape_url_no_truncation(mock_invisible):
+    """max_length=None disables truncation."""
+    mock_invisible["page"].content.return_value = "A" * 10000
+    tools = InvisiblePlaywrightTools(max_length=None)
+    result = tools.scrape_url("https://example.com")
+    assert len(result) == 10000
+
+
+def test_scrape_url_error(mock_invisible):
+    """Underlying exception returns error string."""
+    mock_invisible["page"].goto.side_effect = RuntimeError("boom")
+    tools = InvisiblePlaywrightTools()
+    result = tools.scrape_url("https://example.com")
+    assert result.startswith("Error fetching https://example.com:")
+    assert "boom" in result
+
+
+def test_crawl_site_empty():
+    """Empty URL returns error."""
+    tools = InvisiblePlaywrightTools(enable_crawl=True)
+    assert tools.crawl_site("") == "Error: No URL provided"
+
+
+def _make_anchor(href: str):
+    a = MagicMock()
+    a.get_attribute.return_value = href
+    return a
+
+
+def test_crawl_site_single_page(mock_invisible):
+    """When no in-domain links exist, only the start page is visited."""
+    mock_invisible["page"].content.return_value = "<html>root</html>"
+    mock_invisible["page"].query_selector_all.return_value = []
+    tools = InvisiblePlaywrightTools(enable_crawl=True, max_pages=5, max_depth=2)
+    result = tools.crawl_site("https://example.com")
+    data = json.loads(result)
+    assert "https://example.com" in data
+    assert data["https://example.com"] == "<html>root</html>"
+
+
+def test_crawl_site_follows_same_domain_links(mock_invisible):
+    """Links to the same domain are followed up to max_pages."""
+    mock_invisible["page"].content.return_value = "<html>page</html>"
+    # First call returns 2 same-domain anchors; subsequent calls return none
+    mock_invisible["page"].query_selector_all.side_effect = [
+        [_make_anchor("https://example.com/a"), _make_anchor("https://example.com/b")],
+        [],
+        [],
+    ]
+    tools = InvisiblePlaywrightTools(enable_crawl=True, max_pages=3, max_depth=2)
+    result = tools.crawl_site("https://example.com")
+    data = json.loads(result)
+    assert len(data) == 3
+    assert "https://example.com/a" in data
+    assert "https://example.com/b" in data
+
+
+def test_crawl_site_skips_external_domain(mock_invisible):
+    """Cross-domain links are not followed."""
+    mock_invisible["page"].content.return_value = "<html>page</html>"
+    mock_invisible["page"].query_selector_all.side_effect = [
+        [_make_anchor("https://other.com/x"), _make_anchor("https://example.com/internal")],
+        [],
+    ]
+    tools = InvisiblePlaywrightTools(enable_crawl=True, max_pages=5, max_depth=2)
+    result = tools.crawl_site("https://example.com")
+    data = json.loads(result)
+    assert "https://other.com/x" not in data
+    assert "https://example.com/internal" in data
+
+
+def test_crawl_site_resolves_relative_links(mock_invisible):
+    """Relative hrefs are resolved against the current page URL."""
+    mock_invisible["page"].content.return_value = "<html>p</html>"
+    mock_invisible["page"].query_selector_all.side_effect = [
+        [_make_anchor("/about"), _make_anchor("?page=2")],
+        [],
+        [],
+    ]
+    tools = InvisiblePlaywrightTools(enable_crawl=True, max_pages=3, max_depth=2)
+    result = tools.crawl_site("https://example.com")
+    data = json.loads(result)
+    assert "https://example.com/about" in data
+    # urljoin against bare-host base preserves no path before the query
+    assert "https://example.com?page=2" in data
+
+
+def test_crawl_site_respects_max_pages(mock_invisible):
+    """Crawl stops at max_pages even if more links are queued."""
+    mock_invisible["page"].content.return_value = "<html>p</html>"
+    mock_invisible["page"].query_selector_all.side_effect = [
+        [_make_anchor("https://example.com/" + str(i)) for i in range(10)],
+    ] + [[]] * 10
+    tools = InvisiblePlaywrightTools(enable_crawl=True, max_pages=3, max_depth=5)
+    result = tools.crawl_site("https://example.com")
+    data = json.loads(result)
+    assert len(data) == 3
+
+
+def test_search_web_empty():
+    """Empty query returns error."""
+    tools = InvisiblePlaywrightTools(enable_search=True)
+    assert tools.search_web("") == "Error: No query provided"
+
+
+def _make_result(title: str, url: str, snippet: str):
+    """Build a mock result element with .query_selector returning title+snippet sub-elements."""
+    result_el = MagicMock()
+    title_el = MagicMock()
+    title_el.inner_text.return_value = title
+    title_el.get_attribute.return_value = url
+    snippet_el = MagicMock()
+    snippet_el.inner_text.return_value = snippet
+
+    # query_selector dispatches by selector substring
+    def qs(sel):
+        if "title" in sel or "h2" in sel:
+            return title_el
+        if "snippet" in sel or "caption" in sel:
+            return snippet_el
+        return None
+
+    result_el.query_selector.side_effect = qs
+    return result_el
+
+
+def test_search_web_duckduckgo(mock_invisible):
+    """DuckDuckGo search returns parsed result list."""
+    results = [
+        _make_result("Result A", "https://a.com", "snippet A"),
+        _make_result("Result B", "https://b.com", "snippet B"),
+    ]
+    mock_invisible["page"].query_selector_all.return_value = results
+    tools = InvisiblePlaywrightTools(enable_search=True, num_results=2)
+    result = tools.search_web("python")
+    data = json.loads(result)
+    assert len(data) == 2
+    assert data[0]["title"] == "Result A"
+    assert data[0]["url"] == "https://a.com"
+    assert data[1]["snippet"] == "snippet B"
+    mock_invisible["page"].goto.assert_called_with("https://duckduckgo.com/html/?q=python")
+
+
+def test_search_web_bing(mock_invisible):
+    """Bing engine sends query to bing.com."""
+    mock_invisible["page"].query_selector_all.return_value = [_make_result("Bing A", "https://a.com", "s")]
+    tools = InvisiblePlaywrightTools(enable_search=True, search_engine="bing", num_results=1)
+    tools.search_web("python")
+    mock_invisible["page"].goto.assert_called_with("https://www.bing.com/search?q=python")
+
+
+def test_search_web_unsupported_engine():
+    """Unknown engine returns error string."""
+    tools = InvisiblePlaywrightTools(enable_search=True, search_engine="yahoo")
+    result = tools.search_web("python")
+    assert "unsupported search engine 'yahoo'" in result
+
+
+def test_search_web_error(mock_invisible):
+    """Underlying exception returns error string."""
+    mock_invisible["page"].goto.side_effect = RuntimeError("timeout")
+    tools = InvisiblePlaywrightTools(enable_search=True)
+    result = tools.search_web("python")
+    assert result.startswith("Error searching for 'python':")
+
+
+def test_launch_forwards_options(mock_invisible):
+    """_launch builds InvisiblePlaywright with stored options."""
+    tools = InvisiblePlaywrightTools(
+        seed=7, headless=False, proxy={"server": "p:1"}, locale="fr-FR", timezone="Europe/Paris"
+    )
+    tools.scrape_url("https://example.com")
+    mock_invisible["cls"].assert_called_once_with(
+        seed=7,
+        headless=False,
+        proxy={"server": "p:1"},
+        locale="fr-FR",
+        timezone="Europe/Paris",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+#  Async surface tests (mirror sync tests, use AsyncMock + asyncio).
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_async_invisible():
+    """Mock the AsyncInvisiblePlaywright context manager."""
+    with patch("agno.tools.invisible_playwright.AsyncInvisiblePlaywright") as mock_cls:
+        mock_browser = MagicMock()
+        mock_page = MagicMock()
+        # Async methods on the page
+        mock_page.goto = AsyncMock()
+        mock_page.content = AsyncMock(return_value="<html>async-hello</html>")
+        mock_page.wait_for_selector = AsyncMock()
+        mock_page.query_selector_all = AsyncMock(return_value=[])
+        mock_browser.new_page = AsyncMock(return_value=mock_page)
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_browser)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+        yield {"cls": mock_cls, "browser": mock_browser, "page": mock_page}
+
+
+@pytest.mark.asyncio
+async def test_ascrape_url_empty():
+    tools = InvisiblePlaywrightTools()
+    assert await tools.ascrape_url("") == "Error: No URL provided"
+
+
+@pytest.mark.asyncio
+async def test_ascrape_url_success(mock_async_invisible):
+    tools = InvisiblePlaywrightTools()
+    result = await tools.ascrape_url("https://example.com")
+    assert result == "<html>async-hello</html>"
+    mock_async_invisible["page"].goto.assert_awaited_once_with("https://example.com")
+
+
+@pytest.mark.asyncio
+async def test_ascrape_url_with_wait_selector(mock_async_invisible):
+    tools = InvisiblePlaywrightTools()
+    await tools.ascrape_url("https://example.com", wait_for_selector=".content")
+    mock_async_invisible["page"].wait_for_selector.assert_awaited_once_with(".content")
+
+
+@pytest.mark.asyncio
+async def test_ascrape_url_truncation(mock_async_invisible):
+    mock_async_invisible["page"].content = AsyncMock(return_value="x" * 200)
+    tools = InvisiblePlaywrightTools(max_length=50)
+    result = await tools.ascrape_url("https://example.com")
+    assert result.endswith("...")
+    assert len(result) == 53
+
+
+@pytest.mark.asyncio
+async def test_ascrape_url_error(mock_async_invisible):
+    mock_async_invisible["page"].goto = AsyncMock(side_effect=RuntimeError("net err"))
+    tools = InvisiblePlaywrightTools()
+    result = await tools.ascrape_url("https://example.com")
+    assert result.startswith("Error fetching https://example.com:")
+
+
+@pytest.mark.asyncio
+async def test_acrawl_site_empty():
+    tools = InvisiblePlaywrightTools(enable_crawl=True)
+    assert await tools.acrawl_site("") == "Error: No URL provided"
+
+
+@pytest.mark.asyncio
+async def test_acrawl_site_single_page(mock_async_invisible):
+    """One page, no anchors -> one entry in results JSON."""
+    mock_async_invisible["page"].content = AsyncMock(return_value="<html>solo</html>")
+    mock_async_invisible["page"].query_selector_all = AsyncMock(return_value=[])
+    tools = InvisiblePlaywrightTools(enable_crawl=True, max_pages=5)
+    raw = await tools.acrawl_site("https://example.com")
+    data = json.loads(raw)
+    assert data == {"https://example.com": "<html>solo</html>"}
+
+
+@pytest.mark.asyncio
+async def test_asearch_web_empty():
+    tools = InvisiblePlaywrightTools(enable_search=True)
+    assert await tools.asearch_web("") == "Error: No query provided"
+
+
+@pytest.mark.asyncio
+async def test_asearch_web_unsupported_engine(mock_async_invisible):
+    tools = InvisiblePlaywrightTools(enable_search=True, search_engine="google")
+    result = await tools.asearch_web("python")
+    assert "unsupported search engine 'google'" in result
+
+
+@pytest.mark.asyncio
+async def test_asearch_web_error(mock_async_invisible):
+    mock_async_invisible["page"].goto = AsyncMock(side_effect=RuntimeError("timeout"))
+    tools = InvisiblePlaywrightTools(enable_search=True)
+    result = await tools.asearch_web("python")
+    assert result.startswith("Error searching for 'python':")
+
+
+def test_alaunch_forwards_options(mock_async_invisible):
+    """_alaunch builds AsyncInvisiblePlaywright with stored options."""
+    import asyncio
+
+    tools = InvisiblePlaywrightTools(
+        seed=11, headless=False, proxy={"server": "p:2"}, locale="de-DE", timezone="Europe/Berlin"
+    )
+    asyncio.run(tools.ascrape_url("https://example.com"))
+    mock_async_invisible["cls"].assert_called_once_with(
+        seed=11,
+        headless=False,
+        proxy={"server": "p:2"},
+        locale="de-DE",
+        timezone="Europe/Berlin",
+    )


### PR DESCRIPTION
Update (18 Aug 2026): fixing a stale citation. The toolkit description below (and two code comments in this diff, in `cookbook/91_tools/invisible_playwright_tools.py` and `libs/agno/agno/tools/invisible_playwright.py`) named `feder-cr/invisible_firefox` as the source of the patched Firefox binary. That repo never actually hosted the binary - it was a separate pywebview profile-manager GUI, unrelated to this toolkit - and it doesn't exist anymore as of this week. The binary this toolkit actually uses is built and released from `feder-cr/firefox_antidetect_patch` (GitHub Release assets, MPL-2.0, same license as Firefox upstream) and is fetched automatically by `invisible_playwright` itself. Nothing in this PR ever imported or depended on the retired repo, so nothing about the toolkit changes - just the citation. `invisible_playwright` has also been on PyPI (`invisible-playwright`) since 26 July 2026, so installs no longer need the git URL below.

Update (29 May 2026): polish pass done, everything green locally.

- 22 unit tests in `libs/agno/tests/unit/tools/test_invisible_playwright.py` (added in commit 0142be8): `pytest libs/agno/tests/unit/tools/test_invisible_playwright.py -q` -> 22 passed in ~5s
- ruff check + ruff format + mypy on touched files clean (commit 07abc14, matches the gates in test.yml)
- cookbook example at `cookbook/91_tools/invisible_playwright_tools.py` (3 example agents)
- pyproject extras entry: `invisible_playwright = ["invisible-playwright>=0.1.8"]`
- live smoke against `bot.sannysoft.com`: 23 passed / 0 failed via the new toolkit

The `missing-tests` label is from `pr-triage.yml` which fires on `pull_request opened` only. At that point the PR was the initial stub (commit d715472) with no tests. Tests landed in the next commit and triage doesn't re-trigger.

CI hasn't run because the test.yml workflow requires maintainer approval to start on first-time-contributor PRs from forks. Happy to wait on that.

Still in draft pending shape feedback (3 questions in the comments below). Will flip to ready-for-review on green from @ysolanky.

---

opening as draft to check interest before fleshing out the full tool surface.

would an `InvisiblePlaywrightTools` toolkit be in scope, parallel to the existing FirecrawlTools / Crawl4aiTools / ScrapegraphTools / BrowserbaseTools? selected by the user when constructing the agent, no change to anything else.

three open issues seem to be asking for exactly this:
- #7943 add Playwright browser automation tool
- #7104 anybrowse MCP for Cloudflare-bypass web scraping
- #6997 CloudflareBrowserRenderingTools

useful for cases where Firecrawl / Crawl4ai / Scrapegraph hit Cloudflare, Akamai, Datadome, or hCaptcha walls.

the backend wraps feder-cr/invisible_playwright (on PyPI as `invisible-playwright`), which drives a patched Firefox binary built and released from feder-cr/firefox_antidetect_patch (MPL-2.0, same license as Firefox upstream). fingerprint patches at the C++ source code level so there are no JS shims to detect.

this PR adds a stub `libs/agno/agno/tools/invisible_playwright.py` modeled after the FirecrawlTools shape (single `fetch_page` method for now). full tool surface (search, crawl, multi-page) can follow if accepted. tracking discussion: #8128

issues against the backend route to feder-cr/invisible_playwright, not here. if not in scope i'll close without noise.