### PR TITLE
fix: keep async trace export tasks alive

### DIFF
--- a/libs/agno/agno/tracing/exporter.py
+++ b/libs/agno/agno/tracing/exporter.py
@@ -4,7 +4,7 @@ Custom OpenTelemetry SpanExporter that writes traces to Agno database.
 
 import asyncio
 from collections import defaultdict
-from typing import Dict, List, Sequence, Union
+from typing import Dict, List, Sequence, Set, Union
 
 from opentelemetry.sdk.trace import ReadableSpan  # type: ignore
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult  # type: ignore
@@ -27,6 +27,7 @@ class DatabaseSpanExporter(SpanExporter):
         """
         self.db = db
         self._shutdown = False
+        self._pending_tasks: Set[asyncio.Task] = set()
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         """
@@ -106,19 +107,23 @@ class DatabaseSpanExporter(SpanExporter):
     def _export_async(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Handle async database export"""
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # We're in an async context, schedule the coroutine
-                asyncio.create_task(self._do_async_export(spans_by_trace))
-            else:
-                # No running loop, run in new loop
-                loop.run_until_complete(self._do_async_export(spans_by_trace))
+            loop = asyncio.get_running_loop()
         except RuntimeError:
             # No event loop, create new one
             try:
                 asyncio.run(self._do_async_export(spans_by_trace))
             except Exception as e:
                 log_error(f"Failed to export async traces: {str(e)}")
+        else:
+            # We're in an async context, schedule the coroutine
+            task = loop.create_task(self._do_async_export(spans_by_trace))
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._discard_async_export_task)
+
+    def _discard_async_export_task(self, task: asyncio.Task) -> None:
+        self._pending_tasks.discard(task)
+        if not task.cancelled():
+            task.exception()
 
     async def _do_async_export(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Actually perform the async export"""

--- a/libs/agno/tests/unit/tracing/test_exporter.py
+++ b/libs/agno/tests/unit/tracing/test_exporter.py
@@ -1,0 +1,47 @@
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from agno.tracing.exporter import DatabaseSpanExporter
+
+
+def test_export_async_runs_without_running_loop():
+    exporter = DatabaseSpanExporter(db=object())  # type: ignore[arg-type]
+    exported: List[Dict[str, List[Any]]] = []
+
+    async def fake_export(spans_by_trace):
+        exported.append(spans_by_trace)
+
+    exporter._do_async_export = fake_export  # type: ignore[method-assign]
+
+    spans_by_trace: Dict[str, List[Any]] = {"trace-id": []}
+    exporter._export_async(spans_by_trace)
+
+    assert exported == [spans_by_trace]
+    assert exporter._pending_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_export_async_keeps_running_loop_task_until_done():
+    exporter = DatabaseSpanExporter(db=object())  # type: ignore[arg-type]
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def fake_export(_spans_by_trace):
+        started.set()
+        await release.wait()
+
+    exporter._do_async_export = fake_export  # type: ignore[method-assign]
+
+    exporter._export_async({"trace-id": []})
+    await started.wait()
+
+    assert len(exporter._pending_tasks) == 1
+    task = next(iter(exporter._pending_tasks))
+    assert not task.done()
+
+    release.set()
+    await task
+
+    assert exporter._pending_tasks == set()


### PR DESCRIPTION
﻿## Summary
- keep async trace export tasks strongly referenced until they finish
- replace deprecated `asyncio.get_event_loop()` detection with `get_running_loop()` plus an `asyncio.run()` fallback
- add regression coverage for both no-running-loop and running-loop export paths

## To verify
- `python -m pytest libs\agno\tests\unit\tracing\test_exporter.py -q`
- `python -m ruff check libs\agno\agno\tracing\exporter.py libs\agno\tests\unit\tracing\test_exporter.py`
- `python -m ruff format --check libs\agno\agno\tracing\exporter.py libs\agno\tests\unit\tracing\test_exporter.py`
- `python -m mypy agno\tracing\exporter.py tests\unit\tracing\test_exporter.py`

Fixes #8182
