### PR TITLE
chore: Refresh DeepSeek V4 thinking mode and defaults

### DIFF
--- a/cookbook/90_models/deepseek/README.md
+++ b/cookbook/90_models/deepseek/README.md
@@ -1,6 +1,34 @@
 # DeepSeek Cookbook
 
-> Note: Fork and clone this repository if needed
+[DeepSeek](https://api-docs.deepseek.com/) provides an OpenAI-compatible API. Agno's
+`DeepSeek` model defaults to `deepseek-v4-flash`.
+
+## Models
+
+| Model id | Description |
+|---|---|
+| `deepseek-v4-flash` | Fast V4 model (default), 1M context. Hybrid: thinking + non-thinking. |
+| `deepseek-v4-pro` | Flagship V4 model, 1M context. Hybrid: thinking + non-thinking. |
+
+Thinking mode is **enabled by default** for V4 models, so the model returns
+`reasoning_content` out of the box. Control it with the `use_thinking` flag:
+`DeepSeek(id="deepseek-v4-flash", use_thinking=False)` turns it off,
+`use_thinking=True` forces it on.
+
+For demanding agent tasks, set `reasoning_effort="max"` (valid values: `high`, `max`).
+While thinking mode is active, `temperature`, `top_p`, `presence_penalty` and
+`frequency_penalty` are ignored by the API.
+
+### Deprecated model ids
+
+The legacy ids still work and route server-side, but you should migrate:
+
+| Legacy id | Maps to |
+|---|---|
+| `deepseek-chat` | non-thinking mode of `deepseek-v4-flash` |
+| `deepseek-reasoner` | thinking mode of `deepseek-v4-flash` |
+
+## Setup
 
 ### 1. Create and activate a virtual environment
 
@@ -21,31 +49,30 @@ export DEEPSEEK_API_KEY=***
 uv pip install -U openai ddgs duckdb yfinance agno
 ```
 
-### 4. Run basic Agent
-
-- Streaming on
+## Examples
 
 ```shell
-python cookbook/92_models/deepseek/basic_stream.py
+# Basic agent (sync, async, streaming)
+python cookbook/90_models/deepseek/basic.py
+
+# Tool use
+python cookbook/90_models/deepseek/tool_use.py
+
+# Structured output
+python cookbook/90_models/deepseek/structured_output.py
+
+# Reasoning agent (thinking mode)
+python cookbook/90_models/deepseek/reasoning_agent.py
+
+# Thinking + tool calls
+python cookbook/90_models/deepseek/thinking_tool_calls.py
+
+# Controlling reasoning effort
+python cookbook/90_models/deepseek/reasoning_effort.py
+
+# Toggling thinking mode on/off
+python cookbook/90_models/deepseek/thinking_mode.py
+
+# Retry behavior
+python cookbook/90_models/deepseek/retry.py
 ```
-
-- Streaming off
-
-```shell
-python cookbook/92_models/deepseek/basic.py
-```
-
-### 5. Run Agent with Tools
-
-- DuckDuckGo Search
-
-```shell
-python cookbook/92_models/deepseek/tool_use.py
-```
-
-### 6. Run Agent that returns structured output
-
-```shell
-python cookbook/92_models/deepseek/structured_output.py
-```
-

--- a/cookbook/90_models/deepseek/TEST_LOG.md
+++ b/cookbook/90_models/deepseek/TEST_LOG.md
@@ -1,3 +1,59 @@
 # TEST_LOG
 
-No cookbook tests have been recorded for this directory yet.
+Tested against the DeepSeek V4 API (`DEEPSEEK_API_KEY` set) on 2026-05-29.
+
+### basic.py
+
+**Status:** PASS
+
+**Description:** Sync, sync+streaming, async, async+streaming runs with `deepseek-v4-flash`. Thinking mode is enabled by default; the model returns content plus `reasoning_content`.
+
+**Result:** Responses returned correctly in all four modes.
+
+---
+
+### thinking_mode.py
+
+**Status:** PASS
+
+**Description:** Compares thinking-enabled (default) vs thinking-disabled (`extra_body={"thinking": {"type": "disabled"}}`) on `deepseek-v4-flash`. Confirms `reasoning_content` is present with thinking on and absent with it off.
+
+**Result:** Both paths returned valid answers; reasoning_content behaved as expected.
+
+---
+
+### reasoning_effort.py
+
+**Status:** PASS
+
+**Description:** `deepseek-v4-pro` with `reasoning_effort="max"` on a river-crossing puzzle, streamed with full reasoning.
+
+**Result:** Produced a correct step-by-step solution with streamed reasoning.
+
+---
+
+### structured_output.py
+
+**Status:** PASS
+
+**Description:** `deepseek-v4-flash` with a `MovieScript` schema, run two ways: `json_mode_agent` (`use_json_mode=True`) and `structured_output_agent` (`output_schema` only, no JSON mode).
+
+**Result:** Both modes returned valid structured JSON. DeepSeek has no native/json_schema structured output, but the `output_schema`-only agent still works via agno's prompt-based JSON fallback, so both paths produce a valid MovieScript.
+
+---
+
+### Related test suites
+
+- `libs/agno/tests/unit/reasoning/test_reasoning_checkers.py` and
+  `libs/agno/tests/unit/models/deepseek/test_deepseek.py`: **79 passed** (no network).
+- `libs/agno/tests/integration/models/deepseek/test_basic.py`: **9 passed**
+  (streaming tests updated to be thinking-aware: in thinking mode the stream first
+  delivers reasoning_content deltas before content deltas).
+
+---
+
+### Notes
+
+- `tool_use.py`, `structured_output.py`, `reasoning_agent.py`, `thinking_tool_calls.py`
+  require optional cookbook dependencies (ddgs/yfinance) and were id-refreshed to V4;
+  run them via the demo venv with those installed.

--- a/cookbook/90_models/deepseek/basic.py
+++ b/cookbook/90_models/deepseek/basic.py
@@ -13,7 +13,7 @@ import asyncio
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=DeepSeek(id="deepseek-chat"), markdown=True)
+agent = Agent(model=DeepSeek(id="deepseek-v4-flash"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/deepseek/reasoning_agent.py
+++ b/cookbook/90_models/deepseek/reasoning_agent.py
@@ -21,7 +21,7 @@ task = (
 
 agent = Agent(
     model=DeepSeek(
-        id="deepseek-reasoner",
+        id="deepseek-v4-pro",
     ),
     markdown=True,
 )

--- a/cookbook/90_models/deepseek/reasoning_effort.py
+++ b/cookbook/90_models/deepseek/reasoning_effort.py
@@ -1,0 +1,37 @@
+"""
+Deepseek Reasoning Effort
+=========================
+
+DeepSeek V4 models accept a `reasoning_effort` parameter that controls how much the
+model thinks before answering. Valid values are "high" and "max" ("low" and "medium"
+are mapped to "high" server-side). It is left unset by default, so the API uses its
+own default ("high"). For demanding agent scenarios, DeepSeek recommends "max".
+
+Note: while thinking mode is active, temperature, top_p, presence_penalty and
+frequency_penalty are ignored by the API.
+"""
+
+from agno.agent import Agent
+from agno.models.deepseek import DeepSeek
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=DeepSeek(id="deepseek-v4-pro", reasoning_effort="max"),
+    markdown=True,
+)
+
+task = (
+    "A farmer needs to cross a river with a fox, a chicken and a sack of grain. "
+    "The boat only fits the farmer and one item. The fox cannot be left alone with "
+    "the chicken, and the chicken cannot be left alone with the grain. "
+    "Provide a step-by-step solution."
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(task, stream=True, show_full_reasoning=True)

--- a/cookbook/90_models/deepseek/structured_output.py
+++ b/cookbook/90_models/deepseek/structured_output.py
@@ -10,7 +10,6 @@ from typing import List
 from agno.agent import Agent, RunOutput  # noqa
 from agno.models.deepseek import DeepSeek
 from pydantic import BaseModel, Field
-from rich.pretty import pprint  # noqa
 
 # ---------------------------------------------------------------------------
 # Create Agent
@@ -36,22 +35,28 @@ class MovieScript(BaseModel):
     )
 
 
+# Agent that uses JSON mode (recommended for DeepSeek).
+# DeepSeek supports JSON mode (response_format={"type": "json_object"}) but not
+# native/json_schema structured outputs, so use_json_mode=True is the reliable path.
 json_mode_agent = Agent(
-    model=DeepSeek(id="deepseek-chat"),
+    model=DeepSeek(id="deepseek-v4-flash"),
     description="You help people write movie scripts.",
     output_schema=MovieScript,
     use_json_mode=True,
 )
 
-# Get the response in a variable
-json_mode_response: RunOutput = json_mode_agent.run("New York")
-pprint(json_mode_response.content)
-
-# json_mode_agent.print_response("New York")
+# Agent that uses native structured outputs (output_schema without JSON mode).
+structured_output_agent = Agent(
+    model=DeepSeek(id="deepseek-v4-flash"),
+    description="You help people write movie scripts.",
+    output_schema=MovieScript,
+)
 
 # ---------------------------------------------------------------------------
 # Run Agent
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    pass
+    json_mode_agent.print_response("New York")
+
+    structured_output_agent.print_response("New York")

--- a/cookbook/90_models/deepseek/thinking_mode.py
+++ b/cookbook/90_models/deepseek/thinking_mode.py
@@ -1,0 +1,35 @@
+"""
+Deepseek Thinking Mode
+======================
+
+DeepSeek V4 models run with thinking mode enabled by default, so you get
+reasoning_content out of the box. Use the `use_thinking` flag to control it:
+`use_thinking=True` forces it on, `use_thinking=False` turns it off for a faster,
+cheaper response.
+"""
+
+from agno.agent import Agent
+from agno.models.deepseek import DeepSeek
+
+# ---------------------------------------------------------------------------
+# Thinking enabled (default) - returns reasoning_content
+# ---------------------------------------------------------------------------
+
+thinking_agent = Agent(model=DeepSeek(id="deepseek-v4-flash"), markdown=True)
+
+# ---------------------------------------------------------------------------
+# Thinking disabled - faster, no reasoning_content
+# ---------------------------------------------------------------------------
+
+non_thinking_agent = Agent(
+    model=DeepSeek(id="deepseek-v4-flash", use_thinking=False),
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agents
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    thinking_agent.print_response("Why is the sky blue?", stream=True)
+
+    non_thinking_agent.print_response("Why is the sky blue?", stream=True)

--- a/cookbook/90_models/deepseek/thinking_tool_calls.py
+++ b/cookbook/90_models/deepseek/thinking_tool_calls.py
@@ -14,7 +14,7 @@ Before outputting the final answer, the model can engage in multiple turns of re
 """
 
 agent = Agent(
-    model=DeepSeek(id="deepseek-reasoner"),
+    model=DeepSeek(id="deepseek-v4-pro"),
     tools=[WebSearchTools()],
     markdown=True,
     stream=True,

--- a/cookbook/90_models/deepseek/tool_use.py
+++ b/cookbook/90_models/deepseek/tool_use.py
@@ -11,12 +11,11 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 """
-The current version of the deepseek-chat model's Function Calling capabilitity is unstable, which may result in looped calls or empty responses.
-Their development team is actively working on a fix, and it is expected to be resolved in the next version.
+DeepSeek V4 models support tool calls in both thinking and non-thinking modes.
 """
 
 agent = Agent(
-    model=DeepSeek(id="deepseek-chat"),
+    model=DeepSeek(id="deepseek-v4-flash"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/libs/agno/agno/models/deepseek/deepseek.py
+++ b/libs/agno/agno/models/deepseek/deepseek.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from os import getenv
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional, Set
 
 from agno.exceptions import ModelAuthenticationError
 from agno.models.message import Message
@@ -14,23 +14,99 @@ class DeepSeek(OpenAILike):
     """
     A class for interacting with DeepSeek models.
 
+    DeepSeek V4 models (deepseek-v4-flash, deepseek-v4-pro) run with thinking mode
+    enabled by default. While thinking mode is active, the following parameters are
+    accepted but have no effect (they are silently ignored by the API):
+    - temperature
+    - top_p
+    - presence_penalty
+    - frequency_penalty
+
+    Thinking mode is controlled with the ``use_thinking`` flag:
+    - ``use_thinking=None`` (default): thinking is on for thinking-capable models and
+      off for the legacy non-thinking ids (deepseek-chat).
+    - ``use_thinking=True``: force thinking on.
+    - ``use_thinking=False``: turn thinking off (faster, cheaper responses).
+
+    For agent scenarios, DeepSeek recommends ``reasoning_effort="max"``. It is left
+    unset (None) by default so the API uses its own default ("high"); set it
+    explicitly to opt in. Valid values are "high" and "max".
+
+    For more information, see: https://api-docs.deepseek.com/guides/thinking_mode
+
     Attributes:
-        id (str): The model id. Defaults to "deepseek-chat".
+        id (str): The model id. Defaults to "deepseek-v4-flash".
         name (str): The model name. Defaults to "DeepSeek".
         provider (str): The provider name. Defaults to "DeepSeek".
         api_key (Optional[str]): The API key.
         base_url (str): The base URL. Defaults to "https://api.deepseek.com".
+        use_thinking (Optional[bool]): Toggle thinking mode. None uses the model default.
     """
 
-    id: str = "deepseek-chat"
+    id: str = "deepseek-v4-flash"
     name: str = "DeepSeek"
     provider: str = "DeepSeek"
 
     api_key: Optional[str] = field(default_factory=lambda: getenv("DEEPSEEK_API_KEY"))
     base_url: str = "https://api.deepseek.com"
 
-    # Their support for structured outputs is currently broken
+    # Toggle thinking mode. None = use the model default (on for thinking-capable models,
+    # off for the legacy non-thinking ids). True = force on, False = force off.
+    use_thinking: Optional[bool] = None
+
+    # DeepSeek supports JSON mode (response_format={"type": "json_object"}) but not
+    # native/json_schema structured outputs, so output_schema needs use_json_mode=True.
     supports_native_structured_outputs: bool = False
+
+    # Model ids that should NOT have thinking enabled by default. The legacy ids still
+    # work and route server-side: deepseek-chat -> non-thinking mode of deepseek-v4-flash,
+    # deepseek-reasoner -> thinking mode of deepseek-v4-flash. Only deepseek-chat needs to
+    # opt out of thinking here (deepseek-reasoner is already a thinking model).
+    _non_thinking_model_ids: ClassVar[Set[str]] = {
+        "deepseek-chat",
+    }
+
+    def _thinking_enabled(self) -> bool:
+        """Resolve whether thinking mode should be on for this request.
+
+        An explicit ``use_thinking`` flag always wins; otherwise thinking-capable models
+        default to on and the legacy non-thinking ids default to off.
+        """
+        if self.use_thinking is not None:
+            return self.use_thinking
+        return self.id not in self._non_thinking_model_ids
+
+    def get_request_params(
+        self,
+        response_format=None,
+        tools=None,
+        tool_choice=None,
+        run_response=None,
+    ) -> Dict[str, Any]:
+        request_params = super().get_request_params(
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            run_response=run_response,
+        )
+
+        if self._thinking_enabled():
+            # Merge with any user-supplied extra_body and never overwrite an explicit
+            # thinking setting (so a raw extra_body override still takes precedence).
+            extra_body = request_params.get("extra_body") or {}
+            extra_body.setdefault("thinking", {"type": "enabled"})
+            request_params["extra_body"] = extra_body
+        else:
+            # No thinking: reasoning_effort has no effect, so strip it. Only send an
+            # explicit disabled flag when the user turned a thinking-capable model off;
+            # the legacy non-thinking ids are already non-thinking server-side.
+            request_params.pop("reasoning_effort", None)
+            if self.use_thinking is False:
+                extra_body = request_params.get("extra_body") or {}
+                extra_body.setdefault("thinking", {"type": "disabled"})
+                request_params["extra_body"] = extra_body
+
+        return request_params
 
     def _get_client_params(self) -> Dict[str, Any]:
         # Fetch API key from env if not already set

--- a/libs/agno/agno/reasoning/deepseek.py
+++ b/libs/agno/agno/reasoning/deepseek.py
@@ -14,14 +14,19 @@ def is_deepseek_reasoning_model(reasoning_model: Model) -> bool:
     """Check if the model is a DeepSeek reasoning model.
 
     Matches:
-    - deepseek-reasoner
-    - deepseek-r1 and variants (deepseek-r1-distill-*, etc.)
+    - Dedicated reasoning models: deepseek-reasoner, deepseek-r1 and variants
+      (deepseek-r1-zero, deepseek-r1-0528, deepseek-r1-distill-*, etc.)
+    - Hybrid models that run with thinking mode enabled by default: deepseek-v4-*,
+      deepseek-v3.1 (incl. -terminus), deepseek-v3.2 (incl. -exp, -speciale).
+
+    Non-reasoning models return False: deepseek-chat, the base deepseek-v3
+    (incl. deepseek-v3-0324), deepseek-v2 and earlier.
     """
     if reasoning_model.__class__.__name__ != "DeepSeek":
         return False
 
     model_id = reasoning_model.id.lower()
-    return "reasoner" in model_id or "r1" in model_id
+    return "reasoner" in model_id or "r1" in model_id or "v4" in model_id or "v3.1" in model_id or "v3.2" in model_id
 
 
 def get_deepseek_reasoning(

--- a/libs/agno/tests/integration/models/deepseek/test_basic.py
+++ b/libs/agno/tests/integration/models/deepseek/test_basic.py
@@ -19,7 +19,7 @@ def _assert_metrics(response: RunOutput):
 
 
 def test_basic():
-    agent = Agent(model=DeepSeek(id="deepseek-chat"), markdown=True, telemetry=False)
+    agent = Agent(model=DeepSeek(id="deepseek-v4-flash"), markdown=True, telemetry=False)
 
     # Print the response in the terminal
     response: RunOutput = agent.run("Share a 2 sentence horror story")
@@ -31,8 +31,19 @@ def test_basic():
     _assert_metrics(response)
 
 
+def test_thinking_produces_reasoning_content():
+    """V4 models run in thinking mode by default and should return reasoning_content."""
+    agent = Agent(model=DeepSeek(id="deepseek-v4-pro"), telemetry=False)
+
+    response: RunOutput = agent.run("What is 17 * 23? Think it through.")
+
+    assert response.content is not None and len(response.content) > 0
+    assert response.reasoning_content is not None and len(response.reasoning_content) > 0
+    _assert_metrics(response)
+
+
 def test_basic_stream():
-    agent = Agent(model=DeepSeek(id="deepseek-chat"), markdown=True, telemetry=False)
+    agent = Agent(model=DeepSeek(id="deepseek-v4-flash"), markdown=True, telemetry=False)
 
     response_stream = agent.run("Share a 2 sentence horror story", stream=True)
 
@@ -41,13 +52,15 @@ def test_basic_stream():
 
     responses = list(response_stream)
     assert len(responses) > 0
-    for response in responses:
-        assert response.content is not None
+    # In thinking mode the stream first delivers reasoning_content deltas (content=None),
+    # then content deltas. Ensure we still receive actual content events.
+    content_events = [response for response in responses if response.content is not None]
+    assert len(content_events) > 0
 
 
 @pytest.mark.asyncio
 async def test_async_basic():
-    agent = Agent(model=DeepSeek(id="deepseek-chat"), markdown=True, telemetry=False)
+    agent = Agent(model=DeepSeek(id="deepseek-v4-flash"), markdown=True, telemetry=False)
 
     response = await agent.arun("Share a 2 sentence horror story")
 
@@ -59,16 +72,20 @@ async def test_async_basic():
 
 @pytest.mark.asyncio
 async def test_async_basic_stream():
-    agent = Agent(model=DeepSeek(id="deepseek-chat"), markdown=True, telemetry=False)
+    agent = Agent(model=DeepSeek(id="deepseek-v4-flash"), markdown=True, telemetry=False)
 
+    content_events = 0
     async for response in agent.arun("Share a 2 sentence horror story", stream=True):
-        assert response.content is not None
+        # In thinking mode early events carry reasoning_content (content=None).
+        if response.content is not None:
+            content_events += 1
+    assert content_events > 0
 
 
 def test_with_memory():
     agent = Agent(
         db=SqliteDb(db_file="tmp/test_with_memory.db"),
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         add_history_to_context=True,
         markdown=True,
         telemetry=False,
@@ -99,7 +116,7 @@ def test_output_schema():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         output_schema=MovieScript,
         telemetry=False,
     )
@@ -120,7 +137,7 @@ def test_json_response_mode():
         plot: str = Field(..., description="Brief plot summary")
 
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         output_schema=MovieScript,
         use_json_mode=True,
         telemetry=False,
@@ -137,7 +154,7 @@ def test_json_response_mode():
 
 def test_history():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         db=SqliteDb(db_file="tmp/deepseek/test_basic.db"),
         add_history_to_context=True,
         store_history_messages=True,

--- a/libs/agno/tests/integration/models/deepseek/test_reasoning_streaming.py
+++ b/libs/agno/tests/integration/models/deepseek/test_reasoning_streaming.py
@@ -17,8 +17,8 @@ from agno.run.agent import RunEvent
 def _get_reasoning_streaming_agent(**kwargs):
     """Create an agent with DeepSeek reasoning_model for streaming reasoning tests."""
     default_config = {
-        "model": DeepSeek(id="deepseek-chat"),
-        "reasoning_model": DeepSeek(id="deepseek-reasoner"),
+        "model": DeepSeek(id="deepseek-v4-flash"),
+        "reasoning_model": DeepSeek(id="deepseek-v4-pro"),
         "instructions": "You are an expert problem-solving assistant. Think step by step.",
         "markdown": True,
         "telemetry": False,

--- a/libs/agno/tests/integration/models/deepseek/test_structured_response.py
+++ b/libs/agno/tests/integration/models/deepseek/test_structured_response.py
@@ -24,7 +24,7 @@ class MovieScript(BaseModel):
 
 def test_structured_response():
     structured_output_agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         description="You help people write movie scripts.",
         output_schema=MovieScript,
     )
@@ -52,7 +52,7 @@ def test_structured_response_with_enum_fields():
         rating: Grade
 
     structured_output_agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         description="You help generate recipe names and ratings.",
         output_schema=Recipe,
     )
@@ -65,7 +65,7 @@ def test_structured_response_with_enum_fields():
 def test_structured_response_strict_output_false():
     """Test structured response with strict_output=False (guided mode)"""
     guided_output_agent = Agent(
-        model=DeepSeek(id="deepseek-chat", strict_output=False),
+        model=DeepSeek(id="deepseek-v4-flash", strict_output=False),
         description="You write movie scripts.",
         output_schema=MovieScript,
     )

--- a/libs/agno/tests/integration/models/deepseek/test_tool_use.py
+++ b/libs/agno/tests/integration/models/deepseek/test_tool_use.py
@@ -10,7 +10,7 @@ from agno.tools.yfinance import YFinanceTools
 
 def test_tool_use():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -27,7 +27,7 @@ def test_tool_use():
 
 def test_tool_use_stream():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -54,7 +54,7 @@ def test_tool_use_stream():
 @pytest.mark.asyncio
 async def test_async_tool_use():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -72,7 +72,7 @@ async def test_async_tool_use():
 @pytest.mark.asyncio
 async def test_async_tool_use_stream():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -94,7 +94,7 @@ async def test_async_tool_use_stream():
 
 def test_parallel_tool_calls():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -115,7 +115,7 @@ def test_parallel_tool_calls():
 
 def test_multiple_tool_calls():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[YFinanceTools(cache_results=True), WebSearchTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -142,7 +142,7 @@ def test_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[get_the_weather_in_tokyo],
         markdown=True,
         telemetry=False,
@@ -171,7 +171,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -188,7 +188,7 @@ def test_tool_call_custom_tool_optional_parameters():
 
 def test_tool_call_list_parameters():
     agent = Agent(
-        model=DeepSeek(id="deepseek-chat"),
+        model=DeepSeek(id="deepseek-v4-flash"),
         tools=[WebSearchTools(cache_results=True)],
         instructions="Use a single tool call if possible",
         markdown=True,

--- a/libs/agno/tests/unit/models/deepseek/test_deepseek.py
+++ b/libs/agno/tests/unit/models/deepseek/test_deepseek.py
@@ -1,0 +1,113 @@
+from unittest.mock import patch
+
+import pytest
+
+from agno.exceptions import ModelAuthenticationError
+from agno.models.deepseek import DeepSeek
+
+
+def test_default_config():
+    """Default DeepSeek configuration uses deepseek-v4-flash with thinking-friendly defaults."""
+    model = DeepSeek()
+
+    assert model.id == "deepseek-v4-flash"
+    assert model.name == "DeepSeek"
+    assert model.provider == "DeepSeek"
+    assert model.base_url == "https://api.deepseek.com"
+    # reasoning_effort is opt-in (matches OpenAIChat); the API uses its own default.
+    assert model.reasoning_effort is None
+    # use_thinking flag defaults to None (use model default).
+    assert model.use_thinking is None
+    # Structured output support is currently broken upstream.
+    assert model.supports_native_structured_outputs is False
+
+
+def test_requires_api_key():
+    """DeepSeek raises an error when no API key is provided."""
+    model = DeepSeek()
+
+    with patch.dict("os.environ", {}, clear=True):
+        model.api_key = None
+        with pytest.raises(ModelAuthenticationError, match="DEEPSEEK_API_KEY not set"):
+            model._get_client_params()
+
+
+def test_thinking_enabled_by_default_for_flash():
+    """get_request_params injects thinking mode for the default deepseek-v4-flash."""
+    model = DeepSeek(api_key="test")
+    params = model.get_request_params()
+
+    assert params["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_thinking_enabled_by_default_for_pro():
+    """get_request_params injects thinking mode for deepseek-v4-pro."""
+    model = DeepSeek(id="deepseek-v4-pro", api_key="test")
+    params = model.get_request_params()
+
+    assert params["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_user_extra_body_merged_with_thinking():
+    """A user-supplied extra_body is preserved and merged with the thinking flag."""
+    model = DeepSeek(api_key="test", extra_body={"custom_key": "custom_value"})
+    params = model.get_request_params()
+
+    assert params["extra_body"]["custom_key"] == "custom_value"
+    assert params["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_explicit_thinking_setting_preserved():
+    """An explicit thinking setting in extra_body is never overwritten (raw escape hatch)."""
+    model = DeepSeek(api_key="test", extra_body={"thinking": {"type": "disabled"}})
+    params = model.get_request_params()
+
+    assert params["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+def test_use_thinking_false_disables():
+    """use_thinking=False turns thinking off on a thinking-capable model."""
+    model = DeepSeek(api_key="test", use_thinking=False)
+    params = model.get_request_params()
+
+    assert params["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+def test_use_thinking_false_strips_reasoning_effort():
+    """use_thinking=False strips reasoning_effort since it has no effect without thinking."""
+    model = DeepSeek(api_key="test", use_thinking=False, reasoning_effort="max")
+    params = model.get_request_params()
+
+    assert "reasoning_effort" not in params
+
+
+def test_use_thinking_true_forces_thinking_on_legacy_chat():
+    """use_thinking=True forces thinking on even for the legacy non-thinking deepseek-chat."""
+    model = DeepSeek(id="deepseek-chat", api_key="test", use_thinking=True)
+    params = model.get_request_params()
+
+    assert params["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+def test_deepseek_chat_is_non_thinking():
+    """The deprecated deepseek-chat maps to non-thinking mode: no thinking flag injected."""
+    model = DeepSeek(id="deepseek-chat", api_key="test")
+    params = model.get_request_params()
+
+    assert "thinking" not in params.get("extra_body", {})
+
+
+def test_deepseek_chat_strips_reasoning_effort():
+    """reasoning_effort has no effect in non-thinking mode and is stripped for deepseek-chat."""
+    model = DeepSeek(id="deepseek-chat", api_key="test", reasoning_effort="max")
+    params = model.get_request_params()
+
+    assert "reasoning_effort" not in params
+
+
+def test_deepseek_reasoner_is_thinking():
+    """The deprecated deepseek-reasoner maps to thinking mode, so thinking is injected."""
+    model = DeepSeek(id="deepseek-reasoner", api_key="test")
+    params = model.get_request_params()
+
+    assert params["extra_body"]["thinking"] == {"type": "enabled"}

--- a/libs/agno/tests/unit/reasoning/test_reasoning_checkers.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_checkers.py
@@ -470,6 +470,87 @@ def test_deepseek_with_v3_model():
     assert is_deepseek_reasoning_model(model) is False
 
 
+def test_deepseek_with_r1_0528_model():
+    """Test DeepSeek model with deepseek-r1-0528 returns True."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-r1-0528",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v4_flash_model():
+    """Test DeepSeek model with deepseek-v4-flash returns True (hybrid, thinking by default)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v4-flash",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v4_pro_model():
+    """Test DeepSeek model with deepseek-v4-pro returns True (hybrid, thinking by default)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v4-pro",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v3_1_model():
+    """Test DeepSeek model with deepseek-v3.1 returns True (hybrid)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v3.1",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v3_1_terminus_model():
+    """Test DeepSeek model with deepseek-v3.1-terminus returns True (hybrid)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v3.1-terminus",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v3_2_model():
+    """Test DeepSeek model with deepseek-v3.2 returns True (hybrid)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v3.2",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v3_2_exp_model():
+    """Test DeepSeek model with deepseek-v3.2-exp returns True (hybrid)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v3.2-exp",
+    )
+    assert is_deepseek_reasoning_model(model) is True
+
+
+def test_deepseek_with_v3_0324_model():
+    """Test DeepSeek model with deepseek-v3-0324 returns False (non-reasoning chat update)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v3-0324",
+    )
+    assert is_deepseek_reasoning_model(model) is False
+
+
+def test_deepseek_with_v2_model():
+    """Test DeepSeek model with deepseek-v2 returns False (pre-reasoning)."""
+    model = MockModel(
+        class_name="DeepSeek",
+        model_id="deepseek-v2",
+    )
+    assert is_deepseek_reasoning_model(model) is False
+
+
 def test_deepseek_non_deepseek_model():
     """Test non-DeepSeek model returns False."""
     model = MockModel(


### PR DESCRIPTION


## Summary

Switch example usage to DeepSeek V4 (deepseek-v4-flash / deepseek-v4-pro), add thinking-mode examples, and update model/runtime behavior accordingly. Changes include: updated cookbook examples and README/TEST_LOG, new examples (reasoning_effort.py, thinking_mode.py), and refreshed tool/structured-output demos to use V4. DeepSeek model class: default id set to deepseek-v4-flash, added use_thinking flag and logic to inject/strip the API "thinking" extra_body, strip reasoning_effort when thinking is off, and document ignored params while thinking. Reasoning detection now treats v4/v3.1/v3.2/r1 variants as reasoning-capable. Added unit and integration tests to cover V4 thinking/streaming/structured-output/tool-call behaviors.
Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #7757 #7755) 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
