### PR TITLE
fix: Urgent Bump WhatsApp Graph API version to v25.0

### DIFF
--- a/libs/agno/agno/os/interfaces/whatsapp/helpers.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/helpers.py
@@ -11,7 +11,7 @@ from agno.utils.log import log_error, log_info, log_warning
 from agno.utils.media import get_image_type
 
 _BASE_URL = "https://graph.facebook.com"
-_API_VERSION = "v22.0"
+_API_VERSION = "v25.0"
 
 
 @dataclass


### PR DESCRIPTION


## Summary

Update the WhatsApp helper to use Facebook Graph API v25.0 by changing the _API_VERSION constant from v22.0 to v25.0. This brings the code in line with newer Graph API changes and ensures compatibility with updated endpoints/features.

The old version is deprecated making new accounts unable to use whatsapp api and its features, one example is #7673


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
