### PR TITLE
feat(authz) [6/7]: cloud-shaped responses + RESTful role API

### DIFF
--- a/cookbook/05_agent_os/rbac/manage_users_and_roles.py
+++ b/cookbook/05_agent_os/rbac/manage_users_and_roles.py
@@ -3,9 +3,11 @@ Run an AgentOS that serves the user + role management API (for a frontend)
 
 (New to this? Read managed_roles.py first, then managed_users.py.)
 
-This is the no-login-service "admin backend": it starts a real AgentOS server and
-leaves it running, exposing the /authz management API so a frontend (or your own
-admin UI) can create roles, add users, assign roles, and disable people - live.
+This is the "admin backend": it starts a real AgentOS server and leaves it
+running, exposing the /authz management API so a frontend (or your own admin UI)
+can create roles, add users, assign roles, and disable people - live. It works
+both with a control plane / login service (operators authorized by their token
+scopes) and on its own (end users managed in the OS-local store) - both at once.
 
 What it serves (all admin-only):
     GET    /authz/roles                 list roles
@@ -27,23 +29,29 @@ Run it:
 Then point your frontend at http://localhost:7777 (CORS is open to the usual dev
 ports). The server keeps running until you Ctrl-C.
 
-Two authz planes run in parallel here (CompositeAuthorizationProvider below):
-  - operators: a token that already carries scopes (e.g. an agno-cloud / frontend
-    token) is authorized straight from those scopes.
-  - end users: everyone else is authorized against the OS-local role store you
-    manage at runtime.
+Two authz planes run in parallel here, by default - we pass a LIST of providers
+(``authorization_provider=[ScopeAuthorizationProvider(), roles.provider]``) and a
+request is allowed if either grants:
+  - control plane / operators: a token that already carries scopes (e.g. an
+    agno-cloud / frontend token) is authorized straight from those scopes.
+  - managed store / end users: everyone else is authorized against the OS-local
+    role store you manage at runtime.
 So a scope-bearing frontend token can connect and operate, while the store still
 governs your managed users.
 
-Auth, two modes:
-  - Dev (default): HS256 with a shared secret. On startup it prints a ready-made
+Verifying tokens - pick whichever fits; auto-selected by env, no code change:
+  - Dev (default): a built-in HS256 secret. On startup it prints a ready-made
     admin bearer token you can paste into the frontend / curl to try the API.
-  - Real login service / agno cloud: set JWT_VERIFICATION_KEY to the OS public key
-    (RS256 is detected automatically) and OS_ID to the token audience.
+  - Control plane / IdP: set ONE of
+        JWT_JWKS_URL          a JWKS the control plane / IdP publishes (RS256)
+        JWT_VERIFICATION_KEY  your OS public key (RS256) or an HS256 secret
+    plus OS_ID (the token audience / your os_id) and, optionally,
+        JWT_ISSUER           pin the issuer, e.g. "agent-os-api"
 
 To MANAGE roles/users over /authz you must be an admin. That comes from either an
-``agent_os:admin`` scope on your token, OR being seeded in the store - so set
+``agent_os:admin`` scope on the token, OR being seeded in the store - so set
 ADMIN_SUBJECT to the `sub` of your token (decode it: the `sub` claim). e.g.
+    OS_ID="<your-os-id>" JWT_VERIFICATION_KEY="<os public key>" \\
     ADMIN_SUBJECT="you@company.com" python manage_users_and_roles.py
 """
 

--- a/cookbook/05_agent_os/rbac/manage_users_and_roles.py
+++ b/cookbook/05_agent_os/rbac/manage_users_and_roles.py
@@ -61,13 +61,29 @@ from agno.os.authz.user_store import ManagedUserStore
 from agno.os.config import AuthorizationConfig
 from agno.os.middleware import JWTIssuer  # mint tokens your AgentOS accepts
 
-# --- config (env-overridable so the same file works for a real frontend) ------
-OS_ID = os.getenv("OS_ID", "manage-users-os")  # the token audience
+# --- config: supports BOTH planes by default ---------------------------------
+# Plane 1 - control plane / operators: tokens minted by the agno control plane
+#   (or any IdP) are verified against the OS's public key or a JWKS URL; their
+#   scopes authorize them (the ScopeAuthorizationProvider below).
+# Plane 2 - managed store / end users: roles you manage at runtime in the store.
+# Both are wired by default; you just point verification at your control plane.
+OS_ID = os.getenv("OS_ID", "manage-users-os")  # the token audience (your os_id)
 ADMIN_SUBJECT = os.getenv("ADMIN_SUBJECT", "admin")  # whose `sub` is the bootstrap admin
-# The verification key. A shared secret (HS256) by default; if you paste a public
-# key (PEM) we switch to RS256 automatically - that's the agno-cloud / IdP case.
-VERIFICATION_KEY = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long").replace("\\n", "\n")
-ALGORITHM = "RS256" if "BEGIN" in VERIFICATION_KEY else "HS256"
+ISSUER = os.getenv("JWT_ISSUER") or None  # optionally pin the issuer (e.g. agent-os-api)
+
+# Verification source, in priority order:
+#   1. JWT_JWKS_URL         - a JWKS the control plane / IdP publishes (RS256)
+#   2. JWT_VERIFICATION_KEY  - the OS public key (RS256) or an HS256 secret
+#   3. dev fallback          - a built-in HS256 secret (prints an admin token)
+JWKS_URL = os.getenv("JWT_JWKS_URL") or None
+VERIFICATION_KEY = (os.getenv("JWT_VERIFICATION_KEY") or "").replace("\\n", "\n") or None
+DEV_SECRET = "your-secret-key-at-least-256-bits-long"
+if JWKS_URL:
+    ALGORITHM, KEYS = "RS256", None
+elif VERIFICATION_KEY:
+    ALGORITHM, KEYS = ("RS256" if "BEGIN" in VERIFICATION_KEY else "HS256"), [VERIFICATION_KEY]
+else:
+    ALGORITHM, KEYS = "HS256", [DEV_SECRET]
 
 # Frontends run in the browser, so the server must allow their origin.
 CORS_ORIGINS = [
@@ -111,10 +127,12 @@ agent_os = AgentOS(
     cors_allowed_origins=CORS_ORIGINS,
     authorization=True,
     authorization_config=AuthorizationConfig(
-        verification_keys=[VERIFICATION_KEY],
+        verification_keys=KEYS,
+        jwks_url=JWKS_URL,
         algorithm=ALGORITHM,
         verify_audience=True,
         audience=OS_ID,
+        issuer=ISSUER,
         # Two authz planes on one OS, in parallel - pass a LIST, allowed if any
         # grants:
         #  - ScopeAuthorizationProvider: operators whose token already carries
@@ -135,23 +153,28 @@ if __name__ == "__main__":
     print("\n" + "=" * 78)
     print("USER + ROLE MANAGEMENT AGENTOS - serving for a frontend")
     print("=" * 78)
+    src = "JWKS_URL" if JWKS_URL else ("JWT_VERIFICATION_KEY" if VERIFICATION_KEY else "dev secret")
     print("  endpoint:   http://localhost:7777")
     print("  manage at:  http://localhost:7777/authz/...   (admin-only)")
-    print(f"  auth:       {ALGORITHM}   audience={OS_ID}   admin sub={ADMIN_SUBJECT!r}")
+    print("  planes:     control plane (token scopes) + managed role store, in parallel")
+    print(f"  verify:     {ALGORITHM} via {src}   audience={OS_ID}   admin sub={ADMIN_SUBJECT!r}")
     print(f"  CORS open to: {', '.join(CORS_ORIGINS)}")
 
-    # In dev (HS256) mint a ready-to-use admin token so you can try it immediately.
-    # JWTIssuer is the mint-side helper: same claim names AgentOS verifies, and it
-    # stamps exp/iat/jti for you. (RS256 mode can't mint here - that key is public.)
-    if ALGORITHM == "HS256":
-        issuer = JWTIssuer(VERIFICATION_KEY, audience=OS_ID)
-        admin_token = issuer.create_token(ADMIN_SUBJECT, expires_in=7 * 24 * 3600)
-        print("\n  admin bearer token (paste into your frontend / curl):")
+    # Dev only (built-in HS256 secret): mint a ready-to-use admin token so you can
+    # try it immediately. JWTIssuer is the mint-side helper - same claims AgentOS
+    # verifies, with exp/iat/jti stamped. (Control-plane RS256 tokens are minted by
+    # the control plane, not here - that key is public.)
+    is_dev = ALGORITHM == "HS256" and not VERIFICATION_KEY and not JWKS_URL
+    if is_dev:
+        admin_token = JWTIssuer(DEV_SECRET, audience=OS_ID).create_token(ADMIN_SUBJECT, expires_in=7 * 24 * 3600)
+        print("\n  dev mode - admin bearer token (paste into your frontend / curl):")
         print(f"    {admin_token}")
         print("\n  e.g.:  curl -H 'Authorization: Bearer <token>' http://localhost:7777/authz/users")
     else:
-        print("\n  RS256 mode: the frontend should send a token signed by your IdP/cloud,")
-        print(f"  with aud={OS_ID!r} and sub={ADMIN_SUBJECT!r} for admin access.")
+        print("\n  control-plane mode: the frontend sends a token signed by your control")
+        print(f"  plane / IdP (aud={OS_ID!r}). Operators are authorized by the token's scopes;")
+        print("  end users by the role store. To manage roles, the caller needs agent_os:admin")
+        print(f"  on the token OR be seeded here (ADMIN_SUBJECT={ADMIN_SUBJECT!r}).")
     print("=" * 78 + "\n")
 
     agent_os.serve(app, host="0.0.0.0", port=7777)

--- a/cookbook/05_agent_os/rbac/managed_users.py
+++ b/cookbook/05_agent_os/rbac/managed_users.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
 
     # The admin can list everyone in the directory, with their roles merged in.
     print("\n  the directory (asked for by alice, an admin):")
-    listing = client.get("/authz/users", headers=auth("alice")).json()["users"]
+    listing = client.get("/authz/users", headers=auth("alice")).json()["data"]  # paginated {data, meta}
     for u in listing:
         print(f"    - {u['id']:8s} {str(u['email'] or ''):12s} roles={u['roles']}  disabled={u['disabled']}")
 

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -41,7 +41,8 @@ class AuditEvent:
         actor: the principal who made the change (JWT ``sub`` of the admin), or
             None for changes made in code outside a request (treated as system).
         target: the role name (role changes) or subject id (assignment changes).
-        before: prior state (the role's scopes, or the subject's roles), or None.
+        before: prior state — the subject's roles (list of str) or a role's scope
+            entries (list of ``{"scope", "effect"}`` dicts) — or None.
         after: new state, or None (e.g. on removal).
         timestamp: epoch seconds when the change was recorded.
     """
@@ -49,8 +50,8 @@ class AuditEvent:
     action: str
     actor: Optional[str]
     target: str
-    before: Optional[List[str]] = None
-    after: Optional[List[str]] = None
+    before: Optional[List[Any]] = None
+    after: Optional[List[Any]] = None
     timestamp: int = 0
     metadata: dict = field(default_factory=dict)
 

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -257,8 +257,8 @@ def get_roles_router(
     # ---- roles ----------------------------------------------------------
     @router.get("/roles", response_model=PaginatedResponse[RoleSchema])
     def list_roles(
-        limit: int = Query(default=20, ge=1, description="Items per page"),
-        page: int = Query(default=1, ge=0, description="Page number"),
+        limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number"),
     ):
         roles = [RoleSchema.from_record(r) for r in store.list_roles_detailed()]
         return _page(roles, page, limit)
@@ -353,13 +353,13 @@ def get_roles_router(
 
     # ---- audit ----------------------------------------------------------
     @router.get("/audit")
-    def list_audit(limit: int = 100) -> dict:
+    def list_audit(limit: int = Query(default=100, ge=1, le=1000)) -> dict:
         """Recent *change* events (role/assignment mutations, newest first). Empty
         unless the store was given a readable audit sink (e.g. DbAuditSink)."""
         return {"events": store.audit_log(limit)}
 
     @router.get("/decisions")
-    def list_decisions(request: Request, limit: int = 100) -> dict:
+    def list_decisions(request: Request, limit: int = Query(default=100, ge=1, le=1000)) -> dict:
         """Recent *decision* events (allow/deny per request, newest first).
 
         Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
@@ -396,11 +396,24 @@ def get_roles_router(
         @router.get("/users", response_model=PaginatedResponse[AuthzUserSchema])
         def list_users(
             include_disabled: bool = True,
-            limit: int = Query(default=20, ge=1, description="Items per page"),
-            page: int = Query(default=1, ge=0, description="Page number"),
+            limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+            page: int = Query(default=1, ge=1, description="Page number"),
         ):
-            users = [_user(u) for u in user_store.list(limit=100000, include_disabled=include_disabled)]
-            return _page(users, page, limit)
+            # Paginate in the store (offset/limit + count) so we don't materialise
+            # the whole directory and resolve roles for every user on each call.
+            total = user_store.count(include_disabled=include_disabled)
+            rows = user_store.list(
+                limit=limit, offset=(page - 1) * limit, include_disabled=include_disabled
+            )
+            return PaginatedResponse(
+                data=[_user(u) for u in rows],
+                meta=PaginationInfo(
+                    page=page,
+                    limit=limit,
+                    total_count=total,
+                    total_pages=(total + limit - 1) // limit if limit > 0 else 0,
+                ),
+            )
 
         @router.post("/users", response_model=AuthzUserSchema)
         def create_user(body: CreateUserRequest, actor: str = Depends(require_admin)):

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -139,17 +139,6 @@ class AvailableScopeItem(BaseModel):
         return cls(raw=raw, namespace=ns, sub_namespace=sub, permission=perm)
 
 
-class AvailableScopesResponse(BaseModel):
-    """Available scopes grouped by org and OS level (mirrors the cloud API).
-
-    A self-hosted OS has no org/platform layer, so ``org_scopes`` is empty and
-    everything the OS enforces lives in ``os_scopes``.
-    """
-
-    org_scopes: List[AvailableScopeItem] = Field(default_factory=list, description="Organization-level scopes")
-    os_scopes: List[AvailableScopeItem] = Field(default_factory=list, description="OS-level scopes")
-
-
 class ScopeItem(BaseModel):
     scope: str = Field(description="Scope string, e.g. 'agents:*:read'")
     effect: str = Field("allow", description="'allow' or 'deny'")
@@ -263,22 +252,20 @@ def get_roles_router(
         return {"slug": slug, "deleted": True}
 
     # ---- scope catalog --------------------------------------------------
-    @router.get("/scopes", response_model=AvailableScopesResponse, response_model_exclude_none=True)
-    def list_scopes() -> AvailableScopesResponse:
-        """All scopes this AgentOS understands, in the cloud's available-scopes shape.
+    @router.get("/scopes", response_model=List[AvailableScopeItem], response_model_exclude_none=True)
+    def list_scopes() -> List[AvailableScopeItem]:
+        """All scopes this AgentOS understands, as a flat list.
 
         Derived from the OS's own route→scope map (so it always matches what the OS
-        actually enforces) plus the ``agent_os:admin`` super-scope. A self-hosted OS
-        has no org/platform layer, so ``org_scopes`` is empty and everything is an
-        ``os_scope``. Each item is parsed into ``{raw, namespace, sub_namespace,
-        permission}`` for a UI to render a resource×action grid.
+        actually enforces) plus the ``agent_os:admin`` super-scope. Each item is
+        parsed into ``{raw, namespace, sub_namespace, permission}`` for a UI to
+        render a resource×action grid. (Single OS: no org-level scopes.)
         """
         from agno.os.scopes import get_default_scope_mappings
 
         raws = {scope for required in get_default_scope_mappings().values() for scope in required}
         raws.add("agent_os:admin")
-        os_scopes = [AvailableScopeItem.from_raw(r) for r in sorted(raws)]
-        return AvailableScopesResponse(org_scopes=[], os_scopes=os_scopes)
+        return [AvailableScopeItem.from_raw(r) for r in sorted(raws)]
 
     # ---- audit ----------------------------------------------------------
     @router.get("/audit")

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -153,6 +153,15 @@ class SetRoleScopesRequest(BaseModel):
     is_default: Optional[bool] = Field(None, description="Mark as a default role")
 
 
+class CreateRoleRequest(BaseModel):
+    """Create a role — metadata only; scopes are managed via /roles/{slug}/scopes."""
+
+    slug: str = Field(..., min_length=1, description="Unique role id")
+    name: Optional[str] = Field(None, description="Display name (defaults to slug)")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
+
+
 class UpdateRoleRequest(BaseModel):
     """Metadata-only update (PATCH) — does not touch scopes."""
 
@@ -253,6 +262,18 @@ def get_roles_router(
     ):
         roles = [RoleSchema.from_record(r) for r in store.list_roles_detailed()]
         return _page(roles, page, limit)
+
+    @router.post("/roles", response_model=RoleSchema, status_code=201)
+    def create_role(body: CreateRoleRequest, actor: str = Depends(require_admin)):
+        """Create a role (metadata only — RESTful). Add permissions afterwards via
+        PUT/PATCH /roles/{slug}/scopes. Mirrors the cloud POST /roles."""
+        try:
+            store.create_role(
+                body.slug, name=body.name, description=body.description, is_default=body.is_default, actor=actor
+            )
+        except FileExistsError:
+            raise HTTPException(status_code=409, detail=f"Role {body.slug!r} already exists")
+        return RoleSchema.from_record(_role_or_404(body.slug))
 
     @router.get("/roles/{slug}", response_model=RoleSchema)
     def get_role(slug: str):

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -1,8 +1,7 @@
 """HTTP management API for :class:`ManagedRoleStore` — the governance product surface.
 
-This is the productisation of the managed-roles tier: a small, admin-only REST
-API to create roles, set their permissions (in agno scope terms), and grant or
-revoke them at runtime. Mount it on your AgentOS app:
+Admin-only REST API to create roles, set their permissions (in agno scope terms,
+with allow/deny), and grant or revoke them at runtime. Mount it on your AgentOS:
 
     from agno.os.authz.role_store import ManagedRoleStore
     from agno.os.authz.role_router import get_roles_router
@@ -11,26 +10,32 @@ revoke them at runtime. Mount it on your AgentOS app:
     app = agent_os.get_app()
     app.include_router(get_roles_router(roles))
 
-Every route requires the caller to be an admin (satisfies ``agent_os:admin``,
-whether that comes from a token scope or an admin role in the store). The JWT
-middleware still runs first, so an unauthenticated request is rejected (401)
-before these handlers; a valid-but-non-admin caller gets 403.
+Response shapes mirror the agno cloud RBAC API so a frontend can reuse its
+integration: roles are objects (slug/name/description/is_default/created_at/
+updated_at + parsed scopes), scopes are ``{raw, namespace, sub_namespace,
+permission, value}``, and list endpoints use the SDK ``PaginatedResponse``
+({data, meta}). Single-OS: scopes are a flat list (no org/os split).
+
+Every route is admin-only — admin comes from an ``agent_os:admin`` token scope OR
+an admin role in the store. Unauthenticated requests are rejected (401) by the JWT
+middleware before these handlers; a valid-but-non-admin caller gets 403.
 
 Endpoints (default prefix ``/authz``):
-    GET    /authz/roles                          list roles
-    GET    /authz/roles/{role}                   a role's scopes
-    PUT    /authz/roles/{role}                   set a role's scopes  {"scopes": [...]}
-    DELETE /authz/roles/{role}                   delete a role
+    GET    /authz/roles                          list roles (paginated)
+    GET    /authz/roles/{slug}                   a role with its scopes
+    PUT    /authz/roles/{slug}                   set scopes/metadata  {"scopes":[...]}
+    DELETE /authz/roles/{slug}                   delete a role
     GET    /authz/users/{subject}/roles          a subject's roles
     POST   /authz/users/{subject}/roles          assign a role        {"role": "..."}
     DELETE /authz/users/{subject}/roles/{role}   revoke a role
 """
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from agno.os.schema import PaginatedResponse, PaginationInfo
 from agno.os.scopes import AgentOSScope
 
 if TYPE_CHECKING:
@@ -38,8 +43,100 @@ if TYPE_CHECKING:
     from agno.os.authz.user_store import ManagedUserStore
 
 
+# --------------------------------------------------------------------- schemas
+def _parse_scope(raw: str) -> tuple:
+    """Split a scope string into (namespace, sub_namespace, permission).
+
+    ``agents:read`` -> ("agents", None, "read")
+    ``agents:*:run`` -> ("agents", "*", "run")
+    ``agent_os:admin`` -> ("agent_os", None, "admin")
+    """
+    parts = raw.split(":")
+    if len(parts) == 2:
+        return parts[0], None, parts[1]
+    if len(parts) >= 3:
+        return parts[0], ":".join(parts[1:-1]), parts[-1]
+    return (parts[0] if parts else "unknown"), None, "unknown"
+
+
+class RoleScopeSchema(BaseModel):
+    """A single permission on a role, parsed and with its allow/deny effect."""
+
+    id: Optional[str] = Field(None, description="Scope id (null — scopes aren't individually addressable here)")
+    raw: str = Field(description="Original scope string, e.g. 'agents:*:read'")
+    namespace: str = Field(description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Specific resource id or wildcard '*'")
+    permission: str = Field(description="Action, e.g. 'read' / 'run' / 'write'")
+    value: str = Field(description="'allow' or 'deny'")
+
+    @classmethod
+    def from_entry(cls, entry: dict) -> "RoleScopeSchema":
+        ns, sub, perm = _parse_scope(entry["scope"])
+        return cls(raw=entry["scope"], namespace=ns, sub_namespace=sub, permission=perm, value=entry.get("effect", "allow"))
+
+
+class RoleSchema(BaseModel):
+    """A role with its scopes — mirrors the cloud RoleWithScopes shape (flattened)."""
+
+    slug: str = Field(description="Unique role id")
+    name: str = Field(description="Human-readable display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: bool = Field(False, description="Whether this is a built-in default role")
+    created_at: Optional[int] = Field(None, description="Created (epoch seconds)")
+    updated_at: Optional[int] = Field(None, description="Last updated (epoch seconds)")
+    scopes: List[RoleScopeSchema] = Field(default_factory=list, description="Permissions on this role")
+
+    @classmethod
+    def from_record(cls, rec: dict) -> "RoleSchema":
+        return cls(
+            slug=rec["slug"],
+            name=rec.get("name") or rec["slug"],
+            description=rec.get("description"),
+            is_default=bool(rec.get("is_default", False)),
+            created_at=rec.get("created_at") or None,
+            updated_at=rec.get("updated_at") or None,
+            scopes=[RoleScopeSchema.from_entry(e) for e in rec.get("scopes", [])],
+        )
+
+
+class AuthzUserSchema(BaseModel):
+    """A directory user with roles merged in."""
+
+    id: str = Field(description="User id (the JWT 'sub')")
+    email: Optional[str] = None
+    name: Optional[str] = None
+    status: str = Field(description="'active' or 'disabled'")
+    disabled: bool = False
+    roles: List[str] = Field(default_factory=list, description="Roles assigned to this user")
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
+
+    @classmethod
+    def from_user(cls, user: dict, roles: List[str]) -> "AuthzUserSchema":
+        return cls(
+            id=user["id"],
+            email=user.get("email"),
+            name=user.get("name"),
+            status="disabled" if user.get("disabled") else "active",
+            disabled=bool(user.get("disabled")),
+            roles=roles,
+            created_at=user.get("created_at"),
+            updated_at=user.get("updated_at"),
+        )
+
+
+class ScopeItem(BaseModel):
+    scope: str = Field(description="Scope string, e.g. 'agents:*:read'")
+    effect: str = Field("allow", description="'allow' or 'deny'")
+
+
 class SetRoleScopesRequest(BaseModel):
-    scopes: List[str] = Field(..., description="Permissions in agno scope terms, e.g. ['agents:*:read']")
+    scopes: List[Union[str, ScopeItem]] = Field(
+        ..., description="Permissions: strings (allow) or {scope, effect} objects"
+    )
+    name: Optional[str] = Field(None, description="Display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
 
 
 class AssignRoleRequest(BaseModel):
@@ -55,6 +152,21 @@ class CreateUserRequest(BaseModel):
 class UpdateUserRequest(BaseModel):
     email: Optional[str] = Field(None, description="New email")
     name: Optional[str] = Field(None, description="New display name")
+
+
+def _page(items: list, page: int, limit: int) -> PaginatedResponse:
+    """Wrap a fully-materialised list in the SDK's PaginatedResponse ({data, meta})."""
+    total = len(items)
+    start = max(page - 1, 0) * limit
+    return PaginatedResponse(
+        data=items[start : start + limit],
+        meta=PaginationInfo(
+            page=page,
+            limit=limit,
+            total_count=total,
+            total_pages=(total + limit - 1) // limit if limit > 0 else 0,
+        ),
+    )
 
 
 def get_roles_router(
@@ -90,27 +202,40 @@ def get_roles_router(
 
     router = APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_admin)])
 
+    def _role_or_404(slug: str) -> dict:
+        rec = store.get_role(slug)
+        if rec is None:
+            raise HTTPException(status_code=404, detail=f"Role {slug!r} not found")
+        return rec
+
     # ---- roles ----------------------------------------------------------
-    @router.get("/roles")
-    def list_roles() -> dict:
-        return {"roles": store.list_roles()}
+    @router.get("/roles", response_model=PaginatedResponse[RoleSchema])
+    def list_roles(
+        limit: int = Query(default=20, ge=1, description="Items per page"),
+        page: int = Query(default=1, ge=0, description="Page number"),
+    ):
+        roles = [RoleSchema.from_record(r) for r in store.list_roles_detailed()]
+        return _page(roles, page, limit)
 
-    @router.get("/roles/{role}")
-    def get_role(role: str) -> dict:
-        return {"role": role, "scopes": store.get_role_scopes(role)}
+    @router.get("/roles/{slug}", response_model=RoleSchema)
+    def get_role(slug: str):
+        return RoleSchema.from_record(_role_or_404(slug))
 
-    @router.put("/roles/{role}")
-    def set_role(role: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)) -> dict:
+    @router.put("/roles/{slug}", response_model=RoleSchema)
+    def set_role(slug: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)):
+        scopes = [s if isinstance(s, str) else {"scope": s.scope, "effect": s.effect} for s in body.scopes]
         try:
-            store.set_role_scopes(role, body.scopes, actor=actor)
+            store.set_role_scopes(
+                slug, scopes, actor=actor, name=body.name, description=body.description, is_default=body.is_default
+            )
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
-        return {"role": role, "scopes": store.get_role_scopes(role)}
+        return RoleSchema.from_record(_role_or_404(slug))
 
-    @router.delete("/roles/{role}")
-    def delete_role(role: str, actor: str = Depends(require_admin)) -> dict:
-        store.remove_role(role, actor=actor)
-        return {"role": role, "deleted": True}
+    @router.delete("/roles/{slug}")
+    def delete_role(slug: str, actor: str = Depends(require_admin)) -> dict:
+        store.remove_role(slug, actor=actor)
+        return {"slug": slug, "deleted": True}
 
     # ---- scope catalog --------------------------------------------------
     @router.get("/scopes")
@@ -173,44 +298,46 @@ def get_roles_router(
     # the app's JWT; this is a directory + revocation switch, never credentials.
     if user_store is not None:
 
-        def _with_roles(user: dict) -> dict:
-            return {**user, "roles": store.roles_of(user["id"])}
+        def _user(user: dict) -> AuthzUserSchema:
+            return AuthzUserSchema.from_user(user, store.roles_of(user["id"]))
 
-        @router.get("/users")
-        def list_users(include_disabled: bool = True, limit: int = 1000) -> dict:
-            """All users in the directory (newest first), each with their roles."""
-            return {"users": [_with_roles(u) for u in user_store.list(limit=limit, include_disabled=include_disabled)]}
+        @router.get("/users", response_model=PaginatedResponse[AuthzUserSchema])
+        def list_users(
+            include_disabled: bool = True,
+            limit: int = Query(default=20, ge=1, description="Items per page"),
+            page: int = Query(default=1, ge=0, description="Page number"),
+        ):
+            users = [_user(u) for u in user_store.list(limit=100000, include_disabled=include_disabled)]
+            return _page(users, page, limit)
 
-        @router.post("/users")
-        def create_user(body: CreateUserRequest, actor: str = Depends(require_admin)) -> dict:
-            user = user_store.upsert(body.id, email=body.email, name=body.name, actor=actor)
-            return _with_roles(user)
+        @router.post("/users", response_model=AuthzUserSchema)
+        def create_user(body: CreateUserRequest, actor: str = Depends(require_admin)):
+            return _user(user_store.upsert(body.id, email=body.email, name=body.name, actor=actor))
 
-        @router.get("/users/{user_id}")
-        def get_user(user_id: str) -> dict:
+        @router.get("/users/{user_id}", response_model=AuthzUserSchema)
+        def get_user(user_id: str):
             user = user_store.get(user_id)
             if user is None:
                 raise HTTPException(status_code=404, detail=f"User {user_id!r} not found")
-            return _with_roles(user)
+            return _user(user)
 
-        @router.patch("/users/{user_id}")
-        def update_user(user_id: str, body: UpdateUserRequest, actor: str = Depends(require_admin)) -> dict:
-            user = user_store.upsert(user_id, email=body.email, name=body.name, actor=actor)
-            return _with_roles(user)
+        @router.patch("/users/{user_id}", response_model=AuthzUserSchema)
+        def update_user(user_id: str, body: UpdateUserRequest, actor: str = Depends(require_admin)):
+            return _user(user_store.upsert(user_id, email=body.email, name=body.name, actor=actor))
 
         @router.delete("/users/{user_id}")
         def delete_user(user_id: str, actor: str = Depends(require_admin)) -> dict:
             deleted = user_store.remove(user_id, actor=actor)
             return {"id": user_id, "deleted": deleted}
 
-        @router.post("/users/{user_id}/disable")
-        def disable_user(user_id: str, actor: str = Depends(require_admin)) -> dict:
+        @router.post("/users/{user_id}/disable", response_model=AuthzUserSchema)
+        def disable_user(user_id: str, actor: str = Depends(require_admin)):
             """Revoke a user: they are denied at the enforcement point on their next
             request, even with a still-valid token."""
-            return _with_roles(user_store.set_disabled(user_id, True, actor=actor))
+            return _user(user_store.set_disabled(user_id, True, actor=actor))
 
-        @router.post("/users/{user_id}/enable")
-        def enable_user(user_id: str, actor: str = Depends(require_admin)) -> dict:
-            return _with_roles(user_store.set_disabled(user_id, False, actor=actor))
+        @router.post("/users/{user_id}/enable", response_model=AuthzUserSchema)
+        def enable_user(user_id: str, actor: str = Depends(require_admin)):
+            return _user(user_store.set_disabled(user_id, False, actor=actor))
 
     return router

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -153,6 +153,29 @@ class SetRoleScopesRequest(BaseModel):
     is_default: Optional[bool] = Field(None, description="Mark as a default role")
 
 
+class UpdateRoleRequest(BaseModel):
+    """Metadata-only update (PATCH) — does not touch scopes."""
+
+    name: Optional[str] = Field(None, description="Display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
+
+
+class ReplaceScopesRequest(BaseModel):
+    """Full replace of a role's scopes (PUT /roles/{slug}/scopes)."""
+
+    scopes: List[Union[str, ScopeItem]] = Field(
+        ..., description="Permissions: strings (allow) or {scope, effect} objects"
+    )
+
+
+class PatchScopesRequest(BaseModel):
+    """Scope diff (PATCH /roles/{slug}/scopes): add/flip ``upsert``, drop ``remove``."""
+
+    upsert: List[Union[str, ScopeItem]] = Field(default_factory=list, description="Scopes to add or flip")
+    remove: List[Union[str, ScopeItem]] = Field(default_factory=list, description="Scopes to remove (effect ignored)")
+
+
 class AssignRoleRequest(BaseModel):
     role: str = Field(..., description="Role to grant the subject")
 
@@ -246,10 +269,50 @@ def get_roles_router(
             raise HTTPException(status_code=422, detail=str(e))
         return RoleSchema.from_record(_role_or_404(slug))
 
+    @router.patch("/roles/{slug}", response_model=RoleSchema)
+    def update_role(slug: str, body: UpdateRoleRequest, actor: str = Depends(require_admin)):
+        """Update a role's metadata only (name/description/is_default) — scopes
+        untouched. Mirrors the cloud PATCH /roles/{slug}."""
+        try:
+            store.set_role_meta(
+                slug, name=body.name, description=body.description, is_default=body.is_default, actor=actor
+            )
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"Role {slug!r} not found")
+        return RoleSchema.from_record(_role_or_404(slug))
+
     @router.delete("/roles/{slug}")
     def delete_role(slug: str, actor: str = Depends(require_admin)) -> dict:
         store.remove_role(slug, actor=actor)
         return {"slug": slug, "deleted": True}
+
+    # ---- role scopes (subresource) -------------------------------------
+    def _to_store_scopes(items):
+        return [s if isinstance(s, str) else {"scope": s.scope, "effect": s.effect} for s in items]
+
+    @router.put("/roles/{slug}/scopes", response_model=List[RoleScopeSchema])
+    def replace_role_scopes(slug: str, body: ReplaceScopesRequest, actor: str = Depends(require_admin)):
+        """Replace ALL of a role's scopes (metadata preserved). Mirrors the cloud
+        PUT /roles/{slug}/scopes; returns the resulting scope list."""
+        _role_or_404(slug)
+        try:
+            store.set_role_scopes(slug, _to_store_scopes(body.scopes), actor=actor)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return [RoleScopeSchema.from_entry(e) for e in store.get_role_scope_entries(slug)]
+
+    @router.patch("/roles/{slug}/scopes", response_model=RoleSchema)
+    def patch_role_scopes(slug: str, body: PatchScopesRequest, actor: str = Depends(require_admin)):
+        """Apply a scope diff: add/flip ``upsert``, drop ``remove`` (everything else
+        kept). Mirrors the cloud PATCH /roles/{slug}/scopes; returns the full role."""
+        _role_or_404(slug)
+        try:
+            store.patch_role_scopes(
+                slug, upsert=_to_store_scopes(body.upsert), remove=_to_store_scopes(body.remove), actor=actor
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return RoleSchema.from_record(_role_or_404(slug))
 
     # ---- scope catalog --------------------------------------------------
     @router.get("/scopes", response_model=List[AvailableScopeItem], response_model_exclude_none=True)

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -125,6 +125,31 @@ class AuthzUserSchema(BaseModel):
         )
 
 
+class AvailableScopeItem(BaseModel):
+    """One scope the OS understands (catalog entry — no effect/id, just the shape)."""
+
+    raw: str = Field(description="Scope string, e.g. 'agents:read'")
+    namespace: str = Field(description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Sub-namespace if present")
+    permission: str = Field(description="Action/permission, e.g. 'read'")
+
+    @classmethod
+    def from_raw(cls, raw: str) -> "AvailableScopeItem":
+        ns, sub, perm = _parse_scope(raw)
+        return cls(raw=raw, namespace=ns, sub_namespace=sub, permission=perm)
+
+
+class AvailableScopesResponse(BaseModel):
+    """Available scopes grouped by org and OS level (mirrors the cloud API).
+
+    A self-hosted OS has no org/platform layer, so ``org_scopes`` is empty and
+    everything the OS enforces lives in ``os_scopes``.
+    """
+
+    org_scopes: List[AvailableScopeItem] = Field(default_factory=list, description="Organization-level scopes")
+    os_scopes: List[AvailableScopeItem] = Field(default_factory=list, description="OS-level scopes")
+
+
 class ScopeItem(BaseModel):
     scope: str = Field(description="Scope string, e.g. 'agents:*:read'")
     effect: str = Field("allow", description="'allow' or 'deny'")
@@ -238,26 +263,22 @@ def get_roles_router(
         return {"slug": slug, "deleted": True}
 
     # ---- scope catalog --------------------------------------------------
-    @router.get("/scopes")
-    def list_scopes() -> dict:
-        """The catalog of scopes this AgentOS understands, grouped by resource.
+    @router.get("/scopes", response_model=AvailableScopesResponse, response_model_exclude_none=True)
+    def list_scopes() -> AvailableScopesResponse:
+        """All scopes this AgentOS understands, in the cloud's available-scopes shape.
 
-        Derived from the OS's own route→scope map, so it always matches what the
-        OS actually enforces. A UI renders this as a resource×action grid; a role
-        is then just a set of the resulting ``resource:action`` strings (plus the
-        ``agent_os:admin`` super-scope).
+        Derived from the OS's own route→scope map (so it always matches what the OS
+        actually enforces) plus the ``agent_os:admin`` super-scope. A self-hosted OS
+        has no org/platform layer, so ``org_scopes`` is empty and everything is an
+        ``os_scope``. Each item is parsed into ``{raw, namespace, sub_namespace,
+        permission}`` for a UI to render a resource×action grid.
         """
         from agno.os.scopes import get_default_scope_mappings
 
-        grouped: dict = {}
-        for required in get_default_scope_mappings().values():
-            for scope in required:
-                parts = scope.split(":")
-                if len(parts) == 2:
-                    grouped.setdefault(parts[0], set()).add(parts[1])
-        grouped_sorted = {r: sorted(a) for r, a in sorted(grouped.items())}
-        flat = sorted(f"{r}:{a}" for r, acts in grouped_sorted.items() for a in acts)
-        return {"grouped": grouped_sorted, "scopes": flat, "admin_scope": "agent_os:admin"}
+        raws = {scope for required in get_default_scope_mappings().values() for scope in required}
+        raws.add("agent_os:admin")
+        os_scopes = [AvailableScopeItem.from_raw(r) for r in sorted(raws)]
+        return AvailableScopesResponse(org_scopes=[], os_scopes=os_scopes)
 
     # ---- audit ----------------------------------------------------------
     @router.get("/audit")

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -321,6 +321,22 @@ class ManagedRoleStore:
                 entries.append({"scope": _obj_act_to_scope(p[1], p[2]), "effect": effect})
         return sorted(entries, key=lambda e: (e["scope"], e["effect"]))
 
+    def create_role(
+        self,
+        role: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Create a role with metadata only — no scopes (add those via
+        set_role_scopes / patch_role_scopes). Raises FileExistsError if it exists."""
+        if self.get_role(role) is not None:
+            raise FileExistsError(role)
+        rec = self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.created", role, None, [self._meta_summary(rec)], actor)
+        return rec
+
     def set_role_meta(
         self,
         role: str,

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -30,7 +30,8 @@ Example::
     store.unassign("bob", "member")
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from agno.os.authz._db import engine_from_db as _engine_from_db
 from agno.os.authz.casbin_provider import scope_to_obj_act
@@ -38,18 +39,42 @@ from agno.os.authz.casbin_provider import scope_to_obj_act
 if TYPE_CHECKING:
     from agno.os.authz.audit import AuditSink
 
+# Policies carry an effect (``eft``) so a role can explicitly DENY a scope, not
+# just grant it. Deny overrides allow (``some(allow) && !some(deny)``), matching
+# the cloud RBAC semantics where a scope's ``value`` is allow|deny.
 _MODEL_TEXT = """
 [request_definition]
 r = sub, obj, act
 [policy_definition]
-p = sub, obj, act
+p = sub, obj, act, eft
 [role_definition]
 g = _, _
 [policy_effect]
-e = some(where (p.eft == allow))
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 [matchers]
 m = g(r.sub, p.sub) && (p.obj == "*" || keyMatch2(r.obj, p.obj)) && (p.act == "*" || r.act == p.act)
 """
+
+# A scope plus its effect. Inputs accept a bare string (= allow), a (scope, effect)
+# tuple, or a {"scope": ..., "effect"|"value": ...} dict.
+ScopeInput = Union[str, Tuple[str, str], Dict[str, str]]
+
+
+def _normalize_scope(entry: ScopeInput) -> Tuple[str, str]:
+    """Coerce a scope input into ``(scope, effect)`` with effect in {allow, deny}."""
+    if isinstance(entry, str):
+        scope, effect = entry, "allow"
+    elif isinstance(entry, dict):
+        scope = entry.get("scope") or entry.get("raw")  # type: ignore[assignment]
+        effect = entry.get("effect") or entry.get("value") or "allow"
+    else:  # tuple/list
+        scope, effect = entry[0], (entry[1] if len(entry) > 1 else "allow")
+    if not scope:
+        raise ValueError(f"Unrecognised scope entry: {entry!r}")
+    effect = str(effect).lower()
+    if effect not in ("allow", "deny"):
+        raise ValueError(f"scope effect must be 'allow' or 'deny', got {effect!r}")
+    return scope, effect
 
 
 def _obj_act_to_scope(obj: str, act: str) -> str:
@@ -123,6 +148,21 @@ class ManagedRoleStore:
         self._roles_claim = roles_claim
         self._audit = audit
 
+        # Role metadata (display name / description / is_default / timestamps).
+        # Casbin only stores policies, so metadata needs its own table; reuse the
+        # same DB when one is configured, else keep it in memory.
+        self._meta_mem: Optional[Dict[str, dict]] = None
+        self._meta_engine = None
+        self._meta_table = None
+        if db is not None:
+            self._init_meta_table(_engine_from_db(db))
+        elif db_url is not None:
+            import sqlalchemy as sa
+
+            self._init_meta_table(sa.create_engine(db_url))
+        else:
+            self._meta_mem = {}
+
         if decision_log:
             import logging
 
@@ -154,30 +194,164 @@ class ManagedRoleStore:
             )
         )
 
+    # --------------------------------------------------------- role metadata
+    def _init_meta_table(self, engine: Any) -> None:
+        import sqlalchemy as sa
+
+        self._meta_engine = engine
+        metadata = sa.MetaData()
+        self._meta_table = sa.Table(
+            "authz_roles",
+            metadata,
+            sa.Column("slug", sa.String(255), primary_key=True),  # = the role id/name
+            sa.Column("name", sa.String(255)),  # human-readable display name
+            sa.Column("description", sa.Text),
+            sa.Column("is_default", sa.Boolean, nullable=False, default=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
+            sa.Column("updated_at", sa.Integer, nullable=False),
+        )
+        metadata.create_all(self._meta_engine)
+
+    def _meta_get(self, slug: str) -> Optional[dict]:
+        if self._meta_mem is not None:
+            row = self._meta_mem.get(slug)
+            return dict(row) if row else None
+        import sqlalchemy as sa
+
+        with self._meta_engine.connect() as conn:  # type: ignore[union-attr]
+            r = conn.execute(sa.select(self._meta_table).where(self._meta_table.c.slug == slug)).mappings().first()  # type: ignore[union-attr]
+        return dict(r) if r else None
+
+    def _meta_upsert(
+        self,
+        slug: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+    ) -> dict:
+        existing = self._meta_get(slug)
+        now = int(time.time())
+        if existing is None:
+            row = {
+                "slug": slug,
+                "name": name or slug,
+                "description": description,
+                "is_default": bool(is_default) if is_default is not None else False,
+                "created_at": now,
+                "updated_at": now,
+            }
+        else:
+            row = dict(existing)
+            if name is not None:
+                row["name"] = name
+            if description is not None:
+                row["description"] = description
+            if is_default is not None:
+                row["is_default"] = bool(is_default)
+            row["updated_at"] = now
+        self._meta_write(row, insert=existing is None)
+        return row
+
+    def _meta_write(self, row: dict, insert: bool) -> None:
+        if self._meta_mem is not None:
+            self._meta_mem[row["slug"]] = dict(row)
+            return
+        import sqlalchemy as sa
+
+        with self._meta_engine.begin() as conn:  # type: ignore[union-attr]
+            if insert:
+                conn.execute(sa.insert(self._meta_table).values(**row))  # type: ignore[union-attr]
+            else:
+                conn.execute(sa.update(self._meta_table).where(self._meta_table.c.slug == row["slug"]).values(**row))  # type: ignore[union-attr]
+
+    def _meta_delete(self, slug: str) -> None:
+        if self._meta_mem is not None:
+            self._meta_mem.pop(slug, None)
+            return
+        import sqlalchemy as sa
+
+        with self._meta_engine.begin() as conn:  # type: ignore[union-attr]
+            conn.execute(sa.delete(self._meta_table).where(self._meta_table.c.slug == slug))  # type: ignore[union-attr]
+
+    def _meta_or_default(self, slug: str) -> dict:
+        """Metadata for a role, synthesising defaults for rows defined before
+        metadata existed (or via the raw enforcer)."""
+        meta = self._meta_get(slug)
+        if meta is not None:
+            return meta
+        return {"slug": slug, "name": slug, "description": None, "is_default": False, "created_at": 0, "updated_at": 0}
+
     # ------------------------------------------------------------------ roles
-    def set_role_scopes(self, role: str, scopes: List[str], actor: Optional[str] = None) -> None:
-        """Define (or replace) what a role can do, in agno scope terms."""
+    def set_role_scopes(
+        self,
+        role: str,
+        scopes: List[ScopeInput],
+        actor: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+    ) -> None:
+        """Define (or replace) what a role can do, in agno scope terms.
+
+        ``scopes`` items may be plain strings (granted/allow), ``(scope, effect)``
+        tuples, or ``{"scope": ..., "effect": "allow"|"deny"}`` dicts. Also creates
+        / updates the role's metadata (display ``name`` / ``description`` /
+        ``is_default``)."""
         before = self.get_role_scopes(role) if self._audit else None
         self._enforcer.remove_filtered_policy(0, role)
-        for scope in scopes:
+        for entry in scopes:
+            scope, effect = _normalize_scope(entry)
             obj, act = scope_to_obj_act(scope)
-            self._enforcer.add_policy(role, obj, act)
+            self._enforcer.add_policy(role, obj, act, effect)
+        self._meta_upsert(role, name=name, description=description, is_default=is_default)
         self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
 
     def get_role_scopes(self, role: str) -> List[str]:
-        """Return a role's scopes in agno terms (best-effort read-back)."""
+        """Return a role's scope strings (allow + deny), for display/read-back."""
         return sorted(
             _obj_act_to_scope(p[1], p[2]) for p in self._enforcer.get_filtered_policy(0, role) if len(p) >= 3
         )
+
+    def get_role_scope_entries(self, role: str) -> List[dict]:
+        """Return a role's scopes with effects: ``[{"scope": ..., "effect": ...}]``."""
+        entries = []
+        for p in self._enforcer.get_filtered_policy(0, role):
+            if len(p) >= 3:
+                effect = p[3] if len(p) >= 4 else "allow"
+                entries.append({"scope": _obj_act_to_scope(p[1], p[2]), "effect": effect})
+        return sorted(entries, key=lambda e: (e["scope"], e["effect"]))
+
+    def get_role(self, role: str) -> Optional[dict]:
+        """Full role record: metadata + scope entries, or None if the role has
+        neither policies nor metadata."""
+        scopes = self.get_role_scope_entries(role)
+        meta = self._meta_get(role)
+        if meta is None and not scopes:
+            return None
+        return {**self._meta_or_default(role), "scopes": scopes}
 
     def remove_role(self, role: str, actor: Optional[str] = None) -> None:
         before = self.get_role_scopes(role) if self._audit else None
         self._enforcer.remove_filtered_policy(0, role)
         self._enforcer.remove_filtered_grouping_policy(1, role)
+        self._meta_delete(role)
         self._emit("role.removed", role, before, None, actor)
 
     def list_roles(self) -> List[str]:
-        return sorted({p[0] for p in self._enforcer.get_policy()})
+        """All role slugs (those with policies and/or metadata)."""
+        slugs = {p[0] for p in self._enforcer.get_policy()}
+        if self._meta_mem is not None:
+            slugs |= set(self._meta_mem.keys())
+        elif self._meta_engine is not None:
+            import sqlalchemy as sa
+
+            with self._meta_engine.connect() as conn:
+                slugs |= {r[0] for r in conn.execute(sa.select(self._meta_table.c.slug))}  # type: ignore[union-attr]
+        return sorted(slugs)
+
+    def list_roles_detailed(self) -> List[dict]:
+        """Every role as a full record (metadata + scope entries)."""
+        return [self.get_role(slug) for slug in self.list_roles()]  # type: ignore[misc]
 
     # ------------------------------------------------------------- assignments
     def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -222,6 +222,17 @@ class ManagedRoleStore:
             r = conn.execute(sa.select(self._meta_table).where(self._meta_table.c.slug == slug)).mappings().first()  # type: ignore[union-attr]
         return dict(r) if r else None
 
+    def _meta_get_all(self) -> dict:
+        """All metadata rows as ``{slug: row}`` in a single read, so list views
+        don't do one SELECT per role (N+1)."""
+        if self._meta_mem is not None:
+            return {slug: dict(row) for slug, row in self._meta_mem.items()}
+        import sqlalchemy as sa
+
+        with self._meta_engine.connect() as conn:  # type: ignore[union-attr]
+            rows = conn.execute(sa.select(self._meta_table)).mappings().all()  # type: ignore[union-attr]
+        return {r["slug"]: dict(r) for r in rows}
+
     def _meta_upsert(
         self,
         slug: str,
@@ -297,14 +308,16 @@ class ManagedRoleStore:
         tuples, or ``{"scope": ..., "effect": "allow"|"deny"}`` dicts. Also creates
         / updates the role's metadata (display ``name`` / ``description`` /
         ``is_default``)."""
-        before = self.get_role_scopes(role) if self._audit else None
+        # Audit the full entries (scope + effect) so an allow<->deny flip is visible
+        # in the trail; plain scope strings would show no change.
+        before = self.get_role_scope_entries(role) if self._audit else None
         self._enforcer.remove_filtered_policy(0, role)
         for entry in scopes:
             scope, effect = _normalize_scope(entry)
             obj, act = scope_to_obj_act(scope)
             self._enforcer.add_policy(role, obj, act, effect)
         self._meta_upsert(role, name=name, description=description, is_default=is_default)
-        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+        self._emit("role.set_scopes", role, before, self.get_role_scope_entries(role) if self._audit else None, actor)
 
     def get_role_scopes(self, role: str) -> List[str]:
         """Return a role's scope strings (allow + deny), for display/read-back."""
@@ -363,7 +376,7 @@ class ManagedRoleStore:
     ) -> None:
         """Apply a scope diff: add/flip the ``upsert`` scopes and drop the ``remove``
         scopes, leaving every other scope (and the metadata) intact."""
-        before = self.get_role_scopes(role) if self._audit else None
+        before = self.get_role_scope_entries(role) if self._audit else None
         for entry in upsert or []:
             scope, effect = _normalize_scope(entry)
             obj, act = scope_to_obj_act(scope)
@@ -374,7 +387,7 @@ class ManagedRoleStore:
             obj, act = scope_to_obj_act(scope)
             self._enforcer.remove_filtered_policy(0, role, obj, act)
         self._meta_upsert(role)  # touch updated_at / ensure metadata row exists
-        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+        self._emit("role.set_scopes", role, before, self.get_role_scope_entries(role) if self._audit else None, actor)
 
     @staticmethod
     def _meta_summary(rec: dict) -> str:
@@ -414,8 +427,16 @@ class ManagedRoleStore:
         return sorted(slugs)
 
     def list_roles_detailed(self) -> List[dict]:
-        """Every role as a full record (metadata + scope entries)."""
-        return [self.get_role(slug) for slug in self.list_roles()]  # type: ignore[misc]
+        """Every role as a full record (metadata + scope entries).
+
+        Metadata is fetched in one read (not one SELECT per role)."""
+        meta_all = self._meta_get_all()
+        default = {"name": None, "description": None, "is_default": False, "created_at": 0, "updated_at": 0}
+        out: List[dict] = []
+        for slug in self.list_roles():
+            meta = meta_all.get(slug) or {"slug": slug, **default, "name": slug}
+            out.append({**meta, "scopes": self.get_role_scope_entries(slug)})
+        return out
 
     # ------------------------------------------------------------- assignments
     def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -321,6 +321,54 @@ class ManagedRoleStore:
                 entries.append({"scope": _obj_act_to_scope(p[1], p[2]), "effect": effect})
         return sorted(entries, key=lambda e: (e["scope"], e["effect"]))
 
+    def set_role_meta(
+        self,
+        role: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Update ONLY a role's metadata (display name / description / is_default),
+        leaving its scopes untouched. Raises KeyError if the role doesn't exist."""
+        if self.get_role(role) is None:
+            raise KeyError(role)
+        before = self._meta_or_default(role)
+        rec = self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.updated", role, [self._meta_summary(before)], [self._meta_summary(rec)], actor)
+        return rec
+
+    def patch_role_scopes(
+        self,
+        role: str,
+        upsert: Optional[List[ScopeInput]] = None,
+        remove: Optional[List[ScopeInput]] = None,
+        actor: Optional[str] = None,
+    ) -> None:
+        """Apply a scope diff: add/flip the ``upsert`` scopes and drop the ``remove``
+        scopes, leaving every other scope (and the metadata) intact."""
+        before = self.get_role_scopes(role) if self._audit else None
+        for entry in upsert or []:
+            scope, effect = _normalize_scope(entry)
+            obj, act = scope_to_obj_act(scope)
+            self._enforcer.remove_filtered_policy(0, role, obj, act)  # drop any prior effect
+            self._enforcer.add_policy(role, obj, act, effect)
+        for entry in remove or []:
+            scope, _ = _normalize_scope(entry)
+            obj, act = scope_to_obj_act(scope)
+            self._enforcer.remove_filtered_policy(0, role, obj, act)
+        self._meta_upsert(role)  # touch updated_at / ensure metadata row exists
+        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+
+    @staticmethod
+    def _meta_summary(rec: dict) -> str:
+        bits = [rec.get("name") or rec["slug"]]
+        if rec.get("description"):
+            bits.append(str(rec["description"]))
+        if rec.get("is_default"):
+            bits.append("default")
+        return " · ".join(bits)
+
     def get_role(self, role: str) -> Optional[dict]:
         """Full role record: metadata + scope entries, or None if the role has
         neither policies nor metadata."""

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -187,3 +187,48 @@ def test_management_helpers():
     assert set(store.roles_of("bob")) == {"a", "b"}
     store.unassign("bob", "a")
     assert store.roles_of("bob") == ["b"]
+
+
+# --------------------------------------------------------- metadata + effects
+def test_role_metadata_is_tracked():
+    store = ManagedRoleStore()
+    store.set_role_scopes("viewer", ["agents:*:read"], name="Viewer", description="read-only")
+
+    rec = store.get_role("viewer")
+    assert rec["slug"] == "viewer"
+    assert rec["name"] == "Viewer"
+    assert rec["description"] == "read-only"
+    assert rec["is_default"] is False
+    assert rec["created_at"] > 0 and rec["updated_at"] >= rec["created_at"]
+    assert rec["scopes"] == [{"scope": "agents:read", "effect": "allow"}]
+
+    # list_roles_detailed returns full records
+    slugs = {r["slug"] for r in store.list_roles_detailed()}
+    assert "viewer" in slugs
+
+    # get_role for an unknown role is None
+    assert store.get_role("ghost") is None
+
+
+def test_allow_deny_effect_overrides():
+    """A deny scope overrides an allow for the same action (deny-overrides)."""
+    store = ManagedRoleStore()
+    # member can read any agent, but is explicitly denied reading the secret one
+    store.set_role_scopes(
+        "member",
+        ["agents:*:read", {"scope": "agents:secret-agent:read", "effect": "deny"}],
+    )
+    store.assign("bob", "member")
+    prov = store.provider
+
+    from agno.os.authz.provider import AuthorizationContext
+
+    ok = AuthorizationContext(principal_id="bob", resource_type="agents", resource_id="public-agent", action="read")
+    denied = AuthorizationContext(principal_id="bob", resource_type="agents", resource_id="secret-agent", action="read")
+    assert prov.check(ok) is True
+    assert prov.check(denied) is False  # deny wins
+
+    # the deny is reflected in the read-back entries, and excluded from accessible ids
+    entries = {(e["scope"], e["effect"]) for e in store.get_role_scope_entries("member")}
+    assert ("agents:read", "allow") in entries
+    assert ("agents:secret-agent:read", "deny") in entries

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -206,3 +206,57 @@ def test_admin_via_token_claim_can_manage():
 
     assert client.get("/authz/roles", headers=admin_h).status_code == 200
     assert client.get("/authz/roles", headers=viewer_h).status_code == 403
+
+
+def test_patch_role_metadata_only(client_and_store):
+    """PATCH /roles/{slug} updates name/description without touching scopes."""
+    client, store = client_and_store
+    client.put("/authz/roles/editor", headers=_auth("alice"), json={"scopes": ["agents:*:read"], "name": "Editor"})
+
+    r = client.patch("/authz/roles/editor", headers=_auth("alice"), json={"description": "can edit things"})
+    assert r.status_code == 200, r.text
+    role = r.json()
+    assert role["name"] == "Editor" and role["description"] == "can edit things"
+    # scopes untouched by the metadata patch
+    assert [s["raw"] for s in role["scopes"]] == ["agents:read"]
+
+    # patching a non-existent role -> 404
+    assert client.patch("/authz/roles/ghost", headers=_auth("alice"), json={"name": "x"}).status_code == 404
+
+
+def test_put_scopes_subresource_replaces(client_and_store):
+    """PUT /roles/{slug}/scopes replaces scopes, preserves metadata, returns scopes."""
+    client, store = client_and_store
+    client.put("/authz/roles/editor", headers=_auth("alice"), json={"scopes": ["agents:*:read"], "name": "Editor"})
+
+    r = client.put(
+        "/authz/roles/editor/scopes",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:run", {"scope": "agents:secret:run", "effect": "deny"}]},
+    )
+    assert r.status_code == 200, r.text
+    scopes = r.json()  # returns the scope list
+    by_raw = {s["raw"]: s for s in scopes}
+    assert by_raw["agents:run"]["value"] == "allow"
+    assert by_raw["agents:secret:run"]["value"] == "deny"
+    # metadata (name) preserved through a scopes-only replace
+    assert client.get("/authz/roles/editor", headers=_auth("alice")).json()["name"] == "Editor"
+
+
+def test_patch_scopes_subresource_diffs(client_and_store):
+    """PATCH /roles/{slug}/scopes adds/flips upsert and drops remove, keeping the rest."""
+    client, store = client_and_store
+    client.put(
+        "/authz/roles/editor",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:read", "teams:*:read"]},
+    )
+
+    r = client.patch(
+        "/authz/roles/editor/scopes",
+        headers=_auth("alice"),
+        json={"upsert": [{"scope": "agents:*:run", "effect": "allow"}], "remove": ["teams:read"]},
+    )
+    assert r.status_code == 200, r.text
+    raws = {s["raw"] for s in r.json()["scopes"]}
+    assert raws == {"agents:read", "agents:run"}  # teams:read removed, agents:run added, agents:read kept

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -260,3 +260,24 @@ def test_patch_scopes_subresource_diffs(client_and_store):
     assert r.status_code == 200, r.text
     raws = {s["raw"] for s in r.json()["scopes"]}
     assert raws == {"agents:read", "agents:run"}  # teams:read removed, agents:run added, agents:read kept
+
+
+def test_create_role_metadata_only_then_add_scopes(client_and_store):
+    """POST /roles creates a role with NO scopes (RESTful); scopes are added
+    separately via the /scopes subresource."""
+    client, store = client_and_store
+
+    r = client.post("/authz/roles", headers=_auth("alice"), json={"slug": "support", "name": "Support"})
+    assert r.status_code == 201, r.text
+    role = r.json()
+    assert role["slug"] == "support" and role["name"] == "Support" and role["scopes"] == []
+
+    # creating the same role again -> 409
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "support"}).status_code == 409
+
+    # add permissions via the subresource
+    r = client.put("/authz/roles/support/scopes", headers=_auth("alice"), json={"scopes": ["sessions:read"]})
+    assert r.status_code == 200
+    assert [s["raw"] for s in client.get("/authz/roles/support", headers=_auth("alice")).json()["scopes"]] == [
+        "sessions:read"
+    ]

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -79,11 +79,25 @@ def test_admin_can_list_and_read_roles(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/roles", headers=_auth("alice"))
     assert r.status_code == 200
-    assert set(r.json()["roles"]) == {"viewer", "admin"}
+    body = r.json()  # paginated {data, meta}
+    assert {role["slug"] for role in body["data"]} == {"viewer", "admin"}
+    assert body["meta"]["total_count"] == 2
 
     r = client.get("/authz/roles/viewer", headers=_auth("alice"))
     assert r.status_code == 200
-    assert r.json()["scopes"] == ["agents:read"]  # global read-back form
+    role = r.json()
+    assert role["slug"] == "viewer" and role["name"] == "viewer"
+    # scopes are parsed objects now: {raw, namespace, sub_namespace, permission, value}
+    assert role["scopes"] == [
+        {
+            "id": None,
+            "raw": "agents:read",
+            "namespace": "agents",
+            "sub_namespace": None,
+            "permission": "read",
+            "value": "allow",
+        }
+    ]
 
 
 def test_admin_crud_role(client_and_store):

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -160,10 +160,13 @@ def test_scope_catalog_endpoint(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/scopes", headers=_auth("alice"))
     assert r.status_code == 200
-    body = r.json()
-    assert "agents" in body["grouped"] and "read" in body["grouped"]["agents"]
-    assert "agents:run" in body["scopes"]
-    assert body["admin_scope"] == "agent_os:admin"
+    body = r.json()  # cloud shape: {org_scopes, os_scopes} of {raw, namespace, sub_namespace?, permission}
+    assert body["org_scopes"] == []  # single OS: no org/platform layer
+    by_raw = {s["raw"]: s for s in body["os_scopes"]}
+    assert by_raw["agents:run"] == {"raw": "agents:run", "namespace": "agents", "permission": "run"}
+    assert "agent_os:admin" in by_raw  # the super-scope is included
+    # exclude_none: sub_namespace omitted when absent
+    assert "sub_namespace" not in by_raw["agents:read"]
     # non-admin is blocked
     assert client.get("/authz/scopes", headers=_auth("bob")).status_code == 403
 

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -160,9 +160,9 @@ def test_scope_catalog_endpoint(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/scopes", headers=_auth("alice"))
     assert r.status_code == 200
-    body = r.json()  # cloud shape: {org_scopes, os_scopes} of {raw, namespace, sub_namespace?, permission}
-    assert body["org_scopes"] == []  # single OS: no org/platform layer
-    by_raw = {s["raw"]: s for s in body["os_scopes"]}
+    body = r.json()  # flat list of {raw, namespace, sub_namespace?, permission}
+    assert isinstance(body, list)
+    by_raw = {s["raw"]: s for s in body}
     assert by_raw["agents:run"] == {"raw": "agents:run", "namespace": "agents", "permission": "run"}
     assert "agent_os:admin" in by_raw  # the super-scope is included
     # exclude_none: sub_namespace omitted when absent

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -63,10 +63,12 @@ def test_store_emits_change_events_with_actor_and_diff():
         ("user.unassigned", "bob", "alice"),
         ("role.removed", "member", "alice"),
     ]
-    # before/after captured on the widen
+    # before/after captured on the widen — full entries (scope + effect) so an
+    # allow<->deny flip is visible in the trail.
     widen = sink.events[1]
-    assert widen.before == ["agents:read"]
-    assert set(widen.after) == {"agents:read", "agents:run"}
+    assert widen.before == [{"scope": "agents:read", "effect": "allow"}]
+    assert {e["scope"] for e in widen.after} == {"agents:read", "agents:run"}
+    assert all(e["effect"] == "allow" for e in widen.after)
     # assignment diff
     assign = sink.events[2]
     assert assign.before == [] and assign.after == ["member"]

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -148,15 +148,15 @@ def test_users_api_crud_and_role_merge():
     # create a user
     r = client.post("/authz/users", headers=_auth("alice"), json={"id": "bob", "email": "bob@co"})
     assert r.status_code == 200, r.text
-    assert r.json()["id"] == "bob" and r.json()["roles"] == []
+    assert r.json()["id"] == "bob" and r.json()["roles"] == [] and r.json()["status"] == "active"
 
     # give bob a role; the user view merges it in
     roles.assign("bob", "viewer")
     got = client.get("/authz/users/bob", headers=_auth("alice")).json()
     assert got["email"] == "bob@co" and got["roles"] == ["viewer"]
 
-    # list includes bob with roles
-    listed = client.get("/authz/users", headers=_auth("alice")).json()["users"]
+    # list is paginated ({data, meta}) and includes bob with roles
+    listed = client.get("/authz/users", headers=_auth("alice")).json()["data"]
     assert any(u["id"] == "bob" and u["roles"] == ["viewer"] for u in listed)
 
     # update + delete


### PR DESCRIPTION
**Stack 6/7 — base `authz-5-providers`.** `/authz` responses match the cloud RBAC shape (role objects, parsed scopes w/ allow/deny, SDK `{data,meta}` pagination, flat scopes catalog) and the RESTful role verb split (POST create, PATCH metadata, PUT/PATCH /scopes).