### PR TITLE
fix: enable native structured outputs for supported Bedrock Claude models

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -17,6 +17,7 @@ from agno.tools.function import Function
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.models.claude import (
     MCPServerConfiguration,
+    _extract_claude_core_id,
     _validate_cache_ttl_order,
     build_system_blocks,
     format_messages,
@@ -219,12 +220,16 @@ class Claude(Model):
         """
         Check if the current model supports native structured outputs.
 
+        Handles provider-specific model IDs (Anthropic direct, Bedrock, Vertex AI,
+        LiteLLM) by first normalizing to a canonical core identifier.
+
         Returns:
             bool: True if model supports structured outputs
         """
-        if self.id in self.NON_STRUCTURED_OUTPUT_ALIASES:
+        model_id = _extract_claude_core_id(self.id)
+        if model_id in self.NON_STRUCTURED_OUTPUT_ALIASES:
             return False
-        if self.id.startswith(self.NON_STRUCTURED_OUTPUT_PREFIXES):
+        if model_id.startswith(self.NON_STRUCTURED_OUTPUT_PREFIXES):
             return False
         return True
 

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -45,9 +45,6 @@ class Claude(AnthropicClaude):
     def __post_init__(self):
         """Validate model configuration after initialization"""
         super().__post_init__()
-        # Overwrite output schema support for AWS Bedrock Claude
-        self.supports_native_structured_outputs = False
-        self.supports_json_schema_outputs = False
 
     def _get_client_params(self) -> Dict[str, Any]:
         if self.session:
@@ -212,6 +209,12 @@ class Claude(AnthropicClaude):
         # Build betas list - include existing betas and add new one if needed
         betas_list = list(self.betas) if self.betas else []
 
+        # Add structured outputs beta header if using structured outputs
+        if self._using_structured_outputs(response_format, tools):
+            beta_header = "structured-outputs-2025-11-13"
+            if beta_header not in betas_list:
+                betas_list.append(beta_header)
+
         # Include betas if any are present
         if betas_list:
             _request_params["betas"] = betas_list
@@ -242,6 +245,9 @@ class Claude(AnthropicClaude):
         Returns:
             Dict[str, Any]: The request keyword arguments.
         """
+        # Validate structured outputs usage
+        self._validate_structured_outputs_usage(response_format, tools)
+
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         system = self._build_system(system_message)
@@ -253,6 +259,11 @@ class Claude(AnthropicClaude):
             request_kwargs["tools"] = format_tools_for_model(tools)
 
         self._apply_cache_tools(request_kwargs)
+
+        # Build output_format if response_format is provided
+        output_format = self._build_output_format(response_format)
+        if output_format:
+            request_kwargs["output_format"] = output_format
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -38,14 +38,17 @@ _PREFILL_SUPPORTED_ALIASES = {
 }
 
 
-def supports_prefill(model_id: str) -> bool:
-    """Return True if the given model ID supports assistant message prefill.
+def _extract_claude_core_id(model_id: str) -> str:
+    """Extract the canonical Claude model identifier from a provider-specific ID.
 
-    Handles provider-specific ID formats:
+    Handles:
       - Anthropic direct:  "claude-sonnet-4-5-20250929"
       - Bedrock:           "us.anthropic.claude-sonnet-4-6-v1:0"
       - Vertex AI:         "claude-sonnet-4@20250514"
       - LiteLLM:           "anthropic/claude-sonnet-4-6"
+
+    Returns the core model ID (e.g. "claude-sonnet-4-5-20250929" or
+    "claude-sonnet-4-6"), suitable for prefix / exact-match lookups.
     """
     # Strip LiteLLM provider prefix (e.g. "anthropic/claude-sonnet-4-6")
     core_id = model_id.split("/")[-1] if "/" in model_id else model_id
@@ -56,6 +59,19 @@ def supports_prefill(model_id: str) -> bool:
     # Strip Bedrock version suffix (e.g. "claude-sonnet-4-5-20250929-v1:0")
     if ":0" in core_id:
         core_id = core_id.split("-v")[0] if "-v" in core_id else core_id.split(":")[0]
+    return core_id
+
+
+def supports_prefill(model_id: str) -> bool:
+    """Return True if the given model ID supports assistant message prefill.
+
+    Handles provider-specific ID formats:
+      - Anthropic direct:  "claude-sonnet-4-5-20250929"
+      - Bedrock:           "us.anthropic.claude-sonnet-4-6-v1:0"
+      - Vertex AI:         "claude-sonnet-4@20250514"
+      - LiteLLM:           "anthropic/claude-sonnet-4-6"
+    """
+    core_id = _extract_claude_core_id(model_id)
 
     if not core_id.startswith("claude"):
         return True  # Non-Claude models are unaffected — don't inject trailing messages


### PR DESCRIPTION
Enables native structured output support for Bedrock Claude models.

AWS Bedrock supports native structured outputs for Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5, and Haiku 4.5 (ref: [Anthropic structured outputs docs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) and [AWS Bedrock docs](https://docs.aws.amazon.com/bedrock/latest/userguide/structured-output.html)), but `supports_native_structured_outputs` was hardcoded to `False` for all Bedrock Claude models, so neither the beta header nor the `output_format` parameter was ever sent.

## Changes

1. **Remove hardcoded `supports_native_structured_outputs=False`** in the Bedrock Claude class so the parent `AnthropicClaude` capability check correctly identifies supported models.

2. **Add structured-outputs beta header** to the Bedrock-specific `get_request_params` path so `betas: ["structured-outputs-2025-11-13"]` is included.

3. **Add `output_format` building** to the Bedrock-specific `_prepare_request_kwargs` path so the JSON schema is actually sent to the API.

4. **Normalize provider-specific model IDs** with a shared `_extract_claude_core_id` helper that strips Bedrock/VertexAI/LiteLLM prefixes and version suffixes before checking structured-output support — so `us.anthropic.claude-sonnet-4-5-20250929-v1:0` is recognized as a supported model while `us.anthropic.claude-sonnet-4-0-v1:0` is correctly excluded.

## Verification

Before: `supports_native_structured_outputs: False`, no beta header, no `output_format`
After: `supports_native_structured_outputs: True`, `betas: [structured-outputs-2025-11-13]`, `output_format` included in request

Works correctly for all supported Bedrock models (Opus 4.6, Sonnet 4.6, Sonnet 4.5, Opus 4.5, Haiku 4.5) and correctly excludes unsupported models (Claude 3.x family, Sonnet 4.0, Opus 4.0).

Fixes #8119

🤖 Generated with [Claude Code](https://claude.com/claude-code)