### PR TITLE
fix(team): filter RunOutput/TeamRunOutput accumulators in SSE streamers

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -432,10 +432,9 @@ def _create_events_from_chunk(
             event_buffer.end_reasoning()
 
     # Handle followup suggestions — emit before RUN_FINISHED so the client can render them
-    elif chunk.event == RunEvent.followups_completed:
-        followups = getattr(chunk, "followups", None)
-        if followups:
-            custom_event = CustomEvent(name="followups", value={"suggestions": followups})
+    elif isinstance(chunk, FollowupsCompletedEvent):
+        if chunk.followups:
+            custom_event = CustomEvent(name="followups", value={"suggestions": chunk.followups})
             events_to_emit.append(custom_event)
 
     # Handle custom events

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -32,7 +32,7 @@ from agno.run.agent import ReasoningCompletedEvent as AgentReasoningCompletedEve
 from agno.run.agent import ReasoningContentDeltaEvent as AgentReasoningContentDeltaEvent
 from agno.run.agent import ReasoningStartedEvent as AgentReasoningStartedEvent
 from agno.run.agent import ReasoningStepEvent as AgentReasoningStepEvent
-from agno.run.agent import RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
+from agno.run.agent import FollowupsCompletedEvent, RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
 from agno.run.team import ReasoningCompletedEvent as TeamReasoningCompletedEvent
 from agno.run.team import ReasoningContentDeltaEvent as TeamReasoningContentDeltaEvent
 from agno.run.team import ReasoningStartedEvent as TeamReasoningStartedEvent
@@ -430,6 +430,13 @@ def _create_events_from_chunk(
             )
             events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id))
             event_buffer.end_reasoning()
+
+    # Handle followup suggestions — emit before RUN_FINISHED so the client can render them
+    elif chunk.event == RunEvent.followups_completed:
+        followups = getattr(chunk, "followups", None)
+        if followups:
+            custom_event = CustomEvent(name="followups", value={"suggestions": followups})
+            events_to_emit.append(custom_event)
 
     # Handle custom events
     elif chunk.event == RunEvent.custom_event:

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -45,6 +45,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
+    classify_upload_file,
     find_factory_by_id,
     format_sse_event,
     get_request_kwargs,
@@ -57,7 +58,8 @@ from agno.os.utils import (
 )
 from agno.registry import Registry
 from agno.run.base import RunStatus
-from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.agent import RunOutput
+from agno.run.team import RunErrorEvent as TeamRunErrorEvent, TeamRunOutput
 from agno.team.factory import TeamFactory
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
@@ -109,6 +111,8 @@ async def team_response_streamer(
             **kwargs,
         )
         async for run_response_chunk in run_response:
+            if isinstance(run_response_chunk, (TeamRunOutput, RunOutput)):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(
@@ -419,6 +423,8 @@ async def team_continue_response_streamer(
             **kwargs,
         )
         async for run_response_chunk in continue_response:
+            if isinstance(run_response_chunk, (TeamRunOutput, RunOutput)):
+                continue
             yield format_sse_event(run_response_chunk)  # type: ignore
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(
@@ -639,54 +645,29 @@ def get_team_router(
 
         if files:
             for file in files:
-                if file.content_type in [
-                    "image/png",
-                    "image/jpeg",
-                    "image/jpg",
-                    "image/webp",
-                    "image/heic",
-                    "image/heif",
-                ]:
+                file_category = classify_upload_file(file)
+                if file_category == "image":
                     try:
                         base64_image = process_image(file)
                         base64_images.append(base64_image)
                     except Exception:
                         logger.exception(f"Error processing image {file.filename}")
                         continue
-                elif file.content_type in ["audio/wav", "audio/mp3", "audio/mpeg"]:
+                elif file_category == "audio":
                     try:
                         base64_audio = process_audio(file)
                         base64_audios.append(base64_audio)
                     except Exception:
                         logger.exception(f"Error processing audio {file.filename}")
                         continue
-                elif file.content_type in [
-                    "video/x-flv",
-                    "video/quicktime",
-                    "video/mpeg",
-                    "video/mpegs",
-                    "video/mpgs",
-                    "video/mpg",
-                    "video/mpg",
-                    "video/mp4",
-                    "video/webm",
-                    "video/wmv",
-                    "video/3gpp",
-                ]:
+                elif file_category == "video":
                     try:
                         base64_video = process_video(file)
                         base64_videos.append(base64_video)
                     except Exception:
                         logger.exception(f"Error processing video {file.filename}")
                         continue
-                elif file.content_type in [
-                    "application/pdf",
-                    "text/csv",
-                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                    "application/vnd.ms-outlook",
-                    "text/plain",
-                    "application/json",
-                ]:
+                elif file_category == "document":
                     document_file = process_document(file)
                     if document_file is not None:
                         document_files.append(document_file)

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -1502,3 +1502,77 @@ def test_extract_agui_user_input_multimodal_content():
     result = extract_agui_user_input(messages)
 
     assert result == "describe this image"
+
+
+@pytest.mark.asyncio
+async def test_followups_completed_emits_custom_event():
+    """FollowupsCompletedEvent with non-empty suggestions must emit a CustomEvent
+    named 'followups' with value={'suggestions': [...]} before RUN_FINISHED.
+
+    Regression guard for issue #7398: previously the followups_completed
+    chunk was silently dropped because _create_events_from_chunk had no branch for it.
+    """
+    from agno.run.agent import FollowupsCompletedEvent, RunCompletedEvent
+
+    async def mock_stream_with_followups():
+        text = RunContentEvent()
+        text.content = "Looking for a house"
+        yield text
+        yield FollowupsCompletedEvent(followups=["budget?", "location?", "size?"])
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream_with_followups(), "thread_1", "run_1"):
+        events.append(event)
+
+    followup_events = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followup_events) == 1, f"Expected 1 followups CustomEvent, got {len(followup_events)}"
+    assert getattr(followup_events[0], "value", None) == {"suggestions": ["budget?", "location?", "size?"]}
+
+    event_types = [e.type for e in events]
+    custom_idx = next(i for i, t in enumerate(event_types) if t == EventType.CUSTOM)
+    run_finished_idx = event_types.index(EventType.RUN_FINISHED)
+    assert custom_idx < run_finished_idx, "CustomEvent for followups must precede RUN_FINISHED"
+
+
+@pytest.mark.asyncio
+async def test_followups_completed_empty_skipped():
+    """FollowupsCompletedEvent with empty or None followups must NOT emit a CustomEvent.
+
+    Guards the truthy-check in the new branch; prevents spurious empty payload
+    emissions that would clutter the AGUI stream.
+    """
+    from agno.run.agent import FollowupsCompletedEvent, RunCompletedEvent
+
+    async def mock_stream_with_empty_followups():
+        yield FollowupsCompletedEvent(followups=None)
+        yield FollowupsCompletedEvent(followups=[])
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream_with_empty_followups(), "thread_1", "run_1"
+    ):
+        events.append(event)
+
+    followup_customs = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followup_customs) == 0
+
+
+@pytest.mark.asyncio
+async def test_followups_started_is_noop():
+    """FollowupsStartedEvent carries no payload and must not surface as a CUSTOM event."""
+    from agno.run.agent import FollowupsStartedEvent, RunCompletedEvent
+
+    async def mock_stream_with_followups_started():
+        yield FollowupsStartedEvent()
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream_with_followups_started(), "thread_1", "run_1"
+    ):
+        events.append(event)
+
+    followup_customs = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followup_customs) == 0


### PR DESCRIPTION
## Summary

When a `Team` streams via AgentOS, `team_response_streamer` and `team_continue_response_streamer` pass every chunk from `team.arun()` directly to `format_sse_event()`. That function accesses `event.event` (singular string). But when a member agent or sub-team yields a `RunOutput`/`TeamRunOutput` accumulator object into the parent stream, there is no `.event` attribute — only `.events` (plural list) — causing an `AttributeError` crash.

**Root cause:** `_aroute_requirements_to_members_stream` and related delegation paths call members with `yield_run_output=True`, so accumulator objects leak into the parent stream. The non-streaming background path in `_arun_background_stream` already filters these with an `isinstance` guard; the foreground router streamers did not.

## Changes

- `libs/agno/agno/os/routers/teams/router.py`
  - Added `from agno.run.agent import RunOutput` import
  - Added `TeamRunOutput` to the `agno.run.team` import
  - Added `isinstance(run_response_chunk, (TeamRunOutput, RunOutput))` guard in `team_response_streamer` (skips accumulators before `format_sse_event`)
  - Same guard in `team_continue_response_streamer`

The resumable variants (`team_resumable_response_streamer`, `team_resumable_continue_response_streamer`) use `background=True` and yield pre-formatted SSE strings, so they are unaffected.

## Test Plan

- [ ] Stream a `Team` with member agents through the AgentOS `/teams/{id}/runs` endpoint
- [ ] Confirm no `AttributeError: 'TeamRunOutput' object has no attribute 'event'` in logs
- [ ] Confirm SSE stream completes and client receives all events normally
- [ ] `team_continue_response_streamer` path (HITL continue): same test after a paused run

Fixes #8235