### PR TITLE
fix: close audio files after transcription

### DIFF
--- a/libs/agno/agno/tools/openai.py
+++ b/libs/agno/agno/tools/openai.py
@@ -87,13 +87,12 @@ class OpenAITools(Toolkit):
         """
         log_debug(f"Transcribing audio from {audio_path}")
         try:
-            audio_file = open(audio_path, "rb")
-
-            transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
-                model=self.transcription_model,
-                file=audio_file,
-                response_format="text",
-            )
+            with open(audio_path, "rb") as audio_file:
+                transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
+                    model=self.transcription_model,
+                    file=audio_file,
+                    response_format="text",
+                )
         except Exception as e:  # type: ignore[return]
             log_error(f"Failed to transcribe audio: {str(e)}")
             return f"Failed to transcribe audio: {str(e)}"

--- a/libs/agno/tests/unit/tools/test_openai.py
+++ b/libs/agno/tests/unit/tools/test_openai.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from agno.tools import openai as openai_tools
+from agno.tools.openai import OpenAITools
+
+
+def test_transcribe_audio_closes_file(tmp_path, monkeypatch):
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"fake audio")
+
+    class Transcriptions:
+        opened_file = None
+
+        def create(self, *, model, file, response_format):
+            assert model == "whisper-1"
+            assert response_format == "text"
+            assert not file.closed
+            self.opened_file = file
+            return "transcript text"
+
+    transcriptions = Transcriptions()
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key):
+            assert api_key == "test-key"
+            self.audio = SimpleNamespace(transcriptions=transcriptions)
+
+    monkeypatch.setattr(openai_tools, "OpenAIClient", FakeOpenAIClient)
+
+    tools = OpenAITools(
+        api_key="test-key",
+        enable_image_generation=False,
+        enable_speech_generation=False,
+    )
+
+    assert tools.transcribe_audio(str(audio_path)) == "transcript text"
+    assert transcriptions.opened_file is not None
+    assert transcriptions.opened_file.closed


### PR DESCRIPTION
﻿## Summary

- close the audio file opened by `OpenAITools.transcribe_audio` with a context manager
- add a unit test that verifies the file object is still open during the OpenAI call and closed after the tool returns

Fixes #8160.

## To verify

- `PYTHONPATH=libs/agno python -m pytest -q libs\agno\tests\unit\tools\test_openai.py`
- `PYTHONPATH=libs/agno python -m py_compile libs\agno\agno\tools\openai.py libs\agno\tests\unit\tools\test_openai.py`
- `python -m ruff check libs\agno\agno\tools\openai.py libs\agno\tests\unit\tools\test_openai.py`
- `python -m ruff format --check libs\agno\agno\tools\openai.py libs\agno\tests\unit\tools\test_openai.py`
- `git diff --check`
