### PR TITLE
fix: skip strict tool mode when a parser_model is set on Team

### DIFF
--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -331,7 +331,12 @@ def _determine_tools_for_model(
 
     # Check if we need strict mode for the model
     strict = False
-    if output_schema is not None and not team.use_json_mode and model.supports_native_structured_outputs:
+    if (
+        output_schema is not None
+        and team.parser_model is None
+        and not team.use_json_mode
+        and model.supports_native_structured_outputs
+    ):
         strict = True
 
     for tool in _tools:

--- a/libs/agno/tests/unit/team/test_parser_model_tool_strictness.py
+++ b/libs/agno/tests/unit/team/test_parser_model_tool_strictness.py
@@ -1,0 +1,79 @@
+"""Regression tests for strict tool mode vs. parser_model in team _determine_tools_for_model.
+
+When a parser_model is set, the base model does not produce the structured output
+(the tool-less parser_model does), so the base model's tools must not be marked strict.
+Forcing strict tools makes providers compile a grammar over every tool schema, which can
+exceed provider limits (e.g. Anthropic: "the compiled grammar is too large").
+
+Mirrors libs/agno/tests/unit/agent/test_parser_model_tool_strictness.py for Team.
+"""
+
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from agno.run.base import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session import TeamSession
+from agno.team._tools import _determine_tools_for_model
+from agno.team.team import Team
+
+
+class _Output(BaseModel):
+    summary: str
+
+
+def _native_structured_model():
+    model = MagicMock()
+    model.supports_native_structured_outputs = True
+    return model
+
+
+def _sample_tool(query: str) -> str:
+    """A sample tool."""
+    return "ok"
+
+
+def _run_context() -> RunContext:
+    return RunContext(run_id="test-run", session_id="test-session", output_schema=_Output)
+
+
+def _session() -> TeamSession:
+    return TeamSession(session_id="test-session")
+
+
+def _run_response() -> TeamRunOutput:
+    return TeamRunOutput(run_id="test-run", session_id="test-session", team_id="test-team")
+
+
+def _resolve_tools(team: Team):
+    return _determine_tools_for_model(
+        team=team,
+        model=_native_structured_model(),
+        run_response=_run_response(),
+        run_context=_run_context(),
+        team_run_context={},
+        session=_session(),
+        async_mode=False,
+    )
+
+
+def test_team_tools_strict_with_output_schema_and_no_parser_model():
+    """Base model owns the structured output, so its tools are marked strict."""
+    team = Team(name="t", members=[], tools=[_sample_tool])
+
+    functions = _resolve_tools(team)
+
+    assert len(functions) == 1
+    assert functions[0].strict is True
+
+
+def test_team_tools_not_strict_when_parser_model_is_set():
+    """parser_model owns the structured output, so base model tools must not be strict."""
+    team = Team(name="t", members=[], tools=[_sample_tool])
+    team.parser_model = _native_structured_model()
+
+    functions = _resolve_tools(team)
+
+    assert len(functions) == 1
+    assert not functions[0].strict


### PR DESCRIPTION
## Summary

Follow-up to #8123, which fixed the same bug on `Agent`. `Team` has the identical issue: when a team has both an `output_schema` and a `parser_model`, the base model's tools were still being forced into strict (structured-outputs) mode. On providers that compile a grammar from strict tool schemas (Anthropic) this breaks any team with more than a handful of tools:

```
400 invalid_request_error: "The compiled grammar is too large, which would cause
performance issues. Simplify your tool schemas or reduce the number of strict tools."
```

Since it's a non-retryable 400 on the base model, the run fails and the `parser_model` never runs, so no structured output is produced.

**Root cause:** the strict-mode gate in `team/_tools.py::_determine_tools_for_model` didn't account for `parser_model`. Every other gate on the team side that decides "is the base model responsible for structured output?" already checks `team.parser_model is None`:

- `team/_run.py` (8 call sites): `response_format = get_response_format(team, ...) if team.parser_model is None else None`
- `team/_messages.py`: JSON-output prompt added only when `team.parser_model is None`
- `team/_response.py`: structured-output parsing skipped when `team.parser_model is not None`

The strict tool gate in `team/_tools.py` was the lone outlier, so the base model's tools stayed strict, which enabled the `structured-outputs-2025-11-13` beta on Anthropic and forced a combined grammar over every tool schema.

**Fix:** add the same `parser_model is None` guard the other gates use. Mirrors the one-liner from #8123 for the agent side.

```python
strict = False
if (
    output_schema is not None
    and team.parser_model is None        # base model isn't producing structured output here
    and not team.use_json_mode
    and model.supports_native_structured_outputs
):
    strict = True
```

Also adds a regression test that mirrors the agent-side test added in #8123.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Why this is correct (not just a workaround):** identical reasoning to #8123 — this makes `team/_tools.py` consistent with the established pattern of guarding base-model structured-output behavior on `team.parser_model is None`. Structured-output guarantees are unaffected: they come from the tool-less `parser_model` call.

**Reproduction:** a team with a Claude model (native structured outputs), an `output_schema`, a `parser_model`, and many tools fails on the base model with "The compiled grammar is too large" before the `parser_model` runs. With this fix the base model runs its tools non-strict and the `parser_model` produces the structured output.

**Verification:** the new test fails on `main` (with `assert not functions[0].strict` raising) and passes with the fix applied.