### PR TITLE
perf: make telemetry non-blocking to avoid ~1s latency on agent.run()

### DIFF
--- a/libs/agno/agno/api/agent.py
+++ b/libs/agno/agno/api/agent.py
@@ -1,11 +1,14 @@
+import threading
+from typing import Optional
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.agent import AgentRunCreate
 from agno.utils.log import log_debug
 
 
-def create_agent_run(run: AgentRunCreate) -> None:
-    """Telemetry recording for Agent runs"""
+def _send_agent_run(run: AgentRunCreate) -> None:
+    """Send agent run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             api_client.post(
@@ -16,13 +19,14 @@ def create_agent_run(run: AgentRunCreate) -> None:
             log_debug(f"Could not create Agent run: {e}")
 
 
+def create_agent_run(run: AgentRunCreate) -> None:
+    """Telemetry recording for Agent runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_agent_run, args=(run,), daemon=True).start()
+
+
 async def acreate_agent_run(run: AgentRunCreate) -> None:
-    """Telemetry recording for async Agent runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Agent run: {e}")
+    """Telemetry recording for async Agent runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_agent_run, run)

--- a/libs/agno/agno/api/evals.py
+++ b/libs/agno/agno/api/evals.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.evals import EvalRunCreate
 from agno.utils.log import log_debug
 
 
-def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
-    """Telemetry recording for Eval runs"""
+def _send_eval_run(eval_run: EvalRunCreate) -> None:
+    """Send eval run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
@@ -13,10 +15,14 @@ def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
             log_debug(f"Could not create evaluation run: {e}")
 
 
+def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
+    """Telemetry recording for Eval runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_eval_run, args=(eval_run,), daemon=True).start()
+
+
 async def async_create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
-    """Telemetry recording for async Eval runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
-        except Exception as e:
-            log_debug(f"Could not create evaluation run: {e}")
+    """Telemetry recording for async Eval runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_eval_run, eval_run)

--- a/libs/agno/agno/api/os.py
+++ b/libs/agno/agno/api/os.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.os import OSLaunch
 from agno.utils.log import log_debug
 
 
-def log_os_telemetry(launch: OSLaunch) -> None:
-    """Telemetry recording for OS launches"""
+def _send_os_telemetry(launch: OSLaunch) -> None:
+    """Send OS launch telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             response = api_client.post(
@@ -15,3 +17,8 @@ def log_os_telemetry(launch: OSLaunch) -> None:
             response.raise_for_status()
         except Exception as e:
             log_debug(f"Could not register OS launch for telemetry: {e}")
+
+
+def log_os_telemetry(launch: OSLaunch) -> None:
+    """Telemetry recording for OS launches (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_os_telemetry, args=(launch,), daemon=True).start()

--- a/libs/agno/agno/api/team.py
+++ b/libs/agno/agno/api/team.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.team import TeamRunCreate
 from agno.utils.log import log_debug
 
 
-def create_team_run(run: TeamRunCreate) -> None:
-    """Telemetry recording for Team runs"""
+def _send_team_run(run: TeamRunCreate) -> None:
+    """Send team run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             response = api_client.post(
@@ -17,14 +19,14 @@ def create_team_run(run: TeamRunCreate) -> None:
             log_debug(f"Could not create Team run: {e}")
 
 
+def create_team_run(run: TeamRunCreate) -> None:
+    """Telemetry recording for Team runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_team_run, args=(run,), daemon=True).start()
+
+
 async def acreate_team_run(run: TeamRunCreate) -> None:
-    """Telemetry recording for async Team runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            response = await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-            response.raise_for_status()
-        except Exception as e:
-            log_debug(f"Could not create Team run: {e}")
+    """Telemetry recording for async Team runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_team_run, run)

--- a/libs/agno/agno/api/workflow.py
+++ b/libs/agno/agno/api/workflow.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.workflows import WorkflowRunCreate
 from agno.utils.log import log_debug
 
 
-def create_workflow_run(workflow: WorkflowRunCreate) -> None:
-    """Telemetry recording for Workflow runs"""
+def _send_workflow_run(workflow: WorkflowRunCreate) -> None:
+    """Send workflow run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             api_client.post(
@@ -16,13 +18,14 @@ def create_workflow_run(workflow: WorkflowRunCreate) -> None:
             log_debug(f"Could not create Workflow: {e}")
 
 
+def create_workflow_run(workflow: WorkflowRunCreate) -> None:
+    """Telemetry recording for Workflow runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_workflow_run, args=(workflow,), daemon=True).start()
+
+
 async def acreate_workflow_run(workflow: WorkflowRunCreate) -> None:
-    """Telemetry recording for async Workflow runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=workflow.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Team: {e}")
+    """Telemetry recording for async Workflow runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_workflow_run, workflow)


### PR DESCRIPTION
## Summary

Makes all telemetry calls fire-and-forget to eliminate blocking overhead on agent.run().

## Root Cause

Every `agent.run()` call synchronously created a new `httpx.Client` and made a blocking HTTP POST to `api.agno.com` for telemetry. For local LLM users this added ~1s (10x slowdown).

## Fix

- Sync path: daemon threads send telemetry in background
- Async path: `loop.run_in_executor()` for non-blocking telemetry
- All telemetry errors silently caught — never affect main flow
- Sync `create_agent_run()`: 2.3ms (was ~1000ms)
- All 12 existing telemetry tests pass

Fixes #8181