### PR TITLE
fix: include assembled history in reasoning inputs

### DIFF
--- a/libs/agno/agno/run/messages.py
+++ b/libs/agno/agno/run/messages.py
@@ -22,6 +22,9 @@ class RunMessages:
 
     def get_input_messages(self) -> List[Message]:
         """Get the input messages for the model."""
+        if self.messages:
+            return self.messages
+
         input_messages = []
         if self.system_message is not None:
             input_messages.append(self.system_message)

--- a/libs/agno/tests/unit/run/test_run_messages.py
+++ b/libs/agno/tests/unit/run/test_run_messages.py
@@ -1,0 +1,27 @@
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+
+def test_get_input_messages_uses_assembled_messages() -> None:
+    system = Message(role="system", content="You are helpful.")
+    history_user = Message(role="user", content="My name is Alex.", from_history=True)
+    history_assistant = Message(role="assistant", content="Hi Alex.", from_history=True)
+    current_user = Message(role="user", content="What's my name?")
+
+    run_messages = RunMessages(
+        messages=[system, history_user, history_assistant, current_user],
+        system_message=system,
+        user_message=current_user,
+    )
+
+    assert run_messages.get_input_messages() == [system, history_user, history_assistant, current_user]
+
+
+def test_get_input_messages_falls_back_to_fields() -> None:
+    system = Message(role="system", content="You are helpful.")
+    extra = Message(role="user", content="Additional context")
+    current_user = Message(role="user", content="What's my name?")
+
+    run_messages = RunMessages(system_message=system, user_message=current_user, extra_messages=[extra])
+
+    assert run_messages.get_input_messages() == [system, current_user, extra]


### PR DESCRIPTION
## Summary
- return the fully assembled `RunMessages.messages` sequence from `get_input_messages()` when available
- preserves history that was already injected by `add_history_to_context` before default reasoning agents consume the input
- keep the existing system/user/extra fallback for manually constructed `RunMessages`

Closes #7991.

## Testing
- `PYTHONPATH=/Users/fu/Desktop/ai\ study/builds/pr-candidates/agno-runmessages-history/libs/agno pytest libs/agno/tests/unit/run/test_run_messages.py -q`
- `ruff check libs/agno/agno/run/messages.py libs/agno/tests/unit/run/test_run_messages.py`
- `ruff format --check libs/agno/agno/run/messages.py libs/agno/tests/unit/run/test_run_messages.py`
- `git diff --check`
