### PR TITLE
feat(authz) [1/7]: provider seam + Casbin/managed roles (PoC core)

### DIFF
--- a/cookbook/05_agent_os/rbac/DEMO.md
+++ b/cookbook/05_agent_os/rbac/DEMO.md
@@ -1,0 +1,168 @@
+# AgentOS authorization PoC — end to end
+
+What this is: agno deciding **who is allowed to do what** with agents,
+sessions, etc., on top of whatever login the customer already uses.
+
+PR: https://github.com/agno-agi/agno/pull/8221
+
+## Run it yourself (about a minute)
+
+```bash
+git clone https://github.com/agno-agi/agno.git
+cd agno && git checkout poc/agentos-authz-providers
+pip install -e "libs/agno[casbin,openai]"
+
+cd cookbook/05_agent_os/rbac
+python idp_enforce_only.py        # scenario 1: they have WorkOS, we just enforce
+python managed_roles_api.py       # scenario 2: no login service, we manage it (+ audit log)
+python casbin_external_idp.py     # scenario 3: a mix of both
+```
+
+No OpenAI key needed — each file signs in fake users, makes real requests, and
+prints ALLOWED / BLOCKED. You're seeing the actual authorization layer decide.
+Every file opens with a plain-English explainer; start with `managed_roles.py`.
+
+## What you'll see (captured output)
+
+## Scenario 1 — they have a login service (WorkOS); we only enforce
+
+```
+================================================================================
+THEY HAVE A LOGIN SERVICE - WE ONLY ENFORCE (no user store on our side)
+================================================================================
+  the login service put each person's role on their token. we just read it.
+
+  alice (token says role=member) RUN agent         -> ALLOWED (200)  member can run
+  alice (token says role=member) LOOK at agent     -> ALLOWED (200)  member can look
+  carol (token says role=guest)  LOOK at agent     -> BLOCKED (403)  guest has no permissions -> bounced
+  dave  (token has no role)      LOOK at agent     -> BLOCKED (403)  no role on the token -> bounced
+  root  (token says role=admin)  RUN agent         -> ALLOWED (200)  admin can do anything
+================================================================================
+the point: we stored no users and no assignments. WorkOS owns 'who is a
+member'. we only own 'what a member can do', and we enforce it on every call.
+================================================================================
+```
+
+## Scenario 2 — no login service; we manage users + roles (and log every change)
+
+```
+================================================================================
+MANAGING ROLES OVER THE WEB (and who's allowed to)
+================================================================================
+  alice = admin (allowed to manage) | bob = normal user | anon = nobody logged in
+
+  first, who can even use the management endpoints?
+  alice (admin) opens the roles admin            -> ALLOWED (200)  admins can
+  bob (normal)  opens the roles admin            -> BLOCKED (403)  normal users can't -> bounced
+  nobody        opens the roles admin            -> BLOCKED (401)  not logged in -> bounced harder
+
+  now watch alice give bob a new power, live:
+  bob tries to RUN an agent (before)             -> BLOCKED (403)  bob can't run yet
+    (alice created a 'runner' role that can run agents)
+    (alice gave bob the 'runner' role)
+  bob tries to RUN an agent (after)              -> ALLOWED (200)  same bob, now allowed
+    (alice took the 'runner' role back)
+  bob tries to RUN an agent (after revoke)       -> BLOCKED (403)  bounced again
+================================================================================
+
+THE RECORD: every change is logged - who did it, what changed, before -> after.
+(this is what a security review wants to see)
+  system role.set_scopes    viewer   [] -> ["agents:read"]
+  system role.set_scopes    admin    [] -> ["agent_os:admin"]
+  system user.assigned      alice    [] -> ["admin"]
+  system user.assigned      bob      [] -> ["viewer"]
+  alice  role.set_scopes    runner   [] -> ["agents:run"]
+  alice  user.assigned      bob      ["viewer"] -> ["viewer", "runner"]
+  alice  user.unassigned    bob      ["viewer", "runner"] -> ["viewer"]
+
+```
+
+## Scenario 3 — a mix of both at once
+
+```
+================================================================================
+A MIX: SOME USERS FROM THE LOGIN SERVICE, SOME MANAGED BY US
+================================================================================
+  everyone below is asking to look at the same agent.
+
+  alice  (login service, role on token = member) -> ALLOWED (200)  use the token's role -> in
+  carol  (login service, role on token = guest)  -> BLOCKED (403)  use the token's role -> bounced
+  bob    (not in login service, we listed as member) -> ALLOWED (200)  no role on token, fall back to our list -> in
+  dave   (not in login service, no role anywhere) -> BLOCKED (403)  no role on token, none in our list -> bounced
+================================================================================
+the point: one AgentOS handles both. if the token brings a role we use it;
+if not, we fall back to our own list. same agent, same protection, either way.
+================================================================================
+```
+
+## Building block — what roles are
+
+```
+==============================================================================
+WHO CAN DO WHAT - three roles, two people
+==============================================================================
+  roles:  viewer = look at agents | member = look + run | admin = anything
+  people: bob is a viewer         | alice is an admin
+  below, each person makes a real request. ALLOWED = got in, BLOCKED = bounced.
+
+  bob (viewer)  asks to LOOK at the agent        -> ALLOWED (200)  viewers can look
+  bob (viewer)  asks to RUN the agent            -> BLOCKED (403)  viewers can't run, so he's bounced
+
+  >> now we make bob a 'member' while the server is running...
+
+  bob (member)  asks to RUN the agent            -> ALLOWED (200)  same bob, same token, now allowed
+
+  >> ...and now we take the 'member' role back...
+
+  bob (no role) asks to RUN the agent            -> BLOCKED (403)  bounced again, instantly
+  alice (admin) asks to RUN the agent            -> ALLOWED (200)  admins can do anything
+==============================================================================
+the point: you control access by handing out roles, and a change takes effect
+on the very next request - no new login, no new token.
+==============================================================================
+```
+
+## Building block — roles protecting real data (deleting sessions)
+
+```
+==============================================================================
+WHO CAN TOUCH THE SAVED SESSIONS
+==============================================================================
+  bob = support (look only) | val = operator (look, edit, delete)
+  saved sessions right now: 2
+
+  bob (support)  tries to LOOK at sessions     -> ALLOWED (200)  support can look
+  bob (support)  tries to RENAME a session     -> BLOCKED (403)  editing isn't allowed -> bounced
+  bob (support)  tries to DELETE a session     -> BLOCKED (403)  deleting isn't allowed -> bounced
+  val (operator) tries to DELETE a session     -> ALLOWED (204)  operators can delete -> done for real
+
+  saved sessions now: 1  (was 2 - the operator's delete really happened)
+==============================================================================
+the point: the support person was stopped before any data was touched.
+only the operator's delete went through, and you can see the count drop.
+==============================================================================
+```
+
+## Building block — turning access on/off live
+
+```
+==============================================================================
+TURNING ACCESS ON AND OFF, LIVE
+==============================================================================
+  bob holds ONE login card the whole time. we never give him a new one.
+
+  bob asks to look at the agent      -> BLOCKED (403)  starts with no access -> bounced
+
+  >> grant bob access now (while the server is running)...
+
+  bob asks again (same card)         -> ALLOWED (200)  access flipped on -> he's in
+
+  >> ...now cut his access...
+
+  bob asks again (same card)         -> BLOCKED (403)  access flipped off -> bounced again
+==============================================================================
+the point: you can revoke access instantly. bob never logged in again and
+his card never changed - only the rule on the server side did.
+==============================================================================
+```
+

--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -343,6 +343,40 @@ app.add_middleware(
 - Without this flag, JWT validation occurs but scope checks are skipped
 - All authenticated users will have access to all resources
 
+## Pluggable authorization providers (experimental)
+
+The default scope matcher above is one implementation of a swappable seam:
+`AuthorizationConfig(authorization_provider=...)`. Supply your own
+`AuthorizationProvider` to change the decision engine without touching the
+request pipeline. Two enforcement points (the middleware route gate and the
+per-resource handler check) both go through it.
+
+Three tiers, pick the lowest that fits:
+
+| Tier | You write | Dependency |
+|------|-----------|------------|
+| Scopes (default) | scopes in the JWT | none |
+| Managed roles | `store.set_role_scopes(...)`, `store.assign(...)` in agno scope terms, changed at runtime and persisted to your DB | `agno[casbin]` (hidden) |
+| Raw provider | your own `AuthorizationProvider` (e.g. a Casbin model) | yours |
+
+Each cookbook below runs the whole scenario in-process and prints an
+`ALLOWED`/`DENIED` transcript, then exits (no server, no curl needed):
+
+- `casbin_provider.py` — swap in a Casbin enforcer (roles, hierarchy, wildcards).
+- `casbin_external_idp.py` — one AgentOS trusting both external-IdP tokens (roles
+  from the token) and self-minted tokens (roles from the Casbin store).
+- `casbin_runtime_policy.py` — policy in your own DB, granted/revoked at runtime,
+  reflected on the next request with the same token.
+- `managed_roles.py` — the agno-native managed-roles API: define roles and assign
+  them in scope terms, Casbin hidden inside the store.
+- `managed_roles_api.py` — an admin-only REST API (`/authz/...`) to manage roles
+  over HTTP.
+- `managed_roles_sessions.py` — roles gating the real session endpoints: a
+  read-only role is blocked (403) from deleting sessions; an operator deletes for
+  real.
+
+Install the optional extra first: `pip install "agno[casbin]"`.
+
 ## Additional Resources
 
 - [AgentOS Documentation](https://docs.agno.com/agent-os/security/overview)

--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -359,21 +359,23 @@ Three tiers, pick the lowest that fits:
 | Managed roles | `store.set_role_scopes(...)`, `store.assign(...)` in agno scope terms, changed at runtime and persisted to your DB | `agno[casbin]` (hidden) |
 | Raw provider | your own `AuthorizationProvider` (e.g. a Casbin model) | yours |
 
-Each cookbook below runs the whole scenario in-process and prints an
-`ALLOWED`/`DENIED` transcript, then exits (no server, no curl needed):
+Each cookbook below runs the whole scenario for you and prints a plain
+`ALLOWED` / `BLOCKED` transcript that explains itself, then exits (no server, no
+curl needed). Every file starts with a short plain-English explainer at the top.
 
-- `casbin_provider.py` — swap in a Casbin enforcer (roles, hierarchy, wildcards).
-- `casbin_external_idp.py` — one AgentOS trusting both external-IdP tokens (roles
-  from the token) and self-minted tokens (roles from the Casbin store).
-- `casbin_runtime_policy.py` — policy in your own DB, granted/revoked at runtime,
-  reflected on the next request with the same token.
-- `managed_roles.py` — the agno-native managed-roles API: define roles and assign
-  them in scope terms, Casbin hidden inside the store.
-- `managed_roles_api.py` — an admin-only REST API (`/authz/...`) to manage roles
-  over HTTP.
-- `managed_roles_sessions.py` — roles gating the real session endpoints: a
-  read-only role is blocked (403) from deleting sessions; an operator deletes for
-  real.
+New to authorization? Read them in this order:
+
+1. `managed_roles.py` — start here. What roles are, and how handing someone a role
+   decides what they can do. Shows a change taking effect instantly.
+2. `managed_roles_sessions.py` — roles protecting real data: who is allowed to
+   delete a saved chat session (and who gets stopped before any data is touched).
+3. `managed_roles_api.py` — managing roles over the web, who's allowed to do that,
+   and a permanent record of every change (the audit log).
+4. `casbin_external_idp.py` — where the user's login comes from: an outside login
+   service (Okta/WorkOS/Auth0) vs your own app, both on one AgentOS.
+5. `casbin_runtime_policy.py` — turning a person's access on and off live, instantly.
+6. `casbin_provider.py` — advanced: swapping the rules engine for Casbin while
+   everything else stays the same. Most people won't need this.
 
 Install the optional extra first: `pip install "agno[casbin]"`.
 

--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -369,13 +369,24 @@ New to authorization? Read them in this order:
    decides what they can do. Shows a change taking effect instantly.
 2. `managed_roles_sessions.py` — roles protecting real data: who is allowed to
    delete a saved chat session (and who gets stopped before any data is touched).
-3. `managed_roles_api.py` — managing roles over the web, who's allowed to do that,
-   and a permanent record of every change (the audit log).
-4. `casbin_external_idp.py` — where the user's login comes from: an outside login
-   service (Okta/WorkOS/Auth0) vs your own app, both on one AgentOS.
-5. `casbin_runtime_policy.py` — turning a person's access on and off live, instantly.
-6. `casbin_provider.py` — advanced: swapping the rules engine for Casbin while
+3. `casbin_runtime_policy.py` — turning a person's access on and off live, instantly.
+4. `casbin_provider.py` — advanced: swapping the rules engine for Casbin while
    everything else stays the same. Most people won't need this.
+
+### The three ways a company runs this
+
+A company either already has a login service (WorkOS/Okta/Auth0) or it doesn't,
+and either way we handle the "what are you allowed to do" part. The three setups,
+each with a runnable cookbook:
+
+| # | Their situation | Who owns "who has which role" | Do we store users? | Cookbook |
+|---|---|---|---|---|
+| 1 | They have a login service; we only enforce | the login service (role on the token) | no | `idp_enforce_only.py` |
+| 2 | No login service; they want us to manage it | us (define + assign roles, manage over HTTP) | yes | `managed_roles_api.py` |
+| 3 | A mix of both at once | both — token role if present, else our list | for the non-IdP users | `casbin_external_idp.py` |
+
+The same agent ends up protected the same way in all three; only where the role
+comes from changes.
 
 Install the optional extra first: `pip install "agno[casbin]"`.
 

--- a/cookbook/05_agent_os/rbac/casbin_external_idp.py
+++ b/cookbook/05_agent_os/rbac/casbin_external_idp.py
@@ -1,28 +1,31 @@
 """
-Where does "who are you" come from - outside login vs your own login
+Scenario 3 of 3: a MIX - some users from a login service, some managed by us
 
 (New to this? Read managed_roles.py first.)
 
-Remember the token: the signed ID card a user carries. Someone has to issue that
-card. There are two common situations, and the nice thing is one AgentOS can
-accept both at the same time:
+The three ways a company can run this:
+  1. they already have a login service, we only enforce  -> idp_enforce_only.py
+  2. no login service, they want us to manage it          -> managed_roles_api.py
+  3. THIS FILE - a mix of both, at the same time
 
-1. The company uses an outside login service (Okta, WorkOS, Auth0, Google...).
-   That service issues the card and stamps the person's role right on it. agno
-   trusts cards from that service and reads the role off the card.
-2. The company has no such service, so their own app issues the card. The card
-   just says who the person is; agno looks up that person's role in its own list.
+Why a mix happens: a company's employees log in through WorkOS/Okta (so their
+role rides their token), but they also have external partners or service accounts
+that don't exist in WorkOS, so WE manage those in our own list. One AgentOS has
+to handle both. It does, with one simple rule:
 
-Either way the question agno answers is the same ("what is this person allowed to
-do?"), and the answer comes out the same. This file sets up both kinds of users
-against one AgentOS and shows each one getting ALLOWED or BLOCKED. Don't worry
-about the key/signing plumbing; the point is both login styles just work.
+  if the token already carries a role, use it (that's the login-service user).
+  if it doesn't, fall back to our own list of who-has-which-role.
+
+So the same agent is protected the same way no matter where the user came from.
 
 The cast (all asking to look at the research agent):
-- alice -> outside-login user whose card says role "member"  -> allowed
-- carol -> outside-login user whose card says role "guest"   -> blocked
-- bob   -> own-app user, listed as a "member" in agno         -> allowed
-- dave  -> own-app user with no role                          -> blocked
+- alice -> from the login service, token says role "member"      -> allowed
+- carol -> from the login service, token says role "guest"       -> blocked
+- bob   -> not in the login service; we listed him as a "member" -> allowed (fallback to our list)
+- dave  -> not in the login service; we gave him no role         -> blocked
+
+Don't worry about the key/signing plumbing below; the point is both kinds of user
+get the right answer from one AgentOS.
 
 Run it:
     pip install "agno[casbin]"
@@ -164,14 +167,14 @@ if __name__ == "__main__":
         print(f"  {label:46s} -> {verdict:7s} ({r.status_code})  {note}")
 
     print("\n" + "=" * 80)
-    print("TWO KINDS OF LOGIN, ONE AGENTOS")
+    print("A MIX: SOME USERS FROM THE LOGIN SERVICE, SOME MANAGED BY US")
     print("=" * 80)
     print("  everyone below is asking to look at the same agent.\n")
-    show("alice  (outside login, card says 'member')", alice, "trusted card + good role -> in")
-    show("carol  (outside login, card says 'guest')", carol, "trusted card, wrong role -> bounced")
-    show("bob    (your app's login, listed as member)", bob, "agno looks up his role -> in")
-    show("dave   (your app's login, no role)", dave, "no role anywhere -> bounced")
+    show("alice  (login service, role on token = member)", alice, "use the token's role -> in")
+    show("carol  (login service, role on token = guest)", carol, "use the token's role -> bounced")
+    show("bob    (not in login service, we listed as member)", bob, "no role on token, fall back to our list -> in")
+    show("dave   (not in login service, no role anywhere)", dave, "no role on token, none in our list -> bounced")
     print("=" * 80)
-    print("the point: it doesn't matter who issued the login card. agno asks the same")
-    print("question and protects the agent the same way for both kinds of user.")
+    print("the point: one AgentOS handles both. if the token brings a role we use it;")
+    print("if not, we fall back to our own list. same agent, same protection, either way.")
     print("=" * 80)

--- a/cookbook/05_agent_os/rbac/casbin_external_idp.py
+++ b/cookbook/05_agent_os/rbac/casbin_external_idp.py
@@ -1,19 +1,32 @@
 """
-Casbin with External IdP and Self-Minted Tokens Example with AgentOS
+Where does "who are you" come from - outside login vs your own login
 
-This example demonstrates one AgentOS serving BOTH user populations, because the
-authorization layer only ever sees a `sub`. Only token minting/verification differs:
-- Users WITH an external IdP (Auth0/WorkOS/Clerk): the IdP signs the token; AgentOS
-  verifies it against the IdP's published keys (a JWKS); roles come FROM the token.
-- Users WITHOUT an IdP: your backend self-mints a token with your own key (here a
-  plain jwt.encode); AgentOS verifies it against that key; roles come FROM the Casbin store.
+(New to this? Read managed_roles.py first.)
 
-A single AgentOS trusts both at once via `jwks_file` (the IdP's keys) AND
-`verification_keys` (your self-mint key). The same Casbin policy authorizes both.
+Remember the token: the signed ID card a user carries. Someone has to issue that
+card. There are two common situations, and the nice thing is one AgentOS can
+accept both at the same time:
 
-Prerequisites:
-- pip install "agno[casbin]"
-- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+1. The company uses an outside login service (Okta, WorkOS, Auth0, Google...).
+   That service issues the card and stamps the person's role right on it. agno
+   trusts cards from that service and reads the role off the card.
+2. The company has no such service, so their own app issues the card. The card
+   just says who the person is; agno looks up that person's role in its own list.
+
+Either way the question agno answers is the same ("what is this person allowed to
+do?"), and the answer comes out the same. This file sets up both kinds of users
+against one AgentOS and shows each one getting ALLOWED or BLOCKED. Don't worry
+about the key/signing plumbing; the point is both login styles just work.
+
+The cast (all asking to look at the research agent):
+- alice -> outside-login user whose card says role "member"  -> allowed
+- carol -> outside-login user whose card says role "guest"   -> blocked
+- bob   -> own-app user, listed as a "member" in agno         -> allowed
+- dave  -> own-app user with no role                          -> blocked
+
+Run it:
+    pip install "agno[casbin]"
+    python casbin_external_idp.py
 """
 
 import json
@@ -147,15 +160,18 @@ if __name__ == "__main__":
 
     def show(label: str, tok: str, note: str = "") -> None:
         r = client.get("/agents/research-agent", headers={"Authorization": f"Bearer {tok}"})
-        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
-        print(f"  {label:42s} -> {r.status_code} {verdict}  {note}")
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {verdict:7s} ({r.status_code})  {note}")
 
-    print("\n" + "=" * 70)
-    print("IdP + self-minted tokens — running the scenario for you")
-    print("(every line hits GET /agents/research-agent on the SAME AgentOS)")
-    print("=" * 70)
-    show("alice@corp  IdP token,   roles=[member]", alice, "IdP member -> allowed")
-    show("carol@corp  IdP token,   roles=[guest]", carol, "IdP guest -> blocked")
-    show("bob         self-minted, store member", bob, "store member -> allowed")
-    show("dave        self-minted, no role", dave, "no role -> blocked")
-    print("=" * 70)
+    print("\n" + "=" * 80)
+    print("TWO KINDS OF LOGIN, ONE AGENTOS")
+    print("=" * 80)
+    print("  everyone below is asking to look at the same agent.\n")
+    show("alice  (outside login, card says 'member')", alice, "trusted card + good role -> in")
+    show("carol  (outside login, card says 'guest')", carol, "trusted card, wrong role -> bounced")
+    show("bob    (your app's login, listed as member)", bob, "agno looks up his role -> in")
+    show("dave   (your app's login, no role)", dave, "no role anywhere -> bounced")
+    print("=" * 80)
+    print("the point: it doesn't matter who issued the login card. agno asks the same")
+    print("question and protects the agent the same way for both kinds of user.")
+    print("=" * 80)

--- a/cookbook/05_agent_os/rbac/casbin_external_idp.py
+++ b/cookbook/05_agent_os/rbac/casbin_external_idp.py
@@ -109,6 +109,9 @@ agent_os = AgentOS(
         algorithm="RS256",
         verification_keys=[cust_public],  # verifies self-minted (no-IdP) tokens
         jwks_file=JWKS_PATH,  # verifies external-IdP tokens
+        # In production with a real IdP you'd skip the file and use the IdP's live
+        # keys URL instead - agno fetches and rotates them for you:
+        #   jwks_url="https://<your-workos-or-auth0>/.well-known/jwks.json"
         verify_audience=True,
         audience=OS_ID,
         authorization_provider=CasbinAuthorizationProvider(enforcer, roles_claim="roles"),

--- a/cookbook/05_agent_os/rbac/casbin_external_idp.py
+++ b/cookbook/05_agent_os/rbac/casbin_external_idp.py
@@ -1,0 +1,161 @@
+"""
+Casbin with External IdP and Self-Minted Tokens Example with AgentOS
+
+This example demonstrates one AgentOS serving BOTH user populations, because the
+authorization layer only ever sees a `sub`. Only token minting/verification differs:
+- Users WITH an external IdP (Auth0/WorkOS/Clerk): the IdP signs the token; AgentOS
+  verifies it against the IdP's published keys (a JWKS); roles come FROM the token.
+- Users WITHOUT an IdP: your backend self-mints a token with your own key (here a
+  plain jwt.encode); AgentOS verifies it against that key; roles come FROM the Casbin store.
+
+A single AgentOS trusts both at once via `jwks_file` (the IdP's keys) AND
+`verification_keys` (your self-mint key). The same Casbin policy authorizes both.
+
+Prerequisites:
+- pip install "agno[casbin]"
+- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+"""
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+
+import casbin
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.casbin_provider import CasbinAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+from agno.utils.cryptography import generate_rsa_keys
+from jwt.algorithms import RSAAlgorithm
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+OS_ID = "casbin-idp-os"
+JWKS_PATH = "tmp/idp_jwks.json"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Keys: one keypair simulating the external IdP, one your backend self-mints with.
+# In production the IdP keypair is the IdP's; you fetch its public JWKS.
+idp_private, idp_public = generate_rsa_keys()
+cust_private, cust_public = generate_rsa_keys()
+
+# Publish the IdP public key as a JWKS file (what you'd fetch from the IdP).
+_jwk = json.loads(RSAAlgorithm.to_jwk(RSAAlgorithm(RSAAlgorithm.SHA256).prepare_key(idp_public)))
+_jwk.update({"kid": "idp-key-1", "use": "sig", "alg": "RS256"})
+with open(JWKS_PATH, "w") as f:
+    json.dump({"keys": [_jwk]}, f)
+
+# Casbin policy: a "member" may read+run the research agent. bob (a no-IdP user)
+# is assigned the member role in the store. IdP users carry their role in the token.
+MODEL = """
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[role_definition]
+g = _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+"""
+with open("tmp/casbin_idp_model.conf", "w") as f:
+    f.write(MODEL)
+enforcer = casbin.Enforcer("tmp/casbin_idp_model.conf")
+enforcer.add_policy("member", "agents/research-agent", "read")
+enforcer.add_policy("member", "agents/research-agent", "run")
+enforcer.add_grouping_policy("bob", "member")  # no-IdP user's role lives in the store
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# One AgentOS trusting BOTH token sources, authorized by Casbin.
+# roles_claim="roles" -> read roles off IdP tokens; fall back to the store otherwise.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Casbin AgentOS trusting IdP and self-minted tokens",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        algorithm="RS256",
+        verification_keys=[cust_public],  # verifies self-minted (no-IdP) tokens
+        jwks_file=JWKS_PATH,  # verifies external-IdP tokens
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=CasbinAuthorizationProvider(enforcer, roles_claim="roles"),
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+
+def idp_token(sub: str, roles: list[str]) -> str:
+    """A token as an external IdP (Auth0/WorkOS) would issue: RS256 + kid + roles."""
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "roles": roles, "exp": datetime.now(UTC) + timedelta(hours=24)},
+        idp_private, algorithm="RS256", headers={"kid": "idp-key-1"},
+    )
+
+
+def self_token(sub: str) -> str:
+    """A token your own backend self-mints with your key (no IdP, no roles claim)."""
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+        cust_private, algorithm="RS256",
+    )
+
+
+if __name__ == "__main__":
+    """
+    Run this file to authorize both token sources against the same AgentOS.
+
+    WITH IdP: roles ride the token's `roles` claim.
+    WITHOUT IdP: roles come from the Casbin store (g, <sub>, role).
+    The same policy ("member" can read research-agent) authorizes both, so an IdP
+    member and a self-minted store member both succeed, and non-members are denied.
+    """
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    alice = idp_token("alice@corp", ["member"])  # IdP user, member
+    carol = idp_token("carol@corp", ["guest"])  # IdP user, no grant
+    bob = self_token("bob")  # self-minted, member via the Casbin store
+    dave = self_token("dave")  # self-minted, no role
+
+    def show(label: str, tok: str, note: str = "") -> None:
+        r = client.get("/agents/research-agent", headers={"Authorization": f"Bearer {tok}"})
+        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:42s} -> {r.status_code} {verdict}  {note}")
+
+    print("\n" + "=" * 70)
+    print("IdP + self-minted tokens — running the scenario for you")
+    print("(every line hits GET /agents/research-agent on the SAME AgentOS)")
+    print("=" * 70)
+    show("alice@corp  IdP token,   roles=[member]", alice, "IdP member -> allowed")
+    show("carol@corp  IdP token,   roles=[guest]", carol, "IdP guest -> blocked")
+    show("bob         self-minted, store member", bob, "store member -> allowed")
+    show("dave        self-minted, no role", dave, "no role -> blocked")
+    print("=" * 70)

--- a/cookbook/05_agent_os/rbac/casbin_provider.py
+++ b/cookbook/05_agent_os/rbac/casbin_provider.py
@@ -1,19 +1,27 @@
 """
-Casbin Authorization Provider Example with AgentOS
+Advanced: using Casbin as the rules engine
 
-This example demonstrates how to swap the default scope matcher for a Casbin
-enforcer behind the authorization provider seam, so you get role hierarchy,
-wildcards, and policy stored/edited in your own DB. Casbin is a pure-Python
-library (no service); the default provider stays the zero-dependency scope
-matcher, this is opt-in.
+(New to this? Read managed_roles.py first. This file is the power-user version of
+the same idea and you probably don't need it day to day.)
 
-Policy convention (Casbin `p = sub, obj, act`): sub is the JWT `sub`, obj is
-"<resource_type>/<resource_id>" (use keyMatch2 for wildcards), act is the action.
-Roles via `g, user, role`. In production point the enforcer's adapter at your DB.
+Something has to actually decide "is this person allowed?". By default agno uses
+its own simple rules engine. But agno lets you swap that engine out, so if a
+customer already standardises on a well-known open-source one called Casbin, they
+can plug it in without changing anything else about how AgentOS works.
 
-Prerequisites:
-- pip install "agno[casbin]"
-- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+This file does exactly that swap and then runs the same kind of check you saw in
+managed_roles.py: a few people, a few requests, ALLOWED or BLOCKED for each. The
+takeaway isn't the Casbin syntax, it's that the engine is replaceable while the
+rest stays the same.
+
+The cast:
+- alice is a "member"  -> can look at agents and run the research agent
+- root is an "admin"   -> can do anything
+- mallory has no role  -> can do nothing
+
+Run it:
+    pip install "agno[casbin]"
+    python casbin_provider.py
 """
 
 import os
@@ -128,14 +136,18 @@ if __name__ == "__main__":
         return {"Authorization": f"Bearer {token(sub)}"}
 
     def show(label: str, r, note: str = "") -> None:
-        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
-        print(f"  {label:48s} -> {r.status_code} {verdict}  {note}")
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:44s} -> {verdict:7s} ({r.status_code})  {note}")
 
-    print("\n" + "=" * 70)
-    print("Casbin RBAC — running the scenario for you")
-    print("=" * 70)
-    show("alice (member) GET  /agents/research-agent", client.get("/agents/research-agent", headers=auth("alice")), "can read")
-    show("alice (member) POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "can run")
-    show("mallory (none) GET  /agents/research-agent", client.get("/agents/research-agent", headers=auth("mallory")), "no role -> blocked")
-    show("root (admin)   POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("root"), data={"message": "hi"}), "admin -> all")
-    print("=" * 70)
+    print("\n" + "=" * 78)
+    print("SAME CHECKS, DIFFERENT ENGINE (Casbin instead of agno's built-in)")
+    print("=" * 78)
+    print("  alice = member | root = admin | mallory = no role\n")
+    show("alice (member)  tries to LOOK at the agent", client.get("/agents/research-agent", headers=auth("alice")), "members can look")
+    show("alice (member)  tries to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "members can run this one")
+    show("mallory (none)  tries to LOOK at the agent", client.get("/agents/research-agent", headers=auth("mallory")), "no role -> bounced")
+    show("root (admin)    tries to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("root"), data={"message": "hi"}), "admins can do anything")
+    print("=" * 78)
+    print("the point: the decisions look identical to managed_roles.py - only the engine")
+    print("underneath changed. that's the part worth seeing.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/casbin_provider.py
+++ b/cookbook/05_agent_os/rbac/casbin_provider.py
@@ -1,0 +1,141 @@
+"""
+Casbin Authorization Provider Example with AgentOS
+
+This example demonstrates how to swap the default scope matcher for a Casbin
+enforcer behind the authorization provider seam, so you get role hierarchy,
+wildcards, and policy stored/edited in your own DB. Casbin is a pure-Python
+library (no service); the default provider stays the zero-dependency scope
+matcher, this is opt-in.
+
+Policy convention (Casbin `p = sub, obj, act`): sub is the JWT `sub`, obj is
+"<resource_type>/<resource_id>" (use keyMatch2 for wildcards), act is the action.
+Roles via `g, user, role`. In production point the enforcer's adapter at your DB.
+
+Prerequisites:
+- pip install "agno[casbin]"
+- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import casbin
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.casbin_provider import CasbinAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "casbin-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Casbin model + policy. In production, load policy from your DB with an adapter:
+#   casbin.Enforcer(model, casbin_sqlalchemy_adapter.Adapter("postgresql://..."))
+MODEL = """
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[role_definition]
+g = _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+"""
+POLICY = """
+p, member, agents/*, read
+p, member, agents/research-agent, run
+p, admin, agents/*, *
+g, alice, member
+g, root, admin
+"""
+with open("tmp/casbin_os_model.conf", "w") as f:
+    f.write(MODEL)
+with open("tmp/casbin_os_policy.csv", "w") as f:
+    f.write(POLICY)
+enforcer = casbin.Enforcer("tmp/casbin_os_model.conf", "tmp/casbin_os_policy.csv")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS, swapping in the Casbin-backed provider. One line.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Casbin-protected AgentOS",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=CasbinAuthorizationProvider(enforcer),
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to print Casbin's authorization decision for each caller.
+
+    The policy above grants:
+    - member  -> read all agents, run research-agent
+    - admin   -> everything (agents/*, *)
+    - alice is a member, root is an admin, anyone else has no role.
+
+    Change roles at runtime via Casbin's management API, e.g.
+        enforcer.add_role_for_user("bob", "member"); enforcer.save_policy()
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {r.status_code} {verdict}  {note}")
+
+    print("\n" + "=" * 70)
+    print("Casbin RBAC — running the scenario for you")
+    print("=" * 70)
+    show("alice (member) GET  /agents/research-agent", client.get("/agents/research-agent", headers=auth("alice")), "can read")
+    show("alice (member) POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "can run")
+    show("mallory (none) GET  /agents/research-agent", client.get("/agents/research-agent", headers=auth("mallory")), "no role -> blocked")
+    show("root (admin)   POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("root"), data={"message": "hi"}), "admin -> all")
+    print("=" * 70)

--- a/cookbook/05_agent_os/rbac/casbin_runtime_policy.py
+++ b/cookbook/05_agent_os/rbac/casbin_runtime_policy.py
@@ -1,17 +1,25 @@
 """
-Casbin Runtime Policy Example with AgentOS
+Turning someone's access on and off while the app is running
 
-This example demonstrates policy stored in YOUR database and changed live, with no
-token re-mint. Grant or revoke a role at runtime and the very next request reflects
-it, using the same token. Policy persists in your own DB (here SQLite via the
-SQLAlchemy adapter; in production point it at Postgres).
+(New to this? Read managed_roles.py first.)
 
-This is what token-baked scopes cannot do: revoking a scope in a token means
-waiting for the token to expire. With DB-backed Casbin, "revoke now" is now.
+A real worry: someone leaves the company, or you grant access by mistake. Can you
+cut their access RIGHT NOW, or do you have to wait for their login to expire?
 
-Prerequisites:
-- pip install "agno[casbin]"
-- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+With this setup the answer is "right now". The permissions live in your database,
+not baked into the user's login card. So you can flip a person's access on or off
+and their very next request obeys the new rule, even though they're still holding
+the exact same card.
+
+This file uses one person, bob, who starts with no access. We:
+1. show bob is BLOCKED,
+2. grant him access while the server runs -> he's now ALLOWED,
+3. take it away again -> he's BLOCKED again,
+all without bob logging in again or getting a new card.
+
+Run it:
+    pip install "agno[casbin]"
+    python casbin_runtime_policy.py
 """
 
 import os
@@ -120,16 +128,22 @@ if __name__ == "__main__":
 
     def show(label: str, note: str = "") -> None:
         r = client.get("/agents/research-agent", headers=bob_h)
-        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
-        print(f"  {label:42s} -> {r.status_code} {verdict}  {note}")
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:34s} -> {verdict:7s} ({r.status_code})  {note}")
 
-    print("\n" + "=" * 70)
-    print("Casbin runtime policy — running the scenario for you")
-    print("(bob's token NEVER changes; only the DB-backed policy does)")
-    print("=" * 70)
-    show("bob GET /agents/research-agent", "no role yet -> blocked")
-    enforcer.add_role_for_user("bob", "member")  # grant at runtime, persists to the DB
-    show("bob GET /agents/research-agent", "granted 'member' live -> SAME token")
-    enforcer.delete_role_for_user("bob", "member")  # revoke at runtime
-    show("bob GET /agents/research-agent", "revoked live -> blocked again")
-    print("=" * 70)
+    print("\n" + "=" * 78)
+    print("TURNING ACCESS ON AND OFF, LIVE")
+    print("=" * 78)
+    print("  bob holds ONE login card the whole time. we never give him a new one.\n")
+
+    show("bob asks to look at the agent", "starts with no access -> bounced")
+    print("\n  >> grant bob access now (while the server is running)...\n")
+    enforcer.add_role_for_user("bob", "member")
+    show("bob asks again (same card)", "access flipped on -> he's in")
+    print("\n  >> ...now cut his access...\n")
+    enforcer.delete_role_for_user("bob", "member")
+    show("bob asks again (same card)", "access flipped off -> bounced again")
+    print("=" * 78)
+    print("the point: you can revoke access instantly. bob never logged in again and")
+    print("his card never changed - only the rule on the server side did.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/casbin_runtime_policy.py
+++ b/cookbook/05_agent_os/rbac/casbin_runtime_policy.py
@@ -1,0 +1,135 @@
+"""
+Casbin Runtime Policy Example with AgentOS
+
+This example demonstrates policy stored in YOUR database and changed live, with no
+token re-mint. Grant or revoke a role at runtime and the very next request reflects
+it, using the same token. Policy persists in your own DB (here SQLite via the
+SQLAlchemy adapter; in production point it at Postgres).
+
+This is what token-baked scopes cannot do: revoking a scope in a token means
+waiting for the token to expire. With DB-backed Casbin, "revoke now" is now.
+
+Prerequisites:
+- pip install "agno[casbin]"
+- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import casbin
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.casbin_provider import CasbinAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+from casbin_sqlalchemy_adapter import Adapter
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "casbin-runtime-os"
+POLICY_DB_URL = "sqlite:///tmp/casbin_policy.db"
+MODEL_PATH = "tmp/casbin_runtime_model.conf"
+
+os.makedirs("tmp", exist_ok=True)
+
+MODEL = """
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[role_definition]
+g = _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+"""
+with open(MODEL_PATH, "w") as f:
+    f.write(MODEL)
+
+# Policy lives in YOUR DB via the SQLAlchemy adapter. Use a Postgres URL in prod.
+enforcer = casbin.Enforcer(MODEL_PATH, Adapter(POLICY_DB_URL))
+enforcer.enable_auto_save(True)  # mutations persist to the DB immediately
+# Seed: member may read+run the research agent. bob starts with NO role.
+enforcer.add_policy("member", "agents/research-agent", "read")
+enforcer.add_policy("member", "agents/research-agent", "run")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the DB-backed Casbin enforcer.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Casbin AgentOS with runtime-mutable policy",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=CasbinAuthorizationProvider(enforcer),
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to watch DB-backed policy change at runtime.
+
+    bob's token never changes; only the policy in tmp/casbin_policy.db does. The
+    scenario below grants bob the member role, shows his access flip to 200, then
+    revokes it and shows it flip back to 403, all with the same token.
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    bob_h = {"Authorization": f"Bearer {token('bob')}"}
+
+    def show(label: str, note: str = "") -> None:
+        r = client.get("/agents/research-agent", headers=bob_h)
+        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:42s} -> {r.status_code} {verdict}  {note}")
+
+    print("\n" + "=" * 70)
+    print("Casbin runtime policy — running the scenario for you")
+    print("(bob's token NEVER changes; only the DB-backed policy does)")
+    print("=" * 70)
+    show("bob GET /agents/research-agent", "no role yet -> blocked")
+    enforcer.add_role_for_user("bob", "member")  # grant at runtime, persists to the DB
+    show("bob GET /agents/research-agent", "granted 'member' live -> SAME token")
+    enforcer.delete_role_for_user("bob", "member")  # revoke at runtime
+    show("bob GET /agents/research-agent", "revoked live -> blocked again")
+    print("=" * 70)

--- a/cookbook/05_agent_os/rbac/idp_enforce_only.py
+++ b/cookbook/05_agent_os/rbac/idp_enforce_only.py
@@ -1,0 +1,134 @@
+"""
+Scenario 1 of 3: they HAVE a login service (e.g. WorkOS) - we only enforce
+
+(New to this? Read managed_roles.py first.)
+
+The three ways a company can run this:
+  1. THIS FILE - they already use a login service (WorkOS, Okta, Auth0). It logs
+     people in AND stamps each person's role on their token. We don't store any
+     users or who-has-which-role; that's the login service's job. We only keep a
+     tiny list of "what is each role allowed to do" and enforce it.
+  2. no login service, they want us to manage users + roles  -> managed_roles_api.py
+  3. a mix of both                                           -> casbin_external_idp.py
+
+So in this scenario there is NO user database on our side. Nothing to store. The
+token arrives already saying `role: "member"`, we look up what "member" can do,
+and we allow or block. That's it.
+
+The only thing we define is the role -> permissions list (here, in memory):
+  - member -> can look at agents and run the research agent
+  - admin  -> can do anything
+WorkOS decides WHO is a member or admin; we decide what those words mean.
+
+(Real WorkOS tokens are signed by WorkOS and verified against its public keys -
+see casbin_external_idp.py for that part. Here we use a simple shared secret so
+the example runs on its own; the authorization behaviour is identical.)
+
+Run it:
+    pip install "agno[casbin]"
+    python idp_enforce_only.py
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import casbin
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.casbin_provider import CasbinAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "idp-enforce-only-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# What each role is allowed to do. This is ALL we keep - no users, no assignments.
+# It lives in memory (no database): roles are defined in code and never change here.
+MODEL = """
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[role_definition]
+g = _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+"""
+with open("tmp/idp_enforce_model.conf", "w") as f:
+    f.write(MODEL)
+enforcer = casbin.Enforcer("tmp/idp_enforce_model.conf")  # in-memory, no DB/adapter
+enforcer.add_policy("member", "agents/*", "read")
+enforcer.add_policy("member", "agents/research-agent", "run")
+enforcer.add_policy("admin", "*", "*")
+# Note: there are NO "who has which role" rows here. WorkOS owns that.
+
+db = SqliteDb(db_file="tmp/agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Enforce-only AgentOS (identity + roles come from the login service)",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        # roles_claim="role" -> read the person's role off the token (WorkOS puts
+        # it in a claim called "role"). No store is consulted for assignments.
+        authorization_provider=CasbinAuthorizationProvider(enforcer, roles_claim="role"),
+    ),
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)
+    client = TestClient(app)
+
+    def login_card(sub: str, role: str | None) -> str:
+        # Stand-in for the token WorkOS would issue. The important part is the
+        # `role` claim - that's the person's role, decided by the login service.
+        claims = {"sub": sub, "aud": OS_ID, "exp": datetime.now(UTC) + timedelta(hours=24)}
+        if role is not None:
+            claims["role"] = role
+        return jwt.encode(claims, JWT_SECRET, algorithm="HS256")
+
+    def show(label: str, tok: str, method: str, path: str, note: str = "") -> None:
+        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 80)
+    print("THEY HAVE A LOGIN SERVICE - WE ONLY ENFORCE (no user store on our side)")
+    print("=" * 80)
+    print("  the login service put each person's role on their token. we just read it.\n")
+
+    show("alice (token says role=member) RUN agent", login_card("alice", "member"), "POST", "/agents/research-agent/runs", "member can run")
+    show("alice (token says role=member) LOOK at agent", login_card("alice", "member"), "GET", "/agents/research-agent", "member can look")
+    show("carol (token says role=guest)  LOOK at agent", login_card("carol", "guest"), "GET", "/agents/research-agent", "guest has no permissions -> bounced")
+    show("dave  (token has no role)      LOOK at agent", login_card("dave", None), "GET", "/agents/research-agent", "no role on the token -> bounced")
+    show("root  (token says role=admin)  RUN agent", login_card("root", "admin"), "POST", "/agents/research-agent/runs", "admin can do anything")
+    print("=" * 80)
+    print("the point: we stored no users and no assignments. WorkOS owns 'who is a")
+    print("member'. we only own 'what a member can do', and we enforce it on every call.")
+    print("=" * 80)

--- a/cookbook/05_agent_os/rbac/idp_enforce_only.py
+++ b/cookbook/05_agent_os/rbac/idp_enforce_only.py
@@ -20,9 +20,11 @@ The only thing we define is the role -> permissions list (here, in memory):
   - admin  -> can do anything
 WorkOS decides WHO is a member or admin; we decide what those words mean.
 
-(Real WorkOS tokens are signed by WorkOS and verified against its public keys -
-see casbin_external_idp.py for that part. Here we use a simple shared secret so
-the example runs on its own; the authorization behaviour is identical.)
+(Real WorkOS tokens are signed by WorkOS. In production you point agno at WorkOS's
+live keys URL and it fetches + rotates them for you - no key file to manage:
+    AuthorizationConfig(jwks_url="https://<your-workos>/.well-known/jwks.json", ...)
+Here we use a simple shared secret so the example runs on its own; the
+authorization behaviour is identical.)
 
 Run it:
     pip install "agno[casbin]"

--- a/cookbook/05_agent_os/rbac/managed_roles.py
+++ b/cookbook/05_agent_os/rbac/managed_roles.py
@@ -1,0 +1,121 @@
+"""
+Managed Roles Example with AgentOS
+
+This example demonstrates the agno-native managed-roles tier: you define roles
+and assignments in agno scope terms and change them at runtime, persisted to your
+own DB. There is no Casbin in this file, no model.conf, no Enforcer; the store
+hides that engine. A grant or revoke takes effect on the next request with the
+SAME token (token-baked scopes can't do this, you'd wait for expiry).
+
+Prerequisites:
+- pip install "agno[casbin]"
+- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define your roles in agno scope terms. Policy persists to your DB (point the
+# url at Postgres in production). This is the entire authorization model.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles.db")
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("bob", "viewer")  # bob can read agents but not run them
+roles.assign("alice", "admin")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the managed-role store as the provider. The only wiring.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to print managed-role decisions for each caller.
+
+    Roles (defined above, persisted to tmp/managed_roles.db):
+    - viewer -> read agents
+    - member -> read agents + run research-agent
+    - admin  -> everything
+    bob is a viewer, alice is an admin. No scopes are baked into the tokens; the
+    store decides what each user can do. The scenario below promotes bob to member
+    at runtime, shows his run flip to 200, then revokes it, all with the same token.
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {r.status_code} {verdict}  {note}")
+
+    print("\n" + "=" * 70)
+    print("Managed roles — running the scenario for you")
+    print("=" * 70)
+    show("bob (viewer)  GET  /agents/research-agent", client.get("/agents/research-agent", headers=auth("bob")), "can read")
+    show("bob (viewer)  POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewer -> blocked")
+    roles.assign("bob", "member")  # promote at runtime
+    show("bob (member)  POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "promoted live -> SAME token")
+    roles.unassign("bob", "member")  # revoke at runtime
+    show("bob (revoked) POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "revoked -> blocked again")
+    show("alice (admin) POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "admin -> all")
+    print("=" * 70)

--- a/cookbook/05_agent_os/rbac/managed_roles.py
+++ b/cookbook/05_agent_os/rbac/managed_roles.py
@@ -1,15 +1,32 @@
 """
-Managed Roles Example with AgentOS
+Managed Roles - controlling who can do what in AgentOS
 
-This example demonstrates the agno-native managed-roles tier: you define roles
-and assignments in agno scope terms and change them at runtime, persisted to your
-own DB. There is no Casbin in this file, no model.conf, no Enforcer; the store
-hides that engine. A grant or revoke takes effect on the next request with the
-SAME token (token-baked scopes can't do this, you'd wait for expiry).
+New to this? Start with this file. "Authorization" just means deciding who is
+allowed to do what. Two pieces make it work:
 
-Prerequisites:
-- pip install "agno[casbin]"
-- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+1. A token. When a user signs in they get a token: a small signed ID card they
+   send with every request. It says who they are (e.g. "bob") and can't be faked.
+2. Permissions. On the AgentOS side you decide what each person can do, like
+   "can look at agents" or "can run the research agent".
+
+Listing permissions per person gets messy fast, so we use ROLES: a named bundle
+of permissions. You say once what a role can do ("a viewer can read"), then hand
+people roles ("bob is a viewer"). Change the role and everyone with it changes too.
+
+Permissions are written in a short code called a "scope":
+- "agents:*:read"              -> can look at any agent
+- "agents:research-agent:run"  -> can run the one agent called research-agent
+- "agent_os:admin"             -> can do everything (a super-admin)
+
+This file creates three roles and two people, then makes real requests and prints
+ALLOWED or BLOCKED for each. It also shows the neat part: you can change someone's
+role while the server is running and their very next request reflects it, with no
+new login and no new token.
+
+Run it:
+    pip install "agno[casbin]"
+    python managed_roles.py
+(no OpenAI key needed here - we are only checking who is allowed, not actually chatting)
 """
 
 import os
@@ -105,17 +122,30 @@ if __name__ == "__main__":
         return {"Authorization": f"Bearer {token(sub)}"}
 
     def show(label: str, r, note: str = "") -> None:
-        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
-        print(f"  {label:46s} -> {r.status_code} {verdict}  {note}")
+        # 200 means the request got in; 401/403 means it was bounced.
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {verdict:7s} ({r.status_code})  {note}")
 
-    print("\n" + "=" * 70)
-    print("Managed roles — running the scenario for you")
-    print("=" * 70)
-    show("bob (viewer)  GET  /agents/research-agent", client.get("/agents/research-agent", headers=auth("bob")), "can read")
-    show("bob (viewer)  POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewer -> blocked")
-    roles.assign("bob", "member")  # promote at runtime
-    show("bob (member)  POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "promoted live -> SAME token")
-    roles.unassign("bob", "member")  # revoke at runtime
-    show("bob (revoked) POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "revoked -> blocked again")
-    show("alice (admin) POST /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "admin -> all")
-    print("=" * 70)
+    print("\n" + "=" * 78)
+    print("WHO CAN DO WHAT - three roles, two people")
+    print("=" * 78)
+    print("  roles:  viewer = look at agents | member = look + run | admin = anything")
+    print("  people: bob is a viewer         | alice is an admin")
+    print("  below, each person makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
+
+    show("bob (viewer)  asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
+    show("bob (viewer)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewers can't run, so he's bounced")
+
+    print("\n  >> now we make bob a 'member' while the server is running...\n")
+    roles.assign("bob", "member")
+    show("bob (member)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "same bob, same token, now allowed")
+
+    print("\n  >> ...and now we take the 'member' role back...\n")
+    roles.unassign("bob", "member")
+    show("bob (no role) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "bounced again, instantly")
+
+    show("alice (admin) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "admins can do anything")
+    print("=" * 78)
+    print("the point: you control access by handing out roles, and a change takes effect")
+    print("on the very next request - no new login, no new token.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_roles_api.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_api.py
@@ -1,17 +1,33 @@
 """
-Managed Roles HTTP Management API Example with AgentOS
+Managing roles over the web - and keeping a record of every change
 
-This example demonstrates the admin-only REST API for managed roles. Mount one
-router and admins can create roles and grant/revoke them with plain HTTP calls,
-the change takes effect on the target user's next request (same token). There is
-still no Casbin in this file; the store hides that engine.
+(If roles are new to you, read managed_roles.py first.)
 
-Every /authz/* route requires an admin caller (satisfies agent_os:admin, by token
-scope or by an admin role in the store): non-admins get 403, anonymous 401.
+So far roles were set in code. In real life an admin needs to manage them while
+the app is running, from a dashboard or a script. This file adds a small set of
+web endpoints (a REST API) for exactly that: create a role, give it to someone,
+take it away - all over plain HTTP.
 
-Prerequisites:
-- pip install "agno[casbin]"
-- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+Two important things this shows:
+
+1. Only admins can use these endpoints. If a normal user calls them they get
+   BLOCKED, and someone with no login at all is bounced even harder. So the tool
+   that hands out power is itself protected.
+
+2. Every change is written to an audit log: a permanent, append-only record of
+   who changed what and when (e.g. "alice gave bob the runner role"). This is the
+   kind of trail a security/compliance review asks for. At the end the file prints
+   that log so you can see it.
+
+The endpoints all live under /authz, for example:
+    GET    /authz/roles                  -> list the roles
+    PUT    /authz/roles/{role}           -> set what a role can do
+    POST   /authz/users/{who}/roles      -> give someone a role
+    DELETE /authz/users/{who}/roles/{r}  -> take a role away
+
+Run it:
+    pip install "agno[casbin]"
+    python managed_roles_api.py
 """
 
 import os
@@ -119,29 +135,36 @@ if __name__ == "__main__":
         return {"Authorization": f"Bearer {token(sub)}"}
 
     def show(label: str, r, note: str = "") -> None:
-        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
-        print(f"  {label:48s} -> {r.status_code} {verdict}  {note}")
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {verdict:7s} ({r.status_code})  {note}")
 
-    print("\n" + "=" * 72)
-    print("Managed roles admin API — running the scenario for you")
-    print("=" * 72)
-    show("alice (admin) GET    /authz/roles", client.get("/authz/roles", headers=auth("alice")), "admin")
-    show("bob (viewer)  GET    /authz/roles", client.get("/authz/roles", headers=auth("bob")), "not admin -> blocked")
-    show("anon          GET    /authz/roles", client.get("/authz/roles"), "no token -> 401")
-    show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewer -> blocked")
+    print("\n" + "=" * 80)
+    print("MANAGING ROLES OVER THE WEB (and who's allowed to)")
+    print("=" * 80)
+    print("  alice = admin (allowed to manage) | bob = normal user | anon = nobody logged in\n")
+
+    print("  first, who can even use the management endpoints?")
+    show("alice (admin) opens the roles admin", client.get("/authz/roles", headers=auth("alice")), "admins can")
+    show("bob (normal)  opens the roles admin", client.get("/authz/roles", headers=auth("bob")), "normal users can't -> bounced")
+    show("nobody        opens the roles admin", client.get("/authz/roles"), "not logged in -> bounced harder")
+
+    print("\n  now watch alice give bob a new power, live:")
+    show("bob tries to RUN an agent (before)", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "bob can't run yet")
     client.put("/authz/roles/runner", headers=auth("alice"), json={"scopes": ["agents:*:run"]})
-    g = client.post("/authz/users/bob/roles", headers=auth("alice"), json={"role": "runner"})
-    show("alice         POST   /authz/users/bob/roles", g, f"granted -> bob roles {g.json().get('roles')}")
-    show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "after grant -> SAME token")
-    client.delete("/authz/users/bob/roles/runner", headers=auth("alice"))  # revoke over HTTP
-    show("alice         DELETE /authz/users/bob/roles/runner", client.get("/authz/users/bob/roles", headers=auth("alice")), "revoked -> bob back to viewer")
-    show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "after revoke -> blocked again")
-    print("=" * 72)
+    print("    (alice created a 'runner' role that can run agents)")
+    client.post("/authz/users/bob/roles", headers=auth("alice"), json={"role": "runner"})
+    print("    (alice gave bob the 'runner' role)")
+    show("bob tries to RUN an agent (after)", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "same bob, now allowed")
+    client.delete("/authz/users/bob/roles/runner", headers=auth("alice"))
+    print("    (alice took the 'runner' role back)")
+    show("bob tries to RUN an agent (after revoke)", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "bounced again")
+    print("=" * 80)
 
-    # The append-only audit trail of everything the admin just did over HTTP.
+    # Every change above was written to a permanent record. Here it is.
     import sqlalchemy as sa
 
-    print("\nAudit trail (authz_audit table, actor taken from the admin's jwt):")
+    print("\nTHE RECORD: every change is logged - who did it, what changed, before -> after.")
+    print("(this is what a security review wants to see)")
     eng = sa.create_engine("sqlite:///tmp/authz_audit.db")
     with eng.connect() as conn:
         for row in conn.execute(

--- a/cookbook/05_agent_os/rbac/managed_roles_api.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_api.py
@@ -1,12 +1,22 @@
 """
-Managing roles over the web - and keeping a record of every change
+Scenario 2 of 3: NO login service - they want US to manage users and roles
 
 (If roles are new to you, read managed_roles.py first.)
 
-So far roles were set in code. In real life an admin needs to manage them while
-the app is running, from a dashboard or a script. This file adds a small set of
-web endpoints (a REST API) for exactly that: create a role, give it to someone,
-take it away - all over plain HTTP.
+The three ways a company can run this:
+  1. they already have a login service, we only enforce  -> idp_enforce_only.py
+  2. THIS FILE - no login service, we manage users + roles ourselves
+  3. a mix of both                                        -> casbin_external_idp.py
+
+In this scenario the company has no WorkOS/Okta. Their own app logs people in and
+issues them a token that just says who they are. Everything about permissions
+lives with US: we hold the list of roles, who has which role, and we let admins
+change it. (We are not doing the login itself - no passwords or MFA - just the
+"what are you allowed to do" part, which is what they asked us to provide.)
+
+So this file adds a small set of web endpoints (a REST API) for managing all of
+that while the app runs: create a role, give it to someone, take it away - over
+plain HTTP.
 
 Two important things this shows:
 

--- a/cookbook/05_agent_os/rbac/managed_roles_api.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_api.py
@@ -22,6 +22,7 @@ from agno.agent import Agent
 from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
+from agno.os.authz.audit import DbAuditSink
 from agno.os.authz.role_router import get_roles_router
 from agno.os.authz.role_store import ManagedRoleStore
 from agno.os.config import AuthorizationConfig
@@ -35,9 +36,17 @@ JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bit
 OS_ID = "managed-roles-api-os"
 
 os.makedirs("tmp", exist_ok=True)
+for _f in ("tmp/managed_roles_api.db", "tmp/authz_audit.db"):
+    if os.path.exists(_f):
+        os.remove(_f)
+
+# Every role/assignment change is written to an append-only audit table (the
+# "who changed what, when" trail Casbin can't give you, since it never sees the
+# acting principal). The admin's JWT sub is recorded as the actor.
+audit = DbAuditSink(db_url="sqlite:///tmp/authz_audit.db")
 
 # Define a starting admin + viewer. Everything else can be done over HTTP.
-roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_api.db")
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_api.db", audit=audit)
 roles.set_role_scopes("viewer", ["agents:*:read"])
 roles.set_role_scopes("admin", ["agent_os:admin"])
 roles.assign("alice", "admin")
@@ -128,3 +137,16 @@ if __name__ == "__main__":
     show("alice         DELETE /authz/users/bob/roles/runner", client.get("/authz/users/bob/roles", headers=auth("alice")), "revoked -> bob back to viewer")
     show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "after revoke -> blocked again")
     print("=" * 72)
+
+    # The append-only audit trail of everything the admin just did over HTTP.
+    import sqlalchemy as sa
+
+    print("\nAudit trail (authz_audit table, actor taken from the admin's jwt):")
+    eng = sa.create_engine("sqlite:///tmp/authz_audit.db")
+    with eng.connect() as conn:
+        for row in conn.execute(
+            sa.text("select actor, action, target, before, after from authz_audit order by id")
+        ):
+            actor = row.actor or "system"  # None = changed in code at startup, not via the api
+            print(f"  {actor:6s} {row.action:18s} {row.target:8s} {row.before or '-'} -> {row.after or '-'}")
+    print()

--- a/cookbook/05_agent_os/rbac/managed_roles_api.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_api.py
@@ -1,0 +1,130 @@
+"""
+Managed Roles HTTP Management API Example with AgentOS
+
+This example demonstrates the admin-only REST API for managed roles. Mount one
+router and admins can create roles and grant/revoke them with plain HTTP calls,
+the change takes effect on the target user's next request (same token). There is
+still no Casbin in this file; the store hides that engine.
+
+Every /authz/* route requires an admin caller (satisfies agent_os:admin, by token
+scope or by an admin role in the store): non-admins get 403, anonymous 401.
+
+Prerequisites:
+- pip install "agno[casbin]"
+- Set OPENAI_API_KEY to actually run an agent (authorization is enforced regardless)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_router import get_roles_router
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-api-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define a starting admin + viewer. Everything else can be done over HTTP.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_api.db")
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("alice", "admin")
+roles.assign("bob", "viewer")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS, then mount the admin management router.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS with admin REST API",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+    ),
+)
+
+app = agent_os.get_app()
+app.include_router(get_roles_router(roles))  # the /authz management API
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to walk the admin management API and print each result.
+
+    Management endpoints (all admin-only, prefix /authz):
+    - GET    /authz/roles                         list roles
+    - PUT    /authz/roles/{role}                  set a role's scopes
+    - DELETE /authz/roles/{role}                  delete a role
+    - GET    /authz/users/{subject}/roles         a subject's roles
+    - POST   /authz/users/{subject}/roles         grant a role
+    - DELETE /authz/users/{subject}/roles/{role}  revoke a role
+
+    alice is an admin, bob is a viewer. The scenario below has alice grant a
+    'runner' role to bob over HTTP, shows bob gain run access live (same token),
+    then revokes it again.
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {r.status_code} {verdict}  {note}")
+
+    print("\n" + "=" * 72)
+    print("Managed roles admin API — running the scenario for you")
+    print("=" * 72)
+    show("alice (admin) GET    /authz/roles", client.get("/authz/roles", headers=auth("alice")), "admin")
+    show("bob (viewer)  GET    /authz/roles", client.get("/authz/roles", headers=auth("bob")), "not admin -> blocked")
+    show("anon          GET    /authz/roles", client.get("/authz/roles"), "no token -> 401")
+    show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewer -> blocked")
+    client.put("/authz/roles/runner", headers=auth("alice"), json={"scopes": ["agents:*:run"]})
+    g = client.post("/authz/users/bob/roles", headers=auth("alice"), json={"role": "runner"})
+    show("alice         POST   /authz/users/bob/roles", g, f"granted -> bob roles {g.json().get('roles')}")
+    show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "after grant -> SAME token")
+    client.delete("/authz/users/bob/roles/runner", headers=auth("alice"))  # revoke over HTTP
+    show("alice         DELETE /authz/users/bob/roles/runner", client.get("/authz/users/bob/roles", headers=auth("alice")), "revoked -> bob back to viewer")
+    show("bob           POST   /agents/research-agent/runs", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "after revoke -> blocked again")
+    print("=" * 72)

--- a/cookbook/05_agent_os/rbac/managed_roles_sessions.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_sessions.py
@@ -1,17 +1,26 @@
 """
-Managed Roles Session Access Control Example with AgentOS
+Roles protecting real data - who can delete a chat session
 
-This example demonstrates RBAC gating a real AgentOS resource: sessions. Roles
-govern the actual session endpoints (GET /sessions, PATCH /sessions/{id},
-DELETE /sessions/{id}). A read-only 'support' role can VIEW sessions but is
-blocked (403) from editing or deleting them; an 'operator' can delete, and when
-it does the session is really gone. There is no Casbin in this file; roles are
-defined in agno scope terms and the store hides the engine.
+(If roles are new to you, read managed_roles.py first.)
 
-Two sessions are seeded so the blocking is tangible.
+A "session" is one saved conversation with an agent. Deleting one throws away real
+data, so not everyone should be allowed to. This file shows roles protecting an
+actual operation, not a toy one.
 
-Prerequisites:
-- pip install "agno[casbin]"
+Three jobs:
+- support  -> can LOOK at sessions, nothing else
+- operator -> can look, edit, and DELETE sessions
+- admin    -> can do anything
+
+We put two saved sessions in the database, then watch what each person is allowed
+to do. The key moment: the support person tries to delete a session and gets
+BLOCKED, while the operator deletes one for real and the count drops from 2 to 1.
+That is the whole idea of authorization in one screen: the right people get
+through, the wrong ones get stopped, before any data is touched.
+
+Run it:
+    pip install "agno[casbin]"
+    python managed_roles_sessions.py
 """
 
 import os
@@ -117,20 +126,27 @@ if __name__ == "__main__":
         return {"Authorization": f"Bearer {token(sub)}"}
 
     def show(label: str, r, note: str = "") -> None:
-        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
-        print(f"  {label:46s} -> {r.status_code} {verdict}  {note}")
+        # 200/204 means it went through; 401/403 means it was bounced.
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:44s} -> {verdict:7s} ({r.status_code})  {note}")
 
     def count(sub: str) -> int:
         r = client.get("/sessions?type=agent", headers=auth(sub))
         return r.json()["meta"]["total_count"] if r.status_code == 200 else -1
 
-    print("\n" + "=" * 70)
-    print("Session access control — running the scenario for you")
-    print("=" * 70)
-    print(f"  sessions in the DB to start                    : {count('val')}")
-    show("bob (support)  GET    /sessions", client.get("/sessions?type=agent", headers=auth("bob")), "can view")
-    show("bob (support)  PATCH  /sessions/sess-123", client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}), "write -> blocked")
-    show("bob (support)  DELETE /sessions/sess-123", client.delete("/sessions/sess-123", headers=auth("bob")), "delete -> blocked")
-    show("val (operator) DELETE /sessions/sess-123", client.delete("/sessions/sess-123", headers=auth("val")), "really deleted")
-    print(f"  sessions in the DB now                         : {count('val')}  <- it's gone")
-    print("=" * 70)
+    print("\n" + "=" * 78)
+    print("WHO CAN TOUCH THE SAVED SESSIONS")
+    print("=" * 78)
+    print("  bob = support (look only) | val = operator (look, edit, delete)")
+    print(f"  saved sessions right now: {count('val')}\n")
+
+    show("bob (support)  tries to LOOK at sessions", client.get("/sessions?type=agent", headers=auth("bob")), "support can look")
+    show("bob (support)  tries to RENAME a session", client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}), "editing isn't allowed -> bounced")
+    show("bob (support)  tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("bob")), "deleting isn't allowed -> bounced")
+    show("val (operator) tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("val")), "operators can delete -> done for real")
+
+    print(f"\n  saved sessions now: {count('val')}  (was 2 - the operator's delete really happened)")
+    print("=" * 78)
+    print("the point: the support person was stopped before any data was touched.")
+    print("only the operator's delete went through, and you can see the count drop.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_roles_sessions.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_sessions.py
@@ -1,0 +1,136 @@
+"""
+Managed Roles Session Access Control Example with AgentOS
+
+This example demonstrates RBAC gating a real AgentOS resource: sessions. Roles
+govern the actual session endpoints (GET /sessions, PATCH /sessions/{id},
+DELETE /sessions/{id}). A read-only 'support' role can VIEW sessions but is
+blocked (403) from editing or deleting them; an 'operator' can delete, and when
+it does the session is really gone. There is no Casbin in this file; roles are
+defined in agno scope terms and the store hides the engine.
+
+Two sessions are seeded so the blocking is tangible.
+
+Prerequisites:
+- pip install "agno[casbin]"
+"""
+
+import os
+import time
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+from agno.session import AgentSession
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-sessions-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define roles in agno scope terms. support is read-only; operator can delete.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_sessions.db")
+roles.set_role_scopes("support", ["sessions:read"])
+roles.set_role_scopes("operator", ["sessions:read", "sessions:write", "sessions:delete"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("bob", "support")
+roles.assign("val", "operator")
+roles.assign("alice", "admin")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos_sessions.db")
+
+# Demo fixture: seed two sessions directly so the delete is observable without an
+# API key. Real apps don't do this; sessions are created by running an agent
+# (e.g. agent.print_response("hi", session_id="...")). We seed to stay self-contained.
+_now = int(time.time())
+db.upsert_session(AgentSession(session_id="sess-123", agent_id="research-agent", user_id="customer-a", created_at=_now))
+db.upsert_session(AgentSession(session_id="sess-456", agent_id="research-agent", user_id="customer-b", created_at=_now))
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the managed-role store as the provider.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS gating session access",
+    agents=[research_agent],
+    db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to see roles gate the real session endpoints.
+
+    Roles:
+    - support  -> sessions:read                 (view only)
+    - operator -> sessions:read/write/delete    (full session control)
+    - admin    -> everything
+    bob is support, val is operator. The scenario below shows support being
+    blocked from edit/delete (403) while operator deletes for real (the session
+    count drops from 2 to 1).
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        verdict = "DENIED " if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {r.status_code} {verdict}  {note}")
+
+    def count(sub: str) -> int:
+        r = client.get("/sessions?type=agent", headers=auth(sub))
+        return r.json()["meta"]["total_count"] if r.status_code == 200 else -1
+
+    print("\n" + "=" * 70)
+    print("Session access control — running the scenario for you")
+    print("=" * 70)
+    print(f"  sessions in the DB to start                    : {count('val')}")
+    show("bob (support)  GET    /sessions", client.get("/sessions?type=agent", headers=auth("bob")), "can view")
+    show("bob (support)  PATCH  /sessions/sess-123", client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}), "write -> blocked")
+    show("bob (support)  DELETE /sessions/sess-123", client.delete("/sessions/sess-123", headers=auth("bob")), "delete -> blocked")
+    show("val (operator) DELETE /sessions/sess-123", client.delete("/sessions/sess-123", headers=auth("val")), "really deleted")
+    print(f"  sessions in the DB now                         : {count('val')}  <- it's gone")
+    print("=" * 70)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -986,6 +986,7 @@ class AgentOS:
         admin_scope: Optional[str] = None
         user_isolation = False
         authorization_provider = None
+        authz_audit = None
 
         if self.authorization_config:
             algorithm = self.authorization_config.algorithm or "RS256"
@@ -997,6 +998,7 @@ class AgentOS:
             admin_scope = self.authorization_config.admin_scope
             user_isolation = self.authorization_config.user_isolation
             authorization_provider = self.authorization_config.authorization_provider
+            authz_audit = self.authorization_config.audit
 
         log_info(f"Adding JWT middleware for authorization (algorithm: {algorithm})")
 
@@ -1025,6 +1027,8 @@ class AgentOS:
         from agno.os.authz.scope_provider import ScopeAuthorizationProvider
 
         fastapi_app.state.authorization_provider = authorization_provider or ScopeAuthorizationProvider()
+        # Optional decision-audit sink (records allow/deny at the route gate).
+        fastapi_app.state.authz_audit = authz_audit
 
         # Collect interface route prefixes to exclude from JWT auth.
         # Interfaces use their own authentication mechanisms

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -979,6 +979,7 @@ class AgentOS:
 
         verify_audience = False
         jwks_file = None
+        jwks_url = None
         verification_keys = None
         algorithm = "RS256"
         audience = None
@@ -990,6 +991,7 @@ class AgentOS:
             algorithm = self.authorization_config.algorithm or "RS256"
             verification_keys = self.authorization_config.verification_keys
             jwks_file = self.authorization_config.jwks_file
+            jwks_url = self.authorization_config.jwks_url
             verify_audience = self.authorization_config.verify_audience or False
             audience = self.authorization_config.audience
             admin_scope = self.authorization_config.admin_scope
@@ -1002,6 +1004,7 @@ class AgentOS:
         jwt_validator = JWTValidator(
             verification_keys=verification_keys,
             jwks_file=jwks_file,
+            jwks_url=jwks_url,
             algorithm=algorithm,
         )
         fastapi_app.state.jwt_validator = jwt_validator
@@ -1050,6 +1053,7 @@ class AgentOS:
         middleware_kwargs: Dict[str, Any] = {
             "verification_keys": verification_keys,
             "jwks_file": jwks_file,
+            "jwks_url": jwks_url,
             "algorithm": algorithm,
             "authorization": self.authorization,
             "verify_audience": verify_audience,

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -984,6 +984,7 @@ class AgentOS:
         audience = None
         admin_scope: Optional[str] = None
         user_isolation = False
+        authorization_provider = None
 
         if self.authorization_config:
             algorithm = self.authorization_config.algorithm or "RS256"
@@ -993,6 +994,7 @@ class AgentOS:
             audience = self.authorization_config.audience
             admin_scope = self.authorization_config.admin_scope
             user_isolation = self.authorization_config.user_isolation
+            authorization_provider = self.authorization_config.authorization_provider
 
         log_info(f"Adding JWT middleware for authorization (algorithm: {algorithm})")
 
@@ -1012,6 +1014,14 @@ class AgentOS:
         # JWT/RBAC still apply but the per-user DB wrapper and ownership gates
         # added by the user-scoped-DB work stay dormant.
         fastapi_app.state.user_isolation_enabled = user_isolation
+
+        # Resolve the authorization provider. Defaults to the built-in
+        # scope-based RBAC; a custom AuthorizationProvider can be supplied via
+        # AuthorizationConfig to swap the decision engine (ReBAC/ABAC/external)
+        # without touching the request pipeline.
+        from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+        fastapi_app.state.authorization_provider = authorization_provider or ScopeAuthorizationProvider()
 
         # Collect interface route prefixes to exclude from JWT auth.
         # Interfaces use their own authentication mechanisms

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional, Set
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+from agno.os.scopes import has_required_scopes
 from agno.os.settings import AgnoAPISettings
 
 # Create a global HTTPBearer instance
@@ -153,6 +153,46 @@ def build_insufficient_permissions_detail(required_scopes: Optional[List[str]]) 
     return base
 
 
+def _resolve_authorization_provider(request: Request):
+    """Resolve the active AuthorizationProvider for this request.
+
+    Prefers ``request.app.state.authorization_provider`` (set by AgentOS from
+    ``AuthorizationConfig``); otherwise falls back to the default
+    ``ScopeAuthorizationProvider`` so manual setups keep their original behaviour.
+    This is the per-resource (route-handler) counterpart to the route gate in
+    JWTMiddleware, so both enforcement points consult the same provider.
+    """
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    provider = getattr(getattr(request, "app", None), "state", None)
+    provider = getattr(provider, "authorization_provider", None) if provider is not None else None
+    if provider is not None:
+        return provider
+    return ScopeAuthorizationProvider()
+
+
+def _build_authorization_context(
+    request: Request,
+    resource_type: Optional[str] = None,
+    resource_id: Optional[str] = None,
+    action: Optional[str] = None,
+):
+    """Assemble an AuthorizationContext from the claims on request.state."""
+    from agno.os.authz.provider import AuthorizationContext
+
+    admin_scope_raw = getattr(request.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+    return AuthorizationContext(
+        principal_id=getattr(request.state, "user_id", None),
+        scopes=getattr(request.state, "scopes", []) or [],
+        claims=getattr(request.state, "claims", {}) or {},
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        admin_scope=admin_scope,
+    )
+
+
 def get_accessible_resources(request: Request, resource_type: str) -> Set[str]:
     """
     Get the set of resource IDs the user has access to based on their scopes.
@@ -194,24 +234,12 @@ def get_accessible_resources(request: Request, resource_type: str) -> Set[str]:
     if cached_ids is not None:
         return cached_ids
 
-    # Get user's scopes from request state (set by JWT middleware)
-    user_scopes = getattr(request.state, "scopes", [])
-
-    # Honour any custom admin_scope configured on JWTMiddleware (set on
-    # request.state by the middleware). Without this, list endpoints reject
-    # custom-admin tokens with 403 even though check_resource_access would
-    # accept them.
-    admin_scope_raw = getattr(request.state, "admin_scope", None)
-    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-
-    # Get accessible resource IDs
-    accessible_ids = get_accessible_resource_ids(
-        user_scopes=user_scopes,
-        resource_type=resource_type,
-        admin_scope=admin_scope,
-    )
-
-    return accessible_ids
+    # Delegate to the active authorization provider. The default
+    # ScopeAuthorizationProvider reproduces the original behaviour; a custom
+    # provider can answer from a different model entirely.
+    provider = _resolve_authorization_provider(request)
+    ctx = _build_authorization_context(request, resource_type=resource_type)
+    return provider.accessible_resource_ids(ctx)
 
 
 def filter_resources_by_access(request: Request, resources: List, resource_type: str) -> List:
@@ -279,25 +307,16 @@ def check_resource_access(request: Request, resource_id: str, resource_type: str
         >>> check_resource_access(request, "my-agent", "agents", "run")
         False
     """
-    user_scopes = getattr(request.state, "scopes", [])
-    # Honour the configured admin scope (set by JWTMiddleware on request.state)
-    # so custom-admin tokens are recognised here too. Non-string values (e.g.
-    # MagicMock attributes in tests) are ignored.
-    admin_scope_raw = getattr(request.state, "admin_scope", None)
-    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-    accessible_ids = get_accessible_resource_ids(
-        user_scopes=user_scopes,
-        resource_type=resource_type,
-        action=action,
-        admin_scope=admin_scope,
+    # Delegate to the active authorization provider. The default
+    # ScopeAuthorizationProvider reproduces the original scope-matching
+    # behaviour; a custom provider (Casbin/ReBAC/ABAC/external) can decide from a
+    # different model. This is the per-resource gate that complements the route
+    # gate in JWTMiddleware, both go through the same provider.
+    provider = _resolve_authorization_provider(request)
+    ctx = _build_authorization_context(
+        request, resource_type=resource_type, resource_id=resource_id, action=action
     )
-
-    # Wildcard access grants all permissions
-    if "*" in accessible_ids:
-        return True
-
-    # Check if user has access to this specific resource
-    return resource_id in accessible_ids
+    return provider.check(ctx)
 
 
 def require_resource_access(resource_type: str, action: str, resource_id_param: str):

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -1,0 +1,28 @@
+"""Pluggable authorization providers for AgentOS.
+
+The ``AuthorizationProvider`` interface is the seam between AgentOS's request
+handling and the logic that decides "can this principal do this action on this
+resource". The built-in :class:`ScopeAuthorizationProvider` implements the
+existing JWT-scope RBAC with zero external dependencies, so the default
+behaviour is unchanged.
+
+Customers who need a richer model (relationship-based / ReBAC, attribute-based,
+or an external engine such as Casbin, OpenFGA or Cerbos) implement the same
+interface and pass it via ``AuthorizationConfig(authorization_provider=...)``.
+
+This mirrors the provider pattern used elsewhere in the ecosystem
+(e.g. ``check`` / ``require`` / ``filter_accessible``) so the swap is a config
+change rather than a fork of the request pipeline.
+"""
+
+from agno.os.authz.provider import (
+    AuthorizationContext,
+    AuthorizationProvider,
+)
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+__all__ = [
+    "AuthorizationContext",
+    "AuthorizationProvider",
+    "ScopeAuthorizationProvider",
+]

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -15,6 +15,7 @@ This mirrors the provider pattern used elsewhere in the ecosystem
 change rather than a fork of the request pipeline.
 """
 
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink, LoggingAuditSink
 from agno.os.authz.provider import (
     AuthorizationContext,
     AuthorizationProvider,
@@ -25,4 +26,8 @@ __all__ = [
     "AuthorizationContext",
     "AuthorizationProvider",
     "ScopeAuthorizationProvider",
+    "AuditEvent",
+    "AuditSink",
+    "LoggingAuditSink",
+    "DbAuditSink",
 ]

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -111,6 +111,7 @@ class DbAuditSink(AuditSink):
             sa.Column("target", sa.String(255), nullable=False),
             sa.Column("before", sa.Text),
             sa.Column("after", sa.Text),
+            sa.Column("metadata", sa.Text),
         )
         if create_table:
             metadata.create_all(self._engine)
@@ -125,6 +126,7 @@ class DbAuditSink(AuditSink):
                     target=event.target,
                     before=json.dumps(event.before) if event.before is not None else None,
                     after=json.dumps(event.after) if event.after is not None else None,
+                    metadata=json.dumps(event.metadata) if event.metadata else None,
                 )
             )
 
@@ -146,6 +148,7 @@ class DbAuditSink(AuditSink):
                 "target": r["target"],
                 "before": json.loads(r["before"]) if r["before"] else None,
                 "after": json.loads(r["after"]) if r["after"] else None,
+                "metadata": json.loads(r["metadata"]) if r["metadata"] else None,
             }
             for r in rows
         ]

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -1,0 +1,129 @@
+"""Audit trail for authorization changes.
+
+There are two kinds of "audit" people mean:
+
+1. Decision audit ("was alice allowed to run agent X?") — Casbin already logs
+   every ``enforce()`` to the ``casbin.enforcer`` Python logger (deny at WARNING,
+   allow at INFO). Route that logger to your sink; ``ManagedRoleStore(decision_log=True)``
+   just bumps it to INFO so allows are captured too.
+
+2. Change audit ("who granted alice the admin role, when, before/after?") — Casbin
+   cannot provide this: its management API never sees the acting principal, and
+   ``casbin_rule`` is overwrite-in-place with no history. So it must be captured at
+   the layer that knows the actor — the management API / store. That is what this
+   module is for.
+
+Plug an :class:`AuditSink` into :class:`~agno.os.authz.role_store.ManagedRoleStore`
+(directly or via ``get_roles_router``) and every role/assignment mutation emits a
+structured, append-only :class:`AuditEvent` with the actor and the before/after.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+
+@dataclass
+class AuditEvent:
+    """One authorization-change record. Append-only; never mutated after emit.
+
+    Attributes:
+        action: what happened — ``role.set_scopes`` / ``role.removed`` /
+            ``user.assigned`` / ``user.unassigned``.
+        actor: the principal who made the change (JWT ``sub`` of the admin), or
+            None for changes made in code outside a request (treated as system).
+        target: the role name (role changes) or subject id (assignment changes).
+        before: prior state (the role's scopes, or the subject's roles), or None.
+        after: new state, or None (e.g. on removal).
+        timestamp: epoch seconds when the change was recorded.
+    """
+
+    action: str
+    actor: Optional[str]
+    target: str
+    before: Optional[List[str]] = None
+    after: Optional[List[str]] = None
+    timestamp: int = 0
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "ts": self.timestamp,
+            "actor": self.actor,
+            "action": self.action,
+            "target": self.target,
+            "before": self.before,
+            "after": self.after,
+            **({"metadata": self.metadata} if self.metadata else {}),
+        }
+
+
+class AuditSink(ABC):
+    """Where audit events go. Implement ``record`` to send them anywhere."""
+
+    @abstractmethod
+    def record(self, event: AuditEvent) -> None:
+        """Persist/emit one event. Must not raise into the caller's path."""
+        ...
+
+
+class LoggingAuditSink(AuditSink):
+    """Emit each event as one JSON line to a logger (default ``agno.authz.audit``)."""
+
+    def __init__(self, logger_name: str = "agno.authz.audit", level: int = logging.INFO):
+        self._logger = logging.getLogger(logger_name)
+        self._level = level
+
+    def record(self, event: AuditEvent) -> None:
+        self._logger.log(self._level, json.dumps(event.to_dict()))
+
+
+class DbAuditSink(AuditSink):
+    """Append-only audit table in your own DB (SQLAlchemy).
+
+    Writes are INSERT-only — rows are never updated or deleted — so the table is a
+    tamper-evident trail suitable for SOC2-style evidence. Point it at the same DB
+    as the role store or a separate one.
+    """
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        engine: Optional[Any] = None,
+        table_name: str = "authz_audit",
+        create_table: bool = True,
+    ):
+        import sqlalchemy as sa
+
+        if engine is None and db_url is None:
+            raise ValueError("DbAuditSink needs either db_url or engine")
+        self._engine = engine if engine is not None else sa.create_engine(db_url)
+        metadata = sa.MetaData()
+        self._table = sa.Table(
+            table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("actor", sa.String(255)),
+            sa.Column("action", sa.String(255), nullable=False),
+            sa.Column("target", sa.String(255), nullable=False),
+            sa.Column("before", sa.Text),
+            sa.Column("after", sa.Text),
+        )
+        if create_table:
+            metadata.create_all(self._engine)
+
+    def record(self, event: AuditEvent) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                self._table.insert().values(
+                    ts=event.timestamp,
+                    actor=event.actor,
+                    action=event.action,
+                    target=event.target,
+                    before=json.dumps(event.before) if event.before is not None else None,
+                    after=json.dumps(event.after) if event.after is not None else None,
+                )
+            )

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -127,3 +127,25 @@ class DbAuditSink(AuditSink):
                     after=json.dumps(event.after) if event.after is not None else None,
                 )
             )
+
+    def read(self, limit: int = 100) -> List[dict]:
+        """Return the most recent events (newest first) as plain dicts."""
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = (
+                conn.execute(sa.select(self._table).order_by(self._table.c.id.desc()).limit(limit))
+                .mappings()
+                .all()
+            )
+        return [
+            {
+                "ts": r["ts"],
+                "actor": r["actor"],
+                "action": r["action"],
+                "target": r["target"],
+                "before": json.loads(r["before"]) if r["before"] else None,
+                "after": json.loads(r["after"]) if r["after"] else None,
+            }
+            for r in rows
+        ]

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -1,21 +1,27 @@
 """Audit trail for authorization changes.
 
-There are two kinds of "audit" people mean:
+There are two kinds of "audit" people mean, and we keep them in two separate
+tables (see :class:`DbAuditSink`) because they answer different questions:
 
-1. Decision audit ("was alice allowed to run agent X?") — Casbin already logs
-   every ``enforce()`` to the ``casbin.enforcer`` Python logger (deny at WARNING,
-   allow at INFO). Route that logger to your sink; ``ManagedRoleStore(decision_log=True)``
-   just bumps it to INFO so allows are captured too.
+1. Decision audit ("was alice allowed to run agent X, and with which token?") —
+   recorded by the JWT middleware on every protected request when an
+   :class:`AuditSink` is set on ``AuthorizationConfig(audit=...)``. Each row is an
+   ``access.allowed`` / ``access.denied`` event with the principal, the route, the
+   required scopes, the caller's scopes, and a NON-secret token reference (the
+   token's ``jti`` when present, otherwise a short hash — never the token itself).
+   (Casbin also logs every ``enforce()`` to the ``casbin.enforcer`` logger; that
+   remains available and ``ManagedRoleStore(decision_log=True)`` bumps it to INFO.)
 
 2. Change audit ("who granted alice the admin role, when, before/after?") — Casbin
    cannot provide this: its management API never sees the acting principal, and
    ``casbin_rule`` is overwrite-in-place with no history. So it must be captured at
-   the layer that knows the actor — the management API / store. That is what this
-   module is for.
+   the layer that knows the actor — the management API / store. Plug an
+   :class:`AuditSink` into :class:`~agno.os.authz.role_store.ManagedRoleStore`
+   (directly or via ``get_roles_router``) and every role/assignment mutation emits
+   a structured, append-only :class:`AuditEvent` with the actor and before/after.
 
-Plug an :class:`AuditSink` into :class:`~agno.os.authz.role_store.ManagedRoleStore`
-(directly or via ``get_roles_router``) and every role/assignment mutation emits a
-structured, append-only :class:`AuditEvent` with the actor and the before/after.
+The same :class:`DbAuditSink` instance can serve both: ``record()`` routes change
+events to ``authz_audit`` and decision events to ``authz_decisions``.
 """
 
 import json
@@ -80,11 +86,31 @@ class LoggingAuditSink(AuditSink):
         self._logger.log(self._level, json.dumps(event.to_dict()))
 
 
-class DbAuditSink(AuditSink):
-    """Append-only audit table in your own DB (SQLAlchemy).
+def _is_decision(action: str) -> bool:
+    """Decision events (``access.allowed`` / ``access.denied``) vs change events."""
+    return action.startswith("access.")
 
-    Writes are INSERT-only — rows are never updated or deleted — so the table is a
-    tamper-evident trail suitable for SOC2-style evidence. Point it at the same DB
+
+class DbAuditSink(AuditSink):
+    """Append-only audit tables in your own DB (SQLAlchemy).
+
+    The two kinds of audit are kept in two physically separate tables, because
+    they answer different questions, have different shapes, and grow at very
+    different rates:
+
+    - **changes** (``authz_audit``): who granted/changed a role, with before/after.
+      Low volume, one row per admin action.
+    - **decisions** (``authz_decisions``): every allow/deny on a request, with the
+      required scopes, the granted scopes, and a non-secret token reference. High
+      volume, one row per protected request.
+
+    Keeping them apart means a decision-log flood never buries the change trail,
+    each table has only the columns it needs, and you can retain/export them on
+    different schedules. ``record()`` routes by action; you read each side with
+    :meth:`read` (changes) and :meth:`read_decisions`.
+
+    Writes are INSERT-only — rows are never updated or deleted — so both tables are
+    tamper-evident trails suitable for SOC2-style evidence. Point it at the same DB
     as the role store or a separate one.
     """
 
@@ -93,6 +119,7 @@ class DbAuditSink(AuditSink):
         db_url: Optional[str] = None,
         engine: Optional[Any] = None,
         table_name: str = "authz_audit",
+        decision_table_name: str = "authz_decisions",
         create_table: bool = True,
     ):
         import sqlalchemy as sa
@@ -101,6 +128,7 @@ class DbAuditSink(AuditSink):
             raise ValueError("DbAuditSink needs either db_url or engine")
         self._engine = engine if engine is not None else sa.create_engine(db_url)
         metadata = sa.MetaData()
+        # change trail: role/assignment mutations with before/after
         self._table = sa.Table(
             table_name,
             metadata,
@@ -111,12 +139,30 @@ class DbAuditSink(AuditSink):
             sa.Column("target", sa.String(255), nullable=False),
             sa.Column("before", sa.Text),
             sa.Column("after", sa.Text),
-            sa.Column("metadata", sa.Text),
+        )
+        # decision trail: per-request allow/deny with the token reference
+        self._decisions = sa.Table(
+            decision_table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("actor", sa.String(255)),
+            sa.Column("action", sa.String(255), nullable=False),  # access.allowed / access.denied
+            sa.Column("target", sa.String(512), nullable=False),  # "METHOD /path"
+            sa.Column("token_ref", sa.String(255)),  # jti (preferred) or short hash — never the token
+            sa.Column("required", sa.Text),  # scopes the route required (JSON)
+            sa.Column("scopes", sa.Text),  # scopes the caller had (JSON)
         )
         if create_table:
             metadata.create_all(self._engine)
 
     def record(self, event: AuditEvent) -> None:
+        if _is_decision(event.action):
+            self._record_decision(event)
+        else:
+            self._record_change(event)
+
+    def _record_change(self, event: AuditEvent) -> None:
         with self._engine.begin() as conn:
             conn.execute(
                 self._table.insert().values(
@@ -126,12 +172,26 @@ class DbAuditSink(AuditSink):
                     target=event.target,
                     before=json.dumps(event.before) if event.before is not None else None,
                     after=json.dumps(event.after) if event.after is not None else None,
-                    metadata=json.dumps(event.metadata) if event.metadata else None,
+                )
+            )
+
+    def _record_decision(self, event: AuditEvent) -> None:
+        meta = event.metadata or {}
+        with self._engine.begin() as conn:
+            conn.execute(
+                self._decisions.insert().values(
+                    ts=event.timestamp,
+                    actor=event.actor,
+                    action=event.action,
+                    target=event.target,
+                    token_ref=meta.get("token"),
+                    required=json.dumps(meta.get("required")) if meta.get("required") is not None else None,
+                    scopes=json.dumps(meta.get("scopes")) if meta.get("scopes") is not None else None,
                 )
             )
 
     def read(self, limit: int = 100) -> List[dict]:
-        """Return the most recent events (newest first) as plain dicts."""
+        """Recent *change* events (newest first) as plain dicts."""
         import sqlalchemy as sa
 
         with self._engine.connect() as conn:
@@ -148,7 +208,35 @@ class DbAuditSink(AuditSink):
                 "target": r["target"],
                 "before": json.loads(r["before"]) if r["before"] else None,
                 "after": json.loads(r["after"]) if r["after"] else None,
-                "metadata": json.loads(r["metadata"]) if r["metadata"] else None,
+            }
+            for r in rows
+        ]
+
+    def read_decisions(self, limit: int = 100) -> List[dict]:
+        """Recent *decision* events (newest first) as plain dicts.
+
+        ``metadata`` is reassembled to the same ``{required, token, scopes}`` shape
+        the in-memory event carried, so readers don't care which table it came from.
+        """
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = (
+                conn.execute(sa.select(self._decisions).order_by(self._decisions.c.id.desc()).limit(limit))
+                .mappings()
+                .all()
+            )
+        return [
+            {
+                "ts": r["ts"],
+                "actor": r["actor"],
+                "action": r["action"],
+                "target": r["target"],
+                "metadata": {
+                    "required": json.loads(r["required"]) if r["required"] else None,
+                    "token": r["token_ref"],
+                    "scopes": json.loads(r["scopes"]) if r["scopes"] else None,
+                },
             }
             for r in rows
         ]

--- a/libs/agno/agno/os/authz/casbin_provider.py
+++ b/libs/agno/agno/os/authz/casbin_provider.py
@@ -107,6 +107,8 @@ class CasbinAuthorizationProvider(AuthorizationProvider):
         """
         if self._roles_claim:
             roles = ctx.claims.get(self._roles_claim)
+            if isinstance(roles, str):  # e.g. WorkOS sends a single "role" string
+                roles = [roles]
             if isinstance(roles, list) and roles:
                 return any(bool(self._enforcer.enforce(role, obj, act)) for role in roles)
         if not ctx.principal_id:

--- a/libs/agno/agno/os/authz/casbin_provider.py
+++ b/libs/agno/agno/os/authz/casbin_provider.py
@@ -1,0 +1,181 @@
+"""Optional Casbin-backed AuthorizationProvider.
+
+An advanced, embedded authorization provider for customers who need more than
+flat scopes: role hierarchies, ABAC conditions, and policy persisted/edited in
+their own DB. Casbin is a pure-Python library (no external service) and its DB
+adapter points at the customer's existing database, so this stays fully in the
+customer's infra.
+
+This is OPT-IN. Casbin is not a hard dependency of agno; install it with
+``pip install agno[casbin]`` (or ``pip install casbin``). The import is lazy so
+agno works without it. The default provider remains the zero-dependency
+:class:`~agno.os.authz.scope_provider.ScopeAuthorizationProvider`.
+
+Usage::
+
+    import casbin
+    from agno.os.authz.casbin_provider import CasbinAuthorizationProvider
+    from agno.os.config import AuthorizationConfig
+
+    enforcer = casbin.Enforcer("model.conf", adapter)   # adapter -> your DB
+    agent_os = AgentOS(
+        agents=[...],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[PUBLIC_KEY],
+            authorization_provider=CasbinAuthorizationProvider(enforcer),
+        ),
+    )
+
+Policy convention this provider assumes (Casbin ``p = sub, obj, act``):
+- ``sub`` is the principal (the JWT ``sub`` / ``principal_id``)
+- ``obj`` is ``"<resource_type>/<resource_id>"`` (e.g. ``agents/research-agent``),
+  or ``"<resource_type>"`` for collection-level checks. Use ``keyMatch2`` in the
+  model for wildcards like ``agents/*``.
+- ``act`` is the action (``read`` / ``run`` / ...).
+Role assignment uses Casbin grouping (``g, user, role``).
+"""
+
+from typing import Any, List, Optional, Set, Tuple
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+
+def scope_to_obj_act(scope: str) -> Tuple[str, str]:
+    """Map an agno scope string to this provider's Casbin ``(obj, act)`` convention.
+
+    Single source of truth shared with :class:`ManagedRoleStore` so the policy a
+    role is *written* with and the request it is *checked* against use the same
+    spelling.
+
+    - ``agent_os:admin``             -> ("*", "*")
+    - ``sessions:write``             -> ("sessions/*", "write")   (collection/global)
+    - ``agents:research-agent:run``  -> ("agents/research-agent", "run")
+    - ``agents:*:run``               -> ("agents/*", "run")
+    """
+    if scope == "agent_os:admin":
+        return ("*", "*")
+    parts = scope.split(":")
+    if len(parts) == 2:
+        return (f"{parts[0]}/*", parts[1])
+    if len(parts) == 3:
+        return (f"{parts[0]}/{parts[1]}", parts[2])
+    raise ValueError(f"Unrecognised scope: {scope!r}")
+
+
+class CasbinAuthorizationProvider(AuthorizationProvider):
+    """Authorization decisions delegated to a Casbin enforcer."""
+
+    def __init__(self, enforcer: Any, roles_claim: Optional[str] = None):
+        """
+        Args:
+            enforcer: a configured ``casbin.Enforcer`` (sync). The caller owns
+                the model + adapter (file, string, or a DB adapter pointed at
+                their own database), so policy storage stays in their infra.
+            roles_claim: optional JWT claim name carrying the caller's roles
+                (e.g. ``"roles"`` for an Auth0/WorkOS token). When set and the
+                claim is present, the caller's roles come FROM the token and we
+                authorize each against the policy (handles "users with an IdP").
+                When None or absent, roles come from Casbin's own ``g``
+                assignments keyed on the subject (handles "users without an
+                IdP"). Both populations are served by the same provider.
+        """
+        # Lazy validation: don't import casbin at module load, but fail clearly
+        # if someone passes something that isn't an enforcer.
+        if not hasattr(enforcer, "enforce"):
+            raise TypeError(
+                "CasbinAuthorizationProvider requires a casbin.Enforcer "
+                "(install with `pip install agno[casbin]`). Got: "
+                f"{type(enforcer)!r}"
+            )
+        self._enforcer = enforcer
+        self._roles_claim = roles_claim
+
+    def _obj(self, ctx: AuthorizationContext) -> Optional[str]:
+        if not ctx.resource_type:
+            return None
+        return f"{ctx.resource_type}/{ctx.resource_id}" if ctx.resource_id else ctx.resource_type
+
+    def _enforce(self, ctx: AuthorizationContext, obj: str, act: str) -> bool:
+        """Run one Casbin decision for ``(obj, act)`` against ``ctx``'s identity.
+
+        Roles-from-token (IdP case): if the token carries roles, authorize each
+        role against the policy (a role matches its own policies in Casbin's
+        RBAC), so we don't need stored ``g`` assignments for this user.
+        Roles-from-store (no-IdP case): authorize the subject; Casbin resolves
+        the subject's roles from its own ``g`` assignments.
+        """
+        if self._roles_claim:
+            roles = ctx.claims.get(self._roles_claim)
+            if isinstance(roles, list) and roles:
+                return any(bool(self._enforcer.enforce(role, obj, act)) for role in roles)
+        if not ctx.principal_id:
+            return False
+        return bool(self._enforcer.enforce(ctx.principal_id, obj, act))
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # Non-resource checks can't be expressed as (sub,obj,act); defer (allow)
+        # and let the route gate (authorize_route) handle them via the route's
+        # required scopes.
+        obj = self._obj(ctx)
+        if obj is None or not ctx.action:
+            return True
+        return self._enforce(ctx, obj, ctx.action)
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Route-level gate run by the middleware before the handler.
+
+        For resource-typed routes (agents/teams/workflows) the middleware has
+        already extracted ``(resource_type, resource_id, action)``, so decide on
+        that via :meth:`check`. For every other route (sessions, memory, config,
+        knowledge, ...) the middleware can't tag a resource type — so we evaluate
+        the route's ``required_scopes`` directly against the policy. Without this,
+        those routes would be ungated under this provider (any authenticated
+        caller would pass), unlike the default scope provider which enforces them.
+        Allow if ANY required scope is satisfied (``agent_os:admin`` satisfies all).
+        """
+        if ctx.resource_type:
+            return self.check(ctx)
+        if not required_scopes:
+            return True
+        for scope in required_scopes:
+            try:
+                obj, act = scope_to_obj_act(scope)
+            except ValueError:
+                continue
+            if self._enforce(ctx, obj, act):
+                return True
+        return False
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        """Best-effort list-filtering support, derived from the principal's
+        implicit permissions (direct + via roles). Returns ``{"*"}`` for
+        wildcard/collection grants, otherwise the set of specific ids.
+        """
+        if not ctx.resource_type or not ctx.principal_id:
+            return set()
+
+        rt = ctx.resource_type
+        action = ctx.action
+        try:
+            perms = self._enforcer.get_implicit_permissions_for_user(ctx.principal_id)
+        except Exception:
+            # Some models/adapters don't support implicit perms; fall back to
+            # explicit policy for the user.
+            perms = [p for p in self._enforcer.get_policy() if p and p[0] == ctx.principal_id]
+
+        ids: Set[str] = set()
+        for perm in perms:
+            # perm is [sub, obj, act, ...]
+            p_obj = perm[1] if len(perm) > 1 else None
+            p_act = perm[2] if len(perm) > 2 else None
+            if p_obj is None:
+                continue
+            if action and p_act not in (None, action, "*"):
+                continue
+            if p_obj in ("*", f"{rt}/*", rt):
+                return {"*"}
+            prefix = f"{rt}/"
+            if p_obj.startswith(prefix):
+                ids.add(p_obj[len(prefix):])
+        return ids

--- a/libs/agno/agno/os/authz/provider.py
+++ b/libs/agno/agno/os/authz/provider.py
@@ -1,0 +1,114 @@
+"""Authorization provider interface.
+
+Defines the decision context handed to a provider and the abstract base every
+provider implements. Keeping this dependency-free (only stdlib + typing) means
+the interface can live in the OSS SDK while concrete providers — including ones
+that call out to an external policy engine — are layered on top.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+
+@dataclass
+class AuthorizationContext:
+    """Everything a provider needs to make an access decision.
+
+    A provider is free to use as much or as little of this as its model
+    requires. The built-in scope provider only looks at ``scopes`` /
+    ``resource_type`` / ``resource_id`` / ``action`` / ``admin_scope``; a ReBAC
+    or ABAC provider would additionally lean on ``principal_id`` and the full
+    ``claims`` (tenant, groups, ownership hints, etc.).
+
+    Attributes:
+        principal_id: The authenticated subject (JWT ``sub``), or None when
+            unauthenticated.
+        scopes: Scope strings from the token's ``scopes`` claim.
+        claims: The full decoded JWT payload, for providers that key off
+            arbitrary claims (tenant_id, groups, ...).
+        resource_type: Resource family being accessed ("agents", "teams",
+            "workflows", ...), or None for non-resource checks.
+        resource_id: Specific resource id, or None for list/collection checks.
+        action: Action being attempted ("read", "run", "write", ...).
+        admin_scope: The scope string that grants full bypass (default
+            ``agent_os:admin``), honoured by the built-in provider.
+    """
+
+    principal_id: Optional[str] = None
+    scopes: List[str] = field(default_factory=list)
+    claims: Dict[str, Any] = field(default_factory=dict)
+    resource_type: Optional[str] = None
+    resource_id: Optional[str] = None
+    action: Optional[str] = None
+    admin_scope: Optional[str] = None
+
+
+class AuthorizationProvider(ABC):
+    """Strategy for answering AgentOS authorization questions.
+
+    Two primitives every provider must answer:
+
+    - :meth:`check` — boolean "may this context do this action on this
+      resource?"
+    - :meth:`accessible_resource_ids` — for list endpoints, which resource ids
+      of a type the principal may access (``{"*"}`` means all).
+
+    :meth:`require` and :meth:`filter_accessible` have sensible default
+    implementations on top of those two; override them only if the provider can
+    do something smarter (e.g. a single batch call to an external engine).
+    """
+
+    @abstractmethod
+    def check(self, ctx: AuthorizationContext) -> bool:
+        """Return True if the action in ``ctx`` is allowed."""
+        ...
+
+    @abstractmethod
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        """Return the set of resource ids of ``ctx.resource_type`` the
+        principal may access for ``ctx.action``. ``{"*"}`` denotes wildcard
+        (all) access.
+        """
+        ...
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Route-level gate run by the JWT middleware before the request reaches
+        the endpoint.
+
+        ``required_scopes`` is the scope vocabulary the default route→scope
+        mapping produced for this path (e.g. ``["agents:run"]``). A scope-based
+        provider uses it directly; a provider with a different model (ReBAC/ABAC)
+        ignores it and decides from :meth:`check` instead.
+
+        Default implementation defers to :meth:`check`, so a custom provider
+        gets full control of the route gate without having to understand scope
+        strings. :class:`~agno.os.authz.scope_provider.ScopeAuthorizationProvider`
+        overrides this to preserve the original scope-matching behaviour.
+        """
+        return self.check(ctx)
+
+    def require(self, ctx: AuthorizationContext) -> None:
+        """Raise ``PermissionError`` if :meth:`check` denies ``ctx``.
+
+        The HTTP layer translates this into a 403; keeping the provider raising
+        a plain ``PermissionError`` avoids coupling it to FastAPI.
+        """
+        if not self.check(ctx):
+            raise PermissionError(
+                f"Access denied to {ctx.action} {ctx.resource_type}"
+                + (f"/{ctx.resource_id}" if ctx.resource_id else "")
+            )
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        """Filter ``resources`` (objects with an ``id``) to those the principal
+        may access, using :meth:`accessible_resource_ids`.
+
+        Default implementation does one ``accessible_resource_ids`` call and
+        filters in-process. Providers backed by an external engine may override
+        with a batched authorization query.
+        """
+        accessible = self.accessible_resource_ids(ctx)
+        if "*" in accessible:
+            return resources
+        return [r for r in resources if getattr(r, "id", None) in accessible]

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -68,16 +68,16 @@ def get_roles_router(store: "ManagedRoleStore", prefix: str = "/authz", tags: Li
         return {"role": role, "scopes": store.get_role_scopes(role)}
 
     @router.put("/roles/{role}")
-    def set_role(role: str, body: SetRoleScopesRequest) -> dict:
+    def set_role(role: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)) -> dict:
         try:
-            store.set_role_scopes(role, body.scopes)
+            store.set_role_scopes(role, body.scopes, actor=actor)
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
         return {"role": role, "scopes": store.get_role_scopes(role)}
 
     @router.delete("/roles/{role}")
-    def delete_role(role: str) -> dict:
-        store.remove_role(role)
+    def delete_role(role: str, actor: str = Depends(require_admin)) -> dict:
+        store.remove_role(role, actor=actor)
         return {"role": role, "deleted": True}
 
     # ---- assignments ----------------------------------------------------
@@ -86,13 +86,13 @@ def get_roles_router(store: "ManagedRoleStore", prefix: str = "/authz", tags: Li
         return {"subject": subject, "roles": store.roles_of(subject)}
 
     @router.post("/users/{subject}/roles")
-    def assign_role(subject: str, body: AssignRoleRequest) -> dict:
-        store.assign(subject, body.role)
+    def assign_role(subject: str, body: AssignRoleRequest, actor: str = Depends(require_admin)) -> dict:
+        store.assign(subject, body.role, actor=actor)
         return {"subject": subject, "roles": store.roles_of(subject)}
 
     @router.delete("/users/{subject}/roles/{role}")
-    def revoke_role(subject: str, role: str) -> dict:
-        store.unassign(subject, role)
+    def revoke_role(subject: str, role: str, actor: str = Depends(require_admin)) -> dict:
+        store.unassign(subject, role, actor=actor)
         return {"subject": subject, "roles": store.roles_of(subject)}
 
     return router

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -1,0 +1,98 @@
+"""HTTP management API for :class:`ManagedRoleStore` — the governance product surface.
+
+This is the productisation of the managed-roles tier: a small, admin-only REST
+API to create roles, set their permissions (in agno scope terms), and grant or
+revoke them at runtime. Mount it on your AgentOS app:
+
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.authz.role_router import get_roles_router
+
+    roles = ManagedRoleStore(db_url="postgresql+psycopg://...")
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(roles))
+
+Every route requires the caller to be an admin (satisfies ``agent_os:admin``,
+whether that comes from a token scope or an admin role in the store). The JWT
+middleware still runs first, so an unauthenticated request is rejected (401)
+before these handlers; a valid-but-non-admin caller gets 403.
+
+Endpoints (default prefix ``/authz``):
+    GET    /authz/roles                          list roles
+    GET    /authz/roles/{role}                   a role's scopes
+    PUT    /authz/roles/{role}                   set a role's scopes  {"scopes": [...]}
+    DELETE /authz/roles/{role}                   delete a role
+    GET    /authz/users/{subject}/roles          a subject's roles
+    POST   /authz/users/{subject}/roles          assign a role        {"role": "..."}
+    DELETE /authz/users/{subject}/roles/{role}   revoke a role
+"""
+
+from typing import TYPE_CHECKING, List
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from agno.os.authz.role_store import ManagedRoleStore
+
+
+class SetRoleScopesRequest(BaseModel):
+    scopes: List[str] = Field(..., description="Permissions in agno scope terms, e.g. ['agents:*:read']")
+
+
+class AssignRoleRequest(BaseModel):
+    role: str = Field(..., description="Role to grant the subject")
+
+
+def get_roles_router(store: "ManagedRoleStore", prefix: str = "/authz", tags: List[str] = ["Authorization"]) -> APIRouter:
+    """Build the admin-only roles-management router bound to ``store``."""
+
+    def require_admin(request: Request) -> str:
+        """Gate: caller must be authenticated and an admin of the store."""
+        if not getattr(request.state, "authenticated", False):
+            raise HTTPException(status_code=401, detail="Not authenticated")
+        principal_id = getattr(request.state, "user_id", None)
+        claims = getattr(request.state, "claims", {}) or {}
+        if not store.can_manage(principal_id, claims):
+            raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
+        return principal_id or ""
+
+    router = APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_admin)])
+
+    # ---- roles ----------------------------------------------------------
+    @router.get("/roles")
+    def list_roles() -> dict:
+        return {"roles": store.list_roles()}
+
+    @router.get("/roles/{role}")
+    def get_role(role: str) -> dict:
+        return {"role": role, "scopes": store.get_role_scopes(role)}
+
+    @router.put("/roles/{role}")
+    def set_role(role: str, body: SetRoleScopesRequest) -> dict:
+        try:
+            store.set_role_scopes(role, body.scopes)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return {"role": role, "scopes": store.get_role_scopes(role)}
+
+    @router.delete("/roles/{role}")
+    def delete_role(role: str) -> dict:
+        store.remove_role(role)
+        return {"role": role, "deleted": True}
+
+    # ---- assignments ----------------------------------------------------
+    @router.get("/users/{subject}/roles")
+    def get_user_roles(subject: str) -> dict:
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    @router.post("/users/{subject}/roles")
+    def assign_role(subject: str, body: AssignRoleRequest) -> dict:
+        store.assign(subject, body.role)
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    @router.delete("/users/{subject}/roles/{role}")
+    def revoke_role(subject: str, role: str) -> dict:
+        store.unassign(subject, role)
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    return router

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -80,6 +80,13 @@ def get_roles_router(store: "ManagedRoleStore", prefix: str = "/authz", tags: Li
         store.remove_role(role, actor=actor)
         return {"role": role, "deleted": True}
 
+    # ---- audit ----------------------------------------------------------
+    @router.get("/audit")
+    def list_audit(limit: int = 100) -> dict:
+        """Recent change-audit events (newest first). Empty unless the store was
+        given a readable audit sink (e.g. DbAuditSink)."""
+        return {"events": store.audit_log(limit)}
+
     # ---- assignments ----------------------------------------------------
     @router.get("/users/{subject}/roles")
     def get_user_roles(subject: str) -> dict:

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -105,9 +105,21 @@ def get_roles_router(store: "ManagedRoleStore", prefix: str = "/authz", tags: Li
     # ---- audit ----------------------------------------------------------
     @router.get("/audit")
     def list_audit(limit: int = 100) -> dict:
-        """Recent change-audit events (newest first). Empty unless the store was
-        given a readable audit sink (e.g. DbAuditSink)."""
+        """Recent *change* events (role/assignment mutations, newest first). Empty
+        unless the store was given a readable audit sink (e.g. DbAuditSink)."""
         return {"events": store.audit_log(limit)}
+
+    @router.get("/decisions")
+    def list_decisions(request: Request, limit: int = 100) -> dict:
+        """Recent *decision* events (allow/deny per request, newest first).
+
+        Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
+        on ``app.state.authz_audit`` — a separate table from the change trail above,
+        so a high-volume decision log never buries the change history. Empty unless a
+        readable decision sink (e.g. DbAuditSink) is configured."""
+        sink = getattr(request.app.state, "authz_audit", None)
+        events = sink.read_decisions(limit) if sink is not None and hasattr(sink, "read_decisions") else []
+        return {"events": events}
 
     # ---- assignments ----------------------------------------------------
     @router.get("/users/{subject}/roles")

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -80,6 +80,28 @@ def get_roles_router(store: "ManagedRoleStore", prefix: str = "/authz", tags: Li
         store.remove_role(role, actor=actor)
         return {"role": role, "deleted": True}
 
+    # ---- scope catalog --------------------------------------------------
+    @router.get("/scopes")
+    def list_scopes() -> dict:
+        """The catalog of scopes this AgentOS understands, grouped by resource.
+
+        Derived from the OS's own route→scope map, so it always matches what the
+        OS actually enforces. A UI renders this as a resource×action grid; a role
+        is then just a set of the resulting ``resource:action`` strings (plus the
+        ``agent_os:admin`` super-scope).
+        """
+        from agno.os.scopes import get_default_scope_mappings
+
+        grouped: dict = {}
+        for required in get_default_scope_mappings().values():
+            for scope in required:
+                parts = scope.split(":")
+                if len(parts) == 2:
+                    grouped.setdefault(parts[0], set()).add(parts[1])
+        grouped_sorted = {r: sorted(a) for r, a in sorted(grouped.items())}
+        flat = sorted(f"{r}:{a}" for r, acts in grouped_sorted.items() for a in acts)
+        return {"grouped": grouped_sorted, "scopes": flat, "admin_scope": "agent_os:admin"}
+
     # ---- audit ----------------------------------------------------------
     @router.get("/audit")
     def list_audit(limit: int = 100) -> dict:

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -186,6 +186,16 @@ class ManagedRoleStore:
     def roles_of(self, subject: str) -> List[str]:
         return list(self._enforcer.get_roles_for_user(subject))
 
+    # ------------------------------------------------------------------ audit
+    def audit_log(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Recent change-audit events (newest first), if the audit sink supports
+        reading (e.g. ``DbAuditSink``). Returns ``[]`` when no readable sink is
+        configured (e.g. a logging-only sink, or no audit at all)."""
+        sink = self._audit
+        if sink is not None and hasattr(sink, "read"):
+            return sink.read(limit)
+        return []
+
     # ----------------------------------------------------------------- gating
     def can_manage(self, principal_id: Optional[str], claims: Optional[Dict[str, Any]] = None) -> bool:
         """True if the caller may administer roles (i.e. satisfies ``agent_os:admin``).

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -30,9 +30,12 @@ Example::
     store.unassign("bob", "member")
 """
 
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from agno.os.authz.casbin_provider import scope_to_obj_act
+
+if TYPE_CHECKING:
+    from agno.os.authz.audit import AuditSink
 
 _MODEL_TEXT = """
 [request_definition]
@@ -66,7 +69,13 @@ def _obj_act_to_scope(obj: str, act: str) -> str:
 class ManagedRoleStore:
     """Runtime-mutable, persisted role store. agno-native in, Casbin hidden."""
 
-    def __init__(self, db_url: Optional[str] = None, roles_claim: Optional[str] = None):
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        roles_claim: Optional[str] = None,
+        audit: Optional["AuditSink"] = None,
+        decision_log: bool = False,
+    ):
         """
         Args:
             db_url: SQLAlchemy URL for the DB that holds the policy (e.g.
@@ -76,6 +85,13 @@ class ManagedRoleStore:
             roles_claim: JWT claim carrying a caller's roles (the external-IdP
                 case). When absent, roles come from this store's own assignments
                 (the no-IdP case). Both are served by the same store.
+            audit: optional :class:`~agno.os.authz.audit.AuditSink`. When set,
+                every role/assignment change emits an append-only AuditEvent with
+                the acting principal and the before/after (the change audit Casbin
+                can't give you, since it never sees the actor).
+            decision_log: when True, bump the ``casbin.enforcer`` logger to INFO so
+                *allow* decisions are logged too (denies are already at WARNING).
+                Off by default so we don't touch global logging behind your back.
         """
         try:
             import casbin  # noqa: F401
@@ -97,14 +113,48 @@ class ManagedRoleStore:
             self._enforcer = casbin.Enforcer(model)
         self._enforcer.enable_auto_save(True)  # mutations persist immediately
         self._roles_claim = roles_claim
+        self._audit = audit
+
+        if decision_log:
+            import logging
+
+            logging.getLogger("casbin.enforcer").setLevel(logging.INFO)
+
+    def _emit(
+        self,
+        action: str,
+        target: str,
+        before: Optional[List[str]],
+        after: Optional[List[str]],
+        actor: Optional[str],
+    ) -> None:
+        """Record one change to the audit sink (no-op when no sink is configured)."""
+        if self._audit is None:
+            return
+        import time
+
+        from agno.os.authz.audit import AuditEvent
+
+        self._audit.record(
+            AuditEvent(
+                action=action,
+                actor=actor,
+                target=target,
+                before=before,
+                after=after,
+                timestamp=int(time.time()),
+            )
+        )
 
     # ------------------------------------------------------------------ roles
-    def set_role_scopes(self, role: str, scopes: List[str]) -> None:
+    def set_role_scopes(self, role: str, scopes: List[str], actor: Optional[str] = None) -> None:
         """Define (or replace) what a role can do, in agno scope terms."""
+        before = self.get_role_scopes(role) if self._audit else None
         self._enforcer.remove_filtered_policy(0, role)
         for scope in scopes:
             obj, act = scope_to_obj_act(scope)
             self._enforcer.add_policy(role, obj, act)
+        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
 
     def get_role_scopes(self, role: str) -> List[str]:
         """Return a role's scopes in agno terms (best-effort read-back)."""
@@ -112,20 +162,26 @@ class ManagedRoleStore:
             _obj_act_to_scope(p[1], p[2]) for p in self._enforcer.get_filtered_policy(0, role) if len(p) >= 3
         )
 
-    def remove_role(self, role: str) -> None:
+    def remove_role(self, role: str, actor: Optional[str] = None) -> None:
+        before = self.get_role_scopes(role) if self._audit else None
         self._enforcer.remove_filtered_policy(0, role)
         self._enforcer.remove_filtered_grouping_policy(1, role)
+        self._emit("role.removed", role, before, None, actor)
 
     def list_roles(self) -> List[str]:
         return sorted({p[0] for p in self._enforcer.get_policy()})
 
     # ------------------------------------------------------------- assignments
-    def assign(self, subject: str, role: str) -> None:
+    def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
         """Give a subject a role (runtime, persisted)."""
+        before = self.roles_of(subject) if self._audit else None
         self._enforcer.add_role_for_user(subject, role)
+        self._emit("user.assigned", subject, before, self.roles_of(subject) if self._audit else None, actor)
 
-    def unassign(self, subject: str, role: str) -> None:
+    def unassign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
+        before = self.roles_of(subject) if self._audit else None
         self._enforcer.delete_role_for_user(subject, role)
+        self._emit("user.unassigned", subject, before, self.roles_of(subject) if self._audit else None, actor)
 
     def roles_of(self, subject: str) -> List[str]:
         return list(self._enforcer.get_roles_for_user(subject))

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -1,0 +1,160 @@
+"""Managed roles for AgentOS — agno-native API, Casbin hidden inside.
+
+This is the "governance product" middle tier: create roles, assign them, and
+change them at runtime, persisted to your own DB. You work entirely in agno
+scope terms (``agents:*:read``, ``agents:research-agent:run``,
+``agent_os:admin``); you never write a Casbin model or policy. Casbin + a DB
+adapter is the engine under the hood (so changes persist and take effect on the
+next request, no token re-mint), but it is an implementation detail.
+
+Requires the optional extra: ``pip install "agno[casbin]"``.
+
+Example::
+
+    store = ManagedRoleStore(db_url="postgresql+psycopg://...", roles_claim="roles")
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "member")           # runtime, persisted
+
+    agent_os = AgentOS(
+        agents=[...],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[...],
+            authorization_provider=store.provider,   # plug it in
+        ),
+    )
+
+    # later, live (no redeploy, same token):
+    store.assign("carol", "member")
+    store.unassign("bob", "member")
+"""
+
+from typing import Any, Dict, List, Optional
+
+from agno.os.authz.casbin_provider import scope_to_obj_act
+
+_MODEL_TEXT = """
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[role_definition]
+g = _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub) && (p.obj == "*" || keyMatch2(r.obj, p.obj)) && (p.act == "*" || r.act == p.act)
+"""
+
+
+def _obj_act_to_scope(obj: str, act: str) -> str:
+    """Best-effort reverse of :func:`scope_to_obj_act`, for display/read-back.
+
+    Lossy where two scope spellings collapse to the same policy (``agents:read``
+    and ``agents:*:read`` both store as ``("agents/*", "read")``); we render the
+    global ``resource:action`` form in that case.
+    """
+    if obj == "*":
+        return "agent_os:admin"
+    if obj.endswith("/*"):
+        return f"{obj[:-2]}:{act}"
+    resource, _, rid = obj.partition("/")
+    return f"{resource}:{rid}:{act}"
+
+
+class ManagedRoleStore:
+    """Runtime-mutable, persisted role store. agno-native in, Casbin hidden."""
+
+    def __init__(self, db_url: Optional[str] = None, roles_claim: Optional[str] = None):
+        """
+        Args:
+            db_url: SQLAlchemy URL for the DB that holds the policy (e.g.
+                ``postgresql+psycopg://...`` or ``sqlite:///roles.db``). Use your
+                own database. If omitted, the store is in-memory (not persisted) —
+                fine for tests, not for production.
+            roles_claim: JWT claim carrying a caller's roles (the external-IdP
+                case). When absent, roles come from this store's own assignments
+                (the no-IdP case). Both are served by the same store.
+        """
+        try:
+            import casbin  # noqa: F401
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                "ManagedRoleStore needs the optional casbin extra. "
+                'Install it with: pip install "agno[casbin]"'
+            ) from e
+
+        import casbin
+
+        model = casbin.Model()
+        model.load_model_from_text(_MODEL_TEXT)
+        if db_url:
+            from casbin_sqlalchemy_adapter import Adapter
+
+            self._enforcer = casbin.Enforcer(model, Adapter(db_url))
+        else:
+            self._enforcer = casbin.Enforcer(model)
+        self._enforcer.enable_auto_save(True)  # mutations persist immediately
+        self._roles_claim = roles_claim
+
+    # ------------------------------------------------------------------ roles
+    def set_role_scopes(self, role: str, scopes: List[str]) -> None:
+        """Define (or replace) what a role can do, in agno scope terms."""
+        self._enforcer.remove_filtered_policy(0, role)
+        for scope in scopes:
+            obj, act = scope_to_obj_act(scope)
+            self._enforcer.add_policy(role, obj, act)
+
+    def get_role_scopes(self, role: str) -> List[str]:
+        """Return a role's scopes in agno terms (best-effort read-back)."""
+        return sorted(
+            _obj_act_to_scope(p[1], p[2]) for p in self._enforcer.get_filtered_policy(0, role) if len(p) >= 3
+        )
+
+    def remove_role(self, role: str) -> None:
+        self._enforcer.remove_filtered_policy(0, role)
+        self._enforcer.remove_filtered_grouping_policy(1, role)
+
+    def list_roles(self) -> List[str]:
+        return sorted({p[0] for p in self._enforcer.get_policy()})
+
+    # ------------------------------------------------------------- assignments
+    def assign(self, subject: str, role: str) -> None:
+        """Give a subject a role (runtime, persisted)."""
+        self._enforcer.add_role_for_user(subject, role)
+
+    def unassign(self, subject: str, role: str) -> None:
+        self._enforcer.delete_role_for_user(subject, role)
+
+    def roles_of(self, subject: str) -> List[str]:
+        return list(self._enforcer.get_roles_for_user(subject))
+
+    # ----------------------------------------------------------------- gating
+    def can_manage(self, principal_id: Optional[str], claims: Optional[Dict[str, Any]] = None) -> bool:
+        """True if the caller may administer roles (i.e. satisfies ``agent_os:admin``).
+
+        Only full admins manage the role store. An admin can be defined two ways,
+        both handled here:
+          - by a role in this store (``enforce(sub, "*", "*")``), or
+          - by a role carried on the token, when ``roles_claim`` is set.
+        Note this is intentionally NOT the generic provider ``check`` (which
+        defers non-resource decisions to route scope mappings and would let any
+        authenticated caller through).
+        """
+        if self._roles_claim and claims:
+            roles = claims.get(self._roles_claim)
+            if isinstance(roles, list):
+                if any(bool(self._enforcer.enforce(r, "*", "*")) for r in roles):
+                    return True
+        if principal_id:
+            return bool(self._enforcer.enforce(principal_id, "*", "*"))
+        return False
+
+    # --------------------------------------------------------------- provider
+    @property
+    def provider(self):
+        """The AuthorizationProvider to plug into AuthorizationConfig."""
+        from agno.os.authz.casbin_provider import CasbinAuthorizationProvider
+
+        return CasbinAuthorizationProvider(self._enforcer, roles_claim=self._roles_claim)

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -200,6 +200,8 @@ class ManagedRoleStore:
         """
         if self._roles_claim and claims:
             roles = claims.get(self._roles_claim)
+            if isinstance(roles, str):  # e.g. WorkOS sends a single "role" string
+                roles = [roles]
             if isinstance(roles, list):
                 if any(bool(self._enforcer.enforce(r, "*", "*")) for r in roles):
                     return True

--- a/libs/agno/agno/os/authz/scope_provider.py
+++ b/libs/agno/agno/os/authz/scope_provider.py
@@ -1,0 +1,60 @@
+"""Default authorization provider: JWT-scope RBAC.
+
+This is the built-in implementation and preserves AgentOS's existing behaviour
+exactly — it delegates to :func:`agno.os.scopes.has_required_scopes` and
+:func:`agno.os.scopes.get_accessible_resource_ids`, the same functions the
+request pipeline used before the provider seam existed. No external service, no
+new dependency: it runs against the scopes already in the JWT.
+
+Swapping to a different model (Casbin, OpenFGA, Cerbos, a bespoke ReBAC engine)
+means implementing :class:`agno.os.authz.provider.AuthorizationProvider`
+instead of this class — the rest of the pipeline is unchanged.
+"""
+
+from typing import List, Set
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+
+
+class ScopeAuthorizationProvider(AuthorizationProvider):
+    """RBAC via JWT scope strings (``resource:action``, ``resource:<id>:action``)."""
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type) can't be expressed as a scope
+        # here; treat it as allowed and let route-level scope mappings handle it.
+        if not ctx.resource_type or not ctx.action:
+            return True
+
+        required = [f"{ctx.resource_type}:{ctx.action}"]
+        return has_required_scopes(
+            ctx.scopes,
+            required,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=ctx.admin_scope,
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type:
+            return set()
+        return get_accessible_resource_ids(
+            ctx.scopes,
+            ctx.resource_type,
+            admin_scope=ctx.admin_scope,
+            action=ctx.action,
+        )
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Original middleware route gate: does the token satisfy the scopes the
+        route requires, in the context of the resource being accessed.
+        """
+        if not required_scopes:
+            return True
+        return has_required_scopes(
+            ctx.scopes,
+            required_scopes,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=ctx.admin_scope,
+        )

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -1,6 +1,6 @@
 """Schemas related to the AgentOS configuration"""
 
-from typing import Dict, Generic, List, Optional, TypeVar
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -8,12 +8,19 @@ from pydantic import BaseModel, Field, field_validator
 class AuthorizationConfig(BaseModel):
     """Configuration for the JWT middleware"""
 
+    model_config = {"arbitrary_types_allowed": True}
+
     verification_keys: Optional[List[str]] = None
     jwks_file: Optional[str] = None
     algorithm: Optional[str] = None
     verify_audience: Optional[bool] = None
     audience: Optional[str] = None
     admin_scope: Optional[str] = None
+    # Pluggable authorization strategy. When None, AgentOS uses the built-in
+    # ScopeAuthorizationProvider (JWT-scope RBAC, no external dependency).
+    # Supply an AuthorizationProvider instance to swap in a different model
+    # (ReBAC/ABAC/Casbin/OpenFGA/Cerbos) without changing the request pipeline.
+    authorization_provider: Optional[Any] = None
     # Opt-in per-user data isolation. When True, AgentOS:
     #   - threads the JWT sub as ``user_id`` on every user-scoped DB read
     #     (sessions, memory, traces) for non-admin callers

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -12,6 +12,10 @@ class AuthorizationConfig(BaseModel):
 
     verification_keys: Optional[List[str]] = None
     jwks_file: Optional[str] = None
+    # Remote JWKS URL published by an IdP (e.g. WorkOS/Auth0). Keys are fetched
+    # and cached at startup and re-fetched on key rotation, so no static key file
+    # to snapshot. Use jwks_file for an offline/static key set instead.
+    jwks_url: Optional[str] = None
     algorithm: Optional[str] = None
     verify_audience: Optional[bool] = None
     audience: Optional[str] = None

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -25,6 +25,11 @@ class AuthorizationConfig(BaseModel):
     # Supply an AuthorizationProvider instance to swap in a different model
     # (ReBAC/ABAC/Casbin/OpenFGA/Cerbos) without changing the request pipeline.
     authorization_provider: Optional[Any] = None
+    # Optional AuditSink. When set, AgentOS records each authorization decision
+    # (allow/deny) at the route gate — principal, route, required scopes, and a
+    # non-secret token reference — so you get an access trail, not just a change
+    # trail. Pass the same sink you give ManagedRoleStore to unify both.
+    audit: Optional[Any] = None
     # Opt-in per-user data isolation. When True, AgentOS:
     #   - threads the JWT sub as ``user_id`` on every user-scoped DB read
     #     (sessions, memory, traces) for non-admin callers

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -13,9 +13,9 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from agno.os.auth import INTERNAL_SERVICE_SCOPES, build_insufficient_permissions_detail
+from agno.os.authz.provider import AuthorizationContext
 from agno.os.scopes import (
     AgentOSScope,
-    get_accessible_resource_ids,
     get_default_scope_mappings,
     has_required_scopes,
 )
@@ -531,6 +531,9 @@ class JWTMiddleware(BaseHTTPMiddleware):
         )
         self.admin_scope = admin_scope or AgentOSScope.ADMIN.value
         self.user_isolation = user_isolation
+        # Lazily-built default provider for manual-setup deployments that don't
+        # populate app.state.authorization_provider (see _resolve_provider).
+        self._fallback_provider = None
 
     def _get_default_excluded_routes(self) -> List[str]:
         """Get default routes that should be excluded from RBAC checks."""
@@ -543,6 +546,25 @@ class JWTMiddleware(BaseHTTPMiddleware):
             "/openapi.json",
             "/docs/oauth2-redirect",
         ]
+
+    def _resolve_provider(self, request: Request):
+        """Resolve the active AuthorizationProvider.
+
+        Prefers the instance AgentOS set on ``app.state.authorization_provider``;
+        falls back to a default ``ScopeAuthorizationProvider`` for manual
+        ``app.add_middleware(JWTMiddleware)`` setups that never populated it.
+        Cached on the middleware instance after first use to avoid rebuilding a
+        fallback provider on every request.
+        """
+        provider = getattr(getattr(request, "app", None), "state", None)
+        provider = getattr(provider, "authorization_provider", None) if provider is not None else None
+        if provider is not None:
+            return provider
+        if self._fallback_provider is None:
+            from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+            self._fallback_provider = ScopeAuthorizationProvider()
+        return self._fallback_provider
 
     def _extract_resource_id_from_path(self, path: str, resource_type: str) -> Optional[str]:
         """
@@ -839,29 +861,35 @@ class JWTMiddleware(BaseHTTPMiddleware):
 
                 # Empty list [] means no scopes required (allow access)
                 if required_scopes:
-                    # Use the scope validation system
-                    has_access = has_required_scopes(
-                        scopes,
-                        required_scopes,
+                    # Resolve the active authorization provider. Defaults to the
+                    # scope-based provider (identical behaviour); a custom provider
+                    # configured via AuthorizationConfig owns the decision instead.
+                    # Build one context and reuse it for the route gate and the
+                    # listing-endpoint filtering below.
+                    provider = self._resolve_provider(request)
+                    first_required = required_scopes[0]
+                    action_for_ctx: Optional[str] = (
+                        first_required.rsplit(":", 1)[1] if ":" in first_required else None
+                    )
+                    authz_ctx = AuthorizationContext(
+                        principal_id=user_id,
+                        scopes=scopes,
+                        claims=payload,
                         resource_type=resource_type,
                         resource_id=resource_id,
+                        action=action_for_ctx,
                         admin_scope=self.admin_scope,
                     )
+
+                    has_access = provider.authorize_route(authz_ctx, required_scopes)
 
                     # Special handling for listing endpoints (no resource_id)
                     if not has_access and not resource_id and resource_type:
                         # For listing endpoints, always allow access but store accessible IDs for filtering
                         # This allows endpoints to return filtered results (including empty list) instead of 403.
-                        # Pass the action from required_scopes (e.g. "read" for "agents:read") so the cached
-                        # IDs only include resources the user is authorised for under that action — otherwise
-                        # a user with only `agents:run` would leak through `GET /agents`.
-                        required_action: Optional[str] = None
-                        first_required = required_scopes[0]
-                        if ":" in first_required:
-                            required_action = first_required.rsplit(":", 1)[1]
-                        accessible_ids = get_accessible_resource_ids(
-                            scopes, resource_type, admin_scope=self.admin_scope, action=required_action
-                        )
+                        # The provider decides which IDs are accessible (the scope provider keys off the
+                        # action so a user with only `agents:run` doesn't leak through `GET /agents`).
+                        accessible_ids = provider.accessible_resource_ids(authz_ctx)
                         has_access = True  # Always allow listing endpoints
                         request.state.accessible_resource_ids = accessible_ids
 

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -68,6 +68,7 @@ class JWTValidator:
         self,
         verification_keys: Optional[List[str]] = None,
         jwks_file: Optional[str] = None,
+        jwks_url: Optional[str] = None,
         algorithm: str = "RS256",
         validate: bool = True,
         scopes_claim: str = "scopes",
@@ -122,12 +123,27 @@ class JWTValidator:
             if jwks_file_env:
                 self._load_jwks_file(jwks_file_env)
 
+        # Remote JWKS URL (e.g. an IdP like WorkOS/Auth0 that publishes and rotates
+        # its public keys at a well-known URL). Keys are fetched and cached at
+        # startup, then re-fetched lazily (rate-limited) when a token arrives with
+        # a key id we haven't seen yet - which is how key rotation is handled.
+        self.jwks_url: Optional[str] = jwks_url or getenv("JWT_JWKS_URL", "") or None
+        self._jwks_last_fetch: float = 0.0
+        self._jwks_min_refresh_seconds: float = 300.0
+        if self.jwks_url:
+            try:
+                self._load_jwks_url(self.jwks_url)
+            except Exception as e:
+                # Don't hard-fail startup if the IdP is briefly unreachable; we'll
+                # retry on the first token that needs a key.
+                log_warning(f"Could not fetch JWKS from {self.jwks_url} at startup: {e}")
+
         # Validate that at least one key source is provided if validate=True
-        if self.validate and not self.verification_keys and not self.jwks_keys:
+        if self.validate and not self.verification_keys and not self.jwks_keys and not self.jwks_url:
             raise ValueError(
-                "At least one JWT verification key or JWKS file is required when validate=True. "
+                "At least one JWT verification key or JWKS source is required when validate=True. "
                 "Set via verification_keys parameter, JWT_VERIFICATION_KEY environment variable, "
-                "jwks_file parameter or JWT_JWKS_FILE environment variable."
+                "jwks_file/JWT_JWKS_FILE, or jwks_url/JWT_JWKS_URL."
             )
 
     def _load_jwks_file(self, file_path: str) -> None:
@@ -146,6 +162,40 @@ class JWTValidator:
             raise ValueError(f"JWKS file not found: {file_path}")
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in JWKS file {file_path}: {e}")
+
+    def _load_jwks_url(self, url: str) -> None:
+        """Fetch a JWKS document from a URL and merge its keys into the cache."""
+        import time
+
+        import httpx
+
+        response = httpx.get(url, timeout=5.0)
+        response.raise_for_status()
+        self._parse_jwks_data(response.json())
+        self._jwks_last_fetch = time.time()
+        log_debug(f"Loaded {len(self.jwks_keys)} key(s) from JWKS url: {url}")
+
+    def _maybe_refresh_jwks(self) -> bool:
+        """Re-fetch a remote JWKS, at most once per refresh window.
+
+        Called when a token presents a key id we don't have cached - usually
+        because the IdP rotated its signing keys. Rate-limited so a flood of
+        unknown-kid tokens can't turn into a fetch storm against the IdP.
+        """
+        import time
+
+        if not self.jwks_url:
+            return False
+        if time.time() - self._jwks_last_fetch < self._jwks_min_refresh_seconds:
+            return False
+        try:
+            self._load_jwks_url(self.jwks_url)
+            return True
+        except Exception as e:
+            # Stamp the attempt so a persistent outage doesn't hammer the IdP.
+            self._jwks_last_fetch = time.time()
+            log_warning(f"JWKS refresh from {self.jwks_url} failed: {e}")
+            return False
 
     def _parse_jwks_data(self, jwks_data: Dict[str, Any]) -> None:
         """
@@ -216,8 +266,8 @@ class JWTValidator:
         last_exception: Optional[Exception] = None
         payload: Optional[Dict[str, Any]] = None
 
-        # Try JWKS keys first if configured
-        if self.jwks_keys:
+        # Try JWKS keys first if configured (cached keys, or a remote JWKS url)
+        if self.jwks_keys or self.jwks_url:
             try:
                 # Get the kid from the token header to find the right key
                 unverified_header = jwt.get_unverified_header(token)
@@ -229,6 +279,11 @@ class JWTValidator:
                 elif "_default" in self.jwks_keys:
                     # Fall back to default key if no kid match
                     jwk = self.jwks_keys["_default"]
+
+                # Unknown key id: the IdP may have rotated keys. Re-fetch the
+                # remote JWKS (rate-limited) and look again before giving up.
+                if jwk is None and kid and self.jwks_url and self._maybe_refresh_jwks():
+                    jwk = self.jwks_keys.get(kid)
 
                 if jwk:
                     payload = jwt.decode(token, jwk.key, **decode_kwargs)
@@ -396,6 +451,7 @@ class JWTMiddleware(BaseHTTPMiddleware):
         app,
         verification_keys: Optional[List[str]] = None,
         jwks_file: Optional[str] = None,
+        jwks_url: Optional[str] = None,
         secret_key: Optional[str] = None,  # Deprecated: Use verification_keys instead
         algorithm: str = "RS256",
         validate: bool = True,
@@ -484,6 +540,7 @@ class JWTMiddleware(BaseHTTPMiddleware):
         self.validator = JWTValidator(
             verification_keys=all_verification_keys if all_verification_keys else None,
             jwks_file=jwks_file,
+            jwks_url=jwks_url,
             algorithm=algorithm,
             validate=validate,
             scopes_claim=scopes_claim,

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -634,25 +634,27 @@ class JWTMiddleware(BaseHTTPMiddleware):
         required_scopes: List[str],
         scopes: List[str],
         token: Optional[str],
+        claims: Optional[dict] = None,
     ) -> None:
         """Record one authorization decision to the audit sink (if configured).
 
         Captures the principal, route, required scopes, and a NON-secret token
-        reference (a short SHA-256 of the token, never the token itself) so you
-        can tell which token was used without storing the credential. Never
-        raises into the request path.
+        reference so you can tell which token was used without storing the
+        credential. The reference is the token's ``jti`` (a standard, opaque token
+        id) when the token carries one — stable, correlatable to the issuer's logs,
+        and revocation-friendly — falling back to a short SHA-256 of the token
+        otherwise. Never the token itself, and never raises into the request path.
         """
         state = getattr(getattr(request, "app", None), "state", None)
         sink = getattr(state, "authz_audit", None) if state is not None else None
         if sink is None:
             return
         try:
-            import hashlib
             import time
 
             from agno.os.authz.audit import AuditEvent
 
-            token_ref = hashlib.sha256(token.encode()).hexdigest()[:12] if token else None
+            token_ref = self._token_reference(token, claims)
             sink.record(
                 AuditEvent(
                     action="access.allowed" if allowed else "access.denied",
@@ -664,6 +666,26 @@ class JWTMiddleware(BaseHTTPMiddleware):
             )
         except Exception as e:  # pragma: no cover - audit must never break requests
             log_debug(f"decision audit failed: {e}")
+
+    @staticmethod
+    def _token_reference(token: Optional[str], claims: Optional[dict]) -> Optional[str]:
+        """A non-secret reference to the presented token, for the decision trail.
+
+        Prefer the token's ``jti`` (RFC 7519 JWT ID): it's an opaque identifier the
+        issuer already minted for exactly this purpose, so it correlates to the
+        issuer's own logs and any revocation list. When the token has no ``jti``,
+        fall back to a short SHA-256 of the raw token so we can still tell two
+        distinct tokens apart — without storing the credential itself.
+        """
+        if claims:
+            jti = claims.get("jti")
+            if jti:
+                return str(jti)
+        if token:
+            import hashlib
+
+            return hashlib.sha256(token.encode()).hexdigest()[:12]
+        return None
 
     def _extract_resource_id_from_path(self, path: str, resource_type: str) -> Optional[str]:
         """
@@ -1008,6 +1030,7 @@ class JWTMiddleware(BaseHTTPMiddleware):
                         required_scopes=required_scopes,
                         scopes=scopes,
                         token=token,
+                        claims=payload,
                     )
 
                     if not has_access:

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -169,7 +169,14 @@ class JWTValidator:
 
         import httpx
 
-        response = httpx.get(url, timeout=5.0)
+        # Require https and don't follow redirects: the JWKS is the root of trust
+        # for token verification, so a plaintext fetch (MITM-able) or a redirect to
+        # an attacker-controlled host would let forged keys in.
+        from urllib.parse import urlparse
+
+        if urlparse(url).scheme != "https":
+            raise ValueError(f"JWKS URL must use https (refusing {url!r}): keys fetched over it sign tokens.")
+        response = httpx.get(url, timeout=5.0, follow_redirects=False)
         response.raise_for_status()
         self._parse_jwks_data(response.json())
         self._jwks_last_fetch = time.time()
@@ -276,14 +283,18 @@ class JWTValidator:
                 jwk = None
                 if kid and kid in self.jwks_keys:
                     jwk = self.jwks_keys[kid]
-                elif "_default" in self.jwks_keys:
-                    # Fall back to default key if no kid match
-                    jwk = self.jwks_keys["_default"]
 
-                # Unknown key id: the IdP may have rotated keys. Re-fetch the
-                # remote JWKS (rate-limited) and look again before giving up.
+                # Present-but-unknown kid: the IdP may have rotated keys. Re-fetch
+                # the remote JWKS (rate-limited) and look again. Do this BEFORE any
+                # no-kid fallback so rotation is honoured rather than validating a
+                # rotated token against a stale/unrelated default key.
                 if jwk is None and kid and self.jwks_url and self._maybe_refresh_jwks():
                     jwk = self.jwks_keys.get(kid)
+
+                # Last resort: a no-kid ("_default") cached key. Reached only when
+                # the token carries no kid, or a refresh still didn't resolve one.
+                if jwk is None and "_default" in self.jwks_keys:
+                    jwk = self.jwks_keys["_default"]
 
                 if jwk:
                     payload = jwt.decode(token, jwk.key, **decode_kwargs)
@@ -988,10 +999,13 @@ class JWTMiddleware(BaseHTTPMiddleware):
                     # Build one context and reuse it for the route gate and the
                     # listing-endpoint filtering below.
                     provider = self._resolve_provider(request)
-                    first_required = required_scopes[0]
-                    action_for_ctx: Optional[str] = (
-                        first_required.rsplit(":", 1)[1] if ":" in first_required else None
-                    )
+                    # Derive a single context action only when all required scopes
+                    # agree on one (true for every built-in mapping). For a route
+                    # with mixed actions, leave it None rather than silently picking
+                    # the first — the full required_scopes list is passed to
+                    # authorize_route, which evaluates each one.
+                    _actions = {s.rsplit(":", 1)[1] for s in required_scopes if ":" in s}
+                    action_for_ctx: Optional[str] = next(iter(_actions)) if len(_actions) == 1 else None
                     authz_ctx = AuthorizationContext(
                         principal_id=user_id,
                         scopes=scopes,
@@ -1048,6 +1062,22 @@ class JWTMiddleware(BaseHTTPMiddleware):
                     log_debug(f"Scope check passed for {method} {path}. User scopes: {scopes}")
                 else:
                     log_debug(f"No scopes required for {method} {path}")
+                    # Decision-audit completeness: record allow-by-default routes
+                    # (empty/unmapped scope map) too, so the trail covers EVERY
+                    # authenticated request, not only the scope-gated ones. No-ops
+                    # when no decision sink is configured.
+                    self._record_decision(
+                        request,
+                        allowed=True,
+                        method=method,
+                        path=path,
+                        principal=user_id,
+                        required_scopes=[],
+                        scopes=scopes,
+                        token=token,
+                        claims=payload,
+                        reason="no_scopes_required",
+                    )
 
             log_debug(f"JWT decoded successfully for user: {user_id}")
 

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -623,6 +623,48 @@ class JWTMiddleware(BaseHTTPMiddleware):
             self._fallback_provider = ScopeAuthorizationProvider()
         return self._fallback_provider
 
+    def _record_decision(
+        self,
+        request: Request,
+        *,
+        allowed: bool,
+        method: str,
+        path: str,
+        principal: Optional[str],
+        required_scopes: List[str],
+        scopes: List[str],
+        token: Optional[str],
+    ) -> None:
+        """Record one authorization decision to the audit sink (if configured).
+
+        Captures the principal, route, required scopes, and a NON-secret token
+        reference (a short SHA-256 of the token, never the token itself) so you
+        can tell which token was used without storing the credential. Never
+        raises into the request path.
+        """
+        state = getattr(getattr(request, "app", None), "state", None)
+        sink = getattr(state, "authz_audit", None) if state is not None else None
+        if sink is None:
+            return
+        try:
+            import hashlib
+            import time
+
+            from agno.os.authz.audit import AuditEvent
+
+            token_ref = hashlib.sha256(token.encode()).hexdigest()[:12] if token else None
+            sink.record(
+                AuditEvent(
+                    action="access.allowed" if allowed else "access.denied",
+                    actor=principal,
+                    target=f"{method} {path}",
+                    timestamp=int(time.time()),
+                    metadata={"required": required_scopes, "token": token_ref, "scopes": scopes},
+                )
+            )
+        except Exception as e:  # pragma: no cover - audit must never break requests
+            log_debug(f"decision audit failed: {e}")
+
     def _extract_resource_id_from_path(self, path: str, resource_type: str) -> Optional[str]:
         """
         Extract resource ID from a path.
@@ -954,6 +996,19 @@ class JWTMiddleware(BaseHTTPMiddleware):
                             log_debug(f"User has specific {resource_type} scopes. Accessible IDs: {accessible_ids}")
                         else:
                             log_debug(f"User has no {resource_type} scopes. Will return empty list.")
+
+                    # Decision audit: record the allow/deny with a non-secret
+                    # token reference, if an audit sink is configured.
+                    self._record_decision(
+                        request,
+                        allowed=has_access,
+                        method=method,
+                        path=path,
+                        principal=user_id,
+                        required_scopes=required_scopes,
+                        scopes=scopes,
+                        token=token,
+                    )
 
                     if not has_access:
                         log_warning(

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -72,6 +72,8 @@ dev = [
 
 os = ["fastapi[standard]", "uvicorn", "sqlalchemy", "PyJWT", "opentelemetry-sdk", "openinference-instrumentation-agno", "croniter>=1.3", "pytz>=2023.3"]
 whatsapp-crypto = ["cryptography>=41.0"]
+# Optional Casbin-backed authorization provider (managed roles, ABAC, DB-backed policy)
+casbin = ["casbin>=1.36", "casbin-sqlalchemy-adapter>=1.4"]
 scheduler = ["croniter>=1.3", "pytz>=2023.3"]
 
 # Dependencies for Telemetry

--- a/libs/agno/tests/integration/os/test_casbin_provider.py
+++ b/libs/agno/tests/integration/os/test_casbin_provider.py
@@ -109,6 +109,44 @@ def test_roles_from_token_claim_idp_case(tmp_path):
     assert prov.check(ctx_guest) is False
 
 
+def test_roles_from_token_claim_single_string(tmp_path):
+    """WorkOS sends a single `role` string (not a list); it must still authorize."""
+    prov = CasbinAuthorizationProvider(_enforcer(tmp_path), roles_claim="role")
+    ctx = AuthorizationContext(
+        principal_id="workos|abc", resource_type="agents", resource_id="research-agent",
+        action="run", claims={"role": "member"},  # a bare string, not ["member"]
+    )
+    assert prov.check(ctx) is True
+    ctx_guest = AuthorizationContext(
+        principal_id="workos|abc", resource_type="agents", resource_id="research-agent",
+        action="run", claims={"role": "guest"},
+    )
+    assert prov.check(ctx_guest) is False
+
+
+def test_enforce_only_no_store_assignments(tmp_path):
+    """Scenario 1: roles come from the token, the policy has only role definitions
+    (no `g` user->role rows). Authorization still works with no per-user store."""
+    import casbin
+
+    m = tmp_path / "m.conf"
+    p = tmp_path / "p.csv"
+    m.write_text(MODEL)
+    p.write_text("p, member, agents/*, read\np, member, agents/research-agent, run\n")  # no g rows
+    prov = CasbinAuthorizationProvider(casbin.Enforcer(str(m), str(p)), roles_claim="role")
+
+    allowed = AuthorizationContext(
+        principal_id="anyone", resource_type="agents", resource_id="research-agent",
+        action="run", claims={"role": "member"},
+    )
+    denied = AuthorizationContext(
+        principal_id="anyone", resource_type="agents", resource_id="research-agent",
+        action="run", claims={},  # no role on the token -> nothing to fall back to
+    )
+    assert prov.check(allowed) is True
+    assert prov.check(denied) is False
+
+
 def test_roles_from_store_when_no_claim(tmp_path):
     """Users WITHOUT an IdP: no roles claim -> fall back to Casbin's g store."""
     prov = CasbinAuthorizationProvider(_enforcer(tmp_path), roles_claim="roles")

--- a/libs/agno/tests/integration/os/test_casbin_provider.py
+++ b/libs/agno/tests/integration/os/test_casbin_provider.py
@@ -1,0 +1,148 @@
+"""CasbinAuthorizationProvider: the optional Casbin-backed authz provider.
+
+Proves it (a) implements the provider interface, (b) makes correct role +
+hierarchy + wildcard decisions via a real casbin.Enforcer, and (c) gates a real
+AgentOS end to end behind the provider seam. Default provider is unchanged.
+
+Skipped automatically if casbin isn't installed (it's an opt-in extra).
+"""
+
+from datetime import timedelta
+
+import pytest
+
+pytest.importorskip("casbin")  # opt-in extra; skip if not installed
+
+import casbin  # noqa: E402
+import jwt  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from agno.agent.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz import AuthorizationContext  # noqa: E402
+from agno.os.authz.casbin_provider import CasbinAuthorizationProvider  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "casbin-provider-secret-long-enough-for-hs256-validation"
+OS_ID = "casbin-os"
+
+MODEL = """
+[request_definition]
+r = sub, obj, act
+[policy_definition]
+p = sub, obj, act
+[role_definition]
+g = _, _
+[policy_effect]
+e = some(where (p.eft == allow))
+[matchers]
+m = g(r.sub, p.sub) && keyMatch2(r.obj, p.obj) && (r.act == p.act || p.act == "*")
+"""
+
+# member can read+run agents; admin inherits member and can do everything.
+POLICY = """
+p, member, agents/*, read
+p, member, agents/research-agent, run
+p, admin, agents/*, *
+g, alice, member
+g, root, admin
+"""
+
+
+def _enforcer(tmp_path):
+    m = tmp_path / "m.conf"
+    p = tmp_path / "p.csv"
+    m.write_text(MODEL)
+    p.write_text(POLICY)
+    return casbin.Enforcer(str(m), str(p))
+
+
+def _ctx(sub, rt, rid, act):
+    return AuthorizationContext(principal_id=sub, resource_type=rt, resource_id=rid, action=act)
+
+
+def test_check_decisions(tmp_path):
+    prov = CasbinAuthorizationProvider(_enforcer(tmp_path))
+    assert prov.check(_ctx("alice", "agents", "research-agent", "run")) is True
+    assert prov.check(_ctx("alice", "agents", "research-agent", "read")) is True
+    # alice (member) cannot run a different agent (only research-agent granted run)
+    assert prov.check(_ctx("alice", "agents", "other-agent", "run")) is False
+    # root (admin, via g + wildcard) can do anything
+    assert prov.check(_ctx("root", "agents", "any-agent", "run")) is True
+    # unknown subject -> deny
+    assert prov.check(_ctx("mallory", "agents", "research-agent", "run")) is False
+
+
+def test_non_resource_check_defers(tmp_path):
+    prov = CasbinAuthorizationProvider(_enforcer(tmp_path))
+    assert prov.check(AuthorizationContext(principal_id="alice")) is True  # no resource -> allow
+
+
+def test_accessible_resource_ids(tmp_path):
+    prov = CasbinAuthorizationProvider(_enforcer(tmp_path))
+    # alice has agents/* read -> wildcard
+    assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "read")) == {"*"}
+    # for run, alice only has the specific research-agent
+    assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "run")) == {"research-agent"}
+
+
+def test_bad_enforcer_type():
+    with pytest.raises(TypeError):
+        CasbinAuthorizationProvider(object())
+
+
+def test_roles_from_token_claim_idp_case(tmp_path):
+    """Users WITH an IdP: roles come off the token, no stored g assignment."""
+    prov = CasbinAuthorizationProvider(_enforcer(tmp_path), roles_claim="roles")
+    # idp-user has no g assignment in the policy, but the token carries member.
+    ctx = AuthorizationContext(
+        principal_id="auth0|xyz", resource_type="agents", resource_id="research-agent",
+        action="run", claims={"roles": ["member"]},
+    )
+    assert prov.check(ctx) is True
+    # a role the policy doesn't grant -> denied
+    ctx_guest = AuthorizationContext(
+        principal_id="auth0|xyz", resource_type="agents", resource_id="research-agent",
+        action="run", claims={"roles": ["guest"]},
+    )
+    assert prov.check(ctx_guest) is False
+
+
+def test_roles_from_store_when_no_claim(tmp_path):
+    """Users WITHOUT an IdP: no roles claim -> fall back to Casbin's g store."""
+    prov = CasbinAuthorizationProvider(_enforcer(tmp_path), roles_claim="roles")
+    # alice has g, alice, member in the store; token carries no roles claim.
+    ctx = AuthorizationContext(
+        principal_id="alice", resource_type="agents", resource_id="research-agent",
+        action="run", claims={},
+    )
+    assert prov.check(ctx) is True
+
+
+def test_end_to_end_agentos_uses_casbin(tmp_path):
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent.deep_copy = lambda **_: agent
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=CasbinAuthorizationProvider(_enforcer(tmp_path)),
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    def token(sub):
+        return {"Authorization": "Bearer " + jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [],
+             "exp": __import__("datetime").datetime.now(__import__("datetime").timezone.utc) + timedelta(minutes=5)},
+            SECRET, algorithm="HS256")}
+
+    # alice (member) may run research-agent; mallory (no role) may not.
+    assert client.post("/agents/research-agent/runs", headers=token("alice"), data={"message": "hi"}).status_code == 200
+    assert client.post("/agents/research-agent/runs", headers=token("mallory"), data={"message": "hi"}).status_code == 403

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -1,0 +1,189 @@
+"""Integration tests for ManagedRoleStore — the agno-native managed-roles tier.
+
+Verifies the governance product surface end to end: roles defined in agno scope
+terms, runtime assign/revoke, persistence to a DB, and enforcement through the
+AgentOS request pipeline via the store's provider. No Casbin types appear in the
+test body — the same as user code.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("casbin")
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-test-secret-at-least-256-bits-long-xxxxx"
+OS_ID = "managed-roles-test-os"
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _build(store: ManagedRoleStore) -> TestClient:
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    other = Agent(id="other-agent", name="Other Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent, other],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    return TestClient(agent_os.get_app())
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+def test_role_scopes_enforced_through_pipeline():
+    store = ManagedRoleStore()  # in-memory
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "viewer")
+    store.assign("alice", "admin")
+    client = _build(store)
+
+    # viewer can read
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    # viewer cannot run
+    r = client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403
+    # admin can run
+    r = client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code != 403
+
+
+def test_unassigned_subject_is_denied():
+    store = ManagedRoleStore()
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    client = _build(store)
+    assert client.get("/agents/research-agent", headers=_auth("nobody")).status_code == 403
+
+
+def test_runtime_grant_takes_effect_same_token():
+    store = ManagedRoleStore()
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    client = _build(store)
+
+    # bob has no role yet -> denied to run, with a stable token
+    headers = _auth("bob")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code == 403
+
+    # grant at runtime; SAME token
+    store.assign("bob", "member")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code != 403
+
+    # revoke at runtime; SAME token
+    store.unassign("bob", "member")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code == 403
+
+
+def test_per_resource_scope_is_granular():
+    store = ManagedRoleStore()
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    store.assign("bob", "member")
+    client = _build(store)
+
+    # may run the specific agent
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code != 403
+    # but not a different one
+    assert client.post(
+        "/agents/other-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+
+def test_roles_from_external_idp_claim():
+    """Roles carried on the token (external IdP) authorize against the same store."""
+    store = ManagedRoleStore(roles_claim="roles")
+    store.set_role_scopes("editor", ["agents:*:read", "agents:research-agent:run"])
+    client = _build(store)
+
+    # token carries roles=["editor"]; sub is unknown to the store
+    tok = jwt.encode(
+        {
+            "sub": "idp-user-999",
+            "aud": OS_ID,
+            "scopes": [],
+            "roles": ["editor"],
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        SECRET, algorithm="HS256",
+    )
+    headers = {"Authorization": f"Bearer {tok}"}
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code != 403
+
+
+def test_non_resource_routes_are_gated_sessions():
+    """Sessions endpoints (which the middleware can't tag with a resource_type)
+    are governed by the same role policy — read/write/delete enforced, not open.
+    """
+    from agno.session import AgentSession
+
+    db = InMemoryDb()
+    db.upsert_session(AgentSession(session_id="s1", agent_id="research-agent", user_id="u"))
+
+    store = ManagedRoleStore()
+    store.set_role_scopes("support", ["sessions:read"])  # read only
+    store.set_role_scopes("operator", ["sessions:read", "sessions:delete"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "support")
+    store.assign("val", "operator")
+    store.assign("alice", "admin")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # support can view but NOT delete (the gap this closes: previously open)
+    assert client.get("/sessions?type=agent", headers=_auth("bob")).status_code == 200
+    assert client.delete("/sessions/s1", headers=_auth("bob")).status_code == 403
+    # operator can delete
+    assert client.delete("/sessions/s1", headers=_auth("val")).status_code != 403
+    # admin can view
+    assert client.get("/sessions?type=agent", headers=_auth("alice")).status_code == 200
+    # a subject with no role is denied even on a non-resource route
+    assert client.get("/sessions?type=agent", headers=_auth("nobody")).status_code == 403
+
+
+def test_management_helpers():
+    store = ManagedRoleStore()
+    store.set_role_scopes("a", ["agents:*:read"])
+    store.set_role_scopes("b", ["teams:*:read"])
+    store.assign("bob", "a")
+    store.assign("bob", "b")
+    assert set(store.list_roles()) == {"a", "b"}
+    assert set(store.roles_of("bob")) == {"a", "b"}
+    store.unassign("bob", "a")
+    assert store.roles_of("bob") == ["b"]

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -1,0 +1,179 @@
+"""Integration tests for the ManagedRoleStore HTTP management API.
+
+Exercises the admin-only governance surface end to end: CRUD over roles and
+assignments through HTTP, the admin gate (401/403), and the payoff — a role
+granted via the API takes effect on the target user's next request.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("casbin")
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-api-test-secret-at-least-256-bits-long-xx"
+OS_ID = "managed-roles-api-test-os"
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+@pytest.fixture
+def client_and_store():
+    store = ManagedRoleStore()  # in-memory
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    store.assign("bob", "viewer")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    return TestClient(app), store
+
+
+def test_unauthenticated_is_401(client_and_store):
+    client, _ = client_and_store
+    assert client.get("/authz/roles").status_code == 401
+
+
+def test_non_admin_is_403(client_and_store):
+    client, _ = client_and_store
+    # bob is a viewer, not an admin
+    assert client.get("/authz/roles", headers=_auth("bob")).status_code == 403
+    assert client.post(
+        "/authz/users/carol/roles", headers=_auth("bob"), json={"role": "viewer"}
+    ).status_code == 403
+
+
+def test_admin_can_list_and_read_roles(client_and_store):
+    client, _ = client_and_store
+    r = client.get("/authz/roles", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert set(r.json()["roles"]) == {"viewer", "admin"}
+
+    r = client.get("/authz/roles/viewer", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert r.json()["scopes"] == ["agents:read"]  # global read-back form
+
+
+def test_admin_crud_role(client_and_store):
+    client, store = client_and_store
+    # create a new role
+    r = client.put(
+        "/authz/roles/editor",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:read", "agents:research-agent:run"]},
+    )
+    assert r.status_code == 200
+    assert store.get_role_scopes("editor") == sorted(["agents:read", "agents:research-agent:run"])
+
+    # delete it
+    r = client.delete("/authz/roles/editor", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert "editor" not in store.list_roles()
+
+
+def test_admin_assign_and_revoke(client_and_store):
+    client, store = client_and_store
+    r = client.post("/authz/users/carol/roles", headers=_auth("alice"), json={"role": "viewer"})
+    assert r.status_code == 200
+    assert r.json()["roles"] == ["viewer"]
+    assert store.roles_of("carol") == ["viewer"]
+
+    r = client.delete("/authz/users/carol/roles/viewer", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert store.roles_of("carol") == []
+
+
+def test_granting_via_api_takes_effect_on_next_request(client_and_store):
+    client, _ = client_and_store
+    # bob is a viewer: cannot run the agent
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+    # admin defines a runner role and grants it to bob via the HTTP API
+    assert client.put(
+        "/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
+    ).status_code == 200
+    assert client.post(
+        "/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}
+    ).status_code == 200
+
+    # bob can now run — same token, no re-mint
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code != 403
+
+    # admin revokes it; bob is blocked again
+    assert client.delete("/authz/users/bob/roles/runner", headers=_auth("alice")).status_code == 200
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+
+def test_admin_via_token_claim_can_manage():
+    """When roles come from the token (external IdP), an admin role on the token grants management."""
+    store = ManagedRoleStore(roles_claim="roles")
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.set_role_scopes("viewer", ["agents:*:read"])
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    def idp_token(sub, roles):
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "roles": roles,
+             "exp": datetime.now(UTC) + timedelta(hours=1)},
+            SECRET, algorithm="HS256",
+        )
+
+    admin_h = {"Authorization": f"Bearer {idp_token('idp-admin', ['admin'])}"}
+    viewer_h = {"Authorization": f"Bearer {idp_token('idp-viewer', ['viewer'])}"}
+
+    assert client.get("/authz/roles", headers=admin_h).status_code == 200
+    assert client.get("/authz/roles", headers=viewer_h).status_code == 403

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -142,6 +142,18 @@ def test_granting_via_api_takes_effect_on_next_request(client_and_store):
     ).status_code == 403
 
 
+def test_scope_catalog_endpoint(client_and_store):
+    client, _ = client_and_store
+    r = client.get("/authz/scopes", headers=_auth("alice"))
+    assert r.status_code == 200
+    body = r.json()
+    assert "agents" in body["grouped"] and "read" in body["grouped"]["agents"]
+    assert "agents:run" in body["scopes"]
+    assert body["admin_scope"] == "agent_os:admin"
+    # non-admin is blocked
+    assert client.get("/authz/scopes", headers=_auth("bob")).status_code == 403
+
+
 def test_admin_via_token_claim_can_manage():
     """When roles come from the token (external IdP), an admin role on the token grants management."""
     store = ManagedRoleStore(roles_claim="roles")

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -34,15 +34,15 @@ class _CapturingSink(AuditSink):
         self.events.append(event)
 
 
-def _token(sub: str) -> str:
-    return jwt.encode(
-        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
-        SECRET, algorithm="HS256",
-    )
+def _token(sub: str, jti: str | None = None) -> str:
+    claims = {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)}
+    if jti is not None:
+        claims["jti"] = jti
+    return jwt.encode(claims, SECRET, algorithm="HS256")
 
 
-def _auth(sub: str) -> dict:
-    return {"Authorization": f"Bearer {_token(sub)}"}
+def _auth(sub: str, jti: str | None = None) -> dict:
+    return {"Authorization": f"Bearer {_token(sub, jti)}"}
 
 
 def test_store_emits_change_events_with_actor_and_diff():
@@ -144,10 +144,9 @@ def test_http_api_records_actor_from_jwt():
     ]
 
 
-def test_decision_audit_records_allow_and_deny():
-    """Each authorization decision (allow/deny) is recorded with the principal and
-    a non-secret token reference when an audit sink is on AuthorizationConfig."""
-    sink = _CapturingSink()
+def _decision_os(sink):
+    """An AgentOS where viewer can read agents but not delete sessions, with the
+    given sink wired for decision audit."""
     store = ManagedRoleStore()
     store.set_role_scopes("viewer", ["agents:*:read"])
     store.assign("bob", "viewer")
@@ -168,6 +167,14 @@ def test_decision_audit_records_allow_and_deny():
             audit=sink,  # <- decision audit
         ),
     )
+    return store, agent_os
+
+
+def test_decision_audit_records_allow_and_deny():
+    """Each authorization decision (allow/deny) is recorded with the principal and
+    a non-secret token reference when an audit sink is on AuthorizationConfig."""
+    sink = _CapturingSink()
+    _, agent_os = _decision_os(sink)
     client = TestClient(agent_os.get_app())
 
     client.get("/agents/research-agent", headers=_auth("bob"))  # allowed (viewer reads)
@@ -182,6 +189,106 @@ def test_decision_audit_records_allow_and_deny():
     assert "sessions:delete" in (denied.metadata.get("required") or [])
     # a token reference is captured, but NOT the raw token
     assert denied.metadata.get("token") and len(denied.metadata["token"]) <= 16
+
+
+def test_decision_token_ref_prefers_jti_over_hash():
+    """The token reference is the token's jti when present (so it correlates to the
+    issuer's logs); only without a jti do we fall back to a short hash."""
+    sink = _CapturingSink()
+    _, agent_os = _decision_os(sink)
+    client = TestClient(agent_os.get_app())
+
+    client.get("/agents/research-agent", headers=_auth("bob", jti="tok-abc-123"))  # has jti
+    client.get("/agents/research-agent", headers=_auth("bob"))  # no jti -> hash
+
+    refs = [e.metadata.get("token") for e in sink.events if e.action == "access.allowed"]
+    assert "tok-abc-123" in refs  # jti used verbatim
+    hashed = [r for r in refs if r != "tok-abc-123"]
+    assert hashed and all(len(r) == 12 for r in hashed)  # fallback is the short hash
+
+
+def test_decision_and_change_audit_go_to_separate_tables(tmp_path):
+    """One DbAuditSink, two physically separate tables: role/assignment changes in
+    authz_audit, per-request decisions in authz_decisions."""
+    import sqlalchemy as sa
+
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite:///{db_file}"
+    sink = DbAuditSink(db_url=url)
+
+    store, agent_os = _decision_os(sink)
+    # also route the store's change events to the same sink
+    store._audit = sink  # noqa: SLF001 (test wiring)
+    store.set_role_scopes("viewer", ["agents:*:read", "agents:*:run"], actor="alice")  # a change
+
+    client = TestClient(agent_os.get_app())
+    client.get("/agents/research-agent", headers=_auth("bob", jti="jti-1"))  # a decision (allow)
+    client.delete("/sessions/s1", headers=_auth("bob", jti="jti-2"))  # a decision (deny)
+
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        changes = c.execute(sa.text("select action, target from authz_audit order by id")).fetchall()
+        decisions = c.execute(
+            sa.text("select action, target, token_ref from authz_decisions order by id")
+        ).fetchall()
+
+    # change table holds only the role change, no access.* rows
+    assert [tuple(r) for r in changes] == [("role.set_scopes", "viewer")]
+    # decision table holds only access.* rows, with the jti as the token ref
+    actions = {(r[0], r[2]) for r in decisions}
+    assert ("access.allowed", "jti-1") in actions
+    assert ("access.denied", "jti-2") in actions
+    assert all(r[0].startswith("access.") for r in decisions)
+
+    # the readers are separated too
+    assert all(not e["action"].startswith("access.") for e in sink.read())
+    assert all(e["action"].startswith("access.") for e in sink.read_decisions())
+
+
+def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
+    """GET /authz/decisions returns the decision trail (newest first) for admins;
+    it is separate from /authz/audit (changes)."""
+    db_file = tmp_path / "audit.db"
+    sink = DbAuditSink(db_url=f"sqlite:///{db_file}")
+    store = ManagedRoleStore(audit=sink)
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=sink,  # decisions land here too
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    client.get("/agents/research-agent", headers=_auth("bob", jti="dec-1"))  # allowed decision
+
+    # admin reads the decision trail
+    r = client.get("/authz/decisions", headers=_auth("alice"))
+    assert r.status_code == 200
+    events = r.json()["events"]
+    assert any(e["action"] == "access.allowed" and e["metadata"]["token"] == "dec-1" for e in events)
+
+    # /authz/audit (changes) does NOT contain the access.* decisions
+    changes = client.get("/authz/audit", headers=_auth("alice")).json()["events"]
+    assert all(not e["action"].startswith("access.") for e in changes)
+
+    # non-admin and anonymous are blocked
+    assert client.get("/authz/decisions", headers=_auth("bob")).status_code == 403
+    assert client.get("/authz/decisions").status_code == 401
 
 
 def test_audit_endpoint_returns_trail(tmp_path):

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -142,3 +142,45 @@ def test_http_api_records_actor_from_jwt():
         ("user.assigned", "bob", "alice"),
         ("user.unassigned", "bob", "alice"),
     ]
+
+
+def test_audit_endpoint_returns_trail(tmp_path):
+    """GET /authz/audit returns the change trail (newest first) for admins only."""
+    db_file = tmp_path / "audit.db"
+    store = ManagedRoleStore(audit=DbAuditSink(db_url=f"sqlite:///{db_file}"))
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    # make a couple of changes over the API
+    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
+
+    # admin can read the trail; newest first
+    r = client.get("/authz/audit", headers=_auth("alice"))
+    assert r.status_code == 200
+    events = r.json()["events"]
+    assert events[0]["action"] == "user.assigned" and events[0]["actor"] == "alice"
+    assert events[0]["after"] == ["runner"]
+    assert any(e["action"] == "role.set_scopes" and e["target"] == "runner" for e in events)
+
+    # non-admin and anonymous are blocked
+    store.assign("bob", "runner")  # bob still isn't an admin
+    assert client.get("/authz/audit", headers=_auth("bob")).status_code == 403
+    assert client.get("/authz/audit").status_code == 401

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -1,0 +1,144 @@
+"""Audit trail for managed-role changes.
+
+Casbin can't attribute who changed a policy (its management API never sees the
+actor), so change-audit lives at our layer. These tests verify that role and
+assignment mutations emit append-only AuditEvents with the acting principal and
+the before/after, both via the store directly and through the admin HTTP API.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("casbin")
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-audit-secret-at-least-256-bits-long-xxxx"
+OS_ID = "managed-roles-audit-os"
+
+
+class _CapturingSink(AuditSink):
+    def __init__(self):
+        self.events: list[AuditEvent] = []
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+def test_store_emits_change_events_with_actor_and_diff():
+    sink = _CapturingSink()
+    store = ManagedRoleStore(audit=sink)
+
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.set_role_scopes("member", ["agents:*:read", "agents:*:run"], actor="alice")  # widen
+    store.assign("bob", "member", actor="alice")
+    store.unassign("bob", "member", actor="alice")
+    store.remove_role("member", actor="alice")
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("role.set_scopes", "member", "alice"),
+        ("role.set_scopes", "member", "alice"),
+        ("user.assigned", "bob", "alice"),
+        ("user.unassigned", "bob", "alice"),
+        ("role.removed", "member", "alice"),
+    ]
+    # before/after captured on the widen
+    widen = sink.events[1]
+    assert widen.before == ["agents:read"]
+    assert set(widen.after) == {"agents:read", "agents:run"}
+    # assignment diff
+    assign = sink.events[2]
+    assert assign.before == [] and assign.after == ["member"]
+    # every event is timestamped
+    assert all(e.timestamp > 0 for e in sink.events)
+
+
+def test_no_sink_means_no_overhead_and_no_events():
+    store = ManagedRoleStore()  # no audit
+    # should not raise and should be a no-op for auditing
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.assign("bob", "member", actor="alice")
+    assert store.roles_of("bob") == ["member"]
+
+
+def test_db_audit_sink_is_append_only_table(tmp_path):
+    import sqlalchemy as sa
+
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite:///{db_file}"
+    sink = DbAuditSink(db_url=url)
+    store = ManagedRoleStore(audit=sink)
+
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.assign("bob", "member", actor="alice")
+    store.unassign("bob", "member", actor="carol")
+
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        rows = c.execute(
+            sa.text("select actor, action, target, before, after from authz_audit order by id")
+        ).fetchall()
+    assert [tuple(r[:3]) for r in rows] == [
+        ("alice", "role.set_scopes", "member"),
+        ("alice", "user.assigned", "bob"),
+        ("carol", "user.unassigned", "bob"),
+    ]
+    # before/after persisted as JSON
+    assert rows[1].before == "[]" and rows[1].after == '["member"]'
+
+
+def test_http_api_records_actor_from_jwt():
+    sink = _CapturingSink()
+    store = ManagedRoleStore(audit=sink)
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")  # bootstrap admin (not audited: no actor route)
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    sink.events.clear()
+    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
+    client.delete("/authz/users/bob/roles/runner", headers=_auth("alice"))
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("role.set_scopes", "runner", "alice"),
+        ("user.assigned", "bob", "alice"),
+        ("user.unassigned", "bob", "alice"),
+    ]

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -144,6 +144,46 @@ def test_http_api_records_actor_from_jwt():
     ]
 
 
+def test_decision_audit_records_allow_and_deny():
+    """Each authorization decision (allow/deny) is recorded with the principal and
+    a non-secret token reference when an audit sink is on AuthorizationConfig."""
+    sink = _CapturingSink()
+    store = ManagedRoleStore()
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    db = InMemoryDb()
+    agent = Agent(id="research-agent", name="Research Agent", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=sink,  # <- decision audit
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    client.get("/agents/research-agent", headers=_auth("bob"))  # allowed (viewer reads)
+    client.delete("/sessions/s1", headers=_auth("bob"))  # denied (no sessions:delete)
+
+    by_action = {(e.action, e.actor) for e in sink.events}
+    assert ("access.allowed", "bob") in by_action
+    assert ("access.denied", "bob") in by_action
+
+    denied = next(e for e in sink.events if e.action == "access.denied")
+    assert denied.target.startswith("DELETE /sessions")
+    assert "sessions:delete" in (denied.metadata.get("required") or [])
+    # a token reference is captured, but NOT the raw token
+    assert denied.metadata.get("token") and len(denied.metadata["token"]) <= 16
+
+
 def test_audit_endpoint_returns_trail(tmp_path):
     """GET /authz/audit returns the change trail (newest first) for admins only."""
     db_file = tmp_path / "audit.db"

--- a/libs/agno/tests/unit/os/test_authz_provider.py
+++ b/libs/agno/tests/unit/os/test_authz_provider.py
@@ -1,0 +1,113 @@
+"""Unit tests for the AuthorizationProvider interface + default scope provider."""
+
+import pytest
+
+from agno.os.authz import (
+    AuthorizationContext,
+    AuthorizationProvider,
+    ScopeAuthorizationProvider,
+)
+
+
+def ctx(**kw) -> AuthorizationContext:
+    return AuthorizationContext(**kw)
+
+
+class TestScopeProviderCheck:
+    def setup_method(self):
+        self.p = ScopeAuthorizationProvider()
+
+    def test_global_scope_allows(self):
+        assert self.p.check(ctx(scopes=["agents:run"], resource_type="agents", resource_id="a1", action="run"))
+
+    def test_missing_scope_denies(self):
+        assert not self.p.check(ctx(scopes=["agents:read"], resource_type="agents", resource_id="a1", action="run"))
+
+    def test_per_resource_scope_allows_only_that_resource(self):
+        c_ok = ctx(scopes=["agents:a1:run"], resource_type="agents", resource_id="a1", action="run")
+        c_no = ctx(scopes=["agents:a1:run"], resource_type="agents", resource_id="a2", action="run")
+        assert self.p.check(c_ok)
+        assert not self.p.check(c_no)
+
+    def test_admin_scope_bypasses(self):
+        assert self.p.check(ctx(scopes=["agent_os:admin"], resource_type="agents", resource_id="x", action="run"))
+
+    def test_custom_admin_scope_honoured(self):
+        c = ctx(scopes=["ops:admin"], resource_type="agents", resource_id="x", action="run", admin_scope="ops:admin")
+        assert self.p.check(c)
+
+    def test_non_resource_check_allowed(self):
+        # No resource_type/action → defer to route-level scope mappings.
+        assert self.p.check(ctx(scopes=[]))
+
+
+class TestScopeProviderAccessibleIds:
+    def setup_method(self):
+        self.p = ScopeAuthorizationProvider()
+
+    def test_wildcard(self):
+        assert self.p.accessible_resource_ids(ctx(scopes=["agents:*:read"], resource_type="agents", action="read")) == {"*"}
+
+    def test_specific_ids(self):
+        got = self.p.accessible_resource_ids(
+            ctx(scopes=["agents:a1:read", "agents:a2:read"], resource_type="agents", action="read")
+        )
+        assert got == {"a1", "a2"}
+
+    def test_admin_wildcard(self):
+        assert self.p.accessible_resource_ids(ctx(scopes=["agent_os:admin"], resource_type="agents", action="read")) == {"*"}
+
+
+class TestRequireDefault:
+    def test_require_raises_permission_error(self):
+        p = ScopeAuthorizationProvider()
+        with pytest.raises(PermissionError):
+            p.require(ctx(scopes=["agents:read"], resource_type="agents", resource_id="a1", action="run"))
+
+    def test_require_passes_when_allowed(self):
+        p = ScopeAuthorizationProvider()
+        p.require(ctx(scopes=["agents:run"], resource_type="agents", resource_id="a1", action="run"))  # no raise
+
+
+class TestFilterAccessibleDefault:
+    class _R:
+        def __init__(self, id):
+            self.id = id
+
+    def test_filters_to_accessible(self):
+        p = ScopeAuthorizationProvider()
+        resources = [self._R("a1"), self._R("a2"), self._R("a3")]
+        c = ctx(scopes=["agents:a1:read", "agents:a3:read"], resource_type="agents", action="read")
+        got = {r.id for r in p.filter_accessible(c, resources)}
+        assert got == {"a1", "a3"}
+
+    def test_wildcard_returns_all(self):
+        p = ScopeAuthorizationProvider()
+        resources = [self._R("a1"), self._R("a2")]
+        c = ctx(scopes=["agent_os:admin"], resource_type="agents", action="read")
+        assert len(p.filter_accessible(c, resources)) == 2
+
+
+class TestCustomProviderContract:
+    """A trivial custom provider only needs to implement check +
+    accessible_resource_ids; require/filter_accessible come for free."""
+
+    class AllowList(AuthorizationProvider):
+        def __init__(self, allowed):
+            self.allowed = allowed
+
+        def check(self, c):
+            return c.resource_id in self.allowed
+
+        def accessible_resource_ids(self, c):
+            return set(self.allowed)
+
+    def test_custom_check(self):
+        p = self.AllowList({"a1"})
+        assert p.check(ctx(resource_type="agents", resource_id="a1", action="run"))
+        assert not p.check(ctx(resource_type="agents", resource_id="a2", action="run"))
+
+    def test_inherited_require(self):
+        p = self.AllowList({"a1"})
+        with pytest.raises(PermissionError):
+            p.require(ctx(resource_type="agents", resource_id="a2", action="run"))

--- a/libs/agno/tests/unit/os/test_jwks_url.py
+++ b/libs/agno/tests/unit/os/test_jwks_url.py
@@ -1,0 +1,98 @@
+"""Remote JWKS URL support in JWTValidator.
+
+An IdP (WorkOS/Auth0) publishes its public keys at a URL and rotates them. The
+validator should fetch them at startup, validate tokens signed by those keys, and
+re-fetch when a token arrives with a key id it hasn't seen (rotation) - without a
+static key file to snapshot.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from jwt.algorithms import RSAAlgorithm
+
+from agno.os.middleware.jwt import JWTValidator
+from agno.utils.cryptography import generate_rsa_keys
+
+
+def _jwks(public_pem: str, kid: str) -> dict:
+    jwk = json.loads(RSAAlgorithm.to_jwk(RSAAlgorithm(RSAAlgorithm.SHA256).prepare_key(public_pem)))
+    jwk.update({"kid": kid, "use": "sig", "alg": "RS256"})
+    return {"keys": [jwk]}
+
+
+def _token(private_pem: str, kid: str) -> str:
+    return jwt.encode(
+        {"sub": "alice", "exp": datetime.now(UTC) + timedelta(hours=1)},
+        private_pem, algorithm="RS256", headers={"kid": kid},
+    )
+
+
+class _FakeResp:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def test_jwks_url_fetched_at_startup_and_validates(monkeypatch):
+    private, public = generate_rsa_keys()
+    monkeypatch.setattr("httpx.get", lambda url, timeout=5.0: _FakeResp(_jwks(public, "k1")))
+
+    validator = JWTValidator(jwks_url="https://idp.example/jwks", algorithm="RS256")
+    payload = validator.validate_token(_token(private, "k1"))
+    assert payload["sub"] == "alice"
+
+
+def test_jwks_url_refetches_on_key_rotation(monkeypatch):
+    priv1, pub1 = generate_rsa_keys()
+    priv2, pub2 = generate_rsa_keys()
+    served = {"jwks": _jwks(pub1, "k1")}
+    monkeypatch.setattr("httpx.get", lambda url, timeout=5.0: _FakeResp(served["jwks"]))
+
+    validator = JWTValidator(jwks_url="https://idp.example/jwks", algorithm="RS256")
+    validator._jwks_min_refresh_seconds = 0  # allow an immediate refetch for the test
+
+    # IdP rotates to a brand new key the validator has never seen.
+    served["jwks"] = _jwks(pub2, "k2")
+    payload = validator.validate_token(_token(priv2, "k2"))
+    assert payload["sub"] == "alice"
+
+
+def test_jwks_url_startup_failure_is_not_fatal(monkeypatch):
+    def boom(url, timeout=5.0):
+        raise RuntimeError("idp unreachable")
+
+    monkeypatch.setattr("httpx.get", boom)
+    # Construction must not raise even if the IdP is down at boot.
+    validator = JWTValidator(jwks_url="https://idp.example/jwks", algorithm="RS256")
+    assert validator.jwks_url == "https://idp.example/jwks"
+
+
+def test_unknown_kid_refetch_is_rate_limited(monkeypatch):
+    priv1, pub1 = generate_rsa_keys()
+    priv2, pub2 = generate_rsa_keys()
+    served = {"jwks": _jwks(pub1, "k1")}
+    calls = {"n": 0}
+
+    def fake_get(url, timeout=5.0):
+        calls["n"] += 1
+        return _FakeResp(served["jwks"])
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    validator = JWTValidator(jwks_url="https://idp.example/jwks", algorithm="RS256")
+    assert calls["n"] == 1  # startup fetch
+
+    # A token with an unknown kid arrives but the refresh window hasn't elapsed,
+    # so we should NOT hammer the IdP; validation fails without a second fetch.
+    served["jwks"] = _jwks(pub2, "k2")
+    try:
+        validator.validate_token(_token(priv2, "k2"))
+    except jwt.InvalidTokenError:
+        pass
+    assert calls["n"] == 1  # still just the startup fetch (rate-limited)

--- a/libs/agno/tests/unit/os/test_jwks_url.py
+++ b/libs/agno/tests/unit/os/test_jwks_url.py
@@ -42,7 +42,7 @@ class _FakeResp:
 
 def test_jwks_url_fetched_at_startup_and_validates(monkeypatch):
     private, public = generate_rsa_keys()
-    monkeypatch.setattr("httpx.get", lambda url, timeout=5.0: _FakeResp(_jwks(public, "k1")))
+    monkeypatch.setattr("httpx.get", lambda url, timeout=5.0, **kw: _FakeResp(_jwks(public, "k1")))
 
     validator = JWTValidator(jwks_url="https://idp.example/jwks", algorithm="RS256")
     payload = validator.validate_token(_token(private, "k1"))
@@ -53,7 +53,7 @@ def test_jwks_url_refetches_on_key_rotation(monkeypatch):
     priv1, pub1 = generate_rsa_keys()
     priv2, pub2 = generate_rsa_keys()
     served = {"jwks": _jwks(pub1, "k1")}
-    monkeypatch.setattr("httpx.get", lambda url, timeout=5.0: _FakeResp(served["jwks"]))
+    monkeypatch.setattr("httpx.get", lambda url, timeout=5.0, **kw: _FakeResp(served["jwks"]))
 
     validator = JWTValidator(jwks_url="https://idp.example/jwks", algorithm="RS256")
     validator._jwks_min_refresh_seconds = 0  # allow an immediate refetch for the test
@@ -65,7 +65,7 @@ def test_jwks_url_refetches_on_key_rotation(monkeypatch):
 
 
 def test_jwks_url_startup_failure_is_not_fatal(monkeypatch):
-    def boom(url, timeout=5.0):
+    def boom(url, timeout=5.0, **kw):
         raise RuntimeError("idp unreachable")
 
     monkeypatch.setattr("httpx.get", boom)
@@ -80,7 +80,7 @@ def test_unknown_kid_refetch_is_rate_limited(monkeypatch):
     served = {"jwks": _jwks(pub1, "k1")}
     calls = {"n": 0}
 
-    def fake_get(url, timeout=5.0):
+    def fake_get(url, timeout=5.0, **kw):
         calls["n"] += 1
         return _FakeResp(served["jwks"])
 
@@ -96,3 +96,22 @@ def test_unknown_kid_refetch_is_rate_limited(monkeypatch):
     except jwt.InvalidTokenError:
         pass
     assert calls["n"] == 1  # still just the startup fetch (rate-limited)
+
+
+def test_jwks_url_over_http_is_rejected(monkeypatch):
+    """A plaintext (http) JWKS endpoint is MITM-able and its keys verify tokens,
+    so the fetch must refuse it rather than trust forged keys."""
+    import pytest
+
+    called = {"n": 0}
+
+    def fake_get(url, timeout=5.0, **kw):
+        called["n"] += 1
+        return _FakeResp({"keys": []})
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    with pytest.raises(ValueError, match="https"):
+        JWTValidator(jwks_url="http://idp.example/jwks", algorithm="RS256")._load_jwks_url(
+            "http://idp.example/jwks"
+        )
+    assert called["n"] == 0  # rejected before any network call

--- a/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
+++ b/libs/agno/tests/unit/os/test_jwt_middleware_helpers.py
@@ -424,7 +424,9 @@ def test_raises_error_without_verification_key():
             algorithm="HS256",
         )
 
-    assert "at least one jwt verification key or jwks file is required" in str(exc_info.value).lower()
+    msg = str(exc_info.value).lower()
+    assert "at least one jwt verification key" in msg
+    assert "jwks" in msg
 
 
 def test_authorization_enabled_implicitly_with_scope_mappings():


### PR DESCRIPTION
**Stack 1/7 — base `main`.** The core: pluggable `AuthorizationProvider` seam (default zero-dep `ScopeAuthorizationProvider`), opt-in Casbin + `ManagedRoleStore`, change+decision audit, remote JWKS-URL support, `/authz` scopes catalog, the 3 IdP scenarios, and cookbooks. Answers 'do we need Casbin' — it's opt-in behind the seam. Later PRs stack on this.