### PR TITLE
fix: count existing tool-call results in messages for function_call_count persistence

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -686,7 +686,8 @@ class Model(ABC):
             _log_messages(messages)
             model_response = ModelResponse()
 
-            function_call_count = 0
+            # Count existing tool-call results so function_call_count survives HITL resume
+            function_call_count = sum(1 for m in messages if m.role == "tool")
 
             _tool_dicts = self._format_tools(tools) if tools is not None else []
             _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
@@ -914,7 +915,8 @@ class Model(ABC):
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
 
-            function_call_count = 0
+            # Count existing tool-call results so function_call_count survives HITL resume
+            function_call_count = sum(1 for m in messages if m.role == "tool")
 
             while True:
                 # Compress existing tool results BEFORE making API call to avoid context overflow
@@ -1403,7 +1405,8 @@ class Model(ABC):
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
 
-            function_call_count = 0
+            # Count existing tool-call results so function_call_count survives HITL resume
+            function_call_count = sum(1 for m in messages if m.role == "tool")
 
             while True:
                 # Compress existing tool results BEFORE invoke
@@ -1682,7 +1685,8 @@ class Model(ABC):
             _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
             _compression_manager = compression_manager if _compress_tool_results else None
 
-            function_call_count = 0
+            # Count existing tool-call results so function_call_count survives HITL resume
+            function_call_count = sum(1 for m in messages if m.role == "tool")
 
             while True:
                 # Compress existing tool results BEFORE making API call to avoid context overflow


### PR DESCRIPTION
## Summary

When an agent pauses for HITL (human-in-the-loop) and resumes, `aresponse_stream` / `response_stream` re-initializes `function_call_count` to 0, making `tool_call_limit` ineffective across resumes. With `tool_call_limit=1`, the agent can issue another tool call after resume even though it already made one.

## Root Cause

Four response methods in `models/base.py` (`response`, `aresponse`, `response_stream`, `aresponse_stream`) each start with `function_call_count = 0`. When a tool triggers HITL and the stream pauses, the count is lost. On resume via `acontinue_run`, a fresh call to the response method resets the counter, so the previously-counted tool call is forgotten.

## Fix

Instead of initializing `function_call_count = 0`, count existing `role="tool"` messages already in the conversation history. These messages are created by `format_function_call_results` after each successful tool execution.

In the HITL resume scenario:
1. The HITL-paused tool is approved and executed between invocations
2. A tool result message is added to the messages list
3. On the next `response()`/`aresponse()`/`response_stream()`/`aresponse_stream()` call, the count starts from the number of existing tool results
4. `run_function_calls` receives the correct cumulative count, preventing the limit from being exceeded

## Changes

| File | Change |
|---|---|
| `libs/agno/agno/models/base.py` (×4 methods) | `function_call_count = 0` → `function_call_count = sum(1 for m in messages if m.role == "tool")` |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have not added any unnecessary dependencies or AI slop

## Test Plan

1. Create an Agent with `tool_call_limit=1` and a tool with `requires_confirmation=True`
2. Run the agent, triggering the HITL tool
3. Approve the HITL
4. Verify no further tool calls are made after resume

Fixes #7962
