### PR TITLE
fix(agent): append instructions to system_message when both are set

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -148,6 +148,34 @@ def get_system_message(
                 run_context=run_context,
             )
 
+        # Append instructions if set alongside system_message
+        if agent.instructions is not None:
+            _sys_instructions = agent.instructions
+            if callable(agent.instructions):
+                _sys_instructions = execute_instructions(
+                    agent=agent, instructions=agent.instructions, session_state=session_state, run_context=run_context
+                )
+            instr_list: List[str] = []
+            if isinstance(_sys_instructions, str):
+                instr_list.append(_sys_instructions)
+            elif isinstance(_sys_instructions, list):
+                instr_list.extend(_sys_instructions)
+            if instr_list:
+                if agent.use_instruction_tags:
+                    sys_message_content += "\n<instructions>"
+                    if len(instr_list) > 1:
+                        for _instr in instr_list:
+                            sys_message_content += f"\n- {_instr}"
+                    else:
+                        sys_message_content += "\n" + instr_list[0]
+                    sys_message_content += "\n</instructions>"
+                else:
+                    if len(instr_list) > 1:
+                        for _instr in instr_list:
+                            sys_message_content += f"\n- {_instr}"
+                    else:
+                        sys_message_content += "\n" + instr_list[0]
+
         # type: ignore
         return Message(role=agent.system_message_role, content=sys_message_content)
 
@@ -495,6 +523,34 @@ async def aget_system_message(
                 sys_message_content,
                 run_context=run_context,
             )
+
+        # Append instructions if set alongside system_message
+        if agent.instructions is not None:
+            _sys_instructions = agent.instructions
+            if callable(agent.instructions):
+                _sys_instructions = await aexecute_instructions(
+                    agent=agent, instructions=agent.instructions, session_state=session_state, run_context=run_context
+                )
+            ainstr_list: List[str] = []
+            if isinstance(_sys_instructions, str):
+                ainstr_list.append(_sys_instructions)
+            elif isinstance(_sys_instructions, list):
+                ainstr_list.extend(_sys_instructions)
+            if ainstr_list:
+                if agent.use_instruction_tags:
+                    sys_message_content += "\n<instructions>"
+                    if len(ainstr_list) > 1:
+                        for _instr in ainstr_list:
+                            sys_message_content += f"\n- {_instr}"
+                    else:
+                        sys_message_content += "\n" + ainstr_list[0]
+                    sys_message_content += "\n</instructions>"
+                else:
+                    if len(ainstr_list) > 1:
+                        for _instr in ainstr_list:
+                            sys_message_content += f"\n- {_instr}"
+                    else:
+                        sys_message_content += "\n" + ainstr_list[0]
 
         # type: ignore
         return Message(role=agent.system_message_role, content=sys_message_content)

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -432,10 +432,9 @@ def _create_events_from_chunk(
             event_buffer.end_reasoning()
 
     # Handle followup suggestions — emit before RUN_FINISHED so the client can render them
-    elif chunk.event == RunEvent.followups_completed:
-        followups = getattr(chunk, "followups", None)
-        if followups:
-            custom_event = CustomEvent(name="followups", value={"suggestions": followups})
+    elif isinstance(chunk, FollowupsCompletedEvent):
+        if chunk.followups:
+            custom_event = CustomEvent(name="followups", value={"suggestions": chunk.followups})
             events_to_emit.append(custom_event)
 
     # Handle custom events

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -32,7 +32,7 @@ from agno.run.agent import ReasoningCompletedEvent as AgentReasoningCompletedEve
 from agno.run.agent import ReasoningContentDeltaEvent as AgentReasoningContentDeltaEvent
 from agno.run.agent import ReasoningStartedEvent as AgentReasoningStartedEvent
 from agno.run.agent import ReasoningStepEvent as AgentReasoningStepEvent
-from agno.run.agent import RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
+from agno.run.agent import FollowupsCompletedEvent, RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
 from agno.run.team import ReasoningCompletedEvent as TeamReasoningCompletedEvent
 from agno.run.team import ReasoningContentDeltaEvent as TeamReasoningContentDeltaEvent
 from agno.run.team import ReasoningStartedEvent as TeamReasoningStartedEvent
@@ -430,6 +430,13 @@ def _create_events_from_chunk(
             )
             events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id))
             event_buffer.end_reasoning()
+
+    # Handle followup suggestions — emit before RUN_FINISHED so the client can render them
+    elif chunk.event == RunEvent.followups_completed:
+        followups = getattr(chunk, "followups", None)
+        if followups:
+            custom_event = CustomEvent(name="followups", value={"suggestions": followups})
+            events_to_emit.append(custom_event)
 
     # Handle custom events
     elif chunk.event == RunEvent.custom_event:

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -1502,3 +1502,77 @@ def test_extract_agui_user_input_multimodal_content():
     result = extract_agui_user_input(messages)
 
     assert result == "describe this image"
+
+
+@pytest.mark.asyncio
+async def test_followups_completed_emits_custom_event():
+    """FollowupsCompletedEvent with non-empty suggestions must emit a CustomEvent
+    named 'followups' with value={'suggestions': [...]} before RUN_FINISHED.
+
+    Regression guard for issue #7398: previously the followups_completed
+    chunk was silently dropped because _create_events_from_chunk had no branch for it.
+    """
+    from agno.run.agent import FollowupsCompletedEvent, RunCompletedEvent
+
+    async def mock_stream_with_followups():
+        text = RunContentEvent()
+        text.content = "Looking for a house"
+        yield text
+        yield FollowupsCompletedEvent(followups=["budget?", "location?", "size?"])
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream_with_followups(), "thread_1", "run_1"):
+        events.append(event)
+
+    followup_events = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followup_events) == 1, f"Expected 1 followups CustomEvent, got {len(followup_events)}"
+    assert getattr(followup_events[0], "value", None) == {"suggestions": ["budget?", "location?", "size?"]}
+
+    event_types = [e.type for e in events]
+    custom_idx = next(i for i, t in enumerate(event_types) if t == EventType.CUSTOM)
+    run_finished_idx = event_types.index(EventType.RUN_FINISHED)
+    assert custom_idx < run_finished_idx, "CustomEvent for followups must precede RUN_FINISHED"
+
+
+@pytest.mark.asyncio
+async def test_followups_completed_empty_skipped():
+    """FollowupsCompletedEvent with empty or None followups must NOT emit a CustomEvent.
+
+    Guards the truthy-check in the new branch; prevents spurious empty payload
+    emissions that would clutter the AGUI stream.
+    """
+    from agno.run.agent import FollowupsCompletedEvent, RunCompletedEvent
+
+    async def mock_stream_with_empty_followups():
+        yield FollowupsCompletedEvent(followups=None)
+        yield FollowupsCompletedEvent(followups=[])
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream_with_empty_followups(), "thread_1", "run_1"
+    ):
+        events.append(event)
+
+    followup_customs = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followup_customs) == 0
+
+
+@pytest.mark.asyncio
+async def test_followups_started_is_noop():
+    """FollowupsStartedEvent carries no payload and must not surface as a CUSTOM event."""
+    from agno.run.agent import FollowupsStartedEvent, RunCompletedEvent
+
+    async def mock_stream_with_followups_started():
+        yield FollowupsStartedEvent()
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream_with_followups_started(), "thread_1", "run_1"
+    ):
+        events.append(event)
+
+    followup_customs = [e for e in events if e.type == EventType.CUSTOM and getattr(e, "name", None) == "followups"]
+    assert len(followup_customs) == 0


### PR DESCRIPTION
## Problem

When an `Agent` is configured with both `system_message` and `instructions`, the `instructions` are silently ignored. Both `get_system_message` and `aget_system_message` return early on line 152/500 (respectively) with only the `system_message` content, never reaching the `instructions` block in step 3.

```python
# Before — instructions dropped when system_message is also set
agent = Agent(
    system_message="You are a helpful assistant.",
    instructions=["Always respond in English", "Never use emojis"],
    ...
)
# instructions have no effect
```

## Fix

After building `sys_message_content` from `system_message`, check if `agent.instructions` is also set and append them — using the same formatting logic (`use_instruction_tags`, bullet list vs single item) as the default system message builder.

Both the sync (`get_system_message`) and async (`aget_system_message`) paths are fixed.

## Changes

- `libs/agno/agno/agent/_messages.py`
  - `get_system_message`: appends instructions to `sys_message_content` before returning, using `execute_instructions` for callable instructions
  - `aget_system_message`: same using `await aexecute_instructions`

## Test

```python
from agno.agent import Agent
from agno.models.openai import OpenAIChat

agent = Agent(
    model=OpenAIChat(id="gpt-4o"),
    system_message="You are a helpful assistant.",
    instructions=["Always respond in French"],
)
response = agent.run("Hello!")
# Before: responds in English (instructions ignored)
# After: responds in French (instructions appended to system_message)
```

Fixes #7890