### PR TITLE
fix: preserve assembled RunMessages history

### DIFF
--- a/libs/agno/agno/run/messages.py
+++ b/libs/agno/agno/run/messages.py
@@ -22,6 +22,9 @@ class RunMessages:
 
     def get_input_messages(self) -> List[Message]:
         """Get the input messages for the model."""
+        if self.messages:
+            return self.messages
+
         input_messages = []
         if self.system_message is not None:
             input_messages.append(self.system_message)

--- a/libs/agno/tests/unit/run/test_run_messages.py
+++ b/libs/agno/tests/unit/run/test_run_messages.py
@@ -1,0 +1,27 @@
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+
+def test_get_input_messages_uses_assembled_messages() -> None:
+    system = Message(role="system", content="You are helpful.")
+    history_user = Message(role="user", content="My name is Alex.", from_history=True)
+    history_assistant = Message(role="assistant", content="Hi Alex.", from_history=True)
+    current_user = Message(role="user", content="What's my name?")
+
+    run_messages = RunMessages(
+        messages=[system, history_user, history_assistant, current_user],
+        system_message=system,
+        user_message=current_user,
+    )
+
+    assert run_messages.get_input_messages() == [system, history_user, history_assistant, current_user]
+
+
+def test_get_input_messages_falls_back_to_fields() -> None:
+    system = Message(role="system", content="You are helpful.")
+    extra = Message(role="user", content="Additional context")
+    current_user = Message(role="user", content="What's my name?")
+
+    run_messages = RunMessages(system_message=system, user_message=current_user, extra_messages=[extra])
+
+    assert run_messages.get_input_messages() == [system, current_user, extra]


### PR DESCRIPTION
Fixes #8151

## Summary
- return the pre-assembled `RunMessages.messages` list when present
- keep the existing field-based fallback for callers that only set `system_message`, `user_message`, and `extra_messages`
- add unit coverage for both paths

## Why
`RunMessages.messages` is the canonical assembled model input for runs that include history. Rebuilding input from only the individual fields can drop already assembled history messages.

## Tests
- `PYTHONPATH=. uv run --no-sync pytest tests/unit/run/test_run_messages.py -q` from `libs/agno`
- `uv run ruff check libs/agno/agno/run/messages.py libs/agno/tests/unit/run/test_run_messages.py`
- `git diff --check`