### PR TITLE
fix(anthropic): match cache_tools TTL to extended_cache_time

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -598,9 +598,21 @@ class Claude(Model):
         return None
 
     def _apply_cache_tools(self, request_kwargs: Dict[str, Any]) -> None:
-        """Tag the last tool with cache_control when cache_tools is enabled."""
+        """Tag the last tool with cache_control when cache_tools is enabled.
+
+        The TTL is matched to ``extended_cache_time`` so the tools block is not
+        cached for a shorter duration than the system block. Anthropic processes
+        cache blocks in the order tools -> system -> messages and rejects a
+        shorter TTL appearing before a longer one. A bare ``{"type": "ephemeral"}``
+        defaults to 5m, so emitting it before a 1h system block
+        (``extended_cache_time=True``) is a mixed-TTL violation that the API
+        rejects. Mirror the system-block TTL here to keep the order valid.
+        """
         if self.cache_tools and "tools" in request_kwargs and request_kwargs["tools"]:
-            request_kwargs["tools"][-1]["cache_control"] = {"type": "ephemeral"}
+            cache_control: Dict[str, str] = {"type": "ephemeral"}
+            if self.extended_cache_time:
+                cache_control["ttl"] = "1h"
+            request_kwargs["tools"][-1]["cache_control"] = cache_control
 
     def _build_system(self, system_message: str) -> List[Dict[str, Any]]:
         """Assemble the Anthropic ``system`` array.

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -18,6 +18,7 @@ from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.models.claude import (
     MCPServerConfiguration,
     _validate_cache_ttl_order,
+    build_ephemeral_cache_control,
     build_system_blocks,
     format_messages,
     format_tools_for_model,
@@ -609,10 +610,7 @@ class Claude(Model):
         rejects. Mirror the system-block TTL here to keep the order valid.
         """
         if self.cache_tools and "tools" in request_kwargs and request_kwargs["tools"]:
-            cache_control: Dict[str, str] = {"type": "ephemeral"}
-            if self.extended_cache_time:
-                cache_control["ttl"] = "1h"
-            request_kwargs["tools"][-1]["cache_control"] = cache_control
+            request_kwargs["tools"][-1]["cache_control"] = build_ephemeral_cache_control(bool(self.extended_cache_time))
 
     def _build_system(self, system_message: str) -> List[Dict[str, Any]]:
         """Assemble the Anthropic ``system`` array.

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -370,6 +370,22 @@ def _format_file_for_message(file: File, enable_citations: bool = True) -> Optio
     return document
 
 
+def build_ephemeral_cache_control(extended_cache_time: bool) -> Dict[str, str]:
+    """Build an Anthropic ``cache_control`` dict for an ephemeral cache block.
+
+    A bare ``{"type": "ephemeral"}`` uses Anthropic's default 5m TTL;
+    ``extended_cache_time`` promotes it to 1h. Centralised so the system blocks
+    and the tools block resolve their TTL identically and stay in lockstep with
+    Anthropic's non-increasing-TTL ordering rule (tools -> system -> messages):
+    a tools block cached for a shorter duration than the system block is rejected
+    by the API.
+    """
+    cache_control: Dict[str, str] = {"type": "ephemeral"}
+    if extended_cache_time:
+        cache_control["ttl"] = "1h"
+    return cache_control
+
+
 def build_system_blocks(
     system_message: Union[str, List["SystemPromptBlock"]],
     cache_system_prompt: bool,
@@ -397,10 +413,7 @@ def build_system_blocks(
     if isinstance(system_message, str):
         entry: Dict[str, Any] = {"text": system_message, "type": "text"}
         if cache_system_prompt:
-            cc: Dict[str, str] = {"type": "ephemeral"}
-            if extended_cache_time:
-                cc["ttl"] = "1h"
-            entry["cache_control"] = cc
+            entry["cache_control"] = build_ephemeral_cache_control(extended_cache_time)
         return [entry]
 
     result: List[Dict[str, Any]] = []
@@ -412,10 +425,7 @@ def build_system_blocks(
             # agent-built block, so users can cache custom blocks without also caching
             # the agent-built one (and vice versa).
             effective_ttl = block.ttl if block.ttl is not None else ("1h" if extended_cache_time else "5m")
-            cc = {"type": "ephemeral"}
-            if effective_ttl == "1h":
-                cc["ttl"] = "1h"
-            b["cache_control"] = cc
+            b["cache_control"] = build_ephemeral_cache_control(effective_ttl == "1h")
         result.append(b)
     return result
 

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -261,6 +261,35 @@ def test_cache_tools_disabled_leaves_tools_uncached():
     assert "cache_control" not in kwargs["tools"][-1]
 
 
+def test_aws_cache_tools_inherits_extended_ttl():
+    """AWS Claude inherits _apply_cache_tools, so the tools block must honor extended_cache_time."""
+    pytest.importorskip("boto3")
+    from agno.models.aws.claude import Claude as AwsClaude
+
+    model = AwsClaude(cache_tools=True, extended_cache_time=True)
+    kwargs = model._prepare_request_kwargs("system prompt", tools=[dict(_TOOLS[0])])
+
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_vertexai_cache_tools_inherits_extended_ttl():
+    """VertexAI Claude inherits _apply_cache_tools, so the tools block must honor extended_cache_time."""
+    model = VertexAIClaude(id="claude-haiku-4-5", cache_tools=True, extended_cache_time=True)
+    kwargs = model._prepare_request_kwargs("system prompt", tools=[dict(_TOOLS[0])])
+
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_azure_cache_tools_inherits_extended_ttl():
+    """Azure Claude inherits _apply_cache_tools, so the tools block must honor extended_cache_time."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    model = AzureClaude(id="claude-haiku-4-5", cache_tools=True, extended_cache_time=True)
+    kwargs = model._prepare_request_kwargs("system prompt", tools=[dict(_TOOLS[0])])
+
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
 # =============================================================================
 # temperature / top_p / top_k: zero values must not be silently dropped
 # =============================================================================

--- a/libs/agno/tests/unit/models/test_claude_request_params.py
+++ b/libs/agno/tests/unit/models/test_claude_request_params.py
@@ -227,6 +227,41 @@ def test_vertexai_prepare_request_kwargs_signature_matches_parent():
 
 
 # =============================================================================
+# cache_tools TTL must match extended_cache_time (Anthropic mixed-TTL rule)
+# =============================================================================
+
+_TOOLS = [{"name": "test", "description": "test tool", "input_schema": {"type": "object", "properties": {}}}]
+
+
+def test_cache_tools_uses_1h_ttl_when_extended_cache_time():
+    """With extended_cache_time the tools block must be cached at 1h, matching the system block.
+
+    Anthropic processes cache blocks tools -> system -> messages and rejects a shorter TTL
+    before a longer one, so a bare (5m) tools block before a 1h system block is invalid.
+    """
+    model = AnthropicClaude(id="claude-haiku-4-5", cache_tools=True, extended_cache_time=True)
+    kwargs = model._prepare_request_kwargs("system prompt", tools=[dict(_TOOLS[0])])
+
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_cache_tools_uses_default_ttl_without_extended_cache_time():
+    """Without extended_cache_time the tools block stays at the default (5m) ephemeral cache."""
+    model = AnthropicClaude(id="claude-haiku-4-5", cache_tools=True, extended_cache_time=False)
+    kwargs = model._prepare_request_kwargs("system prompt", tools=[dict(_TOOLS[0])])
+
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_cache_tools_disabled_leaves_tools_uncached():
+    """With cache_tools off the tools block must not carry cache_control."""
+    model = AnthropicClaude(id="claude-haiku-4-5", cache_tools=False, extended_cache_time=True)
+    kwargs = model._prepare_request_kwargs("system prompt", tools=[dict(_TOOLS[0])])
+
+    assert "cache_control" not in kwargs["tools"][-1]
+
+
+# =============================================================================
 # temperature / top_p / top_k: zero values must not be silently dropped
 # =============================================================================
 


### PR DESCRIPTION
## Summary

`Claude._apply_cache_tools` stamps the last tool with a bare `{"type": "ephemeral"}` (which defaults to a 5m TTL) and ignores the `extended_cache_time` flag. The system block, by contrast, honors `extended_cache_time` and is cached at 1h (see `build_system_blocks` in `agno/utils/models/claude.py`).

Anthropic processes cache blocks in the order tools -> system -> messages and rejects a shorter TTL appearing before a longer one. So with:

```python
Claude(cache_tools=True, cache_system_prompt=True, extended_cache_time=True)
```

the tools block (5m) precedes the system block (1h), which is a mixed-TTL violation and the API returns a 400 at inference time. The existing `_validate_cache_ttl_order` only checks the system array, so it does not catch the tools-vs-system mismatch.

## Fix

Mirror the system-block TTL in `_apply_cache_tools`: emit `ttl="1h"` on the tools block when `extended_cache_time` is set, exactly as `build_system_blocks` does. This also covers the Azure, VertexAI, and AWS Claude subclasses, which inherit this method.

## Before / after

```python
m = Claude(id="claude-haiku-4-5", cache_tools=True, extended_cache_time=True)
kw = m._prepare_request_kwargs("system prompt", tools=[...])
kw["tools"][-1]["cache_control"]
# before: {"type": "ephemeral"}              -> 5m before 1h system -> 400
# after:  {"type": "ephemeral", "ttl": "1h"} -> matches system block
```

## Tests

Added unit tests in `tests/unit/models/test_claude_request_params.py` covering the 1h case (with `extended_cache_time`), the default 5m case (without it), and `cache_tools=False`. `ruff format`, `ruff check`, and the full test file pass.