### PR TITLE
feat: extract JWT-style claims from AGUI forwardedProps

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/jwt_claims_auth.py
+++ b/cookbook/05_agent_os/interfaces/agui/jwt_claims_auth.py
@@ -1,0 +1,94 @@
+"""
+JWT Claims Auth via AGUI forwardedProps
+========================================
+
+Demonstrates how to wire JWT-style identity and profile claims from the
+frontend into the agent automatically using AGUI's claim-extraction config.
+
+Pattern:
+1. Your frontend (e.g. CopilotKit) verifies the user's JWT and decodes its
+   claims into a flat dict (e.g. {"sub": ..., "email": ..., "name": ...}).
+2. The frontend places those claims in the AGUI request's `forwardedProps`.
+3. AGUI extracts them per your configuration and feeds them to the agent
+   run as `user_id` and `dependencies`. Setting `dependencies_claims`
+   automatically enables `add_dependencies_to_context=True`, so values
+   appear in prompt templates.
+
+Security note: JWT signature verification must happen on the frontend or in
+upstream middleware. This interface trusts whatever forwardedProps contains.
+
+Heads up: this example's `instructions` reference `{email}` and `{name}`. If
+a request arrives without those keys in `forwardedProps`, the template
+variables pass through as literal text (e.g. "User name: {name}") into the
+LLM prompt - which is agno's documented behavior when dependencies are not
+applied. Verify your wiring first with the curl example in the __main__
+block before connecting from a UI client.
+"""
+
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# The agent's instructions reference {email} and {name} via dependencies.
+# AGUI will fill these in per-request from the decoded JWT claims.
+chat_agent = Agent(
+    name="ClaimsAwareAssistant",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions=(
+        "You are a helpful AI assistant. Greet the user by their first name when relevant. "
+        "User email: {email}. User name: {name}."
+    ),
+    add_datetime_to_context=True,
+    markdown=True,
+)
+
+# Configure AGUI to extract:
+#   - "sub" claim (the JWT subject) -> user_id
+#   - "email" and "name" claims    -> dependencies dict (auto-added to prompt context)
+agent_os = AgentOS(
+    agents=[chat_agent],
+    interfaces=[
+        AGUI(
+            agent=chat_agent,
+            user_id_claim="sub",
+            dependencies_claims=["email", "name"],
+        )
+    ],
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """Run your AgentOS.
+
+    Test with a curl that sets forwardedProps as if the frontend just decoded a JWT:
+
+        curl -N -X POST http://localhost:9001/agui \\
+          -H 'content-type: application/json' \\
+          -d '{
+            "threadId":"t1",
+            "runId":"r1",
+            "state":{},
+            "messages":[{"id":"m1","role":"user","content":"Who am I?"}],
+            "tools":[],
+            "context":[],
+            "forwardedProps":{
+              "sub":"user-123",
+              "email":"alice@example.com",
+              "name":"Alice"
+            }
+          }'
+
+    The agent's response will greet Alice by name and reference her email - those
+    values were pulled from forwardedProps because of dependencies_claims.
+    """
+    agent_os.serve(app="jwt_claims_auth:app", reload=True, port=9001)

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -6,7 +6,7 @@ from fastapi.routing import APIRouter
 
 from agno.agent import Agent
 from agno.agent.remote import RemoteAgent
-from agno.os.interfaces.agui.router import attach_routes
+from agno.os.interfaces.agui.router import DEFAULT_USER_ID_CLAIM, attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
 from agno.team.remote import RemoteTeam
@@ -23,6 +23,8 @@ class AGUI(BaseInterface):
         team: Optional[Union[Team, RemoteTeam]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
+        user_id_claim: Optional[str] = None,
+        dependencies_claims: Optional[List[str]] = None,
     ):
         """
         Initialize the AGUI interface.
@@ -32,11 +34,21 @@ class AGUI(BaseInterface):
             team: The team to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
+            user_id_claim: Key in forwardedProps to extract as user_id (defaults to "user_id").
+                Use this when your frontend's decoded JWT places the user identifier under a
+                different name (e.g. "sub").
+            dependencies_claims: Keys in forwardedProps to extract and pass to the underlying
+                agent/team as a `dependencies` dict. When non-empty, the run is also called
+                with `add_dependencies_to_context=True` so the values become available in
+                prompt templates (e.g. as `{email}` if "email" is in this list). Missing keys
+                are silently skipped.
         """
         self.agent = agent
         self.team = team
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
+        self.user_id_claim = user_id_claim or DEFAULT_USER_ID_CLAIM
+        self.dependencies_claims = dependencies_claims or []
 
         if not (self.agent or self.team):
             raise ValueError("AGUI requires an agent or a team")
@@ -44,6 +56,12 @@ class AGUI(BaseInterface):
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(
+            router=self.router,
+            agent=self.agent,
+            team=self.team,
+            user_id_claim=self.user_id_claim,
+            dependencies_claims=self.dependencies_claims,
+        )
 
         return self.router

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,6 +1,6 @@
 import copy
 import uuid
-from typing import AsyncIterator, Optional, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Union
 
 from agno.utils.log import log_error
 
@@ -26,10 +26,33 @@ from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_ev
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
 
+DEFAULT_USER_ID_CLAIM = "user_id"
+
+
+def _extract_claims(
+    forwarded_props: Optional[Dict[str, Any]],
+    user_id_claim: str,
+    dependencies_claims: List[str],
+) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+    """Extract user_id and dependencies dict from AG-UI forwardedProps using claim names.
+
+    Returns (user_id, dependencies). `dependencies` is None when either no dependency
+    claims were configured or none of the requested keys were present in forwarded_props.
+    """
+    if not forwarded_props or not isinstance(forwarded_props, dict):
+        return None, None
+    user_id = forwarded_props.get(user_id_claim)
+    if not dependencies_claims:
+        return user_id, None
+    deps = {k: forwarded_props[k] for k in dependencies_claims if k in forwarded_props}
+    return user_id, (deps or None)
+
 
 async def run_entity(
     entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
     run_input: RunAgentInput,
+    user_id_claim: str = DEFAULT_USER_ID_CLAIM,
+    dependencies_claims: Optional[List[str]] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Shared handler for running an Agent or Team with AG-UI input/output mapping."""
     run_id = run_input.run_id or str(uuid.uuid4())
@@ -42,16 +65,17 @@ async def run_entity(
 
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
-        user_id = run_input.forwarded_props.get("user_id") if run_input.forwarded_props else None
+        user_id, claim_deps = _extract_claims(run_input.forwarded_props, user_id_claim, dependencies_claims or [])
         session_state = validate_state(run_input.state, run_input.thread_id)
 
         if session_state is not None:
             yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(session_state))
 
         ui_deps = extract_context(run_input.context)
+        merged_deps = {**(claim_deps or {}), **(ui_deps or {})}  # context wins on key collision
         run_kwargs: dict = {}
-        if ui_deps:
-            run_kwargs["dependencies"] = ui_deps
+        if merged_deps:
+            run_kwargs["dependencies"] = merged_deps
             run_kwargs["add_dependencies_to_context"] = True
 
         response_stream = entity.arun(  # type: ignore
@@ -83,7 +107,11 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    user_id_claim: str = DEFAULT_USER_ID_CLAIM,
+    dependencies_claims: Optional[List[str]] = None,
 ) -> APIRouter:
     if agent is None and team is None:
         raise ValueError("Either agent or team must be provided.")
@@ -94,7 +122,7 @@ def attach_routes(
     @router.post("/agui", name="run_agent")
     async def run_agent_agui(run_input: RunAgentInput):
         async def event_generator():
-            async for event in run_entity(entity, run_input):  # type: ignore
+            async for event in run_entity(entity, run_input, user_id_claim, dependencies_claims):  # type: ignore
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -2151,3 +2151,218 @@ def test_extract_context_preserves_none_value():
     item = MagicMock(description="empty", value=None)
     result = extract_context([item])
     assert result == {"empty": None}
+
+
+# ---------------------------------------------------------------------------
+# AGUI claims-props feature - JWT-claim extraction from forwardedProps
+# ---------------------------------------------------------------------------
+
+
+def test_extract_claims_default_user_id_only():
+    """Default claim ('user_id') pulls the user_id and returns no dependencies."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    props = {"user_id": "u-1", "email": "a@b.com"}
+    user_id, deps = _extract_claims(props, user_id_claim="user_id", dependencies_claims=[])
+    assert user_id == "u-1"
+    assert deps is None
+
+
+def test_extract_claims_custom_user_id_claim():
+    """Custom claim name (e.g. 'sub') resolves to user_id correctly."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    props = {"sub": "u-2", "email": "a@b.com"}
+    user_id, deps = _extract_claims(props, user_id_claim="sub", dependencies_claims=[])
+    assert user_id == "u-2"
+    assert deps is None
+
+
+def test_extract_claims_with_dependencies():
+    """Listed dependency claims are extracted into a flat dict with same keys."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    props = {"user_id": "u-3", "email": "a@b.com", "name": "Alice", "extra": "ignored"}
+    user_id, deps = _extract_claims(props, user_id_claim="user_id", dependencies_claims=["email", "name"])
+    assert user_id == "u-3"
+    assert deps == {"email": "a@b.com", "name": "Alice"}
+
+
+def test_extract_claims_missing_dependency_silently_skipped():
+    """Claims requested but not present in forwardedProps are silently skipped."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    props = {"user_id": "u-4"}  # no email/name
+    user_id, deps = _extract_claims(props, user_id_claim="user_id", dependencies_claims=["email", "name"])
+    assert user_id == "u-4"
+    assert deps is None  # empty dict collapses to None per the helper's contract
+
+
+def test_extract_claims_partial_dependencies():
+    """When some claims are present and others missing, only the present ones are extracted."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    props = {"user_id": "u-5", "email": "a@b.com"}  # name missing
+    user_id, deps = _extract_claims(props, user_id_claim="user_id", dependencies_claims=["email", "name"])
+    assert user_id == "u-5"
+    assert deps == {"email": "a@b.com"}
+
+
+def test_extract_claims_no_forwarded_props():
+    """None or non-dict forwarded_props yields (None, None)."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    assert _extract_claims(None, user_id_claim="user_id", dependencies_claims=["email"]) == (None, None)
+    assert _extract_claims({}, user_id_claim="user_id", dependencies_claims=["email"]) == (None, None)
+
+
+def test_extract_claims_user_id_not_in_props():
+    """If the configured user_id_claim isn't present, user_id is None but dependencies still extract."""
+    from agno.os.interfaces.agui.router import _extract_claims
+
+    props = {"email": "a@b.com"}  # no user_id or sub
+    user_id, deps = _extract_claims(props, user_id_claim="user_id", dependencies_claims=["email"])
+    assert user_id is None
+    assert deps == {"email": "a@b.com"}
+
+
+def test_agui_constructor_default_claim_config():
+    """AGUI() defaults preserve current behavior: user_id_claim='user_id', no dependencies_claims."""
+    from agno.agent.agent import Agent
+    from agno.os.interfaces.agui.agui import AGUI
+
+    agent = MagicMock(spec=Agent)
+    iface = AGUI(agent=agent)
+    assert iface.user_id_claim == "user_id"
+    assert iface.dependencies_claims == []
+
+
+def test_agui_constructor_custom_claim_config():
+    """AGUI() with custom claim config stores the values correctly."""
+    from agno.agent.agent import Agent
+    from agno.os.interfaces.agui.agui import AGUI
+
+    agent = MagicMock(spec=Agent)
+    iface = AGUI(agent=agent, user_id_claim="sub", dependencies_claims=["email", "name"])
+    assert iface.user_id_claim == "sub"
+    assert iface.dependencies_claims == ["email", "name"]
+
+
+async def test_run_entity_merges_claim_and_context_dependencies_context_wins():
+    """Claims (#8171) and readable-context (#8201) deps BOTH reach arun, merged; context wins a collision.
+
+    This is the merge landmine: it fails if either source clobbers the other, or if the
+    tie-break is not context-wins.
+    """
+    from agno.os.interfaces.agui.router import run_entity
+
+    class _CaptureEntity:
+        def __init__(self):
+            self.captured: dict = {}
+
+        async def arun(self, **kwargs):
+            self.captured = kwargs
+            return
+            yield  # make this an async generator
+
+    class _Input:
+        messages = [MagicMock(role="user", content="hi")]
+        thread_id = "t-merge"
+        run_id = "r-merge"
+        state = None
+        # "shared" exists in BOTH sources with different values -> context must win.
+        forwarded_props = {"sub": "u-9", "email": "claim@example.com", "shared": "FROM_CLAIMS"}
+        context = [
+            MagicMock(description="page", value="home"),
+            MagicMock(description="shared", value="FROM_CONTEXT"),
+        ]
+
+    entity = _CaptureEntity()
+    async for _ in run_entity(entity, _Input(), user_id_claim="sub", dependencies_claims=["email", "shared"]):
+        pass
+
+    deps = entity.captured.get("dependencies")
+    assert entity.captured.get("user_id") == "u-9"  # user_id resolved from the 'sub' claim
+    assert entity.captured.get("add_dependencies_to_context") is True
+    assert deps == {"email": "claim@example.com", "page": "home", "shared": "FROM_CONTEXT"}
+    assert deps["shared"] == "FROM_CONTEXT", "context must win on a key collision"
+    assert deps["email"] == "claim@example.com", "claim-only dependency must survive the merge"
+    assert deps["page"] == "home", "context-only dependency must survive the merge"
+
+
+def test_agui_team_constructor_claim_config():
+    """AGUI(team=...) stores claim config identically to the agent path."""
+    from agno.os.interfaces.agui.agui import AGUI
+    from agno.team.team import Team
+
+    team = MagicMock(spec=Team)
+    iface = AGUI(team=team, user_id_claim="sub", dependencies_claims=["email", "name"])
+    assert iface.team is team
+    assert iface.user_id_claim == "sub"
+    assert iface.dependencies_claims == ["email", "name"]
+
+
+async def test_run_entity_threads_claims_for_team_entity():
+    """run_entity applies claim extraction + the dependency merge for a Team entity, not just an Agent."""
+    from agno.os.interfaces.agui.router import run_entity
+
+    class _CaptureTeam:
+        def __init__(self):
+            self.captured: dict = {}
+
+        async def arun(self, **kwargs):
+            self.captured = kwargs
+            return
+            yield  # make this an async generator
+
+    class _Input:
+        messages = [MagicMock(role="user", content="hi")]
+        thread_id = "t-team"
+        run_id = "r-team"
+        state = None
+        forwarded_props = {"sub": "team-user", "email": "claim@example.com", "name": "Alice"}
+        context = [MagicMock(description="email", value="context@example.com")]
+
+    team = _CaptureTeam()
+    async for _ in run_entity(team, _Input(), user_id_claim="sub", dependencies_claims=["email", "name"]):
+        pass
+
+    assert team.captured.get("user_id") == "team-user"
+    assert team.captured.get("add_dependencies_to_context") is True
+    # context wins the "email" collision; claim-only "name" survives
+    assert team.captured.get("dependencies") == {"email": "context@example.com", "name": "Alice"}
+
+
+async def test_run_entity_no_claims_configured_does_not_leak_forwarded_props():
+    """Default path (no dependencies_claims): forwardedProps claims are NOT extracted — only context flows.
+
+    Locks the 'byte-identical to #8364 base when unconfigured' guarantee: claim values present in
+    forwardedProps must not leak into dependencies, and user_id uses the default 'user_id' key.
+    """
+    from agno.os.interfaces.agui.router import run_entity
+
+    class _CaptureEntity:
+        def __init__(self):
+            self.captured: dict = {}
+
+        async def arun(self, **kwargs):
+            self.captured = kwargs
+            return
+            yield  # make this an async generator
+
+    class _Input:
+        messages = [MagicMock(role="user", content="hi")]
+        thread_id = "t-default"
+        run_id = "r-default"
+        state = None
+        # email/name present but NO dependencies_claims configured -> must be ignored (no leak)
+        forwarded_props = {"user_id": "u-default", "email": "claim@example.com", "name": "Alice"}
+        context = [MagicMock(description="topic", value="weather")]
+
+    entity = _CaptureEntity()
+    async for _ in run_entity(entity, _Input()):  # defaults: user_id_claim="user_id", dependencies_claims=None
+        pass
+
+    assert entity.captured.get("user_id") == "u-default"  # from the default 'user_id' key
+    assert entity.captured.get("add_dependencies_to_context") is True  # context is present
+    assert entity.captured.get("dependencies") == {"topic": "weather"}  # only context — no email/name leak


### PR DESCRIPTION
## Summary

Wire JWT-style identity and profile claims from an AG-UI frontend (e.g. CopilotKit) into the agent/team run. When the frontend forwards decoded JWT claims in `forwardedProps`, AGUI maps a configurable `user_id_claim` to the run's `user_id` and pulls the configured `dependencies_claims` into the run's `dependencies` (with `add_dependencies_to_context=True`, so they render in prompt templates such as `{email}`).

## Behavior

- `user_id_claim` (default `"user_id"`): `forwarded_props[claim]` → the run's `user_id`.
- `dependencies_claims` (default `[]`): the matching keys from `forwarded_props` → a `dependencies` dict, auto-added to context.
- Missing keys are silently skipped. With no claims configured, behavior is byte-identical to before (fully inert).
- Composes with the existing readable-context feature: `merged_deps = {**claim_deps, **ui_deps}` — **AG-UI context wins** on a key collision, so an explicit context value always overrides a claim of the same name.

## Implementation (3 commits)

1. **`feat(agui): extract JWT-style claims from forwardedProps`** — `router.py` + `agui.py`: the `_extract_claims` helper; the `DEFAULT_USER_ID_CLAIM` single-source-of-truth constant; `run_entity` and `attach_routes` thread `user_id_claim`/`dependencies_claims`; `AGUI.__init__` gains the two constructor params; the `merged_deps` composition with the existing UI context.
2. **`test(agui): cover claims extraction + claim/context deps merge`** — `test_agui_app.py`: `_extract_claims` edge cases, constructor wiring (agent + team), end-to-end `run_entity` threading, a landmine asserting the context-wins tie-break, and a no-leak test.
3. **`cookbook(agui): JWT claims auth example`** — `jwt_claims_auth.py`: a runnable AgentOS example (`user_id_claim="sub"`, `dependencies_claims=["email","name"]`).

## Out of Scope

- **JWT signature verification** — the responsibility of the frontend or an upstream gateway. This interface trusts whatever `forwardedProps` contains (documented in the cookbook).
- **Auth topology / token transport** — not prescribed; any frontend that can populate `forwardedProps` works.

## Verification log (2026-06-24)

- **Unit (clean env, 0 `.pyc`):** full agui suite **89 passed**; the **13** claims / landmine / team / no-leak tests pass.
- **Landmine red-green:** flipping the merge order fails the landmine + team tests; restoring passes — guards the context-wins semantics.
- **Static:** ruff clean, mypy clean, import + symbol-map OK.
- **Live (AG-UI dojo + curl):** claims delivered via the real `properties`→`forwardedProps` seam (agent **and** team); context-only path unchanged (#8201); both-with-collision → context wins; plain run A/B identical to base; multimodal coexists (media extraction + claims in one run).
- **Cross-PR conflict gate:** intersected against all open agui PRs — only the known trivial-textual overlap (#8478) and the documented #8297 SOFT 3-way deps merge; stays out of media-extraction / arun-body / streaming-loop.
- **History-only reshape:** `git diff main` of the final HEAD is byte-identical to the verified 4-file feature diff (470 lines, 0 debug lines).