### PR TITLE
feat: add /learnings/users endpoint to list users with learnings

### DIFF
--- a/cookbook/05_agent_os/learnings/README.md
+++ b/cookbook/05_agent_os/learnings/README.md
@@ -31,6 +31,7 @@ In another, run the REST client:
 |--------|------|-------------|
 | `GET` | `/learnings` | Paginated list with filters |
 | `POST` | `/learnings` | Create a new learning record |
+| `GET` | `/learnings/users` | List the users that own learnings, with per-user counts |
 | `GET` | `/learnings/{learning_id}` | Fetch a single record |
 | `PATCH` | `/learnings/{learning_id}` | Update `content` and/or `metadata` (full replace) |
 | `DELETE` | `/learnings/{learning_id}` | Delete a record |
@@ -43,6 +44,8 @@ When an authenticated request carries a JWT:
   (`user_id IS NULL`) — this covers global, agent, team, session, and
   entity-scoped learnings. An explicit `user_id` query that doesn't match the
   JWT subject is rejected with `403`.
+- **List users**: results are scoped to the JWT subject. An explicit `user_id`
+  query that doesn't match the JWT subject is rejected with `403`.
 - **Create**: the body's `user_id` must either be omitted/null (creates a
   global / non-user-scoped record) or match the JWT subject. A mismatch is
   rejected with `403`.

--- a/cookbook/05_agent_os/learnings/README.md
+++ b/cookbook/05_agent_os/learnings/README.md
@@ -32,7 +32,7 @@ In another, run the REST client:
 | `GET` | `/learnings` | Paginated list with filters |
 | `POST` | `/learnings` | Create a new learning record |
 | `GET` | `/learnings/users` | List the users that own learnings, with last-activity timestamps |
-| `DELETE` | `/learnings/users/{user_id}` | Delete every learning record owned by a user |
+| `DELETE` | `/learnings/users/{user_id}` | Delete a user's learnings (all types, or one via `?learning_type=`) |
 | `GET` | `/learnings/{learning_id}` | Fetch a single record |
 | `PATCH` | `/learnings/{learning_id}` | Update `content` and/or `metadata` (full replace) |
 | `DELETE` | `/learnings/{learning_id}` | Delete a record |

--- a/cookbook/05_agent_os/learnings/README.md
+++ b/cookbook/05_agent_os/learnings/README.md
@@ -31,7 +31,7 @@ In another, run the REST client:
 |--------|------|-------------|
 | `GET` | `/learnings` | Paginated list with filters |
 | `POST` | `/learnings` | Create a new learning record |
-| `GET` | `/learnings/users` | List the users that own learnings, with per-user counts |
+| `GET` | `/learnings/users` | List the users that own learnings, with last-activity timestamps |
 | `GET` | `/learnings/{learning_id}` | Fetch a single record |
 | `PATCH` | `/learnings/{learning_id}` | Update `content` and/or `metadata` (full replace) |
 | `DELETE` | `/learnings/{learning_id}` | Delete a record |

--- a/cookbook/05_agent_os/learnings/README.md
+++ b/cookbook/05_agent_os/learnings/README.md
@@ -39,24 +39,31 @@ In another, run the REST client:
 
 ## Auth and IDOR
 
-When an authenticated request carries a JWT:
+Scoping follows the framework's opt-in `user_isolation` contract (via
+`get_scoped_user_id`). It applies only to a **regular, non-admin** caller when
+user isolation is enabled. **Admins** and requests running with isolation
+disabled are unscoped and have full access — so, for example, an admin's
+`GET /learnings/users` lists *all* users, not just themselves.
 
-- **List**: results are scoped to the JWT subject AND records with no owner
+For a scoped (non-admin) caller:
+
+- **List**: results are scoped to the caller AND records with no owner
   (`user_id IS NULL`) — this covers global, agent, team, session, and
   entity-scoped learnings. An explicit `user_id` query that doesn't match the
-  JWT subject is rejected with `403`.
-- **List users**: results are scoped to the JWT subject. An explicit `user_id`
-  query that doesn't match the JWT subject is rejected with `403`.
-- **Delete user**: only the JWT subject's own learnings may be deleted; a
-  different `user_id` in the path is rejected with `403`.
+  caller is rejected with `403`.
+- **List users**: results are scoped to the caller. An explicit `user_id`
+  query that doesn't match the caller is rejected with `403`.
+- **Delete user**: only the caller's own learnings may be deleted; a different
+  `user_id` in the path is rejected with `403`.
 - **Create**: the body's `user_id` must either be omitted/null (creates a
-  global / non-user-scoped record) or match the JWT subject. A mismatch is
-  rejected with `403`.
+  global / non-user-scoped record) or match the caller. A mismatch is rejected
+  with `403`.
 - **Single record GET / PATCH / DELETE**: records with `user_id IS NULL`
   remain accessible. Records owned by a different user return `404` (not
   `403`) to avoid leaking which IDs exist.
 
-Without a JWT (legacy bearer-token mode) the request passes through.
+With isolation disabled, or for admins, or without a JWT, the request passes
+through unscoped.
 
 ## Identity field rules
 

--- a/cookbook/05_agent_os/learnings/README.md
+++ b/cookbook/05_agent_os/learnings/README.md
@@ -32,6 +32,7 @@ In another, run the REST client:
 | `GET` | `/learnings` | Paginated list with filters |
 | `POST` | `/learnings` | Create a new learning record |
 | `GET` | `/learnings/users` | List the users that own learnings, with last-activity timestamps |
+| `DELETE` | `/learnings/users/{user_id}` | Delete every learning record owned by a user |
 | `GET` | `/learnings/{learning_id}` | Fetch a single record |
 | `PATCH` | `/learnings/{learning_id}` | Update `content` and/or `metadata` (full replace) |
 | `DELETE` | `/learnings/{learning_id}` | Delete a record |
@@ -46,6 +47,8 @@ When an authenticated request carries a JWT:
   JWT subject is rejected with `403`.
 - **List users**: results are scoped to the JWT subject. An explicit `user_id`
   query that doesn't match the JWT subject is rejected with `403`.
+- **Delete user**: only the JWT subject's own learnings may be deleted; a
+  different `user_id` in the path is rejected with `403`.
 - **Create**: the body's `user_id` must either be omitted/null (creates a
   global / non-user-scoped record) or match the JWT subject. A mismatch is
   rejected with `403`.

--- a/cookbook/05_agent_os/learnings/TEST_LOG.md
+++ b/cookbook/05_agent_os/learnings/TEST_LOG.md
@@ -14,8 +14,8 @@
 
 **Status:** PASS
 
-**Description:** Exercises the full CRUD cycle against the running AgentOS: POST creates a `user_profile` learning, GET lists it, GET by id fetches it, PATCH replaces content + metadata, DELETE removes it, and a follow-up GET returns 404.
+**Description:** Exercises the full CRUD cycle against the running AgentOS: POST creates a `user_profile` learning, GET lists it, GET /learnings/users lists the owning users with per-user counts, GET by id fetches it, PATCH replaces content + metadata, DELETE removes it, and a follow-up GET returns 404.
 
-**Result:** All five verbs returned the expected status codes and payloads. Pagination metadata populated correctly. PATCH performed a full replace of `content` and `metadata` while preserving identity fields.
+**Result:** All verbs returned the expected status codes and payloads. The `/learnings/users` listing grouped records by `user_id` with correct counts and last-updated timestamps. Pagination metadata populated correctly. PATCH performed a full replace of `content` and `metadata` while preserving identity fields.
 
 ---

--- a/cookbook/05_agent_os/learnings/TEST_LOG.md
+++ b/cookbook/05_agent_os/learnings/TEST_LOG.md
@@ -14,8 +14,8 @@
 
 **Status:** PASS
 
-**Description:** Exercises the full CRUD cycle against the running AgentOS: POST creates a `user_profile` learning, GET lists it, GET /learnings/users lists the owning users with per-user counts, GET by id fetches it, PATCH replaces content + metadata, DELETE removes it, and a follow-up GET returns 404.
+**Description:** Exercises the full CRUD cycle against the running AgentOS: POST creates a `user_profile` learning, GET lists it, GET /learnings/users lists the owning users with last-updated timestamps, GET by id fetches it, PATCH replaces content + metadata, DELETE removes it (follow-up GET returns 404), then seeds two records for a throwaway user and DELETE /learnings/users/{user_id} removes the user and all their learnings.
 
-**Result:** All verbs returned the expected status codes and payloads. The `/learnings/users` listing grouped records by `user_id` with correct counts and last-updated timestamps. Pagination metadata populated correctly. PATCH performed a full replace of `content` and `metadata` while preserving identity fields.
+**Result:** All verbs returned the expected status codes and payloads. The `/learnings/users` listing grouped records by `user_id` with correct last-updated timestamps. DELETE /learnings/users/{user_id} returned 204 and a follow-up list showed 0 remaining records for the user. Pagination metadata populated correctly. PATCH performed a full replace of `content` and `metadata` while preserving identity fields.
 
 ---

--- a/cookbook/05_agent_os/learnings/rest_api_learnings.py
+++ b/cookbook/05_agent_os/learnings/rest_api_learnings.py
@@ -7,6 +7,7 @@ This example demonstrates:
 - Fetching a single learning via GET /learnings/{id}
 - Updating content/metadata via PATCH /learnings/{id}
 - Deleting via DELETE /learnings/{id}
+- Deleting a user and all their learnings via DELETE /learnings/users/{user_id}
 
 Requires: a running AgentOS server. Start one with:
 
@@ -128,6 +129,33 @@ def main():
     # Verify it's gone
     resp = client.get(f"/learnings/{learning_id}")
     print(f"  Follow-up GET status: {resp.status_code} (expect 404)")
+
+    # =========================================================================
+    # 7. Delete a user and all of their learnings
+    # =========================================================================
+    # Seed a couple of records for a throwaway user, then remove the user and
+    # everything associated with them in one call.
+    print("\n=== Delete Learning User ===\n")
+    for content in ({"note": "first"}, {"note": "second"}):
+        client.post(
+            "/learnings",
+            json={
+                "learning_type": "user_memory",
+                "user_id": "bulk-demo-user",
+                "content": content,
+            },
+        ).raise_for_status()
+
+    resp = client.delete("/learnings/users/bulk-demo-user")
+    resp.raise_for_status()
+    print(f"  Deleted user (status {resp.status_code})")
+
+    # Verify the user no longer has any records
+    resp = client.get("/learnings", params={"user_id": "bulk-demo-user"})
+    resp.raise_for_status()
+    print(
+        f"  Remaining records for user: {resp.json()['meta']['total_count']} (expect 0)"
+    )
 
     print("\nDone.")
 

--- a/cookbook/05_agent_os/learnings/rest_api_learnings.py
+++ b/cookbook/05_agent_os/learnings/rest_api_learnings.py
@@ -3,6 +3,7 @@
 This example demonstrates:
 - Creating a learning record via POST /learnings
 - Listing learnings via GET /learnings
+- Listing the users that own learnings via GET /learnings/users
 - Fetching a single learning via GET /learnings/{id}
 - Updating content/metadata via PATCH /learnings/{id}
 - Deleting via DELETE /learnings/{id}
@@ -68,7 +69,22 @@ def main():
         print(f"  {r['learning_id']} -> {r['learning_type']} (user={r['user_id']})")
 
     # =========================================================================
-    # 3. Fetch a single learning
+    # 3. List the users that own learnings
+    # =========================================================================
+    # Entry point for a per-user view: list users first, then drill into a
+    # single user's learnings via GET /learnings?user_id=...
+    print("\n=== List Learning Users ===\n")
+    resp = client.get("/learnings/users", params={"learning_type": "user_profile"})
+    resp.raise_for_status()
+    for u in resp.json()["data"]:
+        print(
+            "  user={} learnings={} last_updated={}".format(
+                u["user_id"], u["total_learnings"], u["last_learning_updated_at"]
+            )
+        )
+
+    # =========================================================================
+    # 4. Fetch a single learning
     # =========================================================================
     print("\n=== Get Learning ===\n")
     resp = client.get(f"/learnings/{learning_id}")
@@ -79,7 +95,7 @@ def main():
     print(f"  Content keys: {list((detail.get('content') or {}).keys())}")
 
     # =========================================================================
-    # 4. Update content + metadata (full replace)
+    # 5. Update content + metadata (full replace)
     # =========================================================================
     print("\n=== Update Learning ===\n")
     resp = client.patch(
@@ -102,7 +118,7 @@ def main():
     print(f"  Updated metadata: {updated['metadata']}")
 
     # =========================================================================
-    # 5. Delete the learning
+    # 6. Delete the learning
     # =========================================================================
     print("\n=== Delete Learning ===\n")
     resp = client.delete(f"/learnings/{learning_id}")

--- a/cookbook/05_agent_os/learnings/rest_api_learnings.py
+++ b/cookbook/05_agent_os/learnings/rest_api_learnings.py
@@ -78,8 +78,8 @@ def main():
     resp.raise_for_status()
     for u in resp.json()["data"]:
         print(
-            "  user={} learnings={} last_updated={}".format(
-                u["user_id"], u["total_learnings"], u["last_learning_updated_at"]
+            "  user={} last_updated={}".format(
+                u["user_id"], u["last_learning_updated_at"]
             )
         )
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1019,7 +1019,7 @@ class BaseDb(ABC):
         """
         raise NotImplementedError
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,
@@ -1810,7 +1810,7 @@ class AsyncBaseDb(ABC):
         """
         raise NotImplementedError
 
-    async def get_learning_user_stats(
+    async def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -937,14 +937,16 @@ class BaseDb(ABC):
         """
         raise NotImplementedError
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         """Delete every learning record owned by a user.
 
-        Removes all rows where ``user_id`` matches (across all learning types). Records with
-        no owner (``user_id IS NULL``) are not affected.
+        Removes all rows where ``user_id`` matches. Records with no owner
+        (``user_id IS NULL``) are not affected.
 
         Args:
             user_id: The user whose learnings should be deleted.
+            learning_type: When provided, restrict deletion to this single learning type;
+                otherwise all of the user's learnings are removed.
 
         Returns:
             The number of records deleted.
@@ -1741,14 +1743,16 @@ class AsyncBaseDb(ABC):
         """
         raise NotImplementedError
 
-    async def delete_user_learnings(self, user_id: str) -> int:
+    async def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         """Async delete every learning record owned by a user.
 
-        Removes all rows where ``user_id`` matches (across all learning types). Records with
-        no owner (``user_id IS NULL``) are not affected.
+        Removes all rows where ``user_id`` matches. Records with no owner
+        (``user_id IS NULL``) are not affected.
 
         Args:
             user_id: The user whose learnings should be deleted.
+            learning_type: When provided, restrict deletion to this single learning type;
+                otherwise all of the user's learnings are removed.
 
         Returns:
             The number of records deleted.

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -937,6 +937,20 @@ class BaseDb(ABC):
         """
         raise NotImplementedError
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        """Delete every learning record owned by a user.
+
+        Removes all rows where ``user_id`` matches (across all learning types). Records with
+        no owner (``user_id IS NULL``) are not affected.
+
+        Args:
+            user_id: The user whose learnings should be deleted.
+
+        Returns:
+            The number of records deleted.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def get_learnings(
         self,
@@ -1724,6 +1738,20 @@ class AsyncBaseDb(ABC):
 
         Returns:
             True if deleted, False otherwise.
+        """
+        raise NotImplementedError
+
+    async def delete_user_learnings(self, user_id: str) -> int:
+        """Async delete every learning record owned by a user.
+
+        Removes all rows where ``user_id`` matches (across all learning types). Records with
+        no owner (``user_id IS NULL``) are not affected.
+
+        Args:
+            user_id: The user whose learnings should be deleted.
+
+        Returns:
+            The number of records deleted.
         """
         raise NotImplementedError
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -992,6 +992,8 @@ class BaseDb(ABC):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """List learning records with pagination, returning the page and total count.
 
@@ -1009,6 +1011,8 @@ class BaseDb(ABC):
                 ``user_id`` is None.
             limit: Page size.
             page: 1-indexed page number.
+            sort_by: Field to sort by (defaults to ``updated_at``).
+            sort_order: Sort order, ``'asc'`` or ``'desc'`` (defaults to ``desc``).
 
         Returns:
             Tuple of (records, total_count) where records is the requested page.
@@ -1021,6 +1025,8 @@ class BaseDb(ABC):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """List the users that own learning records, with per-user counts.
 
@@ -1034,6 +1040,9 @@ class BaseDb(ABC):
             limit: Page size.
             page: 1-indexed page number.
             user_id: Restrict the result to a single user.
+            sort_by: Field to sort by -- one of ``user_id``, ``total_learnings``, or
+                ``last_learning_updated_at`` (the default).
+            sort_order: Sort order, ``'asc'`` or ``'desc'`` (defaults to ``desc``).
 
         Returns:
             Tuple of (user_stats, total_count) where each entry has the shape
@@ -1774,6 +1783,8 @@ class AsyncBaseDb(ABC):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """Async list learning records with pagination, returning the page and total count.
 
@@ -1791,6 +1802,8 @@ class AsyncBaseDb(ABC):
                 ``user_id`` is None.
             limit: Page size.
             page: 1-indexed page number.
+            sort_by: Field to sort by (defaults to ``updated_at``).
+            sort_order: Sort order, ``'asc'`` or ``'desc'`` (defaults to ``desc``).
 
         Returns:
             Tuple of (records, total_count) where records is the requested page.
@@ -1803,6 +1816,8 @@ class AsyncBaseDb(ABC):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         """Async list the users that own learning records, with per-user counts.
 
@@ -1816,6 +1831,9 @@ class AsyncBaseDb(ABC):
             limit: Page size.
             page: 1-indexed page number.
             user_id: Restrict the result to a single user.
+            sort_by: Field to sort by -- one of ``user_id``, ``total_learnings``, or
+                ``last_learning_updated_at`` (the default).
+            sort_order: Sort order, ``'asc'`` or ``'desc'`` (defaults to ``desc``).
 
         Returns:
             Tuple of (user_stats, total_count) where each entry has the shape

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1015,6 +1015,32 @@ class BaseDb(ABC):
         """
         raise NotImplementedError
 
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List the users that own learning records, with per-user counts.
+
+        Groups the learnings table by ``user_id`` (excluding records with no owner) so a
+        client can present a list of users before drilling into a single user's profile
+        and memories. Mirrors ``get_user_memory_stats``.
+
+        Args:
+            learning_type: Restrict the grouping to a single learning type (e.g.
+                ``'user_profile'`` or ``'user_memory'``).
+            limit: Page size.
+            page: 1-indexed page number.
+            user_id: Restrict the result to a single user.
+
+        Returns:
+            Tuple of (user_stats, total_count) where each entry has the shape
+            ``{"user_id": str, "total_learnings": int, "last_learning_updated_at": int}``.
+        """
+        raise NotImplementedError
+
     # --- Schedules (Optional) ---
     # These methods are optional. Override in subclasses to enable scheduler persistence.
 
@@ -1768,6 +1794,32 @@ class AsyncBaseDb(ABC):
 
         Returns:
             Tuple of (records, total_count) where records is the requested page.
+        """
+        raise NotImplementedError
+
+    async def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """Async list the users that own learning records, with per-user counts.
+
+        Groups the learnings table by ``user_id`` (excluding records with no owner) so a
+        client can present a list of users before drilling into a single user's profile
+        and memories. Mirrors ``get_user_memory_stats``.
+
+        Args:
+            learning_type: Restrict the grouping to a single learning type (e.g.
+                ``'user_profile'`` or ``'user_memory'``).
+            limit: Page size.
+            page: 1-indexed page number.
+            user_id: Restrict the result to a single user.
+
+        Returns:
+            Tuple of (user_stats, total_count) where each entry has the shape
+            ``{"user_id": str, "total_learnings": int, "last_learning_updated_at": int}``.
         """
         raise NotImplementedError
 

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1040,13 +1040,12 @@ class BaseDb(ABC):
             limit: Page size.
             page: 1-indexed page number.
             user_id: Restrict the result to a single user.
-            sort_by: Field to sort by -- one of ``user_id``, ``total_learnings``, or
-                ``last_learning_updated_at`` (the default).
+            sort_by: Field to sort by -- ``user_id`` or ``last_learning_updated_at`` (the default).
             sort_order: Sort order, ``'asc'`` or ``'desc'`` (defaults to ``desc``).
 
         Returns:
             Tuple of (user_stats, total_count) where each entry has the shape
-            ``{"user_id": str, "total_learnings": int, "last_learning_updated_at": int}``.
+            ``{"user_id": str, "last_learning_updated_at": int}``.
         """
         raise NotImplementedError
 
@@ -1831,13 +1830,12 @@ class AsyncBaseDb(ABC):
             limit: Page size.
             page: 1-indexed page number.
             user_id: Restrict the result to a single user.
-            sort_by: Field to sort by -- one of ``user_id``, ``total_learnings``, or
-                ``last_learning_updated_at`` (the default).
+            sort_by: Field to sort by -- ``user_id`` or ``last_learning_updated_at`` (the default).
             sort_order: Sort order, ``'asc'`` or ``'desc'`` (defaults to ``desc``).
 
         Returns:
             Tuple of (user_stats, total_count) where each entry has the shape
-            ``{"user_id": str, "total_learnings": int, "last_learning_updated_at": int}``.
+            ``{"user_id": str, "last_learning_updated_at": int}``.
         """
         raise NotImplementedError
 

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1405,7 +1405,7 @@ class InMemoryDb(BaseDb):
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1400,6 +1400,8 @@ class InMemoryDb(BaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
 
@@ -1409,5 +1411,7 @@ class InMemoryDb(BaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1370,6 +1370,9 @@ class InMemoryDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
+
     def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1402,3 +1402,12 @@ class InMemoryDb(BaseDb):
         page: int = 1,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
+
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1370,7 +1370,7 @@ class InMemoryDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         raise NotImplementedError("Learning methods not yet implemented for InMemoryDb")
 
     def get_learnings(

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1866,3 +1866,12 @@ class JsonDb(BaseDb):
         page: int = 1,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")
+
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        raise NotImplementedError("Learning methods not yet implemented for JsonDb")

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1834,7 +1834,7 @@ class JsonDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")
 
     def get_learnings(

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1869,7 +1869,7 @@ class JsonDb(BaseDb):
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1864,6 +1864,8 @@ class JsonDb(BaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")
 
@@ -1873,5 +1875,7 @@ class JsonDb(BaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1834,6 +1834,9 @@ class JsonDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for JsonDb")
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        raise NotImplementedError("Learning methods not yet implemented for JsonDb")
+
     def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3360,3 +3360,59 @@ class AsyncMongoDb(AsyncBaseDb):
         except Exception as e:
             log_debug(f"Error listing learnings: {e}")
             return [], 0
+
+    async def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            collection = await self._get_collection(table_type="learnings", create_collection_if_not_found=False)
+            if collection is None:
+                return [], 0
+
+            match_stage: Dict[str, Any] = {"user_id": {"$ne": None}}
+            if learning_type is not None:
+                match_stage["learning_type"] = learning_type
+            if user_id is not None:
+                match_stage["user_id"] = user_id
+
+            pipeline: List[Dict[str, Any]] = [
+                {"$match": match_stage},
+                {
+                    "$group": {
+                        "_id": "$user_id",
+                        "total_learnings": {"$sum": 1},
+                        "last_learning_updated_at": {"$max": "$updated_at"},
+                    }
+                },
+                {"$sort": {"last_learning_updated_at": -1}},
+            ]
+
+            count_pipeline = pipeline + [{"$count": "total"}]
+            count_result = await self._aggregate_to_list(collection, count_pipeline, length=1)
+            total_count = count_result[0]["total"] if count_result else 0
+
+            if limit is not None:
+                if page is not None:
+                    pipeline.append({"$skip": (page - 1) * limit})
+                pipeline.append({"$limit": limit})
+
+            results = await self._aggregate_to_list(collection, pipeline, length=None)
+
+            formatted_results = [
+                {
+                    "user_id": result["_id"],
+                    "total_learnings": result["total_learnings"],
+                    "last_learning_updated_at": result["last_learning_updated_at"],
+                }
+                for result in results
+            ]
+
+            return formatted_results, int(total_count)
+
+        except Exception as e:
+            log_debug(f"Error getting learning user stats: {e}")
+            return [], 0

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3221,13 +3221,16 @@ class AsyncMongoDb(AsyncBaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
-    async def delete_user_learnings(self, user_id: str) -> int:
+    async def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         try:
             collection = await self._get_collection(table_type="learnings", create_collection_if_not_found=False)
             if collection is None:
                 return 0
 
-            result = await collection.delete_many({"user_id": user_id})
+            query: Dict[str, Any] = {"user_id": user_id}
+            if learning_type is not None:
+                query["learning_type"] = learning_type
+            result = await collection.delete_many(query)
             return int(result.deleted_count or 0)
 
         except Exception as e:

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3404,7 +3404,6 @@ class AsyncMongoDb(AsyncBaseDb):
                 {
                     "$group": {
                         "_id": "$user_id",
-                        "total_learnings": {"$sum": 1},
                         "last_learning_updated_at": {"$max": "$updated_at"},
                     }
                 },
@@ -3425,7 +3424,6 @@ class AsyncMongoDb(AsyncBaseDb):
             formatted_results = [
                 {
                     "user_id": result["_id"],
-                    "total_learnings": result["total_learnings"],
                     "last_learning_updated_at": result["last_learning_updated_at"],
                 }
                 for result in results

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3221,6 +3221,19 @@ class AsyncMongoDb(AsyncBaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
+    async def delete_user_learnings(self, user_id: str) -> int:
+        try:
+            collection = await self._get_collection(table_type="learnings", create_collection_if_not_found=False)
+            if collection is None:
+                return 0
+
+            result = await collection.delete_many({"user_id": user_id})
+            return int(result.deleted_count or 0)
+
+        except Exception as e:
+            log_debug(f"Error deleting user learnings: {e}")
+            return 0
+
     async def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3369,7 +3369,7 @@ class AsyncMongoDb(AsyncBaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
-    async def get_learning_user_stats(
+    async def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,
@@ -3383,7 +3383,9 @@ class AsyncMongoDb(AsyncBaseDb):
             if collection is None:
                 return [], 0
 
-            match_stage: Dict[str, Any] = {"user_id": {"$ne": None}}
+            # Exclude ownerless records: both explicit null and a missing user_id field
+            # (otherwise they group under _id: null and break LearningUserStats validation).
+            match_stage: Dict[str, Any] = {"user_id": {"$ne": None, "$exists": True}}
             if learning_type is not None:
                 match_stage["learning_type"] = learning_type
             if user_id is not None:
@@ -3432,5 +3434,5 @@ class AsyncMongoDb(AsyncBaseDb):
             return formatted_results, int(total_count)
 
         except Exception as e:
-            log_debug(f"Error getting learning user stats: {e}")
-            return [], 0
+            log_error(f"Error getting learning user stats: {e}")
+            raise e

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3318,6 +3318,8 @@ class AsyncMongoDb(AsyncBaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             collection = await self._get_collection(table_type="learnings", create_collection_if_not_found=False)
@@ -3347,7 +3349,13 @@ class AsyncMongoDb(AsyncBaseDb):
 
             total_count = await collection.count_documents(query)
 
-            cursor = collection.find(query).sort("updated_at", -1).skip((page - 1) * limit).limit(limit)
+            sort_direction = 1 if sort_order == "asc" else -1
+            cursor = (
+                collection.find(query)
+                .sort(sort_by or "updated_at", sort_direction)
+                .skip((page - 1) * limit)
+                .limit(limit)
+            )
             results = await cursor.to_list(length=limit)
 
             learnings = []
@@ -3367,6 +3375,8 @@ class AsyncMongoDb(AsyncBaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             collection = await self._get_collection(table_type="learnings", create_collection_if_not_found=False)
@@ -3379,6 +3389,14 @@ class AsyncMongoDb(AsyncBaseDb):
             if user_id is not None:
                 match_stage["user_id"] = user_id
 
+            # The grouped user_id is the "_id" field after $group.
+            sort_field = (
+                "_id"
+                if (sort_by or "last_learning_updated_at") == "user_id"
+                else (sort_by or "last_learning_updated_at")
+            )
+            sort_direction = 1 if sort_order == "asc" else -1
+
             pipeline: List[Dict[str, Any]] = [
                 {"$match": match_stage},
                 {
@@ -3388,7 +3406,7 @@ class AsyncMongoDb(AsyncBaseDb):
                         "last_learning_updated_at": {"$max": "$updated_at"},
                     }
                 },
-                {"$sort": {"last_learning_updated_at": -1}},
+                {"$sort": {sort_field: sort_direction}},
             ]
 
             count_pipeline = pipeline + [{"$count": "total"}]

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2967,7 +2967,7 @@ class MongoDb(BaseDb):
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2932,6 +2932,9 @@ class MongoDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        raise NotImplementedError("Learning methods not yet implemented for MongoDb")
+
     def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2964,3 +2964,12 @@ class MongoDb(BaseDb):
         page: int = 1,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")
+
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        raise NotImplementedError("Learning methods not yet implemented for MongoDb")

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2962,6 +2962,8 @@ class MongoDb(BaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")
 
@@ -2971,5 +2973,7 @@ class MongoDb(BaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2932,7 +2932,7 @@ class MongoDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         raise NotImplementedError("Learning methods not yet implemented for MongoDb")
 
     def get_learnings(

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3184,11 +3184,9 @@ class AsyncPostgresDb(AsyncBaseDb):
                 return [], 0
 
             async with self.async_session_factory() as sess:
-                total_col = func.count(table.c.learning_id)
                 last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    total_col.label("total_learnings"),
                     last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
@@ -3201,7 +3199,6 @@ class AsyncPostgresDb(AsyncBaseDb):
 
                 sort_columns = {
                     "user_id": table.c.user_id,
-                    "total_learnings": total_col,
                     "last_learning_updated_at": last_updated_col,
                 }
                 sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
@@ -3221,7 +3218,6 @@ class AsyncPostgresDb(AsyncBaseDb):
                 return [
                     {
                         "user_id": row.user_id,
-                        "total_learnings": row.total_learnings,
                         "last_learning_updated_at": row.last_learning_updated_at,
                     }
                     for row in rows

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3169,7 +3169,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
-    async def get_learning_user_stats(
+    async def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,
@@ -3228,8 +3228,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 ], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error getting learning user stats: {e}")
-            return [], 0
+            log_error(f"Error getting learning user stats: {e}")
+            raise e
 
     # --- Components (Not yet supported for async) ---
     def get_component(

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3033,6 +3033,21 @@ class AsyncPostgresDb(AsyncBaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
+    async def delete_user_learnings(self, user_id: str) -> int:
+        try:
+            table = await self._get_table(table_type="learnings")
+            if table is None:
+                return 0
+
+            async with self.async_session_factory() as sess, sess.begin():
+                stmt = table.delete().where(table.c.user_id == user_id)
+                result = await sess.execute(stmt)
+                return getattr(result, "rowcount", 0) or 0
+
+        except Exception as e:
+            log_debug(f"Error deleting user learnings: {e}")
+            return 0
+
     async def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3166,6 +3166,56 @@ class AsyncPostgresDb(AsyncBaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
+    async def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = await self._get_table(table_type="learnings")
+            if table is None:
+                return [], 0
+
+            async with self.async_session_factory() as sess:
+                stmt = select(
+                    table.c.user_id,
+                    func.count(table.c.learning_id).label("total_learnings"),
+                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                )
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                else:
+                    stmt = stmt.where(table.c.user_id.is_not(None))
+                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+
+                count_stmt = select(func.count()).select_from(stmt.subquery())
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+                    if page is not None:
+                        stmt = stmt.offset((page - 1) * limit)
+
+                result = await sess.execute(stmt)
+                rows = result.fetchall()
+                return [
+                    {
+                        "user_id": row.user_id,
+                        "total_learnings": row.total_learnings,
+                        "last_learning_updated_at": row.last_learning_updated_at,
+                    }
+                    for row in rows
+                ], int(total_count)
+
+        except Exception as e:
+            log_debug(f"Error getting learning user stats: {e}")
+            return [], 0
+
     # --- Components (Not yet supported for async) ---
     def get_component(
         self,

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3125,6 +3125,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="learnings")
@@ -3157,7 +3159,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 count_result = await sess.execute(count_stmt)
                 total_count = count_result.scalar() or 0
 
-                stmt = stmt.order_by(table.c.updated_at.desc()).limit(limit).offset((page - 1) * limit)
+                stmt = apply_sorting(stmt, table, sort_by or "updated_at", sort_order or "desc")
+                stmt = stmt.limit(limit).offset((page - 1) * limit)
                 result = await sess.execute(stmt)
                 rows = result.fetchall()
                 return [dict(row._mapping) for row in rows], int(total_count)
@@ -3172,6 +3175,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="learnings")
@@ -3179,10 +3184,12 @@ class AsyncPostgresDb(AsyncBaseDb):
                 return [], 0
 
             async with self.async_session_factory() as sess:
+                total_col = func.count(table.c.learning_id)
+                last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    func.count(table.c.learning_id).label("total_learnings"),
-                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                    total_col.label("total_learnings"),
+                    last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
                     stmt = stmt.where(table.c.learning_type == learning_type)
@@ -3190,7 +3197,15 @@ class AsyncPostgresDb(AsyncBaseDb):
                     stmt = stmt.where(table.c.user_id == user_id)
                 else:
                     stmt = stmt.where(table.c.user_id.is_not(None))
-                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+                stmt = stmt.group_by(table.c.user_id)
+
+                sort_columns = {
+                    "user_id": table.c.user_id,
+                    "total_learnings": total_col,
+                    "last_learning_updated_at": last_updated_col,
+                }
+                sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
+                stmt = stmt.order_by(sort_col.asc() if sort_order == "asc" else sort_col.desc())
 
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 count_result = await sess.execute(count_stmt)

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3033,7 +3033,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
-    async def delete_user_learnings(self, user_id: str) -> int:
+    async def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         try:
             table = await self._get_table(table_type="learnings")
             if table is None:
@@ -3041,6 +3041,8 @@ class AsyncPostgresDb(AsyncBaseDb):
 
             async with self.async_session_factory() as sess, sess.begin():
                 stmt = table.delete().where(table.c.user_id == user_id)
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
                 result = await sess.execute(stmt)
                 return getattr(result, "rowcount", 0) or 0
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4528,7 +4528,7 @@ class PostgresDb(BaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         try:
             table = self._get_table(table_type="learnings")
             if table is None:
@@ -4536,6 +4536,8 @@ class PostgresDb(BaseDb):
 
             with self.Session() as sess, sess.begin():
                 stmt = table.delete().where(table.c.user_id == user_id)
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
                 result = sess.execute(stmt)
                 return result.rowcount or 0
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4528,6 +4528,21 @@ class PostgresDb(BaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        try:
+            table = self._get_table(table_type="learnings")
+            if table is None:
+                return 0
+
+            with self.Session() as sess, sess.begin():
+                stmt = table.delete().where(table.c.user_id == user_id)
+                result = sess.execute(stmt)
+                return result.rowcount or 0
+
+        except Exception as e:
+            log_debug(f"Error deleting user learnings: {e}")
+            return 0
+
     def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4679,11 +4679,9 @@ class PostgresDb(BaseDb):
                 return [], 0
 
             with self.Session() as sess:
-                total_col = func.count(table.c.learning_id)
                 last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    total_col.label("total_learnings"),
                     last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
@@ -4696,7 +4694,6 @@ class PostgresDb(BaseDb):
 
                 sort_columns = {
                     "user_id": table.c.user_id,
-                    "total_learnings": total_col,
                     "last_learning_updated_at": last_updated_col,
                 }
                 sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
@@ -4714,7 +4711,6 @@ class PostgresDb(BaseDb):
                 return [
                     {
                         "user_id": row.user_id,
-                        "total_learnings": row.total_learnings,
                         "last_learning_updated_at": row.last_learning_updated_at,
                     }
                     for row in result

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4664,7 +4664,7 @@ class PostgresDb(BaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,
@@ -4721,8 +4721,8 @@ class PostgresDb(BaseDb):
                 ], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error getting learning user stats: {e}")
-            return [], 0
+            log_error(f"Error getting learning user stats: {e}")
+            raise e
 
     # -- Schedule methods --
     def get_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4661,6 +4661,54 @@ class PostgresDb(BaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = self._get_table(table_type="learnings")
+            if table is None:
+                return [], 0
+
+            with self.Session() as sess:
+                stmt = select(
+                    table.c.user_id,
+                    func.count(table.c.learning_id).label("total_learnings"),
+                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                )
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                else:
+                    stmt = stmt.where(table.c.user_id.is_not(None))
+                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+
+                count_stmt = select(func.count()).select_from(stmt.subquery())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+                    if page is not None:
+                        stmt = stmt.offset((page - 1) * limit)
+
+                result = sess.execute(stmt).fetchall()
+                return [
+                    {
+                        "user_id": row.user_id,
+                        "total_learnings": row.total_learnings,
+                        "last_learning_updated_at": row.last_learning_updated_at,
+                    }
+                    for row in result
+                ], int(total_count)
+
+        except Exception as e:
+            log_debug(f"Error getting learning user stats: {e}")
+            return [], 0
+
     # -- Schedule methods --
     def get_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
         try:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4622,6 +4622,8 @@ class PostgresDb(BaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="learnings")
@@ -4653,7 +4655,8 @@ class PostgresDb(BaseDb):
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 total_count = sess.execute(count_stmt).scalar() or 0
 
-                stmt = stmt.order_by(table.c.updated_at.desc()).limit(limit).offset((page - 1) * limit)
+                stmt = apply_sorting(stmt, table, sort_by or "updated_at", sort_order or "desc")
+                stmt = stmt.limit(limit).offset((page - 1) * limit)
                 result = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in result], int(total_count)
 
@@ -4667,6 +4670,8 @@ class PostgresDb(BaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="learnings")
@@ -4674,10 +4679,12 @@ class PostgresDb(BaseDb):
                 return [], 0
 
             with self.Session() as sess:
+                total_col = func.count(table.c.learning_id)
+                last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    func.count(table.c.learning_id).label("total_learnings"),
-                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                    total_col.label("total_learnings"),
+                    last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
                     stmt = stmt.where(table.c.learning_type == learning_type)
@@ -4685,7 +4692,15 @@ class PostgresDb(BaseDb):
                     stmt = stmt.where(table.c.user_id == user_id)
                 else:
                     stmt = stmt.where(table.c.user_id.is_not(None))
-                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+                stmt = stmt.group_by(table.c.user_id)
+
+                sort_columns = {
+                    "user_id": table.c.user_id,
+                    "total_learnings": total_col,
+                    "last_learning_updated_at": last_updated_col,
+                }
+                sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
+                stmt = stmt.order_by(sort_col.asc() if sort_order == "asc" else sort_col.desc())
 
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 total_count = sess.execute(count_stmt).scalar() or 0

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2203,7 +2203,7 @@ class RedisDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")
 
     def get_learnings(

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2233,6 +2233,8 @@ class RedisDb(BaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")
 
@@ -2242,5 +2244,7 @@ class RedisDb(BaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2238,7 +2238,7 @@ class RedisDb(BaseDb):
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2235,3 +2235,12 @@ class RedisDb(BaseDb):
         page: int = 1,
     ) -> Tuple[List[Dict[str, Any]], int]:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")
+
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        raise NotImplementedError("Learning methods not yet implemented for RedisDb")

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -2203,6 +2203,9 @@ class RedisDb(BaseDb):
     def delete_learning(self, id: str) -> bool:
         raise NotImplementedError("Learning methods not yet implemented for RedisDb")
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        raise NotImplementedError("Learning methods not yet implemented for RedisDb")
+
     def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3301,6 +3301,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="learnings")
@@ -3333,7 +3335,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 count_result = await sess.execute(count_stmt)
                 total_count = count_result.scalar() or 0
 
-                stmt = stmt.order_by(table.c.updated_at.desc()).limit(limit).offset((page - 1) * limit)
+                stmt = apply_sorting(stmt, table, sort_by or "updated_at", sort_order or "desc")
+                stmt = stmt.limit(limit).offset((page - 1) * limit)
                 result = await sess.execute(stmt)
                 results = result.fetchall()
                 return [dict(row._mapping) for row in results], int(total_count)
@@ -3348,6 +3351,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = await self._get_table(table_type="learnings")
@@ -3355,10 +3360,12 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return [], 0
 
             async with self.async_session_factory() as sess:
+                total_col = func.count(table.c.learning_id)
+                last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    func.count(table.c.learning_id).label("total_learnings"),
-                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                    total_col.label("total_learnings"),
+                    last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
                     stmt = stmt.where(table.c.learning_type == learning_type)
@@ -3366,7 +3373,15 @@ class AsyncSqliteDb(AsyncBaseDb):
                     stmt = stmt.where(table.c.user_id == user_id)
                 else:
                     stmt = stmt.where(table.c.user_id.is_not(None))
-                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+                stmt = stmt.group_by(table.c.user_id)
+
+                sort_columns = {
+                    "user_id": table.c.user_id,
+                    "total_learnings": total_col,
+                    "last_learning_updated_at": last_updated_col,
+                }
+                sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
+                stmt = stmt.order_by(sort_col.asc() if sort_order == "asc" else sort_col.desc())
 
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 count_result = await sess.execute(count_stmt)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3360,11 +3360,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return [], 0
 
             async with self.async_session_factory() as sess:
-                total_col = func.count(table.c.learning_id)
                 last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    total_col.label("total_learnings"),
                     last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
@@ -3377,7 +3375,6 @@ class AsyncSqliteDb(AsyncBaseDb):
 
                 sort_columns = {
                     "user_id": table.c.user_id,
-                    "total_learnings": total_col,
                     "last_learning_updated_at": last_updated_col,
                 }
                 sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
@@ -3397,7 +3394,6 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return [
                     {
                         "user_id": row.user_id,
-                        "total_learnings": row.total_learnings,
                         "last_learning_updated_at": row.last_learning_updated_at,
                     }
                     for row in results

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3205,6 +3205,21 @@ class AsyncSqliteDb(AsyncBaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
+    async def delete_user_learnings(self, user_id: str) -> int:
+        try:
+            table = await self._get_table(table_type="learnings")
+            if table is None:
+                return 0
+
+            async with self.async_session_factory() as sess, sess.begin():
+                stmt = table.delete().where(table.c.user_id == user_id)
+                result = await sess.execute(stmt)
+                return getattr(result, "rowcount", 0) or 0
+
+        except Exception as e:
+            log_debug(f"Error deleting user learnings: {e}")
+            return 0
+
     async def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3345,7 +3345,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
-    async def get_learning_user_stats(
+    async def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,
@@ -3404,8 +3404,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 ], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error getting learning user stats: {e}")
-            return [], 0
+            log_error(f"Error getting learning user stats: {e}")
+            raise e
 
     # --- Components (Not yet supported for async) ---
     def get_component(

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3205,7 +3205,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
-    async def delete_user_learnings(self, user_id: str) -> int:
+    async def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         try:
             table = await self._get_table(table_type="learnings")
             if table is None:
@@ -3213,6 +3213,8 @@ class AsyncSqliteDb(AsyncBaseDb):
 
             async with self.async_session_factory() as sess, sess.begin():
                 stmt = table.delete().where(table.c.user_id == user_id)
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
                 result = await sess.execute(stmt)
                 return getattr(result, "rowcount", 0) or 0
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3342,6 +3342,56 @@ class AsyncSqliteDb(AsyncBaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
+    async def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = await self._get_table(table_type="learnings")
+            if table is None:
+                return [], 0
+
+            async with self.async_session_factory() as sess:
+                stmt = select(
+                    table.c.user_id,
+                    func.count(table.c.learning_id).label("total_learnings"),
+                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                )
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                else:
+                    stmt = stmt.where(table.c.user_id.is_not(None))
+                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+
+                count_stmt = select(func.count()).select_from(stmt.subquery())
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+                    if page is not None:
+                        stmt = stmt.offset((page - 1) * limit)
+
+                result = await sess.execute(stmt)
+                results = result.fetchall()
+                return [
+                    {
+                        "user_id": row.user_id,
+                        "total_learnings": row.total_learnings,
+                        "last_learning_updated_at": row.last_learning_updated_at,
+                    }
+                    for row in results
+                ], int(total_count)
+
+        except Exception as e:
+            log_debug(f"Error getting learning user stats: {e}")
+            return [], 0
+
     # --- Components (Not yet supported for async) ---
     def get_component(
         self,

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4514,7 +4514,7 @@ class SqliteDb(BaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
-    def get_learning_user_stats(
+    def get_learnings_user_stats(
         self,
         learning_type: Optional[str] = None,
         limit: Optional[int] = None,
@@ -4571,8 +4571,8 @@ class SqliteDb(BaseDb):
                 ], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error getting learning user stats: {e}")
-            return [], 0
+            log_error(f"Error getting learning user stats: {e}")
+            raise e
 
     # -- Schedule methods --
     def get_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4511,6 +4511,54 @@ class SqliteDb(BaseDb):
             log_debug(f"Error listing learnings: {e}")
             return [], 0
 
+    def get_learning_user_stats(
+        self,
+        learning_type: Optional[str] = None,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = self._get_table(table_type="learnings")
+            if table is None:
+                return [], 0
+
+            with self.Session() as sess:
+                stmt = select(
+                    table.c.user_id,
+                    func.count(table.c.learning_id).label("total_learnings"),
+                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                )
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                else:
+                    stmt = stmt.where(table.c.user_id.is_not(None))
+                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+
+                count_stmt = select(func.count()).select_from(stmt.subquery())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+                    if page is not None:
+                        stmt = stmt.offset((page - 1) * limit)
+
+                results = sess.execute(stmt).fetchall()
+                return [
+                    {
+                        "user_id": row.user_id,
+                        "total_learnings": row.total_learnings,
+                        "last_learning_updated_at": row.last_learning_updated_at,
+                    }
+                    for row in results
+                ], int(total_count)
+
+        except Exception as e:
+            log_debug(f"Error getting learning user stats: {e}")
+            return [], 0
+
     # -- Schedule methods --
     def get_schedule(self, schedule_id: str) -> Optional[Dict[str, Any]]:
         try:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4529,11 +4529,9 @@ class SqliteDb(BaseDb):
                 return [], 0
 
             with self.Session() as sess:
-                total_col = func.count(table.c.learning_id)
                 last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    total_col.label("total_learnings"),
                     last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
@@ -4546,7 +4544,6 @@ class SqliteDb(BaseDb):
 
                 sort_columns = {
                     "user_id": table.c.user_id,
-                    "total_learnings": total_col,
                     "last_learning_updated_at": last_updated_col,
                 }
                 sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
@@ -4564,7 +4561,6 @@ class SqliteDb(BaseDb):
                 return [
                     {
                         "user_id": row.user_id,
-                        "total_learnings": row.total_learnings,
                         "last_learning_updated_at": row.last_learning_updated_at,
                     }
                     for row in results

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4378,6 +4378,21 @@ class SqliteDb(BaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
+    def delete_user_learnings(self, user_id: str) -> int:
+        try:
+            table = self._get_table(table_type="learnings")
+            if table is None:
+                return 0
+
+            with self.Session() as sess, sess.begin():
+                stmt = table.delete().where(table.c.user_id == user_id)
+                result = sess.execute(stmt)
+                return result.rowcount or 0
+
+        except Exception as e:
+            log_debug(f"Error deleting user learnings: {e}")
+            return 0
+
     def get_learnings(
         self,
         learning_type: Optional[str] = None,

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4378,7 +4378,7 @@ class SqliteDb(BaseDb):
             log_debug(f"Error deleting learning: {e}")
             return False
 
-    def delete_user_learnings(self, user_id: str) -> int:
+    def delete_user_learnings(self, user_id: str, learning_type: Optional[str] = None) -> int:
         try:
             table = self._get_table(table_type="learnings")
             if table is None:
@@ -4386,6 +4386,8 @@ class SqliteDb(BaseDb):
 
             with self.Session() as sess, sess.begin():
                 stmt = table.delete().where(table.c.user_id == user_id)
+                if learning_type is not None:
+                    stmt = stmt.where(table.c.learning_type == learning_type)
                 result = sess.execute(stmt)
                 return result.rowcount or 0
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4472,6 +4472,8 @@ class SqliteDb(BaseDb):
         include_global: bool = False,
         limit: int = 100,
         page: int = 1,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="learnings")
@@ -4503,7 +4505,8 @@ class SqliteDb(BaseDb):
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 total_count = sess.execute(count_stmt).scalar() or 0
 
-                stmt = stmt.order_by(table.c.updated_at.desc()).limit(limit).offset((page - 1) * limit)
+                stmt = apply_sorting(stmt, table, sort_by or "updated_at", sort_order or "desc")
+                stmt = stmt.limit(limit).offset((page - 1) * limit)
                 results = sess.execute(stmt).fetchall()
                 return [dict(row._mapping) for row in results], int(total_count)
 
@@ -4517,6 +4520,8 @@ class SqliteDb(BaseDb):
         limit: Optional[int] = None,
         page: Optional[int] = None,
         user_id: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        sort_order: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], int]:
         try:
             table = self._get_table(table_type="learnings")
@@ -4524,10 +4529,12 @@ class SqliteDb(BaseDb):
                 return [], 0
 
             with self.Session() as sess:
+                total_col = func.count(table.c.learning_id)
+                last_updated_col = func.max(table.c.updated_at)
                 stmt = select(
                     table.c.user_id,
-                    func.count(table.c.learning_id).label("total_learnings"),
-                    func.max(table.c.updated_at).label("last_learning_updated_at"),
+                    total_col.label("total_learnings"),
+                    last_updated_col.label("last_learning_updated_at"),
                 )
                 if learning_type is not None:
                     stmt = stmt.where(table.c.learning_type == learning_type)
@@ -4535,7 +4542,15 @@ class SqliteDb(BaseDb):
                     stmt = stmt.where(table.c.user_id == user_id)
                 else:
                     stmt = stmt.where(table.c.user_id.is_not(None))
-                stmt = stmt.group_by(table.c.user_id).order_by(func.max(table.c.updated_at).desc())
+                stmt = stmt.group_by(table.c.user_id)
+
+                sort_columns = {
+                    "user_id": table.c.user_id,
+                    "total_learnings": total_col,
+                    "last_learning_updated_at": last_updated_col,
+                }
+                sort_col = sort_columns.get(sort_by or "last_learning_updated_at", last_updated_col)
+                stmt = stmt.order_by(sort_col.asc() if sort_order == "asc" else sort_col.desc())
 
                 count_stmt = select(func.count()).select_from(stmt.subquery())
                 total_count = sess.execute(count_stmt).scalar() or 0

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -39,9 +39,10 @@ from typing import Any, Dict, List, Optional
 from agno.learn.utils import _parse_json, _safe_get
 from agno.utils.log import log_debug
 
-# Per-memory timestamp fields are owned by the framework and stamped at write time.
-# They are never accepted from the model / caller, so they cannot be spoofed via kwargs.
-_RESERVED_MEMORY_FIELDS = {"id", "created_at", "updated_at"}
+# Per-entry id/timestamp fields (for list items like memories, facts, events) are owned by
+# the framework and stamped at write time. They are never accepted from the model / caller,
+# so they cannot be spoofed via kwargs.
+_RESERVED_ENTRY_FIELDS = {"id", "created_at", "updated_at"}
 
 
 def _utc_now_iso() -> str:
@@ -277,7 +278,7 @@ class Memories:
 
         if content and content.strip():
             now = _utc_now_iso()
-            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_MEMORY_FIELDS}
+            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
             self.memories.append(
                 {"id": memory_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
             )
@@ -303,7 +304,7 @@ class Memories:
         for mem in self.memories:
             if isinstance(mem, dict) and mem.get("id") == memory_id:
                 mem["content"] = content.strip()
-                mem.update({k: v for k, v in kwargs.items() if k not in _RESERVED_MEMORY_FIELDS})
+                mem.update({k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS})
                 mem["updated_at"] = _utc_now_iso()
                 return True
         return False
@@ -672,7 +673,11 @@ class EntityMemory:
         fact_id = str(uuid.uuid4())[:8]
 
         if content and content.strip():
-            self.facts.append({"id": fact_id, "content": content.strip(), **kwargs})
+            now = _utc_now_iso()
+            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
+            self.facts.append(
+                {"id": fact_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
+            )
 
         return fact_id
 
@@ -692,7 +697,9 @@ class EntityMemory:
         event_id = str(uuid.uuid4())[:8]
 
         if content and content.strip():
-            event = {"id": event_id, "content": content.strip(), **kwargs}
+            now = _utc_now_iso()
+            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
+            event = {"id": event_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
             if date:
                 event["date"] = date
             self.events.append(event)
@@ -715,8 +722,18 @@ class EntityMemory:
 
         rel_id = str(uuid.uuid4())[:8]
 
+        now = _utc_now_iso()
+        extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
         self.relationships.append(
-            {"id": rel_id, "entity_id": related_entity_id, "relation": relation, "direction": direction, **kwargs}
+            {
+                "id": rel_id,
+                "entity_id": related_entity_id,
+                "relation": relation,
+                "direction": direction,
+                "created_at": now,
+                "updated_at": now,
+                **extra,
+            }
         )
 
         return rel_id
@@ -737,7 +754,8 @@ class EntityMemory:
         for fact in self.facts:
             if isinstance(fact, dict) and fact.get("id") == fact_id:
                 fact["content"] = content.strip()
-                fact.update(kwargs)
+                fact.update({k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS})
+                fact["updated_at"] = _utc_now_iso()
                 return True
         return False
 

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -39,11 +39,6 @@ from typing import Any, Dict, List, Optional
 from agno.learn.utils import _parse_json, _safe_get
 from agno.utils.log import log_debug
 
-# Per-entry id/timestamp fields (for list items like memories, facts, events) are owned by
-# the framework and stamped at write time. They are never accepted from the model / caller,
-# so they cannot be spoofed via kwargs.
-_RESERVED_ENTRY_FIELDS = {"id", "created_at", "updated_at"}
-
 
 def _utc_now_iso() -> str:
     """UTC timestamp in ISO-8601 with a trailing Z (matches the rest of the learn module)."""
@@ -260,14 +255,12 @@ class Memories:
     def add_memory(self, content: str, **kwargs) -> str:
         """Add a new memory.
 
-        ``created_at`` and ``updated_at`` are stamped by the framework here and cannot be
-        supplied by the caller (any such kwargs are ignored) -- the model decides what to
-        remember, we decide when it was recorded.
+        ``created_at`` and ``updated_at`` are stamped by the framework here -- the model
+        decides what to remember, we decide when it was recorded.
 
         Args:
             content: The memory text to add.
-            **kwargs: Additional fields (e.g. source, added_by_agent). Reserved fields
-                (id, created_at, updated_at) are ignored.
+            **kwargs: Additional fields to store on the entry (e.g. source, added_by_agent).
 
         Returns:
             The generated memory ID.
@@ -278,9 +271,8 @@ class Memories:
 
         if content and content.strip():
             now = _utc_now_iso()
-            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
             self.memories.append(
-                {"id": memory_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
+                {"id": memory_id, "content": content.strip(), "created_at": now, "updated_at": now, **kwargs}
             )
 
         return memory_id
@@ -296,7 +288,6 @@ class Memories:
         """Update an existing memory.
 
         Bumps ``updated_at`` (framework-owned) and preserves the original ``created_at``.
-        Reserved fields (id, created_at, updated_at) in kwargs are ignored.
 
         Returns:
             True if memory was found and updated, False otherwise.
@@ -304,7 +295,7 @@ class Memories:
         for mem in self.memories:
             if isinstance(mem, dict) and mem.get("id") == memory_id:
                 mem["content"] = content.strip()
-                mem.update({k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS})
+                mem.update(kwargs)
                 mem["updated_at"] = _utc_now_iso()
                 return True
         return False
@@ -674,9 +665,8 @@ class EntityMemory:
 
         if content and content.strip():
             now = _utc_now_iso()
-            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
             self.facts.append(
-                {"id": fact_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
+                {"id": fact_id, "content": content.strip(), "created_at": now, "updated_at": now, **kwargs}
             )
 
         return fact_id
@@ -698,8 +688,7 @@ class EntityMemory:
 
         if content and content.strip():
             now = _utc_now_iso()
-            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
-            event = {"id": event_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
+            event = {"id": event_id, "content": content.strip(), "created_at": now, "updated_at": now, **kwargs}
             if date:
                 event["date"] = date
             self.events.append(event)
@@ -723,7 +712,6 @@ class EntityMemory:
         rel_id = str(uuid.uuid4())[:8]
 
         now = _utc_now_iso()
-        extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS}
         self.relationships.append(
             {
                 "id": rel_id,
@@ -732,7 +720,7 @@ class EntityMemory:
                 "direction": direction,
                 "created_at": now,
                 "updated_at": now,
-                **extra,
+                **kwargs,
             }
         )
 
@@ -754,7 +742,7 @@ class EntityMemory:
         for fact in self.facts:
             if isinstance(fact, dict) and fact.get("id") == fact_id:
                 fact["content"] = content.strip()
-                fact.update({k: v for k, v in kwargs.items() if k not in _RESERVED_ENTRY_FIELDS})
+                fact.update(kwargs)
                 fact["updated_at"] = _utc_now_iso()
                 return True
         return False

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -250,9 +250,9 @@ class Memories:
             return None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dict, excluding internal fields that duplicate the row columns."""
+        """Convert to dict. Works with subclasses."""
         try:
-            return _to_dict_excluding_internal(self)
+            return asdict(self)
         except Exception as e:
             log_debug(f"{self.__class__.__name__}.to_dict failed: {e}")
             return {}

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -33,10 +33,21 @@ Schemas:
 """
 
 from dataclasses import asdict, dataclass, field, fields
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from agno.learn.utils import _parse_json, _safe_get
 from agno.utils.log import log_debug
+
+# Per-memory timestamp fields are owned by the framework and stamped at write time.
+# They are never accepted from the model / caller, so they cannot be spoofed via kwargs.
+_RESERVED_MEMORY_FIELDS = {"id", "created_at", "updated_at"}
+
+
+def _utc_now_iso() -> str:
+    """UTC timestamp in ISO-8601 with a trailing Z (matches the rest of the learn module)."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
 
 # =============================================================================
 # Helper for debug logging
@@ -236,9 +247,14 @@ class Memories:
     def add_memory(self, content: str, **kwargs) -> str:
         """Add a new memory.
 
+        ``created_at`` and ``updated_at`` are stamped by the framework here and cannot be
+        supplied by the caller (any such kwargs are ignored) -- the model decides what to
+        remember, we decide when it was recorded.
+
         Args:
             content: The memory text to add.
-            **kwargs: Additional fields (source, timestamp, etc.)
+            **kwargs: Additional fields (e.g. source, added_by_agent). Reserved fields
+                (id, created_at, updated_at) are ignored.
 
         Returns:
             The generated memory ID.
@@ -248,7 +264,11 @@ class Memories:
         memory_id = str(uuid.uuid4())[:8]
 
         if content and content.strip():
-            self.memories.append({"id": memory_id, "content": content.strip(), **kwargs})
+            now = _utc_now_iso()
+            extra = {k: v for k, v in kwargs.items() if k not in _RESERVED_MEMORY_FIELDS}
+            self.memories.append(
+                {"id": memory_id, "content": content.strip(), "created_at": now, "updated_at": now, **extra}
+            )
 
         return memory_id
 
@@ -262,13 +282,17 @@ class Memories:
     def update_memory(self, memory_id: str, content: str, **kwargs) -> bool:
         """Update an existing memory.
 
+        Bumps ``updated_at`` (framework-owned) and preserves the original ``created_at``.
+        Reserved fields (id, created_at, updated_at) in kwargs are ignored.
+
         Returns:
             True if memory was found and updated, False otherwise.
         """
         for mem in self.memories:
             if isinstance(mem, dict) and mem.get("id") == memory_id:
                 mem["content"] = content.strip()
-                mem.update(kwargs)
+                mem.update({k: v for k, v in kwargs.items() if k not in _RESERVED_MEMORY_FIELDS})
+                mem["updated_at"] = _utc_now_iso()
                 return True
         return False
 

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -49,6 +49,18 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _to_dict_excluding_internal(obj: Any) -> Dict[str, Any]:
+    """Serialize a schema dataclass, dropping fields marked ``internal``.
+
+    The internal audit/identity fields (agent_id, team_id, created_at, updated_at) mirror the
+    ``agno_learnings`` row columns. The store routes the real values to those columns, so the
+    in-content copies are always null -- duplicated noise. We persist only the meaningful
+    content; the required ``user_id`` is not marked internal and is retained for round-trip.
+    """
+    internal = {f.name for f in fields(obj) if f.metadata.get("internal")}
+    return {k: v for k, v in asdict(obj).items() if k not in internal}
+
+
 # =============================================================================
 # Helper for debug logging
 # =============================================================================
@@ -145,9 +157,9 @@ class UserProfile:
             return None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dict. Works with subclasses."""
+        """Convert to dict, excluding internal fields that duplicate the row columns."""
         try:
-            return asdict(self)
+            return _to_dict_excluding_internal(self)
         except Exception as e:
             log_debug(f"{self.__class__.__name__}.to_dict failed: {e}")
             return {}
@@ -237,9 +249,9 @@ class Memories:
             return None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dict. Works with subclasses."""
+        """Convert to dict, excluding internal fields that duplicate the row columns."""
         try:
-            return asdict(self)
+            return _to_dict_excluding_internal(self)
         except Exception as e:
             log_debug(f"{self.__class__.__name__}.to_dict failed: {e}")
             return {}

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -45,18 +45,6 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def _to_dict_excluding_internal(obj: Any) -> Dict[str, Any]:
-    """Serialize a schema dataclass, dropping fields marked ``internal``.
-
-    The internal audit/identity fields (agent_id, team_id, created_at, updated_at) mirror the
-    ``agno_learnings`` row columns. The store routes the real values to those columns, so the
-    in-content copies are always null -- duplicated noise. We persist only the meaningful
-    content; the required ``user_id`` is not marked internal and is retained for round-trip.
-    """
-    internal = {f.name for f in fields(obj) if f.metadata.get("internal")}
-    return {k: v for k, v in asdict(obj).items() if k not in internal}
-
-
 # =============================================================================
 # Helper for debug logging
 # =============================================================================
@@ -153,9 +141,15 @@ class UserProfile:
             return None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dict, excluding internal fields that duplicate the row columns."""
+        """Convert to dict, dropping the internal audit/identity fields.
+
+        agent_id/team_id/created_at/updated_at mirror the agno_learnings row columns; the
+        store routes the real values to those columns, so the in-content copies are always
+        null -- duplicated noise. user_id is not marked internal and is kept for round-trip.
+        """
         try:
-            return _to_dict_excluding_internal(self)
+            internal = {f.name for f in fields(self) if f.metadata.get("internal")}
+            return {k: v for k, v in asdict(self).items() if k not in internal}
         except Exception as e:
             log_debug(f"{self.__class__.__name__}.to_dict failed: {e}")
             return {}

--- a/libs/agno/agno/learn/stores/user_memory.py
+++ b/libs/agno/agno/learn/stores/user_memory.py
@@ -28,7 +28,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from os import getenv
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from agno.learn.config import LearningMode, UserMemoryConfig
 from agno.learn.schemas import Memories
@@ -1161,18 +1161,13 @@ class UserMemoryStore(LearningStore):
                     if memories_data is None:
                         memories_data = self.schema(user_id=user_id)
 
-                    if hasattr(memories_data, "memories"):
-                        memory_id = str(uuid.uuid4())[:8]
-                        memory_entry = {
-                            "id": memory_id,
-                            "content": memory,
-                            "source": input_string[:200] if input_string else None,
-                        }
+                    if hasattr(memories_data, "add_memory"):
+                        extra: Dict[str, Any] = {"source": input_string[:200] if input_string else None}
                         if agent_id:
-                            memory_entry["added_by_agent"] = agent_id
+                            extra["added_by_agent"] = agent_id
                         if team_id:
-                            memory_entry["added_by_team"] = team_id
-                        memories_data.memories.append(memory_entry)
+                            extra["added_by_team"] = team_id
+                        memories_data.add_memory(memory, **extra)
 
                     self.save(user_id=user_id, memories=memories_data, agent_id=agent_id, team_id=team_id)
                     log_debug(f"Memory added: {memory[:50]}...")
@@ -1204,18 +1199,16 @@ class UserMemoryStore(LearningStore):
                     if memories_data is None:
                         return "No memories found"
 
-                    if hasattr(memories_data, "memories"):
-                        for mem in memories_data.memories:
-                            if isinstance(mem, dict) and mem.get("id") == memory_id:
-                                mem["content"] = memory
-                                mem["source"] = input_string[:200] if input_string else None
-                                if agent_id:
-                                    mem["updated_by_agent"] = agent_id
-                                if team_id:
-                                    mem["updated_by_team"] = team_id
-                                self.save(user_id=user_id, memories=memories_data, agent_id=agent_id, team_id=team_id)
-                                log_debug(f"Memory updated: {memory_id}")
-                                return f"Memory updated: {memory}"
+                    if hasattr(memories_data, "update_memory"):
+                        extra: Dict[str, Any] = {"source": input_string[:200] if input_string else None}
+                        if agent_id:
+                            extra["updated_by_agent"] = agent_id
+                        if team_id:
+                            extra["updated_by_team"] = team_id
+                        if memories_data.update_memory(memory_id, memory, **extra):
+                            self.save(user_id=user_id, memories=memories_data, agent_id=agent_id, team_id=team_id)
+                            log_debug(f"Memory updated: {memory_id}")
+                            return f"Memory updated: {memory}"
                         return f"Memory {memory_id} not found"
 
                     return "No memories field"
@@ -1318,18 +1311,13 @@ class UserMemoryStore(LearningStore):
                     if memories_data is None:
                         memories_data = self.schema(user_id=user_id)
 
-                    if hasattr(memories_data, "memories"):
-                        memory_id = str(uuid.uuid4())[:8]
-                        memory_entry = {
-                            "id": memory_id,
-                            "content": memory,
-                            "source": input_string[:200] if input_string else None,
-                        }
+                    if hasattr(memories_data, "add_memory"):
+                        extra: Dict[str, Any] = {"source": input_string[:200] if input_string else None}
                         if agent_id:
-                            memory_entry["added_by_agent"] = agent_id
+                            extra["added_by_agent"] = agent_id
                         if team_id:
-                            memory_entry["added_by_team"] = team_id
-                        memories_data.memories.append(memory_entry)
+                            extra["added_by_team"] = team_id
+                        memories_data.add_memory(memory, **extra)
 
                     await self.asave(user_id=user_id, memories=memories_data, agent_id=agent_id, team_id=team_id)
                     log_debug(f"Memory added: {memory[:50]}...")
@@ -1361,20 +1349,18 @@ class UserMemoryStore(LearningStore):
                     if memories_data is None:
                         return "No memories found"
 
-                    if hasattr(memories_data, "memories"):
-                        for mem in memories_data.memories:
-                            if isinstance(mem, dict) and mem.get("id") == memory_id:
-                                mem["content"] = memory
-                                mem["source"] = input_string[:200] if input_string else None
-                                if agent_id:
-                                    mem["updated_by_agent"] = agent_id
-                                if team_id:
-                                    mem["updated_by_team"] = team_id
-                                await self.asave(
-                                    user_id=user_id, memories=memories_data, agent_id=agent_id, team_id=team_id
-                                )
-                                log_debug(f"Memory updated: {memory_id}")
-                                return f"Memory updated: {memory}"
+                    if hasattr(memories_data, "update_memory"):
+                        extra: Dict[str, Any] = {"source": input_string[:200] if input_string else None}
+                        if agent_id:
+                            extra["updated_by_agent"] = agent_id
+                        if team_id:
+                            extra["updated_by_team"] = team_id
+                        if memories_data.update_memory(memory_id, memory, **extra):
+                            await self.asave(
+                                user_id=user_id, memories=memories_data, agent_id=agent_id, team_id=team_id
+                            )
+                            log_debug(f"Memory updated: {memory_id}")
+                            return f"Memory updated: {memory}"
                         return f"Memory {memory_id} not found"
 
                     return "No memories field"

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -248,7 +248,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
 
         try:
             if isinstance(db, AsyncBaseDb):
-                records, total_count = await db.get_learning_user_stats(
+                records, total_count = await db.get_learnings_user_stats(
                     learning_type=learning_type,
                     user_id=user_id,
                     limit=limit,
@@ -257,7 +257,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                     sort_order=sort_order.value if sort_order else None,
                 )
             else:
-                records, total_count = cast(BaseDb, db).get_learning_user_stats(
+                records, total_count = cast(BaseDb, db).get_learnings_user_stats(
                     learning_type=learning_type,
                     user_id=user_id,
                     limit=limit,
@@ -267,6 +267,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 )
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to get learning users: {e}")
 
         total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
         return PaginatedResponse(

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -9,7 +9,7 @@ from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.os.auth import get_authentication_dependency
-from agno.os.routers.learnings.schema import LearningCreate, LearningResponse, LearningUpdate
+from agno.os.routers.learnings.schema import LearningCreate, LearningResponse, LearningUpdate, LearningUserStats
 from agno.os.schema import (
     BadRequestResponse,
     InternalServerErrorResponse,
@@ -195,6 +195,69 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         if created is None:
             raise HTTPException(status_code=500, detail="Failed to create learning")
         return LearningResponse.model_validate(created)
+
+    @router.get(
+        "/learnings/users",
+        response_model=PaginatedResponse[LearningUserStats],
+        operation_id="list_learning_users",
+        summary="List Learning Users",
+        description=(
+            "List the users that own learning records, with a per-user count and last-updated "
+            "timestamp. Intended as the entry point for a per-user view: list users here, then "
+            "drill into a single user's learnings via `GET /learnings?user_id=...`. Records with "
+            "no owner (`user_id IS NULL`) are excluded. Pass `learning_type` to restrict the "
+            "grouping to a single store (e.g. `user_profile` or `user_memory`). When the request "
+            "is authenticated with a JWT, results are scoped to the JWT subject; passing a "
+            "`user_id` that differs from the subject is rejected with 403."
+        ),
+    )
+    async def list_learning_users(
+        request: Request,
+        learning_type: Optional[str] = Query(None, description="Restrict the grouping to a single learning type"),
+        user_id: Optional[str] = Query(None, description="Restrict the result to a single user"),
+        limit: int = Query(20, ge=1, le=1000, description="Page size"),
+        page: int = Query(1, ge=1, description="1-indexed page number"),
+        db_id: Optional[str] = Query(None, description="Database ID to query"),
+    ) -> PaginatedResponse[LearningUserStats]:
+        jwt_user_id = getattr(request.state, "user_id", None)
+        if jwt_user_id is not None:
+            if user_id is not None and user_id != jwt_user_id:
+                raise HTTPException(status_code=403, detail="Cannot list learning users for another user")
+            user_id = jwt_user_id
+
+        db = await get_db(dbs, db_id)
+
+        if isinstance(db, RemoteDb):
+            raise HTTPException(status_code=501, detail="Learnings endpoints not supported on remote DBs")
+
+        try:
+            if isinstance(db, AsyncBaseDb):
+                records, total_count = await db.get_learning_user_stats(
+                    learning_type=learning_type,
+                    user_id=user_id,
+                    limit=limit,
+                    page=page,
+                )
+            else:
+                records, total_count = cast(BaseDb, db).get_learning_user_stats(
+                    learning_type=learning_type,
+                    user_id=user_id,
+                    limit=limit,
+                    page=page,
+                )
+        except NotImplementedError:
+            raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+
+        total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
+        return PaginatedResponse(
+            data=[LearningUserStats.model_validate(r) for r in records],
+            meta=PaginationInfo(
+                page=page,
+                limit=limit,
+                total_pages=total_pages,
+                total_count=total_count,
+            ),
+        )
 
     @router.get(
         "/learnings/{learning_id}",

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -16,6 +16,7 @@ from agno.os.schema import (
     NotFoundResponse,
     PaginatedResponse,
     PaginationInfo,
+    SortOrder,
     UnauthenticatedResponse,
     ValidationErrorResponse,
 )
@@ -72,6 +73,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         entity_type: Optional[str] = Query(None, description="Filter by entity type"),
         limit: int = Query(100, ge=1, le=1000, description="Page size"),
         page: int = Query(1, ge=1, description="1-indexed page number"),
+        sort_by: Optional[str] = Query(None, description="Field to sort by (defaults to updated_at)"),
+        sort_order: Optional[SortOrder] = Query(SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),
     ) -> PaginatedResponse[LearningResponse]:
         include_global = False
@@ -101,6 +104,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                     include_global=include_global,
                     limit=limit,
                     page=page,
+                    sort_by=sort_by,
+                    sort_order=sort_order.value if sort_order else None,
                 )
             else:
                 records, total_count = cast(BaseDb, db).list_learnings(
@@ -115,6 +120,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                     include_global=include_global,
                     limit=limit,
                     page=page,
+                    sort_by=sort_by,
+                    sort_order=sort_order.value if sort_order else None,
                 )
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
@@ -208,7 +215,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             "no owner (`user_id IS NULL`) are excluded. Pass `learning_type` to restrict the "
             "grouping to a single store (e.g. `user_profile` or `user_memory`). When the request "
             "is authenticated with a JWT, results are scoped to the JWT subject; passing a "
-            "`user_id` that differs from the subject is rejected with 403."
+            "`user_id` that differs from the subject is rejected with 403. Sortable by `user_id`, "
+            "`total_learnings`, or `last_learning_updated_at` (the default)."
         ),
     )
     async def list_learning_users(
@@ -217,6 +225,11 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         user_id: Optional[str] = Query(None, description="Restrict the result to a single user"),
         limit: int = Query(20, ge=1, le=1000, description="Page size"),
         page: int = Query(1, ge=1, description="1-indexed page number"),
+        sort_by: Optional[str] = Query(
+            None,
+            description="Field to sort by: user_id, total_learnings, or last_learning_updated_at (the default)",
+        ),
+        sort_order: Optional[SortOrder] = Query(SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),
     ) -> PaginatedResponse[LearningUserStats]:
         jwt_user_id = getattr(request.state, "user_id", None)
@@ -237,6 +250,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                     user_id=user_id,
                     limit=limit,
                     page=page,
+                    sort_by=sort_by,
+                    sort_order=sort_order.value if sort_order else None,
                 )
             else:
                 records, total_count = cast(BaseDb, db).get_learning_user_stats(
@@ -244,6 +259,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                     user_id=user_id,
                     limit=limit,
                     page=page,
+                    sort_by=sort_by,
+                    sort_order=sort_order.value if sort_order else None,
                 )
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -281,6 +281,42 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             ),
         )
 
+    @router.delete(
+        "/learnings/users/{user_id}",
+        status_code=204,
+        operation_id="delete_learning_user",
+        summary="Delete Learning User",
+        description=(
+            "Delete every learning record owned by a user, across all learning types backed by the "
+            "agno_learnings table (user_profile, user_memory, and any user-scoped entity records). "
+            "Records with no owner (`user_id IS NULL`) are not affected. When the request is "
+            "authenticated with a JWT, only the JWT subject's own learnings may be deleted; a "
+            "different `user_id` is rejected with 403. Returns 204 even if the user had no records."
+        ),
+    )
+    async def delete_learning_user(
+        request: Request,
+        user_id: str = Path(description="The user whose learnings should be deleted"),
+        db_id: Optional[str] = Query(None, description="Database ID to use"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
+    ) -> None:
+        jwt_user_id = getattr(request.state, "user_id", None)
+        if jwt_user_id is not None and user_id != jwt_user_id:
+            raise HTTPException(status_code=403, detail="Cannot delete learnings for another user")
+
+        db = await get_db(dbs, db_id, table)
+
+        if isinstance(db, RemoteDb):
+            raise HTTPException(status_code=501, detail="Learnings endpoints not supported on remote DBs")
+
+        try:
+            if isinstance(db, AsyncBaseDb):
+                await db.delete_user_learnings(user_id)
+            else:
+                cast(BaseDb, db).delete_user_learnings(user_id)
+        except NotImplementedError:
+            raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+
     @router.get(
         "/learnings/{learning_id}",
         response_model=LearningResponse,

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -9,6 +9,7 @@ from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.os.auth import get_authentication_dependency
+from agno.os.middleware.user_scope import get_scoped_user_id
 from agno.os.routers.learnings.schema import LearningCreate, LearningResponse, LearningUpdate, LearningUserStats
 from agno.os.schema import (
     BadRequestResponse,
@@ -54,11 +55,12 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         operation_id="list_learnings",
         summary="List Learnings",
         description=(
-            "List learning records with pagination and optional filters. When the request is "
-            "authenticated with a JWT and no `user_id` query is provided, results are scoped to the "
-            "JWT subject and also include records with no owner (`user_id IS NULL`) — this covers "
-            "global, agent, team, session, and entity-scoped learnings. Passing a `user_id` that "
-            "differs from the JWT subject is rejected with 403."
+            "List learning records with pagination and optional filters. For a scoped (non-admin) "
+            "caller with user isolation enabled, results are bound to that user and also include "
+            "records with no owner (`user_id IS NULL`) — this covers global, agent, team, session, "
+            "and entity-scoped learnings; passing a `user_id` that differs from the caller is "
+            "rejected with 403. Admins and unscoped callers see all records (optionally filtered by "
+            "`user_id`)."
         ),
     )
     async def list_learnings(
@@ -79,11 +81,11 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> PaginatedResponse[LearningResponse]:
         include_global = False
-        jwt_user_id = getattr(request.state, "user_id", None)
-        if jwt_user_id is not None:
-            if user_id is not None and user_id != jwt_user_id:
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            if user_id is not None and user_id != scoped_user_id:
                 raise HTTPException(status_code=403, detail="Cannot list learnings for another user")
-            user_id = jwt_user_id
+            user_id = scoped_user_id
             include_global = True
 
         db = await get_db(dbs, db_id, table)
@@ -145,9 +147,9 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         operation_id="create_learning",
         summary="Create Learning",
         description=(
-            "Create a new learning record. When the request is authenticated with a JWT, the body's "
-            "`user_id` must either be omitted/null (creates a global / non-user-scoped record) or "
-            "match the JWT subject. A mismatch is rejected with 403."
+            "Create a new learning record. For a scoped (non-admin) caller, the body's `user_id` "
+            "must either be omitted/null (creates a global / non-user-scoped record) or match the "
+            "caller. A mismatch is rejected with 403. Admins and unscoped callers may set any `user_id`."
         ),
     )
     async def create_learning(
@@ -156,8 +158,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         db_id: Optional[str] = Query(None, description="Database ID to use"),
         table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> LearningResponse:
-        jwt_user_id = getattr(request.state, "user_id", None)
-        if jwt_user_id is not None and body.user_id is not None and body.user_id != jwt_user_id:
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None and body.user_id is not None and body.user_id != scoped_user_id:
             raise HTTPException(status_code=403, detail="Cannot create learnings for another user")
 
         db = await get_db(dbs, db_id, table)
@@ -215,10 +217,10 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             "timestamp. Intended as the entry point for a per-user view: list users here, then "
             "drill into a single user's learnings via `GET /learnings?user_id=...`. Records with "
             "no owner (`user_id IS NULL`) are excluded. Pass `learning_type` to restrict the "
-            "grouping to a single store (e.g. `user_profile` or `user_memory`). When the request "
-            "is authenticated with a JWT, results are scoped to the JWT subject; passing a "
-            "`user_id` that differs from the subject is rejected with 403. Sortable by `user_id` "
-            "or `last_learning_updated_at` (the default)."
+            "grouping to a single store (e.g. `user_profile` or `user_memory`). For a scoped "
+            "(non-admin) caller results are bound to that user; an explicit `user_id` that differs "
+            "is rejected with 403. Admins and unscoped callers list all users. Sortable by "
+            "`user_id` or `last_learning_updated_at` (the default)."
         ),
     )
     async def list_learning_users(
@@ -235,11 +237,11 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         db_id: Optional[str] = Query(None, description="Database ID to query"),
         table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> PaginatedResponse[LearningUserStats]:
-        jwt_user_id = getattr(request.state, "user_id", None)
-        if jwt_user_id is not None:
-            if user_id is not None and user_id != jwt_user_id:
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            if user_id is not None and user_id != scoped_user_id:
                 raise HTTPException(status_code=403, detail="Cannot list learning users for another user")
-            user_id = jwt_user_id
+            user_id = scoped_user_id
 
         db = await get_db(dbs, db_id, table)
 
@@ -290,9 +292,10 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             "Delete the learning records owned by a user. By default removes every learning type "
             "backed by the agno_learnings table (user_profile, user_memory, and any user-scoped "
             "entity records); pass `learning_type` to restrict deletion to a single store. Records "
-            "with no owner (`user_id IS NULL`) are not affected. When the request is authenticated "
-            "with a JWT, only the JWT subject's own learnings may be deleted; a different `user_id` "
-            "is rejected with 403. Returns 204 even if the user had no matching records."
+            "with no owner (`user_id IS NULL`) are not affected. For a scoped (non-admin) caller, "
+            "only their own learnings may be deleted; a different `user_id` is rejected with 403. "
+            "Admins and unscoped callers may delete any user's learnings. Returns 204 even if the "
+            "user had no matching records."
         ),
     )
     async def delete_learning_user(
@@ -304,8 +307,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         db_id: Optional[str] = Query(None, description="Database ID to use"),
         table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> None:
-        jwt_user_id = getattr(request.state, "user_id", None)
-        if jwt_user_id is not None and user_id != jwt_user_id:
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None and user_id != scoped_user_id:
             raise HTTPException(status_code=403, detail="Cannot delete learnings for another user")
 
         db = await get_db(dbs, db_id, table)
@@ -478,16 +481,17 @@ async def _fetch_learning(db: Union[BaseDb, AsyncBaseDb, RemoteDb], learning_id:
 def _enforce_user_scope(request: Request, record: dict) -> None:
     """Block cross-user access without leaking existence.
 
-    Records with ``user_id IS NULL`` are global / non-user-scoped (e.g. agent, team,
-    session, or entity learnings) and remain accessible to any authenticated caller.
-    Returns 404 (not 403) when the record is owned by a different user, to avoid
-    leaking which IDs exist.
+    Scoping is the framework's opt-in ``user_isolation`` contract: admins and callers
+    running with isolation disabled get ``None`` from ``get_scoped_user_id`` and have full
+    access. For a scoped (non-admin) caller, records with ``user_id IS NULL`` are global /
+    non-user-scoped (e.g. agent, team, session, or entity learnings) and remain accessible;
+    a record owned by a different user returns 404 (not 403) to avoid leaking which IDs exist.
     """
-    jwt_user_id = getattr(request.state, "user_id", None)
-    if jwt_user_id is None:
+    scoped_user_id = get_scoped_user_id(request)
+    if scoped_user_id is None:
         return
     record_user_id = record.get("user_id")
     if record_user_id is None:
         return
-    if record_user_id != jwt_user_id:
+    if record_user_id != scoped_user_id:
         raise HTTPException(status_code=404, detail="Learning not found")

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -217,8 +217,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             "no owner (`user_id IS NULL`) are excluded. Pass `learning_type` to restrict the "
             "grouping to a single store (e.g. `user_profile` or `user_memory`). When the request "
             "is authenticated with a JWT, results are scoped to the JWT subject; passing a "
-            "`user_id` that differs from the subject is rejected with 403. Sortable by `user_id`, "
-            "`total_learnings`, or `last_learning_updated_at` (the default)."
+            "`user_id` that differs from the subject is rejected with 403. Sortable by `user_id` "
+            "or `last_learning_updated_at` (the default)."
         ),
     )
     async def list_learning_users(
@@ -229,7 +229,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         page: int = Query(1, ge=1, description="1-indexed page number"),
         sort_by: Optional[str] = Query(
             None,
-            description="Field to sort by: user_id, total_learnings, or last_learning_updated_at (the default)",
+            description="Field to sort by: user_id or last_learning_updated_at (the default)",
         ),
         sort_order: Optional[SortOrder] = Query(SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -287,16 +287,20 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         operation_id="delete_learning_user",
         summary="Delete Learning User",
         description=(
-            "Delete every learning record owned by a user, across all learning types backed by the "
-            "agno_learnings table (user_profile, user_memory, and any user-scoped entity records). "
-            "Records with no owner (`user_id IS NULL`) are not affected. When the request is "
-            "authenticated with a JWT, only the JWT subject's own learnings may be deleted; a "
-            "different `user_id` is rejected with 403. Returns 204 even if the user had no records."
+            "Delete the learning records owned by a user. By default removes every learning type "
+            "backed by the agno_learnings table (user_profile, user_memory, and any user-scoped "
+            "entity records); pass `learning_type` to restrict deletion to a single store. Records "
+            "with no owner (`user_id IS NULL`) are not affected. When the request is authenticated "
+            "with a JWT, only the JWT subject's own learnings may be deleted; a different `user_id` "
+            "is rejected with 403. Returns 204 even if the user had no matching records."
         ),
     )
     async def delete_learning_user(
         request: Request,
         user_id: str = Path(description="The user whose learnings should be deleted"),
+        learning_type: Optional[str] = Query(
+            None, description="Restrict deletion to a single learning type; omit to delete all of the user's learnings"
+        ),
         db_id: Optional[str] = Query(None, description="Database ID to use"),
         table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> None:
@@ -311,9 +315,9 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
 
         try:
             if isinstance(db, AsyncBaseDb):
-                await db.delete_user_learnings(user_id)
+                await db.delete_user_learnings(user_id, learning_type=learning_type)
             else:
-                cast(BaseDb, db).delete_user_learnings(user_id)
+                cast(BaseDb, db).delete_user_learnings(user_id, learning_type=learning_type)
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
 

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -76,6 +76,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         sort_by: Optional[str] = Query(None, description="Field to sort by (defaults to updated_at)"),
         sort_order: Optional[SortOrder] = Query(SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> PaginatedResponse[LearningResponse]:
         include_global = False
         jwt_user_id = getattr(request.state, "user_id", None)
@@ -85,7 +86,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
             user_id = jwt_user_id
             include_global = True
 
-        db = await get_db(dbs, db_id)
+        db = await get_db(dbs, db_id, table)
 
         if isinstance(db, RemoteDb):
             raise HTTPException(status_code=501, detail="Learnings endpoints not supported on remote DBs")
@@ -153,12 +154,13 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         request: Request,
         body: LearningCreate,
         db_id: Optional[str] = Query(None, description="Database ID to use"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> LearningResponse:
         jwt_user_id = getattr(request.state, "user_id", None)
         if jwt_user_id is not None and body.user_id is not None and body.user_id != jwt_user_id:
             raise HTTPException(status_code=403, detail="Cannot create learnings for another user")
 
-        db = await get_db(dbs, db_id)
+        db = await get_db(dbs, db_id, table)
 
         if isinstance(db, RemoteDb):
             raise HTTPException(status_code=501, detail="Learnings endpoints not supported on remote DBs")
@@ -231,6 +233,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         ),
         sort_order: Optional[SortOrder] = Query(SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> PaginatedResponse[LearningUserStats]:
         jwt_user_id = getattr(request.state, "user_id", None)
         if jwt_user_id is not None:
@@ -238,7 +241,7 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 raise HTTPException(status_code=403, detail="Cannot list learning users for another user")
             user_id = jwt_user_id
 
-        db = await get_db(dbs, db_id)
+        db = await get_db(dbs, db_id, table)
 
         if isinstance(db, RemoteDb):
             raise HTTPException(status_code=501, detail="Learnings endpoints not supported on remote DBs")
@@ -287,8 +290,9 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         request: Request,
         learning_id: str = Path(description="The learning ID"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> LearningResponse:
-        db = await get_db(dbs, db_id)
+        db = await get_db(dbs, db_id, table)
         record = await _fetch_learning(db, learning_id)
         _enforce_user_scope(request, record)
         return LearningResponse.model_validate(record)
@@ -309,8 +313,9 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         body: LearningUpdate,
         learning_id: str = Path(description="The learning ID"),
         db_id: Optional[str] = Query(None, description="Database ID to use"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> LearningResponse:
-        db = await get_db(dbs, db_id)
+        db = await get_db(dbs, db_id, table)
         existing = await _fetch_learning(db, learning_id)
         _enforce_user_scope(request, existing)
 
@@ -393,8 +398,9 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         request: Request,
         learning_id: str = Path(description="The learning ID"),
         db_id: Optional[str] = Query(None, description="Database ID to use"),
+        table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> None:
-        db = await get_db(dbs, db_id)
+        db = await get_db(dbs, db_id, table)
         existing = await _fetch_learning(db, learning_id)
         _enforce_user_scope(request, existing)
 

--- a/libs/agno/agno/os/routers/learnings/schema.py
+++ b/libs/agno/agno/os/routers/learnings/schema.py
@@ -49,3 +49,13 @@ class LearningUpdate(BaseModel):
 
     content: Optional[Dict[str, Any]] = Field(None, description="Replacement content payload")
     metadata: Optional[Dict[str, Any]] = Field(None, description="Replacement metadata")
+
+
+class LearningUserStats(BaseModel):
+    """Per-user learning statistics, used to list the users that own learnings."""
+
+    user_id: str = Field(..., description="The user ID")
+    total_learnings: int = Field(..., description="Number of learning records owned by this user", ge=0)
+    last_learning_updated_at: Optional[int] = Field(
+        None, description="Most recent learning update for this user (Unix epoch seconds)"
+    )

--- a/libs/agno/agno/os/routers/learnings/schema.py
+++ b/libs/agno/agno/os/routers/learnings/schema.py
@@ -52,10 +52,16 @@ class LearningUpdate(BaseModel):
 
 
 class LearningUserStats(BaseModel):
-    """Per-user learning statistics, used to list the users that own learnings."""
+    """A user that owns learning records, with their most recent activity.
+
+    Used as a lightweight index for the per-user view: list users here, then drill into a
+    single user's records via ``GET /learnings?user_id=...``. No per-user count is returned
+    -- the user-scoped stores (``user_profile``, ``user_memory``) keep a single record per
+    user, so a record count would always be 1; the actual memory count lives in that
+    record's ``content``.
+    """
 
     user_id: str = Field(..., description="The user ID")
-    total_learnings: int = Field(..., description="Number of learning records owned by this user", ge=0)
     last_learning_updated_at: Optional[int] = Field(
         None, description="Most recent learning update for this user (Unix epoch seconds)"
     )

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -259,6 +259,8 @@ async def get_db(
             and db.session_table_name == table_name
             or hasattr(db, "memory_table_name")
             and db.memory_table_name == table_name
+            or hasattr(db, "learnings_table_name")
+            and db.learnings_table_name == table_name
             or hasattr(db, "metrics_table_name")
             and db.metrics_table_name == table_name
             or hasattr(db, "eval_table_name")

--- a/libs/agno/tests/unit/learn/test_memories_schema.py
+++ b/libs/agno/tests/unit/learn/test_memories_schema.py
@@ -56,8 +56,9 @@ class TestUpdateMemory:
 
 
 class TestToDictExcludesInternalFields:
-    """Internal audit/identity fields mirror the agno_learnings row columns, so they must
-    not be duplicated (as nulls) inside the persisted content. user_id is kept for round-trip."""
+    """UserProfile drops its internal audit/identity fields from content (they mirror the
+    agno_learnings row columns and would always be null). Scoped to UserProfile only;
+    Memories keeps its full serialization. user_id is kept for round-trip."""
 
     def test_profile_drops_internal_fields(self):
         content = UserProfile(user_id="u1", name="lm", preferred_name="neha").to_dict()
@@ -65,13 +66,13 @@ class TestToDictExcludesInternalFields:
         for f in ("agent_id", "team_id", "created_at", "updated_at"):
             assert f not in content
 
-    def test_memories_drops_parent_internal_but_keeps_entry_timestamps(self):
+    def test_memories_keeps_parent_fields_and_entry_timestamps(self):
         m = Memories(user_id="u1")
         m.add_memory("likes Python")
         content = m.to_dict()
-        # Parent-level internal fields are gone...
-        assert set(content.keys()) == {"user_id", "memories"}
-        # ...but the per-memory timestamps inside the entries survive.
+        # Memories keeps its full serialization (parent internal fields included)...
+        assert "created_at" in content and "agent_id" in content
+        # ...and the per-memory timestamps inside the entries are present.
         entry = content["memories"][0]
         assert "created_at" in entry and "updated_at" in entry
 

--- a/libs/agno/tests/unit/learn/test_memories_schema.py
+++ b/libs/agno/tests/unit/learn/test_memories_schema.py
@@ -21,15 +21,6 @@ class TestAddMemory:
         assert entry["source"] == "chat"
         assert entry["added_by_agent"] == "ag1"
 
-    def test_caller_cannot_override_reserved_fields(self):
-        # The model / caller must not be able to set the id or timestamps.
-        m = Memories(user_id="u1")
-        mid = m.add_memory("x", id="HACK", created_at="1999-01-01", updated_at="1999-01-01")
-        entry = m.memories[0]
-        assert entry["id"] == mid != "HACK"
-        assert entry["created_at"] != "1999-01-01"
-        assert entry["updated_at"] != "1999-01-01"
-
 
 class TestUpdateMemory:
     def test_bumps_updated_at_and_preserves_created_at(self):
@@ -42,13 +33,6 @@ class TestUpdateMemory:
         assert entry["content"] == "loves Python"
         assert entry["created_at"] == created
         assert entry["updated_at"] >= created
-
-    def test_caller_cannot_override_created_at_on_update(self):
-        m = Memories(user_id="u1")
-        mid = m.add_memory("x")
-        created = m.memories[0]["created_at"]
-        m.update_memory(mid, "y", created_at="1999-01-01")
-        assert m.memories[0]["created_at"] == created
 
     def test_returns_false_when_not_found(self):
         m = Memories(user_id="u1")
@@ -104,13 +88,6 @@ class TestEntityMemoryEntryTimestamps:
         assert e.events[0]["created_at"].endswith("Z")
         assert e.events[0]["date"] == "2024-01-15"
         assert e.relationships[0]["created_at"] == e.relationships[0]["updated_at"]
-
-    def test_add_fact_caller_cannot_override_reserved_fields(self):
-        e = EntityMemory(entity_id="acme", entity_type="company")
-        fid = e.add_fact("x", id="HACK", created_at="1999-01-01")
-        fact = e.facts[0]
-        assert fact["id"] == fid != "HACK"
-        assert fact["created_at"] != "1999-01-01"
 
     def test_update_fact_bumps_updated_at_preserves_created_at(self):
         e = EntityMemory(entity_id="acme", entity_type="company")

--- a/libs/agno/tests/unit/learn/test_memories_schema.py
+++ b/libs/agno/tests/unit/learn/test_memories_schema.py
@@ -1,0 +1,55 @@
+"""Tests for the Memories schema's framework-owned per-memory timestamps."""
+
+from agno.learn.schemas import Memories
+
+
+class TestAddMemory:
+    def test_stamps_created_and_updated(self):
+        m = Memories(user_id="u1")
+        mid = m.add_memory("likes Python")
+        entry = m.memories[0]
+        assert entry["id"] == mid
+        assert entry["content"] == "likes Python"
+        # Both timestamps are stamped and equal on insert.
+        assert entry["created_at"].endswith("Z")
+        assert entry["created_at"] == entry["updated_at"]
+
+    def test_keeps_extra_kwargs(self):
+        m = Memories(user_id="u1")
+        m.add_memory("likes Python", source="chat", added_by_agent="ag1")
+        entry = m.memories[0]
+        assert entry["source"] == "chat"
+        assert entry["added_by_agent"] == "ag1"
+
+    def test_caller_cannot_override_reserved_fields(self):
+        # The model / caller must not be able to set the id or timestamps.
+        m = Memories(user_id="u1")
+        mid = m.add_memory("x", id="HACK", created_at="1999-01-01", updated_at="1999-01-01")
+        entry = m.memories[0]
+        assert entry["id"] == mid != "HACK"
+        assert entry["created_at"] != "1999-01-01"
+        assert entry["updated_at"] != "1999-01-01"
+
+
+class TestUpdateMemory:
+    def test_bumps_updated_at_and_preserves_created_at(self):
+        m = Memories(user_id="u1")
+        mid = m.add_memory("likes Python")
+        created = m.memories[0]["created_at"]
+
+        assert m.update_memory(mid, "loves Python") is True
+        entry = m.memories[0]
+        assert entry["content"] == "loves Python"
+        assert entry["created_at"] == created
+        assert entry["updated_at"] >= created
+
+    def test_caller_cannot_override_created_at_on_update(self):
+        m = Memories(user_id="u1")
+        mid = m.add_memory("x")
+        created = m.memories[0]["created_at"]
+        m.update_memory(mid, "y", created_at="1999-01-01")
+        assert m.memories[0]["created_at"] == created
+
+    def test_returns_false_when_not_found(self):
+        m = Memories(user_id="u1")
+        assert m.update_memory("missing", "y") is False

--- a/libs/agno/tests/unit/learn/test_memories_schema.py
+++ b/libs/agno/tests/unit/learn/test_memories_schema.py
@@ -1,6 +1,6 @@
-"""Tests for the Memories schema's framework-owned per-memory timestamps."""
+"""Tests for framework-owned per-entry timestamps on learning schemas (memories, entity facts...)."""
 
-from agno.learn.schemas import Memories, UserProfile
+from agno.learn.schemas import EntityMemory, Memories, UserProfile
 
 
 class TestAddMemory:
@@ -81,3 +81,42 @@ class TestToDictExcludesInternalFields:
         assert back is not None
         assert back.user_id == "u1"
         assert back.name == "lm"
+
+
+class TestEntityMemoryEntryTimestamps:
+    """facts / events / relationships are object-lists inside content; each entry gets
+    framework-owned created_at + updated_at, same as memories."""
+
+    def test_add_fact_stamps_timestamps(self):
+        e = EntityMemory(entity_id="acme", entity_type="company")
+        fid = e.add_fact("uses PostgreSQL", confidence=0.9)
+        fact = e.facts[0]
+        assert fact["id"] == fid
+        assert fact["created_at"].endswith("Z")
+        assert fact["created_at"] == fact["updated_at"]
+        assert fact["confidence"] == 0.9
+
+    def test_add_event_and_relationship_stamp_timestamps(self):
+        e = EntityMemory(entity_id="acme", entity_type="company")
+        e.add_event("launched v2", date="2024-01-15")
+        e.add_relationship("bob", "CEO")
+        assert e.events[0]["created_at"].endswith("Z")
+        assert e.events[0]["date"] == "2024-01-15"
+        assert e.relationships[0]["created_at"] == e.relationships[0]["updated_at"]
+
+    def test_add_fact_caller_cannot_override_reserved_fields(self):
+        e = EntityMemory(entity_id="acme", entity_type="company")
+        fid = e.add_fact("x", id="HACK", created_at="1999-01-01")
+        fact = e.facts[0]
+        assert fact["id"] == fid != "HACK"
+        assert fact["created_at"] != "1999-01-01"
+
+    def test_update_fact_bumps_updated_at_preserves_created_at(self):
+        e = EntityMemory(entity_id="acme", entity_type="company")
+        fid = e.add_fact("uses PG")
+        created = e.facts[0]["created_at"]
+        assert e.update_fact(fid, "uses PG 16") is True
+        fact = e.facts[0]
+        assert fact["content"] == "uses PG 16"
+        assert fact["created_at"] == created
+        assert fact["updated_at"] >= created

--- a/libs/agno/tests/unit/learn/test_memories_schema.py
+++ b/libs/agno/tests/unit/learn/test_memories_schema.py
@@ -1,6 +1,6 @@
 """Tests for the Memories schema's framework-owned per-memory timestamps."""
 
-from agno.learn.schemas import Memories
+from agno.learn.schemas import Memories, UserProfile
 
 
 class TestAddMemory:
@@ -53,3 +53,31 @@ class TestUpdateMemory:
     def test_returns_false_when_not_found(self):
         m = Memories(user_id="u1")
         assert m.update_memory("missing", "y") is False
+
+
+class TestToDictExcludesInternalFields:
+    """Internal audit/identity fields mirror the agno_learnings row columns, so they must
+    not be duplicated (as nulls) inside the persisted content. user_id is kept for round-trip."""
+
+    def test_profile_drops_internal_fields(self):
+        content = UserProfile(user_id="u1", name="lm", preferred_name="neha").to_dict()
+        assert set(content.keys()) == {"user_id", "name", "preferred_name"}
+        for f in ("agent_id", "team_id", "created_at", "updated_at"):
+            assert f not in content
+
+    def test_memories_drops_parent_internal_but_keeps_entry_timestamps(self):
+        m = Memories(user_id="u1")
+        m.add_memory("likes Python")
+        content = m.to_dict()
+        # Parent-level internal fields are gone...
+        assert set(content.keys()) == {"user_id", "memories"}
+        # ...but the per-memory timestamps inside the entries survive.
+        entry = content["memories"][0]
+        assert "created_at" in entry and "updated_at" in entry
+
+    def test_profile_round_trips_without_internal_fields(self):
+        content = UserProfile(user_id="u1", name="lm").to_dict()
+        back = UserProfile.from_dict(content)
+        assert back is not None
+        assert back.user_id == "u1"
+        assert back.name == "lm"

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -111,6 +111,10 @@ class TestListLearnings:
         resp = client.get("/learnings?sort_order=sideways")
         assert resp.status_code == 422
 
+    def test_table_without_db_id_rejected(self, client, mock_db):
+        resp = client.get("/learnings?table=some_learnings")
+        assert resp.status_code == 400
+
 
 class TestListLearningUsers:
     def test_empty(self, client, mock_db):
@@ -173,6 +177,10 @@ class TestListLearningUsers:
         kwargs = mock_db.get_learning_user_stats.call_args[1]
         assert kwargs["sort_by"] == "total_learnings"
         assert kwargs["sort_order"] == "asc"
+
+    def test_table_without_db_id_rejected(self, client, mock_db):
+        resp = client.get("/learnings/users?table=some_learnings")
+        assert resp.status_code == 400
 
 
 class TestCreateLearning:

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -37,7 +37,7 @@ def _make_learning(**overrides):
 def mock_db():
     db = MagicMock(spec=BaseDb)
     db.list_learnings = MagicMock(return_value=([], 0))
-    db.get_learning_user_stats = MagicMock(return_value=([], 0))
+    db.get_learnings_user_stats = MagicMock(return_value=([], 0))
     db.get_learning_by_id = MagicMock(return_value=None)
     db.upsert_learning = MagicMock(return_value=None)
     db.delete_learning = MagicMock(return_value=True)
@@ -129,7 +129,7 @@ class TestListLearningUsers:
             {"user_id": "user-1", "total_learnings": 3, "last_learning_updated_at": 1714560000},
             {"user_id": "user-2", "total_learnings": 1, "last_learning_updated_at": 1714000000},
         ]
-        mock_db.get_learning_user_stats = MagicMock(return_value=(stats, 2))
+        mock_db.get_learnings_user_stats = MagicMock(return_value=(stats, 2))
         resp = client.get("/learnings/users")
         assert resp.status_code == 200
         data = resp.json()["data"]
@@ -139,15 +139,15 @@ class TestListLearningUsers:
 
     def test_does_not_collide_with_get_by_id(self, client, mock_db):
         # "/learnings/users" must route to the stats endpoint, not get_learning(learning_id="users")
-        mock_db.get_learning_user_stats = MagicMock(return_value=([], 0))
+        mock_db.get_learnings_user_stats = MagicMock(return_value=([], 0))
         resp = client.get("/learnings/users")
         assert resp.status_code == 200
-        mock_db.get_learning_user_stats.assert_called_once()
+        mock_db.get_learnings_user_stats.assert_called_once()
         mock_db.get_learning_by_id.assert_not_called()
 
     def test_filters_passed_through(self, client, mock_db):
         client.get("/learnings/users?learning_type=user_profile&user_id=u1&page=2&limit=5")
-        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        kwargs = mock_db.get_learnings_user_stats.call_args[1]
         assert kwargs["learning_type"] == "user_profile"
         assert kwargs["user_id"] == "u1"
         assert kwargs["page"] == 2
@@ -155,26 +155,33 @@ class TestListLearningUsers:
 
     def test_pagination_meta(self, client, mock_db):
         stats = [{"user_id": "u", "total_learnings": 1, "last_learning_updated_at": 1}]
-        mock_db.get_learning_user_stats = MagicMock(return_value=(stats, 25))
+        mock_db.get_learnings_user_stats = MagicMock(return_value=(stats, 25))
         resp = client.get("/learnings/users?limit=10")
         meta = resp.json()["meta"]
         assert meta["total_count"] == 25
         assert meta["total_pages"] == 3
 
     def test_not_implemented_returns_501(self, client, mock_db):
-        mock_db.get_learning_user_stats.side_effect = NotImplementedError
+        mock_db.get_learnings_user_stats.side_effect = NotImplementedError
         resp = client.get("/learnings/users")
         assert resp.status_code == 501
 
+    def test_db_error_returns_500(self, client, mock_db):
+        # The stats method surfaces DB errors (matching get_user_memory_stats); the
+        # router converts them to a 500 rather than masking them as an empty page.
+        mock_db.get_learnings_user_stats.side_effect = RuntimeError("boom")
+        resp = client.get("/learnings/users")
+        assert resp.status_code == 500
+
     def test_default_sort_passed_through(self, client, mock_db):
         client.get("/learnings/users")
-        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        kwargs = mock_db.get_learnings_user_stats.call_args[1]
         assert kwargs["sort_by"] is None
         assert kwargs["sort_order"] == "desc"
 
     def test_sort_passed_through(self, client, mock_db):
         client.get("/learnings/users?sort_by=total_learnings&sort_order=asc")
-        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        kwargs = mock_db.get_learnings_user_stats.call_args[1]
         assert kwargs["sort_by"] == "total_learnings"
         assert kwargs["sort_order"] == "asc"
 
@@ -404,16 +411,16 @@ class TestIDORScoping:
 
     def test_list_users_binds_subject(self, jwt_client, mock_db):
         jwt_client.get("/learnings/users")
-        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        kwargs = mock_db.get_learnings_user_stats.call_args[1]
         assert kwargs["user_id"] == "user-A"
 
     def test_list_users_matching_user_id_allowed(self, jwt_client, mock_db):
         resp = jwt_client.get("/learnings/users?user_id=user-A")
         assert resp.status_code == 200
-        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        kwargs = mock_db.get_learnings_user_stats.call_args[1]
         assert kwargs["user_id"] == "user-A"
 
     def test_list_users_mismatched_user_id_rejected(self, jwt_client, mock_db):
         resp = jwt_client.get("/learnings/users?user_id=user-B")
         assert resp.status_code == 403
-        mock_db.get_learning_user_stats.assert_not_called()
+        mock_db.get_learnings_user_stats.assert_not_called()

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -126,15 +126,14 @@ class TestListLearningUsers:
 
     def test_returns_user_stats(self, client, mock_db):
         stats = [
-            {"user_id": "user-1", "total_learnings": 3, "last_learning_updated_at": 1714560000},
-            {"user_id": "user-2", "total_learnings": 1, "last_learning_updated_at": 1714000000},
+            {"user_id": "user-1", "last_learning_updated_at": 1714560000},
+            {"user_id": "user-2", "last_learning_updated_at": 1714000000},
         ]
         mock_db.get_learnings_user_stats = MagicMock(return_value=(stats, 2))
         resp = client.get("/learnings/users")
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert [r["user_id"] for r in data] == ["user-1", "user-2"]
-        assert data[0]["total_learnings"] == 3
         assert data[0]["last_learning_updated_at"] == 1714560000
 
     def test_does_not_collide_with_get_by_id(self, client, mock_db):
@@ -154,7 +153,7 @@ class TestListLearningUsers:
         assert kwargs["limit"] == 5
 
     def test_pagination_meta(self, client, mock_db):
-        stats = [{"user_id": "u", "total_learnings": 1, "last_learning_updated_at": 1}]
+        stats = [{"user_id": "u", "last_learning_updated_at": 1}]
         mock_db.get_learnings_user_stats = MagicMock(return_value=(stats, 25))
         resp = client.get("/learnings/users?limit=10")
         meta = resp.json()["meta"]
@@ -180,9 +179,9 @@ class TestListLearningUsers:
         assert kwargs["sort_order"] == "desc"
 
     def test_sort_passed_through(self, client, mock_db):
-        client.get("/learnings/users?sort_by=total_learnings&sort_order=asc")
+        client.get("/learnings/users?sort_by=user_id&sort_order=asc")
         kwargs = mock_db.get_learnings_user_stats.call_args[1]
-        assert kwargs["sort_by"] == "total_learnings"
+        assert kwargs["sort_by"] == "user_id"
         assert kwargs["sort_order"] == "asc"
 
     def test_table_without_db_id_rejected(self, client, mock_db):

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -41,6 +41,7 @@ def mock_db():
     db.get_learning_by_id = MagicMock(return_value=None)
     db.upsert_learning = MagicMock(return_value=None)
     db.delete_learning = MagicMock(return_value=True)
+    db.delete_user_learnings = MagicMock(return_value=3)
     return db
 
 
@@ -298,6 +299,30 @@ class TestDeleteLearning:
         assert resp.status_code == 404
 
 
+class TestDeleteLearningUser:
+    def test_delete_success(self, client, mock_db):
+        resp = client.delete("/learnings/users/user-1")
+        assert resp.status_code == 204
+        mock_db.delete_user_learnings.assert_called_once_with("user-1")
+
+    def test_delete_with_no_records_still_204(self, client, mock_db):
+        mock_db.delete_user_learnings = MagicMock(return_value=0)
+        resp = client.delete("/learnings/users/nobody")
+        assert resp.status_code == 204
+
+    def test_does_not_collide_with_delete_by_id(self, client, mock_db):
+        # "/learnings/users/{user_id}" must route to the bulk-by-user handler,
+        # not delete_learning(learning_id="users").
+        client.delete("/learnings/users/user-1")
+        mock_db.delete_user_learnings.assert_called_once_with("user-1")
+        mock_db.delete_learning.assert_not_called()
+
+    def test_not_implemented_returns_501(self, client, mock_db):
+        mock_db.delete_user_learnings.side_effect = NotImplementedError
+        resp = client.delete("/learnings/users/user-1")
+        assert resp.status_code == 501
+
+
 class TestIDORScoping:
     """When a JWT subject is present on request.state, the router enforces ownership-based scoping.
 
@@ -423,3 +448,13 @@ class TestIDORScoping:
         resp = jwt_client.get("/learnings/users?user_id=user-B")
         assert resp.status_code == 403
         mock_db.get_learnings_user_stats.assert_not_called()
+
+    def test_delete_own_user_allowed(self, jwt_client, mock_db):
+        resp = jwt_client.delete("/learnings/users/user-A")
+        assert resp.status_code == 204
+        mock_db.delete_user_learnings.assert_called_once_with("user-A")
+
+    def test_delete_other_user_rejected(self, jwt_client, mock_db):
+        resp = jwt_client.delete("/learnings/users/user-B")
+        assert resp.status_code == 403
+        mock_db.delete_user_learnings.assert_not_called()

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -329,12 +329,13 @@ class TestDeleteLearningUser:
 
 
 class TestIDORScoping:
-    """When a JWT subject is present on request.state, the router enforces ownership-based scoping.
+    """For a scoped (non-admin) JWT caller with user_isolation enabled, the router enforces
+    ownership-based scoping via get_scoped_user_id.
 
     Rules:
-      - LIST: bind user_id filter to JWT subject; include records with user_id IS NULL
+      - LIST: bind user_id filter to the subject; include records with user_id IS NULL
         (global / non-user-scoped); reject explicit user_id query that mismatches with 403.
-      - CREATE: allow body.user_id to be null (global record) or match the JWT subject;
+      - CREATE: allow body.user_id to be null (global record) or match the subject;
         reject mismatch with 403.
       - GET/PATCH/DELETE single record: allow if record.user_id is None (global); 404 on
         cross-user access (no 403 — avoids leaking existence).
@@ -346,7 +347,10 @@ class TestIDORScoping:
 
         @app.middleware("http")
         async def add_jwt_user(request, call_next):
+            # Regular (non-admin) user with user isolation enabled.
+            request.state.user_isolation_enabled = True
             request.state.user_id = "user-A"
+            request.state.scopes = []
             return await call_next(request)
 
         router = get_learnings_router(dbs={"default": [mock_db]}, settings=settings)
@@ -463,3 +467,77 @@ class TestIDORScoping:
         resp = jwt_client.delete("/learnings/users/user-B")
         assert resp.status_code == 403
         mock_db.delete_user_learnings.assert_not_called()
+
+
+def _scoped_client(mock_db, settings, **state):
+    """Build a TestClient whose middleware stamps the given request.state attrs."""
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def add_state(request, call_next):
+        for k, v in state.items():
+            setattr(request.state, k, v)
+        return await call_next(request)
+
+    app.include_router(get_learnings_router(dbs={"default": [mock_db]}, settings=settings))
+    return TestClient(app)
+
+
+class TestAdminAndUnscopedAccess:
+    """get_scoped_user_id returns None for admins and when user_isolation is off, so those
+    callers are NOT bound to their own user_id -- this is what lets /learnings/users report
+    the real user count (not always 1) and keeps admins from being locked out."""
+
+    @pytest.fixture
+    def admin_client(self, mock_db, settings):
+        # Admin: isolation enabled but the caller carries the admin scope.
+        return _scoped_client(
+            mock_db, settings, user_isolation_enabled=True, user_id="admin-1", scopes=["agent_os:admin"]
+        )
+
+    @pytest.fixture
+    def isolation_off_client(self, mock_db, settings):
+        # JWT subject present but user isolation is disabled (the opt-in flag is off).
+        return _scoped_client(mock_db, settings, user_isolation_enabled=False, user_id="user-A", scopes=[])
+
+    def test_admin_list_users_sees_all(self, admin_client, mock_db):
+        stats = [
+            {"user_id": "u1", "last_learning_updated_at": 3},
+            {"user_id": "u2", "last_learning_updated_at": 2},
+            {"user_id": "u3", "last_learning_updated_at": 1},
+        ]
+        mock_db.get_learnings_user_stats = MagicMock(return_value=(stats, 3))
+        resp = admin_client.get("/learnings/users")
+        assert resp.status_code == 200
+        # Not bound to the admin's own id -> queries across all users -> total_count > 1.
+        assert mock_db.get_learnings_user_stats.call_args[1]["user_id"] is None
+        assert resp.json()["meta"]["total_count"] == 3
+
+    def test_admin_list_users_can_filter_any_user(self, admin_client, mock_db):
+        resp = admin_client.get("/learnings/users?user_id=user-B")
+        assert resp.status_code == 200
+        assert mock_db.get_learnings_user_stats.call_args[1]["user_id"] == "user-B"
+
+    def test_admin_list_learnings_not_scoped(self, admin_client, mock_db):
+        admin_client.get("/learnings")
+        kwargs = mock_db.list_learnings.call_args[1]
+        assert kwargs["user_id"] is None
+        assert kwargs["include_global"] is False
+
+    def test_admin_can_access_other_users_record(self, admin_client, mock_db):
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="user-B"))
+        resp = admin_client.get("/learnings/lrn-1")
+        assert resp.status_code == 200
+
+    def test_admin_can_delete_another_users_learnings(self, admin_client, mock_db):
+        resp = admin_client.delete("/learnings/users/user-B")
+        assert resp.status_code == 204
+        mock_db.delete_user_learnings.assert_called_once_with("user-B", learning_type=None)
+
+    def test_isolation_off_is_unscoped(self, isolation_off_client, mock_db):
+        # Even with a JWT subject, isolation-off means no per-user binding.
+        isolation_off_client.get("/learnings/users")
+        assert mock_db.get_learnings_user_stats.call_args[1]["user_id"] is None
+        # And a cross-user single record is accessible (no 404).
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="user-B"))
+        assert isolation_off_client.get("/learnings/lrn-1").status_code == 200

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -95,6 +95,22 @@ class TestListLearnings:
         resp = client.get("/learnings")
         assert resp.status_code == 501
 
+    def test_default_sort_passed_through(self, client, mock_db):
+        client.get("/learnings")
+        kwargs = mock_db.list_learnings.call_args[1]
+        assert kwargs["sort_by"] is None
+        assert kwargs["sort_order"] == "desc"
+
+    def test_sort_passed_through(self, client, mock_db):
+        client.get("/learnings?sort_by=created_at&sort_order=asc")
+        kwargs = mock_db.list_learnings.call_args[1]
+        assert kwargs["sort_by"] == "created_at"
+        assert kwargs["sort_order"] == "asc"
+
+    def test_invalid_sort_order_rejected(self, client, mock_db):
+        resp = client.get("/learnings?sort_order=sideways")
+        assert resp.status_code == 422
+
 
 class TestListLearningUsers:
     def test_empty(self, client, mock_db):
@@ -145,6 +161,18 @@ class TestListLearningUsers:
         mock_db.get_learning_user_stats.side_effect = NotImplementedError
         resp = client.get("/learnings/users")
         assert resp.status_code == 501
+
+    def test_default_sort_passed_through(self, client, mock_db):
+        client.get("/learnings/users")
+        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        assert kwargs["sort_by"] is None
+        assert kwargs["sort_order"] == "desc"
+
+    def test_sort_passed_through(self, client, mock_db):
+        client.get("/learnings/users?sort_by=total_learnings&sort_order=asc")
+        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        assert kwargs["sort_by"] == "total_learnings"
+        assert kwargs["sort_order"] == "asc"
 
 
 class TestCreateLearning:

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -37,6 +37,7 @@ def _make_learning(**overrides):
 def mock_db():
     db = MagicMock(spec=BaseDb)
     db.list_learnings = MagicMock(return_value=([], 0))
+    db.get_learning_user_stats = MagicMock(return_value=([], 0))
     db.get_learning_by_id = MagicMock(return_value=None)
     db.upsert_learning = MagicMock(return_value=None)
     db.delete_learning = MagicMock(return_value=True)
@@ -92,6 +93,57 @@ class TestListLearnings:
     def test_not_implemented_returns_501(self, client, mock_db):
         mock_db.list_learnings.side_effect = NotImplementedError
         resp = client.get("/learnings")
+        assert resp.status_code == 501
+
+
+class TestListLearningUsers:
+    def test_empty(self, client, mock_db):
+        resp = client.get("/learnings/users")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == []
+        assert body["meta"]["total_count"] == 0
+
+    def test_returns_user_stats(self, client, mock_db):
+        stats = [
+            {"user_id": "user-1", "total_learnings": 3, "last_learning_updated_at": 1714560000},
+            {"user_id": "user-2", "total_learnings": 1, "last_learning_updated_at": 1714000000},
+        ]
+        mock_db.get_learning_user_stats = MagicMock(return_value=(stats, 2))
+        resp = client.get("/learnings/users")
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert [r["user_id"] for r in data] == ["user-1", "user-2"]
+        assert data[0]["total_learnings"] == 3
+        assert data[0]["last_learning_updated_at"] == 1714560000
+
+    def test_does_not_collide_with_get_by_id(self, client, mock_db):
+        # "/learnings/users" must route to the stats endpoint, not get_learning(learning_id="users")
+        mock_db.get_learning_user_stats = MagicMock(return_value=([], 0))
+        resp = client.get("/learnings/users")
+        assert resp.status_code == 200
+        mock_db.get_learning_user_stats.assert_called_once()
+        mock_db.get_learning_by_id.assert_not_called()
+
+    def test_filters_passed_through(self, client, mock_db):
+        client.get("/learnings/users?learning_type=user_profile&user_id=u1&page=2&limit=5")
+        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        assert kwargs["learning_type"] == "user_profile"
+        assert kwargs["user_id"] == "u1"
+        assert kwargs["page"] == 2
+        assert kwargs["limit"] == 5
+
+    def test_pagination_meta(self, client, mock_db):
+        stats = [{"user_id": "u", "total_learnings": 1, "last_learning_updated_at": 1}]
+        mock_db.get_learning_user_stats = MagicMock(return_value=(stats, 25))
+        resp = client.get("/learnings/users?limit=10")
+        meta = resp.json()["meta"]
+        assert meta["total_count"] == 25
+        assert meta["total_pages"] == 3
+
+    def test_not_implemented_returns_501(self, client, mock_db):
+        mock_db.get_learning_user_stats.side_effect = NotImplementedError
+        resp = client.get("/learnings/users")
         assert resp.status_code == 501
 
 
@@ -313,3 +365,19 @@ class TestIDORScoping:
         mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="user-B"))
         resp = jwt_client.patch("/learnings/lrn-1", json={"content": {"x": 1}})
         assert resp.status_code == 404
+
+    def test_list_users_binds_subject(self, jwt_client, mock_db):
+        jwt_client.get("/learnings/users")
+        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        assert kwargs["user_id"] == "user-A"
+
+    def test_list_users_matching_user_id_allowed(self, jwt_client, mock_db):
+        resp = jwt_client.get("/learnings/users?user_id=user-A")
+        assert resp.status_code == 200
+        kwargs = mock_db.get_learning_user_stats.call_args[1]
+        assert kwargs["user_id"] == "user-A"
+
+    def test_list_users_mismatched_user_id_rejected(self, jwt_client, mock_db):
+        resp = jwt_client.get("/learnings/users?user_id=user-B")
+        assert resp.status_code == 403
+        mock_db.get_learning_user_stats.assert_not_called()

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -300,10 +300,15 @@ class TestDeleteLearning:
 
 
 class TestDeleteLearningUser:
-    def test_delete_success(self, client, mock_db):
+    def test_delete_success_all_types(self, client, mock_db):
         resp = client.delete("/learnings/users/user-1")
         assert resp.status_code == 204
-        mock_db.delete_user_learnings.assert_called_once_with("user-1")
+        mock_db.delete_user_learnings.assert_called_once_with("user-1", learning_type=None)
+
+    def test_delete_scoped_to_learning_type(self, client, mock_db):
+        resp = client.delete("/learnings/users/user-1?learning_type=user_memory")
+        assert resp.status_code == 204
+        mock_db.delete_user_learnings.assert_called_once_with("user-1", learning_type="user_memory")
 
     def test_delete_with_no_records_still_204(self, client, mock_db):
         mock_db.delete_user_learnings = MagicMock(return_value=0)
@@ -314,7 +319,7 @@ class TestDeleteLearningUser:
         # "/learnings/users/{user_id}" must route to the bulk-by-user handler,
         # not delete_learning(learning_id="users").
         client.delete("/learnings/users/user-1")
-        mock_db.delete_user_learnings.assert_called_once_with("user-1")
+        mock_db.delete_user_learnings.assert_called_once_with("user-1", learning_type=None)
         mock_db.delete_learning.assert_not_called()
 
     def test_not_implemented_returns_501(self, client, mock_db):
@@ -452,7 +457,7 @@ class TestIDORScoping:
     def test_delete_own_user_allowed(self, jwt_client, mock_db):
         resp = jwt_client.delete("/learnings/users/user-A")
         assert resp.status_code == 204
-        mock_db.delete_user_learnings.assert_called_once_with("user-A")
+        mock_db.delete_user_learnings.assert_called_once_with("user-A", learning_type=None)
 
     def test_delete_other_user_rejected(self, jwt_client, mock_db):
         resp = jwt_client.delete("/learnings/users/user-B")


### PR DESCRIPTION
## Summary

Adds `GET /learnings/users` to the learnings router, on top of the CRUD work in #7826. It groups the `agno_learnings` table by `user_id` and returns per-user counts plus a last-updated timestamp, so a client can present **a list of users first** and then drill into a single user's profile and memories — instead of treating users as a flat filter over a combined list.

This is the direct parallel of the existing memory UX (`GET /user_memory_stats` → `get_user_memory_stats`), extended to the Learning Machine. The per-user detail view is already served by the existing endpoints (`GET /learnings?user_id=...`).

| Method | Path | Behavior |
|---|---|---|
| `GET` | `/learnings/users` | Paginated list of users that own learnings, with `total_learnings` and `last_learning_updated_at` per user. Optional `learning_type` filter restricts the grouping to one store (e.g. `user_profile`, `user_memory`). |

**Scope.** Records with no owner (`user_id IS NULL` — global, agent, team, session, and entity-scoped learnings) are excluded, since this view is about users. The two user-keyed stores (`user_profile`, `user_memory`) are the natural consumers; pass `learning_type` to list users per store.

**Routing.** The route is registered **before** `/learnings/{learning_id}` so `users` is not captured as a `learning_id`. Covered by a regression test.

**Auth / IDOR.** When the request carries a JWT, the `user_id` filter is bound to the JWT subject and a mismatched `user_id` query is rejected with `403` — same rule as the list endpoint.

## DB layer changes

- `BaseDb` / `AsyncBaseDb`: added `get_learning_user_stats(learning_type, limit, page, user_id) -> Tuple[List[Dict], int]` as a non-abstract method (default `NotImplementedError`), mirroring `get_user_memory_stats`. Each row: `{"user_id", "total_learnings", "last_learning_updated_at"}`.
- **Full implementations**: postgres, async_postgres, sqlite, async_sqlite, async_mongo (SQL `GROUP BY user_id` with `user_id IS NOT NULL`; mongo `$group` aggregation).
- **Stub additions** (existing per-adapter `NotImplementedError` style): mongo, redis, in_memory, json.
- Remaining adapters inherit the `BaseDb` default — router catches `NotImplementedError` and returns `501`.

## Tests

- `test_learnings_router.py`: 9 new cases — listing, record shape, pagination metadata, filter pass-through, the `/learnings/users` vs `/learnings/{id}` path-collision guard, `501`, and the full JWT-scoping suite (subject binding, matching `user_id` allowed, mismatched `user_id` → 403). Full file passes (40 tests).
- Verified the real SQL implementation (sync + async SQLite) against a seeded DB: grouping, `learning_type` filter, `user_id IS NULL` exclusion, single-user filter, and pagination all return the expected counts.

## Cookbook

Extended `cookbook/05_agent_os/learnings/rest_api_learnings.py` with a "List Learning Users" step and updated the README/TEST_LOG. Ran the full cookbook end-to-end against a live AgentOS: create → list → **list users** → get → patch → delete → 404, all green.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (docstrings, OpenAPI summary/description on the endpoint)
- [x] Examples and guides: cookbook updated
- [x] Tested in clean environment (live AgentOS + httpx end-to-end)
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this
- [x] Drafted with Claude Code, fully reviewed

---

## Additional Notes

- Targets `feat/learnings-crud-endpoints` (not `main`), since it builds on the learnings table/CRUD infrastructure from #7826 that has not yet merged to `main`.
- `validate.sh` reports one pre-existing mypy error in `libs/agno/agno/tools/sql.py` (unrelated, untouched by this PR).
