### PR TITLE
[fix] Guard PostgresDb table cache creation

### DIFF
--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1,5 +1,6 @@
 import time
 from datetime import date, datetime, timedelta, timezone
+from threading import RLock
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
 from uuid import uuid4
 
@@ -160,6 +161,7 @@ class PostgresDb(BaseDb):
         self.db_schema: str = db_schema if db_schema is not None else "ai"
         self.metadata: MetaData = MetaData(schema=self.db_schema)
         self.create_schema: bool = create_schema
+        self._table_lock = RLock()
 
         # Initialize database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine, expire_on_commit=False))
@@ -449,139 +451,168 @@ class PostgresDb(BaseDb):
         }
         return table_map.get(logical_name, logical_name)
 
+    def _get_cached_table(self, table_type: str) -> Optional[Table]:
+        table_attr_map = {
+            "sessions": "session_table",
+            "memories": "memory_table",
+            "metrics": "metrics_table",
+            "evals": "eval_table",
+            "knowledge": "knowledge_table",
+            "culture": "culture_table",
+            "versions": "versions_table",
+            "traces": "traces_table",
+            "spans": "spans_table",
+            "components": "component_table",
+            "component_configs": "component_configs_table",
+            "component_links": "component_links_table",
+            "learnings": "learnings_table",
+            "schedules": "schedules_table",
+            "schedule_runs": "schedule_runs_table",
+            "approvals": "approvals_table",
+        }
+        table_attr = table_attr_map.get(table_type)
+        if table_attr is None:
+            return None
+        return getattr(self, table_attr, None)
+
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
-        if table_type == "sessions":
-            self.session_table = self._get_or_create_table(
-                table_name=self.session_table_name,
-                table_type="sessions",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.session_table
+        with self._table_lock:
+            cached_table = self._get_cached_table(table_type)
+            if cached_table is not None:
+                return cached_table
 
-        if table_type == "memories":
-            self.memory_table = self._get_or_create_table(
-                table_name=self.memory_table_name,
-                table_type="memories",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.memory_table
+            if table_type == "sessions":
+                self.session_table = self._get_or_create_table(
+                    table_name=self.session_table_name,
+                    table_type="sessions",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.session_table
 
-        if table_type == "metrics":
-            self.metrics_table = self._get_or_create_table(
-                table_name=self.metrics_table_name,
-                table_type="metrics",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.metrics_table
+            if table_type == "memories":
+                self.memory_table = self._get_or_create_table(
+                    table_name=self.memory_table_name,
+                    table_type="memories",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.memory_table
 
-        if table_type == "evals":
-            self.eval_table = self._get_or_create_table(
-                table_name=self.eval_table_name,
-                table_type="evals",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.eval_table
+            if table_type == "metrics":
+                self.metrics_table = self._get_or_create_table(
+                    table_name=self.metrics_table_name,
+                    table_type="metrics",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.metrics_table
 
-        if table_type == "knowledge":
-            self.knowledge_table = self._get_or_create_table(
-                table_name=self.knowledge_table_name,
-                table_type="knowledge",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.knowledge_table
+            if table_type == "evals":
+                self.eval_table = self._get_or_create_table(
+                    table_name=self.eval_table_name,
+                    table_type="evals",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.eval_table
 
-        if table_type == "culture":
-            self.culture_table = self._get_or_create_table(
-                table_name=self.culture_table_name,
-                table_type="culture",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.culture_table
+            if table_type == "knowledge":
+                self.knowledge_table = self._get_or_create_table(
+                    table_name=self.knowledge_table_name,
+                    table_type="knowledge",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.knowledge_table
 
-        if table_type == "versions":
-            self.versions_table = self._get_or_create_table(
-                table_name=self.versions_table_name,
-                table_type="versions",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.versions_table
+            if table_type == "culture":
+                self.culture_table = self._get_or_create_table(
+                    table_name=self.culture_table_name,
+                    table_type="culture",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.culture_table
 
-        if table_type == "traces":
-            self.traces_table = self._get_or_create_table(
-                table_name=self.trace_table_name,
-                table_type="traces",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.traces_table
+            if table_type == "versions":
+                self.versions_table = self._get_or_create_table(
+                    table_name=self.versions_table_name,
+                    table_type="versions",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.versions_table
 
-        if table_type == "spans":
-            # Ensure traces table exists first (spans has FK to traces)
-            if create_table_if_not_found:
-                self._get_table(table_type="traces", create_table_if_not_found=True)
+            if table_type == "traces":
+                self.traces_table = self._get_or_create_table(
+                    table_name=self.trace_table_name,
+                    table_type="traces",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.traces_table
 
-            self.spans_table = self._get_or_create_table(
-                table_name=self.span_table_name,
-                table_type="spans",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.spans_table
+            if table_type == "spans":
+                # Ensure traces table exists first (spans has FK to traces)
+                if create_table_if_not_found:
+                    self._get_table(table_type="traces", create_table_if_not_found=True)
 
-        if table_type == "components":
-            self.component_table = self._get_or_create_table(
-                table_name=self.components_table_name,
-                table_type="components",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.component_table
+                self.spans_table = self._get_or_create_table(
+                    table_name=self.span_table_name,
+                    table_type="spans",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.spans_table
 
-        if table_type == "component_configs":
-            self.component_configs_table = self._get_or_create_table(
-                table_name=self.component_configs_table_name,
-                table_type="component_configs",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.component_configs_table
+            if table_type == "components":
+                self.component_table = self._get_or_create_table(
+                    table_name=self.components_table_name,
+                    table_type="components",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.component_table
 
-        if table_type == "component_links":
-            self.component_links_table = self._get_or_create_table(
-                table_name=self.component_links_table_name,
-                table_type="component_links",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.component_links_table
-        if table_type == "learnings":
-            self.learnings_table = self._get_or_create_table(
-                table_name=self.learnings_table_name,
-                table_type="learnings",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.learnings_table
+            if table_type == "component_configs":
+                self.component_configs_table = self._get_or_create_table(
+                    table_name=self.component_configs_table_name,
+                    table_type="component_configs",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.component_configs_table
 
-        if table_type == "schedules":
-            self.schedules_table = self._get_or_create_table(
-                table_name=self.schedules_table_name,
-                table_type="schedules",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.schedules_table
+            if table_type == "component_links":
+                self.component_links_table = self._get_or_create_table(
+                    table_name=self.component_links_table_name,
+                    table_type="component_links",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.component_links_table
+            if table_type == "learnings":
+                self.learnings_table = self._get_or_create_table(
+                    table_name=self.learnings_table_name,
+                    table_type="learnings",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.learnings_table
 
-        if table_type == "schedule_runs":
-            self.schedule_runs_table = self._get_or_create_table(
-                table_name=self.schedule_runs_table_name,
-                table_type="schedule_runs",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.schedule_runs_table
+            if table_type == "schedules":
+                self.schedules_table = self._get_or_create_table(
+                    table_name=self.schedules_table_name,
+                    table_type="schedules",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.schedules_table
 
-        if table_type == "approvals":
-            self.approvals_table = self._get_or_create_table(
-                table_name=self.approvals_table_name,
-                table_type="approvals",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.approvals_table
+            if table_type == "schedule_runs":
+                self.schedule_runs_table = self._get_or_create_table(
+                    table_name=self.schedule_runs_table_name,
+                    table_type="schedule_runs",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.schedule_runs_table
 
-        raise ValueError(f"Unknown table type: {table_type}")
+            if table_type == "approvals":
+                self.approvals_table = self._get_or_create_table(
+                    table_name=self.approvals_table_name,
+                    table_type="approvals",
+                    create_table_if_not_found=create_table_if_not_found,
+                )
+                return self.approvals_table
+
+            raise ValueError(f"Unknown table type: {table_type}")
 
     def _get_or_create_table(
         self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False

--- a/libs/agno/tests/unit/db/test_postgres.py
+++ b/libs/agno/tests/unit/db/test_postgres.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -256,6 +258,43 @@ def test_get_table_sessions(postgres_db):
 
     assert table == mock_table
     assert hasattr(postgres_db, "session_table")
+
+
+def test_get_table_uses_cached_table_for_concurrent_first_access(postgres_db):
+    """Concurrent first access should materialize a table only once."""
+    table = Mock(spec=Table)
+    start = threading.Barrier(3)
+    errors = []
+    results = []
+
+    def slow_get_or_create(*args, **kwargs):
+        time.sleep(0.05)
+        return table
+
+    def get_table():
+        try:
+            start.wait(timeout=1)
+            results.append(postgres_db._get_table("evals", create_table_if_not_found=True))
+        except Exception as exc:
+            errors.append(exc)
+
+    with patch.object(postgres_db, "_get_or_create_table", side_effect=slow_get_or_create) as mock_get_or_create:
+        threads = [threading.Thread(target=get_table) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+
+        start.wait(timeout=1)
+
+        for thread in threads:
+            thread.join(timeout=1)
+
+    assert errors == []
+    assert results == [table, table]
+    mock_get_or_create.assert_called_once_with(
+        table_name=postgres_db.eval_table_name,
+        table_type="evals",
+        create_table_if_not_found=True,
+    )
 
 
 def test_get_table_memories(postgres_db):


### PR DESCRIPTION
## Summary

Fixes #8196.

`PostgresDb._get_table()` now serializes the lazy table materialization path with an instance-level `RLock` and returns an already-cached table when another thread has just created or reflected it. This preserves the existing lazy behavior while preventing concurrent first callers from mutating the shared SQLAlchemy `MetaData` cache at the same time.

Added a unit regression test that runs two threads through the first `evals` table lookup and asserts `_get_or_create_table()` is only invoked once.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed locally:

- `PYTHONPATH=/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/agno-postgres-lock/libs/agno .venv/bin/python -m pytest tests/unit/db/test_postgres.py -q` -> 28 passed
- `.venv/bin/ruff check agno/db/postgres/postgres.py tests/unit/db/test_postgres.py` -> passed
- `.venv/bin/ruff format --check agno/db/postgres/postgres.py tests/unit/db/test_postgres.py` -> passed
- `git diff --check` -> passed

I did not run the full `./scripts/format.sh` / `./scripts/validate.sh` suite. A fresh `uv run pytest ...` attempted to resolve all extras and failed before test execution because the current optional dependency set has an `agno[a2a]` vs `agno[brave]` `httpx` constraint conflict involving `brave-search` metadata. I installed only the base/runtime dependencies needed for this targeted unit file and ran the checks above.

This PR was AI-assisted and then self-reviewed against the issue repro and the existing `PostgresDb` lazy table cache pattern.
