### PR TITLE
fix: skip code chunking tokenizer tests on HuggingFace download error

### DIFF
--- a/libs/agno/tests/unit/knowledge/chunking/test_code_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_code_chunking.py
@@ -78,10 +78,15 @@ def test_code_chunking_word_tokenizer(sample_python_code):
 
 def test_code_chunking_gpt2_tokenizer(sample_python_code):
     """Test with gpt2 tokenizer."""
+    from chonkie.tokenizer import InvalidTokenizerError
+
     chunker = CodeChunking(tokenizer="gpt2", chunk_size=30, language="python")
     doc = Document(content=sample_python_code, name="test.py")
 
-    chunks = chunker.chunk(doc)
+    try:
+        chunks = chunker.chunk(doc)
+    except InvalidTokenizerError as e:
+        pytest.skip(f"Tokenizer could not be downloaded: {e}")
 
     assert len(chunks) > 0
     assert all(chunk.content for chunk in chunks)
@@ -89,10 +94,15 @@ def test_code_chunking_gpt2_tokenizer(sample_python_code):
 
 def test_code_chunking_cl100k_tokenizer(sample_python_code):
     """Test with cl100k_base tokenizer."""
+    from chonkie.tokenizer import InvalidTokenizerError
+
     chunker = CodeChunking(tokenizer="cl100k_base", chunk_size=30, language="python")
     doc = Document(content=sample_python_code, name="test.py")
 
-    chunks = chunker.chunk(doc)
+    try:
+        chunks = chunker.chunk(doc)
+    except InvalidTokenizerError as e:
+        pytest.skip(f"Tokenizer could not be downloaded: {e}")
 
     assert len(chunks) > 0
     assert all(chunk.content for chunk in chunks)


### PR DESCRIPTION
## Summary

Two unit tests in `test_code_chunking.py` were failing in CI because they require downloading tokenizer files from HuggingFace at test time. When HuggingFace rate-limits the runner raises `InvalidTokenizerError` and the tests fail.

Failing CI run for reference: https://github.com/agno-agi/agno/actions/runs/26960051316/job/79547722991

> chonkie.tokenizer.InvalidTokenizerError: Tokenizer 'gpt2' could not be loaded: {'tokie (mapped)': 'failed to download tokenizer: request error: https://huggingface.co/openai-community/gpt2/resolve/main/tokenizer.json: status code 429', 'tokie': 'failed to download tokenizer: request error: https://huggingface.co/gpt2/resolve/main/tokenizer.json: status code 429'}



## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
