### PR TITLE
feat: add Slack app manifest for AgentOS interface

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/manifest.json
+++ b/libs/agno/agno/os/interfaces/slack/manifest.json
@@ -47,7 +47,7 @@
         },
         "interactivity": {
             "is_enabled": true,
-            "request_url": "https://YOUR-URL/slack/events"
+            "request_url": "https://YOUR-URL/slack/interactions"
         },
         "org_deploy_enabled": false,
         "socket_mode_enabled": false,

--- a/libs/agno/agno/os/interfaces/slack/manifest.json
+++ b/libs/agno/agno/os/interfaces/slack/manifest.json
@@ -1,6 +1,6 @@
 {
     "display_information": {
-        "name": "My Agent",
+        "name": "Slack Agent",
         "description": "An AI agent powered by Agno"
     },
     "features": {
@@ -10,7 +10,7 @@
             "messages_tab_read_only_enabled": false
         },
         "bot_user": {
-            "display_name": "My Agent",
+            "display_name": "Slack Agent",
             "always_online": true
         },
         "assistant_view": {

--- a/libs/agno/agno/os/interfaces/slack/manifest.json
+++ b/libs/agno/agno/os/interfaces/slack/manifest.json
@@ -1,5 +1,4 @@
 {
-    "_comment": "Slack App manifest for Agno agents. Replace https://YOUR-URL with your server URL.",
     "display_information": {
         "name": "My Agent",
         "description": "An AI agent powered by Agno"

--- a/libs/agno/agno/os/interfaces/slack/manifest.json
+++ b/libs/agno/agno/os/interfaces/slack/manifest.json
@@ -1,0 +1,57 @@
+{
+    "_comment": "Slack App manifest for Agno agents. Replace https://YOUR-URL with your server URL.",
+    "display_information": {
+        "name": "My Agent",
+        "description": "An AI agent powered by Agno"
+    },
+    "features": {
+        "app_home": {
+            "home_tab_enabled": false,
+            "messages_tab_enabled": true,
+            "messages_tab_read_only_enabled": false
+        },
+        "bot_user": {
+            "display_name": "My Agent",
+            "always_online": true
+        },
+        "assistant_view": {
+            "assistant_description": "Ask me anything.",
+            "suggested_prompts": []
+        }
+    },
+    "oauth_config": {
+        "scopes": {
+            "bot": [
+                "app_mentions:read",
+                "assistant:write",
+                "channels:history",
+                "channels:read",
+                "chat:write",
+                "files:read",
+                "files:write",
+                "groups:history",
+                "groups:read",
+                "im:history",
+                "users:read",
+                "users:read.email"
+            ]
+        }
+    },
+    "settings": {
+        "event_subscriptions": {
+            "request_url": "https://YOUR-URL/slack/events",
+            "bot_events": [
+                "app_mention",
+                "assistant_thread_started",
+                "message.im"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true,
+            "request_url": "https://YOUR-URL/slack/events"
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": false,
+        "token_rotation_enabled": false
+    }
+}


### PR DESCRIPTION
## Summary

Adds a pre-configured `manifest.json` that users can download and paste into Slack's "Create from manifest" flow. This reduces Slack setup from ~15 manual steps to 5.

**Scopes included:**
- `app_mentions:read`, `chat:write`, `im:history` — core messaging
- `assistant:write` — Slack's assistant UI with streaming
- `channels:read`, `channels:history` — public channel access
- `groups:read`, `groups:history` — private channel access
- `files:read`, `files:write` — file handling
- `users:read`, `users:read.email` — user lookup

**Events configured:**
- `app_mention` — @mentions
- `message.im` — direct messages
- `assistant_thread_started` — new assistant threads

**Also includes:**
- Interactivity enabled (required for HITL features)
- App Home with Messages Tab enabled

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Cookbook (addition or changes to the cookbook)

## Checklist

- [x] My code follows Agno's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] New and existing tests pass locally
- [x] I have not introduced code that could violate any security policies