### PR TITLE
chore: insert separator between streamed text and post-tool-call text

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1397,6 +1397,19 @@ def handle_model_response_chunk(
                     run_response.content = model_response.content
                     run_response.content_type = content_type
                 else:
+                    # Insert a separator when text resumes after a tool call, so a streamed
+                    # chunk like "## Heading" doesn't get glued onto the prior sentence.
+                    if (
+                        model_response.extra is not None
+                        and model_response.extra.get("pending_text_separator")
+                        and isinstance(model_response_event.content, str)
+                        and model_response_event.content
+                    ):
+                        existing = model_response.content or ""
+                        incoming = model_response_event.content
+                        if existing and not existing.endswith("\n") and not incoming.startswith("\n"):
+                            model_response_event.content = "\n\n" + incoming
+                        model_response.extra.pop("pending_text_separator", None)
                     model_response.content = (model_response.content or "") + model_response_event.content
                     run_response.content = model_response.content
                     run_response.content_type = "str"
@@ -1578,6 +1591,12 @@ def handle_model_response_chunk(
 
         # If the model response is a tool_call_completed, update the existing tool call in the run_response
         elif model_response_event.event == ModelResponseEvent.tool_call_completed.value:
+            # Mark that the next streamed text chunk should be separated from prior content,
+            # so post-tool-call text (e.g. a new "## Heading") doesn't fuse onto the prior sentence.
+            if model_response.extra is None:
+                model_response.extra = {}
+            model_response.extra["pending_text_separator"] = True
+
             if model_response_event.updated_session_state is not None:
                 # update the session_state for RunOutput
                 if session_state is not None:

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1389,6 +1389,18 @@ def _handle_model_response_chunk(
                     )  # type: ignore
                     run_response.content_type = content_type
                 elif isinstance(model_response_event.content, str):
+                    # Insert a separator when text resumes after a tool call, so a streamed
+                    # chunk like "## Heading" doesn't get glued onto the prior sentence.
+                    if (
+                        full_model_response.extra is not None
+                        and full_model_response.extra.get("pending_text_separator")
+                        and model_response_event.content
+                    ):
+                        existing = full_model_response.content or ""
+                        incoming = model_response_event.content
+                        if existing and not existing.endswith("\n") and not incoming.startswith("\n"):
+                            model_response_event.content = "\n\n" + incoming
+                        full_model_response.extra.pop("pending_text_separator", None)
                     full_model_response.content = (full_model_response.content or "") + model_response_event.content
                     run_response.content = full_model_response.content
                 should_yield = True
@@ -1538,6 +1550,12 @@ def _handle_model_response_chunk(
 
         # If the model response is a tool_call_completed, update the existing tool call in the run_response
         elif model_response_event.event == ModelResponseEvent.tool_call_completed.value:
+            # Mark that the next streamed text chunk should be separated from prior content,
+            # so post-tool-call text (e.g. a new "## Heading") doesn't fuse onto the prior sentence.
+            if full_model_response.extra is None:
+                full_model_response.extra = {}
+            full_model_response.extra["pending_text_separator"] = True
+
             if model_response_event.updated_session_state is not None:
                 # Update the session_state variable that TeamRunOutput references
                 if session_state is not None:

--- a/libs/agno/tests/integration/agent/test_event_streaming.py
+++ b/libs/agno/tests/integration/agent/test_event_streaming.py
@@ -1447,3 +1447,120 @@ def test_custom_event_properties_persist_after_db_reload(shared_db):
     assert hasattr(custom_events[0], "data")
     assert custom_events[0].mime_type == "application/echart+json"
     assert custom_events[0].data["title"] == "Test Chart"
+
+
+# ---------------------------------------------------------------------------
+# Streamed-text-after-tool-call separator
+# ---------------------------------------------------------------------------
+# When a streamed run emits a text message, then a tool call, then resumes with
+# more text, the resumed text must not be glued onto the pre-tool-call sentence.
+# Without a separator, a model emitting "...now." then "## Results" produces
+# "...now.## Results" — the heading is swallowed and markdown rendering breaks.
+
+
+def _build_streamed_content(response_generator) -> str:
+    """Concatenate streamed content chunks the way a streaming UI would."""
+    content = ""
+    for event in response_generator:
+        if event.event != RunEvent.run_content:
+            continue
+        chunk = getattr(event, "content", None)
+        if isinstance(chunk, str):
+            content += chunk
+    return content
+
+
+def _assert_heading_not_glued(content: str) -> None:
+    """Headings emitted after a tool call must not fuse onto the prior line."""
+    for line in content.split("\n"):
+        stripped = line.lstrip()
+        if "##" in line and not stripped.startswith("#"):
+            raise AssertionError(f"Markdown heading fused onto prior text without a newline separator: {line!r}")
+
+
+def test_streamed_text_after_tool_call_has_separator():
+    """Streamed text resuming after a tool call must be separated from prior content."""
+
+    def get_weather(city: str) -> str:
+        """Return a fixed weather report so the model has a stable post-tool output."""
+        return f"It is 72F and sunny in {city}."
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_weather],
+        instructions=[
+            "Before calling any tool, say in one sentence what you're about to do, ending with a period.",
+            "After the tool returns, begin your final answer with a markdown heading like '## Summary'.",
+        ],
+        markdown=True,
+        telemetry=False,
+    )
+
+    streamed_content = _build_streamed_content(
+        agent.run("What's the weather in Tokyo?", stream=True, stream_events=True)
+    )
+
+    _assert_heading_not_glued(streamed_content)
+
+
+@pytest.mark.asyncio
+async def test_async_streamed_text_after_tool_call_has_separator():
+    """Async variant of the streamed-after-tool-call separator check."""
+
+    def get_weather(city: str) -> str:
+        return f"It is 72F and sunny in {city}."
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_weather],
+        instructions=[
+            "Before calling any tool, say in one sentence what you're about to do, ending with a period.",
+            "After the tool returns, begin your final answer with a markdown heading like '## Summary'.",
+        ],
+        markdown=True,
+        telemetry=False,
+    )
+
+    content = ""
+    async for event in agent.arun("What's the weather in Tokyo?", stream=True, stream_events=True):
+        if event.event != RunEvent.run_content:
+            continue
+        chunk = getattr(event, "content", None)
+        if isinstance(chunk, str):
+            content += chunk
+
+    _assert_heading_not_glued(content)
+
+
+def test_streamed_content_matches_final_run_output_after_tool_call():
+    """The separator inserted into the stream must also be reflected in run_response.content."""
+
+    def get_weather(city: str) -> str:
+        return f"It is 72F and sunny in {city}."
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[get_weather],
+        instructions=[
+            "Before calling any tool, say in one sentence what you're about to do, ending with a period.",
+            "After the tool returns, begin your final answer with a markdown heading like '## Summary'.",
+        ],
+        markdown=True,
+        telemetry=False,
+    )
+
+    final_run_output: RunOutput | None = None
+    streamed_content = ""
+    for event in agent.run("What's the weather in Tokyo?", stream=True, stream_events=True):
+        if event.event == RunEvent.run_content:
+            chunk = getattr(event, "content", None)
+            if isinstance(chunk, str):
+                streamed_content += chunk
+        elif event.event == RunEvent.run_completed:
+            final_run_output = event  # type: ignore[assignment]
+
+    assert final_run_output is not None
+    assert isinstance(final_run_output.content, str)
+    # The accumulated stream and the final content should agree on the separator.
+    assert final_run_output.content == streamed_content
+    _assert_heading_not_glued(final_run_output.content)

--- a/libs/agno/tests/integration/teams/test_event_streaming.py
+++ b/libs/agno/tests/integration/teams/test_event_streaming.py
@@ -1177,3 +1177,119 @@ def test_tool_parent_run_id():
     assert events[TeamRunEvent.tool_call_started][0].run_id == member_run.parent_run_id
     assert events[TeamRunEvent.tool_call_completed][0].tool.tool_name == "delegate_task_to_member"
     assert events[TeamRunEvent.tool_call_completed][0].run_id == member_run.parent_run_id
+
+
+# ---------------------------------------------------------------------------
+# Streamed-text-after-tool-call separator (team variant)
+# ---------------------------------------------------------------------------
+# Mirrors the agent-level test: when a team streams text, then a tool call,
+# then resumes with more text, the resumed text must not be glued onto the
+# pre-tool-call sentence.
+
+
+def _build_streamed_team_content(response_generator) -> str:
+    content = ""
+    for event in response_generator:
+        if event.event != TeamRunEvent.run_content:
+            continue
+        chunk = getattr(event, "content", None)
+        if isinstance(chunk, str):
+            content += chunk
+    return content
+
+
+def _assert_heading_not_glued(content: str) -> None:
+    for line in content.split("\n"):
+        stripped = line.lstrip()
+        if "##" in line and not stripped.startswith("#"):
+            raise AssertionError(f"Markdown heading fused onto prior text without a newline separator: {line!r}")
+
+
+def test_team_streamed_text_after_tool_call_has_separator():
+    """Streamed team text resuming after a tool call must be separated from prior content."""
+
+    def get_weather(city: str) -> str:
+        """Return a fixed weather report so the model has a stable post-tool output."""
+        return f"It is 72F and sunny in {city}."
+
+    team = Team(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[],
+        tools=[get_weather],
+        instructions=[
+            "Before calling any tool, say in one sentence what you're about to do, ending with a period.",
+            "After the tool returns, begin your final answer with a markdown heading like '## Summary'.",
+        ],
+        markdown=True,
+        telemetry=False,
+    )
+
+    streamed_content = _build_streamed_team_content(
+        team.run("What's the weather in Tokyo?", stream=True, stream_events=True)
+    )
+
+    _assert_heading_not_glued(streamed_content)
+
+
+@pytest.mark.asyncio
+async def test_async_team_streamed_text_after_tool_call_has_separator():
+    """Async variant of the team streamed-after-tool-call separator check."""
+
+    def get_weather(city: str) -> str:
+        return f"It is 72F and sunny in {city}."
+
+    team = Team(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[],
+        tools=[get_weather],
+        instructions=[
+            "Before calling any tool, say in one sentence what you're about to do, ending with a period.",
+            "After the tool returns, begin your final answer with a markdown heading like '## Summary'.",
+        ],
+        markdown=True,
+        telemetry=False,
+    )
+
+    content = ""
+    async for event in team.arun("What's the weather in Tokyo?", stream=True, stream_events=True):
+        if event.event != TeamRunEvent.run_content:
+            continue
+        chunk = getattr(event, "content", None)
+        if isinstance(chunk, str):
+            content += chunk
+
+    _assert_heading_not_glued(content)
+
+
+def test_team_streamed_content_matches_final_run_output_after_tool_call():
+    """The separator inserted into the team stream must also be reflected in run_response.content."""
+
+    def get_weather(city: str) -> str:
+        return f"It is 72F and sunny in {city}."
+
+    team = Team(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[],
+        tools=[get_weather],
+        instructions=[
+            "Before calling any tool, say in one sentence what you're about to do, ending with a period.",
+            "After the tool returns, begin your final answer with a markdown heading like '## Summary'.",
+        ],
+        markdown=True,
+        telemetry=False,
+    )
+
+    final_run_output: TeamRunOutput | None = None
+    streamed_content = ""
+    for event in team.run("What's the weather in Tokyo?", stream=True, stream_events=True):
+        if event.event == TeamRunEvent.run_content:
+            chunk = getattr(event, "content", None)
+            if isinstance(chunk, str):
+                streamed_content += chunk
+        elif event.event == TeamRunEvent.run_completed:
+            final_run_output = event  # type: ignore[assignment]
+
+    assert final_run_output is not None
+    assert isinstance(final_run_output.content, str)
+    assert final_run_output.content == streamed_content
+    _assert_heading_not_glued(final_run_output.content)


### PR DESCRIPTION
## Summary

When a streamed agent or team run emits text, calls a tool, then resumes with more text, the resumed chunk was concatenated directly onto the prior content with no separator. A model emitting `"...now."` followed by `"## Results"` produced `"...now.## Results"`, which fused the markdown heading into the prior sentence and broke rendering in streaming UIs.

Track a `pending_text_separator` flag on the in-flight `ModelResponse` when a `tool_call_completed` event is processed, and prepend `"\n\n"` to the next text chunk if the accumulated content does not already end in a newline.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
