### PR TITLE
fix: add RemoteTeam knowledge filter attributes

### DIFF
--- a/libs/agno/agno/team/remote.py
+++ b/libs/agno/agno/team/remote.py
@@ -21,6 +21,9 @@ class RemoteTeam(BaseRemote):
     # Private cache for team config with TTL: (config, timestamp)
     _cached_team_config: Optional[Tuple["TeamResponse", float]] = None
 
+    knowledge_filters: Optional[Dict[str, Any]] = None
+    enable_agentic_knowledge_filters: Optional[bool] = False
+
     def __init__(
         self,
         base_url: str,

--- a/libs/agno/tests/unit/team/test_remote_team.py
+++ b/libs/agno/tests/unit/team/test_remote_team.py
@@ -1,0 +1,10 @@
+from agno.team.remote import RemoteTeam
+
+
+def test_remote_team_exposes_knowledge_filter_attributes() -> None:
+    remote_team = RemoteTeam.__new__(RemoteTeam)
+    remote_team.agentos_client = None
+
+    assert remote_team.knowledge_filters is None
+    assert remote_team.enable_agentic_knowledge_filters is False
+    assert (not remote_team.knowledge_filters and remote_team.knowledge) is None


### PR DESCRIPTION
## Summary
- add `knowledge_filters` and `enable_agentic_knowledge_filters` defaults to `RemoteTeam`, matching `RemoteAgent`
- add a regression test for the member-delegation access pattern that previously raised `AttributeError`

Fixes #8144.

## Testing
- `.venv/bin/python -m pytest libs/agno/tests/unit/team/test_remote_team.py -q`
- `.venv/bin/ruff check libs/agno/agno/team/remote.py libs/agno/tests/unit/team/test_remote_team.py`
- `.venv/bin/ruff format --check libs/agno/agno/team/remote.py libs/agno/tests/unit/team/test_remote_team.py`

Note: `uv run --project libs/agno pytest ...` could not resolve the repository optional extras because `agno[a2a]` and `agno[brave]` currently require incompatible `httpx` ranges through `a2a-sdk` and `brave-search`. I used a local editable core install for the targeted test instead.