### PR TITLE
fix: filter team delegation tools from member agent schema

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -404,6 +404,13 @@ def parse_tools(
     ):
         strict = True
 
+    # Team-level delegation tools must never appear in a member agent's tool schema.
+    # When this agent runs as a team member (agent._team is not None), filter them out
+    # so the model cannot hallucinate calls to tools that belong to the parent team.
+    _team_only_tool_names: set = (
+        {"delegate_task_to_member", "delegate_task_to_members"} if agent._team is not None else set()
+    )
+
     for tool_index, tool in enumerate(tools):
         if isinstance(tool, Dict):
             # If a dict is passed, it is a builtin tool
@@ -415,6 +422,9 @@ def parse_tools(
             # For each function in the toolkit and process entrypoint
             toolkit_functions = tool.get_async_functions() if async_mode else tool.get_functions()
             for name, _func in toolkit_functions.items():
+                if name in _team_only_tool_names:
+                    log_debug(f"Skipping team-only tool '{name}' for member agent")
+                    continue
                 if name in _function_names:
                     log_warning(
                         f"Duplicate tool name '{name}' from toolkit '{tool.name}' "
@@ -444,6 +454,9 @@ def parse_tools(
             add_toolkit_instructions(tool)
 
         elif isinstance(tool, Function):
+            if tool.name in _team_only_tool_names:
+                log_debug(f"Skipping team-only tool '{tool.name}' for member agent")
+                continue
             source_toolkit = tool.source_toolkit if isinstance(tool.source_toolkit, Toolkit) else None
             emit_toolkit_instructions = source_toolkit is not None and emits_toolkit_instructions(
                 source_toolkit, tool_index
@@ -485,6 +498,9 @@ def parse_tools(
             try:
                 function_name = tool.__name__
 
+                if function_name in _team_only_tool_names:
+                    log_debug(f"Skipping team-only tool '{function_name}' for member agent")
+                    continue
                 if function_name in _function_names:
                     log_warning(
                         f"Duplicate tool name '{function_name}' already registered on agent; skipping the duplicate."

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -429,6 +429,13 @@ def parse_tools(
     ):
         strict = True
 
+    # Team-level delegation tools must never appear in a member agent's tool schema.
+    # When this agent runs as a team member (agent._team is not None), filter them out
+    # so the model cannot hallucinate calls to tools that belong to the parent team.
+    _team_only_tool_names: set = (
+        {"delegate_task_to_member", "delegate_task_to_members"} if agent._team is not None else set()
+    )
+
     for tool_index, tool in enumerate(tools):
         # ComponentTool markers are rejected at the API boundary (Agent __init__ /
         # set_tools / add_tool), so anything reaching here is already a real tool -- no
@@ -443,6 +450,9 @@ def parse_tools(
             # For each function in the toolkit and process entrypoint
             toolkit_functions = tool.get_async_functions() if async_mode else tool.get_functions()
             for name, _func in toolkit_functions.items():
+                if name in _team_only_tool_names:
+                    log_debug(f"Skipping team-only tool '{name}' for member agent")
+                    continue
                 if name in _function_names:
                     log_warning(
                         f"Duplicate tool name '{name}' from toolkit '{tool.name}' "
@@ -472,6 +482,9 @@ def parse_tools(
             add_toolkit_instructions(tool)
 
         elif isinstance(tool, Function):
+            if tool.name in _team_only_tool_names:
+                log_debug(f"Skipping team-only tool '{tool.name}' for member agent")
+                continue
             source_toolkit = tool.source_toolkit if isinstance(tool.source_toolkit, Toolkit) else None
             emit_toolkit_instructions = source_toolkit is not None and emits_toolkit_instructions(
                 source_toolkit, tool_index
@@ -513,6 +526,9 @@ def parse_tools(
             try:
                 function_name = tool.__name__
 
+                if function_name in _team_only_tool_names:
+                    log_debug(f"Skipping team-only tool '{function_name}' for member agent")
+                    continue
                 if function_name in _function_names:
                     log_warning(
                         f"Duplicate tool name '{function_name}' already registered on agent; skipping the duplicate."

--- a/libs/agno/tests/unit/agent/test_team_tool_propagation.py
+++ b/libs/agno/tests/unit/agent/test_team_tool_propagation.py
@@ -537,3 +537,82 @@ def test_cloned_toolkit_and_its_rehydrated_members_are_one_toolkit():
 
     parse_tools(agent=copied, tools=copied.tools, model=_mock_model())
     assert copied._tool_instructions == ["first-rule", "second-rule", "toolkit-level-rule"]
+
+
+# -- Team-only tool filtering (issue #7965) -----------------------------------
+# Member agents must never see delegate_task_to_member or delegate_task_to_members
+# in their tool schema even if those names somehow appear in their tools list.
+
+
+def _make_delegate_function(name: str) -> Function:
+    """Return a bare Function with the given name (no entrypoint needed for schema tests)."""
+    func = Function(name=name)
+    return func
+
+
+def test_delegate_task_to_member_filtered_for_member_agent():
+    """delegate_task_to_member is stripped when the agent has a parent team."""
+    delegate_func = _make_delegate_function("delegate_task_to_member")
+    agent = Agent(tools=[delegate_func])
+    agent._team = _mock_team()
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    names = [f.name for f in functions if isinstance(f, Function)]
+    assert "delegate_task_to_member" not in names
+
+
+def test_delegate_task_to_members_filtered_for_member_agent():
+    """delegate_task_to_members is stripped when the agent has a parent team."""
+    delegate_func = _make_delegate_function("delegate_task_to_members")
+    agent = Agent(tools=[delegate_func])
+    agent._team = _mock_team()
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    names = [f.name for f in functions if isinstance(f, Function)]
+    assert "delegate_task_to_members" not in names
+
+
+def test_delegate_task_to_member_not_filtered_for_standalone_agent():
+    """delegate_task_to_member is kept when the agent has no parent team."""
+    delegate_func = _make_delegate_function("delegate_task_to_member")
+    agent = Agent(tools=[delegate_func])
+    # agent._team is None (default)
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    names = [f.name for f in functions if isinstance(f, Function)]
+    assert "delegate_task_to_member" in names
+
+
+def test_legitimate_tools_kept_alongside_filtered_delegate_tool():
+    """Filtering delegate tools does not remove the agent's own legitimate tools."""
+
+    def send_message(text: str) -> str:
+        return text
+
+    delegate_func = _make_delegate_function("delegate_task_to_member")
+    agent = Agent(tools=[send_message, delegate_func])
+    agent._team = _mock_team()
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    names = [f.name for f in functions if isinstance(f, Function)]
+    assert "send_message" in names
+    assert "delegate_task_to_member" not in names
+
+
+def test_delegate_callable_filtered_for_member_agent():
+    """A raw callable named delegate_task_to_member is also filtered."""
+
+    def delegate_task_to_member(member_id: str, task: str) -> str:
+        return "delegated"
+
+    agent = Agent(tools=[delegate_task_to_member])
+    agent._team = _mock_team()
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model())
+
+    names = [f.name for f in functions if isinstance(f, Function)]
+    assert "delegate_task_to_member" not in names


### PR DESCRIPTION
## Summary

Fixes #7965

When an Agent runs as a member of a Team, the model's tool schema can include `delegate_task_to_member` — a team-level coordination tool that only makes sense at the Team layer. The model then attempts to call it with hallucinated member IDs (e.g. passing the agent's own tool name as `member_id`), producing errors like:

```
Member with ID send_message not found in the team or any subteams
```

These error strings leak into user-facing content through the parent team's continuation message.

**Root cause:** The tool filtering in `parse_tools()` didn't distinguish between an agent's own tools and team-level delegation tools that may have been injected into the agent's tool list.

**Fix:** In `parse_tools()`, when the agent has a parent team (`agent._team is not None`), skip registration of `delegate_task_to_member` and `delegate_task_to_members`. The check covers all three tool registration paths (Toolkit functions, Function objects, raw callables). Standalone agents are completely unaffected.

## Test plan

- Added 5 new tests to `test_team_tool_propagation.py`:
  - `delegate_task_to_member` Function is filtered for member agents
  - `delegate_task_to_members` Function is filtered for member agents
  - `delegate_task_to_member` is NOT filtered for standalone agents (no regression)
  - Legitimate tools are kept alongside filtered delegation tools
  - Raw callable named `delegate_task_to_member` is also filtered
- All 15 tests in `test_team_tool_propagation.py` pass