### PR TITLE
[fix] normalize empty OpenAI tool call arguments

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -310,6 +310,28 @@ class OpenAIChat(Model):
         """
         return cls(**data)
 
+    @staticmethod
+    def _normalize_tool_calls(tool_calls: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+        """Ensure OpenAI tool call arguments are valid JSON strings."""
+        if tool_calls is None:
+            return None
+
+        normalized_tool_calls: List[Dict[str, Any]] = []
+        for tool_call in tool_calls:
+            normalized_tool_call = tool_call.copy()
+            function = tool_call.get("function")
+
+            if isinstance(function, dict):
+                normalized_function = function.copy()
+                arguments = normalized_function.get("arguments")
+                if arguments is None or (isinstance(arguments, str) and arguments.strip() == ""):
+                    normalized_function["arguments"] = "{}"
+                normalized_tool_call["function"] = normalized_function
+
+            normalized_tool_calls.append(normalized_tool_call)
+
+        return normalized_tool_calls
+
     def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
         """
         Format a message into the format expected by OpenAI.
@@ -328,7 +350,7 @@ class OpenAIChat(Model):
             "content": tool_result,
             "name": message.name,
             "tool_call_id": message.tool_call_id,
-            "tool_calls": message.tool_calls,
+            "tool_calls": self._normalize_tool_calls(message.tool_calls),
         }
         message_dict = {k: v for k, v in message_dict.items() if v is not None}
 
@@ -783,7 +805,7 @@ class OpenAIChat(Model):
                     tool_call_entry["id"] = _tool_call_id
                 if _tool_call_type:
                     tool_call_entry["type"] = _tool_call_type
-        return tool_calls
+        return OpenAIChat._normalize_tool_calls(tool_calls) or []
 
     def _should_collect_metrics(self, response: ChatCompletionChunk) -> bool:
         """

--- a/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
+++ b/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
 
 
@@ -69,3 +70,31 @@ def test_parse_tool_calls_multiple_tools_independent():
     assert result[0]["function"]["name"] == "tool_a"
     assert result[1]["function"]["name"] == "tool_b"
     assert result[0] is not result[1]
+
+
+def test_parse_tool_calls_normalizes_empty_arguments():
+    """Ensure zero-argument tool calls still produce valid JSON arguments."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(index=0, tool_id="call_1", tool_type="function", func_name="schema_inspect"),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert result[0]["function"]["name"] == "schema_inspect"
+    assert result[0]["function"]["arguments"] == "{}"
+
+
+def test_format_message_normalizes_empty_tool_call_arguments_without_mutating_message():
+    """Ensure OpenAI-compatible history never sends empty tool call argument strings."""
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "schema_inspect", "arguments": ""},
+        }
+    ]
+    message = Message(role="assistant", content="", tool_calls=tool_calls)
+
+    formatted_message = OpenAIChat(api_key="test")._format_message(message)
+
+    assert formatted_message["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert message.tool_calls == tool_calls


### PR DESCRIPTION
## Summary

Fixes #8312.

Normalizes empty OpenAI-compatible tool call `function.arguments` values to the valid JSON object string `{}` before sending assistant history back to the provider. This covers zero-argument tools returned with an empty argument string and prevents OpenAI-compatible endpoints such as Databricks from rejecting the next chat completion request.

This also normalizes fully aggregated streaming tool calls and keeps the original `Message.tool_calls` object unchanged while formatting provider messages.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run:

- `PYTHONPATH=/Users/baihe/Documents/New\ project\ 21/agno-8312/libs/agno pytest libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`
- `uvx ruff format --check libs/agno/agno/models/openai/chat.py libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`
- `uvx ruff check libs/agno/agno/models/openai/chat.py libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`

I could not run the full `uv run pytest ...` path because the current package dependency resolution fails before tests start: `agno[a2a]` and `agno[brave]` require incompatible `httpx` ranges through `a2a-sdk` and `brave-search`. The targeted unit test was run directly against the source tree instead.

AI assistance was used to prepare this patch; I reviewed the changed code and verified the focused tests locally.