### PR TITLE
[fix] Preserve AG-UI readable context

### DIFF
--- a/libs/agno/agno/agent/_managers.py
+++ b/libs/agno/agno/agent/_managers.py
@@ -67,7 +67,9 @@ def make_memories(
         non_empty_messages = [
             msg
             for msg in parsed_messages
-            if msg.content and (not isinstance(msg.content, str) or msg.content.strip() != "")
+            if msg.add_to_agent_memory
+            and msg.content
+            and (not isinstance(msg.content, str) or msg.content.strip() != "")
         ]
         if len(non_empty_messages) > 0:
             if agent.memory_manager is not None and agent.update_memory_on_run:
@@ -122,7 +124,9 @@ async def amake_memories(
         non_empty_messages = [
             msg
             for msg in parsed_messages
-            if msg.content and (not isinstance(msg.content, str) or msg.content.strip() != "")
+            if msg.add_to_agent_memory
+            and msg.content
+            and (not isinstance(msg.content, str) or msg.content.strip() != "")
         ]
         if len(non_empty_messages) > 0:
             if agent.memory_manager is not None and agent.update_memory_on_run:

--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1211,12 +1211,19 @@ def get_run_messages(
         run_messages.messages.append(system_message)
 
     # 2. Add extra messages to run_messages if provided
+    additional_input = kwargs.pop("additional_input", None)
+    all_additional_input = []
     if agent.additional_input is not None:
+        all_additional_input.extend(agent.additional_input)
+    if additional_input is not None:
+        all_additional_input.extend(additional_input)
+
+    if all_additional_input:
         messages_to_add_to_run_response: List[Message] = []
         if run_messages.extra_messages is None:
             run_messages.extra_messages = []
 
-        for _m in agent.additional_input:
+        for _m in all_additional_input:
             if isinstance(_m, Message):
                 messages_to_add_to_run_response.append(_m)
                 run_messages.messages.append(_m)
@@ -1416,12 +1423,19 @@ async def aget_run_messages(
         run_messages.messages.append(system_message)
 
     # 2. Add extra messages to run_messages if provided
+    additional_input = kwargs.pop("additional_input", None)
+    all_additional_input = []
     if agent.additional_input is not None:
+        all_additional_input.extend(agent.additional_input)
+    if additional_input is not None:
+        all_additional_input.extend(additional_input)
+
+    if all_additional_input:
         messages_to_add_to_run_response: List[Message] = []
         if run_messages.extra_messages is None:
             run_messages.extra_messages = []
 
-        for _m in agent.additional_input:
+        for _m in all_additional_input:
             if isinstance(_m, Message):
                 messages_to_add_to_run_response.append(_m)
                 run_messages.messages.append(_m)

--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -584,9 +584,13 @@ class AgentOSClient:
         if files:
             data["files"] = json.dumps([f.model_dump() for f in files])
 
-        # Add kwargs to data, serializing dicts as JSON
+        # Add kwargs to data, serializing structured values as JSON
         for key, value in kwargs.items():
-            if isinstance(value, dict):
+            if key == "additional_input" and isinstance(value, list):
+                data[key] = json.dumps(
+                    [item.model_dump(mode="json") if hasattr(item, "model_dump") else item for item in value]
+                )
+            elif isinstance(value, dict):
                 data[key] = json.dumps(value)
             else:
                 data[key] = value
@@ -645,7 +649,11 @@ class AgentOSClient:
             data["files"] = json.dumps([f.model_dump() for f in files])
 
         for key, value in kwargs.items():
-            if isinstance(value, dict):
+            if key == "additional_input" and isinstance(value, list):
+                data[key] = json.dumps(
+                    [item.model_dump(mode="json") if hasattr(item, "model_dump") else item for item in value]
+                )
+            elif isinstance(value, dict):
                 data[key] = json.dumps(value)
             else:
                 data[key] = value
@@ -856,9 +864,13 @@ class AgentOSClient:
         if files:
             data["files"] = json.dumps(files)
 
-        # Add kwargs to data, serializing dicts as JSON
+        # Add kwargs to data, serializing structured values as JSON
         for key, value in kwargs.items():
-            if isinstance(value, dict):
+            if key == "additional_input" and isinstance(value, list):
+                data[key] = json.dumps(
+                    [item.model_dump(mode="json") if hasattr(item, "model_dump") else item for item in value]
+                )
+            elif isinstance(value, dict):
                 data[key] = json.dumps(value)
             else:
                 data[key] = value
@@ -916,9 +928,13 @@ class AgentOSClient:
         if files:
             data["files"] = json.dumps(files)
 
-        # Add kwargs to data, serializing dicts as JSON
+        # Add kwargs to data, serializing structured values as JSON
         for key, value in kwargs.items():
-            if isinstance(value, dict):
+            if key == "additional_input" and isinstance(value, list):
+                data[key] = json.dumps(
+                    [item.model_dump(mode="json") if hasattr(item, "model_dump") else item for item in value]
+                )
+            elif isinstance(value, dict):
                 data[key] = json.dumps(value)
             else:
                 data[key] = value

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -1,7 +1,8 @@
 """Async router handling exposing an Agno Agent or Team in an AG-UI compatible format."""
 
+import json
 import uuid
-from typing import AsyncIterator, Optional, Union
+from typing import Any, AsyncIterator, List, Optional, Union
 
 from agno.utils.log import log_error
 
@@ -21,13 +22,30 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
+from agno.models.message import Message
 from agno.os.interfaces.agui.utils import (
     async_stream_agno_response_as_agui_events,
+    extract_agui_context,
     extract_agui_user_input,
     validate_agui_state,
 )
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+
+
+def _additional_input_from_agui_context(context: Any) -> Optional[List[Message]]:
+    agui_context = extract_agui_context(context)
+    if agui_context is None:
+        return None
+
+    context_json = json.dumps({"agui_context": agui_context}, indent=2, ensure_ascii=False)
+    return [
+        Message(
+            role="user",
+            content=f"<additional context>\n{context_json}\n</additional context>",
+            add_to_agent_memory=False,
+        )
+    ]
 
 
 async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) -> AsyncIterator[BaseEvent]:
@@ -38,6 +56,7 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
         # AG-UI frontends send full conversation history every request.
         # Extract only the last user message — agent manages history via session DB.
         user_input = extract_agui_user_input(run_input.messages or [])
+        additional_input = _additional_input_from_agui_context(getattr(run_input, "context", None))
 
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
@@ -49,7 +68,10 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
         # Validating the session state is of the expected type (dict)
         session_state = validate_agui_state(run_input.state, run_input.thread_id)
 
-        # Request streaming response from agent
+        run_kwargs = {}
+        if additional_input is not None:
+            run_kwargs["additional_input"] = additional_input
+
         response_stream = agent.arun(  # type: ignore
             input=user_input,
             session_id=run_input.thread_id,
@@ -58,6 +80,7 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
             user_id=user_id,
             session_state=session_state,
             run_id=run_id,
+            **run_kwargs,
         )
 
         # Stream the response content in AG-UI format
@@ -81,6 +104,7 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
         # AG-UI frontends send full conversation history every request.
         # Extract only the last user message — team manages history via session DB.
         user_input = extract_agui_user_input(input.messages or [])
+        additional_input = _additional_input_from_agui_context(getattr(input, "context", None))
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=input.thread_id, run_id=run_id)
 
         # Look for user_id in input.forwarded_props
@@ -91,7 +115,10 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
         # Validating the session state is of the expected type (dict)
         session_state = validate_agui_state(input.state, input.thread_id)
 
-        # Request streaming response from team
+        run_kwargs = {}
+        if additional_input is not None:
+            run_kwargs["additional_input"] = additional_input
+
         response_stream = team.arun(  # type: ignore
             input=user_input,
             session_id=input.thread_id,
@@ -100,6 +127,7 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
             user_id=user_id,
             session_state=session_state,
             run_id=run_id,
+            **run_kwargs,
         )
 
         # Stream the response content in AG-UI format

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -176,6 +176,32 @@ def extract_agui_user_input(messages: List[AGUIMessage]) -> str:
     return ""
 
 
+def extract_agui_context(context: Optional[List[Any]]) -> Optional[List[Dict[str, Any]]]:
+    """Convert AG-UI context entries into serializable context records."""
+    if not context:
+        return None
+
+    context_entries: List[Dict[str, Any]] = []
+    for index, item in enumerate(context, start=1):
+        description = getattr(item, "description", None)
+        value = getattr(item, "value", None)
+
+        if isinstance(item, dict):
+            description = item.get("description", description)
+            value = item.get("value", value)
+
+        description = description if isinstance(description, str) and description else f"context_{index}"
+        if isinstance(value, str):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                pass
+
+        context_entries.append({"description": description, "value": value})
+
+    return context_entries or None
+
+
 def extract_team_response_chunk_content(response: TeamRunContentEvent) -> str:
     """Given a response stream chunk, find and extract the content."""
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -108,6 +108,21 @@ async def get_request_kwargs(request: Request, endpoint_func: Callable) -> Dict[
             kwargs.pop("metadata")
             log_warning(f"Invalid metadata parameter couldn't be loaded: {metadata}: {str(e)}")
 
+    if additional_input := kwargs.get("additional_input"):
+        try:
+            if isinstance(additional_input, str):
+                from agno.models.message import Message
+
+                additional_input_data = json.loads(additional_input)
+                if isinstance(additional_input_data, list):
+                    kwargs["additional_input"] = [Message.model_validate(message) for message in additional_input_data]
+        except json.JSONDecodeError as e:
+            kwargs.pop("additional_input")
+            log_warning(f"Invalid additional_input parameter couldn't be loaded: {additional_input}: {str(e)}")
+        except Exception as e:
+            kwargs.pop("additional_input")
+            log_warning(f"Invalid additional_input message payload: {str(e)}")
+
     if knowledge_filters := kwargs.get("knowledge_filters"):
         try:
             if isinstance(knowledge_filters, str):

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -856,12 +856,19 @@ def _get_run_messages(
         run_messages.messages.append(system_message)
 
     # 2. Add extra messages to run_messages if provided
+    additional_input = kwargs.pop("additional_input", None)
+    all_additional_input = []
     if team.additional_input is not None:
+        all_additional_input.extend(team.additional_input)
+    if additional_input is not None:
+        all_additional_input.extend(additional_input)
+
+    if all_additional_input:
         messages_to_add_to_run_response: List[Message] = []
         if run_messages.extra_messages is None:
             run_messages.extra_messages = []
 
-        for _m in team.additional_input:
+        for _m in all_additional_input:
             if isinstance(_m, Message):
                 messages_to_add_to_run_response.append(_m)
                 run_messages.messages.append(_m)
@@ -991,12 +998,19 @@ async def _aget_run_messages(
         run_messages.messages.append(system_message)
 
     # 2. Add extra messages to run_messages if provided
+    additional_input = kwargs.pop("additional_input", None)
+    all_additional_input = []
     if team.additional_input is not None:
+        all_additional_input.extend(team.additional_input)
+    if additional_input is not None:
+        all_additional_input.extend(additional_input)
+
+    if all_additional_input:
         messages_to_add_to_run_response: List[Message] = []
         if run_messages.extra_messages is None:
             run_messages.extra_messages = []
 
-        for _m in team.additional_input:
+        for _m in all_additional_input:
             if isinstance(_m, Message):
                 messages_to_add_to_run_response.append(_m)
                 run_messages.messages.append(_m)

--- a/libs/agno/tests/unit/agent/test_run_regressions.py
+++ b/libs/agno/tests/unit/agent/test_run_regressions.py
@@ -3,9 +3,10 @@ from typing import Any, Optional
 
 import pytest
 
-from agno.agent import _init, _messages, _response, _run, _session, _storage, _tools
+from agno.agent import _init, _managers, _messages, _response, _run, _session, _storage, _tools
 from agno.agent.agent import Agent
 from agno.db.base import SessionType
+from agno.models.message import Message
 from agno.run import RunContext
 from agno.run.agent import RunErrorEvent, RunOutput
 from agno.run.base import RunStatus
@@ -51,7 +52,7 @@ def _patch_sync_dispatch_dependencies(
 
 
 def test_run_dispatch_cleans_up_registered_run_on_setup_failure(monkeypatch: pytest.MonkeyPatch):
-    agent = Agent(name="test-agent")
+    agent = Agent(name="test-agent", build_context=False)
     _patch_sync_dispatch_dependencies(agent, monkeypatch, runs=[])
 
     def failing_initialize_agent(debug_mode=None):
@@ -105,6 +106,48 @@ def test_run_dispatch_does_not_reset_cancellation_before_impl(monkeypatch: pytes
 
     assert observed["cancelled_before_model"] is True
     assert run_id not in get_active_runs()
+
+
+def test_get_run_messages_accepts_runtime_additional_input():
+    agent = Agent(name="test-agent", system_message=Message(role="system", content="system"))
+    extra_message = Message(role="user", content="request context")
+    run_response = RunOutput(run_id="run-extra", session_id="session-extra")
+    run_context = RunContext(run_id="run-extra", session_id="session-extra")
+    session = AgentSession(session_id="session-extra", runs=[])
+
+    run_messages = _messages.get_run_messages(
+        agent,
+        run_response=run_response,
+        run_context=run_context,
+        input="question",
+        session=session,
+        additional_input=[extra_message],
+    )
+
+    assert extra_message in run_messages.extra_messages
+    assert run_response.additional_input == [extra_message]
+    assert run_messages.user_message is not None
+    assert run_messages.user_message.content == "question"
+
+
+def test_make_memories_skips_extra_messages_marked_non_memory():
+    class MemoryManager:
+        def __init__(self):
+            self.messages = None
+
+        def create_user_memories(self, **kwargs):
+            self.messages = kwargs.get("messages")
+
+    memory_manager = MemoryManager()
+    agent = Agent(name="test-agent", update_memory_on_run=True)
+    agent.memory_manager = memory_manager  # type: ignore[assignment]
+    persistent_message = Message(role="user", content="remember this")
+    transient_message = Message(role="user", content="do not remember this", add_to_agent_memory=False)
+    run_messages = RunMessages(extra_messages=[transient_message, persistent_message])
+
+    _managers.make_memories(agent, run_messages)
+
+    assert memory_manager.messages == [persistent_message]
 
 
 def test_continue_run_dispatch_handles_none_session_runs(monkeypatch: pytest.MonkeyPatch):

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,16 +9,18 @@ from agno.os.interfaces.agui.router import run_agent, run_team
 
 
 class FakeRunInput:
-    def __init__(self):
+    def __init__(self, context=None):
         self.messages = [MagicMock(role="user", content="test")]
         self.thread_id = "test-thread"
         self.run_id = "test-run"
         self.forwarded_props = None
         self.state = None
+        self.context = context
 
 
 class CaptureKwargsTeam:
-    def __init__(self):
+    def __init__(self, dependencies=None):
+        self.dependencies = dependencies
         self.captured_kwargs = {}
 
     async def arun(self, **kwargs):
@@ -27,7 +30,8 @@ class CaptureKwargsTeam:
 
 
 class CaptureKwargsAgent:
-    def __init__(self):
+    def __init__(self, dependencies=None):
+        self.dependencies = dependencies
         self.captured_kwargs = {}
 
     async def arun(self, **kwargs):
@@ -48,6 +52,8 @@ async def test_run_team_passes_stream_events_not_stream_steps():
     assert fake_team.captured_kwargs.get("stream") is True
     assert fake_team.captured_kwargs.get("stream_events") is True
     assert "stream_steps" not in fake_team.captured_kwargs
+    assert "dependencies" not in fake_team.captured_kwargs
+    assert "add_dependencies_to_context" not in fake_team.captured_kwargs
 
 
 @pytest.mark.asyncio
@@ -62,3 +68,63 @@ async def test_run_agent_passes_stream_events():
     assert fake_agent.captured_kwargs.get("stream") is True
     assert fake_agent.captured_kwargs.get("stream_events") is True
     assert "stream_steps" not in fake_agent.captured_kwargs
+    assert "dependencies" not in fake_agent.captured_kwargs
+    assert "add_dependencies_to_context" not in fake_agent.captured_kwargs
+
+
+@pytest.mark.asyncio
+async def test_run_agent_adds_agui_context_to_input():
+    fake_agent = CaptureKwargsAgent(dependencies={"robot_name": "Anna"})
+    context = [
+        MagicMock(description="Visible movies", value='{"count": 2, "movies": ["Apex", "Hoppers"]}'),
+        MagicMock(description="Search query", value="family movies"),
+        MagicMock(description="Search query", value="new releases"),
+    ]
+    run_input = FakeRunInput(context=context)
+
+    events = []
+    async for event in run_agent(fake_agent, run_input):
+        events.append(event)
+
+    assert "dependencies" not in fake_agent.captured_kwargs
+    assert "add_dependencies_to_context" not in fake_agent.captured_kwargs
+    assert fake_agent.captured_kwargs["input"] == "test"
+    context_message = fake_agent.captured_kwargs["additional_input"][0]
+    context_json = context_message.content.removeprefix("<additional context>\n").removesuffix(
+        "\n</additional context>"
+    )
+    assert context_message.role == "user"
+    assert context_message.add_to_agent_memory is False
+    assert context_message.temporary is False
+    assert json.loads(context_json) == {
+        "agui_context": [
+            {"description": "Visible movies", "value": {"count": 2, "movies": ["Apex", "Hoppers"]}},
+            {"description": "Search query", "value": "family movies"},
+            {"description": "Search query", "value": "new releases"},
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_team_adds_agui_context_to_input():
+    fake_team = CaptureKwargsTeam(dependencies={"team_mode": "route"})
+    context = [MagicMock(description="Visible movies", value='{"count": 1, "movies": ["Apex"]}')]
+    run_input = FakeRunInput(context=context)
+
+    events = []
+    async for event in run_team(fake_team, run_input):
+        events.append(event)
+
+    assert "dependencies" not in fake_team.captured_kwargs
+    assert "add_dependencies_to_context" not in fake_team.captured_kwargs
+    assert fake_team.captured_kwargs["input"] == "test"
+    context_message = fake_team.captured_kwargs["additional_input"][0]
+    context_json = context_message.content.removeprefix("<additional context>\n").removesuffix(
+        "\n</additional context>"
+    )
+    assert context_message.role == "user"
+    assert context_message.add_to_agent_memory is False
+    assert context_message.temporary is False
+    assert json.loads(context_json) == {
+        "agui_context": [{"description": "Visible movies", "value": {"count": 1, "movies": ["Apex"]}}],
+    }

--- a/libs/agno/tests/unit/os/test_client.py
+++ b/libs/agno/tests/unit/os/test_client.py
@@ -13,10 +13,12 @@ Tests cover:
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
+import json
 
 import pytest
 
 from agno.client import AgentOSClient
+from agno.models.message import Message
 
 
 def test_init_with_base_url():
@@ -81,6 +83,29 @@ async def test_post_method():
         call_args = mock_http_client.request.call_args
         assert call_args[0][0] == "POST"
         assert result == {"created": True}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_serializes_additional_input_messages(monkeypatch):
+    client = AgentOSClient(base_url="http://localhost:7777")
+    message = Message(role="user", content="request context", add_to_agent_memory=False)
+    captured = {}
+
+    async def fake_apost(endpoint, data=None, headers=None, as_form=False):
+        captured["endpoint"] = endpoint
+        captured["data"] = data
+        captured["as_form"] = as_form
+        return {"run_id": "run-id"}
+
+    monkeypatch.setattr(client, "_apost", fake_apost)
+
+    await client.run_agent("agent-id", "hello", additional_input=[message])
+
+    assert captured["endpoint"] == "/agents/agent-id/runs"
+    assert captured["as_form"] is True
+    additional_input = json.loads(captured["data"]["additional_input"])
+    assert additional_input[0]["content"] == "request context"
+    assert additional_input[0]["add_to_agent_memory"] is False
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/os/test_utils.py
+++ b/libs/agno/tests/unit/os/test_utils.py
@@ -1,6 +1,7 @@
 """Unit tests for OS utility functions."""
 
 import io
+import json
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -8,9 +9,11 @@ import pytest
 from starlette.datastructures import Headers, UploadFile
 
 from agno.media import File
+from agno.models.message import Message
 from agno.os.utils import (
     DOCUMENT_MIME_TYPES,
     classify_upload_file,
+    get_request_kwargs,
     process_document,
     to_utc_datetime,
 )
@@ -106,6 +109,28 @@ def _make_upload_file(filename: str, content_type: Optional[str], data: bytes = 
     """Build an UploadFile mirroring what Starlette passes the routers from a multipart upload."""
     headers = Headers({"content-type": content_type}) if content_type is not None else Headers({})
     return UploadFile(filename=filename, file=io.BytesIO(data), headers=headers)
+
+
+class _FakeRequest:
+    def __init__(self, form_data):
+        self._form_data = form_data
+
+    async def form(self):
+        return self._form_data
+
+
+async def _run_endpoint(message: str):
+    return message
+
+
+@pytest.mark.asyncio
+async def test_get_request_kwargs_deserializes_additional_input_messages():
+    message = Message(role="user", content="request context", add_to_agent_memory=False)
+    request = _FakeRequest({"message": "hello", "additional_input": json.dumps([message.model_dump(mode="json")])})
+
+    kwargs = await get_request_kwargs(request, _run_endpoint)
+
+    assert kwargs["additional_input"] == [message]
 
 
 # Single source of truth for the document formats the API accepts: (extension, canonical MIME).

--- a/libs/agno/tests/unit/team/test_run_context_precedence.py
+++ b/libs/agno/tests/unit/team/test_run_context_precedence.py
@@ -2,11 +2,12 @@ from typing import Any, Optional
 
 import pytest
 
+from agno.models.message import Message
 from agno.run import RunContext
 from agno.run.cancel import cleanup_run
 from agno.run.team import TeamRunOutput
 from agno.session.team import TeamSession
-from agno.team import _init, _response, _run, _run_options, _storage, _utils
+from agno.team import _init, _messages, _response, _run, _run_options, _storage, _utils
 from agno.team.team import Team
 
 
@@ -71,6 +72,28 @@ def _patch_team_dispatch_dependencies(team: Team, monkeypatch: pytest.MonkeyPatc
             else team.output_schema,
         ),
     )
+
+
+def test_get_run_messages_accepts_runtime_additional_input_for_team():
+    team = Team(name="test-team", members=[], system_message=Message(role="system", content="system"))
+    extra_message = Message(role="user", content="request context")
+    run_response = TeamRunOutput(run_id="run-extra", session_id="session-extra")
+    run_context = RunContext(run_id="run-extra", session_id="session-extra")
+    session = TeamSession(session_id="session-extra", runs=[])
+
+    run_messages = _messages._get_run_messages(
+        team,
+        run_response=run_response,
+        run_context=run_context,
+        input_message="question",
+        session=session,
+        additional_input=[extra_message],
+    )
+
+    assert extra_message in run_messages.extra_messages
+    assert run_response.additional_input == [extra_message]
+    assert run_messages.user_message is not None
+    assert run_messages.user_message.content == "question"
 
 
 def test_run_respects_run_context_precedence(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Summary

Fixes #7805.

AG-UI `RunAgentInput.context` is now converted into request-scoped additional input for agent and team runs so CopilotKit/readable frontend context reaches the model without changing the primary user query or exposing configured dependencies.

This also adds runtime `additional_input` support for agent/team message builders and serializes/deserializes it across AgentOS remote client/server form transport. Synthetic AG-UI context messages are marked `add_to_agent_memory=False`, and memory creation now respects that flag for extra messages.

Duplicate screening: I searched open PRs for `7805`, `AG-UI adapter context run_input.context Agent.arun`, and `AGUI run_input context Agent.arun context`. PR #7812 was closed unmerged after maintainer feedback that passing `context=` directly was not an actual fix; no equivalent active PR is open.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Focused verification run:

```bash
libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/os/interfaces/test_agui_router.py libs/agno/tests/unit/agent/test_run_regressions.py::test_get_run_messages_accepts_runtime_additional_input libs/agno/tests/unit/agent/test_run_regressions.py::test_make_memories_skips_extra_messages_marked_non_memory libs/agno/tests/unit/team/test_run_context_precedence.py::test_get_run_messages_accepts_runtime_additional_input_for_team libs/agno/tests/unit/os/test_utils.py::test_get_request_kwargs_deserializes_additional_input_messages libs/agno/tests/unit/os/test_client.py::test_run_agent_serializes_additional_input_messages
libs/agno/.venv/bin/python -m ruff check libs/agno/agno/os/interfaces/agui/router.py libs/agno/agno/os/interfaces/agui/utils.py libs/agno/agno/agent/_messages.py libs/agno/agno/team/_messages.py libs/agno/agno/client/os.py libs/agno/agno/os/utils.py libs/agno/agno/agent/_managers.py libs/agno/tests/unit/os/interfaces/test_agui_router.py libs/agno/tests/unit/agent/test_run_regressions.py libs/agno/tests/unit/team/test_run_context_precedence.py libs/agno/tests/unit/os/test_utils.py libs/agno/tests/unit/os/test_client.py
libs/agno/.venv/bin/python -m ruff format --check libs/agno/agno/os/interfaces/agui/router.py libs/agno/agno/os/interfaces/agui/utils.py libs/agno/agno/agent/_messages.py libs/agno/agno/team/_messages.py libs/agno/agno/client/os.py libs/agno/agno/os/utils.py libs/agno/agno/agent/_managers.py libs/agno/tests/unit/os/interfaces/test_agui_router.py libs/agno/tests/unit/agent/test_run_regressions.py libs/agno/tests/unit/team/test_run_context_precedence.py libs/agno/tests/unit/os/test_utils.py libs/agno/tests/unit/os/test_client.py
git diff --check
```

I did not run the full `./scripts/validate.sh`; this PR is limited to focused AG-UI/additional-input behavior and targeted checks above.
