### PR TITLE
fix: break agent loop when all tool calls are blocked by tool_call_limit

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -851,6 +851,13 @@ class Model(ABC):
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
 
+                    # If every tool call in this batch was blocked by the tool-call limit,
+                    # stop immediately. Without this guard the model receives only
+                    # "limit reached" errors, ignores them, and retries the same tools
+                    # indefinitely — burning tokens in an infinite loop.
+                    if function_call_results and all(m.tool_call_error for m in function_call_results):
+                        break
+
                     # Continue loop to get next response
                     continue
 
@@ -1071,6 +1078,13 @@ class Model(ABC):
                     if run_response is not None and run_response.requirements:
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
+
+                    # If every tool call in this batch was blocked by the tool-call limit,
+                    # stop immediately. Without this guard the model receives only
+                    # "limit reached" errors, ignores them, and retries the same tools
+                    # indefinitely — burning tokens in an infinite loop.
+                    if function_call_results and all(m.tool_call_error for m in function_call_results):
+                        break
 
                     # Continue loop to get next response
                     continue
@@ -1578,6 +1592,13 @@ class Model(ABC):
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
 
+                    # If every tool call in this batch was blocked by the tool-call limit,
+                    # stop immediately. Without this guard the model receives only
+                    # "limit reached" errors, ignores them, and retries the same tools
+                    # indefinitely — burning tokens in an infinite loop.
+                    if function_call_results and all(m.tool_call_error for m in function_call_results):
+                        break
+
                     # Continue loop to get next response
                     continue
 
@@ -1856,6 +1877,13 @@ class Model(ABC):
                     if run_response is not None and run_response.requirements:
                         if any(not req.is_resolved() for req in run_response.requirements):
                             break
+
+                    # If every tool call in this batch was blocked by the tool-call limit,
+                    # stop immediately. Without this guard the model receives only
+                    # "limit reached" errors, ignores them, and retries the same tools
+                    # indefinitely — burning tokens in an infinite loop.
+                    if function_call_results and all(m.tool_call_error for m in function_call_results):
+                        break
 
                     # Continue loop to get next response
                     continue

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -862,6 +862,14 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
+
                 # Continue loop to get next response
                 continue
 
@@ -1084,6 +1092,14 @@ class Model(ABC):
                 if run_response is not None and run_response.requirements:
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
+
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
 
                 # Continue loop to get next response
                 continue
@@ -1593,6 +1609,14 @@ class Model(ABC):
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
 
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
+
                 # Continue loop to get next response
                 continue
 
@@ -1873,6 +1897,14 @@ class Model(ABC):
                 if run_response is not None and run_response.requirements:
                     if any(not req.is_resolved() for req in run_response.requirements):
                         break
+
+                # If every tool call in this batch was refused because the tool call
+                # limit was exhausted, no further tool work is possible: the budget is
+                # spent, so the next turn can only produce the same refusals. Break
+                # instead of looping. Ordinary tool failures are deliberately excluded
+                # here - the model should still see those and be able to recover.
+                if function_call_results and all(m.tool_call_limit_reached for m in function_call_results):
+                    break
 
                 # Continue loop to get next response
                 continue
@@ -2222,6 +2254,7 @@ class Model(ABC):
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,
             tool_call_error=True,
+            tool_call_limit_reached=True,
         )
 
     def run_function_call(

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -104,6 +104,11 @@ class Message(BaseModel):
     tool_args: Optional[Any] = None
     # The error of the tool call
     tool_call_error: Optional[bool] = None
+    # True only when this result is the synthetic refusal produced because the
+    # tool call limit was exhausted. tool_call_error alone cannot be used to
+    # detect that case: it is also set for ordinary runtime tool failures,
+    # which the model should still be allowed to see and recover from.
+    tool_call_limit_reached: Optional[bool] = None
     # If True, the agent will stop executing after this tool call.
     stop_after_tool_call: bool = False
     # When True, the message will be added to the agent's memory.
@@ -321,6 +326,7 @@ class Message(BaseModel):
             "tool_name": self.tool_name,
             "tool_args": self.tool_args,
             "tool_call_error": self.tool_call_error,
+            "tool_call_limit_reached": self.tool_call_limit_reached,
             "tool_calls": self.tool_calls,
             "redacted_reasoning_content": self.redacted_reasoning_content,
             "provider_data": self.provider_data,

--- a/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit_stop.py
@@ -1,0 +1,247 @@
+"""Regression tests for the tool_call_limit no-progress stop guard.
+
+Covers the bug in #8304: when every tool call in a batch is refused because
+``tool_call_limit`` is exhausted, the model loop used to feed those refusals
+back to the model, which re-proposed the same tools, looping until timeout.
+
+The stop predicate must key off ``tool_call_limit_reached`` and not
+``tool_call_error``: the latter is also set for ordinary runtime tool
+failures (``create_function_call_result`` sets ``tool_call_error=not
+success``), which the model should still see and be able to recover from.
+
+These tests drive the real ``Model`` code with a local echo model, so they
+need no API keys and no network.
+"""
+
+from typing import List, Optional
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.tools.function import Function, FunctionCall
+
+
+class _EchoModel(Model):
+    """Minimal concrete Model. Only the tool-result plumbing is exercised."""
+
+    def __init__(self):
+        super().__init__(id="echo", name="Echo", provider="test")
+
+    # The abstract request methods are never reached by these tests.
+    def invoke(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+    def _parse_provider_response(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, *args, **kwargs):  # pragma: no cover
+        raise NotImplementedError
+
+
+def _make_call(name: str, fn) -> FunctionCall:
+    function = Function(name=name, entrypoint=fn)
+    function.process_entrypoint()
+    return FunctionCall(function=function, arguments={}, call_id=f"call_{name}")
+
+
+def _ok_tool() -> str:
+    return "ok"
+
+
+def _boom_tool() -> str:
+    raise RuntimeError("upstream API is down")
+
+
+def _drain(model: Model, calls: List[FunctionCall], limit: Optional[int], count: int = 0) -> List[Message]:
+    results: List[Message] = []
+    for _ in model.run_function_calls(
+        function_calls=calls,
+        function_call_results=results,
+        current_function_call_count=count,
+        function_call_limit=limit,
+    ):
+        pass
+    return results
+
+
+# --- marker semantics -------------------------------------------------------
+
+
+def test_limit_refusal_is_marked_and_ordinary_success_is_not():
+    """A call refused by the limit carries the marker; an executed call does not."""
+    model = _EchoModel()
+    calls = [_make_call("first", _ok_tool), _make_call("second", _ok_tool)]
+
+    results = _drain(model, calls, limit=1)
+
+    assert len(results) == 2
+    # First call is inside the budget and runs normally.
+    assert results[0].tool_call_limit_reached is None
+    assert not results[0].tool_call_error
+    # Second call is refused by the limit.
+    assert results[1].tool_call_limit_reached is True
+    assert results[1].tool_call_error is True
+
+
+def test_ordinary_tool_failure_is_not_marked_as_limit_reached():
+    """The core of the bug: a runtime failure sets tool_call_error but not the marker.
+
+    Stopping on ``all(tool_call_error)`` would end the run here and deny the
+    model any chance to recover from a transient tool failure.
+    """
+    model = _EchoModel()
+
+    results = _drain(model, [_make_call("boom", _boom_tool)], limit=None)
+
+    assert len(results) == 1
+    assert results[0].tool_call_error is True
+    assert results[0].tool_call_limit_reached is None
+
+
+# --- stop predicate ---------------------------------------------------------
+#
+# The guard applied in each of the four response loops is:
+#     all(m.tool_call_limit_reached for m in function_call_results)
+
+
+def _should_stop(results: List[Message]) -> bool:
+    return bool(results) and all(m.tool_call_limit_reached for m in results)
+
+
+def test_all_blocked_by_limit_stops():
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+
+    # Budget already spent, so every call in the batch is refused.
+    results = _drain(model, calls, limit=1, count=1)
+
+    assert [m.tool_call_limit_reached for m in results] == [True, True]
+    assert _should_stop(results) is True
+
+
+def test_all_ordinary_errors_do_not_stop():
+    model = _EchoModel()
+    calls = [_make_call("boom1", _boom_tool), _make_call("boom2", _boom_tool)]
+
+    results = _drain(model, calls, limit=None)
+
+    assert all(m.tool_call_error for m in results)
+    assert _should_stop(results) is False
+
+
+def test_mixed_batch_does_not_stop():
+    """One call succeeded, so progress was made; the model gets to use it."""
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+
+    results = _drain(model, calls, limit=1)
+
+    assert results[1].tool_call_limit_reached is True
+    assert _should_stop(results) is False
+
+
+def test_budget_carries_across_turns_so_the_run_terminates():
+    """The termination guarantee for #8304, across consecutive turns.
+
+    A mixed batch does not stop the run, so this asserts the thing that makes
+    that safe: the response loops keep a single running ``function_call_count``
+    across ``while`` iterations (initialised once before the loop, incremented
+    by ``_limit_charge_for`` after each batch). The turn after the budget runs
+    out is therefore refused in full, and the guard fires.
+    """
+    model = _EchoModel()
+    budget = 1
+
+    # Turn 1: budget runs out mid-batch -> mixed, keep going.
+    turn1 = _drain(model, [_make_call("a", _ok_tool), _make_call("b", _ok_tool)], limit=budget, count=0)
+    assert _should_stop(turn1) is False
+
+    # The loop charges the batch against the running total exactly as the
+    # response loops do.
+    count = model._limit_charge_for(turn1, None)
+    assert count == 2
+
+    # Turn 2: the model re-proposes, every call is now refused, the run ends.
+    turn2 = _drain(model, [_make_call("a", _ok_tool), _make_call("b", _ok_tool)], limit=budget, count=count)
+    assert [m.tool_call_limit_reached for m in turn2] == [True, True]
+    assert _should_stop(turn2) is True
+
+
+def test_no_limit_configured_never_stops():
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+
+    results = _drain(model, calls, limit=None)
+
+    assert not any(m.tool_call_limit_reached for m in results)
+    assert _should_stop(results) is False
+
+
+# --- async parity -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_limit_refusal_is_marked():
+    model = _EchoModel()
+    calls = [_make_call("a", _ok_tool), _make_call("b", _ok_tool)]
+    results: List[Message] = []
+
+    async for _ in model.arun_function_calls(
+        function_calls=calls,
+        function_call_results=results,
+        current_function_call_count=1,
+        function_call_limit=1,
+    ):
+        pass
+
+    assert [m.tool_call_limit_reached for m in results] == [True, True]
+    assert _should_stop(results) is True
+
+
+@pytest.mark.asyncio
+async def test_async_ordinary_failure_is_not_marked():
+    model = _EchoModel()
+    results: List[Message] = []
+
+    async for _ in model.arun_function_calls(
+        function_calls=[_make_call("boom", _boom_tool)],
+        function_call_results=results,
+        function_call_limit=None,
+    ):
+        pass
+
+    assert results[0].tool_call_error is True
+    assert results[0].tool_call_limit_reached is None
+    assert _should_stop(results) is False
+
+
+# --- the guard is present in every response loop ----------------------------
+
+
+def test_guard_present_in_all_four_response_loops():
+    """Sync, async, streaming and async-streaming loops must all carry the guard."""
+    import inspect
+
+    import agno.models.base as base
+
+    for fn in (
+        base.Model.response,
+        base.Model.aresponse,
+        base.Model.response_stream,
+        base.Model.aresponse_stream,
+    ):
+        source = inspect.getsource(fn)
+        assert "all(m.tool_call_limit_reached for m in function_call_results)" in source, (
+            f"{fn.__name__} is missing the tool_call_limit stop guard"
+        )


### PR DESCRIPTION
## Summary

Fixes the unbounded tool-call loop described in #8304 (originally #6984).

When `tool_call_limit` is exhausted, `run_function_calls` appends a synthetic refusal for every remaining proposal and the response loop unconditionally `continue`s. The model receives only "limit reached" messages, ignores them, and re-proposes the same tools — looping until timeout or context overflow.

## What changed since the first version

The original patch stopped on `all(m.tool_call_error)`. Review on #8304 / #8324 / #8758 correctly identified that as too broad, and it is verifiable in the source: `create_function_call_result` sets `tool_call_error=not success`, so the same flag marks **ordinary runtime tool failures**. Stopping on it would have ended the run on a transient tool error instead of letting the model see and recover from it.

This version uses a limit-specific marker instead:

- **`Message.tool_call_limit_reached`** — set only by `create_tool_call_limit_error_result`, never by ordinary failures.
- **The stop guard** — `all(m.tool_call_limit_reached for m in function_call_results)`, applied to all four response loops: `response()`, `aresponse()`, `response_stream()`, `aresponse_stream()`.

Ordinary tool errors are left entirely alone.

### Mixed batches deliberately do not stop

If some call in the batch succeeded, progress was made, and the model should get to use those results rather than have the run end on the refusal.

This does not reintroduce the loop. `function_call_count` is initialised once *before* the `while` loop and accumulated by `_limit_charge_for` after each batch, so the turn after the budget runs out is refused in full and the guard fires there. Cost is exactly one extra provider round trip. `test_budget_carries_across_turns_so_the_run_terminates` covers this, since it is the actual termination guarantee.

### Why not `stop_after_tool_call`

It was suggested that the synthetic refusal could just set `stop_after_tool_call=True`, reusing the existing `any(m.stop_after_tool_call): break` in the four loops. That guard does exist and it would be a smaller change, but:

1. it is `any()`, so a batch where the budget ran out mid-way would stop despite successful calls; and
2. `stop_after_tool_call` means "this tool result *is* the run's answer" (see `_substitute_tool_result`), so the caller would receive `"Tool call limit reached. Tool call X not executed."` as the final output, discarding results that did succeed.

Happy to switch if maintainers prefer the smaller change.

## Tests

`libs/agno/tests/unit/models/test_tool_call_limit_stop.py` — 10 tests, deterministic, no API keys and no network (the existing `tests/integration/agent/test_tool_call_limit.py` needs a live OpenAI key).

Coverage:
- limit refusal is marked; executed calls are not
- ordinary runtime failure sets `tool_call_error` but **not** the marker
- stop predicate: all-blocked → stop; all ordinary errors → no stop; mixed → no stop; no limit configured → no stop
- cross-turn budget carry-forward → the run terminates
- async parity via `arun_function_calls`
- the guard is present in all four response loops

**Results:** 10/10 pass with this patch, 10/10 fail without it. Against `tests/unit/models` + `tests/unit/agent`, results are identical with and without the change (696 passed / 139 failed either way — those 139 are pre-existing failures from optional provider SDKs missing in my environment). The full unit suite could not be run locally: ~323 files fail to collect on missing optional deps (pinecone, qdrant, weaviate, …), so CI is the real check there.

**Known gap:** `test_guard_present_in_all_four_response_loops` asserts on `inspect.getsource`, not behaviour. It is a structural guard and currently the only coverage of the streaming paths; behavioural coverage of `response_stream`/`aresponse_stream` needs a provider double. @MISTRYUSER has offered to contribute that plus an agentic-RAG repro on top of this branch.

Fixes #8304.
