### PR TITLE
fix: include learnings config in MCP AgentOS config

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -85,6 +85,7 @@ def get_mcp_server(
             manifest=os.config.manifest if os.config else None,
             session=os._get_session_config(),
             memory=os._get_memory_config(),
+            learning=os._get_learning_config(),
             knowledge=os._get_knowledge_config(),
             evals=os._get_evals_config(),
             metrics=os._get_metrics_config(),

--- a/libs/agno/agno/remote/base.py
+++ b/libs/agno/agno/remote/base.py
@@ -50,6 +50,7 @@ class RemoteDb:
     session_table_name: Optional[str] = None
     knowledge_table_name: Optional[str] = None
     memory_table_name: Optional[str] = None
+    learnings_table_name: Optional[str] = None
     metrics_table_name: Optional[str] = None
     eval_table_name: Optional[str] = None
     traces_table_name: Optional[str] = None
@@ -77,6 +78,7 @@ class RemoteDb:
         session_table_name = None
         knowledge_table_name = None
         memory_table_name = None
+        learnings_table_name = None
         metrics_table_name = None
         eval_table_name = None
         traces_table_name = None
@@ -92,6 +94,10 @@ class RemoteDb:
         if config and config.memory and config.memory.dbs is not None:
             memory_dbs = [db for db in config.memory.dbs if db.db_id == db_id]
             memory_table_name = memory_dbs[0].tables[0] if memory_dbs and memory_dbs[0].tables else None
+
+        if config and config.learning and config.learning.dbs is not None:
+            learning_dbs = [db for db in config.learning.dbs if db.db_id == db_id]
+            learnings_table_name = learning_dbs[0].tables[0] if learning_dbs and learning_dbs[0].tables else None
 
         if config and config.metrics and config.metrics.dbs is not None:
             metrics_dbs = [db for db in config.metrics.dbs if db.db_id == db_id]
@@ -111,6 +117,7 @@ class RemoteDb:
             session_table_name=session_table_name,
             knowledge_table_name=knowledge_table_name,
             memory_table_name=memory_table_name,
+            learnings_table_name=learnings_table_name,
             metrics_table_name=metrics_table_name,
             eval_table_name=eval_table_name,
             traces_table_name=traces_table_name,

--- a/libs/agno/tests/system/tests/test_mcp_routes.py
+++ b/libs/agno/tests/system/tests/test_mcp_routes.py
@@ -243,6 +243,7 @@ async def test_get_agentos_config(mcp_client: MCPTestClient):
     workflow_ids = [workflow["id"] for workflow in result["workflows"]]
     assert "gateway-workflow" in workflow_ids, "Local workflow 'gateway-workflow' should be present"
     assert "qa-workflow" in workflow_ids, "Remote workflow 'qa-workflow' should be present"
+    assert "learning" in result
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/remote/test_remote_db.py
+++ b/libs/agno/tests/unit/remote/test_remote_db.py
@@ -1,0 +1,48 @@
+from agno.os.config import (
+    DatabaseConfig,
+    LearningConfig,
+    LearningDomainConfig,
+    SessionConfig,
+    SessionDomainConfig,
+)
+from agno.os.schema import ConfigResponse
+from agno.remote.base import RemoteDb
+
+
+def test_remote_db_from_config_includes_learning_table_name() -> None:
+    config = ConfigResponse(
+        os_id="remote-os",
+        databases=["remote-db"],
+        session=SessionConfig(
+            dbs=[
+                DatabaseConfig(
+                    db_id="remote-db",
+                    domain_config=SessionDomainConfig(display_name="remote-db"),
+                    tables=["remote_sessions"],
+                )
+            ]
+        ),
+        learning=LearningConfig(
+            dbs=[
+                DatabaseConfig(
+                    db_id="remote-db",
+                    domain_config=LearningDomainConfig(display_name="remote-db"),
+                    tables=["remote_learnings"],
+                )
+            ]
+        ),
+        agents=[],
+        teams=[],
+        workflows=[],
+        interfaces=[],
+    )
+
+    remote_db = RemoteDb.from_config(
+        db_id="remote-db",
+        client=object(),  # type: ignore[arg-type]
+        config=config,
+    )
+
+    assert remote_db is not None
+    assert remote_db.session_table_name == "remote_sessions"
+    assert remote_db.learnings_table_name == "remote_learnings"


### PR DESCRIPTION
## Summary

- include `learning` in the MCP `get_agentos_config` response for parity with HTTP `/config`
- teach `RemoteDb.from_config()` to carry `learnings_table_name` from remote AgentOS config
- add a unit test covering the remote config parsing path used by gateway `RemoteAgent`/`RemoteTeam`/`RemoteWorkflow` entries

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- This also fixes the gateway case where `os.dbs` contains `RemoteDb` instances synthesized from remote `/config`; those instances previously lacked `learnings_table_name`, which caused `_get_learning_config()` to raise.
- Verified with:
  - `PYTHONPATH=/Users/yash/conductor/workspaces/agno/havana/.context/mcp-learning-config-fix/libs/agno /Users/yash/conductor/workspaces/agno/havana/.venv/bin/pytest libs/agno/tests/unit/remote/test_remote_db.py`
  - `PYTHONPATH=/Users/yash/conductor/workspaces/agno/havana/.context/mcp-learning-config-fix/libs/agno /Users/yash/conductor/workspaces/agno/havana/.venv/bin/pytest libs/agno/tests/integration/os/test_built_in_endpoints.py -k learning`
- Attempted `libs/agno/tests/system/tests/test_mcp_routes.py -k get_agentos_config`, but the MCP system harness failed during session initialization before reaching the new assertion in this local environment.