### PR TITLE
fix(os): filter accumulator objects in SSE router streamers (#8235)

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -115,6 +115,8 @@ async def agent_response_streamer(
             **kwargs,
         )
         async for run_response_chunk in run_response:  # type: ignore[union-attr]
+            if isinstance(run_response_chunk, RunOutput):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
     except (InputCheckError, OutputCheckError) as e:
         error_response = RunErrorEvent(
@@ -235,6 +237,8 @@ async def agent_continue_response_streamer(
             **kwargs,
         )
         async for run_response_chunk in continue_response:
+            if isinstance(run_response_chunk, RunOutput):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
     except (InputCheckError, OutputCheckError) as e:
         error_response = RunErrorEvent(

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -58,7 +58,7 @@ from agno.os.utils import (
 )
 from agno.registry import Registry
 from agno.run.base import RunStatus
-from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent, TeamRunOutput
 from agno.team.factory import TeamFactory
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
@@ -110,6 +110,8 @@ async def team_response_streamer(
             **kwargs,
         )
         async for run_response_chunk in run_response:
+            if isinstance(run_response_chunk, TeamRunOutput):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(
@@ -420,6 +422,8 @@ async def team_continue_response_streamer(
             **kwargs,
         )
         async for run_response_chunk in continue_response:
+            if isinstance(run_response_chunk, TeamRunOutput):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -55,7 +55,7 @@ from agno.os.utils import (
     resolve_workflow,
 )
 from agno.run.base import RunStatus
-from agno.run.workflow import WorkflowErrorEvent
+from agno.run.workflow import WorkflowErrorEvent, WorkflowRunOutput
 from agno.utils.log import log_debug, log_warning, logger
 from agno.utils.serialize import json_serializer
 from agno.workflow.factory import WorkflowFactory
@@ -620,6 +620,8 @@ async def workflow_response_streamer(
         )
 
         async for run_response_chunk in run_response:
+            if isinstance(run_response_chunk, WorkflowRunOutput):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
 
         # If the workflow paused, yield the full WorkflowRunOutput as a final SSE event
@@ -744,6 +746,8 @@ async def workflow_continue_response_streamer(
         )
 
         async for run_response_chunk in run_response:
+            if isinstance(run_response_chunk, WorkflowRunOutput):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
 
         # If the workflow re-paused, yield the full WorkflowRunOutput as a final SSE event

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -196,7 +196,7 @@ def format_sse_event(event: Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRu
     """
     try:
         # Parse the JSON to extract the event type
-        event_type = event.event or "message"
+        event_type = getattr(event, "event", None) or "message"
 
         # Serialize to valid JSON with double quotes and no newlines
         clean_json = event.to_json(separators=(",", ":"), indent=None)

--- a/libs/agno/tests/unit/os/test_agent_sse_filtering.py
+++ b/libs/agno/tests/unit/os/test_agent_sse_filtering.py
@@ -1,0 +1,168 @@
+"""Unit tests for agent router accumulator filtering.
+
+Regression tests for https://github.com/agno-agi/agno/issues/8235
+
+Before the fix, RunOutput accumulator objects could leak into the SSE stream
+via agent_response_streamer and agent_continue_response_streamer, causing
+format_sse_event to crash with:
+
+    AttributeError: 'RunOutput' object has no attribute 'event'
+
+The isinstance filtering (`if isinstance(run_response_chunk, RunOutput): continue`)
+ensures only RunOutputEvent objects reach format_sse_event.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.os.routers.agents.router import (
+    agent_continue_response_streamer,
+    agent_response_streamer,
+)
+from agno.run.agent import RunContentEvent, RunOutput, RunStartedEvent
+
+
+def _make_run_output():
+    """Create a MagicMock that satisfies isinstance(chunk, RunOutput)."""
+    mock = MagicMock(spec=RunOutput)
+    mock.events = []  # RunOutput has .events (plural), not .event
+    return mock
+
+
+def _make_run_started_event():
+    """Create a real RunStartedEvent instance."""
+    event = RunStartedEvent()
+    return event
+
+
+def _make_run_content_event(content="hello"):
+    """Create a real RunContentEvent instance."""
+    event = RunContentEvent(content=content)
+    return event
+
+
+async def _async_gen_run_output_and_events():
+    """Async generator yielding a mix of RunOutput and RunOutputEvent objects."""
+    yield _make_run_output()
+    yield _make_run_started_event()
+    yield _make_run_output()
+    yield _make_run_content_event(content="world")
+    yield _make_run_output()
+
+
+async def _async_gen_events_only():
+    """Async generator yielding only valid RunOutputEvent objects."""
+    yield _make_run_started_event()
+    yield _make_run_content_event(content="hello")
+    yield _make_run_content_event(content="world")
+
+
+class TestAgentSSEAccumulatorFiltering:
+    """Tests that agent_response_streamer and agent_continue_response_streamer
+    filter out RunOutput accumulator objects and only yield formatted SSE events
+    for valid RunOutputEvent objects."""
+
+    @pytest.mark.asyncio
+    async def test_response_streamer_filters_run_output(self):
+        """agent_response_streamer must skip RunOutput accumulator objects."""
+        fake_agent = MagicMock()
+        fake_agent.arun = MagicMock(return_value=_async_gen_run_output_and_events())
+
+        collected = []
+        with patch(
+            "agno.os.routers.agents.router.format_sse_event",
+            side_effect=lambda e: f"event: {getattr(e, 'event', 'msg')}\ndata: {{}}\n\n",
+        ):
+            async for chunk in agent_response_streamer(
+                agent=fake_agent,
+                message="test",
+            ):
+                collected.append(chunk)
+
+        # RunOutput objects are filtered out, so only 2 events pass through
+        assert len(collected) == 2
+
+    @pytest.mark.asyncio
+    async def test_response_streamer_passes_events(self):
+        """agent_response_streamer must yield SSE strings for valid RunOutputEvent objects."""
+        fake_agent = MagicMock()
+        fake_agent.arun = MagicMock(return_value=_async_gen_events_only())
+
+        format_calls = []
+
+        def fake_format(event):
+            format_calls.append(event)
+            event_type = getattr(event, "event", "message")
+            return f"event: {event_type}\ndata: {{}}\n\n"
+
+        collected = []
+        with patch(
+            "agno.os.routers.agents.router.format_sse_event",
+            side_effect=fake_format,
+        ):
+            async for chunk in agent_response_streamer(
+                agent=fake_agent,
+                message="test",
+            ):
+                collected.append(chunk)
+
+        # All 3 events pass through
+        assert len(collected) == 3
+        # format_sse_event received exactly 3 calls with real event objects
+        assert len(format_calls) == 3
+        # None of the format_sse_event args are RunOutput instances
+        for call_arg in format_calls:
+            assert not isinstance(call_arg, RunOutput)
+
+    @pytest.mark.asyncio
+    async def test_continue_response_streamer_filters_run_output(self):
+        """agent_continue_response_streamer must skip RunOutput accumulator objects."""
+        fake_agent = MagicMock()
+        fake_agent.acontinue_run = MagicMock(return_value=_async_gen_run_output_and_events())
+
+        collected = []
+        with patch(
+            "agno.os.routers.agents.router.format_sse_event",
+            side_effect=lambda e: f"event: {getattr(e, 'event', 'msg')}\ndata: {{}}\n\n",
+        ):
+            async for chunk in agent_continue_response_streamer(
+                agent=fake_agent,
+                run_id="test-run-id",
+            ):
+                collected.append(chunk)
+
+        # RunOutput objects are filtered out, so only 2 events pass through
+        assert len(collected) == 2
+
+    @pytest.mark.asyncio
+    async def test_continue_response_streamer_passes_events(self):
+        """agent_continue_response_streamer must yield SSE strings for valid RunOutputEvent objects."""
+        fake_agent = MagicMock()
+        fake_agent.acontinue_run = MagicMock(return_value=_async_gen_events_only())
+
+        format_calls = []
+
+        def fake_format(event):
+            format_calls.append(event)
+            event_type = getattr(event, "event", "message")
+            return f"event: {event_type}\ndata: {{}}\n\n"
+
+        collected = []
+        with patch(
+            "agno.os.routers.agents.router.format_sse_event",
+            side_effect=fake_format,
+        ):
+            async for chunk in agent_continue_response_streamer(
+                agent=fake_agent,
+                run_id="test-run-id",
+            ):
+                collected.append(chunk)
+
+        # All 3 events pass through
+        assert len(collected) == 3
+        # format_sse_event received exactly 3 calls with real event objects
+        assert len(format_calls) == 3
+        # None of the format_sse_event args are RunOutput instances
+        for call_arg in format_calls:
+            assert not isinstance(call_arg, RunOutput)

--- a/libs/agno/tests/unit/os/test_team_sse_filtering.py
+++ b/libs/agno/tests/unit/os/test_team_sse_filtering.py
@@ -1,0 +1,163 @@
+"""Unit tests for team SSE accumulator filtering.
+
+Regression tests for https://github.com/agno-agi/agno/issues/8235
+
+TeamRunOutput accumulator objects must be filtered out by the team
+response streamers so they never reach format_sse_event (which expects
+objects with an `.event` attribute, not `.events`).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.os.routers.teams.router import (
+    team_continue_response_streamer,
+    team_response_streamer,
+)
+from agno.run.team import TeamRunOutput
+
+
+def _make_accumulator_mock() -> MagicMock:
+    """Create a mock that satisfies isinstance(obj, TeamRunOutput)."""
+    return MagicMock(spec=TeamRunOutput)
+
+
+def _make_event_mock(event_type: str = "TeamRunContent") -> MagicMock:
+    """Create a mock event object with `.event` attribute and `.to_json()`."""
+    mock_event = MagicMock()
+    mock_event.event = event_type
+    mock_event.to_json.return_value = '{"event": "' + event_type + '"}'
+    return mock_event
+
+
+def _fake_format_sse_event(event) -> str:
+    """Simple stand-in for format_sse_event: returns SSE-wrapped JSON."""
+    return f"data: {event.to_json()}\n\n"
+
+
+class TestTeamSSEAccumulatorFiltering:
+    """Verify that TeamRunOutput accumulators are filtered and events pass through."""
+
+    @pytest.mark.asyncio
+    async def test_response_streamer_filters_team_run_output(self):
+        """team_response_streamer must skip TeamRunOutput accumulator objects."""
+        accumulator = _make_accumulator_mock()
+        event = _make_event_mock()
+
+        mock_team = MagicMock()
+
+        # arun returns an async generator that yields accumulator then event
+        async def _async_gen(*args, **kwargs):
+            yield accumulator
+            yield event
+
+        mock_team.arun = MagicMock(return_value=_async_gen())
+
+        collected = []
+        with patch(
+            "agno.os.routers.teams.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in team_response_streamer(team=mock_team, message="hello"):
+                collected.append(chunk)
+
+        # Accumulator should have been skipped — format_sse_event called only once (for the event)
+        assert mock_format.call_count == 1
+        mock_format.assert_called_once_with(event)
+
+        # Only the event's SSE string should be in the output
+        assert len(collected) == 1
+        assert "TeamRunContent" in collected[0]
+
+    @pytest.mark.asyncio
+    async def test_response_streamer_passes_events(self):
+        """team_response_streamer must yield valid TeamRunOutputEvent objects."""
+        event1 = _make_event_mock("TeamRunStarted")
+        event2 = _make_event_mock("TeamRunContent")
+        event3 = _make_event_mock("TeamRunCompleted")
+
+        mock_team = MagicMock()
+
+        async def _async_gen(*args, **kwargs):
+            yield event1
+            yield event2
+            yield event3
+
+        mock_team.arun = MagicMock(return_value=_async_gen())
+
+        collected = []
+        with patch(
+            "agno.os.routers.teams.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in team_response_streamer(team=mock_team, message="hello"):
+                collected.append(chunk)
+
+        # All three events should pass through
+        assert mock_format.call_count == 3
+        assert len(collected) == 3
+        assert "TeamRunStarted" in collected[0]
+        assert "TeamRunContent" in collected[1]
+        assert "TeamRunCompleted" in collected[2]
+
+    @pytest.mark.asyncio
+    async def test_continue_response_streamer_filters_team_run_output(self):
+        """team_continue_response_streamer must skip TeamRunOutput accumulator objects."""
+        accumulator = _make_accumulator_mock()
+        event = _make_event_mock()
+
+        mock_team = MagicMock()
+
+        # acontinue_run returns an async generator
+        async def _async_gen(*args, **kwargs):
+            yield accumulator
+            yield event
+
+        mock_team.acontinue_run = MagicMock(return_value=_async_gen())
+
+        collected = []
+        with patch(
+            "agno.os.routers.teams.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in team_continue_response_streamer(team=mock_team, run_id="test-run", requirements=[]):
+                collected.append(chunk)
+
+        # Accumulator filtered — format_sse_event called only for the event
+        assert mock_format.call_count == 1
+        mock_format.assert_called_once_with(event)
+
+        assert len(collected) == 1
+        assert "TeamRunContent" in collected[0]
+
+    @pytest.mark.asyncio
+    async def test_continue_response_streamer_passes_events(self):
+        """team_continue_response_streamer must yield valid TeamRunOutputEvent objects."""
+        event1 = _make_event_mock("TeamRunContinued")
+        event2 = _make_event_mock("TeamRunContent")
+        event3 = _make_event_mock("TeamRunCompleted")
+
+        mock_team = MagicMock()
+
+        async def _async_gen(*args, **kwargs):
+            yield event1
+            yield event2
+            yield event3
+
+        mock_team.acontinue_run = MagicMock(return_value=_async_gen())
+
+        collected = []
+        with patch(
+            "agno.os.routers.teams.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in team_continue_response_streamer(team=mock_team, run_id="test-run", requirements=[]):
+                collected.append(chunk)
+
+        # All three events should pass through
+        assert mock_format.call_count == 3
+        assert len(collected) == 3
+        assert "TeamRunContinued" in collected[0]
+        assert "TeamRunContent" in collected[1]
+        assert "TeamRunCompleted" in collected[2]

--- a/libs/agno/tests/unit/os/test_workflow_sse_filtering.py
+++ b/libs/agno/tests/unit/os/test_workflow_sse_filtering.py
@@ -1,0 +1,169 @@
+"""Unit tests for workflow SSE accumulator filtering.
+
+Regression tests for https://github.com/agno-agi/agno/issues/8235
+
+WorkflowRunOutput accumulator objects must be filtered out by the workflow
+response streamers so they never reach format_sse_event (which expects
+objects with an `.event` attribute, not `.events`).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.os.routers.workflows.router import (
+    workflow_continue_response_streamer,
+    workflow_response_streamer,
+)
+from agno.run.workflow import WorkflowRunOutput
+
+
+def _make_accumulator_mock() -> MagicMock:
+    """Create a mock that satisfies isinstance(obj, WorkflowRunOutput)."""
+    return MagicMock(spec=WorkflowRunOutput)
+
+
+def _make_event_mock(event_type: str = "WorkflowStarted") -> MagicMock:
+    """Create a mock event object with `.event` attribute and `.to_json()`."""
+    mock_event = MagicMock()
+    mock_event.event = event_type
+    mock_event.to_json.return_value = '{"event": "' + event_type + '"}'
+    return mock_event
+
+
+def _fake_format_sse_event(event) -> str:
+    """Simple stand-in for format_sse_event: returns SSE-wrapped JSON."""
+    return f"data: {event.to_json()}\n\n"
+
+
+class TestWorkflowSSEAccumulatorFiltering:
+    """Verify that WorkflowRunOutput accumulators are filtered and events pass through."""
+
+    @pytest.mark.asyncio
+    async def test_response_streamer_filters_workflow_run_output(self):
+        """workflow_response_streamer must skip WorkflowRunOutput accumulator objects."""
+        accumulator = _make_accumulator_mock()
+        event = _make_event_mock()
+
+        mock_workflow = MagicMock()
+
+        # arun returns an async generator that yields accumulator then event
+        async def _async_gen(*args, **kwargs):
+            yield accumulator
+            yield event
+
+        mock_workflow.arun = MagicMock(return_value=_async_gen())
+        # Avoid hitting the paused-workflow yield at end of streamer
+        mock_workflow.get_session = MagicMock(return_value=None)
+
+        collected = []
+        with patch(
+            "agno.os.routers.workflows.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in workflow_response_streamer(workflow=mock_workflow, input="hello"):
+                collected.append(chunk)
+
+        # Accumulator should have been skipped — format_sse_event called only once (for the event)
+        assert mock_format.call_count == 1
+        mock_format.assert_called_once_with(event)
+
+        # Only the event's SSE string should be in the output
+        assert len(collected) == 1
+        assert "WorkflowStarted" in collected[0]
+
+    @pytest.mark.asyncio
+    async def test_response_streamer_passes_events(self):
+        """workflow_response_streamer must yield valid WorkflowRunOutputEvent objects."""
+        event1 = _make_event_mock("WorkflowStarted")
+        event2 = _make_event_mock("StepStarted")
+        event3 = _make_event_mock("WorkflowCompleted")
+
+        mock_workflow = MagicMock()
+
+        async def _async_gen(*args, **kwargs):
+            yield event1
+            yield event2
+            yield event3
+
+        mock_workflow.arun = MagicMock(return_value=_async_gen())
+        mock_workflow.get_session = MagicMock(return_value=None)
+
+        collected = []
+        with patch(
+            "agno.os.routers.workflows.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in workflow_response_streamer(workflow=mock_workflow, input="hello"):
+                collected.append(chunk)
+
+        # All three events should pass through
+        assert mock_format.call_count == 3
+        assert len(collected) == 3
+        assert "WorkflowStarted" in collected[0]
+        assert "StepStarted" in collected[1]
+        assert "WorkflowCompleted" in collected[2]
+
+    @pytest.mark.asyncio
+    async def test_continue_response_streamer_filters_workflow_run_output(self):
+        """workflow_continue_response_streamer must skip WorkflowRunOutput accumulator objects."""
+        accumulator = _make_accumulator_mock()
+        event = _make_event_mock()
+
+        mock_workflow = MagicMock()
+
+        # acontinue_run is awaited — it returns a coroutine that resolves to an async iterable
+        async def _async_gen(*args, **kwargs):
+            yield accumulator
+            yield event
+
+        # await workflow.acontinue_run(...) returns the async generator
+        mock_workflow.acontinue_run = AsyncMock(return_value=_async_gen())
+        mock_workflow.get_session = MagicMock(return_value=None)
+
+        collected = []
+        with patch(
+            "agno.os.routers.workflows.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in workflow_continue_response_streamer(workflow=mock_workflow, run_id="test-run"):
+                collected.append(chunk)
+
+        # Accumulator filtered — format_sse_event called only for the event
+        assert mock_format.call_count == 1
+        mock_format.assert_called_once_with(event)
+
+        assert len(collected) == 1
+        assert "WorkflowStarted" in collected[0]
+
+    @pytest.mark.asyncio
+    async def test_continue_response_streamer_passes_events(self):
+        """workflow_continue_response_streamer must yield valid WorkflowRunOutputEvent objects."""
+        event1 = _make_event_mock("StepContinued")
+        event2 = _make_event_mock("StepCompleted")
+        event3 = _make_event_mock("WorkflowCompleted")
+
+        mock_workflow = MagicMock()
+
+        async def _async_gen(*args, **kwargs):
+            yield event1
+            yield event2
+            yield event3
+
+        mock_workflow.acontinue_run = AsyncMock(return_value=_async_gen())
+        mock_workflow.get_session = MagicMock(return_value=None)
+
+        collected = []
+        with patch(
+            "agno.os.routers.workflows.router.format_sse_event",
+            side_effect=_fake_format_sse_event,
+        ) as mock_format:
+            async for chunk in workflow_continue_response_streamer(workflow=mock_workflow, run_id="test-run"):
+                collected.append(chunk)
+
+        # All three events should pass through
+        assert mock_format.call_count == 3
+        assert len(collected) == 3
+        assert "StepContinued" in collected[0]
+        assert "StepCompleted" in collected[1]
+        assert "WorkflowCompleted" in collected[2]


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'TeamRunOutput' object has no attribute 'event'` crash in team SSE streaming (#8235).

When a `Team` streams a response through AgentOS, the SSE streaming crashes because `format_sse_event` accesses `event.event` but receives `TeamRunOutput` accumulator objects that have `.events` (plural) instead of `.event` (singular).

## Root Cause

Two-part type mismatch:
1. `format_sse_event` assumes `event.event` (singular string attribute)
2. Router streamers pass ALL stream chunks to `format_sse_event` without filtering accumulator objects

## Changes

### 1. Defensive check in `format_sse_event` (belt-and-suspenders)
- `libs/agno/agno/os/utils.py`: Changed `event.event or "message"` → `getattr(event, "event", None) or "message"`
- Prevents crash if any accumulator object ever reaches `format_sse_event`

### 2. isinstance filtering in all 6 SSE router streamers (primary fix)
- `libs/agno/agno/os/routers/teams/router.py`: Added `if isinstance(run_response_chunk, TeamRunOutput): continue` in `team_response_streamer` and `team_continue_response_streamer`
- `libs/agno/agno/os/routers/agents/router.py`: Added `if isinstance(run_response_chunk, RunOutput): continue` in `agent_response_streamer` and `agent_continue_response_streamer`
- `libs/agno/agno/os/routers/workflows/router.py`: Added `if isinstance(run_response_chunk, WorkflowRunOutput): continue` in `workflow_response_streamer` and `workflow_continue_response_streamer`

This matches the existing proven pattern in `_arun_background_stream` (`team/_run.py:3478`, `agent/_run.py:2054`).

### 3. Unit tests
- `libs/agno/tests/unit/os/test_team_sse_filtering.py` — 4 tests
- `libs/agno/tests/unit/os/test_agent_sse_filtering.py` — 4 tests
- `libs/agno/tests/unit/os/test_workflow_sse_filtering.py` — 4 tests

All 12 tests passing. Tests use `MagicMock(spec=...)` to properly verify isinstance checks.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/agno-agi/agno/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] My changes generate no new warnings
- [x] I have not added any unnecessary dependencies or AI slop

Fixes #8235