### PR TITLE
[fix] warn when Postgres session upsert returns no row

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -43,6 +43,14 @@ except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+def _log_session_upsert_no_row(session_dict: Dict[str, Any]) -> None:
+    log_warning(
+        "Async Postgres session upsert returned no row for "
+        f"session_id={session_dict.get('session_id')!r}, user_id={session_dict.get('user_id')!r}. "
+        "The update may have been blocked by the session user_id isolation condition."
+    )
+
+
 class AsyncPostgresDb(AsyncBaseDb):
     def __init__(
         self,
@@ -860,6 +868,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                     result = await sess.execute(stmt)
                     row = result.fetchone()
                     if row is None:
+                        _log_session_upsert_no_row(session_dict)
                         return None
                     session_dict = dict(row._mapping)
 
@@ -901,6 +910,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                     result = await sess.execute(stmt)
                     row = result.fetchone()
                     if row is None:
+                        _log_session_upsert_no_row(session_dict)
                         return None
                     session_dict = dict(row._mapping)
 
@@ -942,6 +952,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                     result = await sess.execute(stmt)
                     row = result.fetchone()
                     if row is None:
+                        _log_session_upsert_no_row(session_dict)
                         return None
                     session_dict = dict(row._mapping)
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -57,6 +57,14 @@ except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 
+def _log_session_upsert_no_row(session_dict: Dict[str, Any]) -> None:
+    log_warning(
+        "Postgres session upsert returned no row for "
+        f"session_id={session_dict.get('session_id')!r}, user_id={session_dict.get('user_id')!r}. "
+        "The update may have been blocked by the session user_id isolation condition."
+    )
+
+
 class PostgresDb(BaseDb):
     def __init__(
         self,
@@ -1015,6 +1023,7 @@ class PostgresDb(BaseDb):
                     result = sess.execute(stmt)
                     row = result.fetchone()
                     if row is None:
+                        _log_session_upsert_no_row(session_dict)
                         return None
                     session_dict = dict(row._mapping)
 
@@ -1054,6 +1063,7 @@ class PostgresDb(BaseDb):
                     result = sess.execute(stmt)
                     row = result.fetchone()
                     if row is None:
+                        _log_session_upsert_no_row(session_dict)
                         return None
                     session_dict = dict(row._mapping)
 
@@ -1093,6 +1103,7 @@ class PostgresDb(BaseDb):
                     result = sess.execute(stmt)
                     row = result.fetchone()
                     if row is None:
+                        _log_session_upsert_no_row(session_dict)
                         return None
                     session_dict = dict(row._mapping)
 

--- a/libs/agno/tests/unit/db/test_async_postgres.py
+++ b/libs/agno/tests/unit/db/test_async_postgres.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from agno.db.postgres.async_postgres import AsyncPostgresDb
+from agno.session import AgentSession
 
 
 @pytest.fixture
@@ -64,3 +65,35 @@ async def test_get_or_create_table_creates_when_not_available_and_create_flag_se
 
     assert result == mock_table
     async_postgres_db._create_table.assert_called_once_with(table_name="test_table", table_type="sessions")
+
+
+@pytest.mark.asyncio
+async def test_upsert_session_warns_when_user_id_condition_blocks_update(async_postgres_db):
+    """Warn when async PostgreSQL upsert returns no row due to user_id isolation."""
+    mock_session = AsyncMock()
+    async_postgres_db.async_session_factory = Mock(return_value=mock_session)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.begin = Mock(return_value=mock_session)
+
+    result = Mock()
+    result.fetchone.return_value = None
+    mock_session.execute.return_value = result
+
+    async_postgres_db._create_table = AsyncMock(wraps=async_postgres_db._create_table)
+    with patch("agno.db.postgres.async_postgres.acreate_schema", new_callable=AsyncMock):
+        table = await async_postgres_db._create_table("test_sessions", "sessions")
+    async_postgres_db._get_table = AsyncMock(return_value=table)
+
+    with patch("agno.db.postgres.async_postgres.log_warning") as mock_warning:
+        upserted = await async_postgres_db.upsert_session(
+            AgentSession(session_id="session-1", agent_id="agent-1", user_id="user-b"),
+            deserialize=False,
+        )
+
+    assert upserted is None
+    mock_warning.assert_called_once()
+    warning = mock_warning.call_args.args[0]
+    assert "session_id='session-1'" in warning
+    assert "user_id='user-b'" in warning
+    assert "user_id isolation condition" in warning

--- a/libs/agno/tests/unit/db/test_postgres.py
+++ b/libs/agno/tests/unit/db/test_postgres.py
@@ -15,6 +15,7 @@ from agno.db.postgres.schemas import (
     get_table_schema_definition,
 )
 from agno.db.utils import json_serializer
+from agno.session import AgentSession
 
 
 @pytest.fixture
@@ -306,6 +307,32 @@ def test_get_table_invalid_type(postgres_db):
     """Test getting table with invalid type"""
     with pytest.raises(ValueError, match="Unknown table type"):
         postgres_db._get_table("invalid_type")
+
+
+def test_upsert_session_warns_when_user_id_condition_blocks_update(postgres_db, mock_session):
+    """Warn when PostgreSQL upsert returns no row due to user_id isolation."""
+    postgres_db.Session = Mock(return_value=mock_session)
+    result = Mock()
+    result.fetchone.return_value = None
+    mock_session.execute.return_value = result
+
+    with patch.object(Table, "create"):
+        with patch("agno.db.postgres.postgres.create_schema"):
+            table = postgres_db._create_table("test_sessions", "sessions")
+
+    with patch.object(postgres_db, "_get_table", return_value=table):
+        with patch("agno.db.postgres.postgres.log_warning") as mock_warning:
+            upserted = postgres_db.upsert_session(
+                AgentSession(session_id="session-1", agent_id="agent-1", user_id="user-b"),
+                deserialize=False,
+            )
+
+    assert upserted is None
+    mock_warning.assert_called_once()
+    warning = mock_warning.call_args.args[0]
+    assert "session_id='session-1'" in warning
+    assert "user_id='user-b'" in warning
+    assert "user_id isolation condition" in warning
 
 
 @patch("agno.db.postgres.postgres.is_table_available")


### PR DESCRIPTION
## Summary

Adds warnings when Postgres session upserts return no row, which can happen when the existing row is blocked by the `user_id` isolation condition.

Fixes #7957

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`python -m ruff format ...` and `python -m ruff check ...`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This PR adds focused sync and async unit coverage for the no-row upsert path.

Verification run:

- `python -m ruff format libs\agno\agno\db\postgres\postgres.py libs\agno\agno\db\postgres\async_postgres.py libs\agno\tests\unit\db\test_postgres.py libs\agno\tests\unit\db\test_async_postgres.py`
- `python -m ruff check libs\agno\agno\db\postgres\postgres.py libs\agno\agno\db\postgres\async_postgres.py libs\agno\tests\unit\db\test_postgres.py libs\agno\tests\unit\db\test_async_postgres.py`
- `python -m pytest libs\agno\tests\unit\db\test_postgres.py::test_upsert_session_warns_when_user_id_condition_blocks_update libs\agno\tests\unit\db\test_async_postgres.py::test_upsert_session_warns_when_user_id_condition_blocks_update -q`

Focused tests passed with `2 passed`.

AI assistance was used to prepare this PR, and I reviewed the changes before submitting.