### PR TITLE
fix: use drop_ratio_search for Milvus sparse vector search params

### DIFF
--- a/libs/agno/agno/vectordb/milvus/milvus.py
+++ b/libs/agno/agno/vectordb/milvus/milvus.py
@@ -858,7 +858,7 @@ class Milvus(VectorDb):
             sparse_search_param = {
                 "data": [sparse_vector],
                 "anns_field": "sparse_vector",
-                "param": {"metric_type": "IP", "params": {"drop_ratio_build": 0.2}},
+                "param": {"metric_type": "IP", "params": {"drop_ratio_search": 0.2}},
                 "limit": limit * 2,  # Match dense search limit to ensure balanced candidate pool for reranking
             }
 
@@ -947,7 +947,7 @@ class Milvus(VectorDb):
             sparse_search_param = {
                 "data": [sparse_vector],
                 "anns_field": "sparse_vector",
-                "param": {"metric_type": "IP", "params": {"drop_ratio_build": 0.2}},
+                "param": {"metric_type": "IP", "params": {"drop_ratio_search": 0.2}},
                 "limit": limit * 2,  # Match dense search limit to ensure balanced candidate pool for reranking
             }
 


### PR DESCRIPTION
## Summary
- Fixed incorrect parameter name in Milvus hybrid search: `drop_ratio_build` → `drop_ratio_search`
- The search was silently ignoring the optimization because pymilvus ignores unrecognized parameters

## Context
Milvus has two distinct parameters for sparse vectors:
- `drop_ratio_build`: Used during **index creation** to filter small values from stored documents
- `drop_ratio_search`: Used during **search** to filter small values from the query vector

The original hybrid search implementation (PR #3164, May 2025) correctly used `drop_ratio_build` for index creation but copy-pasted the same parameter name into search params where `drop_ratio_search` should be used.

## Test plan
- [x] Ran `milvus_db_hybrid_search.py` cookbook — works correctly
- [x] Verified with pymilvus SDK documentation and official examples
- [x] format.sh and validate.sh pass

Fixes #5171