### PR TITLE
feat: Add HTML file generation and example app

### DIFF
--- a/cookbook/05_agent_os/file_generation/file_generation_os.py
+++ b/cookbook/05_agent_os/file_generation/file_generation_os.py
@@ -13,7 +13,6 @@ Files are returned as base64-encoded artifacts in the AgentOS response (see
 File._normalise_content in agno/media.py) AND saved to tmp/file_gen_out/.
 """
 
-from dotenv import load_dotenv
 
 
 from agno.agent import Agent
@@ -50,4 +49,4 @@ app = agent_os.get_app()
 
 
 if __name__ == "__main__":
-    agent_os.serve(app="filegenerationos:app", reload=True)
+    agent_os.serve(app="file_generation_os:app", reload=True)

--- a/cookbook/05_agent_os/file_generation/file_generation_os.py
+++ b/cookbook/05_agent_os/file_generation/file_generation_os.py
@@ -1,9 +1,8 @@
 """
 
-Run:
-    .venvs/demo/bin/python tmp/test_file_gen_os.py
 
-Then open os.agno.com and chat with the agent, e.g.:
+
+open os.agno.com and chat with the agent, e.g.:
     "Generate a DOCX report on Q4 sales trends."
     "Generate a PDF about renewable energy."
     "Generate a CSV of 5 fictional employees."

--- a/cookbook/05_agent_os/file_generation/file_generation_os.py
+++ b/cookbook/05_agent_os/file_generation/file_generation_os.py
@@ -38,6 +38,7 @@ file_agent = Agent(
     instructions=[
         "When asked to create a file, pick the right generator tool for the requested format.",
         "Always provide meaningful content and a descriptive filename.",
+        "When generating HTML files, produce a complete HTML5 document with doctype, html, head, and body tags.",
         "Briefly explain what was generated.",
     ],
     markdown=True,

--- a/cookbook/05_agent_os/file_generation/file_generation_os.py
+++ b/cookbook/05_agent_os/file_generation/file_generation_os.py
@@ -1,19 +1,20 @@
-"""
+"""File generation with AgentOS.
+
+This example serves an agent that generates files (JSON, CSV, PDF, DOCX, TXT, HTML)
+through AgentOS using the FileGenerationTools toolkit.
 
 Run:
-    .venvs/demo/bin/python tmp/test_file_gen_os.py
+    .venvs/demo/bin/python cookbook/05_agent_os/file_generation/file_generation_os.py
 
-Then open os.agno.com and chat with the agent, e.g.:
+Then open os.agno.com, connect to the local server, and chat with the agent, e.g.:
     "Generate a DOCX report on Q4 sales trends."
     "Generate a PDF about renewable energy."
     "Generate a CSV of 5 fictional employees."
     "Generate an HTML landing page for a coffee shop."
 
-Files are returned as base64-encoded artifacts in the AgentOS response (see
-File._normalise_content in agno/media.py) AND saved to tmp/file_gen_out/.
+Generated files are returned as base64-encoded artifacts in the AgentOS response
+and saved to tmp/file_gen_out/.
 """
-
-
 
 from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
@@ -30,6 +31,7 @@ file_agent = Agent(
     tools=[
         FileGenerationTools(
             all=True,
+            output_directory="tmp/file_gen_out",
         )
     ],
     description="You generate files (JSON, CSV, PDF, DOCX, TXT, HTML) on request.",
@@ -46,7 +48,6 @@ file_agent = Agent(
 
 agent_os = AgentOS(agents=[file_agent])
 app = agent_os.get_app()
-
 
 if __name__ == "__main__":
     agent_os.serve(app="file_generation_os:app", reload=True)

--- a/cookbook/06_agent_os/filegen/filegenerationos.py
+++ b/cookbook/06_agent_os/filegen/filegenerationos.py
@@ -1,0 +1,53 @@
+"""
+
+Run:
+    .venvs/demo/bin/python tmp/test_file_gen_os.py
+
+Then open os.agno.com and chat with the agent, e.g.:
+    "Generate a DOCX report on Q4 sales trends."
+    "Generate a PDF about renewable energy."
+    "Generate a CSV of 5 fictional employees."
+    "Generate an HTML landing page for a coffee shop."
+
+Files are returned as base64-encoded artifacts in the AgentOS response (see
+File._normalise_content in agno/media.py) AND saved to tmp/file_gen_out/.
+"""
+
+from dotenv import load_dotenv
+
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os.app import AgentOS
+from agno.tools.file_generation import FileGenerationTools
+
+agent_db = SqliteDb(db_file="tmp/file_gen_os.db")
+
+file_agent = Agent(
+    name="File Generator",
+    model=OpenAIResponses(id="gpt-5.4"),
+    db=agent_db,
+    tools=[
+        FileGenerationTools(
+            all=True,
+        )
+    ],
+    description="You generate files (JSON, CSV, PDF, DOCX, TXT, HTML) on request.",
+    instructions=[
+        "When asked to create a file, pick the right generator tool for the requested format.",
+        "Always provide meaningful content and a descriptive filename.",
+        "Briefly explain what was generated.",
+    ],
+    markdown=True,
+    debug_mode=True,
+    add_history_to_context=True,
+    num_history_runs=3,
+)
+
+agent_os = AgentOS(agents=[file_agent])
+app = agent_os.get_app()
+
+
+if __name__ == "__main__":
+    agent_os.serve(app="test_file_gen_os:app", reload=True)

--- a/cookbook/06_agent_os/filegen/filegenerationos.py
+++ b/cookbook/06_agent_os/filegen/filegenerationos.py
@@ -50,4 +50,4 @@ app = agent_os.get_app()
 
 
 if __name__ == "__main__":
-    agent_os.serve(app="test_file_gen_os:app", reload=True)
+    agent_os.serve(app="filegenerationos:app", reload=True)

--- a/cookbook/91_tools/file_generation_tools.py
+++ b/cookbook/91_tools/file_generation_tools.py
@@ -1,6 +1,6 @@
 """
 File Generation Tool Example
-This cookbook shows how to use the FileGenerationTool to generate various file types (JSON, CSV, PDF, TXT).
+This cookbook shows how to use the FileGenerationTool to generate various file types (JSON, CSV, PDF, TXT, DOCX, HTML).
 The tool can generate files from agent responses and make them available for download or further processing.
 
 By default, files are returned as in-memory artifacts only (save_files=False).
@@ -96,6 +96,21 @@ def example_docx_generation():
     print("=== DOCX File Generation Example ===")
     response = agent.run(
         "Create a DOCX report about customer onboarding best practices. Include sections for welcome email, product tour, and success check-ins."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+
+
+def example_html_generation():
+    """Example: Generate an HTML file"""
+    print("=== HTML File Generation Example ===")
+    response = agent.run(
+        "Create an HTML landing page for a coffee shop. Include a heading, a short intro, and a list of three signature drinks."
     )
     print(response.content)
     if response.files:

--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -44,6 +44,7 @@ class FileGenerationTools(Toolkit):
         enable_pdf_generation: bool = True,
         enable_docx_generation: bool = True,
         enable_txt_generation: bool = True,
+        enable_html_generation: bool = True,
         output_directory: Optional[str] = None,
         save_files: bool = False,
         all: bool = False,
@@ -54,6 +55,7 @@ class FileGenerationTools(Toolkit):
         self.enable_pdf_generation = enable_pdf_generation and PDF_AVAILABLE
         self.enable_docx_generation = enable_docx_generation and DOCX_AVAILABLE
         self.enable_txt_generation = enable_txt_generation
+        self.enable_html_generation = enable_html_generation
         # output_directory implies save_files=True for backward compatibility
         self.save_files = save_files or (output_directory is not None)
 
@@ -85,6 +87,8 @@ class FileGenerationTools(Toolkit):
             tools.append(self.generate_docx_file)
         if all or enable_txt_generation:
             tools.append(self.generate_text_file)
+        if all or enable_html_generation:
+            tools.append(self.generate_html_file)
 
         super().__init__(name="file_generation", tools=tools, **kwargs)
 
@@ -343,6 +347,55 @@ class FileGenerationTools(Toolkit):
         except Exception as e:
             logger.exception("Failed to generate text file")
             return ToolResult(content=f"Error generating text file: {e}")
+
+    def generate_html_file(
+        self, content: str, filename: Optional[str] = None, title: Optional[str] = None
+    ) -> ToolResult:
+        """Generate an HTML file from the provided content.
+
+        If the content already contains a full HTML document (an ``<html>`` tag), it is used
+        as-is. Otherwise the content is wrapped in a minimal HTML5 skeleton.
+
+        Args:
+            content: The HTML markup or body content to write to the file.
+            filename: Optional filename for the generated file. If not provided, a UUID will be used.
+            title: Optional document title. Only used when content is wrapped in a skeleton.
+
+        Returns:
+            ToolResult: Result containing the generated HTML file as a FileArtifact.
+        """
+        try:
+            log_debug(f"Generating HTML file with content length: {len(content)}")
+
+            if "<html" in content.lower():
+                html_content = content
+            else:
+                page_title = title or "Generated Document"
+                html_content = (
+                    "<!DOCTYPE html>\n"
+                    '<html lang="en">\n'
+                    "<head>\n"
+                    '    <meta charset="utf-8">\n'
+                    '    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n'
+                    f"    <title>{page_title}</title>\n"
+                    "</head>\n"
+                    "<body>\n"
+                    f"{content}\n"
+                    "</body>\n"
+                    "</html>\n"
+                )
+
+            return self._create_file_artifact(
+                html_content,
+                filename,
+                file_type="html",
+                mime_type="text/html",
+                display_name="HTML",
+            )
+
+        except Exception as e:
+            logger.exception("Failed to generate HTML file")
+            return ToolResult(content=f"Error generating HTML file: {e}")
 
     def generate_docx_file(
         self, content: str, filename: Optional[str] = None, title: Optional[str] = None

--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -348,18 +348,12 @@ class FileGenerationTools(Toolkit):
             logger.exception("Failed to generate text file")
             return ToolResult(content=f"Error generating text file: {e}")
 
-    def generate_html_file(
-        self, content: str, filename: Optional[str] = None, title: Optional[str] = None
-    ) -> ToolResult:
+    def generate_html_file(self, content: str, filename: Optional[str] = None) -> ToolResult:
         """Generate an HTML file from the provided content.
 
-        If the content already starts with a full HTML document (``<!doctype`` or ``<html``),
-        it is used as-is. Otherwise the content is wrapped in a minimal HTML5 skeleton.
-
         Args:
-            content: The HTML markup or body content to write to the file.
+            content: A complete, valid HTML5 document (including doctype, html, head, and body tags).
             filename: Optional filename for the generated file. If not provided, a UUID will be used.
-            title: Optional document title. Only used when content is wrapped in a skeleton.
 
         Returns:
             ToolResult: Result containing the generated HTML file as a FileArtifact.
@@ -367,27 +361,8 @@ class FileGenerationTools(Toolkit):
         try:
             log_debug(f"Generating HTML file with content length: {len(content)}")
 
-            stripped = content.lstrip()
-            if stripped[:9].lower().startswith(("<!doctype", "<html")):
-                html_content = content
-            else:
-                page_title = title or "Generated Document"
-                html_content = (
-                    "<!DOCTYPE html>\n"
-                    '<html lang="en">\n'
-                    "<head>\n"
-                    '    <meta charset="utf-8">\n'
-                    '    <meta name="viewport" content="width=device-width, initial-scale=1.0">\n'
-                    f"    <title>{page_title}</title>\n"
-                    "</head>\n"
-                    "<body>\n"
-                    f"{content}\n"
-                    "</body>\n"
-                    "</html>\n"
-                )
-
             return self._create_file_artifact(
-                html_content,
+                content,
                 filename,
                 file_type="html",
                 mime_type="text/html",

--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -353,8 +353,8 @@ class FileGenerationTools(Toolkit):
     ) -> ToolResult:
         """Generate an HTML file from the provided content.
 
-        If the content already contains a full HTML document (an ``<html>`` tag), it is used
-        as-is. Otherwise the content is wrapped in a minimal HTML5 skeleton.
+        If the content already starts with a full HTML document (``<!doctype`` or ``<html``),
+        it is used as-is. Otherwise the content is wrapped in a minimal HTML5 skeleton.
 
         Args:
             content: The HTML markup or body content to write to the file.
@@ -367,7 +367,8 @@ class FileGenerationTools(Toolkit):
         try:
             log_debug(f"Generating HTML file with content length: {len(content)}")
 
-            if "<html" in content.lower():
+            stripped = content.lstrip()
+            if stripped[:9].lower().startswith(("<!doctype", "<html")):
                 html_content = content
             else:
                 page_title = title or "Generated Document"

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -15,9 +15,13 @@ from ag_ui.core.types import (
     VideoInputContent,
 )
 
-from agno.os.interfaces.agui.router import run_agent, run_team
 from agno.os.interfaces.agui.media import extract_agui_media
-from agno.os.interfaces.agui.utils import EventBuffer, async_stream_agno_response_as_agui_events, extract_agui_user_input
+from agno.os.interfaces.agui.router import run_agent, run_team
+from agno.os.interfaces.agui.utils import (
+    EventBuffer,
+    async_stream_agno_response_as_agui_events,
+    extract_agui_user_input,
+)
 from agno.run.agent import RunContentEvent, RunEvent, ToolCallCompletedEvent, ToolCallStartedEvent
 
 


### PR DESCRIPTION


## Summary
Introduce HTML generation support to FileGenerationTools and add a Cookbook AgentOS example. Changes include: add enable_html_generation flag and instance property; register generate_html_file in the toolkit when requested; implement generate_html_file which wraps content in a minimal HTML5 skeleton if no <html> tag is present and returns a FileArtifact (text/html). Also add cookbook/06_agent_os/filegen/filegenerationos.py, an example AgentOS app demonstrating file generation (saves outputs to tmp/file_gen_out/ and returns base64 artifacts in responses).
(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
