### PR TITLE
Fix async trace exporter task handling

### DIFF
--- a/libs/agno/agno/tracing/exporter.py
+++ b/libs/agno/agno/tracing/exporter.py
@@ -4,7 +4,7 @@ Custom OpenTelemetry SpanExporter that writes traces to Agno database.
 
 import asyncio
 from collections import defaultdict
-from typing import Dict, List, Sequence, Union
+from typing import Dict, List, Sequence, Set, Union
 
 from opentelemetry.sdk.trace import ReadableSpan  # type: ignore
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult  # type: ignore
@@ -27,6 +27,7 @@ class DatabaseSpanExporter(SpanExporter):
         """
         self.db = db
         self._shutdown = False
+        self._background_tasks: Set[asyncio.Task] = set()
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         """
@@ -106,40 +107,46 @@ class DatabaseSpanExporter(SpanExporter):
     def _export_async(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Handle async database export"""
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # We're in an async context, schedule the coroutine
-                asyncio.create_task(self._do_async_export(spans_by_trace))
-            else:
-                # No running loop, run in new loop
-                loop.run_until_complete(self._do_async_export(spans_by_trace))
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             # No event loop, create new one
             try:
                 asyncio.run(self._do_async_export(spans_by_trace))
             except Exception as e:
                 log_error(f"Failed to export async traces: {str(e)}")
+            return
+
+        # We're in an async context, schedule the coroutine and keep a strong
+        # reference until it completes so exceptions are observed.
+        task = loop.create_task(self._do_async_export(spans_by_trace))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._handle_background_task_done)
+
+    def _handle_background_task_done(self, task: asyncio.Task) -> None:
+        """Release completed async export tasks and observe their exceptions."""
+        self._background_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            log_error(f"Failed to export async traces: {str(e)}")
 
     async def _do_async_export(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Actually perform the async export"""
-        try:
-            # Create trace and span records for each trace
-            for trace_id, spans in spans_by_trace.items():
-                # Create trace record (aggregate of all spans)
-                trace = create_trace_from_spans(spans)
-                if trace:
-                    create_trace_result = self.db.upsert_trace(trace)  # type: ignore
-                    if create_trace_result is not None:
-                        await create_trace_result
+        # Create trace and span records for each trace
+        for trace_id, spans in spans_by_trace.items():
+            # Create trace record (aggregate of all spans)
+            trace = create_trace_from_spans(spans)
+            if trace:
+                create_trace_result = self.db.upsert_trace(trace)  # type: ignore
+                if create_trace_result is not None:
+                    await create_trace_result
 
-                # Create span records
-                create_spans_result = self.db.create_spans(spans)  # type: ignore
-                if create_spans_result is not None:
-                    await create_spans_result
-
-        except Exception as e:
-            log_error(f"Failed to do async export: {str(e)}")
-            raise
+            # Create span records
+            create_spans_result = self.db.create_spans(spans)  # type: ignore
+            if create_spans_result is not None:
+                await create_spans_result
 
     def shutdown(self) -> None:
         """Shutdown the exporter"""

--- a/libs/agno/tests/unit/tracing/test_exporter.py
+++ b/libs/agno/tests/unit/tracing/test_exporter.py
@@ -1,0 +1,76 @@
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from agno.tracing.exporter import DatabaseSpanExporter
+from agno.tracing.schemas import Span
+
+
+def _exporter() -> DatabaseSpanExporter:
+    return DatabaseSpanExporter(db=object())  # type: ignore[arg-type]
+
+
+def test_export_async_keeps_background_task_until_it_completes() -> None:
+    async def run_test() -> None:
+        exporter = _exporter()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def fake_export(spans_by_trace: Dict[str, List[Span]]) -> None:
+            started.set()
+            await release.wait()
+
+        exporter._do_async_export = fake_export  # type: ignore[method-assign]
+
+        exporter._export_async({"trace-id": []})
+
+        assert len(exporter._background_tasks) == 1
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert len(exporter._background_tasks) == 1
+
+        task = next(iter(exporter._background_tasks))
+        release.set()
+        await asyncio.wait_for(task, timeout=1)
+
+        assert exporter._background_tasks == set()
+
+    asyncio.run(run_test())
+
+
+def test_export_async_observes_background_task_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def run_test() -> None:
+        exporter = _exporter()
+        errors: List[str] = []
+
+        async def failing_export(spans_by_trace: Dict[str, List[Span]]) -> None:
+            raise RuntimeError("boom")
+
+        exporter._do_async_export = failing_export  # type: ignore[method-assign]
+        monkeypatch.setattr("agno.tracing.exporter.log_error", errors.append)
+
+        exporter._export_async({"trace-id": []})
+        task = next(iter(exporter._background_tasks))
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await asyncio.wait_for(task, timeout=1)
+
+        assert exporter._background_tasks == set()
+        assert errors == ["Failed to export async traces: boom"]
+
+    asyncio.run(run_test())
+
+
+def test_export_async_runs_directly_without_running_loop() -> None:
+    exporter = _exporter()
+    calls: List[Any] = []
+
+    async def fake_export(spans_by_trace: Dict[str, List[Span]]) -> None:
+        calls.append(spans_by_trace)
+
+    exporter._do_async_export = fake_export  # type: ignore[method-assign]
+
+    exporter._export_async({"trace-id": []})
+
+    assert calls == [{"trace-id": []}]
+    assert exporter._background_tasks == set()


### PR DESCRIPTION
## Summary
- track async DatabaseSpanExporter background tasks until completion instead of letting them be garbage collected
- use get_running_loop for in-loop exports and asyncio.run when sync export runs outside a loop
- log exceptions raised by background export tasks

## Tests
- PYTHONPATH=libs/agno uv run --no-project --with pytest --with rich --with opentelemetry-sdk --with docstring-parser --with gitpython --with h11 --with httpx[http2] --with packaging --with pydantic-settings --with pydantic --with python-dotenv --with python-multipart --with pyyaml --with typer --with typing-extensions python -m pytest libs/agno/tests/unit/tracing/test_exporter.py
- uv run --no-project --with ruff ruff check libs/agno/agno/tracing/exporter.py libs/agno/tests/unit/tracing/test_exporter.py

Fixes #8182