### PR TITLE
[fix] Sanitize OpenAI-compatible tool call arguments

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -1,3 +1,5 @@
+import ast
+import json
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from os import getenv
@@ -310,6 +312,60 @@ class OpenAIChat(Model):
         """
         return cls(**data)
 
+    @staticmethod
+    def _normalize_tool_call_arguments(arguments: Any) -> str:
+        """Return a provider-safe JSON string for tool call arguments."""
+        if arguments is None:
+            return "{}"
+
+        if not isinstance(arguments, str):
+            try:
+                return json.dumps(arguments, ensure_ascii=False)
+            except TypeError:
+                return "{}"
+
+        stripped_arguments = arguments.strip()
+        if not stripped_arguments:
+            return "{}"
+
+        try:
+            json.loads(stripped_arguments)
+            return stripped_arguments
+        except Exception:
+            pass
+
+        try:
+            parsed_arguments = ast.literal_eval(arguments)
+            return json.dumps(parsed_arguments, ensure_ascii=False)
+        except Exception:
+            return "{}"
+
+    @staticmethod
+    def _normalize_tool_calls(tool_calls: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+        """Ensure OpenAI-compatible tool call arguments are valid JSON strings."""
+        if tool_calls is None:
+            return None
+
+        normalized_tool_calls: List[Dict[str, Any]] = []
+        for tool_call in tool_calls:
+            if not isinstance(tool_call, dict):
+                normalized_tool_calls.append(tool_call)
+                continue
+
+            normalized_tool_call = tool_call.copy()
+            function = tool_call.get("function")
+
+            if isinstance(function, dict):
+                normalized_function = function.copy()
+                normalized_function["arguments"] = OpenAIChat._normalize_tool_call_arguments(
+                    normalized_function.get("arguments")
+                )
+                normalized_tool_call["function"] = normalized_function
+
+            normalized_tool_calls.append(normalized_tool_call)
+
+        return normalized_tool_calls
+
     def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
         """
         Format a message into the format expected by OpenAI.
@@ -328,7 +384,7 @@ class OpenAIChat(Model):
             "content": tool_result,
             "name": message.name,
             "tool_call_id": message.tool_call_id,
-            "tool_calls": message.tool_calls,
+            "tool_calls": self._normalize_tool_calls(message.tool_calls),
         }
         message_dict = {k: v for k, v in message_dict.items() if v is not None}
 
@@ -783,7 +839,7 @@ class OpenAIChat(Model):
                     tool_call_entry["id"] = _tool_call_id
                 if _tool_call_type:
                     tool_call_entry["type"] = _tool_call_type
-        return tool_calls
+        return OpenAIChat._normalize_tool_calls(tool_calls) or []
 
     def _should_collect_metrics(self, response: ChatCompletionChunk) -> bool:
         """

--- a/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
+++ b/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
 
 
@@ -196,3 +197,77 @@ def test_parse_response_delta_without_annotations_has_no_citations():
 
     assert model_response.citations is None
     assert model_response.content == "hi"
+
+
+def test_parse_tool_calls_normalizes_empty_arguments():
+    """Ensure zero-argument tool calls still produce valid JSON arguments."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(index=0, tool_id="call_1", tool_type="function", func_name="schema_inspect"),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert result[0]["function"]["name"] == "schema_inspect"
+    assert result[0]["function"]["arguments"] == "{}"
+
+
+def test_format_message_normalizes_empty_tool_call_arguments_without_mutating_message():
+    """Ensure OpenAI-compatible history never sends empty tool call argument strings."""
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "schema_inspect", "arguments": ""},
+        }
+    ]
+    message = Message(role="assistant", content="", tool_calls=tool_calls)
+
+    formatted_message = OpenAIChat(api_key="test")._format_message(message)
+
+    assert formatted_message["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert message.tool_calls == tool_calls
+
+
+def test_format_message_serializes_non_string_tool_call_arguments_without_mutating_message():
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": {"query": "agno", "limit": 3}},
+        }
+    ]
+    message = Message(role="assistant", content="", tool_calls=tool_calls)
+
+    formatted_message = OpenAIChat(api_key="test")._format_message(message)
+
+    assert formatted_message["tool_calls"][0]["function"]["arguments"] == '{"query": "agno", "limit": 3}'
+    assert message.tool_calls == tool_calls
+
+
+def test_format_message_repairs_python_literal_tool_call_arguments():
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": "{'query': 'agno', 'limit': 3}"},
+        }
+    ]
+    message = Message(role="assistant", content="", tool_calls=tool_calls)
+
+    formatted_message = OpenAIChat(api_key="test")._format_message(message)
+
+    assert formatted_message["tool_calls"][0]["function"]["arguments"] == '{"query": "agno", "limit": 3}'
+
+
+def test_format_message_replaces_invalid_tool_call_arguments_with_empty_object():
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search", "arguments": '{"query": "agno"'},
+        }
+    ]
+    message = Message(role="assistant", content="", tool_calls=tool_calls)
+
+    formatted_message = OpenAIChat(api_key="test")._format_message(message)
+
+    assert formatted_message["tool_calls"][0]["function"]["arguments"] == "{}"


### PR DESCRIPTION
## Summary

Fixes #8343.

Strict OpenAI-compatible providers validate historical `tool_calls[*].function.arguments` before the next model turn starts. When a prior provider emitted non-JSON arguments, the next request could fail with HTTP 400 before Agno's tool error message reached the model.

This change normalizes only the provider-facing payload:

- `None` and empty arguments become `{}`
- JSON-serializable non-string arguments are serialized
- valid JSON strings are preserved byte-for-byte
- Python literal dict/list strings are repaired into JSON
- unrepairable values fall back to `{}`
- the original `Message.tool_calls` remains unchanged

Streaming tool-call aggregation is normalized through the same helper.

## Relationship to #8314

#8314 focuses on empty arguments for zero-argument tools. This PR also covers non-empty malformed historical arguments and non-string argument shapes. It can subsume the empty-argument case while preserving the broader provider-safety regression coverage.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format and validation scripts
- [x] Self-review completed
- [x] Tested on current `upstream/main`
- [x] Tests added
- [x] Searched for duplicate issues and PRs
- [x] AI assistance disclosed

## Verification

- `pytest libs/agno/tests/unit/models/openai -q`: 77 passed
- `ruff check libs/agno`: passed
- `mypy libs/agno`: passed for 920 source files
- `git diff --check`: passed

The branch was rebased onto `upstream/main` at `f7c2a0a88` on 2026-07-15.

## AI assistance

This patch was prepared with Codex under human direction. I reviewed the final two-file diff, regression coverage, and validation output.