### PR TITLE
fix: team telemetry blocks critical path when os-api.agno.com is unreachable v2

### DIFF
--- a/libs/agno/agno/api/api.py
+++ b/libs/agno/agno/api/api.py
@@ -6,6 +6,8 @@ from httpx import Response
 
 from agno.api.settings import agno_api_settings
 
+TELEMETRY_TIMEOUT = 5  # seconds — telemetry must never block the main flow
+
 
 class Api:
     def __init__(self):
@@ -27,6 +29,24 @@ class Api:
             base_url=agno_api_settings.api_url,
             headers=self.headers,
             timeout=60,
+            http2=True,
+        )
+
+    def TelemetryClient(self) -> HttpxClient:
+        """Short-timeout client for fire-and-forget telemetry POSTs."""
+        return HttpxClient(
+            base_url=agno_api_settings.api_url,
+            headers=self.headers,
+            timeout=TELEMETRY_TIMEOUT,
+            http2=True,
+        )
+
+    def AsyncTelemetryClient(self) -> HttpxAsyncClient:
+        """Short-timeout async client for fire-and-forget telemetry POSTs."""
+        return HttpxAsyncClient(
+            base_url=agno_api_settings.api_url,
+            headers=self.headers,
+            timeout=TELEMETRY_TIMEOUT,
             http2=True,
         )
 

--- a/libs/agno/agno/api/team.py
+++ b/libs/agno/agno/api/team.py
@@ -6,7 +6,7 @@ from agno.utils.log import log_debug
 
 def create_team_run(run: TeamRunCreate) -> None:
     """Telemetry recording for Team runs"""
-    with api.Client() as api_client:
+    with api.TelemetryClient() as api_client:
         try:
             response = api_client.post(
                 ApiRoutes.RUN_CREATE,
@@ -19,7 +19,7 @@ def create_team_run(run: TeamRunCreate) -> None:
 
 async def acreate_team_run(run: TeamRunCreate) -> None:
     """Telemetry recording for async Team runs"""
-    async with api.AsyncClient() as api_client:
+    async with api.AsyncTelemetryClient() as api_client:
         try:
             response = await api_client.post(
                 ApiRoutes.RUN_CREATE,

--- a/libs/agno/agno/team/_telemetry.py
+++ b/libs/agno/agno/team/_telemetry.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from agno.utils.log import log_debug
+from agno.utils.log import log_debug, log_warning
 
 if TYPE_CHECKING:
     from agno.team.team import Team
@@ -54,21 +55,32 @@ def log_team_telemetry(team: "Team", session_id: str, run_id: Optional[str] = No
             run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team)),
         )
     except Exception as e:
-        log_debug(f"Could not create Team run telemetry event: {e}")
+        log_warning(f"Could not create Team run telemetry event: {e}")
+
+
+async def _alog_team_telemetry_task(team: "Team", session_id: str, run_id: Optional[str]) -> None:
+    """Background task that performs the async telemetry POST."""
+    from agno.api.team import TeamRunCreate, acreate_team_run
+
+    try:
+        await acreate_team_run(
+            run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team))
+        )
+    except Exception as e:
+        log_warning(f"Could not create Team run telemetry event: {e}")
 
 
 async def alog_team_telemetry(team: "Team", session_id: str, run_id: Optional[str] = None) -> None:
-    """Send a telemetry event to the API for a created Team async run"""
+    """Send a telemetry event to the API for a created Team async run.
 
+    Schedules the HTTP POST as a background task so it never blocks the caller,
+    even if os-api.agno.com is unreachable and the request hangs until timeout.
+    """
     from agno.team._init import _set_telemetry
 
     _set_telemetry(team)
     if not team.telemetry:
         return
 
-    from agno.api.team import TeamRunCreate, acreate_team_run
-
-    try:
-        await acreate_team_run(run=TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team)))
-    except Exception as e:
-        log_debug(f"Could not create Team run telemetry event: {e}")
+    asyncio.create_task(_alog_team_telemetry_task(team, session_id=session_id, run_id=run_id))
+    log_debug("Team telemetry task scheduled (fire-and-forget)")

--- a/libs/agno/tests/unit/telemetry/test_team_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_team_telemetry.py
@@ -58,3 +58,21 @@ async def test_team_telemetry_async():
         assert call_args.kwargs["session_id"] is not None
         assert "run_id" in call_args.kwargs
         assert call_args.kwargs["run_id"] is not None
+
+@pytest.mark.asyncio
+async def test_alog_team_telemetry_is_fire_and_forget():
+    """Test that alog_team_telemetry schedules a background task instead of blocking."""
+    from unittest.mock import patch
+
+    from agno.team._telemetry import alog_team_telemetry
+
+    agent = Agent()
+    team = Team(members=[agent])
+    team.telemetry = True
+
+    with patch("agno.team._init._set_telemetry"):
+        with patch("agno.team._telemetry.asyncio.create_task") as mock_create_task:
+            await alog_team_telemetry(team, session_id="test-session", run_id="test-run")
+
+            # Must schedule a background task, not block
+            mock_create_task.assert_called_once()


### PR DESCRIPTION
## Summary

Describe key changes, mention related issues or motivation for the changes.

Fixes Issue Number: #8294 

## Type of change

- Bug Fix

---

## Checklist

- Self-review completed
- Tests added/updated - existing tests/unit/telemetry/test_team_telemetry.py passes (both sync and async)

### Duplicate and AI-Generated PR Check

- I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- Check if this PR was entirely AI-generated - No, developed manually with step-by-step code review and verification

---

## Additional Notes

Problem
When Team.telemetry=True (the default), alog_team_telemetry() was awaited directly inside the async generator. If os-api.agno.com is unreachable (firewall, air-gapped, DNS failure), the POST hangs for the full 60s httpx timeout before silently failing, adding 60s to every team run with no indication to the user.

Changes
team/_telemetry.py: Schedule the telemetry POST via asyncio.create_task() (fire-and-forget) instead of awaiting it on the critical path. Upgrade failure logging from log_debug to log_warning.
api/api.py: Add TelemetryClient / AsyncTelemetryClient with a 5s timeout so the background task fails fast rather than hanging for 60s.
api/team.py: Use the new telemetry-specific clients.
