### PR TITLE
fix: coerce RunOutput.status to RunStatus in from_dict

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -900,6 +900,10 @@ class RunOutput:
         if references is not None:
             references = [MessageReferences.model_validate(reference) for reference in references]
 
+        # Restore the persisted status string to the RunStatus enum (see RunStatus.coerce).
+        if "status" in data:
+            data["status"] = RunStatus.coerce(data["status"])
+
         # Filter data to only include fields that are actually defined in the RunOutput dataclass
         from dataclasses import fields
 

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -319,3 +319,24 @@ class RunStatus(str, Enum):
     paused = "PAUSED"
     cancelled = "CANCELLED"
     error = "ERROR"
+
+    @classmethod
+    def coerce(cls, value: Any) -> Any:
+        """Restore a persisted status value to a ``RunStatus`` member.
+
+        ``RunOutput.to_dict()`` serializes ``status`` as the enum's string value;
+        ``from_dict()`` must call this so the reconstructed dataclass matches its
+        declared ``status: RunStatus`` annotation and downstream consumers can rely
+        on ``status.value`` / ``status == RunStatus.completed``.
+
+        Unknown strings (legacy data or forward-compat values that don't map to a
+        current member) are returned unchanged rather than coerced to an arbitrary
+        default, preserving no-data-loss. Non-string and already-coerced values are
+        returned as-is.
+        """
+        if isinstance(value, str) and not isinstance(value, RunStatus):
+            try:
+                return cls(value)
+            except ValueError:
+                return value
+        return value

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -979,6 +979,10 @@ class TeamRunOutput:
         citations = data.pop("citations", None)
         citations = Citations.model_validate(citations) if citations else None
 
+        # Restore the persisted status string to the RunStatus enum (see RunStatus.coerce).
+        if "status" in data:
+            data["status"] = RunStatus.coerce(data["status"])
+
         # Filter data to only include fields that are actually defined in the TeamRunOutput dataclass
         from dataclasses import fields
 

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -1027,6 +1027,10 @@ class WorkflowRunOutput:
 
         input_data = data.pop("input", None)
 
+        # Restore the persisted status string to the RunStatus enum (see RunStatus.coerce).
+        if "status" in data:
+            data["status"] = RunStatus.coerce(data["status"])
+
         # Filter data to only include fields that are actually defined in the WorkflowRunOutput dataclass
         from dataclasses import fields
 

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -435,3 +435,95 @@ def test_requirements_in_run_paused_event():
     assert reconstructed.requirements[0].tool_execution.tool_name == "get_the_weather"
     assert reconstructed.requirements[0].tool_execution.requires_confirmation is True
     assert reconstructed.requirements[0].needs_confirmation is True
+
+
+def test_run_output_from_dict_coerces_string_status_to_enum():
+    """RunOutput.to_dict() emits status as a string but from_dict() previously
+    left it as a string, breaking downstream callers that relied on the typed
+    shape (e.g. ``status.value``). from_dict() must restore the enum."""
+    from agno.run.agent import RunOutput
+    from agno.run.base import RunStatus
+
+    run_output = RunOutput(run_id="run_123", agent_id="agent_456", status=RunStatus.completed)
+    run_dict = run_output.to_dict()
+    assert run_dict["status"] == "COMPLETED"  # serialized as string
+
+    reconstructed = RunOutput.from_dict(run_dict)
+    assert reconstructed.status == RunStatus.completed
+    assert isinstance(reconstructed.status, RunStatus)
+    # The original bug: this attribute access would raise AttributeError when
+    # ``status`` came back as a plain string from the database.
+    assert reconstructed.status.value == "COMPLETED"
+
+
+def test_run_output_from_dict_status_round_trips_for_every_enum_member():
+    """Every RunStatus value should survive the to_dict / from_dict round trip."""
+    from agno.run.agent import RunOutput
+    from agno.run.base import RunStatus
+
+    for status in RunStatus:
+        run_output = RunOutput(run_id=f"run_{status.value}", status=status)
+        reconstructed = RunOutput.from_dict(run_output.to_dict())
+        assert reconstructed.status == status
+        assert isinstance(reconstructed.status, RunStatus)
+
+
+def test_run_output_from_dict_preserves_unknown_status_string():
+    """Unknown status strings (legacy data, forward-compat) must not crash
+    from_dict — the value is preserved as-is so callers can decide how to
+    cope."""
+    from agno.run.agent import RunOutput
+
+    reconstructed = RunOutput.from_dict({"run_id": "run_123", "status": "MYSTERY"})
+    # Field stays a string rather than being coerced into an arbitrary enum
+    # member or being silently dropped.
+    assert reconstructed.status == "MYSTERY"
+
+
+def test_team_run_output_from_dict_coerces_string_status_to_enum():
+    from agno.run.base import RunStatus
+    from agno.run.team import TeamRunOutput
+
+    team_output = TeamRunOutput(run_id="team_123", team_id="team_456", status=RunStatus.cancelled)
+    team_dict = team_output.to_dict()
+    assert team_dict["status"] == "CANCELLED"
+
+    reconstructed = TeamRunOutput.from_dict(team_dict)
+    assert reconstructed.status == RunStatus.cancelled
+    assert isinstance(reconstructed.status, RunStatus)
+    assert reconstructed.status.value == "CANCELLED"
+
+
+def test_workflow_run_output_from_dict_coerces_string_status_to_enum():
+    from agno.run.base import RunStatus
+    from agno.run.workflow import WorkflowRunOutput
+
+    workflow_output = WorkflowRunOutput(run_id="wf_123", workflow_name="test", status=RunStatus.error)
+    workflow_dict = workflow_output.to_dict()
+    assert workflow_dict["status"] == "ERROR"
+
+    reconstructed = WorkflowRunOutput.from_dict(workflow_dict)
+    assert reconstructed.status == RunStatus.error
+    assert isinstance(reconstructed.status, RunStatus)
+    assert reconstructed.status.value == "ERROR"
+
+
+def test_run_status_coerce_helper():
+    """RunStatus.coerce centralizes the from_dict status handling shared by the
+    three RunOutput classes; verify each branch in isolation."""
+    from agno.run.base import RunStatus
+
+    # Known string -> enum member
+    coerced = RunStatus.coerce("COMPLETED")
+    assert coerced is RunStatus.completed
+    assert isinstance(coerced, RunStatus)
+
+    # Already a RunStatus -> returned unchanged
+    assert RunStatus.coerce(RunStatus.error) is RunStatus.error
+
+    # Unknown string -> preserved as-is (no-data-loss, no arbitrary default)
+    assert RunStatus.coerce("MYSTERY") == "MYSTERY"
+    assert not isinstance(RunStatus.coerce("MYSTERY"), RunStatus)
+
+    # Non-string (e.g. missing/None) -> returned unchanged
+    assert RunStatus.coerce(None) is None


### PR DESCRIPTION
Fixes #8454

## Summary

`RunOutput.to_dict()` serializes `status` as the enum's string value, but `RunOutput.from_dict()` never restores it to a `RunStatus`. After a database-backed reload, `run_output.status` is a plain `str`, which silently breaks any caller that depends on the field's declared type.

Most visibly, the resume-stream replay path in `agno/os/routers/agents/router.py` calls `run_output.status.value` while emitting the SSE `replay` meta:

```python
"status": run_output.status.value if run_output.status else "unknown",
```

This raises `AttributeError: 'str' object has no attribute 'value'` and aborts the replay, leaving the frontend showing a completed run with no final assistant content.

This PR restores the `to_dict` / `from_dict` symmetry for the three `RunOutput` classes:

- `agno.run.agent.RunOutput`
- `agno.run.team.TeamRunOutput`
- `agno.run.workflow.WorkflowRunOutput`

so the reconstructed dataclass always matches its declared `status: RunStatus` annotation.

The coercion lives in a single `RunStatus.coerce()` classmethod next to the enum in `agno/run/base.py`; each `from_dict()` calls it on one line. This keeps the three parallel `from_dict` methods in sync and gives the forward-compat semantics a single documented, independently-tested home.

**Unknown status strings** (legacy data or forward-compat values that don't map to a current `RunStatus` member) are left as-is rather than coerced to an arbitrary default — preserves no-data-loss while still fixing every reachable-via-known-enum-value caller.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (the `RunStatus.coerce` docstring explains the symmetry contract)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — N/A (internal serialization correctness; no public API change)
- [x] Tested in clean environment (`pytest libs/agno/tests/unit/run/test_run_events.py` — 19 passed)
- [x] Tests added/updated — 6 new regression tests in `libs/agno/tests/unit/run/test_run_events.py`:
  - `test_run_output_from_dict_coerces_string_status_to_enum`
  - `test_run_output_from_dict_status_round_trips_for_every_enum_member`
  - `test_run_output_from_dict_preserves_unknown_status_string`
  - `test_team_run_output_from_dict_coerces_string_status_to_enum`
  - `test_workflow_run_output_from_dict_coerces_string_status_to_enum`
  - `test_run_status_coerce_helper` (covers the helper's branches in isolation)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue (searched `RunOutput status`, `from_dict status`, `resume replay status`)
- [x] If a similar PR exists, I have explained below why this PR is a better approach — none found
- [x] This PR was drafted with AI assistance (Claude Code). The author has read every line and is responsible for its correctness.

---

## Additional Notes

**Why fix at `from_dict` rather than at the router callsite?** `to_dict` already documents the dual-shape contract (`self.status.value if isinstance(self.status, RunStatus) else self.status` in all three classes). The router was just the first downstream consumer to trip over the missing coercion on the deserialization side. Fixing at the source means every other current and future consumer of `RunOutput.status` after a DB load gets the declared type for free, and the router can keep using `status.value` directly.

**Why a shared helper?** The three `from_dict` methods are intentionally parallel, so the coercion is identical in each. Putting it in `RunStatus.coerce()` next to the enum (rather than copy-pasting the block three times) keeps the forward-compat semantics — known string → enum, unknown string preserved, already-typed/None passed through — in one place that can drift only once, and lets the behavior be unit-tested directly.

**Backwards compatibility.** No public API change. Callers that previously received a `str` from `from_dict` and treated it as a string still work — `RunStatus` is `class RunStatus(str, Enum)`, so equality with plain string values (e.g. `status == "COMPLETED"`) continues to hold.