### PR TITLE
[fix] Quote DaytonaTools shell paths

### DIFF
--- a/libs/agno/agno/tools/daytona.py
+++ b/libs/agno/agno/tools/daytona.py
@@ -1,4 +1,6 @@
 import json
+import posixpath
+import shlex
 from os import getenv
 from pathlib import Path
 from textwrap import dedent
@@ -290,16 +292,16 @@ class DaytonaTools(Toolkit):
                 # Resolve relative paths
                 if not new_path.is_absolute():
                     # Get current absolute path first
-                    result = current_sandbox.process.exec(f"cd {cwd} && pwd", cwd="/")
+                    result = current_sandbox.process.exec(f"cd {shlex.quote(cwd)} && pwd", cwd="/")
                     current_abs_path = Path(result.result.strip())
                     new_path = current_abs_path / new_path
 
-                # Normalize the path
-                new_path_str = str(new_path.resolve())
+                # Normalize using POSIX semantics because Daytona sandbox paths are Linux paths.
+                new_path_str = posixpath.normpath(str(new_path))
 
                 # Test if directory exists
                 test_result = current_sandbox.process.exec(
-                    f"test -d {new_path_str} && echo 'exists' || echo 'not found'", cwd="/"
+                    f"test -d {shlex.quote(new_path_str)} && echo 'exists' || echo 'not found'", cwd="/"
                 )
                 if "exists" in test_result.result:
                     self._set_working_directory(agent, new_path_str)
@@ -339,14 +341,14 @@ class DaytonaTools(Toolkit):
             # Create directory if needed
             parent_dir = str(path.parent)
             if parent_dir and parent_dir != "/":
-                result = current_sandbox.process.exec(f"mkdir -p {parent_dir}")
+                result = current_sandbox.process.exec(f"mkdir -p {shlex.quote(parent_dir)}")
                 if result.exit_code != 0:
                     return json.dumps({"status": "error", "message": f"Failed to create directory: {result.result}"})
 
             # Write the file using shell command
             # Use cat with heredoc for better handling of special characters
             escaped_content = content.replace("'", "'\"'\"'")
-            command = f"cat > '{path_str}' << 'EOF'\n{escaped_content}\nEOF"
+            command = f"cat > {shlex.quote(path_str)} << 'EOF'\n{escaped_content}\nEOF"
             result = current_sandbox.process.exec(command)
 
             if result.exit_code != 0:
@@ -378,7 +380,7 @@ class DaytonaTools(Toolkit):
             path_str = str(path)
 
             # Read file using cat
-            result = current_sandbox.process.exec(f"cat '{path_str}'")
+            result = current_sandbox.process.exec(f"cat {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
                 return json.dumps({"status": "error", "message": f"Error reading file: {result.result}"})
@@ -411,7 +413,7 @@ class DaytonaTools(Toolkit):
             path_str = str(dir_path)
 
             # List files using ls -la for detailed info
-            result = current_sandbox.process.exec(f"ls -la '{path_str}'")
+            result = current_sandbox.process.exec(f"ls -la {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
                 return json.dumps({"status": "error", "message": f"Error listing directory: {result.result}"})
@@ -442,14 +444,16 @@ class DaytonaTools(Toolkit):
             path_str = str(path)
 
             # Check if it's a directory or file
-            check_result = current_sandbox.process.exec(f"test -d '{path_str}' && echo 'directory' || echo 'file'")
+            check_result = current_sandbox.process.exec(
+                f"test -d {shlex.quote(path_str)} && echo 'directory' || echo 'file'"
+            )
 
             if "directory" in check_result.result:
                 # Remove directory recursively
-                result = current_sandbox.process.exec(f"rm -rf '{path_str}'")
+                result = current_sandbox.process.exec(f"rm -rf {shlex.quote(path_str)}")
             else:
                 # Remove file
-                result = current_sandbox.process.exec(f"rm -f '{path_str}'")
+                result = current_sandbox.process.exec(f"rm -f {shlex.quote(path_str)}")
 
             if result.exit_code != 0:
                 return json.dumps({"status": "error", "message": f"Failed to delete: {result.result}"})
@@ -468,8 +472,6 @@ class DaytonaTools(Toolkit):
             Success message or error
         """
         try:
-            result = self.run_shell_command(agent, f"cd {directory}")
-            self._set_working_directory(agent, directory)
-            return result
+            return self.run_shell_command(agent, f"cd {directory}")
         except Exception as e:
             return json.dumps({"status": "error", "message": f"Error changing directory: {str(e)}"})

--- a/libs/agno/tests/unit/tools/test_daytona.py
+++ b/libs/agno/tests/unit/tools/test_daytona.py
@@ -1,5 +1,6 @@
 """Test DaytonaTools functionality."""
 
+import shlex
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -165,6 +166,25 @@ class TestDaytonaTools:
             assert "Changed directory to:" in result
             assert "/home/test" in result
 
+    def test_run_shell_command_cd_quotes_path(self, mock_daytona, mock_agent):
+        """Test cd path checks quote shell metacharacters."""
+        mock_client, mock_sandbox, mock_process, _ = mock_daytona
+
+        with patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}):
+            tools = DaytonaTools()
+
+            mock_test = MagicMock()
+            mock_test.result = "not found"
+            mock_process.exec.return_value = mock_test
+
+            path = "/home/daytona/vuln; id;"
+            result = tools.run_shell_command(mock_agent, f"cd {path}")
+
+            assert f"Directory {path} not found" in result
+            mock_process.exec.assert_called_once_with(
+                f"test -d {shlex.quote(path)} && echo 'exists' || echo 'not found'", cwd="/"
+            )
+
     def test_create_file(self, mock_daytona, mock_agent):
         """Test create_file method."""
         mock_client, mock_sandbox, mock_process, _ = mock_daytona
@@ -180,6 +200,27 @@ class TestDaytonaTools:
             # Test file creation
             result = tools.create_file(mock_agent, "test.txt", "Hello, World!")
             assert "File created/updated: /home/daytona/test.txt" in result
+
+    def test_create_file_quotes_path(self, mock_daytona, mock_agent):
+        """Test create_file quotes derived shell paths."""
+        mock_client, mock_sandbox, mock_process, _ = mock_daytona
+
+        with patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}):
+            tools = DaytonaTools()
+
+            mock_execution = MagicMock()
+            mock_execution.exit_code = 0
+            mock_process.exec.return_value = mock_execution
+
+            file_path = "dir; id;/name's.txt"
+            path = "/home/daytona/dir; id;/name's.txt"
+            parent_dir = "/home/daytona/dir; id;"
+
+            result = tools.create_file(mock_agent, file_path, "Hello, World!")
+
+            assert f"File created/updated: {path}" in result
+            assert mock_process.exec.call_args_list[0].args[0] == f"mkdir -p {shlex.quote(parent_dir)}"
+            assert mock_process.exec.call_args_list[1].args[0].startswith(f"cat > {shlex.quote(path)} << 'EOF'")
 
     def test_read_file(self, mock_daytona, mock_agent):
         """Test read_file method."""
@@ -198,6 +239,24 @@ class TestDaytonaTools:
             result = tools.read_file(mock_agent, "test.txt")
             assert result == "File contents"
 
+    def test_read_file_quotes_path(self, mock_daytona, mock_agent):
+        """Test read_file quotes derived shell paths."""
+        mock_client, mock_sandbox, mock_process, _ = mock_daytona
+
+        with patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}):
+            tools = DaytonaTools()
+
+            mock_execution = MagicMock()
+            mock_execution.exit_code = 0
+            mock_execution.result = "File contents"
+            mock_process.exec.return_value = mock_execution
+
+            path = "/home/daytona/name'; id;.txt"
+            result = tools.read_file(mock_agent, "name'; id;.txt")
+
+            assert result == "File contents"
+            mock_process.exec.assert_called_once_with(f"cat {shlex.quote(path)}")
+
     def test_list_files(self, mock_daytona, mock_agent):
         """Test list_files method."""
         mock_client, mock_sandbox, mock_process, _ = mock_daytona
@@ -215,6 +274,24 @@ class TestDaytonaTools:
             result = tools.list_files(mock_agent, ".")
             assert "file1.txt" in result
             assert "file2.py" in result
+
+    def test_list_files_quotes_path(self, mock_daytona, mock_agent):
+        """Test list_files quotes derived shell paths."""
+        mock_client, mock_sandbox, mock_process, _ = mock_daytona
+
+        with patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}):
+            tools = DaytonaTools()
+
+            mock_execution = MagicMock()
+            mock_execution.exit_code = 0
+            mock_execution.result = "file1.txt"
+            mock_process.exec.return_value = mock_execution
+
+            path = "/home/daytona/dir'; id;"
+            result = tools.list_files(mock_agent, "dir'; id;")
+
+            assert "file1.txt" in result
+            mock_process.exec.assert_called_once_with(f"ls -la {shlex.quote(path)}")
 
     def test_delete_file(self, mock_daytona, mock_agent):
         """Test delete_file method."""
@@ -238,6 +315,33 @@ class TestDaytonaTools:
             result = tools.delete_file(mock_agent, "test.txt")
             assert result == "Deleted: /home/daytona/test.txt"
 
+    def test_delete_file_quotes_path(self, mock_daytona, mock_agent):
+        """Test delete_file quotes derived shell paths."""
+        mock_client, mock_sandbox, mock_process, _ = mock_daytona
+
+        with patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}):
+            tools = DaytonaTools()
+
+            mock_check = MagicMock()
+            mock_check.result = "file"
+            mock_delete = MagicMock()
+            mock_delete.exit_code = 0
+
+            mock_process.exec.side_effect = [
+                mock_check,
+                mock_delete,
+            ]
+
+            path = "/home/daytona/name'; id;.txt"
+            result = tools.delete_file(mock_agent, "name'; id;.txt")
+
+            assert result == f"Deleted: {path}"
+            assert (
+                mock_process.exec.call_args_list[0].args[0]
+                == f"test -d {shlex.quote(path)} && echo 'directory' || echo 'file'"
+            )
+            assert mock_process.exec.call_args_list[1].args[0] == f"rm -f {shlex.quote(path)}"
+
     def test_change_directory(self, mock_daytona, mock_agent):
         """Test change_directory method."""
         mock_client, mock_sandbox, mock_process, _ = mock_daytona
@@ -258,6 +362,28 @@ class TestDaytonaTools:
 
             # Check that working directory was updated
             assert mock_agent.session_state["working_directory"] == "/home/test"
+
+    def test_change_directory_keeps_resolved_directory(self, mock_daytona, mock_agent):
+        """Test change_directory does not overwrite the verified sandbox path."""
+        mock_client, mock_sandbox, mock_process, _ = mock_daytona
+
+        with patch.dict("os.environ", {"DAYTONA_API_KEY": "test-key"}):
+            tools = DaytonaTools()
+
+            mock_pwd = MagicMock()
+            mock_pwd.result = "/home/daytona\n"
+            mock_test = MagicMock()
+            mock_test.result = "exists"
+
+            mock_process.exec.side_effect = [
+                mock_pwd,
+                mock_test,
+            ]
+
+            result = tools.change_directory(mock_agent, "subdir")
+
+            assert "Changed directory to: /home/daytona/subdir" in result
+            assert mock_agent.session_state["working_directory"] == "/home/daytona/subdir"
 
     def test_ssl_configuration(self):
         """Test SSL configuration."""


### PR DESCRIPTION
## Summary

Fixes #8288.

This PR quotes path-derived shell fragments in `DaytonaTools` before they are passed to Daytona's sandbox shell. It covers the internal file and directory helpers (`create_file`, `read_file`, `list_files`, `delete_file`) and the `cd` path checks in `run_shell_command`, so path metacharacters are treated as literal path text instead of shell syntax.

It also normalizes Daytona sandbox paths with POSIX semantics and removes the extra `change_directory` state write that could overwrite the verified sandbox working directory with the raw input path.

## Validation

From `libs/agno`:

- `.venv/bin/python -m pytest tests/unit/tools/test_daytona.py -q` -> 21 passed
- `.venv/bin/ruff format --check agno/tools/daytona.py tests/unit/tools/test_daytona.py`
- `.venv/bin/ruff check agno/tools/daytona.py tests/unit/tools/test_daytona.py`
- `git diff --check`

I also tried the documented `uv run --extra dev pytest tests/unit/tools/test_daytona.py -q`, but dependency resolution failed before running tests because the repo-level dev extras currently pull a `brave-search` package version whose metadata declares an invalid `httpx` specifier, while another extra requires a newer `httpx` range. The targeted checks above were run in the existing local `.venv` with the package installed editable.

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the patch and ran the validation commands listed above.
