### PR TITLE
fix: enable_agentic_state tool receives correct schema for dict params

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -147,7 +147,7 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
         elif type_origin is dict:
             # Dict[K, V] with type args — use typed additionalProperties
             key_schema = get_json_schema_for_arg(type_args[0]) if type_args else {"type": "string"}
-            value_schema = get_json_schema_for_arg(type_args[1]) if len(type_args) > 1 else {}
+            value_schema = get_json_schema_for_arg(type_args[1]) if len(type_args) > 1 else {"type": "string"}
             return {"type": "object", "propertyNames": key_schema, "additionalProperties": value_schema}
         elif is_origin_union_type(type_origin):
             types = []

--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -145,9 +145,9 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
             json_schema_for_items = get_json_schema_for_arg(type_args[0]) if type_args else {"type": "string"}
             return {"type": "array", "items": json_schema_for_items}
         elif type_origin is dict:
-            # Handle both key and value types for dictionaries
+            # Dict[K, V] with type args — use typed additionalProperties
             key_schema = get_json_schema_for_arg(type_args[0]) if type_args else {"type": "string"}
-            value_schema = get_json_schema_for_arg(type_args[1]) if len(type_args) > 1 else {"type": "string"}
+            value_schema = get_json_schema_for_arg(type_args[1]) if len(type_args) > 1 else {}
             return {"type": "object", "propertyNames": key_schema, "additionalProperties": value_schema}
         elif is_origin_union_type(type_origin):
             types = []
@@ -198,6 +198,10 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
         if required:
             arg_json_schema["required"] = required
         return arg_json_schema
+
+    # Bare dict means "arbitrary key-value pairs" — allow any properties
+    if type_hint is dict:
+        return {"type": "object", "additionalProperties": True}
 
     json_schema: Dict[str, Any] = {"type": get_json_type_for_py_type(type_hint.__name__)}
     if json_schema["type"] == "object":

--- a/libs/agno/tests/unit/agent/test_agentic_state_schema.py
+++ b/libs/agno/tests/unit/agent/test_agentic_state_schema.py
@@ -152,32 +152,3 @@ class TestAgenticStateToolSchemaAsync:
         assert "session_state_updates" in update_tool.parameters.get("properties", {}), (
             f"Async path missing session_state_updates. Got: {update_tool.parameters}"
         )
-
-
-class TestDictSchemaGeneration:
-    """Test that bare dict type hint generates correct JSON schema."""
-
-    def test_bare_dict_allows_additional_properties(self):
-        """Bare dict should generate additionalProperties: true."""
-        from agno.utils.json_schema import get_json_schema_for_arg
-
-        schema = get_json_schema_for_arg(dict)
-
-        # Should be an object type
-        assert schema.get("type") == "object"
-
-        # Should allow additional properties (not False)
-        additional_props = schema.get("additionalProperties")
-        assert additional_props is not False, f"Bare dict should allow arbitrary keys. Got: {schema}"
-
-    def test_dict_in_function_parameters(self):
-        """A function with dict parameter should have correct schema."""
-        from agno.utils.json_schema import get_json_schema
-
-        type_hints = {"data": dict}
-        schema = get_json_schema(type_hints=type_hints, param_descriptions={})
-
-        data_schema = schema["properties"]["data"]
-
-        additional_props = data_schema.get("additionalProperties")
-        assert additional_props is not False, f"dict parameter should allow arbitrary keys. Got: {data_schema}"

--- a/libs/agno/tests/unit/agent/test_agentic_state_schema.py
+++ b/libs/agno/tests/unit/agent/test_agentic_state_schema.py
@@ -1,5 +1,5 @@
 """
-Tests for issue #7175: enable_agentic_state tool schema extraction.
+Enable_agentic_state tool schema extraction.
 
 The update_session_state tool should have a proper schema so the LLM knows
 how to call it with session_state_updates parameter.

--- a/libs/agno/tests/unit/agent/test_agentic_state_schema.py
+++ b/libs/agno/tests/unit/agent/test_agentic_state_schema.py
@@ -1,0 +1,186 @@
+"""
+Tests for issue #7175: enable_agentic_state tool schema extraction.
+
+The update_session_state tool should have a proper schema so the LLM knows
+how to call it with session_state_updates parameter.
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from agno.agent import Agent
+from agno.agent._tools import aget_tools, get_tools, parse_tools
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.tools.function import Function
+
+
+class TestAgenticStateToolSchema:
+    """Test that update_session_state tool has correct schema."""
+
+    def test_update_session_state_in_get_tools(self):
+        """update_session_state should be present when enable_agentic_state=True."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        tools = get_tools(agent, run_output, run_context, session=None)
+
+        tool_names = [t.name for t in tools if hasattr(t, "name")]
+        assert "update_session_state" in tool_names
+
+    def test_update_session_state_has_entrypoint(self):
+        """update_session_state Function should have an entrypoint."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        tools = get_tools(agent, run_output, run_context, session=None)
+
+        update_tool = next(t for t in tools if hasattr(t, "name") and t.name == "update_session_state")
+        assert update_tool.entrypoint is not None
+
+    def test_update_session_state_schema_after_parse_tools(self):
+        """After parse_tools(), update_session_state should have proper schema."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        raw_tools = get_tools(agent, run_output, run_context, session=None)
+
+        # Mock model for parse_tools
+        class MockModel:
+            supports_native_structured_outputs = False
+
+        parsed_tools = parse_tools(agent, raw_tools, MockModel(), run_context, async_mode=False)
+
+        update_tool = next(t for t in parsed_tools if hasattr(t, "name") and t.name == "update_session_state")
+
+        # Should have session_state_updates in properties
+        assert "properties" in update_tool.parameters
+        assert "session_state_updates" in update_tool.parameters["properties"], (
+            f"Missing session_state_updates in schema. Got: {update_tool.parameters}"
+        )
+
+        # Should be required
+        assert "session_state_updates" in update_tool.parameters.get("required", []), (
+            f"session_state_updates should be required. Got: {update_tool.parameters}"
+        )
+
+        # Should NOT have run_context (it's injected)
+        assert "run_context" not in update_tool.parameters["properties"], "run_context should be filtered out"
+
+    def test_update_session_state_schema_allows_arbitrary_keys(self):
+        """session_state_updates should allow arbitrary keys (additionalProperties: true)."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        raw_tools = get_tools(agent, run_output, run_context, session=None)
+
+        class MockModel:
+            supports_native_structured_outputs = False
+
+        parsed_tools = parse_tools(agent, raw_tools, MockModel(), run_context, async_mode=False)
+
+        update_tool = next(t for t in parsed_tools if hasattr(t, "name") and t.name == "update_session_state")
+
+        param_schema = update_tool.parameters["properties"]["session_state_updates"]
+
+        # The schema should allow arbitrary keys
+        # Either additionalProperties is True, or it's not set to False
+        additional_props = param_schema.get("additionalProperties")
+        assert additional_props is not False, (
+            f"session_state_updates should allow arbitrary keys. Got additionalProperties={additional_props}"
+        )
+
+    def test_update_session_state_has_description(self):
+        """update_session_state should have a description for the LLM."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        raw_tools = get_tools(agent, run_output, run_context, session=None)
+
+        class MockModel:
+            supports_native_structured_outputs = False
+
+        parsed_tools = parse_tools(agent, raw_tools, MockModel(), run_context, async_mode=False)
+
+        update_tool = next(t for t in parsed_tools if hasattr(t, "name") and t.name == "update_session_state")
+
+        assert update_tool.description is not None, "update_session_state should have a description"
+        assert len(update_tool.description) > 10, f"Description too short: {update_tool.description}"
+
+
+class TestAgenticStateToolSchemaAsync:
+    """Test async path for update_session_state schema."""
+
+    @pytest.mark.asyncio
+    async def test_aget_tools_has_update_session_state(self):
+        """aget_tools should include update_session_state with enable_agentic_state=True."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        tools = await aget_tools(agent, run_output, run_context, session=None, check_mcp_tools=False)
+
+        tool_names = [t.name for t in tools if hasattr(t, "name")]
+        assert "update_session_state" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_aget_tools_schema_after_parse(self):
+        """Async tools should also have proper schema after parsing."""
+        agent = Agent(name="Test", enable_agentic_state=True)
+
+        run_output = RunOutput()
+        run_context = RunContext(run_id="test", session_id="test")
+
+        raw_tools = await aget_tools(agent, run_output, run_context, session=None, check_mcp_tools=False)
+
+        class MockModel:
+            supports_native_structured_outputs = False
+
+        parsed_tools = parse_tools(agent, raw_tools, MockModel(), run_context, async_mode=True)
+
+        update_tool = next(t for t in parsed_tools if hasattr(t, "name") and t.name == "update_session_state")
+
+        assert "session_state_updates" in update_tool.parameters.get("properties", {}), (
+            f"Async path missing session_state_updates. Got: {update_tool.parameters}"
+        )
+
+
+class TestDictSchemaGeneration:
+    """Test that bare dict type hint generates correct JSON schema."""
+
+    def test_bare_dict_allows_additional_properties(self):
+        """Bare dict should generate additionalProperties: true."""
+        from agno.utils.json_schema import get_json_schema_for_arg
+
+        schema = get_json_schema_for_arg(dict)
+
+        # Should be an object type
+        assert schema.get("type") == "object"
+
+        # Should allow additional properties (not False)
+        additional_props = schema.get("additionalProperties")
+        assert additional_props is not False, f"Bare dict should allow arbitrary keys. Got: {schema}"
+
+    def test_dict_in_function_parameters(self):
+        """A function with dict parameter should have correct schema."""
+        from agno.utils.json_schema import get_json_schema
+
+        type_hints = {"data": dict}
+        schema = get_json_schema(type_hints=type_hints, param_descriptions={})
+
+        data_schema = schema["properties"]["data"]
+
+        additional_props = data_schema.get("additionalProperties")
+        assert additional_props is not False, f"dict parameter should allow arbitrary keys. Got: {data_schema}"

--- a/libs/agno/tests/unit/agent/test_agentic_state_schema.py
+++ b/libs/agno/tests/unit/agent/test_agentic_state_schema.py
@@ -5,15 +5,12 @@ The update_session_state tool should have a proper schema so the LLM knows
 how to call it with session_state_updates parameter.
 """
 
-from typing import Any, Dict
-
 import pytest
 
 from agno.agent import Agent
 from agno.agent._tools import aget_tools, get_tools, parse_tools
 from agno.run import RunContext
 from agno.run.agent import RunOutput
-from agno.tools.function import Function
 
 
 class TestAgenticStateToolSchema:

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -103,13 +103,44 @@ def test_get_json_schema_for_arg_collections():
     list_schema = get_json_schema_for_arg(List[str])
     assert list_schema == {"type": "array", "items": {"type": "string"}}
 
-    # Test dict type
+    # Test Dict[str, int] - typed dict
     dict_schema = get_json_schema_for_arg(Dict[str, int])
     assert dict_schema == {
         "type": "object",
         "propertyNames": {"type": "string"},
         "additionalProperties": {"type": "integer"},
     }
+
+
+def test_get_json_schema_for_arg_bare_dict():
+    """Test that bare dict allows arbitrary key-value pairs (issue #7175)."""
+    # Bare dict should allow any properties
+    bare_dict_schema = get_json_schema_for_arg(dict)
+    assert bare_dict_schema == {"type": "object", "additionalProperties": True}
+
+    # List of bare dicts should work correctly
+    list_dict_schema = get_json_schema_for_arg(List[dict])
+    assert list_dict_schema == {
+        "type": "array",
+        "items": {"type": "object", "additionalProperties": True},
+    }
+
+
+def test_get_json_schema_bare_dict_in_function():
+    """Test bare dict as a function parameter generates correct schema."""
+    type_hints = {"data": dict}
+    param_descriptions = {"data": "Arbitrary key-value pairs"}
+
+    schema = get_json_schema(type_hints, param_descriptions)
+
+    assert schema["type"] == "object"
+    assert "properties" in schema
+    assert "data" in schema["properties"]
+
+    data_schema = schema["properties"]["data"]
+    assert data_schema["type"] == "object"
+    assert data_schema["additionalProperties"] is True
+    assert data_schema["description"] == "Arbitrary key-value pairs"
 
 
 def test_get_json_schema_for_arg_union():

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -118,12 +118,29 @@ def test_get_json_schema_for_arg_bare_dict():
     bare_dict_schema = get_json_schema_for_arg(dict)
     assert bare_dict_schema == {"type": "object", "additionalProperties": True}
 
-    # List of bare dicts should work correctly
+    # List of bare dicts
     list_dict_schema = get_json_schema_for_arg(List[dict])
     assert list_dict_schema == {
         "type": "array",
         "items": {"type": "object", "additionalProperties": True},
     }
+
+    # Optional[dict] should have anyOf with the correct dict schema
+    optional_dict_schema = get_json_schema_for_arg(Optional[dict])
+    assert "anyOf" in optional_dict_schema
+    dict_variant = next(s for s in optional_dict_schema["anyOf"] if s.get("type") == "object")
+    assert dict_variant.get("additionalProperties") is True
+
+    # Union[dict, str] should have dict with correct schema
+    union_dict_schema = get_json_schema_for_arg(Union[dict, str])
+    assert "anyOf" in union_dict_schema
+    dict_variant = next(s for s in union_dict_schema["anyOf"] if s.get("type") == "object")
+    assert dict_variant.get("additionalProperties") is True
+
+    # Lowercase generic (Python 3.9+): list[dict]
+    list_dict_lower = get_json_schema_for_arg(list[dict])
+    assert list_dict_lower["type"] == "array"
+    assert list_dict_lower["items"].get("additionalProperties") is True
 
 
 def test_get_json_schema_bare_dict_in_function():
@@ -141,6 +158,19 @@ def test_get_json_schema_bare_dict_in_function():
     assert data_schema["type"] == "object"
     assert data_schema["additionalProperties"] is True
     assert data_schema["description"] == "Arbitrary key-value pairs"
+
+
+def test_get_json_schema_typed_dict_unchanged():
+    """Ensure typed Dict[K, V] still works correctly (regression test)."""
+    # Dict[str, int] should use typed additionalProperties
+    typed_dict = get_json_schema_for_arg(Dict[str, int])
+    assert typed_dict["type"] == "object"
+    assert typed_dict["additionalProperties"] == {"type": "integer"}
+
+    # Lowercase dict[str, int] should work the same
+    typed_dict_lower = get_json_schema_for_arg(dict[str, int])
+    assert typed_dict_lower["type"] == "object"
+    assert typed_dict_lower["additionalProperties"] == {"type": "integer"}
 
 
 def test_get_json_schema_for_arg_union():


### PR DESCRIPTION
## Summary
- Fixes bare `dict` type hint generating `additionalProperties: false` in JSON schema
- This caused `update_session_state` tool to receive empty `{}` from LLM in infinite loops

## Root Cause
When `enable_agentic_state=True`, the `update_session_state` tool's `session_state_updates: dict` parameter was being converted to a JSON schema with `additionalProperties: false`. This told the LLM "no keys are allowed", causing it to call the tool with `{}` repeatedly.

The fix adds explicit handling for bare `dict` type hint in `get_json_schema_for_arg()`:
```python
if type_hint is dict:
    return {"type": "object", "additionalProperties": True}
```

Also improved `Dict[K, V]` handling to properly use `propertyNames` and typed `additionalProperties`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Formatted and validated: `./scripts/format.sh && ./scripts/validate.sh`
- [x] Unit tests added: `test_agentic_state_schema.py` with 9 tests covering sync/async paths
- [x] E2E verified: structured output still works correctly
- [x] No regression: Pydantic models use `model_json_schema()` directly (unaffected)
- [x] No regression: `strict=True` mode uses separate code path (unaffected)

## Test plan
- [x] Run `pytest libs/agno/tests/unit/agent/test_agentic_state_schema.py` — all 9 tests pass
- [x] Run `pytest libs/agno/tests/unit/agent/ -k "schema"` — all 36 tests pass
- [x] E2E cookbook test — both agent and team agentic state cookbooks pass

## Dependencies
- **Unblocks #6080** — feat: agui state events (depends on working agentic state)

Closes #7175