### PR TITLE
fix: send agent telemetry off the run path

### DIFF
--- a/libs/agno/agno/api/agent.py
+++ b/libs/agno/agno/api/agent.py
@@ -1,10 +1,12 @@
+from threading import Thread
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.agent import AgentRunCreate
 from agno.utils.log import log_debug
 
 
-def create_agent_run(run: AgentRunCreate) -> None:
+def _send_agent_run(run: AgentRunCreate) -> None:
     """Telemetry recording for Agent runs"""
     with api.Client() as api_client:
         try:
@@ -14,6 +16,11 @@ def create_agent_run(run: AgentRunCreate) -> None:
             )
         except Exception as e:
             log_debug(f"Could not create Agent run: {e}")
+
+
+def create_agent_run(run: AgentRunCreate) -> None:
+    """Telemetry recording for Agent runs"""
+    Thread(target=_send_agent_run, args=(run,), daemon=True).start()
 
 
 async def acreate_agent_run(run: AgentRunCreate) -> None:

--- a/libs/agno/tests/unit/api/test_agent_run_telemetry.py
+++ b/libs/agno/tests/unit/api/test_agent_run_telemetry.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from agno.api.agent import create_agent_run
+from agno.api.schemas.agent import AgentRunCreate
+
+
+def test_create_agent_run_uses_background_thread():
+    run = AgentRunCreate(session_id="session", run_id="run", data={"model": "local"})
+
+    with patch("agno.api.agent.Thread") as thread_cls:
+        thread = thread_cls.return_value
+
+        create_agent_run(run)
+
+    thread_cls.assert_called_once()
+    assert thread_cls.call_args.kwargs["target"].__name__ == "_send_agent_run"
+    assert thread_cls.call_args.kwargs["args"] == (run,)
+    assert thread_cls.call_args.kwargs["daemon"] is True
+    thread.start.assert_called_once_with()


### PR DESCRIPTION
﻿## Summary
- move sync Agent run telemetry POST into a daemon background thread
- keep the async telemetry path unchanged
- add a unit test for the background scheduling path

## To verify
- `.\.venv\Scripts\python.exe -m pytest tests\unit\api\test_agent_run_telemetry.py tests\unit\telemetry\test_agent_telemetry.py -q`
- `.\.venv\Scripts\python.exe -m ruff check agno\api\agent.py tests\unit\api\test_agent_run_telemetry.py`
- `.\.venv\Scripts\python.exe -m ruff format --check agno\api\agent.py tests\unit\api\test_agent_run_telemetry.py`
- `git diff --check`

Refs #8181
