### PR TITLE
refactor: drop stale Phase 2 labels from decision logs

### DIFF
--- a/libs/agno/agno/learn/__init__.py
+++ b/libs/agno/agno/learn/__init__.py
@@ -51,14 +51,14 @@ __all__ = [
     "EntityMemoryConfig",
     "SessionContextConfig",
     "LearnedKnowledgeConfig",
-    "DecisionLogConfig",  # Phase 2
+    "DecisionLogConfig",
     # Schemas
     "UserProfile",
     "Memories",
     "EntityMemory",
     "SessionContext",
     "LearnedKnowledge",
-    "DecisionLog",  # Phase 2
+    "DecisionLog",
     # Stores
     "LearningStore",
     "UserProfileStore",
@@ -67,5 +67,5 @@ __all__ = [
     "SessionContextStore",
     "LearnedKnowledgeStore",
     "EntityMemoryStore",
-    "DecisionLogStore",  # Phase 2
+    "DecisionLogStore",
 ]

--- a/libs/agno/agno/learn/config.py
+++ b/libs/agno/agno/learn/config.py
@@ -371,7 +371,7 @@ class EntityMemoryConfig:
 
 
 # =============================================================================
-# Phase 2 Configurations (Placeholders)
+# Decision Log Configuration
 # =============================================================================
 
 
@@ -383,8 +383,6 @@ class DecisionLogConfig:
     and context. Useful for auditing and learning from past decisions.
 
     Scope: AGENT (fixed) - Stored and retrieved by agent_id.
-
-    Note: Deferred to Phase 2.
     """
 
     # Required fields
@@ -407,6 +405,11 @@ class DecisionLogConfig:
 
     def __repr__(self) -> str:
         return f"DecisionLogConfig(mode={self.mode.value})"
+
+
+# =============================================================================
+# Placeholder Configurations (Not yet implemented)
+# =============================================================================
 
 
 @dataclass

--- a/libs/agno/agno/learn/machine.py
+++ b/libs/agno/agno/learn/machine.py
@@ -82,7 +82,7 @@ class LearningMachine:
     session_context: SessionContextInput = False
     entity_memory: EntityMemoryInput = False
     learned_knowledge: LearnedKnowledgeInput = False
-    decision_log: DecisionLogInput = False  # Phase 2
+    decision_log: DecisionLogInput = False
 
     # Namespace for entity_memory and learned_knowledge
     namespace: str = "global"
@@ -147,7 +147,7 @@ class LearningMachine:
                 store_type="learned_knowledge",
             )
 
-        # Decision Log (Phase 2)
+        # Decision Log
         if self.decision_log:
             self._stores["decision_log"] = self._resolve_store(
                 input_value=self.decision_log,

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -27,7 +27,7 @@ Schemas:
 - SessionContext: Current session state
 - LearnedKnowledge: Reusable knowledge/insights
 - EntityMemory: Third-party entity facts
-- Decision: Decision logs (Phase 2)
+- DecisionLog: Decision logs
 - Feedback: Behavioral feedback (Phase 2)
 - InstructionUpdate: Self-improvement (Phase 3)
 """
@@ -888,7 +888,7 @@ class SessionPlanningExtractionResponse:
 
 
 # =============================================================================
-# Phase 2 Schemas (Placeholders)
+# Decision Log Schema
 # =============================================================================
 
 
@@ -1011,6 +1011,11 @@ class DecisionLog:
 
 # Backwards compatibility alias
 Decision = DecisionLog
+
+
+# =============================================================================
+# Placeholder Schemas (Not yet implemented)
+# =============================================================================
 
 
 @dataclass

--- a/libs/agno/agno/learn/stores/__init__.py
+++ b/libs/agno/agno/learn/stores/__init__.py
@@ -15,7 +15,7 @@ Available Stores:
 - SessionContextStore: Current session state
 - LearnedKnowledgeStore: Reusable knowledge/insights
 - EntityMemoryStore: Third-party entity facts
-- DecisionLogStore: Agent decision logging (Phase 2)
+- DecisionLogStore: Agent decision logging
 """
 
 from agno.learn.stores.decision_log import DecisionLogStore


### PR DESCRIPTION
## Summary

Decision logs in the learning module (`libs/agno/agno/learn/`) are fully implemented, but several comments and docstrings still labeled them as "Phase 2" / placeholders, which is now inaccurate. The feature ships with:

- `DecisionLog` schema (`schemas.py`) with full `from_dict`/`to_dict`/`to_text`
- `DecisionLogConfig` (`config.py`)
- `DecisionLogStore` (`stores/decision_log.py`) supporting both `ALWAYS` (auto-extraction) and `AGENTIC` (explicit logging) modes, agent tools (`log_decision`, `search_decisions`, `record_outcome`), and full async variants
- `LearningMachine` integration (`machine.py`)
- Public exports in `learn/__init__.py` and `stores/__init__.py`
- Cookbook examples under `cookbook/08_learning/09_decision_logs/` and `cookbook/03_teams/12_learning/`

This PR removes the stale "Phase 2" labels associated with decision logs across the module:

- `schemas.py`: section header `Phase 2 Schemas (Placeholders)` -> `Decision Log Schema`; module docstring line updated; introduced a dedicated `Placeholder Schemas (Not yet implemented)` header for the still-unimplemented `Feedback`
- `config.py`: section header `Phase 2 Configurations (Placeholders)` -> `Decision Log Configuration`; removed `Note: Deferred to Phase 2.` from `DecisionLogConfig`; introduced a `Placeholder Configurations` header for `FeedbackConfig`
- `machine.py`: removed `# Phase 2` comments on the `decision_log` field and store init
- `learn/__init__.py` and `stores/__init__.py`: removed `# Phase 2` / `(Phase 2)` annotations

The `Phase 2` label is intentionally retained on `Feedback` / `FeedbackConfig`, which are genuine placeholders, and `Phase 3` on `InstructionUpdate`.

## Type of change

- [x] Improvement
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Comment/docstring-only changes; no behavior changes. `mypy` and `ruff` both pass.
