### PR TITLE
[feat] Allow excluding session_state from persisted RunOutput snapshots

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -5750,6 +5750,8 @@ def _scrub_and_propagate_session_state(
     if run_context is not None and run_context.session_state is not None:
         run_response.session_state = run_context.session_state
         storage_copy.session_state = run_context.session_state
+    if not getattr(agent, "store_run_session_state", True):
+        storage_copy.session_state = None
 
     return storage_copy
 

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -604,6 +604,8 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
         config["store_tool_messages"] = agent.store_tool_messages
     if agent.store_history_messages:
         config["store_history_messages"] = agent.store_history_messages
+    if not agent.store_run_session_state:
+        config["store_run_session_state"] = agent.store_run_session_state
 
     # --- System message settings ---
     # Skip system_message if it's a callable or Message object
@@ -933,6 +935,7 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
         store_media=config.get("store_media", True),
         store_tool_messages=config.get("store_tool_messages", True),
         store_history_messages=config.get("store_history_messages", False),
+        store_run_session_state=config.get("store_run_session_state", True),
         # --- System message settings ---
         system_message=config.get("system_message"),
         system_message_role=config.get("system_message_role", "system"),

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -226,6 +226,8 @@ class Agent:
     # When True: Each run stores all messages including history from previous runs.
     # This allows inspecting full context in stored runs but causes quadratic storage growth.
     store_history_messages: bool = False
+    # If True, store session_state snapshots in run output history.
+    store_run_session_state: bool = True
 
     # --- System message settings ---
     # Provide the system message as a string or function
@@ -423,6 +425,7 @@ class Agent:
         store_media: bool = True,
         store_tool_messages: bool = True,
         store_history_messages: bool = False,
+        store_run_session_state: bool = True,
         knowledge: Optional[KnowledgeProtocol] = None,
         knowledge_filters: Optional[Union[Dict[str, Any], List[FilterExpr]]] = None,
         enable_agentic_knowledge_filters: Optional[bool] = None,
@@ -577,6 +580,7 @@ class Agent:
         self.store_media = store_media
         self.store_tool_messages = store_tool_messages
         self.store_history_messages = store_history_messages
+        self.store_run_session_state = store_run_session_state
 
         self.knowledge = knowledge
         self.knowledge_filters = knowledge_filters

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -159,6 +159,7 @@ class TestAgentToDict:
         assert "retries" not in config  # defaults to 0
         assert "add_history_to_context" not in config  # defaults to False
         assert "store_history_messages" not in config  # defaults to False
+        assert "store_run_session_state" not in config  # defaults to True
 
     def test_to_dict_includes_store_history_messages_when_true(self):
         """Test that store_history_messages=True is serialized."""
@@ -167,6 +168,13 @@ class TestAgentToDict:
 
         assert "store_history_messages" in config
         assert config["store_history_messages"] is True
+
+    def test_to_dict_includes_store_run_session_state_when_false(self):
+        """Test that store_run_session_state=False is serialized."""
+        agent = Agent(id="compact-runs-agent", store_run_session_state=False)
+        config = agent.to_dict()
+
+        assert config["store_run_session_state"] is False
 
     def test_to_dict_with_db(self, basic_agent, mock_db):
         """Test to_dict includes database configuration."""
@@ -368,6 +376,13 @@ class TestAgentFromDict:
         reconstructed = Agent.from_dict(config)
 
         assert reconstructed.store_history_messages is False
+
+    def test_from_dict_roundtrip_store_run_session_state_false(self):
+        """Test that store_run_session_state=False survives a config round-trip."""
+        agent = Agent(id="compact-runs-agent", store_run_session_state=False)
+        reconstructed = Agent.from_dict(agent.to_dict())
+
+        assert reconstructed.store_run_session_state is False
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/agent/test_checkpoint_steps.py
+++ b/libs/agno/tests/unit/agent/test_checkpoint_steps.py
@@ -351,6 +351,41 @@ class TestPersistRunInSession:
 
         assert run_response.session_state == {"k": "v"}
         assert session.session_data == {"session_state": {"k": "v"}}
+        assert session.runs is not None
+        assert session.runs[0].session_state == {"k": "v"}
+
+    def test_persist_can_omit_run_session_state_snapshot(self):
+        db = InMemoryDb()
+        agent = _make_agent(db=db)
+        agent.store_run_session_state = False
+        run_response = _make_run_response()
+        session = _make_session()
+        session_state = {"large_registry": {"item": "value"}}
+        run_context = RunContext(run_id="r1", session_id="s1", session_state=session_state)
+
+        persist_run_in_session(agent, run_response, session, run_context=run_context)
+
+        assert run_response.session_state is session_state
+        assert session.session_data == {"session_state": session_state}
+        assert session.runs is not None
+        assert session.runs[0].session_state is None
+
+    @pytest.mark.asyncio
+    async def test_apersist_can_omit_run_session_state_snapshot(self):
+        db = InMemoryDb()
+        agent = _make_agent(db=db)
+        agent.store_run_session_state = False
+        run_response = _make_run_response()
+        session = _make_session()
+        session_state = {"large_registry": {"item": "value"}}
+        run_context = RunContext(run_id="r1", session_id="s1", session_state=session_state)
+
+        await apersist_run_in_session(agent, run_response, session, run_context=run_context)
+
+        assert run_response.session_state is session_state
+        assert session.session_data == {"session_state": session_state}
+        assert session.runs is not None
+        assert session.runs[0].session_state is None
 
 
 class TestCallbackEndToEnd:


### PR DESCRIPTION
## Summary

Closes #8308.

Adds `Agent(store_run_session_state=False)` for applications that need the canonical session-level state but do not want the same state snapshot duplicated in every persisted run.

The default remains `True`, so existing behavior is unchanged.

When disabled:

- live `RunOutput.session_state` remains available
- `session.session_data["session_state"]` remains the canonical persisted state
- stored terminal and checkpoint run copies omit `session_state`
- Agent config serialization/deserialization preserves the setting

The option is applied to the unified storage copy, keeping live run objects unchanged.

## Tradeoff

Disabling the option removes per-run session-state audit snapshots. Because the same scrubbed storage copy is used by the current `save_response_to_file` path, file-saved run output also omits the state when this option is disabled.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other

## Verification

- focused and adjacent Agent persistence/config tests: 196 passed, 2 deselected
- `ruff format`: passed
- `ruff check`: passed
- `mypy`: passed for 920 source files
- `git diff --check`: passed

Two excluded DB deserialization mock tests fail identically on unmodified `upstream/main`; they are unrelated to this change.

## Checklist

- [x] Backward-compatible default
- [x] Live state behavior preserved
- [x] Session-level persistence preserved
- [x] Terminal and checkpoint storage covered
- [x] Config round-trip covered
- [x] Tested on current `upstream/main`
- [x] AI assistance disclosed

## AI assistance

This patch was rebuilt with Codex under human direction against the current unified storage-copy architecture. I reviewed the final five-file diff and validation output.