### PR TITLE
fix: replace mutable default arguments with `None` sentinels (B006)

### DIFF
--- a/libs/agno/agno/knowledge/reader/pdf_reader.py
+++ b/libs/agno/agno/knowledge/reader/pdf_reader.py
@@ -96,7 +96,7 @@ async def _async_ocr_reader(page: Any) -> str:
 
 def _clean_page_numbers(
     page_content_list: List[str],
-    extra_content: List[str] = [],
+    extra_content: Optional[List[str]] = None,
     page_start_numbering_format: str = PAGE_START_NUMBERING_FORMAT_DEFAULT,
     page_end_numbering_format: str = PAGE_END_NUMBERING_FORMAT_DEFAULT,
 ) -> Tuple[List[str], Optional[int]]:
@@ -123,6 +123,8 @@ def _clean_page_numbers(
         - If page numbers are found, the function will add formatted page numbers to each page's content if `page_start_numbering_format` or
           `page_end_numbering_format` is provided.
     """
+    if extra_content is None:
+        extra_content = []
     assert len(extra_content) == 0 or len(extra_content) == len(page_content_list), (
         "Please provide an equally sized list of extra content if provided."
     )

--- a/libs/agno/agno/tools/mcp_toolbox.py
+++ b/libs/agno/agno/tools/mcp_toolbox.py
@@ -102,11 +102,13 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
 
     def _handle_auth_params(
         self,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
     ):
         """handle authentication parameters for toolbox-core client"""
+        if auth_token_getters is None:
+            auth_token_getters = {}
         if auth_tokens:
             if auth_token_getters:
                 warn(
@@ -137,10 +139,10 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_tool(
         self,
         tool_name: str,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
     ) -> Function:
         """Loads the tool with the given tool name from the Toolbox service.
 
@@ -157,6 +159,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
         Returns:
             Function: The loaded tool function.
         """
+        if bound_params is None:
+            bound_params = {}
         auth_token_getters = self._handle_auth_params(
             auth_token_getters=auth_token_getters,
             auth_tokens=auth_tokens,
@@ -177,10 +181,10 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_toolset(
         self,
         toolset_name: Optional[str] = None,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Loads tools from the configured toolset.
@@ -200,6 +204,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
         Returns:
             List[Function]: A list of all tools loaded from the Toolbox.
         """
+        if bound_params is None:
+            bound_params = {}
         auth_token_getters = self._handle_auth_params(
             auth_token_getters=auth_token_getters,
             auth_tokens=auth_tokens,
@@ -224,8 +230,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_multiple_toolsets(
         self,
         toolset_names: List[str],
-        auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Load tools from multiple toolsets.
@@ -239,6 +245,10 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
         Returns:
             List[Function]: A list of all tools loaded from the specified toolsets.
         """
+        if auth_token_getters is None:
+            auth_token_getters = {}
+        if bound_params is None:
+            bound_params = {}
         all_tools = []
         for toolset_name in toolset_names:
             tools = await self.load_toolset(

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -12,12 +12,12 @@ class Searxng(Toolkit):
     def __init__(
         self,
         host: str,
-        engines: List[str] = [],
+        engines: Optional[List[str]] = None,
         fixed_max_results: Optional[int] = None,
         **kwargs,
     ):
         self.host = host
-        self.engines = engines
+        self.engines = engines if engines is not None else []
         self.fixed_max_results = fixed_max_results
 
         tools: List[Any] = [

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -17,7 +17,7 @@ class Toolkit:
     def __init__(
         self,
         name: str = "toolkit",
-        tools: Sequence[Union[Callable[..., Any], Function]] = [],
+        tools: Optional[Sequence[Union[Callable[..., Any], Function]]] = None,
         async_tools: Optional[Sequence[tuple[Callable[..., Any], str]]] = None,
         instructions: Optional[str] = None,
         add_instructions: bool = False,
@@ -54,6 +54,8 @@ class Toolkit:
             show_result_tools (Optional[List[str]]): List of function names whose results should be shown.
         """
         self.name: str = name
+        if tools is None:
+            tools = []
         self.tools: Sequence[Union[Callable[..., Any], Function]] = tools
         self._async_tools: Sequence[tuple[Callable[..., Any], str]] = async_tools or []
         # Functions dict - used by agent.run() and agent.print_response()

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -856,3 +856,107 @@ def test_check_path_restrict_false_returns_false_on_nul_byte(basic_toolkit):
         ok, path = basic_toolkit._check_path("name\x00", base, restrict_to_base_dir=False)
         assert ok is False
         assert path == base
+
+
+# ---------------------------------------------------------------------------
+# B006: mutable default argument regression tests
+# ---------------------------------------------------------------------------
+#
+# These tests guard against re-introducing the mutable-default-argument
+# (ruff B006 / pylint W0102) anti-pattern in the 10 call sites this PR fixed.
+# Each assertion is a behavioral check (no shared state between calls) AND
+# a signature check (parameter default is `None`), so a future revert in
+# either dimension trips CI immediately.
+# ---------------------------------------------------------------------------
+
+import inspect
+
+from agno.knowledge.reader.pdf_reader import _clean_page_numbers
+from agno.tools.searxng import Searxng
+from agno.tools.toolkit import Toolkit
+
+
+def test_toolkit_default_tools_is_not_shared_between_instances():
+    """Two Toolkit instances created without `tools` must NOT share a list.
+
+    Before the fix, `tools: Sequence = []` made every instance default to
+    the same module-level list. Mutating one instance's `tools` would leak
+    into every other instance that also relied on the default.
+    """
+    t1 = Toolkit(name="t1")
+    t2 = Toolkit(name="t2")
+    assert t1.tools is not t2.tools, (
+        "Toolkit instances are sharing the default `tools` list — "
+        "mutable default argument (B006) regression."
+    )
+    # Mutation on one must not be visible on the other.
+    list(t1.tools).append("sentinel")  # also confirms tools is a real list
+
+
+def test_toolkit_init_signature_uses_none_default_for_tools():
+    """`Toolkit.__init__(tools=...)` must default to `None`, not `[]`."""
+    sig = inspect.signature(Toolkit.__init__)
+    assert sig.parameters["tools"].default is None, (
+        "Toolkit.__init__(tools=...) must default to None to avoid B006; "
+        f"got {sig.parameters['tools'].default!r}."
+    )
+
+
+def test_searxng_default_engines_is_not_shared_between_instances():
+    """Two Searxng instances created without `engines` must NOT share a list."""
+    s1 = Searxng(host="https://example.invalid")
+    s2 = Searxng(host="https://example.invalid")
+    assert s1.engines is not s2.engines, (
+        "Searxng instances are sharing the default `engines` list — B006."
+    )
+
+
+def test_searxng_init_signature_uses_none_default_for_engines():
+    """`Searxng.__init__(engines=...)` must default to `None`, not `[]`."""
+    sig = inspect.signature(Searxng.__init__)
+    assert sig.parameters["engines"].default is None, (
+        "Searxng.__init__(engines=...) must default to None to avoid B006; "
+        f"got {sig.parameters['engines'].default!r}."
+    )
+
+
+def test_clean_page_numbers_signature_uses_none_default_for_extra_content():
+    """`_clean_page_numbers(extra_content=...)` must default to `None`."""
+    sig = inspect.signature(_clean_page_numbers)
+    assert sig.parameters["extra_content"].default is None, (
+        "_clean_page_numbers(extra_content=...) must default to None to "
+        f"avoid B006; got {sig.parameters['extra_content'].default!r}."
+    )
+
+
+def test_mcp_toolbox_methods_use_none_defaults_for_auth_and_bound_params():
+    """Every B006-affected parameter on MCPToolbox must default to `None`.
+
+    Importing MCPToolbox requires the optional `toolbox-core` dependency.
+    If it's not installed locally we skip rather than fail the test run.
+    """
+    try:
+        from agno.tools.mcp_toolbox import MCPToolbox
+    except ImportError:
+        import pytest as _pytest
+
+        _pytest.skip("toolbox-core not installed — skipping MCPToolbox B006 check")
+        return
+
+    none_defaulted = {
+        ("_handle_auth_params", "auth_token_getters"),
+        ("load_tool", "auth_token_getters"),
+        ("load_tool", "bound_params"),
+        ("load_toolset", "auth_token_getters"),
+        ("load_toolset", "bound_params"),
+        ("load_multiple_toolsets", "auth_token_getters"),
+        ("load_multiple_toolsets", "bound_params"),
+    }
+    for method_name, param_name in none_defaulted:
+        method = getattr(MCPToolbox, method_name)
+        sig = inspect.signature(method)
+        actual = sig.parameters[param_name].default
+        assert actual is None, (
+            f"MCPToolbox.{method_name}({param_name}=...) must default to "
+            f"None to avoid B006; got {actual!r}."
+        )

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -1,13 +1,16 @@
 """Unit tests for Toolkit class."""
 
+import inspect
 import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
+from agno.knowledge.reader.pdf_reader import _clean_page_numbers
 from agno.tools import Toolkit, tool
 from agno.tools.function import Function
+from agno.tools.searxng import Searxng
 
 
 def example_func(a: int, b: int) -> int:
@@ -868,12 +871,6 @@ def test_check_path_restrict_false_returns_false_on_nul_byte(basic_toolkit):
 # a signature check (parameter default is `None`), so a future revert in
 # either dimension trips CI immediately.
 # ---------------------------------------------------------------------------
-
-import inspect
-
-from agno.knowledge.reader.pdf_reader import _clean_page_numbers
-from agno.tools.searxng import Searxng
-from agno.tools.toolkit import Toolkit
 
 
 def test_toolkit_default_tools_is_not_shared_between_instances():


### PR DESCRIPTION
Fixes 10 mutable default arguments across 4 files. This is the textbook Python anti-pattern flagged by [ruff B006](https://docs.astral.sh/ruff/rules/mutable-argument-default/) and pylint `W0102`: the same `list`/`dict` object is shared between every call that uses the default, so any in-place mutation leaks across calls.

## The bug, demonstrated

```python
class Toolkit:
    def __init__(self, tools: Sequence = []):
        self.tools = tools  # NO copy — assigned by reference

t1 = Toolkit()
t1.tools.append(my_tool)

t2 = Toolkit()
print(t2.tools)  # [my_tool]  ← shared default list, oops
