### PR TITLE
fix: update arxiv `Client.results()` in `ArxivReader`

### DIFF
--- a/libs/agno/agno/knowledge/reader/arxiv_reader.py
+++ b/libs/agno/agno/knowledge/reader/arxiv_reader.py
@@ -45,6 +45,13 @@ class ArxivReader(Reader):
 
         # ArxivReader-specific attributes
         self.sort_by = sort_by
+        self._client: Optional[arxiv.Client] = None
+
+    def get_client(self) -> arxiv.Client:
+        """Return a cached arxiv.Client, creating it on first use."""
+        if self._client is None:
+            self._client = arxiv.Client()
+        return self._client
 
     def read(self, query: str) -> List[Document]:
         """
@@ -57,10 +64,9 @@ class ArxivReader(Reader):
         """
 
         documents = []
-        client = arxiv.Client()
         search = arxiv.Search(query=query, max_results=self.max_results, sort_by=self.sort_by)
 
-        for result in client.results(search):
+        for result in self.get_client().results(search):
             links = ", ".join([x.href for x in result.links])
 
             documents.append(

--- a/libs/agno/agno/knowledge/reader/arxiv_reader.py
+++ b/libs/agno/agno/knowledge/reader/arxiv_reader.py
@@ -57,9 +57,10 @@ class ArxivReader(Reader):
         """
 
         documents = []
+        client = arxiv.Client()
         search = arxiv.Search(query=query, max_results=self.max_results, sort_by=self.sort_by)
 
-        for result in search.results():
+        for result in client.results(search):
             links = ", ".join([x.href for x in result.links])
 
             documents.append(

--- a/libs/agno/tests/unit/reader/test_arxiv_reader.py
+++ b/libs/agno/tests/unit/reader/test_arxiv_reader.py
@@ -22,9 +22,9 @@ def mock_search_results(mock_arxiv_result):
 
 
 def test_read_basic_query(mock_search_results):
-    with patch("arxiv.Search") as mock_search:
-        # Setup mock search
-        mock_search.return_value.results.return_value = mock_search_results
+    with patch("arxiv.Search"), patch("arxiv.Client") as mock_client:
+        # Setup mock client to return our results
+        mock_client.return_value.results.return_value = mock_search_results
 
         reader = ArxivReader()
         documents = reader.read("quantum computing")
@@ -37,9 +37,9 @@ def test_read_basic_query(mock_search_results):
 
 
 def test_read_empty_results():
-    with patch("arxiv.Search") as mock_search:
-        # Setup mock search with no results
-        mock_search.return_value.results.return_value = []
+    with patch("arxiv.Search"), patch("arxiv.Client") as mock_client:
+        # Setup mock client with no results
+        mock_client.return_value.results.return_value = []
 
         reader = ArxivReader()
         documents = reader.read("nonexistent topic")
@@ -48,7 +48,7 @@ def test_read_empty_results():
 
 
 def test_read_max_results():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
         # Create mock results
         mock_result = Mock()
         mock_result.title = "Test Paper"
@@ -57,12 +57,12 @@ def test_read_max_results():
         mock_result.links = [Mock(href="https://arxiv.org/abs/1234.5678")]
 
         # Create a list generator that respects max_results
-        def mock_results():
+        def mock_results(search):
             for i in range(3):  # Only yield 3 results
                 yield mock_result
 
-        # Setup the mock to use our generator
-        mock_search.return_value.results = mock_results
+        # Setup the mock client to use our generator
+        mock_client.return_value.results = mock_results
 
         reader = ArxivReader()
         reader.max_results = 3
@@ -75,7 +75,9 @@ def test_read_max_results():
 
 
 def test_read_sort_criterion():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
+        mock_client.return_value.results.return_value = []
+
         reader = ArxivReader()
         reader.read("quantum computing")
 
@@ -87,14 +89,14 @@ def test_read_sort_criterion():
 
 
 def test_read_with_special_characters():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
         mock_result = Mock()
         mock_result.title = "Test Paper"
         mock_result.summary = "Abstract"
         mock_result.pdf_url = "https://arxiv.org/pdf/1234.5678"
         mock_result.links = [Mock(href="https://arxiv.org/abs/1234.5678")]
 
-        mock_search.return_value.results.return_value = [mock_result]
+        mock_client.return_value.results.return_value = [mock_result]
 
         reader = ArxivReader()
         documents = reader.read("quantum & computing + AI")
@@ -106,7 +108,9 @@ def test_read_with_special_characters():
 
 
 def test_read_different_sort_criterions():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
+        mock_client.return_value.results.return_value = []
+
         # Test with different sort criterions
         reader = ArxivReader()
 
@@ -127,9 +131,9 @@ def test_read_different_sort_criterions():
 
 @pytest.mark.asyncio
 async def test_async_read_basic_query(mock_search_results):
-    with patch("arxiv.Search") as mock_search:
-        # Setup mock search
-        mock_search.return_value.results.return_value = mock_search_results
+    with patch("arxiv.Search"), patch("arxiv.Client") as mock_client:
+        # Setup mock client to return our results
+        mock_client.return_value.results.return_value = mock_search_results
 
         reader = ArxivReader()
         documents = await reader.async_read("quantum computing")
@@ -143,9 +147,9 @@ async def test_async_read_basic_query(mock_search_results):
 
 @pytest.mark.asyncio
 async def test_async_read_empty_results():
-    with patch("arxiv.Search") as mock_search:
-        # Setup mock search with no results
-        mock_search.return_value.results.return_value = []
+    with patch("arxiv.Search"), patch("arxiv.Client") as mock_client:
+        # Setup mock client with no results
+        mock_client.return_value.results.return_value = []
 
         reader = ArxivReader()
         documents = await reader.async_read("nonexistent topic")
@@ -155,7 +159,7 @@ async def test_async_read_empty_results():
 
 @pytest.mark.asyncio
 async def test_async_read_max_results():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
         # Create mock results
         mock_result = Mock()
         mock_result.title = "Test Paper"
@@ -164,12 +168,12 @@ async def test_async_read_max_results():
         mock_result.links = [Mock(href="https://arxiv.org/abs/1234.5678")]
 
         # Create a list generator that respects max_results
-        def mock_results():
+        def mock_results(search):
             for i in range(3):  # Only yield 3 results
                 yield mock_result
 
-        # Setup the mock to use our generator
-        mock_search.return_value.results = mock_results
+        # Setup the mock client to use our generator
+        mock_client.return_value.results = mock_results
 
         reader = ArxivReader()
         reader.max_results = 3
@@ -183,7 +187,9 @@ async def test_async_read_max_results():
 
 @pytest.mark.asyncio
 async def test_async_read_sort_criterion():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
+        mock_client.return_value.results.return_value = []
+
         reader = ArxivReader()
         await reader.async_read("quantum computing")
 
@@ -196,14 +202,14 @@ async def test_async_read_sort_criterion():
 
 @pytest.mark.asyncio
 async def test_async_read_with_special_characters():
-    with patch("arxiv.Search") as mock_search:
+    with patch("arxiv.Search") as mock_search, patch("arxiv.Client") as mock_client:
         mock_result = Mock()
         mock_result.title = "Test Paper"
         mock_result.summary = "Abstract"
         mock_result.pdf_url = "https://arxiv.org/pdf/1234.5678"
         mock_result.links = [Mock(href="https://arxiv.org/abs/1234.5678")]
 
-        mock_search.return_value.results.return_value = [mock_result]
+        mock_client.return_value.results.return_value = [mock_result]
 
         reader = ArxivReader()
         documents = await reader.async_read("quantum & computing + AI")


### PR DESCRIPTION
## Summary

The CI run was failing with:

```
FAILED libs/agno/tests/integration/knowledge/test_arxiv_knowledge.py::test_arxiv_knowledge_base_integration - AttributeError: 'Search' object has no attribute 'results'
FAILED libs/agno/tests/integration/knowledge/test_arxiv_knowledge.py::test_arxiv_knowledge_base_search_integration - AttributeError: 'Search' object has no attribute 'results'
FAILED libs/agno/tests/integration/knowledge/test_arxiv_knowledge.py::test_arxiv_knowledge_base_async_integration - AttributeError: 'Search' object has no attribute 'results'
```
in release branch https://github.com/agno-agi/agno/pull/8256
https://github.com/agno-agi/agno/actions/runs/27000018970/job/79678147990?pr=8256


`ArxivReader` called the deprecated `arxiv.Search.results()` method. This PR switches the reader to the latest API, `arxiv.Client().results(search)`. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Successful run:
https://github.com/agno-agi/agno/actions/runs/27010546821/job/79712785154?pr=8261 