### PR TITLE
[feat] Add tool metadata to tool execution events

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2293,6 +2293,7 @@ class Model(ABC):
                     result=str(function_call_result.content),
                     stop_after_tool_call=function_call_result.stop_after_tool_call,
                     metrics=tool_metrics,
+                    tool_metadata=function_call.function.metadata,
                 )
             ],
             event=ModelResponseEvent.tool_call_completed.value,
@@ -2966,6 +2967,7 @@ class Model(ABC):
                         result=str(function_call_result.content),
                         stop_after_tool_call=function_call_result.stop_after_tool_call,
                         metrics=tool_metrics,
+                        tool_metadata=function_call.function.metadata,
                     )
                 ],
                 event=ModelResponseEvent.tool_call_completed.value,

--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -63,6 +63,9 @@ class ToolExecution:
     # ID of the approval record created for this tool (set when the run pauses).
     approval_id: Optional[str] = None
 
+    # User-defined metadata copied from the registered tool (Function.metadata).
+    tool_metadata: Optional[Dict[str, Any]] = None
+
     @property
     def is_paused(self) -> bool:
         return bool(self.requires_confirmation or self.requires_user_input or self.external_execution_required)
@@ -105,6 +108,7 @@ class ToolExecution:
             external_execution_silent=data.get("external_execution_silent"),
             approval_type=data.get("approval_type"),
             approval_id=data.get("approval_id"),
+            tool_metadata=data.get("tool_metadata"),
             metrics=ToolCallMetrics.from_dict(data["metrics"]) if data.get("metrics") else None,
             **{"created_at": data["created_at"]} if "created_at" in data else {},
         )

--- a/libs/agno/agno/tools/decorator.py
+++ b/libs/agno/agno/tools/decorator.py
@@ -78,6 +78,7 @@ def tool(
     cache_results: bool = False,
     cache_dir: Optional[str] = None,
     cache_ttl: int = 3600,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> Callable[[F], Function]: ...
 
 
@@ -107,6 +108,7 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
         cache_results: bool - If True, enable caching of function results
         cache_dir: Optional[str] - Directory to store cache files
         cache_ttl: int - Time-to-live for cached results in seconds
+        metadata: Optional[Dict[str, Any]] - Arbitrary user-defined metadata attached to the tool. Surfaced on ToolExecution.tool_metadata for event/hook consumers.
 
     Returns:
         Union[Function, Callable[[F], Function]]: Decorated function or decorator
@@ -145,6 +147,7 @@ def tool(*args, **kwargs) -> Union[Function, Callable[[F], Function]]:
             "cache_results",
             "cache_dir",
             "cache_ttl",
+            "metadata",
         }
     )
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -187,6 +187,11 @@ class Function(BaseModel):
     # Set via the @approval decorator, not directly via @tool().
     approval_type: Optional[str] = None
 
+    # Arbitrary user-defined metadata attached to this tool.
+    # Surfaced on ToolExecution.tool_metadata so event/hook consumers can react to a tool
+    # without maintaining a separate tool_name -> metadata lookup. Should be JSON-serializable.
+    metadata: Optional[Dict[str, Any]] = None
+
     # Caching configuration
     cache_results: bool = False
     cache_dir: Optional[str] = None
@@ -217,6 +222,7 @@ class Function(BaseModel):
                 "requires_confirmation",
                 "external_execution",
                 "approval_type",
+                "metadata",
             },
         )
 
@@ -232,6 +238,7 @@ class Function(BaseModel):
             requires_confirmation=data.get("requires_confirmation", False),
             external_execution=data.get("external_execution", False),
             approval_type=data.get("approval_type"),
+            metadata=data.get("metadata"),
         )
 
     def model_copy(self, *, deep: bool = False) -> "Function":

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -294,6 +294,7 @@ class Toolkit:
             cache_results=function.cache_results if function.cache_results else self.cache_results,
             cache_dir=function.cache_dir if function.cache_dir else self.cache_dir,
             cache_ttl=function.cache_ttl if function.cache_ttl != 3600 else self.cache_ttl,
+            metadata=function.metadata,
         )
 
         if is_async:

--- a/libs/agno/tests/unit/models/test_tool_metadata_events.py
+++ b/libs/agno/tests/unit/models/test_tool_metadata_events.py
@@ -1,0 +1,128 @@
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.response import ModelResponseEvent, ToolExecution
+from agno.tools.decorator import tool
+from agno.tools.function import Function, FunctionCall
+from agno.tools.toolkit import Toolkit
+
+
+@dataclass
+class StubModel(Model):
+    """Minimal concrete Model so the real run_function_call(s) path can be exercised.
+
+    The abstract provider methods are never called: run_function_call(s) only executes the
+    FunctionCall locally and constructs the ToolExecution surfaced on the completed event.
+    """
+
+    id: str = "stub"
+
+    def invoke(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def _parse_provider_response(self, response: Any, **kwargs):
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response: Any):
+        raise NotImplementedError
+
+
+def _completed_tool_execution(model_responses) -> ToolExecution:
+    completed = [r for r in model_responses if r.event == ModelResponseEvent.tool_call_completed.value]
+    assert completed, "expected a tool_call_completed ModelResponse"
+    tool_executions = completed[0].tool_executions
+    assert tool_executions, "expected tool_executions on the completed response"
+    return tool_executions[0]
+
+
+def test_tool_decorator_sets_function_metadata():
+    @tool(metadata={"data_mutation": True, "domain": "shifts"})
+    def update_shift() -> str:
+        return "updated"
+
+    assert update_shift.metadata == {"data_mutation": True, "domain": "shifts"}
+
+
+def test_run_function_call_completed_event_includes_tool_metadata():
+    @tool(metadata={"data_mutation": True})
+    def update_shift() -> str:
+        return "updated"
+
+    fc = FunctionCall(function=update_shift, arguments={}, call_id="call_1")
+
+    responses = list(StubModel().run_function_call(function_call=fc, function_call_results=[]))
+
+    tool_execution = _completed_tool_execution(responses)
+    assert tool_execution.tool_metadata == {"data_mutation": True}
+
+
+@pytest.mark.asyncio
+async def test_arun_function_calls_completed_event_includes_tool_metadata():
+    @tool(metadata={"data_mutation": True})
+    def update_shift() -> str:
+        return "updated"
+
+    fc = FunctionCall(function=update_shift, arguments={}, call_id="call_1")
+
+    responses = [r async for r in StubModel().arun_function_calls(function_calls=[fc], function_call_results=[])]
+
+    tool_execution = _completed_tool_execution(responses)
+    assert tool_execution.tool_metadata == {"data_mutation": True}
+
+
+def test_completed_event_tool_metadata_none_when_not_set():
+    @tool
+    def read_shift() -> str:
+        return "shift"
+
+    fc = FunctionCall(function=read_shift, arguments={}, call_id="call_1")
+
+    responses = list(StubModel().run_function_call(function_call=fc, function_call_results=[]))
+
+    tool_execution = _completed_tool_execution(responses)
+    assert tool_execution.tool_metadata is None
+
+
+def test_tool_execution_metadata_roundtrips_through_dict():
+    tool_execution = ToolExecution(
+        tool_call_id="call_1",
+        tool_name="update_shift",
+        tool_metadata={"data_mutation": True},
+    )
+
+    restored = ToolExecution.from_dict(tool_execution.to_dict())
+
+    assert restored.tool_metadata == {"data_mutation": True}
+
+
+def test_function_metadata_roundtrips_through_dict():
+    function = Function(name="update_shift", metadata={"data_mutation": True})
+
+    assert function.to_dict()["metadata"] == {"data_mutation": True}
+    assert Function.from_dict(function.to_dict()).metadata == {"data_mutation": True}
+
+
+def test_toolkit_preserves_decorated_tool_metadata():
+    class ShiftToolkit(Toolkit):
+        def __init__(self):
+            super().__init__(name="shift_toolkit", tools=[self.update_shift])
+
+        @tool(metadata={"data_mutation": True})
+        def update_shift(self) -> str:
+            return "updated"
+
+    toolkit = ShiftToolkit()
+
+    assert toolkit.functions["update_shift"].metadata == {"data_mutation": True}


### PR DESCRIPTION
## Summary

Event consumers today only get `tool_name` on `ToolExecution` (e.g. via `ToolCallCompletedEvent.tool`). To react to *categories* of tools rather than a specific name, an app has to maintain its own out-of-band `tool_name -> metadata` map and keep it in sync with the tools it registers — brittle, breaks silently on rename, and doesn't survive serialization.

This PR lets metadata declared on a registered tool flow through to the tool execution surfaced on events:

- Add `Function.metadata: Optional[Dict[str, Any]]`, settable via `@tool(metadata=...)`.
- Add `ToolExecution.tool_metadata: Optional[Dict[str, Any]]` (included in `to_dict`/`from_dict` so it round-trips through session storage and traces).
- Copy `function_call.function.metadata` into the `ToolExecution` constructed for the `tool_call_completed` event, in both the sync (`run_function_call`) and async (`arun_function_calls`) paths.
- Preserve `metadata` when an `@tool`-decorated method is registered on a `Toolkit`.

Example:

```python
@tool(metadata={"data_mutation": True})
def update_shift(...): ...

# in an event handler
if isinstance(event, ToolCallCompletedEvent) and event.tool and event.tool.tool_metadata:
    if event.tool.tool_metadata.get("data_mutation"):
        invalidate_caches(...)
```

### Design notes (per the issue discussion)

- A generic metadata bag, not a one-off typed field — mirrors #8032, which moved resolved-approval data out of a typed field into a metadata bag.
- No raw function/toolkit object references are exposed: they're non-serializable and unsafe for traces/session storage. Only a JSON-serializable dict.
- No app-specific concepts (e.g. `data_mutation`) baked into Agno; the application owns the keys.
- Toolkit-source stamping (`toolkit_name`/`toolkit_class` via `Toolkit.register`) is intentionally left out of v1 to keep the surface minimal — happy to add as a follow-up if maintainers want it.

Issue number: #8170

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

`ruff check` and `mypy` pass on the changed modules. New tests:

```
python -m pytest libs/agno/tests/unit/models/test_tool_metadata_events.py -v
```

covering: `@tool(metadata=...)` sets `Function.metadata`; `tool_metadata` appears on the completed event for both sync and async execution; it is `None` when unset; `ToolExecution`/`Function` dict round-trips; and `Toolkit` preserves decorated-tool metadata.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR was drafted with AI assistance (Cursor) and reviewed by me before submitting.

---

## Additional Notes

The change is additive and backward compatible: both new fields default to `None`, and `tool_metadata` is only populated when a tool defines `metadata`. No public signatures change for existing callers.

Made with [Cursor](https://cursor.com)