### PR TITLE
[feat] Add add_file_ids_to_session_state parameter to track uploaded …

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -1347,6 +1347,35 @@ def get_run_messages(
                 except Exception as e:
                     log_warning(f"Failed to validate message: {str(e)}")
 
+    # Add uploaded file metadata to session_state when the agent is configured to
+    # track files but not send them to the model. This lets the agent know which
+    # files are available for tool calls.
+    if (
+        run_context is not None
+        and not agent.send_media_to_model
+        and agent.add_file_ids_to_session_state
+        and files
+    ):
+        file_list = []
+        for f in files:
+            if hasattr(f, "id") or hasattr(f, "filename"):
+                file_list.append(
+                    {
+                        k: v
+                        for k, v in {
+                            "file_id": getattr(f, "id", None),
+                            "filename": getattr(f, "filename", None),
+                            "url": getattr(f, "url", None),
+                        }.items()
+                        if v is not None
+                    }
+                )
+        if file_list:
+            if run_context.session_state is None:
+                run_context.session_state = {}
+            existing = run_context.session_state.get("files", [])
+            run_context.session_state["files"] = existing + file_list
+
     # Add user message to run_messages
     if user_message is not None:
         run_messages.user_message = user_message
@@ -1551,6 +1580,35 @@ async def aget_run_messages(
                     run_messages.extra_messages.append(msg)
                 except Exception as e:
                     log_warning(f"Failed to validate message: {str(e)}")
+
+    # Add uploaded file metadata to session_state when the agent is configured to
+    # track files but not send them to the model. This lets the agent know which
+    # files are available for tool calls.
+    if (
+        run_context is not None
+        and not agent.send_media_to_model
+        and agent.add_file_ids_to_session_state
+        and files
+    ):
+        file_list = []
+        for f in files:
+            if hasattr(f, "id") or hasattr(f, "filename"):
+                file_list.append(
+                    {
+                        k: v
+                        for k, v in {
+                            "file_id": getattr(f, "id", None),
+                            "filename": getattr(f, "filename", None),
+                            "url": getattr(f, "url", None),
+                        }.items()
+                        if v is not None
+                    }
+                )
+        if file_list:
+            if run_context.session_state is None:
+                run_context.session_state = {}
+            existing = run_context.session_state.get("files", [])
+            run_context.session_state["files"] = existing + file_list
 
     # Add user message to run_messages
     if user_message is not None:

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -600,6 +600,8 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
         config["send_media_to_model"] = agent.send_media_to_model
     if not agent.store_media:
         config["store_media"] = agent.store_media
+    if agent.add_file_ids_to_session_state:
+        config["add_file_ids_to_session_state"] = agent.add_file_ids_to_session_state
     if not agent.store_tool_messages:
         config["store_tool_messages"] = agent.store_tool_messages
     if agent.store_history_messages:
@@ -935,6 +937,7 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
         read_tool_call_history=config.get("read_tool_call_history", False),
         send_media_to_model=config.get("send_media_to_model", True),
         store_media=config.get("store_media", True),
+        add_file_ids_to_session_state=config.get("add_file_ids_to_session_state", False),
         store_tool_messages=config.get("store_tool_messages", True),
         store_history_messages=config.get("store_history_messages", False),
         # --- System message settings ---

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -210,6 +210,10 @@ class Agent:
     send_media_to_model: bool = True
     # If True, store media in run output
     store_media: bool = True
+    # If True, automatically add uploaded file IDs/filenames to session_state
+    # when send_media_to_model is False. This allows the agent to know which
+    # files are available for tool calls even though they are not sent to the model.
+    add_file_ids_to_session_state: bool = False
     # If True, store tool results in run output
     store_tool_messages: bool = True
     # If True, store history messages in run output.
@@ -412,6 +416,7 @@ class Agent:
         num_history_messages: Optional[int] = None,
         max_tool_calls_from_history: Optional[int] = None,
         store_media: bool = True,
+        add_file_ids_to_session_state: bool = False,
         store_tool_messages: bool = True,
         store_history_messages: bool = False,
         knowledge: Optional[KnowledgeProtocol] = None,
@@ -565,6 +570,7 @@ class Agent:
         self.max_tool_calls_from_history = max_tool_calls_from_history
 
         self.store_media = store_media
+        self.add_file_ids_to_session_state = add_file_ids_to_session_state
         self.store_tool_messages = store_tool_messages
         self.store_history_messages = store_history_messages
 

--- a/libs/agno/tests/unit/agent/test_add_file_ids_to_session_state.py
+++ b/libs/agno/tests/unit/agent/test_add_file_ids_to_session_state.py
@@ -1,0 +1,208 @@
+"""
+Unit tests for add_file_ids_to_session_state feature.
+
+When send_media_to_model=False and add_file_ids_to_session_state=True,
+uploaded file metadata should be automatically added to session_state.
+"""
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.media import File
+from agno.run.agent import RunOutput
+from agno.run.base import RunContext
+from agno.session.agent import AgentSession
+from agno.agent._messages import get_run_messages
+
+
+@pytest.fixture
+def run_context():
+    """Create a RunContext with an empty session_state."""
+    return RunContext(
+        run_id="test-run",
+        session_id="test-session",
+        session_state={},
+    )
+
+
+@pytest.fixture
+def run_response():
+    """Create a mock RunOutput."""
+    return RunOutput(run_id="test-run")
+
+
+@pytest.fixture
+def session():
+    """Create a minimal AgentSession."""
+    return AgentSession(session_id="test-session")
+
+
+class TestAddFileIdsToSessionState:
+    """Tests for the add_file_ids_to_session_state feature."""
+
+    def test_adds_file_metadata_when_enabled(self, run_context, run_response, session):
+        """When add_file_ids_to_session_state=True and send_media_to_model=False,
+        file metadata should be added to session_state."""
+        agent = Agent(
+            id="test-agent",
+            name="Test Agent",
+            send_media_to_model=False,
+            add_file_ids_to_session_state=True,
+        )
+        files = [
+            File(id="file-1", filename="report.pdf", url="https://example.com/report.pdf"),
+            File(id="file-2", filename="data.csv"),
+        ]
+
+        get_run_messages(
+            agent,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input="Analyze these files",
+            files=files,
+        )
+
+        assert "files" in run_context.session_state
+        assert len(run_context.session_state["files"]) == 2
+        assert run_context.session_state["files"][0]["file_id"] == "file-1"
+        assert run_context.session_state["files"][0]["filename"] == "report.pdf"
+        assert run_context.session_state["files"][0]["url"] == "https://example.com/report.pdf"
+        assert run_context.session_state["files"][1]["file_id"] == "file-2"
+        assert run_context.session_state["files"][1]["filename"] == "data.csv"
+
+    def test_does_not_add_when_disabled(self, run_context, run_response, session):
+        """When add_file_ids_to_session_state=False, files should not be added."""
+        agent = Agent(
+            id="test-agent",
+            name="Test Agent",
+            send_media_to_model=False,
+            add_file_ids_to_session_state=False,
+        )
+        files = [File(id="file-1", filename="report.pdf")]
+
+        get_run_messages(
+            agent,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input="Analyze this file",
+            files=files,
+        )
+
+        assert "files" not in run_context.session_state
+
+    def test_does_not_add_when_send_media_to_model_true(self, run_context, run_response, session):
+        """When send_media_to_model=True, files should not be added to session_state
+        (since the model already receives them directly)."""
+        agent = Agent(
+            id="test-agent",
+            name="Test Agent",
+            send_media_to_model=True,
+            add_file_ids_to_session_state=True,
+        )
+        files = [File(id="file-1", filename="report.pdf")]
+
+        get_run_messages(
+            agent,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input="Analyze this file",
+            files=files,
+        )
+
+        assert "files" not in run_context.session_state
+
+    def test_does_not_add_when_no_files(self, run_context, run_response, session):
+        """When there are no files, nothing should be added."""
+        agent = Agent(
+            id="test-agent",
+            name="Test Agent",
+            send_media_to_model=False,
+            add_file_ids_to_session_state=True,
+        )
+
+        get_run_messages(
+            agent,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input="Hello",
+            files=None,
+        )
+
+        assert "files" not in run_context.session_state
+
+    def test_appends_to_existing_files_in_session_state(self, run_context, run_response, session):
+        """File metadata should be appended to existing 'files' key in session_state."""
+        run_context.session_state["files"] = [{"file_id": "existing-file", "filename": "old.txt"}]
+        agent = Agent(
+            id="test-agent",
+            name="Test Agent",
+            send_media_to_model=False,
+            add_file_ids_to_session_state=True,
+        )
+        files = [File(id="new-file", filename="new.txt")]
+
+        get_run_messages(
+            agent,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input="Compare files",
+            files=files,
+        )
+
+        assert len(run_context.session_state["files"]) == 2
+        assert run_context.session_state["files"][0]["file_id"] == "existing-file"
+        assert run_context.session_state["files"][1]["file_id"] == "new-file"
+
+    def test_initializes_session_state_when_none(self, run_response, session):
+        """When session_state is None, it should be initialized with file metadata."""
+        run_context = RunContext(
+            run_id="test-run",
+            session_id="test-session",
+            session_state=None,
+        )
+        agent = Agent(
+            id="test-agent",
+            name="Test Agent",
+            send_media_to_model=False,
+            add_file_ids_to_session_state=True,
+        )
+        files = [File(id="file-1", filename="report.pdf")]
+
+        get_run_messages(
+            agent,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            input="Analyze",
+            files=files,
+        )
+
+        assert run_context.session_state is not None
+        assert "files" in run_context.session_state
+        assert len(run_context.session_state["files"]) == 1
+
+    def test_default_is_false(self):
+        """The default value of add_file_ids_to_session_state should be False."""
+        agent = Agent(id="test-agent")
+        assert agent.add_file_ids_to_session_state is False
+
+    def test_persists_in_to_dict(self):
+        """When True, the setting should appear in to_dict output."""
+        agent = Agent(
+            id="test-agent",
+            send_media_to_model=False,
+            add_file_ids_to_session_state=True,
+        )
+        config = agent.to_dict()
+        assert config.get("add_file_ids_to_session_state") is True
+
+    def test_not_in_to_dict_when_false(self):
+        """When False (default), the setting should NOT appear in to_dict."""
+        agent = Agent(id="test-agent")
+        config = agent.to_dict()
+        assert "add_file_ids_to_session_state" not in config


### PR DESCRIPTION
 ## Summary
  - Adds `add_file_ids_to_session_state` parameter to Agent (default `False`)
  - When enabled with `send_media_to_model=False`, auto-injects uploaded file metadata into `session_state`
  - Updates both sync and async message pipelines
  - Includes serialization in `to_dict`/`from_dict`
  - 9 unit tests covering all edge cases

  Closes #7306

  ## Test plan
  - File metadata added when enabled + send_media_to_model=False
  - No changes when disabled or send_media_to_model=True
  - Appends to existing files / initializes session_state when None
  - Default is False; to_dict verified

  > **Note:** This PR was generated with assistance from Claude Code.
  > All changes have been reviewed by the author.