### PR TITLE
Make agent telemetry non-blocking

### DIFF
--- a/libs/agno/agno/agent/_telemetry.py
+++ b/libs/agno/agno/agent/_telemetry.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, Optional
+import asyncio
+from queue import Full, Queue
+from threading import Lock, Thread
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
 if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
 from agno.utils.log import log_debug
+
+_BACKGROUND_AGENT_TELEMETRY_TASKS: Set[asyncio.Task] = set()
+_AGENT_TELEMETRY_QUEUE = Queue(maxsize=128)
+_AGENT_TELEMETRY_WORKER_LOCK = Lock()
+_AGENT_TELEMETRY_WORKER_STARTED = False
 
 
 def get_telemetry_data(agent: Agent) -> Dict[str, Any]:
@@ -36,6 +44,55 @@ def get_telemetry_data(agent: Agent) -> Dict[str, Any]:
     }
 
 
+def _create_agent_run_background(run: Any) -> None:
+    from agno.api.agent import create_agent_run
+
+    try:
+        create_agent_run(run=run)
+    except Exception as e:
+        log_debug(f"Could not create Agent run telemetry event: {e}")
+
+
+def _agent_telemetry_worker() -> None:
+    while True:
+        run = _AGENT_TELEMETRY_QUEUE.get()
+        try:
+            _create_agent_run_background(run)
+        finally:
+            _AGENT_TELEMETRY_QUEUE.task_done()
+
+
+def _ensure_agent_telemetry_worker() -> None:
+    global _AGENT_TELEMETRY_WORKER_STARTED
+
+    if _AGENT_TELEMETRY_WORKER_STARTED:
+        return
+
+    with _AGENT_TELEMETRY_WORKER_LOCK:
+        if _AGENT_TELEMETRY_WORKER_STARTED:
+            return
+        Thread(target=_agent_telemetry_worker, daemon=True, name="agno-agent-telemetry").start()
+        _AGENT_TELEMETRY_WORKER_STARTED = True
+
+
+def _enqueue_agent_telemetry_run(run: Any) -> None:
+    _ensure_agent_telemetry_worker()
+    try:
+        _AGENT_TELEMETRY_QUEUE.put_nowait(run)
+    except Full:
+        log_debug("Could not create Agent run telemetry event: background queue is full")
+
+
+def _handle_agent_telemetry_task_done(task: asyncio.Task) -> None:
+    _BACKGROUND_AGENT_TELEMETRY_TASKS.discard(task)
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception as e:
+        log_debug(f"Could not create Agent run telemetry event: {e}")
+
+
 def log_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = None) -> None:
     """Send a telemetry event to the API for a created Agent run."""
     from agno.agent import _init
@@ -44,16 +101,15 @@ def log_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = N
     if not agent.telemetry:
         return
 
-    from agno.api.agent import AgentRunCreate, create_agent_run
+    from agno.api.agent import AgentRunCreate
 
     try:
-        create_agent_run(
-            run=AgentRunCreate(
-                session_id=session_id,
-                run_id=run_id,
-                data=get_telemetry_data(agent),
-            ),
+        run = AgentRunCreate(
+            session_id=session_id,
+            run_id=run_id,
+            data=get_telemetry_data(agent),
         )
+        _enqueue_agent_telemetry_run(run)
     except Exception as e:
         log_debug(f"Could not create Agent run telemetry event: {e}")
 
@@ -69,12 +125,13 @@ async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[s
     from agno.api.agent import AgentRunCreate, acreate_agent_run
 
     try:
-        await acreate_agent_run(
-            run=AgentRunCreate(
-                session_id=session_id,
-                run_id=run_id,
-                data=get_telemetry_data(agent),
-            )
+        run = AgentRunCreate(
+            session_id=session_id,
+            run_id=run_id,
+            data=get_telemetry_data(agent),
         )
+        task = asyncio.create_task(acreate_agent_run(run=run))
+        _BACKGROUND_AGENT_TELEMETRY_TASKS.add(task)
+        task.add_done_callback(_handle_agent_telemetry_task_done)
     except Exception as e:
         log_debug(f"Could not create Agent run telemetry event: {e}")

--- a/libs/agno/tests/unit/telemetry/test_agent_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_agent_telemetry.py
@@ -1,8 +1,18 @@
+import asyncio
+from types import ModuleType
+import time
+from threading import Event
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agno.agent import _telemetry
 from agno.agent.agent import Agent
+
+
+class FakeAgentRunCreate:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
 
 
 def test_agent_telemetry():
@@ -54,3 +64,60 @@ async def test_agent_telemetry_async():
         assert call_args.kwargs["session_id"] is not None
         assert "run_id" in call_args.kwargs
         assert call_args.kwargs["run_id"] is not None
+
+
+def test_log_agent_telemetry_does_not_block_on_api_call():
+    agent = Agent()
+    started = Event()
+    release = Event()
+
+    def slow_create_agent_run(run):
+        started.set()
+        release.wait(timeout=1)
+
+    fake_agent_api = ModuleType("agno.api.agent")
+    fake_agent_api.AgentRunCreate = FakeAgentRunCreate
+    fake_agent_api.create_agent_run = MagicMock(side_effect=slow_create_agent_run)
+
+    with patch.dict("sys.modules", {"agno.api.agent": fake_agent_api}):
+        start = time.perf_counter()
+        _telemetry.log_agent_telemetry(agent, session_id="session-id", run_id="run-id")
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.5
+        assert started.wait(timeout=1)
+        release.set()
+        assert fake_agent_api.create_agent_run.call_count == 1
+
+
+def test_alog_agent_telemetry_does_not_block_on_api_call():
+    async def run_test():
+        agent = Agent()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_acreate_agent_run(run):
+            started.set()
+            await release.wait()
+
+        fake_agent_api = ModuleType("agno.api.agent")
+        fake_agent_api.AgentRunCreate = FakeAgentRunCreate
+        fake_agent_api.acreate_agent_run = AsyncMock(side_effect=slow_acreate_agent_run)
+
+        with patch.dict("sys.modules", {"agno.api.agent": fake_agent_api}):
+            start = time.perf_counter()
+            await _telemetry.alog_agent_telemetry(agent, session_id="session-id", run_id="run-id")
+            elapsed = time.perf_counter() - start
+
+            assert elapsed < 0.5
+            await asyncio.wait_for(started.wait(), timeout=1)
+            assert len(_telemetry._BACKGROUND_AGENT_TELEMETRY_TASKS) == 1
+
+            task = next(iter(_telemetry._BACKGROUND_AGENT_TELEMETRY_TASKS))
+            release.set()
+            await asyncio.wait_for(task, timeout=1)
+
+            assert _telemetry._BACKGROUND_AGENT_TELEMETRY_TASKS == set()
+            assert fake_agent_api.acreate_agent_run.call_count == 1
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- move sync agent telemetry posting to a bounded background queue with a single daemon worker
- schedule async telemetry with tracked background tasks instead of awaiting network calls in the agent path
- surface background telemetry failures through debug logs without adding run latency

## Tests
- PYTHONPATH=libs/agno uv run --no-project --with pytest --with pytest-asyncio --with rich --with opentelemetry-sdk --with docstring-parser --with gitpython --with h11 --with httpx[http2] --with packaging --with pydantic-settings --with pydantic --with python-dotenv --with python-multipart --with pyyaml --with typer --with typing-extensions python -m pytest libs/agno/tests/unit/telemetry/test_agent_telemetry.py
- uv run --no-project --with ruff ruff check libs/agno/agno/agent/_telemetry.py libs/agno/tests/unit/telemetry/test_agent_telemetry.py

Fixes #8181