### PR TITLE
fix: include assembled run history in reasoning input

### DIFF
--- a/libs/agno/agno/run/messages.py
+++ b/libs/agno/agno/run/messages.py
@@ -22,6 +22,9 @@ class RunMessages:
 
     def get_input_messages(self) -> List[Message]:
         """Get the input messages for the model."""
+        if self.messages:
+            return list(self.messages)
+
         input_messages = []
         if self.system_message is not None:
             input_messages.append(self.system_message)

--- a/libs/agno/tests/unit/run/test_run_messages.py
+++ b/libs/agno/tests/unit/run/test_run_messages.py
@@ -1,0 +1,39 @@
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+
+def test_get_input_messages_uses_assembled_messages() -> None:
+    assembled_messages = [
+        Message(role="system", content="You are helpful"),
+        Message(role="user", content="My name is Alex"),
+        Message(role="assistant", content="Nice to meet you, Alex"),
+        Message(role="user", content="What is my name?"),
+    ]
+    run_messages = RunMessages(
+        messages=assembled_messages,
+        system_message=Message(role="system", content="fallback system"),
+        user_message=Message(role="user", content="fallback user"),
+        extra_messages=[Message(role="assistant", content="fallback assistant")],
+    )
+
+    input_messages = run_messages.get_input_messages()
+
+    assert input_messages == assembled_messages
+    assert input_messages is not assembled_messages
+
+
+def test_get_input_messages_falls_back_to_parts_when_unassembled() -> None:
+    system_message = Message(role="system", content="You are helpful")
+    user_message = Message(role="user", content="Hello")
+    extra_messages = [Message(role="assistant", content="Hi")]
+    run_messages = RunMessages(
+        system_message=system_message,
+        user_message=user_message,
+        extra_messages=extra_messages,
+    )
+
+    assert run_messages.get_input_messages() == [
+        system_message,
+        user_message,
+        *extra_messages,
+    ]


### PR DESCRIPTION
## Summary
- Make `RunMessages.get_input_messages()` use the assembled `messages` list when it is already populated.
- Keep the previous `system_message` / `user_message` / `extra_messages` fallback for unassembled `RunMessages` objects.
- Add unit coverage for both paths.

## Why
`reasoning.manager` seeds reasoning sub-agents with `run_messages.get_input_messages()`. When `add_history_to_context=True`, the full conversation history is assembled into `run_messages.messages`, but the previous helper rebuilt input from only the current system/user/extra fields and dropped that history.

Fixes #7991.

## To verify
- `python -m pytest libs/agno/tests/unit/run/test_run_messages.py -q`
- `python -m ruff check libs/agno/agno/run/messages.py libs/agno/tests/unit/run/test_run_messages.py`
- `python -m py_compile libs/agno/agno/run/messages.py libs/agno/tests/unit/run/test_run_messages.py`
- `git diff --check`
