### PR TITLE
fix: close audio files after transcription

### DIFF
--- a/libs/agno/agno/tools/openai.py
+++ b/libs/agno/agno/tools/openai.py
@@ -87,13 +87,12 @@ class OpenAITools(Toolkit):
         """
         log_debug(f"Transcribing audio from {audio_path}")
         try:
-            audio_file = open(audio_path, "rb")
-
-            transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
-                model=self.transcription_model,
-                file=audio_file,
-                response_format="text",
-            )
+            with open(audio_path, "rb") as audio_file:
+                transcript = OpenAIClient(api_key=self.api_key).audio.transcriptions.create(
+                    model=self.transcription_model,
+                    file=audio_file,
+                    response_format="text",
+                )
         except Exception as e:  # type: ignore[return]
             log_error(f"Failed to transcribe audio: {str(e)}")
             return f"Failed to transcribe audio: {str(e)}"

--- a/libs/agno/tests/unit/tools/test_openai.py
+++ b/libs/agno/tests/unit/tools/test_openai.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from agno.tools import openai as openai_tools
+from agno.tools.openai import OpenAITools
+
+
+def test_transcribe_audio_closes_file(tmp_path, monkeypatch):
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"fake audio")
+
+    class Transcriptions:
+        opened_file = None
+
+        def create(self, *, model, file, response_format):
+            assert model == "whisper-1"
+            assert response_format == "text"
+            assert not file.closed
+            self.opened_file = file
+            return "transcript text"
+
+    transcriptions = Transcriptions()
+
+    class FakeOpenAIClient:
+        def __init__(self, *, api_key):
+            assert api_key == "test-key"
+            self.audio = SimpleNamespace(transcriptions=transcriptions)
+
+    monkeypatch.setattr(openai_tools, "OpenAIClient", FakeOpenAIClient)
+
+    tools = OpenAITools(
+        api_key="test-key",
+        enable_image_generation=False,
+        enable_speech_generation=False,
+    )
+
+    assert tools.transcribe_audio(str(audio_path)) == "transcript text"
+    assert transcriptions.opened_file is not None
+    assert transcriptions.opened_file.closed


### PR DESCRIPTION
## Summary
- close the audio file handle with a context manager before returning from `OpenAITools.transcribe_audio`
- add a regression test that asserts the file is still open while passed to the OpenAI client and closed after transcription returns

Fixes #8160.

## To verify
- cd libs/agno
- .venv\Scripts\python.exe -m pytest tests\unit\tools\test_openai.py -q
- .venv\Scripts\python.exe -m ruff check agno\tools\openai.py tests\unit\tools\test_openai.py
- .venv\Scripts\python.exe -m ruff format --check agno\tools\openai.py tests\unit\tools\test_openai.py