### PR TITLE
feat: surface learnings domain in AgentOS config

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -29,6 +29,8 @@ from agno.os.config import (
     KnowledgeDatabaseConfig,
     KnowledgeDomainConfig,
     KnowledgeInstanceConfig,
+    LearningConfig,
+    LearningDomainConfig,
     MemoryConfig,
     MemoryDomainConfig,
     MetricsConfig,
@@ -1285,6 +1287,7 @@ class AgentOS:
             "session_table_name": db.session_table_name,
             "culture_table_name": db.culture_table_name,
             "memory_table_name": db.memory_table_name,
+            "learnings_table_name": db.learnings_table_name,
             "metrics_table_name": db.metrics_table_name,
             "evals_table_name": db.eval_table_name,
             "knowledge_table_name": db.knowledge_table_name,
@@ -1427,6 +1430,28 @@ class AgentOS:
                 )
 
         return memory_config
+
+    def _get_learning_config(self) -> LearningConfig:
+        learning_config = self.config.learning if self.config and self.config.learning else LearningConfig()
+
+        if learning_config.dbs is None:
+            learning_config.dbs = []
+
+        dbs_with_specific_config = [db.db_id for db in learning_config.dbs]
+
+        for db_id, dbs in self.dbs.items():
+            if db_id not in dbs_with_specific_config:
+                # Collect unique table names from all databases with the same id
+                unique_tables = list(set(db.learnings_table_name for db in dbs))
+                learning_config.dbs.append(
+                    DatabaseConfig(
+                        db_id=db_id,
+                        domain_config=LearningDomainConfig(display_name=db_id),
+                        tables=unique_tables,
+                    )
+                )
+
+        return learning_config
 
     def _get_knowledge_config(self) -> KnowledgeConfig:
         knowledge_config = self.config.knowledge if self.config and self.config.knowledge else KnowledgeConfig()

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -66,6 +66,12 @@ class MemoryDomainConfig(BaseModel):
     display_name: Optional[str] = None
 
 
+class LearningDomainConfig(BaseModel):
+    """Configuration for the Learning domain of the AgentOS"""
+
+    display_name: Optional[str] = None
+
+
 class TracesDomainConfig(BaseModel):
     """Configuration for the Traces domain of the AgentOS"""
 
@@ -99,6 +105,12 @@ class MemoryConfig(MemoryDomainConfig):
     """Configuration for the Memory domain of the AgentOS"""
 
     dbs: Optional[List[DatabaseConfig[MemoryDomainConfig]]] = None
+
+
+class LearningConfig(LearningDomainConfig):
+    """Configuration for the Learning domain of the AgentOS"""
+
+    dbs: Optional[List[DatabaseConfig[LearningDomainConfig]]] = None
 
 
 class KnowledgeDatabaseConfig(BaseModel):
@@ -179,6 +191,7 @@ class AgentOSConfig(BaseModel):
     evals: Optional[EvalsConfig] = None
     knowledge: Optional[KnowledgeConfig] = None
     memory: Optional[MemoryConfig] = None
+    learning: Optional[LearningConfig] = None
     session: Optional[SessionConfig] = None
     metrics: Optional[MetricsConfig] = None
     traces: Optional[TracesConfig] = None

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -178,6 +178,7 @@ def get_base_router(
             manifest=os.config.manifest if os.config else None,
             session=os._get_session_config(),
             memory=os._get_memory_config(),
+            learning=os._get_learning_config(),
             knowledge=os._get_knowledge_config(),
             evals=os._get_evals_config(),
             metrics=os._get_metrics_config(),

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -14,6 +14,7 @@ from agno.os.config import (
     ChatConfig,
     EvalsConfig,
     KnowledgeConfig,
+    LearningConfig,
     Manifest,
     MemoryConfig,
     MetricsConfig,
@@ -251,6 +252,7 @@ class ConfigResponse(BaseModel):
     session: Optional[SessionConfig] = Field(None, description="Session configuration")
     metrics: Optional[MetricsConfig] = Field(None, description="Metrics configuration")
     memory: Optional[MemoryConfig] = Field(None, description="Memory configuration")
+    learning: Optional[LearningConfig] = Field(None, description="Learning configuration")
     knowledge: Optional[KnowledgeConfig] = Field(None, description="Knowledge configuration")
     evals: Optional[EvalsConfig] = Field(None, description="Evaluations configuration")
     traces: Optional[TracesConfig] = Field(None, description="Traces configuration")

--- a/libs/agno/tests/integration/os/test_built_in_endpoints.py
+++ b/libs/agno/tests/integration/os/test_built_in_endpoints.py
@@ -124,6 +124,7 @@ def test_config_endpoint_with_databases(test_os_client_with_dbs: TestClient):
     assert response_data["session"]["dbs"]
     assert response_data["metrics"]["dbs"]
     assert response_data["memory"]["dbs"]
+    assert response_data["learning"]["dbs"]
     assert response_data["evals"]["dbs"]
 
 
@@ -141,6 +142,31 @@ def test_config_endpoint_with_databases_with_multiple_tables(test_os_client_with
     assert response_data["session"]["dbs"][1]["tables"] == ["team_sessions"]
     assert response_data["session"]["dbs"][2]["db_id"] == "workflow-test-db"
     assert response_data["session"]["dbs"][2]["tables"] == ["workflow_sessions"]
+
+
+def test_config_endpoint_exposes_learnings_tables():
+    """Test that the config endpoint reports the learnings domain with its configured table names."""
+    agent = Agent(
+        name="test-agent-with-db",
+        db=SqliteDb(
+            "tmp/test.db", id="agent-test-db", session_table="agent_sessions", learnings_table="agent_learnings"
+        ),
+    )
+    agent_os = AgentOS(
+        id="test-os-learnings",
+        name="Test AgentOS with Learnings",
+        agents=[agent],
+    )
+    client = TestClient(agent_os.get_app())
+
+    response = client.get("/config")
+    assert response.status_code == 200
+
+    response_data = response.json()
+    assert "learning" in response_data
+    assert response_data["learning"]["dbs"]
+    learning_db = next(db for db in response_data["learning"]["dbs"] if db["db_id"] == "agent-test-db")
+    assert learning_db["tables"] == ["agent_learnings"]
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Surfaces the **Learning** domain through the AgentOS `/config` endpoint, so the control plane / UI can discover the databases and tables backing learnings — the same way it already does for `memory`, `knowledge`, `traces`, `metrics`, `session`, and `evals`.

This builds on the learnings CRUD work in #7826. Without this, the learnings endpoints exist but the `/config` payload never reports the learning domain, so a client has no way to discover which db/table to use.

It also closes an adjacent gap: `AgentOS._get_db_table_names()` listed every domain's table name **except** `learnings_table_name`.

### Changes

- Add `LearningDomainConfig` / `LearningConfig` and wire `learning` into `AgentOSConfig` and `ConfigResponse`.
- Add `AgentOS._get_learning_config()`, an exact mirror of `_get_memory_config()`.
- Include `learnings_table_name` in `AgentOS._get_db_table_names()`.
- Tests: assert the learning domain is reported on `/config`, including configured table names.

### Relationship to #8212

This **supersedes #8212** (`feat: add configuration for Learning domain in AgentOS`). That PR had merge conflicts in `schema.py` after the base branch picked up the `manifest` field. This PR re-applies the same config plumbing cleanly on top of the current base **and** adds the missing `_get_db_table_names` entry plus tests. #8212 can be closed in favor of this one.

(Issue number: N/A — follow-up to #7826)

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach (see "Relationship to #8212")
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Targets `feat/learnings-crud-endpoints` (not `main`), since it depends on the learnings table/CRUD infrastructure from #7826 that has not yet merged to `main`. Non-breaking: `learning` is a new optional field and `get_learnings` / existing config are untouched.
