### PR TITLE
Replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/libs/agno/agno/tracing/exporter.py
+++ b/libs/agno/agno/tracing/exporter.py
@@ -106,7 +106,11 @@ class DatabaseSpanExporter(SpanExporter):
     def _export_async(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Handle async database export"""
         try:
-            loop = asyncio.get_event_loop()
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
             if loop.is_running():
                 # We're in an async context, schedule the coroutine
                 asyncio.create_task(self._do_async_export(spans_by_trace))


### PR DESCRIPTION
## Problem

`asyncio.get_event_loop()` is deprecated in Python 3.12+. Using it in a fire-and-forget context silently drops traces when the default loop changes.

## Fix

Use `get_running_loop()` when a loop is active, falling back to `new_event_loop()` + `set_event_loop()` otherwise.

Closes #8182