### PR TITLE
fix: avoid mutable default arguments

### DIFF
--- a/libs/agno/agno/knowledge/reader/pdf_reader.py
+++ b/libs/agno/agno/knowledge/reader/pdf_reader.py
@@ -96,7 +96,7 @@ async def _async_ocr_reader(page: Any) -> str:
 
 def _clean_page_numbers(
     page_content_list: List[str],
-    extra_content: List[str] = [],
+    extra_content: Optional[List[str]] = None,
     page_start_numbering_format: str = PAGE_START_NUMBERING_FORMAT_DEFAULT,
     page_end_numbering_format: str = PAGE_END_NUMBERING_FORMAT_DEFAULT,
 ) -> Tuple[List[str], Optional[int]]:
@@ -123,6 +123,8 @@ def _clean_page_numbers(
         - If page numbers are found, the function will add formatted page numbers to each page's content if `page_start_numbering_format` or
           `page_end_numbering_format` is provided.
     """
+    if extra_content is None:
+        extra_content = []
     assert len(extra_content) == 0 or len(extra_content) == len(page_content_list), (
         "Please provide an equally sized list of extra content if provided."
     )

--- a/libs/agno/agno/tools/mcp_toolbox.py
+++ b/libs/agno/agno/tools/mcp_toolbox.py
@@ -104,11 +104,13 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
 
     def _handle_auth_params(
         self,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
     ):
         """handle authentication parameters for toolbox-core client"""
+        if auth_token_getters is None:
+            auth_token_getters = {}
         if auth_tokens:
             if auth_token_getters:
                 warn(
@@ -139,10 +141,10 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_tool(
         self,
         tool_name: str,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
     ) -> Function:
         """Loads the tool with the given tool name from the Toolbox service.
 
@@ -164,6 +166,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
             auth_tokens=auth_tokens,
             auth_headers=auth_headers,
         )
+        if bound_params is None:
+            bound_params = {}
 
         core_sync_tool = await self.__core_client.load_tool(
             name=tool_name,
@@ -179,10 +183,10 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_toolset(
         self,
         toolset_name: Optional[str] = None,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Loads tools from the configured toolset.
@@ -207,6 +211,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
             auth_tokens=auth_tokens,
             auth_headers=auth_headers,
         )
+        if bound_params is None:
+            bound_params = {}
 
         core_sync_tools = await self.__core_client.load_toolset(
             name=toolset_name,
@@ -226,8 +232,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_multiple_toolsets(
         self,
         toolset_names: List[str],
-        auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Load tools from multiple toolsets.
@@ -241,6 +247,10 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
         Returns:
             List[Function]: A list of all tools loaded from the specified toolsets.
         """
+        if auth_token_getters is None:
+            auth_token_getters = {}
+        if bound_params is None:
+            bound_params = {}
         all_tools = []
         for toolset_name in toolset_names:
             tools = await self.load_toolset(

--- a/libs/agno/tests/unit/reader/test_pdf_reader.py
+++ b/libs/agno/tests/unit/reader/test_pdf_reader.py
@@ -317,6 +317,18 @@ def test_clean_page_numbers_single_page_leading_digit_preserved(p_nr_format):
     assert not clean_content[0].startswith(p_nr_format["start"].format(page_nr=2))
 
 
+def test_clean_page_numbers_default_extra_content_is_not_shared():
+    from inspect import signature
+
+    assert signature(_clean_page_numbers).parameters["extra_content"].default is None
+
+    first, _ = _clean_page_numbers(["page one"])
+    second, _ = _clean_page_numbers(["page two"])
+
+    assert first == ["page one"]
+    assert second == ["page two"]
+
+
 def _create_encrypted_pdf_with_empty_password() -> BytesIO:
     from pypdf import PdfWriter
 


### PR DESCRIPTION
﻿Fixes #8155.

## Summary
- replace mutable `[]` / `{}` defaults with `None` in Toolkit, Searxng, MCPToolbox, and PDF page cleanup helpers
- create fresh empty containers inside each call while preserving explicitly supplied empty containers
- add regression coverage for shared default-list behavior in Toolkit, Searxng, and `_clean_page_numbers`

## To verify
- `python -m pytest libs/agno/tests/unit/tools/test_toolkit.py::test_toolkit_default_tools_are_not_shared libs/agno/tests/unit/tools/test_searxng.py::test_searxng_default_engines_are_not_shared libs/agno/tests/unit/reader/test_pdf_reader.py::test_clean_page_numbers_default_extra_content_is_not_shared -q`
- `python -m py_compile libs/agno/agno/tools/mcp_toolbox.py libs/agno/agno/knowledge/reader/pdf_reader.py libs/agno/agno/tools/toolkit.py libs/agno/agno/tools/searxng.py`
- `python -m ruff check libs/agno/agno/tools/toolkit.py libs/agno/agno/tools/searxng.py libs/agno/agno/tools/mcp_toolbox.py libs/agno/agno/knowledge/reader/pdf_reader.py libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/reader/test_pdf_reader.py`
- `python -m ruff format --check libs/agno/agno/tools/toolkit.py libs/agno/agno/tools/searxng.py libs/agno/agno/tools/mcp_toolbox.py libs/agno/agno/knowledge/reader/pdf_reader.py libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/reader/test_pdf_reader.py`

Note: I also ran the full selected file set `python -m pytest libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/reader/test_pdf_reader.py -q`; the new tests passed, but the run exposed an existing Windows-only failure in `test_check_path_restrict_false_returns_false_on_nul_byte`, unrelated to this change.
