### PR TITLE
fix: close OpenAI transcription files

### DIFF
--- a/libs/agno/agno/tools/openai.py
+++ b/libs/agno/agno/tools/openai.py
@@ -87,13 +87,12 @@ class OpenAITools(Toolkit):
         """
         log_debug(f"Transcribing audio from {audio_path}")
         try:
-            audio_file = open(audio_path, "rb")
-
-            transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
-                model=self.transcription_model,
-                file=audio_file,
-                response_format="text",
-            )
+            with open(audio_path, "rb") as audio_file:
+                transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
+                    model=self.transcription_model,
+                    file=audio_file,
+                    response_format="text",
+                )
         except Exception as e:  # type: ignore[return]
             log_error(f"Failed to transcribe audio: {str(e)}")
             return f"Failed to transcribe audio: {str(e)}"

--- a/libs/agno/tests/unit/tools/test_openai_tools.py
+++ b/libs/agno/tests/unit/tools/test_openai_tools.py
@@ -1,0 +1,45 @@
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from agno.tools.openai import OpenAITools
+
+
+@pytest.fixture(autouse=True)
+def openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-api-key")
+
+
+@patch("agno.tools.toolkit.Toolkit.__init__", return_value=None)
+@patch("agno.tools.openai.OpenAIClient")
+def test_transcribe_audio_closes_file(mock_client_cls, mock_toolkit_init):
+    mock_client = MagicMock()
+    mock_client.audio.transcriptions.create.return_value = "transcript"
+    mock_client_cls.return_value = mock_client
+
+    opened = mock_open(read_data=b"audio")
+    with patch("builtins.open", opened):
+        result = OpenAITools().transcribe_audio("/tmp/audio.wav")
+
+    assert result == "transcript"
+    opened.return_value.close.assert_called_once()
+    mock_client.audio.transcriptions.create.assert_called_once_with(
+        model="whisper-1",
+        file=opened.return_value,
+        response_format="text",
+    )
+
+
+@patch("agno.tools.toolkit.Toolkit.__init__", return_value=None)
+@patch("agno.tools.openai.OpenAIClient")
+def test_transcribe_audio_closes_file_on_api_error(mock_client_cls, mock_toolkit_init):
+    mock_client = MagicMock()
+    mock_client.audio.transcriptions.create.side_effect = RuntimeError("api down")
+    mock_client_cls.return_value = mock_client
+
+    opened = mock_open(read_data=b"audio")
+    with patch("builtins.open", opened):
+        result = OpenAITools().transcribe_audio("/tmp/audio.wav")
+
+    assert "Failed to transcribe audio: api down" == result
+    opened.return_value.close.assert_called_once()


### PR DESCRIPTION
﻿## Summary
- close the audio file in `OpenAITools.transcribe_audio` with a context manager
- add a regression test for both successful transcription and API-error paths

Fixes #8160.

## To verify
- `python -m pytest libs/agno/tests/unit/tools/test_openai_tools.py -q`
- `python -m ruff check libs/agno/agno/tools/openai.py libs/agno/tests/unit/tools/test_openai_tools.py`
- `python -m ruff format --check libs/agno/agno/tools/openai.py libs/agno/tests/unit/tools/test_openai_tools.py`
- `git diff --check`
