### PR TITLE
fix: remove deprecated Tantivy FTS, fix Redis hset mypy error

### DIFF
--- a/cookbook/02_agents/07_knowledge/agentic_rag_with_reranking.py
+++ b/cookbook/02_agents/07_knowledge/agentic_rag_with_reranking.py
@@ -2,7 +2,7 @@
 Agentic Rag With Reranking
 =============================
 
-1. Run: `uv pip install openai agno cohere lancedb tantivy sqlalchemy` to install the dependencies.
+1. Run: `uv pip install openai agno cohere lancedb sqlalchemy` to install the dependencies.
 """
 
 from agno.agent import Agent

--- a/cookbook/07_knowledge/05_integrations/vector_dbs/02_local.py
+++ b/cookbook/07_knowledge/05_integrations/vector_dbs/02_local.py
@@ -12,7 +12,7 @@ ChromaDB:
 LanceDB:
 - File-based storage (no server needed)
 - Supports hybrid search
-- pip install lancedb tantivy
+- pip install lancedb
 
 See also: 01_qdrant.py for production, 03_managed.py for Pinecone, 04_pgvector.py for PostgreSQL.
 """
@@ -56,7 +56,7 @@ try:
     )
 except ImportError:
     knowledge_lance = None
-    print("LanceDB not installed. Run: pip install lancedb tantivy")
+    print("LanceDB not installed. Run: pip install lancedb")
 
 # ---------------------------------------------------------------------------
 # Run Demo

--- a/cookbook/07_knowledge/09_archive/custom_retriever/knowledge_tools.py
+++ b/cookbook/07_knowledge/09_archive/custom_retriever/knowledge_tools.py
@@ -1,7 +1,7 @@
 """
 Here is a tool with reasoning capabilities to allow agents to search and analyze information from a knowledge base.
 
-1. Run: `uv pip install openai agno lancedb tantivy sqlalchemy` to install the dependencies
+1. Run: `uv pip install openai agno lancedb sqlalchemy` to install the dependencies
 2. Export your OPENAI_API_KEY
 3. Run: `python cookbook/07_knowledge/knowledge_tools.py` to run the agent
 """

--- a/cookbook/90_models/dashscope/knowledge_tools.py
+++ b/cookbook/90_models/dashscope/knowledge_tools.py
@@ -1,7 +1,7 @@
 """
 Here is a tool with reasoning capabilities to allow agents to search and analyze information from a knowledge base.
 
-1. Run: `uv pip install openai agno lancedb tantivy sqlalchemy` to install the dependencies
+1. Run: `uv pip install openai agno lancedb sqlalchemy` to install the dependencies
 2. Export your OPENAI_API_KEY
 3. Run: `cookbook/92_models/dashscope/knowledge_tools.py` to run the agent
 """

--- a/cookbook/90_models/groq/deep_knowledge.py
+++ b/cookbook/90_models/groq/deep_knowledge.py
@@ -10,7 +10,7 @@ Key Features:
 - Iteratively searches a knowledge base
 - Source attribution and citations
 
-Run `uv pip install openai lancedb tantivy inquirer agno groq` to install dependencies.
+Run `uv pip install openai lancedb inquirer agno groq` to install dependencies.
 """
 
 from textwrap import dedent

--- a/libs/agno/agno/vectordb/lancedb/lance_db.py
+++ b/libs/agno/agno/vectordb/lancedb/lance_db.py
@@ -39,7 +39,7 @@ class LanceDb(VectorDb):
         distance: The distance metric to use when searching for documents.
         nprobes: The number of probes to use when searching for documents.
         reranker: The reranker to use when reranking documents.
-        use_tantivy: Whether to use Tantivy for full text search.
+        use_tantivy: Deprecated. LanceDB now uses native FTS. This parameter is ignored.
         on_bad_vectors: What to do if the vector is bad. One of "error", "drop", "fill", "null".
         fill_value: The value to fill the vector with if on_bad_vectors is "fill".
     """
@@ -61,7 +61,7 @@ class LanceDb(VectorDb):
         distance: Distance = Distance.cosine,
         nprobes: Optional[int] = None,
         reranker: Optional[Reranker] = None,
-        use_tantivy: bool = True,
+        use_tantivy: bool = False,
         on_bad_vectors: Optional[str] = None,  # One of "error", "drop", "fill", "null".
         fill_value: Optional[float] = None,  # Only used if on_bad_vectors is "fill"
     ):
@@ -161,15 +161,9 @@ class LanceDb(VectorDb):
         self.on_bad_vectors: Optional[str] = on_bad_vectors
         self.fill_value: Optional[float] = fill_value
         self.fts_index_exists = False
-        self.use_tantivy = use_tantivy
 
-        if self.use_tantivy and (self.search_type in [SearchType.keyword, SearchType.hybrid]):
-            try:
-                import tantivy  # noqa: F401
-            except ImportError:
-                raise ImportError(
-                    "Please install tantivy-py `pip install tantivy` to use the full text search feature."  # noqa: E501
-                )
+        if use_tantivy:
+            log_warning("use_tantivy is deprecated. LanceDB now uses native FTS. This parameter is ignored.")
 
         log_debug(f"Initialized LanceDb with table: '{self.table_name}'")
 
@@ -615,7 +609,7 @@ class LanceDb(VectorDb):
             return []
 
         if not self.fts_index_exists:
-            self.table.create_fts_index("payload", use_tantivy=self.use_tantivy, replace=True)
+            self.table.create_fts_index("payload", replace=True)
             self.fts_index_exists = True
 
         results = (
@@ -641,7 +635,7 @@ class LanceDb(VectorDb):
             return []
 
         if not self.fts_index_exists:
-            self.table.create_fts_index("payload", use_tantivy=self.use_tantivy, replace=True)
+            self.table.create_fts_index("payload", replace=True)
             self.fts_index_exists = True
 
         results = self.table.search(

--- a/libs/agno/agno/vectordb/redis/redisdb.py
+++ b/libs/agno/agno/vectordb/redis/redisdb.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 try:
     from redis import Redis
@@ -650,7 +650,7 @@ class RedisDB(VectorDb):
             log_error(f"Error deleting documents by content_id: {str(e)}")
             return False
 
-    def update_metadata(self, content_id: str, metadata: Dict[str, Any]) -> None:
+    def update_metadata(self, content_id: str, metadata: Mapping[str, Any]) -> None:
         """Update metadata for documents with the given content ID."""
         try:
             # Find documents with the given content_id
@@ -661,16 +661,13 @@ class RedisDB(VectorDb):
                 num_results=1000,  # Get all matching documents
             )
             results = self.index.query(query)
+            parsed = convert_bytes(results)
 
             # Update metadata for each found document
-            for result in results:
-                doc_id = result.get("id")
-                if doc_id:
-                    # result['id'] is the Redis key
-                    key = result.get("id")
-                    # Update the hash with new metadata
-                    if key:
-                        self.redis_client.hset(key, mapping=metadata)
+            for result in parsed:
+                key = result.get("id")
+                if key:
+                    self.redis_client.hset(key, mapping=metadata)  # type: ignore[arg-type]
 
             log_debug(f"Updated metadata for documents with content_id '{content_id}'")
         except Exception as e:

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -169,7 +169,7 @@ mysql = ["pymysql", "asyncmy"]
 # Dependencies for Vector databases
 pgvector = ["pgvector"]
 chromadb = ["chromadb"]
-lancedb = ["lancedb>=0.26.0", "tantivy"]
+lancedb = ["lancedb>=0.26.0"]
 pylance = ["pylance"]
 qdrant = ["qdrant-client"]
 couchbase = ["couchbase"]
@@ -561,7 +561,6 @@ module = [
   "sqlalchemy.*",
   "starlette.*",
   "streamlit.*",
-  "tantivy.*",
   "tavily.*",
   "telebot.*",
   "textract.*",


### PR DESCRIPTION
## Summary

Fixes CI failures on main caused by:
1. **LanceDB FTS tests failing** - LanceDB v0.32.0 removed Tantivy-based FTS and now uses native FTS. Our code passed `use_tantivy=True` which now raises `ValueError`.
2. **Redis mypy error** - `hset(mapping=metadata)` where `metadata: Dict[str, Any]` was incompatible with stricter redis-py type stubs.

## Changes

### LanceDB (`lance_db.py`)
- Changed `use_tantivy` default from `True` to `False`
- Removed passing `use_tantivy` to `create_fts_index()` calls (lines 618, 644)
- Removed the tantivy import guard (dead code now)
- Added deprecation warning when `use_tantivy=True` is passed

### Redis (`redisdb.py`)
- Added `convert_bytes()` call in `update_metadata()` to match other methods
- Changed parameter type from `Dict[str, Any]` to `Mapping[str, Any]`
- Added `# type: ignore[arg-type]` for the redis-py stub incompatibility

### Dependencies (`pyproject.toml`)
- Removed `tantivy` from lancedb extras
- Removed `tantivy.*` from mypy ignore list

### Cookbooks
- Updated 5 cookbooks to remove `tantivy` from install instructions

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] `./scripts/format.sh` passes
- [x] `./scripts/validate.sh` passes (no new mypy errors introduced)
- [x] Tests pass locally (`test_keyword_search`, `test_hybrid_search`)