### PR TITLE
[fix] Preserve workflow trace run IDs

### DIFF
--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -2236,6 +2236,9 @@ class DynamoDb(BaseDb):
                 )
                 new_level = get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
                 should_update_name = new_level > existing_level
+                should_update_run_id = trace.run_id is not None and (
+                    existing.get("run_id") is None or new_level > existing_level
+                )
 
                 # Parse existing start_time to calculate correct duration
                 existing_start_time_str = existing.get("start_time")
@@ -2268,7 +2271,7 @@ class DynamoDb(BaseDb):
                 # that the existing row left blank. Otherwise a later upsert from
                 # a child span (e.g. a post-hook agent's run with a different
                 # session_id) would overwrite the trace's already-correct context.
-                if existing.get("run_id") is None and trace.run_id is not None:
+                if should_update_run_id:
                     update_parts.append("run_id = :run_id")
                     expression_attr_values[":run_id"] = {"S": trace.run_id}
                 if existing.get("session_id") is None and trace.session_id is not None:

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -1931,6 +1931,9 @@ class FirestoreDb(BaseDb):
                 )
                 new_level = get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
                 should_update_name = new_level > existing_level
+                should_update_run_id = trace.run_id is not None and (
+                    existing_data.get("run_id") is None or new_level > existing_level
+                )
 
                 # Parse existing start_time to calculate correct duration
                 existing_start_time_str = existing_data.get("start_time")
@@ -1954,7 +1957,7 @@ class FirestoreDb(BaseDb):
                 # that the existing row left blank. Otherwise a later upsert from
                 # a child span (e.g. a post-hook agent's run with a different
                 # session_id) would overwrite the trace's already-correct context.
-                if existing_data.get("run_id") is None and trace.run_id is not None:
+                if should_update_run_id:
                     update_values["run_id"] = trace.run_id
                 if existing_data.get("session_id") is None and trace.session_id is not None:
                     update_values["session_id"] = trace.session_id

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -1427,6 +1427,9 @@ class GcsJsonDb(BaseDb):
                 )
                 new_level = get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
                 should_update_name = new_level > existing_level
+                should_update_run_id = trace.run_id is not None and (
+                    existing.get("run_id") is None or new_level > existing_level
+                )
 
                 # Parse existing start_time to calculate correct duration
                 existing_start_time_str = existing.get("start_time")
@@ -1448,7 +1451,7 @@ class GcsJsonDb(BaseDb):
                 # that the existing row left blank. Otherwise a later upsert from
                 # a child span (e.g. a post-hook agent's run with a different
                 # session_id) would overwrite the trace's already-correct context.
-                if existing.get("run_id") is None and trace.run_id is not None:
+                if should_update_run_id:
                     existing["run_id"] = trace.run_id
                 if existing.get("session_id") is None and trace.session_id is not None:
                     existing["session_id"] = trace.session_id

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1412,6 +1412,9 @@ class JsonDb(BaseDb):
                 )
                 new_level = get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
                 should_update_name = new_level > existing_level
+                should_update_run_id = trace.run_id is not None and (
+                    existing.get("run_id") is None or new_level > existing_level
+                )
 
                 # Parse existing start_time to calculate correct duration
                 existing_start_time_str = existing.get("start_time")
@@ -1433,7 +1436,7 @@ class JsonDb(BaseDb):
                 # that the existing row left blank. Otherwise a later upsert from
                 # a child span (e.g. a post-hook agent's run with a different
                 # session_id) would overwrite the trace's already-correct context.
-                if existing.get("run_id") is None and trace.run_id is not None:
+                if should_update_run_id:
                     existing["run_id"] = trace.run_id
                 if existing.get("session_id") is None and trace.session_id is not None:
                     existing["session_id"] = trace.session_id

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -2342,6 +2342,27 @@ class AsyncMongoDb(AsyncBaseDb):
 
             # Calculate the component level for the new trace
             new_level = self._get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
+            existing_level_expr = {
+                "$switch": {
+                    "branches": [
+                        {
+                            "case": {
+                                "$not": {
+                                    "$or": [
+                                        {"$regexMatch": {"input": {"$ifNull": ["$name", ""]}, "regex": "\\.run"}},
+                                        {"$regexMatch": {"input": {"$ifNull": ["$name", ""]}, "regex": "\\.arun"}},
+                                    ]
+                                }
+                            },
+                            "then": 0,
+                        },
+                        {"case": {"$ne": ["$workflow_id", None]}, "then": 3},
+                        {"case": {"$ne": ["$team_id", None]}, "then": 2},
+                        {"case": {"$ne": ["$agent_id", None]}, "then": 1},
+                    ],
+                    "default": 0,
+                }
+            }
 
             # Use MongoDB aggregation pipeline update for atomic upsert
             # This allows conditional logic within a single atomic operation
@@ -2372,7 +2393,15 @@ class AsyncMongoDb(AsyncBaseDb):
                         # Otherwise a later upsert from a child span (e.g. a post-hook
                         # agent's run with a different session_id) would overwrite
                         # the trace's already-correct context.
-                        "run_id": {"$ifNull": ["$run_id", trace.run_id]},
+                        "run_id": {
+                            "$cond": {
+                                "if": {
+                                    "$and": [{"$ne": [trace.run_id, None]}, {"$gt": [new_level, existing_level_expr]}]
+                                },
+                                "then": trace.run_id,
+                                "else": {"$ifNull": ["$run_id", trace.run_id]},
+                            }
+                        },
                         "session_id": {"$ifNull": ["$session_id", trace.session_id]},
                         "user_id": {"$ifNull": ["$user_id", trace.user_id]},
                         "agent_id": {"$ifNull": ["$agent_id", trace.agent_id]},

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2164,6 +2164,27 @@ class MongoDb(BaseDb):
 
             # Calculate the component level for the new trace
             new_level = self._get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
+            existing_level_expr = {
+                "$switch": {
+                    "branches": [
+                        {
+                            "case": {
+                                "$not": {
+                                    "$or": [
+                                        {"$regexMatch": {"input": {"$ifNull": ["$name", ""]}, "regex": "\\.run"}},
+                                        {"$regexMatch": {"input": {"$ifNull": ["$name", ""]}, "regex": "\\.arun"}},
+                                    ]
+                                }
+                            },
+                            "then": 0,
+                        },
+                        {"case": {"$ne": ["$workflow_id", None]}, "then": 3},
+                        {"case": {"$ne": ["$team_id", None]}, "then": 2},
+                        {"case": {"$ne": ["$agent_id", None]}, "then": 1},
+                    ],
+                    "default": 0,
+                }
+            }
 
             # Use MongoDB aggregation pipeline update for atomic upsert
             # This allows conditional logic within a single atomic operation
@@ -2194,7 +2215,15 @@ class MongoDb(BaseDb):
                         # Otherwise a later upsert from a child span (e.g. a post-hook
                         # agent's run with a different session_id) would overwrite
                         # the trace's already-correct context.
-                        "run_id": {"$ifNull": ["$run_id", trace.run_id]},
+                        "run_id": {
+                            "$cond": {
+                                "if": {
+                                    "$and": [{"$ne": [trace.run_id, None]}, {"$gt": [new_level, existing_level_expr]}]
+                                },
+                                "then": trace.run_id,
+                                "else": {"$ifNull": ["$run_id", trace.run_id]},
+                            }
+                        },
                         "session_id": {"$ifNull": ["$session_id", trace.session_id]},
                         "user_id": {"$ifNull": ["$user_id", trace.user_id]},
                         "agent_id": {"$ifNull": ["$agent_id", trace.agent_id]},

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -2520,7 +2520,7 @@ class AsyncMySQLDb(AsyncBaseDb):
         Args:
             trace: The Trace object to store (one per trace_id).
         """
-        from sqlalchemy import case
+        from sqlalchemy import and_, case
 
         try:
             table = await self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -2578,7 +2578,13 @@ class AsyncMySQLDb(AsyncBaseDb):
                     # Otherwise a later upsert from a child span (e.g. a post-hook
                     # agent's run with a different session_id) would overwrite
                     # the trace's already-correct context.
-                    run_id=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    run_id=case(
+                        (
+                            and_(insert_stmt.inserted.run_id.isnot(None), new_level > existing_level),
+                            insert_stmt.inserted.run_id,
+                        ),
+                        else_=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    ),
                     session_id=func.coalesce(table.c.session_id, insert_stmt.inserted.session_id),
                     user_id=func.coalesce(table.c.user_id, insert_stmt.inserted.user_id),
                     agent_id=func.coalesce(table.c.agent_id, insert_stmt.inserted.agent_id),

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -2542,7 +2542,7 @@ class MySQLDb(BaseDb):
         Args:
             trace: The Trace object to store (one per trace_id).
         """
-        from sqlalchemy import case
+        from sqlalchemy import and_, case
 
         try:
             table = self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -2600,7 +2600,13 @@ class MySQLDb(BaseDb):
                     # Otherwise a later upsert from a child span (e.g. a post-hook
                     # agent's run with a different session_id) would overwrite
                     # the trace's already-correct context.
-                    run_id=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    run_id=case(
+                        (
+                            and_(insert_stmt.inserted.run_id.isnot(None), new_level > existing_level),
+                            insert_stmt.inserted.run_id,
+                        ),
+                        else_=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    ),
                     session_id=func.coalesce(table.c.session_id, insert_stmt.inserted.session_id),
                     user_id=func.coalesce(table.c.user_id, insert_stmt.inserted.user_id),
                     agent_id=func.coalesce(table.c.agent_id, insert_stmt.inserted.agent_id),

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -2459,7 +2459,13 @@ class AsyncPostgresDb(AsyncBaseDb):
                         # Otherwise a later upsert from a child span (e.g. a post-hook
                         # agent's run with a different session_id) would overwrite
                         # the trace's already-correct context.
-                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "run_id": case(
+                            (
+                                and_(insert_stmt.excluded.run_id.isnot(None), new_level > existing_level),
+                                insert_stmt.excluded.run_id,
+                            ),
+                            else_=func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        ),
                         "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
                         "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
                         "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -2902,7 +2902,13 @@ class PostgresDb(BaseDb):
                         # Otherwise a later upsert from a child span (e.g. a post-hook
                         # agent's run with a different session_id) would overwrite
                         # the trace's already-correct context.
-                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "run_id": case(
+                            (
+                                and_(insert_stmt.excluded.run_id.isnot(None), new_level > existing_level),
+                                insert_stmt.excluded.run_id,
+                            ),
+                            else_=func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        ),
                         "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
                         "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
                         "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -1759,6 +1759,9 @@ class RedisDb(BaseDb):
 
                 # Only update name if new trace is from a higher or equal level
                 should_update_name = new_level > existing_level
+                should_update_run_id = trace.run_id is not None and (
+                    existing.get("run_id") is None or new_level > existing_level
+                )
 
                 # Parse existing start_time to calculate correct duration
                 existing_start_time_str = existing.get("start_time")
@@ -1780,7 +1783,7 @@ class RedisDb(BaseDb):
                 # that the existing row left blank. Otherwise a later upsert from
                 # a child span (e.g. a post-hook agent's run with a different
                 # session_id) would overwrite the trace's already-correct context.
-                if existing.get("run_id") is None and trace.run_id is not None:
+                if should_update_run_id:
                     existing["run_id"] = trace.run_id
                 if existing.get("session_id") is None and trace.session_id is not None:
                     existing["session_id"] = trace.session_id

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -2493,7 +2493,7 @@ class SingleStoreDb(BaseDb):
         Args:
             trace: The Trace object to store (one per trace_id).
         """
-        from sqlalchemy import case
+        from sqlalchemy import and_, case
 
         try:
             table = self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -2550,7 +2550,13 @@ class SingleStoreDb(BaseDb):
                     # Otherwise a later upsert from a child span (e.g. a post-hook
                     # agent's run with a different session_id) would overwrite
                     # the trace's already-correct context.
-                    run_id=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    run_id=case(
+                        (
+                            and_(insert_stmt.inserted.run_id.isnot(None), new_level > existing_level),
+                            insert_stmt.inserted.run_id,
+                        ),
+                        else_=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    ),
                     session_id=func.coalesce(table.c.session_id, insert_stmt.inserted.session_id),
                     user_id=func.coalesce(table.c.user_id, insert_stmt.inserted.user_id),
                     agent_id=func.coalesce(table.c.agent_id, insert_stmt.inserted.agent_id),

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -2580,7 +2580,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         Args:
             trace: The Trace object to store (one per trace_id).
         """
-        from sqlalchemy import case
+        from sqlalchemy import and_, case
 
         try:
             table = await self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -2640,7 +2640,13 @@ class AsyncSqliteDb(AsyncBaseDb):
                         # Otherwise a later upsert from a child span (e.g. a post-hook
                         # agent's run with a different session_id) would overwrite
                         # the trace's already-correct context.
-                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "run_id": case(
+                            (
+                                and_(insert_stmt.excluded.run_id.isnot(None), new_level > existing_level),
+                                insert_stmt.excluded.run_id,
+                            ),
+                            else_=func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        ),
                         "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
                         "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
                         "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -2463,7 +2463,7 @@ class SqliteDb(BaseDb):
         Args:
             trace: The Trace object to store (one per trace_id).
         """
-        from sqlalchemy import case
+        from sqlalchemy import and_, case
 
         try:
             table = self._get_table(table_type="traces", create_table_if_not_found=True)
@@ -2523,7 +2523,13 @@ class SqliteDb(BaseDb):
                         # Otherwise a later upsert from a child span (e.g. a post-hook
                         # agent's run with a different session_id) would overwrite
                         # the trace's already-correct context.
-                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "run_id": case(
+                            (
+                                and_(insert_stmt.excluded.run_id.isnot(None), new_level > existing_level),
+                                insert_stmt.excluded.run_id,
+                            ),
+                            else_=func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        ),
                         "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
                         "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
                         "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -1502,6 +1502,9 @@ class SurrealDb(BaseDb):
                 )
                 new_level = get_component_level(trace.workflow_id, trace.team_id, trace.agent_id, trace.name)
                 should_update_name = new_level > existing_level
+                should_update_run_id = trace.run_id is not None and (
+                    existing.get("run_id") is None or new_level > existing_level
+                )
 
                 # Parse existing start_time to calculate correct duration
                 existing_start_time = existing.get("start_time")
@@ -1531,7 +1534,7 @@ class SurrealDb(BaseDb):
                 # that the existing row left blank. Otherwise a later upsert from
                 # a child span (e.g. a post-hook agent's run with a different
                 # session_id) would overwrite the trace's already-correct context.
-                if existing.get("run_id") is None and trace.run_id is not None:
+                if should_update_run_id:
                     update_fields.append("run_id = $run_id")
                     update_vars["run_id"] = trace.run_id
                 if existing.get("session_id") is None and trace.session_id is not None:

--- a/libs/agno/agno/tracing/schemas.py
+++ b/libs/agno/agno/tracing/schemas.py
@@ -215,6 +215,14 @@ class Span:
         )
 
 
+def _extract_run_id(attrs: Dict[str, Any]) -> Optional[str]:
+    return attrs.get("run_id") or attrs.get("agno.run.id")
+
+
+def _find_run_id(spans: List[Span]) -> Optional[str]:
+    return next((run_id for span in spans if (run_id := _extract_run_id(span.attributes))), None)
+
+
 def create_trace_from_spans(spans: List[Span]) -> Optional[Trace]:
     """
     Create a Trace object from a list of Span objects with the same trace_id.
@@ -231,9 +239,11 @@ def create_trace_from_spans(spans: List[Span]) -> Optional[Trace]:
     # Find a true root span (no parent) in this batch.
     # If none is present (e.g. only child spans were exported in this batch,
     # which happens when a post-hook agent's spans finish before the outer
-    # parent span ends), we must NOT pull context fields from a non-root span:
-    # those would carry the child run's session_id / agent_id / etc., which
-    # would clobber the parent trace's identity at the upsert layer.
+    # parent span ends), we must NOT pull root context fields from a non-root
+    # span: those would carry the child run's session_id / agent_id / etc.,
+    # which would clobber the parent trace's identity at the upsert layer.
+    # run_id is the exception because workflow root spans can omit it while
+    # their child agent spans still carry the run id users query traces by.
     root_span = next((s for s in spans if not s.parent_span_id), None)
 
     # Calculate aggregated metrics
@@ -250,17 +260,19 @@ def create_trace_from_spans(spans: List[Span]) -> Optional[Trace]:
     if root_span is not None:
         attrs = root_span.attributes
         name = root_span.name
-        run_id = attrs.get("run_id") or attrs.get("agno.run.id")
+        run_id = _extract_run_id(attrs) or _find_run_id(spans)
         session_id = attrs.get("session_id") or attrs.get("agno.session.id") or attrs.get("session.id")
         user_id = attrs.get("user_id") or attrs.get("agno.user.id") or attrs.get("user.id")
         agent_id = attrs.get("agent_id") or attrs.get("agno.agent.id")
         team_id = attrs.get("team_id") or attrs.get("agno.team.id")
         workflow_id = attrs.get("workflow_id") or attrs.get("agno.workflow.id")
     else:
-        # Child-only batch: leave context fields blank so the upsert's COALESCE
-        # preserves whatever the root-span batch wrote (or will write).
+        # Child-only batch: leave root context fields blank so the upsert's
+        # COALESCE preserves whatever the root-span batch wrote (or will
+        # write). run_id may be filled from child spans because workflow root
+        # spans can omit it entirely.
         name = spans[0].name
-        run_id = None
+        run_id = _find_run_id(spans)
         session_id = None
         user_id = None
         agent_id = None

--- a/libs/agno/tests/integration/db/sqlite/test_trace_exporter_integration.py
+++ b/libs/agno/tests/integration/db/sqlite/test_trace_exporter_integration.py
@@ -26,17 +26,18 @@ agno_traces row carries the TEAM's session_id, not the child's.
 from typing import Any, Iterator
 
 import pytest
+from agno.db.sqlite import SqliteDb
+from agno.tracing.exporter import DatabaseSpanExporter
 from opentelemetry import trace as trace_api  # type: ignore
 from opentelemetry.sdk.trace import TracerProvider  # type: ignore
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor  # type: ignore
-
-from agno.db.sqlite import SqliteDb
-from agno.tracing.exporter import DatabaseSpanExporter
 
 TEAM_SESSION = "mobile_session_chris@example.com"
 TEAM_ID = "customer_support_team"
 RATING_SESSION = "ratings_mobile_session_chris@example.com"
 RATING_AGENT_ID = "rating"
+WORKFLOW_ID = "research_workflow"
+AGENT_RUN_ID = "agent-run-1"
 
 
 @pytest.fixture
@@ -229,6 +230,40 @@ def test_batch_processor_size_one_root_ends_first(db):
     assert row["session_id"] == TEAM_SESSION
     assert row["team_id"] == TEAM_ID
     assert row["agent_id"] is None
+
+
+def test_simple_processor_workflow_root_without_run_id_keeps_child_run_id(db):
+    """Workflow root spans can omit agno.run.id while their child agent spans
+    carry the run_id users query traces by."""
+    tracer, provider = _make_tracer(db, batch=False)
+    try:
+        workflow_span = tracer.start_span(
+            "research_workflow.run",
+            attributes={"session.id": TEAM_SESSION, "agno.workflow.id": WORKFLOW_ID},
+        )
+        workflow_ctx = trace_api.set_span_in_context(workflow_span)
+
+        agent_span = tracer.start_span(
+            "ResearchAgent.run",
+            context=workflow_ctx,
+            attributes={
+                "session.id": RATING_SESSION,
+                "agno.agent.id": RATING_AGENT_ID,
+                "agno.run.id": AGENT_RUN_ID,
+            },
+        )
+        agent_span.end()
+        workflow_span.end()
+        trace_id = _otel_trace_id_hex(workflow_span)
+    finally:
+        provider.shutdown()
+
+    row = _read_trace(db, trace_id)
+    assert row["name"] == "research_workflow.run"
+    assert row["session_id"] == TEAM_SESSION
+    assert row["workflow_id"] == WORKFLOW_ID
+    assert row["agent_id"] is None
+    assert row["run_id"] == AGENT_RUN_ID
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/integration/db/sqlite/test_upsert_trace_preserves_context.py
+++ b/libs/agno/tests/integration/db/sqlite/test_upsert_trace_preserves_context.py
@@ -11,7 +11,9 @@ There were two bugs that combined to override the outer trace's session_id:
 1. `create_trace_from_spans` fell back to `spans[0]` when no true root span was
    present in the batch, then read `session_id`/`agent_id`/etc. from that
    non-root span. So a batch containing only the post-hook agent's child spans
-   produced a Trace dict tagged with the post-hook agent's session_id.
+   produced a Trace dict tagged with the post-hook agent's session_id. The
+   run_id is allowed to come from child spans because workflow root spans can
+   omit it entirely.
 
 2. `upsert_trace`'s ON CONFLICT clause used
        COALESCE(insert_stmt.excluded.session_id, table.c.session_id)
@@ -28,8 +30,7 @@ This file covers both layers:
 from datetime import datetime, timedelta, timezone
 
 import pytest
-
-from agno.db.sqlite import SqliteDb
+from agno.db.sqlite import AsyncSqliteDb, SqliteDb
 from agno.tracing.schemas import Span, Trace, create_trace_from_spans
 
 
@@ -86,6 +87,15 @@ def _read_trace(db: SqliteDb, trace_id: str) -> dict:
         return dict(row)
 
 
+async def _aread_trace(db: AsyncSqliteDb, trace_id: str) -> dict:
+    from sqlalchemy import select
+
+    table = await db._get_table(table_type="traces", create_table_if_not_found=True)
+    async with db.async_session_factory() as sess:
+        row = (await sess.execute(select(table).where(table.c.trace_id == trace_id))).mappings().one()
+        return dict(row)
+
+
 def test_upsert_trace_preserves_session_id_when_inner_context_arrives_after(db):
     """Outer team's correct session_id must survive a follow-up upsert tagged
     with the post-hook (rating) agent's session_id."""
@@ -133,6 +143,7 @@ def _make_span(
     session_id=None,
     agent_id=None,
     team_id=None,
+    workflow_id=None,
     run_id=None,
     user_id=None,
     start_offset_s: float = 0.0,
@@ -147,6 +158,8 @@ def _make_span(
         attrs["agno.agent.id"] = agent_id
     if team_id is not None:
         attrs["agno.team.id"] = team_id
+    if workflow_id is not None:
+        attrs["agno.workflow.id"] = workflow_id
     if run_id is not None:
         attrs["agno.run.id"] = run_id
     if user_id is not None:
@@ -171,7 +184,8 @@ def test_create_trace_from_spans_skips_context_when_no_root_in_batch():
     """A child-only batch (post-hook agent's spans exporting before the parent
     span ends) must not produce a Trace tagged with the child's session_id.
     Context fields stay None so the upsert COALESCE preserves whatever the
-    root-span batch wrote."""
+    root-span batch wrote. run_id is the exception because workflow root spans
+    can lack it."""
     trace_id = "trace-child-only"
 
     inner_run = _make_span(
@@ -196,7 +210,41 @@ def test_create_trace_from_spans_skips_context_when_no_root_in_batch():
     assert trace is not None
     assert trace.session_id is None
     assert trace.agent_id is None
-    assert trace.run_id is None
+    assert trace.run_id == "run-inner-1"
+
+
+def test_create_trace_from_spans_uses_child_run_id_when_root_omits_it():
+    """Workflow root spans can carry workflow/session context while child
+    agent spans carry the queryable agent run_id."""
+    trace_id = "trace-workflow-child-run-id"
+
+    workflow_run = _make_span(
+        span_id="workflow-run",
+        parent_span_id=None,
+        trace_id=trace_id,
+        name="research_workflow.run",
+        session_id="workflow-session-1",
+        workflow_id="research-workflow",
+    )
+    agent_run = _make_span(
+        span_id="agent-run",
+        parent_span_id="workflow-run",
+        trace_id=trace_id,
+        name="ResearchAgent.run",
+        session_id="agent-session-1",
+        agent_id="research-agent",
+        run_id="agent-run-1",
+        start_offset_s=0.05,
+    )
+
+    trace = create_trace_from_spans([workflow_run, agent_run])
+
+    assert trace is not None
+    assert trace.name == "research_workflow.run"
+    assert trace.session_id == "workflow-session-1"
+    assert trace.workflow_id == "research-workflow"
+    assert trace.agent_id is None
+    assert trace.run_id == "agent-run-1"
 
 
 def test_create_trace_from_spans_uses_root_when_present():
@@ -267,6 +315,81 @@ def test_pipeline_inner_batch_first_then_root_batch(db):
     assert row["team_id"] == "customer_support_team"
     assert row["run_id"] == "run-outer-1"
     assert row["name"] == "customer_support_team.run"
+
+
+def test_pipeline_preserves_child_run_id_when_workflow_root_omits_it(db):
+    """Full pipeline: a workflow root can fill root context after a child agent
+    batch has supplied the only run_id."""
+    trace_id = "trace-workflow-child-run-id"
+
+    agent_run = _make_span(
+        span_id="agent-run",
+        parent_span_id="workflow-run",
+        trace_id=trace_id,
+        name="ResearchAgent.run",
+        session_id="agent-session-1",
+        agent_id="research-agent",
+        run_id="agent-run-1",
+        start_offset_s=0.05,
+    )
+    db.upsert_trace(create_trace_from_spans([agent_run]))
+
+    workflow_run = _make_span(
+        span_id="workflow-run",
+        parent_span_id=None,
+        trace_id=trace_id,
+        name="research_workflow.run",
+        session_id="workflow-session-1",
+        workflow_id="research-workflow",
+    )
+    db.upsert_trace(create_trace_from_spans([workflow_run]))
+
+    row = _read_trace(db, trace_id)
+    assert row["name"] == "research_workflow.run"
+    assert row["session_id"] == "workflow-session-1"
+    assert row["workflow_id"] == "research-workflow"
+    assert row["agent_id"] is None
+    assert row["run_id"] == "agent-run-1"
+
+
+async def test_async_pipeline_preserves_child_run_id_when_workflow_root_omits_it(tmp_path):
+    """Async SQLite follows the same run_id merge behavior as sync SQLite."""
+    db = AsyncSqliteDb(db_file=str(tmp_path / "trace_context_async.db"))
+    await db._get_table(table_type="traces", create_table_if_not_found=True)
+    trace_id = "trace-async-workflow-child-run-id"
+
+    try:
+        agent_run = _make_span(
+            span_id="agent-run",
+            parent_span_id="workflow-run",
+            trace_id=trace_id,
+            name="ResearchAgent.run",
+            session_id="agent-session-1",
+            agent_id="research-agent",
+            run_id="agent-run-1",
+            start_offset_s=0.05,
+        )
+        await db.upsert_trace(create_trace_from_spans([agent_run]))
+
+        workflow_run = _make_span(
+            span_id="workflow-run",
+            parent_span_id=None,
+            trace_id=trace_id,
+            name="research_workflow.run",
+            session_id="workflow-session-1",
+            workflow_id="research-workflow",
+        )
+        await db.upsert_trace(create_trace_from_spans([workflow_run]))
+
+        row = await _aread_trace(db, trace_id)
+    finally:
+        await db.close()
+
+    assert row["name"] == "research_workflow.run"
+    assert row["session_id"] == "workflow-session-1"
+    assert row["workflow_id"] == "research-workflow"
+    assert row["agent_id"] is None
+    assert row["run_id"] == "agent-run-1"
 
 
 def test_pipeline_root_batch_first_then_inner_batch(db):


### PR DESCRIPTION
## Summary

Fixes #8243.

- Preserve workflow trace `run_id` by falling back to child agent spans when the workflow root span does not include `agno.run.id`
- Keep session/user/agent/team/workflow context rooted so child-only batches cannot misattribute root trace context
- Let higher-level root traces replace a lower-level child `run_id` across trace upsert backends while preserving the existing context-field protection
- Add sync/async SQLite and exporter regression coverage for the workflow-root-without-run-id path

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI-assisted: yes. I reviewed the change and verified the focused regression path.

Targeted verification run:

- `ruff format` on changed Agno files with `libs/agno/pyproject.toml`
- `ruff check` on changed Agno files with `libs/agno/pyproject.toml`
- `python -m py_compile` on changed Python files
- `python -m pytest libs/agno/tests/integration/db/sqlite/test_upsert_trace_preserves_context.py libs/agno/tests/integration/db/sqlite/test_trace_exporter_integration.py -q`

Full repo-wide `./scripts/format.sh` and `./scripts/validate.sh` were not run because this change was verified with targeted checks for the affected Agno trace paths.
