### PR TITLE
fix: json_schema handle Optional dataclass fields without a type

### DIFF
--- a/libs/agno/agno/utils/json_schema.py
+++ b/libs/agno/agno/utils/json_schema.py
@@ -181,12 +181,15 @@ def get_json_schema_for_arg(type_hint: Any) -> Optional[Dict[str, Any]]:
             if (
                 field_schema
                 and "anyOf" in field_schema
-                and any(schema["type"] == "null" for schema in field_schema["anyOf"])
+                and any(schema.get("type") == "null" for schema in field_schema["anyOf"])
             ):
-                field_schema["type"] = next(
-                    schema["type"] for schema in field_schema["anyOf"] if schema["type"] != "null"
+                non_null_type = next(
+                    (schema["type"] for schema in field_schema["anyOf"] if schema.get("type") not in (None, "null")),
+                    None,
                 )
-                field_schema.pop("anyOf")
+                if non_null_type is not None:
+                    field_schema["type"] = non_null_type
+                    field_schema.pop("anyOf")
             else:
                 required.append(field_name)
 

--- a/libs/agno/tests/unit/utils/test_json_schema.py
+++ b/libs/agno/tests/unit/utils/test_json_schema.py
@@ -262,6 +262,24 @@ def test_get_json_schema_with_dataclass():
     assert user_schema["properties"]["tags"]["type"] == "array"
 
 
+def test_get_json_schema_dataclass_optional_field_without_type():
+    """A dataclass field whose Optional members lack a "type" key (e.g. a mixed-type
+    Literal yields {"enum": [...]}) must not crash schema generation with KeyError."""
+
+    @dataclass
+    class MixedLiteralDataclass:
+        mode: Optional[Literal[1, "a"]] = None
+
+    # Direct call previously raised KeyError: 'type'
+    arg_schema = get_json_schema_for_arg(MixedLiteralDataclass)
+    assert arg_schema["type"] == "object"
+    assert "mode" in arg_schema["properties"]
+
+    # And the parameter must survive instead of being silently dropped
+    schema = get_json_schema({"cfg": MixedLiteralDataclass})
+    assert "cfg" in schema["properties"]
+
+
 def test_get_json_schema_strict():
     type_hints = {"name": str, "age": int}
     schema = get_json_schema(type_hints, strict=True)


### PR DESCRIPTION
## What's broken

Registering a tool whose parameter is a dataclass with a field like `Optional[Literal[1, "a"]]` crashes schema generation. `get_json_schema_for_arg` does `schema["type"]` on every `anyOf` member, but some members legitimately have no `type` — a mixed-type `Literal` renders as `{"enum": [...]}` — so it raises `KeyError: 'type'`. The public caller wraps this in `try/except`, so the result is worse than a crash: the entire parameter is silently dropped and the model never learns the argument exists.

```python
@dataclass
class Config:
    mode: Optional[Literal[1, "a"]] = None

get_json_schema_for_arg(Config)   # -> KeyError: 'type'
```

## Why it happens

`schema["type"]` is dereferenced unconditionally over `anyOf` members, which aren't guaranteed to carry a `type` key.

## Fix

Use `schema.get("type")` and only collapse `anyOf` to a single `type` when a concrete non-null type exists; otherwise leave `anyOf` intact (still valid JSON Schema).

## Test

A dataclass with `Optional[Literal[1, "a"]]` now produces a schema instead of raising.

Fixes #8328
