### PR TITLE
fix: close text message before reasoning events in AG-UI (#5466)

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -426,11 +426,12 @@ def _create_events_from_chunk(
                 # Emit state delta after tool call completion (state may have been mutated by the tool)
                 events_to_emit.extend(_create_state_delta_events(run_state, event_buffer))
 
-    # Handle reasoning — isinstance() dispatch for Agent and Team event types.
-    # Two producers: native model reasoning (o4-mini, Claude extended thinking)
-    # emits ReasoningContentDeltaEvent with true streaming deltas, while
-    # ReasoningTools (think/analyze) emits ReasoningStepEvent with a ReasoningStep object.
+    # Handle reasoning events
     elif isinstance(chunk, (AgentReasoningStartedEvent, TeamReasoningStartedEvent)):
+        if message_started:
+            events_to_emit.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+            message_started = False
+            message_id = str(uuid.uuid4())
         reasoning_id = event_buffer.start_reasoning()
         events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
         events_to_emit.append(
@@ -440,7 +441,10 @@ def _create_events_from_chunk(
         )
 
     elif isinstance(chunk, (AgentReasoningContentDeltaEvent, TeamReasoningContentDeltaEvent)):
-        # Native model reasoning — chunk.reasoning_content is a true streaming delta
+        if message_started:
+            events_to_emit.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+            message_started = False
+            message_id = str(uuid.uuid4())
         reasoning_id, is_new = event_buffer.ensure_reasoning_started()
         if is_new:
             events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
@@ -457,8 +461,10 @@ def _create_events_from_chunk(
             )
 
     elif isinstance(chunk, (AgentReasoningStepEvent, TeamReasoningStepEvent)):
-        # ReasoningTools — chunk.reasoning_content is accumulated (all steps so far),
-        # so we format chunk.content (the single ReasoningStep) as the delta instead
+        if message_started:
+            events_to_emit.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id))
+            message_started = False
+            message_id = str(uuid.uuid4())
         reasoning_id, is_new = event_buffer.ensure_reasoning_started()
         if is_new:
             events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))

--- a/libs/agno/tests/unit/app/test_agui_reasoning_tools.py
+++ b/libs/agno/tests/unit/app/test_agui_reasoning_tools.py
@@ -1,0 +1,116 @@
+import pytest
+from ag_ui.core import EventType
+
+from agno.os.interfaces.agui.utils import async_stream_agno_response_as_agui_events
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import (
+    ReasoningCompletedEvent,
+    ReasoningContentDeltaEvent,
+    ReasoningStartedEvent,
+    ReasoningStepEvent,
+    RunCompletedEvent,
+    RunContentEvent,
+)
+
+
+def _check_no_reasoning_inside_text_message(event_types: list) -> None:
+    """Verify REASONING_START never occurs between TEXT_MESSAGE_START and TEXT_MESSAGE_END."""
+    text_start_indices = [i for i, t in enumerate(event_types) if t == EventType.TEXT_MESSAGE_START]
+    text_end_indices = [i for i, t in enumerate(event_types) if t == EventType.TEXT_MESSAGE_END]
+    reasoning_start_indices = [i for i, t in enumerate(event_types) if t == EventType.REASONING_START]
+
+    for text_start_idx in text_start_indices:
+        matching_end_indices = [i for i in text_end_indices if i > text_start_idx]
+        if matching_end_indices:
+            text_end_idx = min(matching_end_indices)
+            violating = [i for i in reasoning_start_indices if text_start_idx < i < text_end_idx]
+            assert not violating, f"REASONING_START at {violating} between TEXT_MESSAGE_START and END"
+
+
+@pytest.mark.asyncio
+async def test_reasoning_started_closes_open_text_message():
+    async def mock_stream():
+        text1 = RunContentEvent()
+        text1.content = "Let me think..."
+        yield text1
+
+        yield ReasoningStartedEvent()
+
+        step = ReasoningStepEvent()
+        step.content = ReasoningStep(title="Analyze", reasoning="Thinking...")
+        step.reasoning_content = "## Analyze\nThinking..."
+        yield step
+
+        yield ReasoningCompletedEvent()
+
+        text2 = RunContentEvent()
+        text2.content = "The answer is 42."
+        yield text2
+
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+
+    assert EventType.REASONING_START in event_types
+    assert EventType.TEXT_MESSAGE_START in event_types
+    assert EventType.TEXT_MESSAGE_END in event_types
+
+    _check_no_reasoning_inside_text_message(event_types)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_content_delta_closes_open_text_message():
+    async def mock_stream():
+        text1 = RunContentEvent()
+        text1.content = "Processing..."
+        yield text1
+
+        delta = ReasoningContentDeltaEvent()
+        delta.reasoning_content = "Thinking about the problem..."
+        yield delta
+
+        yield ReasoningCompletedEvent()
+
+        text2 = RunContentEvent()
+        text2.content = "Done."
+        yield text2
+
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+
+    assert EventType.REASONING_START in event_types
+    _check_no_reasoning_inside_text_message(event_types)
+
+
+@pytest.mark.asyncio
+async def test_reasoning_step_closes_open_text_message():
+    async def mock_stream():
+        text1 = RunContentEvent()
+        text1.content = "Analyzing..."
+        yield text1
+
+        step = ReasoningStepEvent()
+        step.content = ReasoningStep(title="Step 1", reasoning="First step...")
+        step.reasoning_content = "## Step 1\nFirst step..."
+        yield step
+
+        yield ReasoningCompletedEvent()
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+
+    assert EventType.REASONING_START in event_types
+    _check_no_reasoning_inside_text_message(event_types)


### PR DESCRIPTION
## Summary

Fixes #5466 - AG-UI with reasoning tools throws event ordering errors.

The bug: When an agent with ReasoningTools (or native reasoning models like o4-mini) streams text and then reasoning events, the AG-UI protocol was violated:

```
Event sequence: TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT → REASONING_START → ...
                                                            ↑ VIOLATION!
```

The AG-UI protocol requires `TEXT_MESSAGE_END` before starting a new message type. Clients (like CopilotKit) enforce this and throw:
> "Cannot send event type 'X' after 'TEXT_MESSAGE_START': Send 'TEXT_MESSAGE_END' first."

**Root cause:** The reasoning event handlers in `_create_events_from_chunk()` didn't close open text messages before emitting reasoning events, unlike the tool call handlers which already did this correctly.

## Changes

- Added text message closing logic to all 3 reasoning event handlers:
  - `ReasoningStartedEvent` 
  - `ReasoningContentDeltaEvent` (native model reasoning)
  - `ReasoningStepEvent` (ReasoningTools think/analyze)
- Added 3 regression tests that reproduce the exact protocol violation

## Test plan

- [x] New tests pass: `pytest libs/agno/tests/unit/app/test_agui_reasoning_tools.py -v`
- [x] All existing AG-UI tests pass: `pytest libs/agno/tests/unit/app/test_agui_app.py -v` (52 tests)
- [x] Format and validate pass
- [ ] Manual test with dojo (if available)

🤖 Generated with [Claude Code](https://claude.ai/code)