### PR TITLE
cookbook: fix duplicate word typos in image agent and supabase examples

### DIFF
--- a/cookbook/90_models/ibm/watsonx/image_agent_bytes.py
+++ b/cookbook/90_models/ibm/watsonx/image_agent_bytes.py
@@ -26,7 +26,7 @@ image_path = Path(__file__).parent.joinpath("sample.jpg")
 image_bytes = image_path.read_bytes()
 
 agent.print_response(
-    "Tell me about this image and and give me the latest news about it.",
+    "Tell me about this image and give me the latest news about it.",
     images=[
         Image(content=image_bytes),
     ],

--- a/cookbook/91_tools/mcp/supabase.py
+++ b/cookbook/91_tools/mcp/supabase.py
@@ -1,6 +1,6 @@
 """Supabase MCP Agent - Showcase Supabase MCP Capabilities
 
-This example demonstrates how to use the Supabase MCP server to create create projects, database schemas, edge functions, and more.
+This example demonstrates how to use the Supabase MCP server to create projects, database schemas, edge functions, and more.
 
 Setup:
 1. Install Python dependencies:


### PR DESCRIPTION
## Summary

Fixed two accidental duplicate-word typos in cookbook examples:

| File | Before | After |
|------|--------|-------|
| `cookbook/90_models/ibm/watsonx/image_agent_bytes.py:29` | `"...about this image and and give me..."` | `"...about this image and give me..."` |
| `cookbook/91_tools/mcp/supabase.py:3` | `"...the Supabase MCP server to create create projects..."` | `"...the Supabase MCP server to create projects..."` |

Pure text fixes — no behavior change. Both files run identically; the `image_agent_bytes.py` change also slightly improves the prompt sent to the model.

## Type of change

- [x] Bug fix (cookbook)

## Checklist

- [x] My code follows the style guidelines of this project (no code changes, text only)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
