### PR TITLE
fix: include metadata in content hash so `upsert=False` inserts of the same document don't collapse

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import io
+import json
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -2210,9 +2211,9 @@ class Knowledge(RemoteKnowledge):
         """
         Build the content hash from the content.
 
-        For URLs and paths, includes the name and description in the hash if provided
-        to ensure unique content with the same URL/path but different names/descriptions
-        get different hashes.
+        For URLs and paths, includes the name, description and metadata in the hash if
+        provided to ensure unique content with the same URL/path but different
+        names/descriptions/metadata get different hashes.
 
         Hash format:
         - URL with name and description: hash("{name}:{description}:{url}")
@@ -2220,12 +2221,19 @@ class Knowledge(RemoteKnowledge):
         - URL with description only: hash("{description}:{url}")
         - URL without name/description: hash("{url}") (backward compatible)
         - Same logic applies to paths
+        - When metadata is provided, a deterministic representation of it is appended
+          so the same content inserted with different metadata produces distinct hashes
+          (this allows `upsert=False` inserts of the same document with different
+          metadata to coexist instead of collapsing onto each other).
         """
         hash_parts = []
         if content.name:
             hash_parts.append(content.name)
         if content.description:
             hash_parts.append(content.description)
+        if content.metadata:
+
+            hash_parts.append(json.dumps(content.metadata, sort_keys=True, default=str))
 
         remote_identity = self._build_remote_content_identity(content.remote_content)
         if remote_identity:
@@ -2293,6 +2301,8 @@ class Knowledge(RemoteKnowledge):
             hash_parts.append(content.name)
         if content.description:
             hash_parts.append(content.description)
+        if content.metadata:
+            hash_parts.append(json.dumps(content.metadata, sort_keys=True, default=str))
 
         # Use document's own URL if available (set by WebsiteReader)
         doc_url = document.meta_data.get("url") if document.meta_data else None

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -688,3 +688,74 @@ def test_non_remote_content_hash_unchanged():
 
     # Identical (no remote_content on either) → identical hash, preserves dedup behavior.
     assert knowledge._build_content_hash(content_a) == knowledge._build_content_hash(content_b)
+
+
+def test_same_path_different_metadata_produces_different_hashes():
+    """Inserting the same document with different metadata and
+    upsert=False must not collapse onto the same content identity
+    """
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content1 = Content(path="./demo.pdf", metadata={"doc_id": 1, "collection_id": 1, "server_id": "10"})
+    content2 = Content(path="./demo.pdf", metadata={"doc_id": 1, "collection_id": 1, "server_id": "11"})
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+
+    assert hash1 != hash2
+
+
+def test_same_path_same_metadata_produces_same_hash():
+    """Identical content + identical metadata must still dedup."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    metadata = {"doc_id": 1, "collection_id": 1, "server_id": "10"}
+    content1 = Content(path="./demo.pdf", metadata=dict(metadata))
+    content2 = Content(path="./demo.pdf", metadata=dict(metadata))
+
+    assert knowledge._build_content_hash(content1) == knowledge._build_content_hash(content2)
+
+
+def test_metadata_hash_independent_of_key_order():
+    """The same metadata declared in a different key order must hash identically."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content1 = Content(path="./demo.pdf", metadata={"doc_id": 1, "server_id": "10", "collection_id": 1})
+    content2 = Content(path="./demo.pdf", metadata={"server_id": "10", "collection_id": 1, "doc_id": 1})
+
+    assert knowledge._build_content_hash(content1) == knowledge._build_content_hash(content2)
+
+
+def test_path_hash_without_metadata_backward_compatible():
+    """A path with no metadata must hash the same as when no metadata segment is added."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_no_meta = Content(path="./demo.pdf")
+    content_empty_meta = Content(path="./demo.pdf", metadata={})
+
+    assert knowledge._build_content_hash(content_no_meta) == knowledge._build_content_hash(content_empty_meta)
+
+
+def test_url_hash_with_metadata_differs_from_without():
+    """Adding metadata to otherwise-identical URL content changes the hash."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_no_meta = Content(url="https://example.com/doc.pdf", name="Doc")
+    content_with_meta = Content(url="https://example.com/doc.pdf", name="Doc", metadata={"tenant": "a"})
+
+    assert knowledge._build_content_hash(content_no_meta) != knowledge._build_content_hash(content_with_meta)
+
+
+def test_document_content_hash_includes_metadata():
+    """Multi-page document hash also incorporates content metadata for uniqueness."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content1 = Content(url="https://example.com", metadata={"server_id": "10"})
+    content2 = Content(url="https://example.com", metadata={"server_id": "11"})
+
+    doc = Document(content="Page content", meta_data={"url": "https://example.com/page"})
+
+    hash1 = knowledge._build_document_content_hash(doc, content1)
+    hash2 = knowledge._build_document_content_hash(doc, content2)
+
+    assert hash1 != hash2


### PR DESCRIPTION
## Summary

Inserting the same document into `Knowledge` twice with different metadata and `upsert=False` collapsed both inserts onto a single content identity as the second insert overwrites the first's metadata, so both rows ended up with the most recent metadata instead of coexisting as separate entries.

This PR fixes this by including `metadata` in the content hash in both `_build_content_hash()` and `_build_document_content_hash()`. 

Fixes #8211 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
