### PR TITLE
fix: enable native structured outputs for supported Bedrock Claude models

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -17,6 +17,7 @@ from agno.tools.function import Function
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.models.claude import (
     MCPServerConfiguration,
+    _extract_claude_core_id,
     _validate_cache_ttl_order,
     build_system_blocks,
     format_messages,
@@ -219,12 +220,16 @@ class Claude(Model):
         """
         Check if the current model supports native structured outputs.
 
+        Handles provider-specific model IDs (Anthropic direct, Bedrock, Vertex AI,
+        LiteLLM) by first normalizing to a canonical core identifier.
+
         Returns:
             bool: True if model supports structured outputs
         """
-        if self.id in self.NON_STRUCTURED_OUTPUT_ALIASES:
+        model_id = _extract_claude_core_id(self.id)
+        if model_id in self.NON_STRUCTURED_OUTPUT_ALIASES:
             return False
-        if self.id.startswith(self.NON_STRUCTURED_OUTPUT_PREFIXES):
+        if model_id.startswith(self.NON_STRUCTURED_OUTPUT_PREFIXES):
             return False
         return True
 

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -45,9 +45,6 @@ class Claude(AnthropicClaude):
     def __post_init__(self):
         """Validate model configuration after initialization"""
         super().__post_init__()
-        # Overwrite output schema support for AWS Bedrock Claude
-        self.supports_native_structured_outputs = False
-        self.supports_json_schema_outputs = False
 
     def _get_client_params(self) -> Dict[str, Any]:
         if self.session:
@@ -212,6 +209,12 @@ class Claude(AnthropicClaude):
         # Build betas list - include existing betas and add new one if needed
         betas_list = list(self.betas) if self.betas else []
 
+        # Add structured outputs beta header if using structured outputs
+        if self._using_structured_outputs(response_format, tools):
+            beta_header = "structured-outputs-2025-11-13"
+            if beta_header not in betas_list:
+                betas_list.append(beta_header)
+
         # Include betas if any are present
         if betas_list:
             _request_params["betas"] = betas_list
@@ -242,6 +245,9 @@ class Claude(AnthropicClaude):
         Returns:
             Dict[str, Any]: The request keyword arguments.
         """
+        # Validate structured outputs usage
+        self._validate_structured_outputs_usage(response_format, tools)
+
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         system = self._build_system(system_message)
@@ -253,6 +259,11 @@ class Claude(AnthropicClaude):
             request_kwargs["tools"] = format_tools_for_model(tools)
 
         self._apply_cache_tools(request_kwargs)
+
+        # Build output_format if response_format is provided
+        output_format = self._build_output_format(response_format)
+        if output_format:
+            request_kwargs["output_format"] = output_format
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -38,14 +38,17 @@ _PREFILL_SUPPORTED_ALIASES = {
 }
 
 
-def supports_prefill(model_id: str) -> bool:
-    """Return True if the given model ID supports assistant message prefill.
+def _extract_claude_core_id(model_id: str) -> str:
+    """Extract the canonical Claude model identifier from a provider-specific ID.
 
-    Handles provider-specific ID formats:
+    Handles:
       - Anthropic direct:  "claude-sonnet-4-5-20250929"
       - Bedrock:           "us.anthropic.claude-sonnet-4-6-v1:0"
       - Vertex AI:         "claude-sonnet-4@20250514"
       - LiteLLM:           "anthropic/claude-sonnet-4-6"
+
+    Returns the core model ID (e.g. "claude-sonnet-4-5-20250929" or
+    "claude-sonnet-4-6"), suitable for prefix / exact-match lookups.
     """
     # Strip LiteLLM provider prefix (e.g. "anthropic/claude-sonnet-4-6")
     core_id = model_id.split("/")[-1] if "/" in model_id else model_id
@@ -56,6 +59,19 @@ def supports_prefill(model_id: str) -> bool:
     # Strip Bedrock version suffix (e.g. "claude-sonnet-4-5-20250929-v1:0")
     if ":0" in core_id:
         core_id = core_id.split("-v")[0] if "-v" in core_id else core_id.split(":")[0]
+    return core_id
+
+
+def supports_prefill(model_id: str) -> bool:
+    """Return True if the given model ID supports assistant message prefill.
+
+    Handles provider-specific ID formats:
+      - Anthropic direct:  "claude-sonnet-4-5-20250929"
+      - Bedrock:           "us.anthropic.claude-sonnet-4-6-v1:0"
+      - Vertex AI:         "claude-sonnet-4@20250514"
+      - LiteLLM:           "anthropic/claude-sonnet-4-6"
+    """
+    core_id = _extract_claude_core_id(model_id)
 
     if not core_id.startswith("claude"):
         return True  # Non-Claude models are unaffected — don't inject trailing messages

--- a/libs/agno/tests/unit/models/anthropic/test_structured_output_capability.py
+++ b/libs/agno/tests/unit/models/anthropic/test_structured_output_capability.py
@@ -112,3 +112,105 @@ class TestSupportsStructuredOutputs:
         assert model.supports_native_structured_outputs is False, (
             f"Model '{model_id}' should have supports_native_structured_outputs=False after init"
         )
+
+    # --- Bedrock provider-specific model IDs ---
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            # Bedrock format: region.anthropic.model-suffix
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-sonnet-4-6-v1:0",
+            "us.anthropic.claude-opus-4-6-20251201-v1:0",
+            "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            # Bedrock regional variants with different prefix
+            "apac.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "eu-central-1.anthropic.claude-opus-4-5-20251101-v1:0",
+        ],
+    )
+    def test_bedrock_model_ids_support_structured_outputs(self, model_id: str):
+        """Bedrock Claude model IDs (region.anthropic.X-v1:0) should be
+        correctly normalized by _extract_claude_core_id and recognized as
+        supporting native structured outputs."""
+        model = Claude(id=model_id)
+        assert model._supports_structured_outputs() is True, (
+            f"Bedrock model '{model_id}' should support structured outputs"
+        )
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-opus-4-6-20251201-v1:0",
+            "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        ],
+    )
+    def test_bedrock_native_structured_outputs_flag_set_in_post_init(self, model_id: str):
+        """__post_init__ on the Anthropic Claude class should set
+        supports_native_structured_outputs=True for Bedrock model IDs after
+        _extract_claude_core_id normalization."""
+        model = Claude(id=model_id)
+        assert model.supports_native_structured_outputs is True, (
+            f"Bedrock model '{model_id}' should have supports_native_structured_outputs=True after init"
+        )
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            # Bedrock Claude 3.x (unsupported)
+            "us.anthropic.claude-3-sonnet-20240229-v1:0",
+            "us.anthropic.claude-3-haiku-20240307-v1:0",
+            "us.anthropic.claude-3-opus-20240229-v1:0",
+            # Bedrock Claude 3.5 (unsupported)
+            "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+            # Bedrock Claude Sonnet 4.0 (unsupported)
+            "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            # Bedrock Claude Opus 4.0 (unsupported)
+            "us.anthropic.claude-opus-4-20250514-v1:0",
+        ],
+    )
+    def test_bedrock_unsupported_model_ids(self, model_id: str):
+        """Bedrock model IDs for legacy/unsupported models should not report
+        native structured output support."""
+        model = Claude(id=model_id)
+        assert model._supports_structured_outputs() is False, (
+            f"Bedrock model '{model_id}' should NOT support structured outputs"
+        )
+
+    # --- Vertex AI provider-specific model IDs ---
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "claude-sonnet-4-5@20250929",
+            "claude-opus-4-6@20251201",
+            "claude-haiku-4-5@20251001",
+        ],
+    )
+    def test_vertex_ai_model_ids_support_structured_outputs(self, model_id: str):
+        """Vertex AI Claude model IDs (X@YYYYMMDD) should be normalized by
+        _extract_claude_core_id and recognized as supporting structured outputs."""
+        model = Claude(id=model_id)
+        assert model._supports_structured_outputs() is True, (
+            f"Vertex AI model '{model_id}' should support structured outputs"
+        )
+
+    # --- LiteLLM provider-specific model IDs ---
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "anthropic/claude-sonnet-4-5-20250929",
+            "anthropic/claude-opus-4-6-20251201",
+        ],
+    )
+    def test_litellm_model_ids_support_structured_outputs(self, model_id: str):
+        """LiteLLM Claude model IDs (anthropic/X) should be normalized by
+        _extract_claude_core_id and recognized as supporting structured outputs."""
+        model = Claude(id=model_id)
+        assert model._supports_structured_outputs() is True, (
+            f"LiteLLM model '{model_id}' should support structured outputs"
+        )

--- a/libs/agno/tests/unit/models/aws/test_claude_client.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_client.py
@@ -238,6 +238,54 @@ class TestApiKeyPath:
             model._get_client_params()
 
 
+class TestStructuredOutputSupport:
+    """Verify that the Bedrock Claude class (inheriting from Anthropic Claude)
+    correctly reports native structured output support."""
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "us.anthropic.claude-sonnet-4-6-v1:0",
+            "us.anthropic.claude-opus-4-6-20251201-v1:0",
+            "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+        ],
+    )
+    def test_bedrock_claude_supports_native_structured_outputs(self, model_id):
+        """The AWS Bedrock Claude class should inherit _supports_structured_outputs
+        and flag supports_native_structured_outputs=True after __post_init__."""
+        model = Claude(
+            id=model_id,
+            aws_access_key="AKIA_TEST",
+            aws_secret_key="test-secret",
+            aws_region="us-east-1",
+        )
+        assert model.supports_native_structured_outputs is True, (
+            f"Bedrock model '{model_id}' should have supports_native_structured_outputs=True"
+        )
+
+    @pytest.mark.parametrize(
+        "model_id",
+        [
+            "us.anthropic.claude-3-sonnet-20240229-v1:0",
+            "us.anthropic.claude-3-haiku-20240307-v1:0",
+            "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        ],
+    )
+    def test_bedrock_claude_unsupported_models_no_native_structured_outputs(self, model_id):
+        """Legacy/unsupported Bedrock Claude models should have
+        supports_native_structured_outputs=False."""
+        model = Claude(
+            id=model_id,
+            aws_access_key="AKIA_TEST",
+            aws_secret_key="test-secret",
+            aws_region="us-east-1",
+        )
+        assert model.supports_native_structured_outputs is False, (
+            f"Bedrock model '{model_id}' should have supports_native_structured_outputs=False"
+        )
+
+
 class TestSessionNullCredentials:
     def test_raises_on_null_credentials(self):
         mock_session = MagicMock(spec=Session)


### PR DESCRIPTION
Fixes #8119

## Changes
- Added `_extract_claude_core_id()` to normalize provider-specific Claude model IDs (Bedrock, Vertex AI, LiteLLM) into canonical form
- Fixed `_supports_structured_outputs()` to use the normalized core ID for blocklist checks, so Bedrock models like `us.anthropic.claude-sonnet-4-5-20250929-v1:0` are correctly recognized
- Bedrock `Claude` class inherits this behavior via `super().__post_init__()`, setting `supports_native_structured_outputs = True` for supported models

## Tests Added
- Bedrock model IDs support structured outputs after normalization
- Bedrock Claude instances have `supports_native_structured_outputs=True` after init
- Legacy/unsupported Bedrock model IDs are correctly excluded
- Vertex AI and LiteLLM model IDs are also handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)