### PR TITLE
fix: extract reasoning field from Groq gpt-oss models

### DIFF
--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -506,6 +506,10 @@ class Groq(Model):
         if response_message.content is not None:
             model_response.content = response_message.content
 
+        # Add reasoning content (gpt-oss models return reasoning in a separate field)
+        if hasattr(response_message, "reasoning") and response_message.reasoning is not None:
+            model_response.reasoning_content = response_message.reasoning
+
         # Add tool calls
         if response_message.tool_calls is not None and len(response_message.tool_calls) > 0:
             try:
@@ -538,6 +542,10 @@ class Groq(Model):
                 # Add content
                 if choice_delta.content is not None:
                     model_response.content = choice_delta.content
+
+                # Add reasoning content (gpt-oss models return reasoning in a separate field)
+                if hasattr(choice_delta, "reasoning") and choice_delta.reasoning is not None:
+                    model_response.reasoning_content = choice_delta.reasoning
 
                 # Add tool calls
                 if choice_delta.tool_calls is not None:

--- a/libs/agno/tests/unit/models/groq_model/test_groq_reasoning.py
+++ b/libs/agno/tests/unit/models/groq_model/test_groq_reasoning.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestGroqReasoningExtraction:
+    """Test that Groq model extracts reasoning from gpt-oss models."""
+
+    def test_parse_provider_response_extracts_reasoning(self):
+        """Test that _parse_provider_response extracts reasoning field from gpt-oss."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="openai/gpt-oss-20b", api_key="test-key")
+
+        # Mock the response structure from Groq API
+        mock_message = MagicMock()
+        mock_message.role = "assistant"
+        mock_message.content = "2 + 2 = 4"
+        mock_message.reasoning = "The user asks for 2+2. Simple addition. Answer is 4."
+        mock_message.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+
+        result = model._parse_provider_response(mock_response)
+
+        assert result.content == "2 + 2 = 4"
+        assert result.reasoning_content == "The user asks for 2+2. Simple addition. Answer is 4."
+
+    def test_parse_provider_response_no_reasoning(self):
+        """Test that _parse_provider_response works when no reasoning field is present."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="llama-3.3-70b-versatile", api_key="test-key")
+
+        mock_message = MagicMock()
+        mock_message.role = "assistant"
+        mock_message.content = "Hello!"
+        mock_message.tool_calls = None
+        # No reasoning attribute
+        del mock_message.reasoning
+
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = None
+
+        result = model._parse_provider_response(mock_response)
+
+        assert result.content == "Hello!"
+        assert result.reasoning_content is None
+
+    def test_parse_provider_response_delta_extracts_reasoning(self):
+        """Test that _parse_provider_response_delta extracts reasoning from streaming chunks."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="openai/gpt-oss-20b", api_key="test-key")
+
+        mock_delta = MagicMock()
+        mock_delta.content = "The answer"
+        mock_delta.reasoning = "Thinking..."
+        mock_delta.tool_calls = None
+
+        mock_choice = MagicMock()
+        mock_choice.delta = mock_delta
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.x_groq = None
+
+        result = model._parse_provider_response_delta(mock_response)
+
+        assert result.content == "The answer"
+        assert result.reasoning_content == "Thinking..."
+
+    def test_parse_provider_response_delta_no_reasoning(self):
+        """Test that _parse_provider_response_delta works when no reasoning field is present."""
+        from agno.models.groq import Groq
+
+        model = Groq(id="llama-3.3-70b-versatile", api_key="test-key")
+
+        mock_delta = MagicMock()
+        mock_delta.content = "Hello"
+        mock_delta.tool_calls = None
+        del mock_delta.reasoning
+
+        mock_choice = MagicMock()
+        mock_choice.delta = mock_delta
+
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.x_groq = None
+
+        result = model._parse_provider_response_delta(mock_response)
+
+        assert result.content == "Hello"
+        assert result.reasoning_content is None


### PR DESCRIPTION
## Summary

GPT-OSS models (gpt-oss-20b, gpt-oss-120b) on Groq return reasoning in a separate `reasoning` field rather than embedded in `<think>` tags like other reasoning models (QwQ, Qwen3, DeepSeek-R1).

This PR adds handling for that field in both non-streaming and streaming response parsing.

## Changes

- `libs/agno/agno/models/groq/groq.py`: Extract `reasoning` field from response message into `model_response.reasoning_content`
- `libs/agno/tests/unit/models/groq_model/`: Add unit tests for reasoning extraction

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] Unit tests added and passing
- [x] E2E tested with gpt-oss-20b via Groq API

## Related

- Related to #6748 (reasoning model detection)
- Fixes reasoning extraction for gpt-oss models mentioned in #6254

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Tests added for new functionality
- [x] format.sh and validate.sh pass