### PR TITLE
Fix Team SSE streaming AttributeError on format_sse_event

### DIFF
--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -196,7 +196,7 @@ def format_sse_event(event: Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRu
     """
     try:
         # Parse the JSON to extract the event type
-        event_type = event.event or "message"
+        event_type = getattr(event, "event", None) or getattr(event, "events", None) or "message"
 
         # Serialize to valid JSON with double quotes and no newlines
         clean_json = event.to_json(separators=(",", ":"), indent=None)
@@ -228,7 +228,7 @@ def format_sse_event_with_index(
     from agno.utils.serialize import json_serializer
 
     try:
-        event_type = event.event or "message"
+        event_type = getattr(event, "event", None) or getattr(event, "events", None) or "message"
         event_dict = event.to_dict()
 
         if event_index is not None:


### PR DESCRIPTION
## Problem

`format_sse_event` accesses `event.event` (singular), but `TeamRunOutput` objects have `.events` (plural). This crashes with `AttributeError` when a Team streams responses via SSE.

## Fix

Use `getattr` to try both `event` (singular) and `events` (plural), falling back to `"message"` if neither exists.

Closes #8235