### PR TITLE
fix(knowledge): include metadata in content hash to prevent overwrites

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2226,6 +2226,9 @@ class Knowledge(RemoteKnowledge):
             hash_parts.append(content.name)
         if content.description:
             hash_parts.append(content.description)
+        if content.metadata:
+            meta_str = ":".join(f"{k}={v}" for k, v in sorted(content.metadata.items()))
+            hash_parts.append(meta_str)
 
         remote_identity = self._build_remote_content_identity(content.remote_content)
         if remote_identity:

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -688,3 +688,67 @@ def test_non_remote_content_hash_unchanged():
 
     # Identical (no remote_content on either) → identical hash, preserves dedup behavior.
     assert knowledge._build_content_hash(content_a) == knowledge._build_content_hash(content_b)
+
+
+def test_path_hash_with_different_metadata():
+    """Same path with different metadata produces different hashes (issue #8211)."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(path="/path/to/demo.pdf", metadata={"doc_id": 1, "server_id": "10"})
+    content2 = Content(path="/path/to/demo.pdf", metadata={"doc_id": 1, "server_id": "11"})
+    content3 = Content(path="/path/to/demo.pdf")
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+    hash3 = knowledge._build_content_hash(content3)
+
+    assert hash1 != hash2
+    assert hash1 != hash3
+    assert hash2 != hash3
+
+
+def test_path_hash_with_same_metadata():
+    """Same path with same metadata produces identical hashes."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(path="/path/to/demo.pdf", metadata={"doc_id": 1, "server_id": "10"})
+    content2 = Content(path="/path/to/demo.pdf", metadata={"doc_id": 1, "server_id": "10"})
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+
+    assert hash1 == hash2
+
+
+def test_metadata_order_does_not_affect_hash():
+    """Metadata dict key order does not affect the hash (sorted internally)."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(path="/path/to/file.pdf", metadata={"a": "1", "b": "2"})
+    content2 = Content(path="/path/to/file.pdf", metadata={"b": "2", "a": "1"})
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+
+    assert hash1 == hash2
+
+
+def test_url_hash_with_different_metadata():
+    """Same URL with different metadata produces different hashes."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(url="https://example.com/doc.pdf", metadata={"version": "1"})
+    content2 = Content(url="https://example.com/doc.pdf", metadata={"version": "2"})
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+
+    assert hash1 != hash2
+
+
+def test_no_metadata_backward_compatible():
+    """Content without metadata produces the same hash as before the fix."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(path="/path/to/file.pdf")
+    content2 = Content(path="/path/to/file.pdf")
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+
+    assert hash1 == hash2


### PR DESCRIPTION
## Summary

Fixes #8211

When inserting the same document twice with different metadata and `upsert=False`, the second insert overwrites the first row's metadata instead of creating a separate row. This happens because `_build_content_hash()` only hashes `name`, `description`, and `path`/`url` — metadata is ignored entirely, so both inserts produce the same content hash and record ID.

**Root cause:** `_build_content_hash()` in `knowledge.py` does not include `content.metadata` in the hash computation.

**Fix:** Include sorted metadata key-value pairs in the hash, so the same file with different metadata produces distinct content hashes. This is a 3-line change that follows the existing pattern used for `name` and `description`.

**Backward compatible:** Content without metadata produces the exact same hash as before.

## Test plan

- Added 5 new tests to `test_knowledge_content_hash.py`:
  - Same path with different metadata → different hashes
  - Same path with same metadata → same hash
  - Metadata dict key order doesn't affect hash (sorted internally)
  - Same URL with different metadata → different hashes
  - No metadata → backward compatible (unchanged hash)
- All 42 content hash tests pass
- All 57 knowledge unit tests pass