### PR TITLE
Fix mutable default argument in Toolkit.__init__

### DIFF
--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -17,7 +17,7 @@ class Toolkit:
     def __init__(
         self,
         name: str = "toolkit",
-        tools: Sequence[Union[Callable[..., Any], Function]] = [],
+        tools: Sequence[Union[Callable[..., Any], Function]] | None = None,
         async_tools: Optional[Sequence[tuple[Callable[..., Any], str]]] = None,
         instructions: Optional[str] = None,
         add_instructions: bool = False,


### PR DESCRIPTION
Replace mutable default list `[]` with `None` to fix B006 lint error and prevent shared-state bugs.

Closes #8155