### PR TITLE
fix(tracing): retain async export tasks and replace deprecated get_event_loop

### DIFF
--- a/libs/agno/agno/tracing/exporter.py
+++ b/libs/agno/agno/tracing/exporter.py
@@ -27,6 +27,7 @@ class DatabaseSpanExporter(SpanExporter):
         """
         self.db = db
         self._shutdown = False
+        self._pending_tasks: set = set()
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         """
@@ -106,15 +107,15 @@ class DatabaseSpanExporter(SpanExporter):
     def _export_async(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Handle async database export"""
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # We're in an async context, schedule the coroutine
-                asyncio.create_task(self._do_async_export(spans_by_trace))
-            else:
-                # No running loop, run in new loop
-                loop.run_until_complete(self._do_async_export(spans_by_trace))
+            loop = asyncio.get_running_loop()
         except RuntimeError:
-            # No event loop, create new one
+            loop = None
+
+        if loop is not None and loop.is_running():
+            task = loop.create_task(self._do_async_export(spans_by_trace))
+            self._pending_tasks.add(task)
+            task.add_done_callback(self._pending_tasks.discard)
+        else:
             try:
                 asyncio.run(self._do_async_export(spans_by_trace))
             except Exception as e:

--- a/libs/agno/tests/unit/tracing/test_exporter_task_retention.py
+++ b/libs/agno/tests/unit/tracing/test_exporter_task_retention.py
@@ -1,0 +1,77 @@
+"""Unit tests for DatabaseSpanExporter async task retention."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agno.tracing.exporter import DatabaseSpanExporter
+
+
+@pytest.fixture
+def async_db():
+    """Create a mock async database."""
+    from agno.db.base import AsyncBaseDb
+
+    db = MagicMock(spec=AsyncBaseDb)
+    db.upsert_trace = AsyncMock(return_value=None)
+    db.create_spans = AsyncMock(return_value=None)
+    return db
+
+
+@pytest.fixture
+def exporter(async_db):
+    return DatabaseSpanExporter(db=async_db)
+
+
+def test_pending_tasks_set_initialized(exporter):
+    """Exporter should initialize with an empty pending tasks set."""
+    assert hasattr(exporter, "_pending_tasks")
+    assert isinstance(exporter._pending_tasks, set)
+    assert len(exporter._pending_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_export_async_retains_task_reference(exporter):
+    """Tasks created during async export should be strongly referenced."""
+    mock_spans_by_trace = {"trace-1": [MagicMock()]}
+
+    exporter._do_async_export = AsyncMock()
+    exporter._export_async(mock_spans_by_trace)
+
+    assert len(exporter._pending_tasks) == 1
+
+    # Let the task complete
+    await asyncio.sleep(0.05)
+    # After completion, the done callback should have removed it
+    assert len(exporter._pending_tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_export_async_cleans_up_after_completion(exporter):
+    """Completed tasks should be automatically removed from _pending_tasks."""
+    mock_spans = {"trace-1": [MagicMock()]}
+
+    exporter._do_async_export = AsyncMock()
+
+    exporter._export_async(mock_spans)
+    assert len(exporter._pending_tasks) == 1
+
+    # Wait for task to finish
+    task = next(iter(exporter._pending_tasks))
+    await task
+
+    assert len(exporter._pending_tasks) == 0
+
+
+def test_export_async_falls_back_to_asyncio_run_outside_loop(async_db):
+    """When no event loop is running, should fall back to asyncio.run()."""
+    exporter = DatabaseSpanExporter(db=async_db)
+    mock_spans = {"trace-1": [MagicMock()]}
+
+    exporter._do_async_export = AsyncMock()
+    # Outside any running loop, this should use asyncio.run()
+    exporter._export_async(mock_spans)
+
+    exporter._do_async_export.assert_called_once_with(mock_spans)
+    assert len(exporter._pending_tasks) == 0


### PR DESCRIPTION
Fixes #8182.

## Problem

`DatabaseSpanExporter._export_async` has two issues that cause silent trace loss in production:

1. **Fire-and-forget task (RUF006):** `asyncio.create_task(...)` result is discarded. The event loop only holds a *weak* reference to tasks, so the garbage collector can finalize the export coroutine before it completes — silently dropping traces/spans under load.

2. **Deprecated `asyncio.get_event_loop()`:** Since Python 3.10, calling `get_event_loop()` when no loop is running emits a `DeprecationWarning` and is slated for removal.

## Fix

1. Store pending tasks in `self._pending_tasks` (a `set`), with a `done_callback` that removes each task on completion. This is the pattern recommended by the [Python docs](https://docs.python.org/3/library/asyncio-task.html#creating-tasks):

   ```python
   task = loop.create_task(self._do_async_export(spans_by_trace))
   self._pending_tasks.add(task)
   task.add_done_callback(self._pending_tasks.discard)
   ```

2. Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()`, catching `RuntimeError` to detect the no-loop case and falling back to `asyncio.run()`.

## Tests

Added 4 unit tests:
- `_pending_tasks` set is initialized empty
- Tasks are strongly referenced during export
- Tasks are cleaned up after completion
- Falls back to `asyncio.run()` when no event loop is running