### PR TITLE
fix: avoid blocking sleep in Couchbase async setup

### DIFF
--- a/libs/agno/agno/vectordb/couchbase/couchbase.py
+++ b/libs/agno/agno/vectordb/couchbase/couchbase.py
@@ -749,7 +749,7 @@ class CouchbaseSearch(VectorDb):
                     collection_name=self.collection_name, scope_name=self.scope_name
                 )
                 logger.info(f"Successfully dropped collection '{self.collection_name}'.")
-                time.sleep(1)  # Brief wait after drop, as in original code
+                await asyncio.sleep(1)  # Brief wait after drop, as in original code
             except CollectionNotFoundException:
                 logger.info(
                     f"Collection '{self.collection_name}' not found in scope '{self.scope_name}'. No need to drop."

--- a/libs/agno/tests/unit/vectordb/test_couchbase.py
+++ b/libs/agno/tests/unit/vectordb/test_couchbase.py
@@ -627,6 +627,30 @@ async def test_async_create(couchbase_fts):
 
 
 @pytest.mark.asyncio
+async def test_async_create_collection_with_overwrite_uses_non_blocking_sleep(couchbase_fts_overwrite):
+    collection_manager = Mock()
+    collection_manager.create_scope = AsyncMock()
+    collection_manager.drop_collection = AsyncMock()
+    collection_manager.create_collection = AsyncMock()
+
+    async_bucket = Mock()
+    async_bucket.collections.return_value = collection_manager
+
+    with (
+        patch.object(couchbase_fts_overwrite, "get_async_bucket", AsyncMock(return_value=async_bucket)),
+        patch("agno.vectordb.couchbase.couchbase.asyncio.sleep", new_callable=AsyncMock) as sleep,
+        patch("agno.vectordb.couchbase.couchbase.time.sleep") as blocking_sleep,
+    ):
+        await couchbase_fts_overwrite._async_create_collection_and_scope()
+
+    collection_manager.drop_collection.assert_awaited_once_with(
+        collection_name=couchbase_fts_overwrite.collection_name, scope_name=couchbase_fts_overwrite.scope_name
+    )
+    sleep.assert_awaited_once_with(1)
+    blocking_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_async_id_exists(couchbase_fts):
     """Test the async_id_exists method."""
     mock_collection_inst = AsyncMock(spec=AsyncCollection)


### PR DESCRIPTION
﻿## Summary
- replace the blocking `time.sleep(1)` in the async Couchbase overwrite path with `await asyncio.sleep(1)`
- add a regression test that asserts the async path yields through `asyncio.sleep` and does not call the blocking sleep helper

Fixes #8157.

## To verify
- `python -m pytest libs/agno/tests/unit/vectordb/test_couchbase.py -q`
- `python -m ruff check libs/agno/agno/vectordb/couchbase/couchbase.py libs/agno/tests/unit/vectordb/test_couchbase.py`
- `python -m ruff format --check libs/agno/agno/vectordb/couchbase/couchbase.py libs/agno/tests/unit/vectordb/test_couchbase.py`
- `git diff --check`
