### PR TITLE
fix(authz) [2/7]: resource-type bypass + audience fail-closed

### DIFF
--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -698,6 +698,26 @@ class JWTMiddleware(BaseHTTPMiddleware):
             return hashlib.sha256(token.encode()).hexdigest()[:12]
         return None
 
+    # Resource families that get per-resource scopes + list filtering. Order is
+    # irrelevant — a path has at most one leading family segment.
+    _RESOURCE_TYPES = ("agents", "teams", "workflows")
+
+    def _detect_resource_type(self, path: str) -> Optional[str]:
+        """Classify a path's resource family by its FIRST segment, not a substring.
+
+        Must be a leading-segment match (``/agents`` or ``/agents/...``). A naive
+        ``"/agents" in path`` substring test misclassifies unrelated routes whose
+        id segment merely contains the family name — e.g. ``/sessions/agents-1``
+        (a session whose id starts with "agents") would be tagged as an *agents*
+        route with no resource id, and the list-endpoint fallback would then wave
+        it through without the scope the route actually requires. Anchoring to the
+        first segment closes that bypass.
+        """
+        for rt in self._RESOURCE_TYPES:
+            if path == f"/{rt}" or path.startswith(f"/{rt}/"):
+                return rt
+        return None
+
     def _extract_resource_id_from_path(self, path: str, resource_type: str) -> Optional[str]:
         """
         Extract resource ID from a path.
@@ -920,6 +940,21 @@ class JWTMiddleware(BaseHTTPMiddleware):
             expected_audience = None
             if self.verify_audience:
                 expected_audience = self.audience or agent_os_id
+                # Fail closed: audience verification was explicitly requested but
+                # there is nothing to verify against (no configured audience and no
+                # AgentOS id on app.state). Silently skipping the check would accept
+                # tokens minted for any audience, defeating the point of enabling it.
+                if not expected_audience:
+                    log_warning(
+                        "verify_audience=True but no audience is configured and no AgentOS id is "
+                        "available; rejecting the request instead of skipping the audience check."
+                    )
+                    return self._create_error_response(
+                        401,
+                        "Audience verification is enabled but no expected audience is configured",
+                        origin,
+                        cors_allowed_origins,
+                    )
             payload: Dict[str, Any] = self.validator.validate_token(token, expected_audience)  # type: ignore
 
             # Extract standard claims and store in request.state
@@ -975,16 +1010,8 @@ class JWTMiddleware(BaseHTTPMiddleware):
             # RBAC scope checking (only if enabled)
             if self.authorization:
                 # Extract resource type and ID from path
-                resource_type = None
+                resource_type = self._detect_resource_type(path)
                 resource_id = None
-
-                if "/agents" in path:
-                    resource_type = "agents"
-                elif "/teams" in path:
-                    resource_type = "teams"
-                elif "/workflows" in path:
-                    resource_type = "workflows"
-
                 if resource_type:
                     resource_id = self._extract_resource_id_from_path(path, resource_type)
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1252,9 +1252,14 @@ def get_team_router(
             # Exclude teams whose IDs are owned by the registry
             exclude_ids = registry.get_team_ids() if registry else None
             db_teams = get_teams(db=os.db, registry=registry, exclude_component_ids=exclude_ids or None)
-            for db_team in db_teams:
-                team_response = await TeamResponse.from_team(team=db_team, is_component=True)
-                teams.append(team_response)
+            if db_teams:
+                # Apply the same RBAC filtering to DB-loaded teams (mirrors get_agents);
+                # without this, a caller scoped to a single team sees every DB team.
+                if getattr(request.state, "authorization_enabled", False):
+                    db_teams = filter_resources_by_access(request, db_teams, "teams")
+                for db_team in db_teams:
+                    team_response = await TeamResponse.from_team(team=db_team, is_component=True)
+                    teams.append(team_response)
 
         return teams
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1025,13 +1025,21 @@ def get_workflow_router(
         if os.db and isinstance(os.db, BaseDb):
             from agno.workflow.workflow import get_workflows
 
-            for db_workflow in get_workflows(db=os.db, registry=os.registry):
-                try:
-                    workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow, is_component=True))
-                except Exception:
-                    workflow_id = getattr(db_workflow, "id", "unknown")
-                    logger.exception(f"Error converting workflow {workflow_id} to response")
-                    continue
+            db_workflows = get_workflows(db=os.db, registry=os.registry)
+            if db_workflows:
+                # Apply the same RBAC filtering to DB-loaded workflows (mirrors get_agents);
+                # without this, a caller scoped to a single workflow sees every DB workflow.
+                if getattr(request.state, "authorization_enabled", False):
+                    from agno.os.auth import filter_resources_by_access
+
+                    db_workflows = filter_resources_by_access(request, db_workflows, "workflows")
+                for db_workflow in db_workflows:
+                    try:
+                        workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow, is_component=True))
+                    except Exception:
+                        workflow_id = getattr(db_workflow, "id", "unknown")
+                        logger.exception(f"Error converting workflow {workflow_id} to response")
+                        continue
 
         return workflows
 

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -403,6 +403,7 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "POST /agents/*/runs": ["agents:run"],
         "POST /agents/*/runs/*/continue": ["agents:run"],
         "POST /agents/*/runs/*/cancel": ["agents:run"],
+        "POST /agents/*/runs/*/resume": ["agents:run"],
         # Team endpoints
         "GET /teams": ["teams:read"],
         "GET /teams/*": ["teams:read"],
@@ -412,6 +413,7 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "POST /teams/*/runs": ["teams:run"],
         "POST /teams/*/runs/*/continue": ["teams:run"],
         "POST /teams/*/runs/*/cancel": ["teams:run"],
+        "POST /teams/*/runs/*/resume": ["teams:run"],
         # Workflow endpoints
         "GET /workflows": ["workflows:read"],
         "GET /workflows/*": ["workflows:read"],
@@ -421,6 +423,7 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "POST /workflows/*/runs": ["workflows:run"],
         "POST /workflows/*/runs/*/continue": ["workflows:run"],
         "POST /workflows/*/runs/*/cancel": ["workflows:run"],
+        "POST /workflows/*/runs/*/resume": ["workflows:run"],
         # Session endpoints
         "GET /sessions": ["sessions:read"],
         "GET /sessions/*": ["sessions:read"],

--- a/libs/agno/tests/integration/os/test_authorization.py
+++ b/libs/agno/tests/integration/os/test_authorization.py
@@ -3161,3 +3161,73 @@ def test_real_agents_routes_unaffected_by_detection_fix(test_agent):
     # without agents:read it is denied (not silently allowed)
     no = create_jwt_token(scopes=["config:read"])
     assert client.get("/agents/test-agent", headers={"Authorization": f"Bearer {no}"}).status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Regression: DB-loaded resources must be filtered too.
+#
+# get_agents() filtered both static and DB-loaded agents, but get_teams() and
+# get_workflows() filtered only the static (os.teams/os.workflows) list and
+# appended DB-loaded ("component") resources unfiltered. A caller scoped to a
+# single team/workflow therefore saw EVERY team/workflow stored in the DB. We
+# masquerade a second resource as DB-loaded (monkeypatching the module-level
+# loader the handler imports) and assert it is filtered exactly like the static
+# ones.
+# ---------------------------------------------------------------------------
+
+
+def test_get_teams_filters_db_loaded_teams(test_team, second_team, shared_db, monkeypatch):
+    import agno.team.team as team_mod
+
+    # second_team stands in for a team loaded from the DB (is_component=True path)
+    monkeypatch.setattr(team_mod, "get_teams", lambda **kwargs: [second_team])
+
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        teams=[test_team],  # only test-team is static
+        db=shared_db,  # BaseDb -> the db-loaded branch runs
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # scoped to test-team only: the DB-loaded second-team must NOT leak
+    scoped = create_jwt_token(scopes=["teams:test-team:read"])
+    r = client.get("/teams", headers={"Authorization": f"Bearer {scoped}"})
+    assert r.status_code == 200, r.text
+    ids = {t["id"] for t in r.json()}
+    assert "second-team" not in ids, f"DB-loaded team leaked to a scoped caller: {ids}"
+    assert ids == {"test-team"}
+
+    # global teams:read still sees the DB-loaded team (not over-filtered)
+    glob = create_jwt_token(scopes=["teams:read"])
+    r2 = client.get("/teams", headers={"Authorization": f"Bearer {glob}"})
+    assert r2.status_code == 200, r2.text
+    assert "second-team" in {t["id"] for t in r2.json()}
+
+
+def test_get_workflows_filters_db_loaded_workflows(test_workflow, second_workflow, shared_db, monkeypatch):
+    import agno.workflow.workflow as wf_mod
+
+    monkeypatch.setattr(wf_mod, "get_workflows", lambda **kwargs: [second_workflow])
+
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        workflows=[test_workflow],  # only test-workflow is static
+        db=shared_db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    scoped = create_jwt_token(scopes=["workflows:test-workflow:read"])
+    r = client.get("/workflows", headers={"Authorization": f"Bearer {scoped}"})
+    assert r.status_code == 200, r.text
+    ids = {w["id"] for w in r.json()}
+    assert "second-workflow" not in ids, f"DB-loaded workflow leaked to a scoped caller: {ids}"
+    assert ids == {"test-workflow"}
+
+    glob = create_jwt_token(scopes=["workflows:read"])
+    r2 = client.get("/workflows", headers={"Authorization": f"Bearer {glob}"})
+    assert r2.status_code == 200, r2.text
+    assert "second-workflow" in {w["id"] for w in r2.json()}

--- a/libs/agno/tests/integration/os/test_authorization.py
+++ b/libs/agno/tests/integration/os/test_authorization.py
@@ -3096,3 +3096,68 @@ def test_jwks_parameter_takes_precedence_over_env(test_agent, rsa_key_pair, jwks
 
     # Should work because jwks_file parameter has the correct key
     assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Regression: resource-type detection must anchor to the first path segment.
+#
+# A naive substring check ("/agents" in path) misclassified unrelated routes
+# whose id segment merely starts with a resource-family name (e.g. a session
+# whose id is "agents-1" -> path "/sessions/agents-1"). The route would be
+# tagged as an *agents* route with no resource id, and the list-endpoint
+# fallback would wave it through WITHOUT the scope the route actually requires
+# ("sessions:read"). These tests pin the bypass shut.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("session_id", ["agents-1", "agents", "teams-x", "workflows_7"])
+def test_session_id_resembling_resource_family_is_not_a_bypass(test_agent, session_id):
+    """A caller without sessions:read must be denied on /sessions/<id> even when
+    <id> starts with a resource-family name. Previously this returned 404 (the
+    authz gate was skipped and the handler was reached); it must be 403."""
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        agents=[test_agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    token = create_jwt_token(scopes=["config:read"])  # explicitly NOT sessions:read
+    response = client.get(f"/sessions/{session_id}", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 403, response.text
+
+
+def test_session_with_proper_scope_still_reaches_handler(test_agent):
+    """The fix must not over-block: with sessions:read, /sessions/agents-1 passes
+    the authz gate (handler then 404s on the nonexistent session)."""
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        agents=[test_agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    token = create_jwt_token(scopes=["sessions:read"])
+    response = client.get("/sessions/agents-1", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code != 403, response.text
+
+
+def test_real_agents_routes_unaffected_by_detection_fix(test_agent):
+    """Genuine /agents routes still classify as the agents resource family."""
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        agents=[test_agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # per-resource read on the real agent is allowed with a global agents:read
+    ok = create_jwt_token(scopes=["agents:read"])
+    assert client.get("/agents/test-agent", headers={"Authorization": f"Bearer {ok}"}).status_code == 200
+
+    # without agents:read it is denied (not silently allowed)
+    no = create_jwt_token(scopes=["config:read"])
+    assert client.get("/agents/test-agent", headers={"Authorization": f"Bearer {no}"}).status_code == 403

--- a/libs/agno/tests/integration/os/test_jwt_middleware.py
+++ b/libs/agno/tests/integration/os/test_jwt_middleware.py
@@ -2148,3 +2148,74 @@ def test_audience_verification_missing_custom_audience_claim(jwt_test_agent):
 
     assert response.status_code == 401
     assert 'missing the "custom_aud" claim' in response.json()["detail"]
+
+
+def test_verify_audience_without_expected_audience_fails_closed():
+    """verify_audience=True with no configured audience and no AgentOS id on
+    app.state must REJECT (fail closed), not silently skip the audience check.
+
+    Without this, the middleware would resolve expected_audience to None and the
+    validator would accept a token minted for any audience."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    def whoami():
+        return {"ok": True}
+
+    # Manual setup: no AgentOS, so request.app.state has no agent_os_id, and we
+    # deliberately don't pass an audience.
+    app.add_middleware(
+        JWTMiddleware,
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,  # enabled...
+        # ...but no audience= and no AgentOS id to fall back on
+        authorization=False,
+    )
+
+    client = TestClient(app)
+
+    token = jwt.encode(
+        {"sub": "u", "aud": "some-other-audience", "exp": datetime.now(UTC) + timedelta(hours=1)},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    response = client.get("/whoami", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 401, response.text
+    assert "audience" in response.json()["detail"].lower()
+
+
+def test_verify_audience_with_configured_audience_still_enforces():
+    """Sanity: when an audience IS configured, verification still works both ways."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    @app.get("/whoami")
+    def whoami():
+        return {"ok": True}
+
+    app.add_middleware(
+        JWTMiddleware,
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience="expected-os",
+        authorization=False,
+    )
+    client = TestClient(app)
+
+    good = jwt.encode(
+        {"sub": "u", "aud": "expected-os", "exp": datetime.now(UTC) + timedelta(hours=1)},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    bad = jwt.encode(
+        {"sub": "u", "aud": "wrong-os", "exp": datetime.now(UTC) + timedelta(hours=1)},
+        JWT_SECRET,
+        algorithm="HS256",
+    )
+    assert client.get("/whoami", headers={"Authorization": f"Bearer {good}"}).status_code == 200
+    assert client.get("/whoami", headers={"Authorization": f"Bearer {bad}"}).status_code == 401

--- a/libs/agno/tests/unit/os/test_scopes.py
+++ b/libs/agno/tests/unit/os/test_scopes.py
@@ -102,6 +102,16 @@ class TestDefaultScopeMappings:
         mappings = get_default_scope_mappings()
         assert mappings["GET /registry"] == ["registry:read"]
 
+    def test_run_lifecycle_endpoints_including_resume_require_run(self):
+        """resume must be gated like continue/cancel; it was previously missing from
+        the map, so the middleware gate fell open and protection depended solely on
+        the route-level dependency."""
+        mappings = get_default_scope_mappings()
+        for family in ("agents", "teams", "workflows"):
+            for action_path in ("continue", "cancel", "resume"):
+                key = f"POST /{family}/*/runs/*/{action_path}"
+                assert mappings[key] == [f"{family}:run"], f"missing/incorrect scope for {key}"
+
     def test_components_endpoints_have_scope_mappings(self):
         mappings = get_default_scope_mappings()
         # Read


### PR DESCRIPTION
**Stack 2/7 — base `authz-1-core`.** Middleware enforcement fixes: resource-type detection anchors to the first path segment (was a substring test that misclassified e.g. `/sessions/agents-1`); `verify_audience=True` now fails closed when no audience is resolvable. (The DB-leak/resume fixes are in the standalone `authz-data-leak-fix` PR.)