### PR TITLE
fix: update arxiv `Client.results()` in `ArxivReader`

### DIFF
--- a/libs/agno/agno/knowledge/reader/arxiv_reader.py
+++ b/libs/agno/agno/knowledge/reader/arxiv_reader.py
@@ -57,9 +57,10 @@ class ArxivReader(Reader):
         """
 
         documents = []
+        client = arxiv.Client()
         search = arxiv.Search(query=query, max_results=self.max_results, sort_by=self.sort_by)
 
-        for result in search.results():
+        for result in client.results(search):
             links = ", ".join([x.href for x in result.links])
 
             documents.append(


### PR DESCRIPTION
## Summary

The CI run was failing with:

```
FAILED libs/agno/tests/integration/knowledge/test_arxiv_knowledge.py::test_arxiv_knowledge_base_integration - AttributeError: 'Search' object has no attribute 'results'
FAILED libs/agno/tests/integration/knowledge/test_arxiv_knowledge.py::test_arxiv_knowledge_base_search_integration - AttributeError: 'Search' object has no attribute 'results'
FAILED libs/agno/tests/integration/knowledge/test_arxiv_knowledge.py::test_arxiv_knowledge_base_async_integration - AttributeError: 'Search' object has no attribute 'results'
```
https://github.com/agno-agi/agno/actions/runs/27000018970/job/79678147990?pr=8256


`ArxivReader` called the deprecated `arxiv.Search.results()` method. This PR switches the reader to the latest API, `arxiv.Client().results(search)`. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
