### PR TITLE
fix: keep non-upsert metadata variants separate

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import io
+import json
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -150,7 +151,7 @@ class Knowledge(RemoteKnowledge):
             reader=reader,
             auth=auth,
         )
-        content.content_hash = self._build_content_hash(content)
+        content.content_hash = self._build_insert_content_hash(content, upsert)
         content.id = generate_id(content.content_hash)
 
         self._load_content(content, upsert, skip_if_exists, include, exclude)
@@ -218,7 +219,7 @@ class Knowledge(RemoteKnowledge):
             reader=reader,
             auth=auth,
         )
-        content.content_hash = self._build_content_hash(content)
+        content.content_hash = self._build_insert_content_hash(content, upsert)
         content.id = generate_id(content.content_hash)
 
         await self._aload_content(content, upsert, skip_if_exists, include, exclude)
@@ -2272,6 +2273,14 @@ class Knowledge(RemoteKnowledge):
 
         hash_input = ":".join(hash_parts)
         return hashlib.sha256(hash_input.encode()).hexdigest()
+
+    def _build_insert_content_hash(self, content: Content, upsert: bool) -> str:
+        content_hash = self._build_content_hash(content)
+        if upsert or not content.metadata:
+            return content_hash
+
+        metadata = json.dumps(content.metadata, sort_keys=True, default=str, separators=(",", ":"))
+        return hashlib.sha256(f"{content_hash}:metadata:{metadata}".encode()).hexdigest()
 
     def _build_document_content_hash(self, document: Document, content: Content) -> str:
         """

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -182,6 +182,30 @@ def test_path_hash_backward_compatibility():
     assert hash1 == hash2
 
 
+def test_insert_hash_includes_metadata_when_upsert_is_false():
+    """Different metadata should make non-upsert inserts distinct."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(path="/path/to/file.pdf", metadata={"server_id": "10"})
+    content2 = Content(path="/path/to/file.pdf", metadata={"server_id": "11"})
+
+    hash1 = knowledge._build_insert_content_hash(content1, upsert=False)
+    hash2 = knowledge._build_insert_content_hash(content2, upsert=False)
+
+    assert hash1 != hash2
+
+
+def test_insert_hash_ignores_metadata_when_upsert_is_true():
+    """Upsert keeps the same content identity when only metadata changes."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(path="/path/to/file.pdf", metadata={"server_id": "10"})
+    content2 = Content(path="/path/to/file.pdf", metadata={"server_id": "11"})
+
+    hash1 = knowledge._build_insert_content_hash(content1, upsert=True)
+    hash2 = knowledge._build_insert_content_hash(content2, upsert=True)
+
+    assert hash1 == hash2
+
+
 def test_same_url_name_description_produces_same_hash():
     """Test that identical URL, name, and description produce the same hash."""
     knowledge = Knowledge(vector_db=MockVectorDb())


### PR DESCRIPTION
## Summary
- include user metadata in the insert identity only when `upsert=False`
- keep the existing upsert identity unchanged so metadata-only changes still update the same content
- add regression coverage for both paths

Fixes #8211.

## To verify
- `PYTHONPATH=libs/agno python -m pytest libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py -q`
- `PYTHONPATH=libs/agno python -m pytest libs/agno/tests/unit/knowledge/test_knowledge_metadata_propagation.py -q`
- `python -m py_compile libs/agno/agno/knowledge/knowledge.py libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py`
- `python -m ruff check libs/agno/agno/knowledge/knowledge.py libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py`
- `python -m ruff format --check libs/agno/agno/knowledge/knowledge.py libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py`