### PR TITLE
fix(litellm): propagate finish_reason in streaming and non-streaming responses

### DIFF
--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -368,6 +368,11 @@ class LiteLLM(Model):
         if response.usage is not None:
             model_response.response_usage = self._get_metrics(response.usage)
 
+        finish_reason = getattr(response.choices[0], 'finish_reason', None)
+        if finish_reason is not None:
+            model_response.provider_data = model_response.provider_data or {}
+            model_response.provider_data['finish_reason'] = finish_reason
+
         return model_response
 
     def _parse_provider_response_delta(self, response_delta: Any) -> ModelResponse:
@@ -409,6 +414,12 @@ class LiteLLM(Model):
                         processed_tool_calls.append(tool_call_dict)
 
                     model_response.tool_calls = processed_tool_calls
+
+        if hasattr(response_delta, "choices") and len(response_delta.choices) > 0:
+            finish_reason = getattr(response_delta.choices[0], "finish_reason", None)
+            if finish_reason is not None:
+                model_response.provider_data = model_response.provider_data or {}
+                model_response.provider_data["finish_reason"] = finish_reason
 
         # Add usage metrics if present in streaming response
         if hasattr(response_delta, "usage") and response_delta.usage is not None:

--- a/libs/agno/tests/unit/models/litellm/test_finish_reason.py
+++ b/libs/agno/tests/unit/models/litellm/test_finish_reason.py
@@ -1,0 +1,88 @@
+"""Unit tests for LiteLLM finish_reason propagation."""
+
+import pytest
+
+pytest.importorskip("litellm")
+
+from agno.models.litellm import LiteLLM
+
+
+class MockDelta:
+    def __init__(self, content=None, tool_calls=None, reasoning_content=None):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.reasoning_content = reasoning_content
+
+
+class MockChoice:
+    def __init__(self, delta=None, message=None, finish_reason=None):
+        self.delta = delta
+        self.message = message
+        self.finish_reason = finish_reason
+
+
+class MockMessage:
+    def __init__(self, content=None, tool_calls=None, reasoning_content=None):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.reasoning_content = reasoning_content
+
+
+class MockResponse:
+    def __init__(self, choices=None, usage=None):
+        self.choices = choices or []
+        self.usage = usage
+
+
+def test_streaming_finish_reason_stop():
+    """finish_reason='stop' on final streaming chunk should appear in provider_data."""
+    model = LiteLLM(id="test-model")
+    chunk = MockResponse(
+        choices=[MockChoice(delta=MockDelta(content="done"), finish_reason="stop")]
+    )
+    result = model._parse_provider_response_delta(chunk)
+    assert result.provider_data is not None
+    assert result.provider_data["finish_reason"] == "stop"
+
+
+def test_streaming_finish_reason_length():
+    """finish_reason='length' (truncated) should be propagated so callers can detect it."""
+    model = LiteLLM(id="test-model")
+    chunk = MockResponse(
+        choices=[MockChoice(delta=MockDelta(content="truncat"), finish_reason="length")]
+    )
+    result = model._parse_provider_response_delta(chunk)
+    assert result.provider_data is not None
+    assert result.provider_data["finish_reason"] == "length"
+
+
+def test_streaming_no_finish_reason():
+    """Intermediate streaming chunks without finish_reason should not set provider_data."""
+    model = LiteLLM(id="test-model")
+    chunk = MockResponse(
+        choices=[MockChoice(delta=MockDelta(content="hello"), finish_reason=None)]
+    )
+    result = model._parse_provider_response_delta(chunk)
+    assert result.provider_data is None
+
+
+def test_non_streaming_finish_reason():
+    """Non-streaming responses should also propagate finish_reason."""
+    model = LiteLLM(id="test-model")
+    response = MockResponse(
+        choices=[MockChoice(message=MockMessage(content="The answer is 42."), finish_reason="stop")]
+    )
+    result = model._parse_provider_response(response)
+    assert result.provider_data is not None
+    assert result.provider_data["finish_reason"] == "stop"
+
+
+def test_non_streaming_finish_reason_length():
+    """Non-streaming truncated response should expose finish_reason='length'."""
+    model = LiteLLM(id="test-model")
+    response = MockResponse(
+        choices=[MockChoice(message=MockMessage(content="This essay is about"), finish_reason="length")]
+    )
+    result = model._parse_provider_response(response)
+    assert result.provider_data is not None
+    assert result.provider_data["finish_reason"] == "length"


### PR DESCRIPTION
Fixes #7985.

## Problem

`LiteLLM._parse_provider_response_delta()` never reads `finish_reason` from streaming chunks. When a response is truncated due to `max_tokens` (`finish_reason='length'`), callers have no way to detect it — the response silently appears complete.

The same gap exists in the non-streaming `_parse_provider_response()`.

## Root Cause

The streaming delta parser extracts `content`, `reasoning_content`, `tool_calls`, and `usage` from each chunk, but skips `choices[0].finish_reason` entirely. The OpenAI provider stores provider metadata in `ModelResponse.provider_data`, which flows through to `RunOutput.model_provider_data` — but LiteLLM never populated this field.

## Fix

Extract `finish_reason` from `choices[0]` in both:
- `_parse_provider_response_delta` (streaming path)
- `_parse_provider_response` (non-streaming path)

Store it in `model_response.provider_data["finish_reason"]`, which the agent framework already propagates to `RunOutput.model_provider_data`.

After this fix, callers can check:
```python
response = agent.run("Write a long essay", stream=False)
if response.model_provider_data and response.model_provider_data.get("finish_reason") == "length":
    print("Response was truncated")
```

## Tests

Added 5 unit tests covering:
- `finish_reason='stop'` on final streaming chunk
- `finish_reason='length'` on truncated streaming chunk
- Intermediate chunks without `finish_reason` (no `provider_data` set)
- Non-streaming `finish_reason='stop'`
- Non-streaming `finish_reason='length'`

All 11 LiteLLM unit tests pass (6 existing + 5 new).