### PR TITLE
fix: team hitl stale requirements

### DIFF
--- a/libs/agno/agno/team/_hooks.py
+++ b/libs/agno/agno/team/_hooks.py
@@ -85,6 +85,19 @@ def _member_approval_already_exists(run_response: TeamRunOutput) -> bool:
     )
 
 
+def _drop_resolved_requirements(run_response: TeamRunOutput) -> None:
+    """Strip resolved requirements before re-emitting a pause to clients.
+
+    On chained HITL flows (e.g. team-level tool resolved, then a member tool
+    pauses), the resolved requirements would otherwise still appear in the
+    re-paused output and cause clients to re-render an already-handled prompt.
+    Their resolved state remains visible in ``run_response.tools``.
+    """
+    if not run_response.requirements:
+        return
+    run_response.requirements = [req for req in run_response.requirements if not req.is_resolved()]
+
+
 def handle_team_run_paused(
     team: "Team",
     run_response: TeamRunOutput,
@@ -95,6 +108,9 @@ def handle_team_run_paused(
     from agno.team._run import _cleanup_and_store
 
     run_response.status = RunStatus.paused
+    # Strip any already-resolved requirements so clients don't re-render old prompts
+    # when this is a chained pause (e.g. team-level resolved, member tool now paused).
+    _drop_resolved_requirements(run_response)
     if not run_response.content:
         run_response.content = _get_team_paused_content(run_response)
 
@@ -132,6 +148,9 @@ def handle_team_run_paused_stream(
     from agno.team._run import _cleanup_and_store
 
     run_response.status = RunStatus.paused
+    # Strip any already-resolved requirements so clients don't re-render old prompts
+    # when this is a chained pause (e.g. team-level resolved, member tool now paused).
+    _drop_resolved_requirements(run_response)
     if not run_response.content:
         run_response.content = _get_team_paused_content(run_response)
 
@@ -169,6 +188,9 @@ async def ahandle_team_run_paused(
     from agno.team._run import _acleanup_and_store
 
     run_response.status = RunStatus.paused
+    # Strip any already-resolved requirements so clients don't re-render old prompts
+    # when this is a chained pause (e.g. team-level resolved, member tool now paused).
+    _drop_resolved_requirements(run_response)
     if not run_response.content:
         run_response.content = _get_team_paused_content(run_response)
 
@@ -204,6 +226,9 @@ async def ahandle_team_run_paused_stream(
     from agno.team._run import _acleanup_and_store
 
     run_response.status = RunStatus.paused
+    # Strip any already-resolved requirements so clients don't re-render old prompts
+    # when this is a chained pause (e.g. team-level resolved, member tool now paused).
+    _drop_resolved_requirements(run_response)
     if not run_response.content:
         run_response.content = _get_team_paused_content(run_response)
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5141,16 +5141,18 @@ def _route_requirements_to_members(
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
+    # Group requirements by (member_agent_id, member_run_id). The same member can have
+    # multiple paused child runs in one team run (batch delegation), and each child run
+    # must be resumed independently — grouping by agent_id alone would conflate them.
+    member_reqs: Dict[Tuple[str, Optional[str]], List[RunRequirement]] = {}
     for req in run_response.requirements or []:
         mid = getattr(req, "member_agent_id", None)
         if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+            member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
 
     member_results: List[str] = []
 
-    for member_id, reqs in member_reqs.items():
+    for (member_id, _member_run_id), reqs in member_reqs.items():
         route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
         if route_result is None:
             log_warning(f"Could not find member with ID {member_id} for continue_run routing")
@@ -5256,14 +5258,16 @@ def _route_requirements_to_members_stream(
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
+    # Group requirements by (member_agent_id, member_run_id). The same member can have
+    # multiple paused child runs in one team run (batch delegation), and each child run
+    # must be resumed independently — grouping by agent_id alone would conflate them.
+    member_reqs: Dict[Tuple[str, Optional[str]], List[RunRequirement]] = {}
     for req in run_response.requirements or []:
         mid = getattr(req, "member_agent_id", None)
         if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+            member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
 
-    for member_id, reqs in member_reqs.items():
+    for (member_id, _member_run_id), reqs in member_reqs.items():
         route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
         if route_result is None:
             log_warning(f"Could not find member with ID {member_id} for continue_run routing")
@@ -5379,12 +5383,14 @@ async def _aroute_requirements_to_members(
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
+    # Group requirements by (member_agent_id, member_run_id). The same member can have
+    # multiple paused child runs in one team run (batch delegation), and each child run
+    # must be resumed independently — grouping by agent_id alone would conflate them.
+    member_reqs: Dict[Tuple[str, Optional[str]], List[RunRequirement]] = {}
     for req in run_response.requirements or []:
         mid = getattr(req, "member_agent_id", None)
         if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+            member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
 
     if not member_reqs:
         return []
@@ -5459,7 +5465,7 @@ async def _aroute_requirements_to_members(
             content = getattr(member_response, "content", None) or "Task completed"
             return f"[{member.name or member_id}]: {content}"
 
-    tasks = [_continue_member(mid, reqs) for mid, reqs in member_reqs.items()]
+    tasks = [_continue_member(agent_id, reqs) for (agent_id, _member_run_id), reqs in member_reqs.items()]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
     member_results: List[str] = []
@@ -5499,14 +5505,16 @@ async def _aroute_requirements_to_members_stream(
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
-    # Group requirements by member
-    member_reqs: Dict[str, List[RunRequirement]] = {}
+    # Group requirements by (member_agent_id, member_run_id). The same member can have
+    # multiple paused child runs in one team run (batch delegation), and each child run
+    # must be resumed independently — grouping by agent_id alone would conflate them.
+    member_reqs: Dict[Tuple[str, Optional[str]], List[RunRequirement]] = {}
     for req in run_response.requirements or []:
         mid = getattr(req, "member_agent_id", None)
         if mid is not None:
-            member_reqs.setdefault(mid, []).append(req)
+            member_reqs.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
 
-    for member_id, reqs in member_reqs.items():
+    for (member_id, _member_run_id), reqs in member_reqs.items():
         route_result = _find_member_route_by_id(team, member_id, run_context=run_context)
         if route_result is None:
             log_warning(f"Could not find member with ID {member_id} for continue_run routing")
@@ -5994,6 +6002,12 @@ def continue_run_dispatch(
             run_context=run_context,
         )
 
+        # Mixed case: when we resolved member HITL alongside team-level HITL, replace the
+        # "Member 'X' requires human input before continuing" placeholder with the actual
+        # member results so the team model sees the real outcome.
+        if member_results:
+            _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+
         # Handle tool call updates (execute confirmed tools, etc.)
         _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
 
@@ -6216,6 +6230,11 @@ def _continue_run_dispatch_stream_with_member_events(
             add_history_to_context=team.add_history_to_context,
             run_context=run_context,
         )
+
+        # Mixed case: when we resolved member HITL alongside team-level HITL, replace the
+        # delegation placeholder with the actual member results.
+        if member_results:
+            _prepare_member_hitl_continuation(run_response, run_messages, member_results)
 
         _handle_team_tool_call_updates(team, run_response=run_response, run_messages=run_messages, tools=_tools)
 
@@ -7236,6 +7255,11 @@ async def _acontinue_run(
                         run_context=run_context,
                     )
 
+                    # Mixed case: when we resolved member HITL alongside team-level HITL,
+                    # replace the delegation placeholder with the actual member results.
+                    if member_results:
+                        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+
                     await _ahandle_team_tool_call_updates(
                         team, run_response=run_response, run_messages=run_messages, tools=_tools
                     )
@@ -7603,6 +7627,11 @@ async def _acontinue_run_stream(
                         add_history_to_context=team.add_history_to_context,
                         run_context=run_context,
                     )
+
+                    # Mixed case: when we resolved member HITL alongside team-level HITL,
+                    # replace the delegation placeholder with the actual member results.
+                    if member_results:
+                        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
 
                     run_response.status = RunStatus.running
                     run_response.content = None

--- a/libs/agno/tests/unit/team/test_hitl_repause_and_routing.py
+++ b/libs/agno/tests/unit/team/test_hitl_repause_and_routing.py
@@ -1,0 +1,140 @@
+"""Regression tests for #7864:
+1. Resolved requirements should not be re-emitted to clients on chained pauses.
+2. Requirement routing must distinguish child runs by (member_agent_id, member_run_id),
+   not only by member_agent_id, so batch delegations to the same member resume each
+   paused child run independently.
+"""
+
+from typing import Dict, List, Optional, Tuple
+from unittest.mock import MagicMock
+
+from agno.models.response import ToolExecution
+from agno.run.requirement import RunRequirement
+from agno.team._hooks import _drop_resolved_requirements
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_te(tool_name: str, **overrides) -> ToolExecution:
+    defaults: Dict = {"tool_name": tool_name, "tool_args": {}}
+    defaults.update(overrides)
+    return ToolExecution(**defaults)
+
+
+def _resolved_req(tool_name: str, member_agent_id: Optional[str] = None) -> RunRequirement:
+    # A confirmed-true tool execution -> requirement.is_resolved() == True
+    req = RunRequirement(tool_execution=_make_te(tool_name, requires_confirmation=True, confirmed=True))
+    if member_agent_id is not None:
+        req.member_agent_id = member_agent_id
+    return req
+
+
+def _unresolved_req(tool_name: str, member_agent_id: Optional[str] = None) -> RunRequirement:
+    req = RunRequirement(tool_execution=_make_te(tool_name, requires_confirmation=True, confirmed=None))
+    if member_agent_id is not None:
+        req.member_agent_id = member_agent_id
+    return req
+
+
+# ===========================================================================
+# Fix #2: _drop_resolved_requirements
+# ===========================================================================
+
+
+class TestDropResolvedRequirements:
+    """The hook helper that strips resolved entries before re-pausing."""
+
+    def test_drops_resolved_keeps_unresolved(self):
+        run = MagicMock()
+        run.requirements = [
+            _resolved_req("collect_team_input"),
+            _unresolved_req("collect_member_input", member_agent_id="agent-1"),
+        ]
+
+        _drop_resolved_requirements(run)
+
+        assert len(run.requirements) == 1
+        assert run.requirements[0].tool_execution.tool_name == "collect_member_input"
+
+    def test_noop_when_no_requirements(self):
+        run = MagicMock()
+        run.requirements = None
+        _drop_resolved_requirements(run)
+        assert run.requirements is None
+
+    def test_drops_all_when_all_resolved(self):
+        run = MagicMock()
+        run.requirements = [
+            _resolved_req("a"),
+            _resolved_req("b"),
+        ]
+        _drop_resolved_requirements(run)
+        assert run.requirements == []
+
+    def test_keeps_all_when_none_resolved(self):
+        run = MagicMock()
+        reqs = [_unresolved_req("a"), _unresolved_req("b")]
+        run.requirements = reqs
+        _drop_resolved_requirements(run)
+        assert run.requirements == reqs
+
+
+# ===========================================================================
+# Fix #3: routing groups by (member_agent_id, member_run_id)
+# ===========================================================================
+
+
+class TestRoutingGroupKey:
+    """Validates the grouping key used by _route_requirements_to_members and friends.
+
+    We don't invoke the routing functions directly (they call member.continue_run);
+    we exercise the grouping logic the same way they do to guarantee that two
+    paused child runs of the same member each get their own bucket.
+    """
+
+    @staticmethod
+    def _group_by_member(reqs: List[RunRequirement]) -> Dict[Tuple[str, Optional[str]], List[RunRequirement]]:
+        # Mirror the production grouping in _route_requirements_to_members*.
+        out: Dict[Tuple[str, Optional[str]], List[RunRequirement]] = {}
+        for req in reqs:
+            mid = getattr(req, "member_agent_id", None)
+            if mid is not None:
+                out.setdefault((mid, getattr(req, "member_run_id", None)), []).append(req)
+        return out
+
+    def test_same_agent_two_paused_runs_get_separate_buckets(self):
+        req_a = _unresolved_req("archive_item", member_agent_id="agent-1")
+        req_a.member_run_id = "child-run-A"
+        req_b = _unresolved_req("archive_item", member_agent_id="agent-1")
+        req_b.member_run_id = "child-run-B"
+
+        groups = self._group_by_member([req_a, req_b])
+
+        assert len(groups) == 2
+        assert groups[("agent-1", "child-run-A")] == [req_a]
+        assert groups[("agent-1", "child-run-B")] == [req_b]
+
+    def test_same_agent_same_run_id_groups_together(self):
+        """Multiple requirements for the same child run remain together."""
+        req_a = _unresolved_req("archive_item", member_agent_id="agent-1")
+        req_a.member_run_id = "child-run-A"
+        req_b = _unresolved_req("delete_item", member_agent_id="agent-1")
+        req_b.member_run_id = "child-run-A"
+
+        groups = self._group_by_member([req_a, req_b])
+
+        assert len(groups) == 1
+        assert groups[("agent-1", "child-run-A")] == [req_a, req_b]
+
+    def test_different_agents_get_separate_buckets(self):
+        req_a = _unresolved_req("do_a", member_agent_id="agent-1")
+        req_a.member_run_id = "child-A"
+        req_b = _unresolved_req("do_b", member_agent_id="agent-2")
+        req_b.member_run_id = "child-B"
+
+        groups = self._group_by_member([req_a, req_b])
+
+        assert len(groups) == 2


### PR DESCRIPTION
## Summary

- Member result lost behind delegation placeholder. When a team had its own HITL tool resolved AND delegated to a member whose tool also paused, the team-level continuation branch never replaced the "Member 'X' requires human input before continuing." placeholder with the real member result. The team model then echoed the placeholder back as the member's answer.

- Resolved requirements re-emitted on chained pause. On the second pause, run_response.requirements still contained the already-resolved team-level requirement, causing clients to re-render an old prompt.

- Routing collapsed batch delegations. Requirements were grouped only by member_agent_id, so when the same member had multiple paused child runs (batch delegation), they shared a bucket and only one was resumed correctly.

(If applicable, issue number: https://github.com/agno-agi/agno/issues/7864)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
