### PR TITLE
feat: Add Tzafon (Lightcone) tools and example

### DIFF
--- a/cookbook/91_tools/tzafon_tools.py
+++ b/cookbook/91_tools/tzafon_tools.py
@@ -1,0 +1,63 @@
+"""
+Tzafon Tools
+=============================
+
+Demonstrates the Tzafon (Lightcone) cloud-computer tools: an agent visits a website
+and describes it from a screenshot it can actually see.
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.tools.tzafon import TzafonTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Tzafon Configuration
+# -------------------------------
+# TZAFON_API_KEY: Your API key from the Lightcone developer dashboard.
+#   - Required for authentication
+#   - Get your API key from https://lightcone.ai/developer
+
+# The agent uses a vision-capable model to "see" the screenshots the toolkit
+# returns, plus the TzafonTools to drive a Tzafon cloud browser.
+
+agent = Agent(
+    name="Tzafon Web Assistant",
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[TzafonTools(kind="browser")],
+    instructions=[
+        "You browse the web using a Tzafon cloud browser.",
+        "When given a URL:",
+        "1. Navigate to the page.",
+        "2. Take a screenshot so you can see the page.",
+        "3. Describe what is on the page.",
+        "4. Include the hosted screenshot URL in your answer.",
+        "5. Close the session when you are done.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Visit https://news.ycombinator.com and describe the top stories"
+    )
+
+    # ==================== Async Usage ====================
+    # The same agent works for async - just use aprint_response, which routes to the
+    # async tool variants automatically.
+    #
+    # import asyncio
+    #
+    #
+    # async def main():
+    #     await agent.aprint_response(
+    #         "Visit https://news.ycombinator.com and describe the top stories"
+    #     )
+    #
+    #
+    # asyncio.run(main())

--- a/libs/agno/agno/tools/tzafon.py
+++ b/libs/agno/agno/tools/tzafon.py
@@ -1,0 +1,317 @@
+import asyncio
+import json
+from os import getenv
+from typing import Any, List, Optional
+from uuid import uuid4
+
+from agno.media import Image
+from agno.tools import Toolkit
+from agno.tools.function import ToolResult
+from agno.utils.log import log_debug, logger
+
+try:
+    from tzafon import Lightcone
+except ImportError:
+    raise ImportError("`tzafon` not installed. Please install using `pip install tzafon`")
+
+
+class TzafonTools(Toolkit):
+    """Drive a Lightcone (Tzafon) cloud computer with native SDK actions.
+
+    Uses the `tzafon` SDK directly (navigate, click, type, scroll, wait, screenshot) -
+    no Playwright or CDP required. See https://docs.lightcone.ai.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        kind: str = "browser",
+        enable_navigate: bool = True,
+        enable_screenshot: bool = True,
+        enable_click: bool = True,
+        enable_type: bool = True,
+        enable_scroll: bool = True,
+        enable_wait: bool = True,
+        enable_close: bool = True,
+        all: bool = False,
+        **kwargs,
+    ):
+        """Initialize TzafonTools.
+
+        Args:
+            api_key (str, optional): Tzafon API key. If not provided, it is read from the
+                `TZAFON_API_KEY` environment variable. Get one from the Lightcone developer
+                dashboard at https://lightcone.ai/developer.
+            kind (str): The kind of cloud computer to create, passed straight to Lightcone.
+                Use "browser" (Chromium in the foreground) or "desktop" (full Lightcone OS
+                desktop). Defaults to "browser".
+            enable_navigate (bool): Enable the navigate_to tool. Defaults to True.
+            enable_screenshot (bool): Enable the screenshot tool. Defaults to True.
+            enable_click (bool): Enable the click tool. Defaults to True.
+            enable_type (bool): Enable the type_text tool. Defaults to True.
+            enable_scroll (bool): Enable the scroll tool. Defaults to True.
+            enable_wait (bool): Enable the wait tool. Defaults to True.
+            enable_close (bool): Enable the close_session tool. Defaults to True.
+            all (bool): Enable all tools. Defaults to False.
+        """
+        self.kind = kind
+
+        self.api_key = api_key or getenv("TZAFON_API_KEY")
+        if not self.api_key:
+            raise ValueError("TZAFON_API_KEY is required. Get your API key from https://lightcone.ai/developer")
+
+        self.app = Lightcone(api_key=self.api_key)
+
+        # A single cloud computer is created lazily and reused across tool calls.
+        self._computer = None
+
+        tools: List[Any] = []
+        async_tools: List[tuple] = []
+
+        if all or enable_navigate:
+            tools.append(self.navigate_to)
+            async_tools.append((self.anavigate_to, "navigate_to"))
+        if all or enable_screenshot:
+            tools.append(self.screenshot)
+            async_tools.append((self.ascreenshot, "screenshot"))
+        if all or enable_click:
+            tools.append(self.click)
+            async_tools.append((self.aclick, "click"))
+        if all or enable_type:
+            tools.append(self.type_text)
+            async_tools.append((self.atype_text, "type_text"))
+        if all or enable_scroll:
+            tools.append(self.scroll)
+            async_tools.append((self.ascroll, "scroll"))
+        if all or enable_wait:
+            tools.append(self.wait)
+            async_tools.append((self.await_, "wait"))
+        if all or enable_close:
+            tools.append(self.close_session)
+            async_tools.append((self.aclose_session, "close_session"))
+
+        super().__init__(name="tzafon_tools", tools=tools, async_tools=async_tools, **kwargs)
+        log_debug(f"Initialized TzafonTools with tools: {tools}")
+
+    def _ensure_computer(self):
+        """Create the cloud computer on first use, then reuse it."""
+        if self._computer is None:
+            try:
+                self._computer = self.app.computer.create(kind=self.kind)  # type: ignore
+                log_debug(f"Created new Tzafon {self.kind} computer")
+            except Exception:
+                logger.exception("Failed to create Tzafon computer")
+                raise
+        return self._computer
+
+    def _capture(self) -> str:
+        """Take a screenshot and return its hosted URL (native SDK)."""
+        computer = self._ensure_computer()
+        result = computer.screenshot()
+        return computer.get_screenshot_url(result)
+
+    def _build_screenshot_result(self, url: str) -> ToolResult:
+        image = Image(id=str(uuid4()), url=url, mime_type="image/png")
+        return ToolResult(
+            content=f"Screenshot captured and attached. Return this hosted URL to the user: {url}",
+            images=[image],
+        )
+
+    # ------------------------------------------------------------------
+    # Sync tools
+    # ------------------------------------------------------------------
+    def navigate_to(self, url: str) -> str:
+        """Navigates the cloud computer to a URL.
+
+        Args:
+            url (str): The URL to navigate to.
+
+        Returns:
+            JSON string with navigation status.
+        """
+        try:
+            self._ensure_computer().navigate(url)
+            return json.dumps({"status": "complete", "url": url})
+        except Exception as e:
+            logger.error(f"Failed to navigate to {url}: {str(e)}")
+            raise e
+
+    def screenshot(self) -> ToolResult:
+        """Takes a screenshot of the current screen.
+
+        Returns:
+            A ToolResult with the screenshot attached as an image and its hosted URL.
+        """
+        try:
+            url = self._capture()
+            return self._build_screenshot_result(url)
+        except Exception as e:
+            logger.error(f"Failed to take screenshot: {str(e)}")
+            return ToolResult(content=f"Error taking screenshot: {str(e)}")
+
+    def click(self, x: int, y: int) -> str:
+        """Clicks at the given coordinates.
+
+        Args:
+            x (int): The x coordinate to click.
+            y (int): The y coordinate to click.
+
+        Returns:
+            JSON string with click status.
+        """
+        try:
+            self._ensure_computer().click(x, y)
+            return json.dumps({"status": "complete", "action": "click", "x": x, "y": y})
+        except Exception as e:
+            logger.error(f"Failed to click at ({x}, {y}): {str(e)}")
+            raise e
+
+    def type_text(self, text: str) -> str:
+        """Types text into the focused element.
+
+        Args:
+            text (str): The text to type.
+
+        Returns:
+            JSON string with type status.
+        """
+        try:
+            self._ensure_computer().type(text)
+            return json.dumps({"status": "complete", "action": "type"})
+        except Exception as e:
+            logger.error(f"Failed to type text: {str(e)}")
+            raise e
+
+    def scroll(self, dx: int, dy: int, x: int = 0, y: int = 0) -> str:
+        """Scrolls the screen.
+
+        Args:
+            dx (int): Horizontal scroll delta.
+            dy (int): Vertical scroll delta.
+            x (int): The x coordinate to scroll from. Defaults to 0.
+            y (int): The y coordinate to scroll from. Defaults to 0.
+
+        Returns:
+            JSON string with scroll status.
+        """
+        try:
+            self._ensure_computer().scroll(dx, dy, x, y)
+            return json.dumps({"status": "complete", "action": "scroll", "dx": dx, "dy": dy})
+        except Exception as e:
+            logger.error(f"Failed to scroll: {str(e)}")
+            raise e
+
+    def wait(self, seconds: float) -> str:
+        """Waits for the given number of seconds.
+
+        Args:
+            seconds (float): How long to wait.
+
+        Returns:
+            JSON string with wait status.
+        """
+        try:
+            self._ensure_computer().wait(seconds)
+            return json.dumps({"status": "complete", "action": "wait", "seconds": seconds})
+        except Exception as e:
+            logger.error(f"Failed to wait: {str(e)}")
+            raise e
+
+    def close_session(self) -> str:
+        """Terminates the cloud computer and releases resources.
+
+        Returns:
+            JSON string with closure status.
+        """
+        if self._computer is None:
+            return json.dumps({"status": "closed", "message": "No active Tzafon computer."})
+        try:
+            self._computer.terminate()
+        except Exception as e:
+            logger.warning(f"Failed to terminate Tzafon computer: {str(e)}")
+        finally:
+            self._computer = None
+        return json.dumps({"status": "closed", "message": "Tzafon computer terminated."})
+
+    # ------------------------------------------------------------------
+    # Async tools (the tzafon SDK is synchronous; wrap calls in a thread)
+    # ------------------------------------------------------------------
+    async def anavigate_to(self, url: str) -> str:
+        """Navigates the cloud computer to a URL asynchronously.
+
+        Args:
+            url (str): The URL to navigate to.
+
+        Returns:
+            JSON string with navigation status.
+        """
+        return await asyncio.to_thread(self.navigate_to, url)
+
+    async def ascreenshot(self) -> ToolResult:
+        """Takes a screenshot of the current screen asynchronously.
+
+        Returns:
+            A ToolResult with the screenshot attached as an image and its hosted URL.
+        """
+        try:
+            url = await asyncio.to_thread(self._capture)
+            return self._build_screenshot_result(url)
+        except Exception as e:
+            logger.error(f"Failed to take screenshot: {str(e)}")
+            return ToolResult(content=f"Error taking screenshot: {str(e)}")
+
+    async def aclick(self, x: int, y: int) -> str:
+        """Clicks at the given coordinates asynchronously.
+
+        Args:
+            x (int): The x coordinate to click.
+            y (int): The y coordinate to click.
+
+        Returns:
+            JSON string with click status.
+        """
+        return await asyncio.to_thread(self.click, x, y)
+
+    async def atype_text(self, text: str) -> str:
+        """Types text into the focused element asynchronously.
+
+        Args:
+            text (str): The text to type.
+
+        Returns:
+            JSON string with type status.
+        """
+        return await asyncio.to_thread(self.type_text, text)
+
+    async def ascroll(self, dx: int, dy: int, x: int = 0, y: int = 0) -> str:
+        """Scrolls the screen asynchronously.
+
+        Args:
+            dx (int): Horizontal scroll delta.
+            dy (int): Vertical scroll delta.
+            x (int): The x coordinate to scroll from. Defaults to 0.
+            y (int): The y coordinate to scroll from. Defaults to 0.
+
+        Returns:
+            JSON string with scroll status.
+        """
+        return await asyncio.to_thread(self.scroll, dx, dy, x, y)
+
+    async def await_(self, seconds: float) -> str:
+        """Waits for the given number of seconds asynchronously.
+
+        Args:
+            seconds (float): How long to wait.
+
+        Returns:
+            JSON string with wait status.
+        """
+        return await asyncio.to_thread(self.wait, seconds)
+
+    async def aclose_session(self) -> str:
+        """Terminates the cloud computer asynchronously.
+
+        Returns:
+            JSON string with closure status.
+        """
+        return await asyncio.to_thread(self.close_session)

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -145,6 +145,7 @@ reportlab = ["reportlab"]
 salesforce = ["simple-salesforce"]
 scrapegraph = ["scrapegraph-py>=2.0.0"]
 todoist = ["todoist-api-python"]
+tzafon = ["tzafon"]
 valyu = ["valyu"]
 webex = ["webexpythonsdk"]
 yfinance = ["yfinance"]
@@ -289,6 +290,7 @@ tools = [
   "agno[redshift]",
   "agno[reportlab]",
   "agno[trafilatura]",
+  "agno[tzafon]",
   "agno[neo4j]",
 ]
 
@@ -572,6 +574,7 @@ module = [
   "todoist_api_python.*",
   "tweepy.*",
   "twilio.*",
+  "tzafon.*",
   "tzlocal.*",
   "upstash_vector.*",
   "urllib3.*",

--- a/libs/agno/tests/unit/tools/test_tzafon.py
+++ b/libs/agno/tests/unit/tools/test_tzafon.py
@@ -1,0 +1,153 @@
+"""Unit tests for TzafonTools."""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agno.media import Image
+from agno.tools.function import ToolResult
+from agno.tools.tzafon import TzafonTools
+
+TEST_API_KEY = "test_api_key"
+TEST_SCREENSHOT_URL = "https://api.tzafon.ai/screenshots/abc.png"
+
+
+@pytest.fixture
+def mock_lightcone():
+    """Patch the Lightcone client and return (client, computer) mocks."""
+    with patch("agno.tools.tzafon.Lightcone") as mock_lightcone_cls:
+        mock_client = Mock()
+        mock_computer = Mock()
+        mock_computer.screenshot.return_value = {"raw": "result"}
+        mock_computer.get_screenshot_url.return_value = TEST_SCREENSHOT_URL
+        mock_client.computer.create.return_value = mock_computer
+        mock_lightcone_cls.return_value = mock_client
+        yield mock_client, mock_computer
+
+
+@pytest.fixture
+def tools(mock_lightcone):
+    return TzafonTools(api_key=TEST_API_KEY)
+
+
+def test_initialization_with_api_key(mock_lightcone):
+    tools = TzafonTools(api_key=TEST_API_KEY, kind="desktop")
+    assert tools.api_key == TEST_API_KEY
+    assert tools.kind == "desktop"
+    assert tools._computer is None
+
+
+def test_initialization_reads_env(mock_lightcone):
+    with patch.dict(os.environ, {"TZAFON_API_KEY": "env_key"}, clear=True):
+        tools = TzafonTools()
+        assert tools.api_key == "env_key"
+
+
+def test_initialization_without_api_key_raises():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError):
+            TzafonTools()
+
+
+def test_ensure_computer_creates_once(tools, mock_lightcone):
+    mock_client, mock_computer = mock_lightcone
+    first = tools._ensure_computer()
+    second = tools._ensure_computer()
+    assert first is mock_computer
+    assert second is mock_computer
+    mock_client.computer.create.assert_called_once_with(kind="browser")
+
+
+def test_navigate_to(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    result = json.loads(tools.navigate_to("https://news.ycombinator.com"))
+    mock_computer.navigate.assert_called_once_with("https://news.ycombinator.com")
+    assert result["status"] == "complete"
+    assert result["url"] == "https://news.ycombinator.com"
+
+
+def test_click(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    tools.click(10, 20)
+    mock_computer.click.assert_called_once_with(10, 20)
+
+
+def test_type_text(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    tools.type_text("hello")
+    mock_computer.type.assert_called_once_with("hello")
+
+
+def test_scroll(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    tools.scroll(0, 100)
+    mock_computer.scroll.assert_called_once_with(0, 100, 0, 0)
+
+
+def test_wait(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    tools.wait(2)
+    mock_computer.wait.assert_called_once_with(2)
+
+
+def test_screenshot_returns_image_and_url(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    result = tools.screenshot()
+    assert isinstance(result, ToolResult)
+    assert TEST_SCREENSHOT_URL in result.content
+    assert result.images is not None
+    assert isinstance(result.images[0], Image)
+    assert result.images[0].url == TEST_SCREENSHOT_URL
+    mock_computer.screenshot.assert_called_once()
+    mock_computer.get_screenshot_url.assert_called_once_with({"raw": "result"})
+
+
+def test_screenshot_error_returns_toolresult(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    mock_computer.screenshot.side_effect = Exception("boom")
+    result = tools.screenshot()
+    assert isinstance(result, ToolResult)
+    assert "Error taking screenshot" in result.content
+    assert not result.images
+
+
+def test_close_session_terminates_and_resets(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    tools._ensure_computer()
+    result = json.loads(tools.close_session())
+    mock_computer.terminate.assert_called_once()
+    assert tools._computer is None
+    assert result["status"] == "closed"
+
+
+def test_close_session_without_computer(tools):
+    result = json.loads(tools.close_session())
+    assert result["status"] == "closed"
+    assert "No active" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_anavigate_to(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    result = json.loads(await tools.anavigate_to("https://example.com"))
+    mock_computer.navigate.assert_called_once_with("https://example.com")
+    assert result["status"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_ascreenshot(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    result = await tools.ascreenshot()
+    assert isinstance(result, ToolResult)
+    assert result.images[0].url == TEST_SCREENSHOT_URL
+
+
+@pytest.mark.asyncio
+async def test_aclose_session(tools, mock_lightcone):
+    _, mock_computer = mock_lightcone
+    tools._ensure_computer()
+    result = json.loads(await tools.aclose_session())
+    mock_computer.terminate.assert_called_once()
+    assert result["status"] == "closed"


### PR DESCRIPTION


## Summary

 This PR adds TzafonTools, a new toolkit that lets an Agno agent drive a
  Tzafon/Lightcone (https://docs.lightcone.ai) cloud computer (browser or
  desktop) using the native tzafon SDK — no Playwright or CDP required,
  matching how Lightcone's own LangChain/CrewAI integrations work. The
  toolkit creates a single cloud computer lazily (reused across calls) via
  Lightcone().computer.create(kind=...), where kind is passed straight
  through ("browser" or "desktop"), and exposes navigate_to, click,
  type_text, scroll, wait, screenshot, and close_session, each with an async
  variant (the sync SDK is wrapped in asyncio.to_thread). The screenshot tool
  returns both the captured image (as an Agno Image so a vision model can
  see the page) and the hosted screenshot URL in the tool result, so the
  model can relay the link back to the user. Includes a cookbook example
  (cookbook/91_tools/tzafon_tools.py) where an agent visits Hacker News and
  describes the top stories, mocked unit tests covering all tools sync and
  async (16 passing, no network), and the tzafon optional dependency + mypy
  entries in pyproject.toml. Auth is via TZAFON_API_KEY (key from the
  Lightcone developer dashboard). This is scoped to the tools integration
  only; the Tzafon model provider is handled separately in #6813.
(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
