### PR TITLE
feat: add Latitude via OpenInference observability example

### DIFF
--- a/cookbook/92_integrations/observability/README.md
+++ b/cookbook/92_integrations/observability/README.md
@@ -15,6 +15,7 @@ Observability examples for tracing and monitoring Agno agents, teams, and workfl
 - `langsmith_via_openinference.py`
 - `langtrace_op.py`
 - `langwatch_op.py`
+- `latitude_via_openinference.py`
 - `logfire_via_openinference.py`
 - `mlflow_via_openinference.py`
 - `maxim_ops.py`

--- a/cookbook/92_integrations/observability/latitude_via_openinference.py
+++ b/cookbook/92_integrations/observability/latitude_via_openinference.py
@@ -1,0 +1,59 @@
+"""
+Latitude Via OpenInference
+==========================
+
+Demonstrates instrumenting an Agno agent with OpenInference and sending traces to Latitude.
+"""
+
+import asyncio
+import os
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.yfinance import YFinanceTools
+from openinference.instrumentation.agno import AgnoInstrumentor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+# Latitude's ingestion endpoint speaks standard OTLP over HTTP. The exporter
+# appends "/v1/traces" to the base OTEL_EXPORTER_OTLP_ENDPOINT.
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://ingest.latitude.so"
+os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = (
+    f"Authorization=Bearer {os.getenv('LATITUDE_API_KEY')},"
+    f"X-Latitude-Project={os.getenv('LATITUDE_PROJECT')}"
+)
+
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+
+# Start instrumenting agno
+AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    name="Stock Price Agent",
+    model=OpenAIChat(id="gpt-5.2"),
+    tools=[YFinanceTools()],
+    instructions="You are a stock price agent. Answer questions in the style of a stock analyst.",
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    await agent.aprint_response(
+        "What is the current price of Tesla? Then find the current price of NVIDIA",
+        stream=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a cookbook example showing how to instrument an Agno agent with OpenInference and export traces to [Latitude](https://latitude.so), an open-source LLM observability and evaluation platform.

This mirrors the existing `langfuse_via_openinference.py` / `arize_phoenix_via_openinference.py` examples: it points a standard OTLP HTTP exporter at Latitude's ingestion endpoint (`https://ingest.latitude.so`) using the documented `Authorization: Bearer` + `X-Latitude-Project` headers, then calls `AgnoInstrumentor().instrument()`.

## Changes

- `cookbook/92_integrations/observability/latitude_via_openinference.py` — new runnable example
- `cookbook/92_integrations/observability/README.md` — list the example under Root Integrations

## Notes

Companion docs PR (integration page + nav + example page): agno-agi/docs#669

Latitude already ingests Agno traces today via the OpenInference instrumentor, so no library changes are required — this is an example only.