### PR TITLE
[fix] Prevent silent trace drops in DatabaseSpanExporter async export

### DIFF
--- a/libs/agno/agno/tracing/exporter.py
+++ b/libs/agno/agno/tracing/exporter.py
@@ -106,15 +106,15 @@ class DatabaseSpanExporter(SpanExporter):
     def _export_async(self, spans_by_trace: Dict[str, List[Span]]) -> None:
         """Handle async database export"""
         try:
-            loop = asyncio.get_event_loop()
-            if loop.is_running():
-                # We're in an async context, schedule the coroutine
-                asyncio.create_task(self._do_async_export(spans_by_trace))
-            else:
-                # No running loop, run in new loop
-                loop.run_until_complete(self._do_async_export(spans_by_trace))
+            loop = asyncio.get_running_loop()
+            # We're in an async context, schedule the coroutine.
+            # Store the task reference to prevent GC from cancelling it
+            # before completion (Ruff RUF006). See: #8182
+            self._export_task = asyncio.ensure_future(
+                self._do_async_export(spans_by_trace)
+            )
         except RuntimeError:
-            # No event loop, create new one
+            # No running event loop — create one and run the export.
             try:
                 asyncio.run(self._do_async_export(spans_by_trace))
             except Exception as e:


### PR DESCRIPTION
## Description

Fixes #8182

The `_export_async` method in `DatabaseSpanExporter` had two async-safety issues:

### 1. Fire-and-forget task drops traces
`asyncio.create_task()` was called without storing the returned `Task` object. The event loop only holds a **weak reference** to unreferenced tasks, so the export coroutine could be garbage-collected before finishing — silently dropping traces and spans. This is the pattern Ruff flags as RUF006.

### 2. Deprecated `asyncio.get_event_loop()`
Used to detect the running loop. Since Python 3.10 this is deprecated when there is no running loop and emits a `DeprecationWarning`.

### Fix
- Replace `get_event_loop()` + `is_running()` with `get_running_loop()` which directly raises `RuntimeError` when no loop is running (the recommended pattern since Python 3.10).
- Store the task reference via `asyncio.ensure_future()` as `self._export_task` to prevent GC cancellation.
- Remove the dead `else` branch (`run_until_complete` on a running loop would raise `RuntimeError` anyway).

### Before
```python
loop = asyncio.get_event_loop()        # deprecated
if loop.is_running():
    asyncio.create_task(...)            # result discarded → GC risk
else:
    loop.run_until_complete(...)        # dead branch (loop is running)
```

### After
```python
loop = asyncio.get_running_loop()      # recommended since 3.10
self._export_task = asyncio.ensure_future(...)  # stored → no GC
```

## Type of Change
- [x] Bug fix

## Test Coverage
- [x] No tests needed (minimal change, replaces deprecated API with recommended equivalent)

---

*Bug identified and fix generated with [GitWire](https://gitwire.erlab.uk) — self-hosted AI governance for GitHub automation.*