### PR TITLE
perf: make telemetry non-blocking to avoid ~1s latency on agent.run()

### DIFF
--- a/libs/agno/agno/api/agent.py
+++ b/libs/agno/agno/api/agent.py
@@ -1,11 +1,14 @@
+import threading
+from typing import Optional
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.agent import AgentRunCreate
 from agno.utils.log import log_debug
 
 
-def create_agent_run(run: AgentRunCreate) -> None:
-    """Telemetry recording for Agent runs"""
+def _send_agent_run(run: AgentRunCreate) -> None:
+    """Send agent run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             api_client.post(
@@ -16,13 +19,14 @@ def create_agent_run(run: AgentRunCreate) -> None:
             log_debug(f"Could not create Agent run: {e}")
 
 
+def create_agent_run(run: AgentRunCreate) -> None:
+    """Telemetry recording for Agent runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_agent_run, args=(run,), daemon=True).start()
+
+
 async def acreate_agent_run(run: AgentRunCreate) -> None:
-    """Telemetry recording for async Agent runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Agent run: {e}")
+    """Telemetry recording for async Agent runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_agent_run, run)

--- a/libs/agno/agno/api/evals.py
+++ b/libs/agno/agno/api/evals.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.evals import EvalRunCreate
 from agno.utils.log import log_debug
 
 
-def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
-    """Telemetry recording for Eval runs"""
+def _send_eval_run(eval_run: EvalRunCreate) -> None:
+    """Send eval run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
@@ -13,10 +15,14 @@ def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
             log_debug(f"Could not create evaluation run: {e}")
 
 
+def create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
+    """Telemetry recording for Eval runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_eval_run, args=(eval_run,), daemon=True).start()
+
+
 async def async_create_eval_run_telemetry(eval_run: EvalRunCreate) -> None:
-    """Telemetry recording for async Eval runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(ApiRoutes.EVAL_RUN_CREATE, json=eval_run.model_dump(exclude_none=True))
-        except Exception as e:
-            log_debug(f"Could not create evaluation run: {e}")
+    """Telemetry recording for async Eval runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_eval_run, eval_run)

--- a/libs/agno/agno/api/os.py
+++ b/libs/agno/agno/api/os.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.os import OSLaunch
 from agno.utils.log import log_debug
 
 
-def log_os_telemetry(launch: OSLaunch) -> None:
-    """Telemetry recording for OS launches"""
+def _send_os_telemetry(launch: OSLaunch) -> None:
+    """Send OS launch telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             response = api_client.post(
@@ -15,3 +17,8 @@ def log_os_telemetry(launch: OSLaunch) -> None:
             response.raise_for_status()
         except Exception as e:
             log_debug(f"Could not register OS launch for telemetry: {e}")
+
+
+def log_os_telemetry(launch: OSLaunch) -> None:
+    """Telemetry recording for OS launches (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_os_telemetry, args=(launch,), daemon=True).start()

--- a/libs/agno/agno/api/team.py
+++ b/libs/agno/agno/api/team.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.team import TeamRunCreate
 from agno.utils.log import log_debug
 
 
-def create_team_run(run: TeamRunCreate) -> None:
-    """Telemetry recording for Team runs"""
+def _send_team_run(run: TeamRunCreate) -> None:
+    """Send team run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             response = api_client.post(
@@ -17,14 +19,14 @@ def create_team_run(run: TeamRunCreate) -> None:
             log_debug(f"Could not create Team run: {e}")
 
 
+def create_team_run(run: TeamRunCreate) -> None:
+    """Telemetry recording for Team runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_team_run, args=(run,), daemon=True).start()
+
+
 async def acreate_team_run(run: TeamRunCreate) -> None:
-    """Telemetry recording for async Team runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            response = await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=run.model_dump(exclude_none=True),
-            )
-            response.raise_for_status()
-        except Exception as e:
-            log_debug(f"Could not create Team run: {e}")
+    """Telemetry recording for async Team runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_team_run, run)

--- a/libs/agno/agno/api/workflow.py
+++ b/libs/agno/agno/api/workflow.py
@@ -1,11 +1,13 @@
+import threading
+
 from agno.api.api import api
 from agno.api.routes import ApiRoutes
 from agno.api.schemas.workflows import WorkflowRunCreate
 from agno.utils.log import log_debug
 
 
-def create_workflow_run(workflow: WorkflowRunCreate) -> None:
-    """Telemetry recording for Workflow runs"""
+def _send_workflow_run(workflow: WorkflowRunCreate) -> None:
+    """Send workflow run telemetry via HTTP (called from background thread)."""
     with api.Client() as api_client:
         try:
             api_client.post(
@@ -16,13 +18,14 @@ def create_workflow_run(workflow: WorkflowRunCreate) -> None:
             log_debug(f"Could not create Workflow: {e}")
 
 
+def create_workflow_run(workflow: WorkflowRunCreate) -> None:
+    """Telemetry recording for Workflow runs (fire-and-forget in background thread)."""
+    threading.Thread(target=_send_workflow_run, args=(workflow,), daemon=True).start()
+
+
 async def acreate_workflow_run(workflow: WorkflowRunCreate) -> None:
-    """Telemetry recording for async Workflow runs"""
-    async with api.AsyncClient() as api_client:
-        try:
-            await api_client.post(
-                ApiRoutes.RUN_CREATE,
-                json=workflow.model_dump(exclude_none=True),
-            )
-        except Exception as e:
-            log_debug(f"Could not create Team: {e}")
+    """Telemetry recording for async Workflow runs (fire-and-forget via executor)."""
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    loop.run_in_executor(None, _send_workflow_run, workflow)

--- a/libs/agno/tests/unit/telemetry/test_agent_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_agent_telemetry.py
@@ -54,3 +54,129 @@ async def test_agent_telemetry_async():
         assert call_args.kwargs["session_id"] is not None
         assert "run_id" in call_args.kwargs
         assert call_args.kwargs["run_id"] is not None
+
+
+# =============================================================================
+# Non-blocking telemetry tests — verify fire-and-forget behavior
+# =============================================================================
+
+
+def test_create_agent_run_is_non_blocking():
+    """create_agent_run should return immediately without waiting for the
+    HTTP response to complete. It spawns a daemon thread and returns."""
+    import time
+
+    from agno.api.agent import AgentRunCreate, create_agent_run
+    from agno.api.api import api
+
+    # Make the actual HTTP call block for a long time inside the daemon thread
+    with patch.object(api, "Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.post = lambda *a, **kw: time.sleep(3.0)
+        mock_client_cls.return_value = mock_client
+
+        run = AgentRunCreate(session_id="s1", run_id="r1")
+        start = time.perf_counter()
+        create_agent_run(run)
+        elapsed = time.perf_counter() - start
+
+        # Should return in under 0.5s — the 3s sleep runs in a daemon thread
+        assert elapsed < 0.5, (
+            f"create_agent_run blocked for {elapsed:.2f}s, expected immediate return (< 0.5s)"
+        )
+
+
+def test_create_team_run_is_non_blocking():
+    """create_team_run should return immediately (fire-and-forget)."""
+    import time
+
+    from agno.api.api import api
+    from agno.api.team import TeamRunCreate, create_team_run
+
+    with patch.object(api, "Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.post = lambda *a, **kw: time.sleep(3.0)
+        mock_client_cls.return_value = mock_client
+
+        run = TeamRunCreate(session_id="s1", run_id="r1")
+        start = time.perf_counter()
+        create_team_run(run)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.5, (
+            f"create_team_run blocked for {elapsed:.2f}s, expected immediate return (< 0.5s)"
+        )
+
+
+def test_create_workflow_run_is_non_blocking():
+    """create_workflow_run should return immediately (fire-and-forget)."""
+    import time
+
+    from agno.api.api import api
+    from agno.api.workflow import WorkflowRunCreate, create_workflow_run
+
+    with patch.object(api, "Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.post = lambda *a, **kw: time.sleep(3.0)
+        mock_client_cls.return_value = mock_client
+
+        run = WorkflowRunCreate(session_id="s1", run_id="r1")
+        start = time.perf_counter()
+        create_workflow_run(run)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.5, (
+            f"create_workflow_run blocked for {elapsed:.2f}s, expected immediate return (< 0.5s)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_acreate_agent_run_is_non_blocking():
+    """acreate_agent_run should return near-immediately using run_in_executor."""
+    import time
+
+    from agno.api.agent import AgentRunCreate, acreate_agent_run
+    from agno.api.api import api
+
+    with patch.object(api, "Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.post = lambda *a, **kw: time.sleep(3.0)
+        mock_client_cls.return_value = mock_client
+
+        run = AgentRunCreate(session_id="s1", run_id="r1")
+        start = time.perf_counter()
+        await acreate_agent_run(run)
+        elapsed = time.perf_counter() - start
+
+        # run_in_executor submits to a thread pool and returns immediately
+        assert elapsed < 0.5, (
+            f"acreate_agent_run blocked for {elapsed:.2f}s, expected immediate return (< 0.5s)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_acreate_team_run_is_non_blocking():
+    """acreate_team_run should return near-immediately using run_in_executor."""
+    import time
+
+    from agno.api.api import api
+    from agno.api.team import TeamRunCreate, acreate_team_run
+
+    with patch.object(api, "Client") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.__enter__.return_value = mock_client
+        mock_client.post = lambda *a, **kw: time.sleep(3.0)
+        mock_client_cls.return_value = mock_client
+
+        run = TeamRunCreate(session_id="s1", run_id="r1")
+        start = time.perf_counter()
+        await acreate_team_run(run)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 0.5, (
+            f"acreate_team_run blocked for {elapsed:.2f}s, expected immediate return (< 0.5s)"
+        )


### PR DESCRIPTION
Fixes #8181

## Changes
Made all telemetry calls fire-and-forget to eliminate the ~1s latency penalty on agent.run() and team.run():
- `create_agent_run()` / `create_team_run()` / `create_workflow_run()` now use daemon threads
- `acreate_agent_run()` / `acreate_team_run()` / `acreate_workflow_run()` now use `run_in_executor`
- All telemetry HTTP calls return instantly without waiting for the response

## Tests Added
Non-blocking tests in `libs/agno/tests/unit/telemetry/test_agent_telemetry.py`:
- Each test patches the HTTP client with a 3s delay and asserts the telemetry function returns in under 0.5s
- Covers sync (daemon thread) and async (run_in_executor) paths for agent, team, and workflow telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)