### PR TITLE
fix: improve Claude 4.6 trailing user message defaults and visibility

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -164,7 +164,7 @@ class Claude(Model):
     # Set to True to append a trailing user turn when the conversation ends with an assistant message.
     # Defaults to True for Claude 4.6+ models.
     append_trailing_user_message: Optional[bool] = None
-    trailing_user_message_content: str = "continue"
+    trailing_user_message_content: str = "Please continue from where you left off."
 
     # Client parameters
     api_key: Optional[str] = None

--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -79,7 +79,7 @@ class AwsBedrock(Model):
     stop_sequences: Optional[List[str]] = None
     request_params: Optional[Dict[str, Any]] = None
     append_trailing_user_message: Optional[bool] = None
-    trailing_user_message_content: str = "continue"
+    trailing_user_message_content: str = "Please continue from where you left off."
 
     client: Optional[AwsClient] = None
     async_client: Optional[Any] = None

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -48,7 +48,7 @@ class LiteLLM(Model):
     extra_body: Optional[Dict[str, Any]] = None
     request_params: Optional[Dict[str, Any]] = None
     append_trailing_user_message: Optional[bool] = None
-    trailing_user_message_content: str = "continue"
+    trailing_user_message_content: str = "Please continue from where you left off."
 
     client: Optional[Any] = None
 

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -452,7 +452,7 @@ def format_messages(
     messages: List[Message],
     compress_tool_results: bool = False,
     append_trailing_user_message: Optional[bool] = False,
-    trailing_user_message_content: str = "continue",
+    trailing_user_message_content: str = "Please continue from where you left off.",
     enable_citations: bool = True,
 ) -> Tuple[List[Dict[str, Union[str, list]]], str]:
     """
@@ -461,8 +461,15 @@ def format_messages(
     Args:
         messages (List[Message]): The list of messages to process.
         compress_tool_results: Whether to compress tool results.
-        append_trailing_user_message: If True, append a dummy user message when the conversation
-            ends with an assistant turn. Required for models that do not support assistant prefill.
+        append_trailing_user_message: If True, append a user message when the conversation
+            ends with an assistant turn. Required for models that do not support assistant prefill
+            (e.g., Claude 4.6+). The default trailing message is a generic continuation prompt.
+            For better results, consider use-case-specific alternatives:
+            - Structured output: use ``output_config.format`` with a ``json_schema``.
+            - Multi-agent handoff: synthesize a fresh user task instead of forwarding the
+              orchestrator's terminal assistant turn.
+            - Continuation: use an explicit continuation prompt like
+              ``"Your previous response was interrupted. Continue from where you left off."``.
         trailing_user_message_content: The text content of the injected trailing user message.
         enable_citations: Default for document citation attachment.
 
@@ -634,7 +641,12 @@ def format_messages(
     # Claude 4.6+ models do not support assistant message prefill.
     # Append a trailing user turn so the request ends with a user message.
     if append_trailing_user_message and merged_messages and merged_messages[-1]["role"] == "assistant":
-        log_info("Appending trailing user message because this model does not support assistant message prefill")
+        log_warning(
+            "Appending trailing user message because this model does not support assistant message prefill. "
+            "For structured output, use output_config.format instead. "
+            "For multi-agent handoff, rewrite the orchestrator's terminal assistant turn into a fresh user task. "
+            "For continuation, the default trailing message is: 'Please continue from where you left off.'"
+        )
         merged_messages.append({"role": "user", "content": [{"type": "text", "text": trailing_user_message_content}]})
 
     return merged_messages, " ".join(system_messages)

--- a/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
+++ b/libs/agno/tests/unit/models/anthropic/test_append_trailing_user_message.py
@@ -63,7 +63,7 @@ ONLY_SYSTEM_AND_USER = [
 class TestAnthropicFormatMessages:
     """Tests for the shared Anthropic format_messages utility."""
 
-    def _format(self, messages, append=False, content="continue"):
+    def _format(self, messages, append=False, content="Please continue from where you left off."):
         from agno.utils.models.claude import format_messages
 
         formatted, _ = format_messages(
@@ -76,7 +76,7 @@ class TestAnthropicFormatMessages:
     def test_appends_when_ends_with_assistant(self):
         msgs = self._format(ENDS_WITH_ASSISTANT, append=True)
         assert msgs[-1]["role"] == "user"
-        assert msgs[-1]["content"] == [{"type": "text", "text": "continue"}]
+        assert msgs[-1]["content"] == [{"type": "text", "text": "Please continue from where you left off."}]
 
     def test_no_append_when_flag_false(self):
         msgs = self._format(ENDS_WITH_ASSISTANT, append=False)
@@ -122,7 +122,7 @@ class TestAnthropicFormatMessages:
 class TestBedrockFormatMessages:
     """Tests for AwsBedrock._format_messages trailing message."""
 
-    def _format(self, messages, append=False, content="continue"):
+    def _format(self, messages, append=False, content="Please continue from where you left off."):
         from agno.models.aws.bedrock import AwsBedrock
 
         model = AwsBedrock(
@@ -137,7 +137,7 @@ class TestBedrockFormatMessages:
     def test_appends_when_ends_with_assistant(self):
         msgs = self._format(ENDS_WITH_ASSISTANT, append=True)
         assert msgs[-1]["role"] == "user"
-        assert msgs[-1]["content"] == [{"text": "continue"}]
+        assert msgs[-1]["content"] == [{"text": "Please continue from where you left off."}]
 
     def test_no_append_when_flag_false(self):
         msgs = self._format(ENDS_WITH_ASSISTANT, append=False)
@@ -163,7 +163,7 @@ class TestBedrockFormatMessages:
 class TestLiteLLMFormatMessages:
     """Tests for LiteLLM._format_messages trailing message."""
 
-    def _format(self, messages, append=False, content="continue"):
+    def _format(self, messages, append=False, content="Please continue from where you left off."):
         from agno.models.litellm.chat import LiteLLM
 
         model = LiteLLM(
@@ -176,7 +176,7 @@ class TestLiteLLMFormatMessages:
     def test_appends_when_ends_with_assistant(self):
         msgs = self._format(ENDS_WITH_ASSISTANT, append=True)
         assert msgs[-1]["role"] == "user"
-        assert msgs[-1]["content"] == "continue"
+        assert msgs[-1]["content"] == "Please continue from where you left off."
 
     def test_no_append_when_flag_false(self):
         msgs = self._format(ENDS_WITH_ASSISTANT, append=False)


### PR DESCRIPTION
## Summary

Replaces the generic `"continue"` trailing user message with a more contextual prompt `"Please continue from where you left off."" and upgrades the silent `log_info` to a visible `log_warning` with guidance on proper alternatives per [Anthropic's 4.6 migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide).

Fixes #8039

## Changes

1. **Better default**: Changed `trailing_user_message_content` from `"continue"` to `"Please continue from where you left off."` across Claude, AwsBedrock, and LiteLLM providers
2. **Visible warning**: Replaced `log_info` with `log_warning` that explains the proper alternatives:
   - Structured output → use `output_config.format`
   - Multi-agent handoff → rewrite orchestrator's terminal assistant turn as fresh user task
   - Continuation → use explicit continuation prompt
3. **Updated docstring**: Documents use-case-specific alternatives in the `format_messages` docstring
4. **Updated tests**: 6 test assertions updated to match new default

## Before

```python
trailing_user_message_content: str = "continue"  # silently injected
log_info("Appending trailing user message...")    # not visible by default
```

## After

```python
trailing_user_message_content: str = "Please continue from where you left off."
log_warning(
    "Appending trailing user message..."
    "For structured output, use output_config.format instead. "
    "For multi-agent handoff, rewrite the orchestrator's terminal "
    "assistant turn into a fresh user task."
)
```

## Test Plan

- [x] All 31 unit tests pass (7 LiteLLM tests skipped — litellm not installed)
- [x] Syntax verified on all 5 changed files