### PR TITLE
fix: update SeltzTools for current SDK

### DIFF
--- a/cookbook/90_models/groq/research_agent_seltz.py
+++ b/cookbook/90_models/groq/research_agent_seltz.py
@@ -18,7 +18,7 @@ if not tmp.exists():
 
 agent = Agent(
     model=Groq(id="llama-3.3-70b-versatile"),
-    tools=[SeltzTools(max_documents=10, show_results=True)],
+    tools=[SeltzTools(max_results=10, show_results=True)],
     description="You are an advanced AI researcher writing a report on a topic.",
     instructions=[
         "For the provided topic, run 3 different searches.",

--- a/libs/agno/agno/tools/seltz.py
+++ b/libs/agno/agno/tools/seltz.py
@@ -1,4 +1,5 @@
 import json
+from inspect import Parameter, signature
 from os import getenv
 from typing import Any, List, Optional
 
@@ -6,7 +7,7 @@ from agno.tools import Toolkit
 from agno.utils.log import log_error, log_info, logger
 
 try:
-    from seltz import Includes, Seltz
+    from seltz import Seltz
     from seltz.exceptions import (
         SeltzAPIError,
         SeltzAuthenticationError,
@@ -16,6 +17,11 @@ try:
         SeltzRateLimitError,
         SeltzTimeoutError,
     )
+
+    try:
+        from seltz import Includes
+    except ImportError:
+        Includes = None
 except ImportError as exc:
     raise ImportError("`seltz` not installed. Please install using `pip install seltz`") from exc
 
@@ -27,9 +33,10 @@ class SeltzTools(Toolkit):
         api_key: Seltz API key. If not provided, uses the `SELTZ_API_KEY` env var.
         endpoint: Optional Seltz gRPC endpoint. If not provided, uses SDK default.
         insecure: Use an insecure gRPC channel. Defaults to False.
-        max_documents: Default maximum number of documents to return per search.
-        context: Default context to improve search quality (e.g., "user is looking for Python docs").
-        profile: Default search profile to use for ranking.
+        max_results: Default maximum number of results to return per search.
+        max_documents: Deprecated alias for `max_results`.
+        context: Legacy SDK context to improve search quality.
+        profile: Legacy SDK search profile to use for ranking.
         show_results: Log search results for debugging.
         enable_search: Enable search tool functionality. Defaults to True.
         all: Enable all tools. Overrides individual flags when True. Defaults to False.
@@ -40,7 +47,8 @@ class SeltzTools(Toolkit):
         api_key: Optional[str] = None,
         endpoint: Optional[str] = None,
         insecure: bool = False,
-        max_documents: int = 10,
+        max_results: Optional[int] = None,
+        max_documents: Optional[int] = None,
         context: Optional[str] = None,
         profile: Optional[str] = None,
         show_results: bool = False,
@@ -48,8 +56,7 @@ class SeltzTools(Toolkit):
         all: bool = False,
         **kwargs: Any,
     ):
-        if max_documents <= 0:
-            raise ValueError("max_documents must be greater than 0")
+        default_max_results = self._resolve_max_results(max_results=max_results, max_documents=max_documents)
 
         self.api_key = api_key or getenv("SELTZ_API_KEY")
         if not self.api_key:
@@ -57,7 +64,8 @@ class SeltzTools(Toolkit):
 
         self.endpoint = endpoint
         self.insecure = insecure
-        self.max_documents = max_documents
+        self.max_results = default_max_results
+        self.max_documents = default_max_results
         self.context = context
         self.profile = profile
         self.show_results = show_results
@@ -92,18 +100,106 @@ class SeltzTools(Toolkit):
                 parsed.append(doc_dict)
         return json.dumps(parsed, indent=4, ensure_ascii=False)
 
+    @staticmethod
+    def _resolve_max_results(max_results: Optional[int] = None, max_documents: Optional[int] = None) -> int:
+        """Resolve current and legacy result limit names into a positive integer."""
+        limit = max_results if max_results is not None else max_documents if max_documents is not None else 10
+        parameter_name = "max_results" if max_results is not None else "max_documents"
+
+        if limit <= 0:
+            raise ValueError(f"{parameter_name} must be greater than 0")
+
+        return limit
+
+    def _client_supports_search_parameter(self, parameter_name: str) -> bool:
+        """Return whether the installed Seltz SDK search method accepts a parameter."""
+        if not self.client:
+            return False
+
+        try:
+            search_parameters = signature(self.client.search).parameters
+        except (TypeError, ValueError):
+            return True
+
+        return parameter_name in search_parameters or any(
+            parameter.kind == Parameter.VAR_KEYWORD for parameter in search_parameters.values()
+        )
+
+    def _search_current_sdk(
+        self,
+        query: str,
+        max_results: int,
+        scope: Optional[str] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+    ) -> Any:
+        """Search with the current Seltz SDK API."""
+        if not self.client:
+            raise ValueError("SELTZ_API_KEY not set. Please set the SELTZ_API_KEY environment variable.")
+
+        search_kwargs: dict[str, Any] = {"query": query, "max_results": max_results}
+        if scope is not None:
+            search_kwargs["scope"] = scope
+        if include_domains is not None:
+            search_kwargs["include_domains"] = include_domains
+        if exclude_domains is not None:
+            search_kwargs["exclude_domains"] = exclude_domains
+        if from_date is not None:
+            search_kwargs["from_date"] = from_date
+        if to_date is not None:
+            search_kwargs["to_date"] = to_date
+
+        return self.client.search(**search_kwargs)
+
+    def _search_legacy_sdk(
+        self,
+        query: str,
+        max_results: int,
+        context: Optional[str] = None,
+        scope: Optional[str] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+    ) -> Any:
+        """Search with the legacy Seltz SDK API that uses Includes."""
+        if not self.client:
+            raise ValueError("SELTZ_API_KEY not set. Please set the SELTZ_API_KEY environment variable.")
+        if Includes is None:
+            raise ValueError("Installed seltz SDK does not support search result limits. Upgrade seltz.")
+        if any(value is not None for value in (scope, include_domains, exclude_domains, from_date, to_date)):
+            raise ValueError("scope, include_domains, exclude_domains, from_date, and to_date require seltz>=1.2.0.")
+
+        search_context = context if context is not None else self.context
+        includes = Includes(max_documents=max_results)
+        return self.client.search(query=query, includes=includes, context=search_context, profile=self.profile)
+
     def search_seltz(
         self,
         query: str,
+        max_results: Optional[int] = None,
         max_documents: Optional[int] = None,
+        scope: Optional[str] = None,
+        include_domains: Optional[List[str]] = None,
+        exclude_domains: Optional[List[str]] = None,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
         context: Optional[str] = None,
     ) -> str:
         """Use this function to search Seltz for a query.
 
         Args:
             query: The query to search for.
-            max_documents: Maximum number of documents to return. Defaults to toolkit `max_documents`.
-            context: Additional context to improve search quality. Defaults to toolkit `context`.
+            max_results: Maximum number of results to return. Defaults to toolkit `max_results`.
+            max_documents: Deprecated alias for `max_results`.
+            scope: Restrict the search to a supported scope, such as "news".
+            include_domains: Only include results from these domains.
+            exclude_domains: Exclude results from these domains.
+            from_date: Only include results published on or after this ISO 8601 date.
+            to_date: Only include results published on or before this ISO 8601 date.
+            context: Legacy SDK context. Ignored by current Seltz SDK versions.
 
         Returns:
             str: Search results in JSON format.
@@ -114,23 +210,39 @@ class SeltzTools(Toolkit):
         if not self.client:
             return "Error: SELTZ_API_KEY not set. Please set the SELTZ_API_KEY environment variable."
 
-        limit = max_documents if max_documents is not None else self.max_documents
-        if limit <= 0:
-            return "Error: max_documents must be greater than 0."
-
-        search_context = context if context is not None else self.context
+        if max_results is None and max_documents is None:
+            limit = self.max_results
+        else:
+            try:
+                limit = self._resolve_max_results(max_results=max_results, max_documents=max_documents)
+            except ValueError as exc:
+                return f"Error: {exc}."
 
         try:
             if self.show_results:
                 log_info(f"Searching Seltz for: {query}")
 
-            includes = Includes(max_documents=limit)
-            response = self.client.search(
-                query=query,
-                includes=includes,
-                context=search_context,
-                profile=self.profile,
-            )
+            if self._client_supports_search_parameter("max_results"):
+                response = self._search_current_sdk(
+                    query=query,
+                    max_results=limit,
+                    scope=scope,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                    from_date=from_date,
+                    to_date=to_date,
+                )
+            else:
+                response = self._search_legacy_sdk(
+                    query=query,
+                    max_results=limit,
+                    context=context,
+                    scope=scope,
+                    include_domains=include_domains,
+                    exclude_domains=exclude_domains,
+                    from_date=from_date,
+                    to_date=to_date,
+                )
             result = self._parse_documents(response.documents)
 
             if self.show_results:

--- a/libs/agno/tests/integration/tools/test_seltz.py
+++ b/libs/agno/tests/integration/tools/test_seltz.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from inspect import signature
 
 import pytest
 
@@ -17,7 +18,14 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 def seltz_tools():
-    return SeltzTools(max_documents=3, show_results=False)
+    return SeltzTools(max_results=3, show_results=False)
+
+
+def _client_supports_search_parameter(seltz_tools: SeltzTools, parameter_name: str) -> bool:
+    if not seltz_tools.client:
+        return False
+
+    return parameter_name in signature(seltz_tools.client.search).parameters
 
 
 def test_search_returns_documents(seltz_tools):
@@ -31,23 +39,26 @@ def test_search_returns_documents(seltz_tools):
         assert doc["url"].startswith("http")
 
 
-def test_search_respects_max_documents(seltz_tools):
-    """Search respects the max_documents parameter."""
-    result = seltz_tools.search_seltz("python programming", max_documents=2)
+def test_search_respects_max_results(seltz_tools):
+    """Search respects the max_results parameter."""
+    result = seltz_tools.search_seltz("python programming", max_results=2)
     data = json.loads(result)
 
     assert len(data) <= 2
 
 
-def test_search_with_context(seltz_tools):
-    """Search with context parameter does not error."""
+def test_search_with_domain_filter(seltz_tools):
+    """Search with a current SDK filter parameter does not error."""
+    if not _client_supports_search_parameter(seltz_tools, "include_domains"):
+        pytest.skip("Installed seltz SDK does not support include_domains.")
+
     result = seltz_tools.search_seltz(
-        "web frameworks",
-        context="looking for modern Python web frameworks",
+        "python programming",
+        include_domains=["python.org"],
     )
     data = json.loads(result)
 
-    assert len(data) > 0
+    assert isinstance(data, list)
 
 
 def test_search_empty_query(seltz_tools):
@@ -56,7 +67,7 @@ def test_search_empty_query(seltz_tools):
     assert "Error" in result
 
 
-def test_search_invalid_max_documents(seltz_tools):
-    """Zero max_documents returns an error string, not an exception."""
-    result = seltz_tools.search_seltz("test", max_documents=0)
+def test_search_invalid_max_results(seltz_tools):
+    """Zero max_results returns an error string, not an exception."""
+    result = seltz_tools.search_seltz("test", max_results=0)
     assert "Error" in result

--- a/libs/agno/tests/unit/tools/test_seltz.py
+++ b/libs/agno/tests/unit/tools/test_seltz.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 try:
-    from seltz import Includes, Seltz  # noqa: F401
+    from seltz import Seltz  # noqa: F401
     from seltz.exceptions import (
         SeltzAPIError,
         SeltzAuthenticationError,
@@ -24,20 +24,18 @@ except (ImportError, Exception):
 def mock_seltz_client():
     """Create a mock Seltz API client."""
     with patch("agno.tools.seltz.Seltz") as mock_seltz:
-        with patch("agno.tools.seltz.Includes"):
-            mock_client = Mock()
-            mock_seltz.return_value = mock_client
-            return mock_client
+        mock_client = Mock()
+        mock_seltz.return_value = mock_client
+        return mock_client
 
 
 @pytest.fixture
 def seltz_tools(mock_seltz_client):
     """Create SeltzTools instance with mocked API."""
-    with patch("agno.tools.seltz.Includes"):
-        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-            tools = SeltzTools()
-            tools.client = mock_seltz_client
-            return tools
+    with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+        tools = SeltzTools()
+        tools.client = mock_seltz_client
+        return tools
 
 
 def create_mock_document(url: str, content: str | None = None):
@@ -51,27 +49,24 @@ def create_mock_document(url: str, content: str | None = None):
 def test_init_with_api_key():
     """Test initialization with provided API key."""
     with patch("agno.tools.seltz.Seltz") as mock_seltz:
-        with patch("agno.tools.seltz.Includes"):
-            with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-                SeltzTools()
-                mock_seltz.assert_called_once_with(api_key="test_key")
+        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+            SeltzTools()
+            mock_seltz.assert_called_once_with(api_key="test_key")
 
 
 def test_init_with_search_disabled():
     """Test initialization with search tool disabled."""
-    with patch("agno.tools.seltz.Includes"):
-        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-            tools = SeltzTools(enable_search=False)
-            assert "search_seltz" not in [func.name for func in tools.functions.values()]
+    with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+        tools = SeltzTools(enable_search=False)
+        assert "search_seltz" not in [func.name for func in tools.functions.values()]
 
 
 def test_init_with_custom_endpoint():
     """Test initialization with custom endpoint and insecure flag."""
     with patch("agno.tools.seltz.Seltz") as mock_seltz:
-        with patch("agno.tools.seltz.Includes"):
-            with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-                SeltzTools(endpoint="custom.endpoint.ai", insecure=True)
-                mock_seltz.assert_called_once_with(api_key="test_key", endpoint="custom.endpoint.ai", insecure=True)
+        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+            SeltzTools(endpoint="custom.endpoint.ai", insecure=True)
+            mock_seltz.assert_called_once_with(api_key="test_key", endpoint="custom.endpoint.ai", insecure=True)
 
 
 def test_search_success(seltz_tools, mock_seltz_client):
@@ -80,47 +75,53 @@ def test_search_success(seltz_tools, mock_seltz_client):
     mock_response.documents = [create_mock_document(url="https://example.com", content="Example content")]
     mock_seltz_client.search.return_value = mock_response
 
-    with patch("agno.tools.seltz.Includes") as mock_includes:
-        mock_includes_instance = Mock()
-        mock_includes.return_value = mock_includes_instance
+    result = seltz_tools.search_seltz("test query", max_results=3)
+    result_data = json.loads(result)
 
-        result = seltz_tools.search_seltz("test query", max_documents=3)
-        result_data = json.loads(result)
-
-        assert len(result_data) == 1
-        assert result_data[0]["url"] == "https://example.com"
-        assert result_data[0]["content"] == "Example content"
-        mock_includes.assert_called_with(max_documents=3)
-        mock_seltz_client.search.assert_called_with(
-            query="test query",
-            includes=mock_includes_instance,
-            context=None,
-            profile=None,
-        )
+    assert len(result_data) == 1
+    assert result_data[0]["url"] == "https://example.com"
+    assert result_data[0]["content"] == "Example content"
+    mock_seltz_client.search.assert_called_with(query="test query", max_results=3)
 
 
 def test_search_default_limit(seltz_tools, mock_seltz_client):
-    """Test search uses default max_documents when not provided."""
+    """Test search uses default max_results when not provided."""
     mock_response = Mock()
     mock_response.documents = [create_mock_document(url="https://example.com")]
     mock_seltz_client.search.return_value = mock_response
 
-    with patch("agno.tools.seltz.Includes") as mock_includes:
-        mock_includes_instance = Mock()
-        mock_includes.return_value = mock_includes_instance
+    result = seltz_tools.search_seltz("test query")
+    result_data = json.loads(result)
 
-        result = seltz_tools.search_seltz("test query")
-        result_data = json.loads(result)
+    assert len(result_data) == 1
+    assert result_data[0]["url"] == "https://example.com"
+    mock_seltz_client.search.assert_called_with(query="test query", max_results=10)
 
-        assert len(result_data) == 1
-        assert result_data[0]["url"] == "https://example.com"
-        mock_includes.assert_called_with(max_documents=10)
-        mock_seltz_client.search.assert_called_with(
-            query="test query",
-            includes=mock_includes_instance,
-            context=None,
-            profile=None,
-        )
+
+def test_search_uses_toolkit_default_max_results(mock_seltz_client):
+    """Test search uses configured toolkit max_results when not provided."""
+    mock_response = Mock()
+    mock_response.documents = [create_mock_document(url="https://example.com")]
+    mock_seltz_client.search.return_value = mock_response
+
+    with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+        tools = SeltzTools(max_results=4)
+        tools.client = mock_seltz_client
+
+    tools.search_seltz("test query")
+
+    mock_seltz_client.search.assert_called_with(query="test query", max_results=4)
+
+
+def test_search_accepts_legacy_max_documents_alias(seltz_tools, mock_seltz_client):
+    """Test search accepts legacy max_documents alias."""
+    mock_response = Mock()
+    mock_response.documents = [create_mock_document(url="https://example.com")]
+    mock_seltz_client.search.return_value = mock_response
+
+    seltz_tools.search_seltz("test query", max_documents=3)
+
+    mock_seltz_client.search.assert_called_with(query="test query", max_results=3)
 
 
 def test_parse_documents_with_missing_fields(seltz_tools):
@@ -147,25 +148,31 @@ def test_search_empty_query(seltz_tools):
 def test_search_without_api_key():
     """Test search without API key returns error."""
     with patch("agno.tools.seltz.Seltz"):
-        with patch("agno.tools.seltz.Includes"):
-            with patch.dict("os.environ", {"SELTZ_API_KEY": ""}, clear=False):
-                with patch.object(SeltzTools, "__init__", lambda self, **kwargs: None):
-                    tools = SeltzTools()
-                    tools.client = None
-                    tools.max_documents = 10
-                    tools.context = None
-                    tools.profile = None
-                    tools.show_results = False
-                    result = tools.search_seltz("test query")
-                    assert "SELTZ_API_KEY not set" in result
+        with patch.dict("os.environ", {"SELTZ_API_KEY": ""}, clear=False):
+            with patch.object(SeltzTools, "__init__", lambda self, **kwargs: None):
+                tools = SeltzTools()
+                tools.client = None
+                tools.max_results = 10
+                tools.max_documents = 10
+                tools.context = None
+                tools.profile = None
+                tools.show_results = False
+                result = tools.search_seltz("test query")
+                assert "SELTZ_API_KEY not set" in result
+
+
+def test_init_invalid_max_results():
+    """Test initialization with invalid max_results raises error."""
+    with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+        with pytest.raises(ValueError, match="max_results must be greater than 0"):
+            SeltzTools(max_results=0)
 
 
 def test_init_invalid_max_documents():
-    """Test initialization with invalid max_documents raises error."""
-    with patch("agno.tools.seltz.Includes"):
-        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-            with pytest.raises(ValueError, match="max_documents must be greater than 0"):
-                SeltzTools(max_documents=0)
+    """Test initialization with invalid max_documents alias raises error."""
+    with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+        with pytest.raises(ValueError, match="max_documents must be greater than 0"):
+            SeltzTools(max_documents=0)
 
 
 def test_search_invalid_max_documents(seltz_tools):
@@ -173,6 +180,13 @@ def test_search_invalid_max_documents(seltz_tools):
     result = seltz_tools.search_seltz("test query", max_documents=0)
     assert "Error" in result
     assert "max_documents must be greater than 0" in result
+
+
+def test_search_invalid_max_results(seltz_tools):
+    """Test search with invalid max_results returns error."""
+    result = seltz_tools.search_seltz("test query", max_results=0)
+    assert "Error" in result
+    assert "max_results must be greater than 0" in result
 
 
 def test_parse_documents_skips_empty(seltz_tools):
@@ -190,10 +204,9 @@ def test_parse_documents_skips_empty(seltz_tools):
 def test_init_with_all_flag():
     """Test initialization with all=True enables all tools."""
     with patch("agno.tools.seltz.Seltz"):
-        with patch("agno.tools.seltz.Includes"):
-            with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-                tools = SeltzTools(all=True, enable_search=False)
-                assert "search_seltz" in [func.name for func in tools.functions.values()]
+        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+            tools = SeltzTools(all=True, enable_search=False)
+            assert "search_seltz" in [func.name for func in tools.functions.values()]
 
 
 @pytest.mark.parametrize(
@@ -211,38 +224,78 @@ def test_error_handling(seltz_tools, mock_seltz_client, exception):
     """Test error handling in search."""
     mock_seltz_client.search.side_effect = exception
 
-    with patch("agno.tools.seltz.Includes"):
-        result = seltz_tools.search_seltz("test query")
-        assert "Error" in result
+    result = seltz_tools.search_seltz("test query")
+    assert "Error" in result
 
 
-def test_search_with_context(seltz_tools, mock_seltz_client):
-    """Test search with context parameter."""
+def test_search_with_current_sdk_filters(seltz_tools, mock_seltz_client):
+    """Test search with current SDK filter parameters."""
     mock_response = Mock()
     mock_response.documents = [create_mock_document(url="https://example.com", content="Example content")]
     mock_seltz_client.search.return_value = mock_response
+
+    result = seltz_tools.search_seltz(
+        "test query",
+        max_results=3,
+        scope="news",
+        include_domains=["example.com"],
+        exclude_domains=["exclude.com"],
+        from_date="2026-01-01",
+        to_date="2026-01-31",
+    )
+    result_data = json.loads(result)
+
+    assert len(result_data) == 1
+    mock_seltz_client.search.assert_called_with(
+        query="test query",
+        max_results=3,
+        scope="news",
+        include_domains=["example.com"],
+        exclude_domains=["exclude.com"],
+        from_date="2026-01-01",
+        to_date="2026-01-31",
+    )
+
+
+def test_search_with_legacy_sdk_uses_includes_and_context(seltz_tools):
+    """Test search with the legacy SDK API."""
+
+    class LegacySeltzClient:
+        def __init__(self, response):
+            self.response = response
+            self.search_mock = Mock()
+
+        def search(self, query: str, *, includes=None, context=None, profile=None):
+            self.search_mock(query=query, includes=includes, context=context, profile=profile)
+            return self.response
+
+    mock_response = Mock()
+    mock_response.documents = [create_mock_document(url="https://example.com", content="Example content")]
+    legacy_client = LegacySeltzClient(response=mock_response)
+    seltz_tools.client = legacy_client
+    seltz_tools.context = "default context"
+    seltz_tools.profile = "test_profile"
 
     with patch("agno.tools.seltz.Includes") as mock_includes:
         mock_includes_instance = Mock()
         mock_includes.return_value = mock_includes_instance
 
-        result = seltz_tools.search_seltz("test query", context="looking for Python tutorials")
-        result_data = json.loads(result)
+        result = seltz_tools.search_seltz("test query", max_documents=3, context="search context")
 
-        assert len(result_data) == 1
-        mock_seltz_client.search.assert_called_with(
+        assert len(json.loads(result)) == 1
+        mock_includes.assert_called_once_with(max_documents=3)
+        legacy_client.search_mock.assert_called_once_with(
             query="test query",
             includes=mock_includes_instance,
-            context="looking for Python tutorials",
-            profile=None,
+            context="search context",
+            profile="test_profile",
         )
 
 
 def test_init_with_context_and_profile():
     """Test initialization with context and profile parameters."""
     with patch("agno.tools.seltz.Seltz"):
-        with patch("agno.tools.seltz.Includes"):
-            with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
-                tools = SeltzTools(context="default context", profile="test_profile")
-                assert tools.context == "default context"
-                assert tools.profile == "test_profile"
+        with patch.dict("os.environ", {"SELTZ_API_KEY": "test_key"}):
+            tools = SeltzTools(context="default context", profile="test_profile")
+            assert tools.context == "default context"
+            assert tools.profile == "test_profile"


### PR DESCRIPTION
## Summary

solves #8178 

- Updates SeltzTools for the current seltz SDK, where `Includes` is no longer exported and search uses `max_results` plus filter parameters.
- Keeps `max_documents`, `context`, and `profile` compatibility for legacy seltz SDK installs.
- Updates Seltz unit/integration tests and the Groq cookbook example to use `max_results`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

## Duplicate PR Check

- [x] Searched existing open pull requests for `seltz`; no matching open PRs found.

---

## Validation

- `PATH="/home/will/github/phidata/.venv/bin:$PATH" ./scripts/format.sh`
- `PATH="/home/will/github/phidata/.venv/bin:$PATH" ./scripts/validate.sh` (full script completed; `libs/agno` mypy reports unrelated existing errors in `utils/cryptography.py`, `tools/sql.py`, and `os/interfaces/whatsapp/router.py`)
- `PATH="/home/will/github/phidata/.venv/bin:$PATH" mypy libs/agno/agno/tools/seltz.py libs/agno/tests/unit/tools/test_seltz.py libs/agno/tests/integration/tools/test_seltz.py --config-file libs/agno/pyproject.toml`
- `PATH="/home/will/github/phidata/.venv/bin:$PATH" ruff check libs/agno/agno/tools/seltz.py libs/agno/tests/unit/tools/test_seltz.py libs/agno/tests/integration/tools/test_seltz.py cookbook/90_models/groq/research_agent_seltz.py`
- `.venv/bin/python -m pytest libs/agno/tests/unit/tools/test_seltz.py` (25 passed)
- Loaded `SELTZ_API_KEY` from local `.env` and ran `.venv/bin/python -m pytest libs/agno/tests/integration/tools/test_seltz.py -q` (4 passed, 1 skipped with installed `seltz==0.2.0`)
- Loaded `SELTZ_API_KEY` from local `.env` and smoke-tested live basic search plus `include_domains` through patched Agno source with `seltz==1.2.0` from a separate virtualenv.