### PR TITLE
fix: preserve assembled run messages

### DIFF
--- a/libs/agno/agno/run/messages.py
+++ b/libs/agno/agno/run/messages.py
@@ -22,6 +22,9 @@ class RunMessages:
 
     def get_input_messages(self) -> List[Message]:
         """Get the input messages for the model."""
+        if self.messages:
+            return self.messages
+
         input_messages = []
         if self.system_message is not None:
             input_messages.append(self.system_message)

--- a/libs/agno/tests/unit/run/test_messages.py
+++ b/libs/agno/tests/unit/run/test_messages.py
@@ -1,0 +1,22 @@
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+
+def test_get_input_messages_returns_assembled_messages_first():
+    history = Message(role="user", content="earlier question")
+    current = Message(role="user", content="current question")
+    fallback = Message(role="user", content="fallback only")
+
+    run_messages = RunMessages(messages=[history, current], user_message=fallback)
+
+    assert run_messages.get_input_messages() == [history, current]
+
+
+def test_get_input_messages_keeps_field_fallback():
+    system = Message(role="system", content="system")
+    user = Message(role="user", content="user")
+    extra = Message(role="assistant", content="extra")
+
+    run_messages = RunMessages(system_message=system, user_message=user, extra_messages=[extra])
+
+    assert run_messages.get_input_messages() == [system, user, extra]


### PR DESCRIPTION
﻿## Summary

- return the already assembled `RunMessages.messages` list from `get_input_messages()` when it is present
- keep the existing `system_message` / `user_message` / `extra_messages` fallback for callers that have not populated `messages`
- add unit coverage for both paths

Fixes #8151.

## To verify

- `PYTHONPATH=libs/agno python -m pytest -q libs\agno\tests\unit\run\test_messages.py`
- `PYTHONPATH=libs/agno python -m py_compile libs\agno\agno\run\messages.py libs\agno\tests\unit\run\test_messages.py`
- `python -m ruff check libs\agno\agno\run\messages.py libs\agno\tests\unit\run\test_messages.py`
- `python -m ruff format --check libs\agno\agno\run\messages.py libs\agno\tests\unit\run\test_messages.py`
- `git diff --check`
