### PR TITLE
[fix] Accept string PII custom patterns

### DIFF
--- a/libs/agno/agno/guardrails/pii.py
+++ b/libs/agno/agno/guardrails/pii.py
@@ -26,7 +26,7 @@ class PIIDetectionGuardrail(BaseGuardrail):
         enable_credit_card_check: bool = True,
         enable_email_check: bool = True,
         enable_phone_check: bool = True,
-        custom_patterns: Optional[Dict[str, Pattern[str]]] = None,
+        custom_patterns: Optional[Dict[str, Union[Pattern[str], str]]] = None,
     ):
         import re
 
@@ -43,7 +43,12 @@ class PIIDetectionGuardrail(BaseGuardrail):
             self.pii_patterns["Phone"] = re.compile(r"\b\d{3}[\s.-]?\d{3}[\s.-]?\d{4}\b")
 
         if custom_patterns:
-            self.pii_patterns.update(custom_patterns)
+            self.pii_patterns.update(
+                {
+                    pii_type: re.compile(pattern) if isinstance(pattern, str) else pattern
+                    for pii_type, pattern in custom_patterns.items()
+                }
+            )
 
     def check(self, run_input: Union[RunInput, TeamRunInput]) -> None:
         """Check for PII patterns in the input."""

--- a/libs/agno/tests/unit/agent/test_hooks_guardrails.py
+++ b/libs/agno/tests/unit/agent/test_hooks_guardrails.py
@@ -538,3 +538,20 @@ class TestPIIGuardrailTypeSafety:
         run_input = RunInput(input_content="Contact user@example.com")
         with pytest.raises(InputCheckError, match="Potential PII detected"):
             guardrail.check(run_input)
+
+    def test_custom_pii_patterns_accept_raw_regex_strings(self):
+        from agno.guardrails.pii import PIIDetectionGuardrail
+
+        guardrail = PIIDetectionGuardrail(
+            enable_ssn_check=False,
+            enable_credit_card_check=False,
+            enable_email_check=False,
+            enable_phone_check=False,
+            custom_patterns={"Bank Account": r"\b\d{10}\b"},
+        )
+        run_input = RunInput(input_content="Bank account 1234567890")
+
+        with pytest.raises(InputCheckError) as exc_info:
+            guardrail.check(run_input)
+
+        assert exc_info.value.additional_data == {"detected_pii": ["Bank Account"]}


### PR DESCRIPTION
## Summary

Fixes #7770.

`PIIDetectionGuardrail` documented `custom_patterns` as custom PII patterns, but the implementation stored raw values directly and later called `pattern.search(...)`. Passing a raw regex string therefore raised `AttributeError: 'str' object has no attribute 'search'`.

This PR compiles string custom patterns during initialization while preserving already-compiled regex patterns. It also adds a regression test covering raw regex strings.

(If applicable, issue number: #7770)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run:

- Reproduced the original `AttributeError` locally before the fix.
- Verified the same raw string pattern now raises `InputCheckError` with `detected_pii: ["Bank Account"]`.
- `python -m pytest libs/agno/tests/unit/agent/test_hooks_guardrails.py::TestPIIGuardrailTypeSafety::test_custom_pii_patterns_accept_raw_regex_strings -q`
- `python -m ruff check libs/agno/agno/guardrails/pii.py libs/agno/tests/unit/agent/test_hooks_guardrails.py`
- `python -m ruff format --check libs/agno/agno/guardrails/pii.py libs/agno/tests/unit/agent/test_hooks_guardrails.py`

I could not run the full repository `./scripts/format.sh` / `./scripts/validate.sh` in this fresh worktree because dependency resolution failed before tests due to invalid `brave-search==0.2.0` metadata in the configured package index. The targeted formatting, linting, and regression test above passed using an existing Agno development virtualenv.
