### PR TITLE
Fix OpenAI audio handle and Seltz SDK compatibility

### DIFF
--- a/libs/agno/agno/tools/openai.py
+++ b/libs/agno/agno/tools/openai.py
@@ -87,13 +87,12 @@ class OpenAITools(Toolkit):
         """
         log_debug(f"Transcribing audio from {audio_path}")
         try:
-            audio_file = open(audio_path, "rb")
-
-            transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
-                model=self.transcription_model,
-                file=audio_file,
-                response_format="text",
-            )
+            with open(audio_path, "rb") as audio_file:
+                transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
+                    model=self.transcription_model,
+                    file=audio_file,
+                    response_format="text",
+                )
         except Exception as e:  # type: ignore[return]
             log_error(f"Failed to transcribe audio: {str(e)}")
             return f"Failed to transcribe audio: {str(e)}"

--- a/libs/agno/agno/tools/seltz.py
+++ b/libs/agno/agno/tools/seltz.py
@@ -6,7 +6,7 @@ from agno.tools import Toolkit
 from agno.utils.log import log_error, log_info, logger
 
 try:
-    from seltz import Includes, Seltz
+    from seltz import Seltz
     from seltz.exceptions import (
         SeltzAPIError,
         SeltzAuthenticationError,
@@ -18,6 +18,11 @@ try:
     )
 except ImportError as exc:
     raise ImportError("`seltz` not installed. Please install using `pip install seltz`") from exc
+
+try:
+    from seltz import Includes
+except ImportError:
+    Includes = None  # type: ignore[assignment]
 
 
 class SeltzTools(Toolkit):
@@ -124,13 +129,17 @@ class SeltzTools(Toolkit):
             if self.show_results:
                 log_info(f"Searching Seltz for: {query}")
 
-            includes = Includes(max_documents=limit)
-            response = self.client.search(
-                query=query,
-                includes=includes,
-                context=search_context,
-                profile=self.profile,
-            )
+            search_kwargs: dict[str, Any] = {
+                "query": query,
+                "context": search_context,
+                "profile": self.profile,
+            }
+            if Includes is not None:
+                search_kwargs["includes"] = Includes(max_documents=limit)
+            else:
+                search_kwargs["max_results"] = limit
+
+            response = self.client.search(**search_kwargs)
             result = self._parse_documents(response.documents)
 
             if self.show_results:

--- a/libs/agno/tests/unit/tools/test_openai.py
+++ b/libs/agno/tests/unit/tools/test_openai.py
@@ -1,0 +1,28 @@
+"""Unit tests for OpenAITools."""
+
+from unittest.mock import Mock, mock_open, patch
+
+from agno.tools.openai import OpenAITools
+
+
+def test_transcribe_audio_closes_file():
+    """Test audio file handles are closed after transcription."""
+    mocked_file = mock_open(read_data=b"audio")
+    mock_client = Mock()
+    mock_client.audio.transcriptions.create.return_value = "transcript"
+
+    with (
+        patch("agno.tools.openai.open", mocked_file),
+        patch("agno.tools.openai.OpenAIClient", return_value=mock_client),
+    ):
+        tools = OpenAITools(api_key="test-key", enable_image_generation=False, enable_speech_generation=False)
+        result = tools.transcribe_audio("test.wav")
+
+    assert result == "transcript"
+    mocked_file.assert_called_once_with("test.wav", "rb")
+    mocked_file.return_value.__exit__.assert_called_once()
+    mock_client.audio.transcriptions.create.assert_called_once_with(
+        model="whisper-1",
+        file=mocked_file.return_value.__enter__.return_value,
+        response_format="text",
+    )

--- a/libs/agno/tests/unit/tools/test_seltz.py
+++ b/libs/agno/tests/unit/tools/test_seltz.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 try:
-    from seltz import Includes, Seltz  # noqa: F401
+    from seltz import Seltz  # noqa: F401
     from seltz.exceptions import (
         SeltzAPIError,
         SeltzAuthenticationError,
@@ -118,6 +118,25 @@ def test_search_default_limit(seltz_tools, mock_seltz_client):
         mock_seltz_client.search.assert_called_with(
             query="test query",
             includes=mock_includes_instance,
+            context=None,
+            profile=None,
+        )
+
+
+def test_search_uses_max_results_with_current_seltz_sdk(seltz_tools, mock_seltz_client):
+    """Test search uses max_results when the installed SDK does not expose Includes."""
+    mock_response = Mock()
+    mock_response.documents = [create_mock_document(url="https://example.com")]
+    mock_seltz_client.search.return_value = mock_response
+
+    with patch("agno.tools.seltz.Includes", None):
+        result = seltz_tools.search_seltz("test query", max_documents=3)
+        result_data = json.loads(result)
+
+        assert len(result_data) == 1
+        mock_seltz_client.search.assert_called_with(
+            query="test query",
+            max_results=3,
             context=None,
             profile=None,
         )


### PR DESCRIPTION
## Summary
- close OpenAI transcription file handles with a context manager
- support current Seltz SDK versions that no longer export Includes
- keep compatibility with older Seltz SDKs that still use Includes
- add unit coverage for both regressions

Fixes #8160
Fixes #8178

## Testing
- python3 -m py_compile libs/agno/agno/tools/openai.py libs/agno/agno/tools/seltz.py libs/agno/tests/unit/tools/test_openai.py libs/agno/tests/unit/tools/test_seltz.py
- Not run: pytest, because this local Python environment is missing pytest and project test dependencies.