### PR TITLE
fix: filter DB-loaded teams/workflows from list APIs + gate resume routes

### DIFF
--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1252,9 +1252,14 @@ def get_team_router(
             # Exclude teams whose IDs are owned by the registry
             exclude_ids = registry.get_team_ids() if registry else None
             db_teams = get_teams(db=os.db, registry=registry, exclude_component_ids=exclude_ids or None)
-            for db_team in db_teams:
-                team_response = await TeamResponse.from_team(team=db_team, is_component=True)
-                teams.append(team_response)
+            if db_teams:
+                # Apply the same RBAC filtering to DB-loaded teams (mirrors get_agents);
+                # without this, a caller scoped to a single team sees every DB team.
+                if getattr(request.state, "authorization_enabled", False):
+                    db_teams = filter_resources_by_access(request, db_teams, "teams")
+                for db_team in db_teams:
+                    team_response = await TeamResponse.from_team(team=db_team, is_component=True)
+                    teams.append(team_response)
 
         return teams
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1025,13 +1025,21 @@ def get_workflow_router(
         if os.db and isinstance(os.db, BaseDb):
             from agno.workflow.workflow import get_workflows
 
-            for db_workflow in get_workflows(db=os.db, registry=os.registry):
-                try:
-                    workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow, is_component=True))
-                except Exception:
-                    workflow_id = getattr(db_workflow, "id", "unknown")
-                    logger.exception(f"Error converting workflow {workflow_id} to response")
-                    continue
+            db_workflows = get_workflows(db=os.db, registry=os.registry)
+            if db_workflows:
+                # Apply the same RBAC filtering to DB-loaded workflows (mirrors get_agents);
+                # without this, a caller scoped to a single workflow sees every DB workflow.
+                if getattr(request.state, "authorization_enabled", False):
+                    from agno.os.auth import filter_resources_by_access
+
+                    db_workflows = filter_resources_by_access(request, db_workflows, "workflows")
+                for db_workflow in db_workflows:
+                    try:
+                        workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow, is_component=True))
+                    except Exception:
+                        workflow_id = getattr(db_workflow, "id", "unknown")
+                        logger.exception(f"Error converting workflow {workflow_id} to response")
+                        continue
 
         return workflows
 

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -403,6 +403,7 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "POST /agents/*/runs": ["agents:run"],
         "POST /agents/*/runs/*/continue": ["agents:run"],
         "POST /agents/*/runs/*/cancel": ["agents:run"],
+        "POST /agents/*/runs/*/resume": ["agents:run"],
         # Team endpoints
         "GET /teams": ["teams:read"],
         "GET /teams/*": ["teams:read"],
@@ -412,6 +413,7 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "POST /teams/*/runs": ["teams:run"],
         "POST /teams/*/runs/*/continue": ["teams:run"],
         "POST /teams/*/runs/*/cancel": ["teams:run"],
+        "POST /teams/*/runs/*/resume": ["teams:run"],
         # Workflow endpoints
         "GET /workflows": ["workflows:read"],
         "GET /workflows/*": ["workflows:read"],
@@ -421,6 +423,7 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "POST /workflows/*/runs": ["workflows:run"],
         "POST /workflows/*/runs/*/continue": ["workflows:run"],
         "POST /workflows/*/runs/*/cancel": ["workflows:run"],
+        "POST /workflows/*/runs/*/resume": ["workflows:run"],
         # Session endpoints
         "GET /sessions": ["sessions:read"],
         "GET /sessions/*": ["sessions:read"],

--- a/libs/agno/tests/integration/os/test_authorization.py
+++ b/libs/agno/tests/integration/os/test_authorization.py
@@ -3096,3 +3096,71 @@ def test_jwks_parameter_takes_precedence_over_env(test_agent, rsa_key_pair, jwks
 
     # Should work because jwks_file parameter has the correct key
     assert response.status_code == 200
+# ---------------------------------------------------------------------------
+# Regression: DB-loaded resources must be filtered too.
+#
+# get_agents() filtered both static and DB-loaded agents, but get_teams() and
+# get_workflows() filtered only the static (os.teams/os.workflows) list and
+# appended DB-loaded ("component") resources unfiltered. A caller scoped to a
+# single team/workflow therefore saw EVERY team/workflow stored in the DB. We
+# masquerade a second resource as DB-loaded (monkeypatching the module-level
+# loader the handler imports) and assert it is filtered exactly like the static
+# ones.
+# ---------------------------------------------------------------------------
+
+
+def test_get_teams_filters_db_loaded_teams(test_team, second_team, shared_db, monkeypatch):
+    import agno.team.team as team_mod
+
+    # second_team stands in for a team loaded from the DB (is_component=True path)
+    monkeypatch.setattr(team_mod, "get_teams", lambda **kwargs: [second_team])
+
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        teams=[test_team],  # only test-team is static
+        db=shared_db,  # BaseDb -> the db-loaded branch runs
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # scoped to test-team only: the DB-loaded second-team must NOT leak
+    scoped = create_jwt_token(scopes=["teams:test-team:read"])
+    r = client.get("/teams", headers={"Authorization": f"Bearer {scoped}"})
+    assert r.status_code == 200, r.text
+    ids = {t["id"] for t in r.json()}
+    assert "second-team" not in ids, f"DB-loaded team leaked to a scoped caller: {ids}"
+    assert ids == {"test-team"}
+
+    # global teams:read still sees the DB-loaded team (not over-filtered)
+    glob = create_jwt_token(scopes=["teams:read"])
+    r2 = client.get("/teams", headers={"Authorization": f"Bearer {glob}"})
+    assert r2.status_code == 200, r2.text
+    assert "second-team" in {t["id"] for t in r2.json()}
+
+
+def test_get_workflows_filters_db_loaded_workflows(test_workflow, second_workflow, shared_db, monkeypatch):
+    import agno.workflow.workflow as wf_mod
+
+    monkeypatch.setattr(wf_mod, "get_workflows", lambda **kwargs: [second_workflow])
+
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        workflows=[test_workflow],  # only test-workflow is static
+        db=shared_db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    scoped = create_jwt_token(scopes=["workflows:test-workflow:read"])
+    r = client.get("/workflows", headers={"Authorization": f"Bearer {scoped}"})
+    assert r.status_code == 200, r.text
+    ids = {w["id"] for w in r.json()}
+    assert "second-workflow" not in ids, f"DB-loaded workflow leaked to a scoped caller: {ids}"
+    assert ids == {"test-workflow"}
+
+    glob = create_jwt_token(scopes=["workflows:read"])
+    r2 = client.get("/workflows", headers={"Authorization": f"Bearer {glob}"})
+    assert r2.status_code == 200, r2.text
+    assert "second-workflow" in {w["id"] for w in r2.json()}

--- a/libs/agno/tests/unit/os/test_scopes.py
+++ b/libs/agno/tests/unit/os/test_scopes.py
@@ -102,6 +102,16 @@ class TestDefaultScopeMappings:
         mappings = get_default_scope_mappings()
         assert mappings["GET /registry"] == ["registry:read"]
 
+    def test_run_lifecycle_endpoints_including_resume_require_run(self):
+        """resume must be gated like continue/cancel; it was previously missing from
+        the map, so the middleware gate fell open and protection depended solely on
+        the route-level dependency."""
+        mappings = get_default_scope_mappings()
+        for family in ("agents", "teams", "workflows"):
+            for action_path in ("continue", "cancel", "resume"):
+                key = f"POST /{family}/*/runs/*/{action_path}"
+                assert mappings[key] == [f"{family}:run"], f"missing/incorrect scope for {key}"
+
     def test_components_endpoints_have_scope_mappings(self):
         mappings = get_default_scope_mappings()
         # Read


### PR DESCRIPTION
**Standalone security fix (off `main`, independently mergeable).**

## Why this matters

Two AgentOS endpoints were handing out resources the caller was never authorized to see:

1. **Tenant data leak on list endpoints.** When teams/workflows are loaded from the database (the component path), `GET /teams` and `GET /workflows` returned **every** row regardless of the caller's scopes. A user provisioned for a single team — e.g. one customer in a multi-tenant deployment — could list every other team/workflow in the database. The in-memory (statically-registered) resources were already filtered; the DB path simply skipped that step, so the leak was invisible unless you happened to store resources in the DB.

2. **Resume routes fell open.** `POST /{agents,teams,workflows}/*/runs/*/resume` had no entry in the route→scope map, and the middleware's default for an unmapped protected route was to allow it. So anyone authenticated could resume a paused run — including runs belonging to another user — without holding the matching `:run` scope.

Net effect: an authenticated-but-low-privilege caller could enumerate other tenants' resources and act on runs that weren't theirs. This fix closes both holes.

## The fix

- `GET /teams` and `GET /workflows`: filter DB-loaded resources through the same `filter_resources_by_access(...)` the static list already used (mirrors `get_agents`). A caller now sees only the teams/workflows their scopes grant.
- Added the missing `:run` scope-map entries for the resume routes, so the middleware gate enforces them like every other run route instead of falling open.

## Scope / testing

- 3 tests pass against `main` (DB-leak filter for teams + workflows, resume scope-map).
- Carved out of the AgentOS authz PoC for independent review — depends on nothing else in the stack and is safe to merge on its own.