### PR TITLE
feat(session): gate summaries by token use

### DIFF
--- a/libs/agno/agno/session/summary.py
+++ b/libs/agno/agno/session/summary.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from agno.models.base import Model
 from agno.models.utils import get_model
 from agno.run.agent import Message
-from agno.utils.log import log_debug, log_warning
+from agno.utils.log import log_debug, log_info, log_warning
 
 # TODO: Look into moving all managers into a separate dir
 if TYPE_CHECKING:
@@ -93,6 +93,15 @@ class SessionSummaryManager:
     # Maximum number of messages to include in the summary conversation. None means no limit.
     conversation_limit: Optional[int] = None
 
+    # Only create/update a summary when run token usage reaches this fraction of token_limit.
+    # None preserves the default Agno behavior: summarize whenever called.
+    token_limit: Optional[int] = None
+    token_limit_ratio: float = 0.8
+
+    # Remove older runs after a summary is created, keeping recent unsummarized context.
+    compact_history_after_summary: bool = False
+    compact_history_keep_last_n_runs: int = 1
+
     def __post_init__(self) -> None:
         if self.id is None:
             self.id = f"session_summary_manager_{uuid4().hex[:8]}"
@@ -100,6 +109,56 @@ class SessionSummaryManager:
             raise ValueError(f"last_n_runs must be a positive integer, got {self.last_n_runs}")
         if self.conversation_limit is not None and self.conversation_limit <= 0:
             raise ValueError(f"conversation_limit must be a positive integer, got {self.conversation_limit}")
+        if self.token_limit is not None and self.token_limit <= 0:
+            raise ValueError(f"token_limit must be a positive integer, got {self.token_limit}")
+        if not 0 < self.token_limit_ratio <= 1:
+            raise ValueError(f"token_limit_ratio must be > 0 and <= 1, got {self.token_limit_ratio}")
+        if self.compact_history_keep_last_n_runs <= 0:
+            raise ValueError(
+                "compact_history_keep_last_n_runs must be a positive integer, "
+                f"got {self.compact_history_keep_last_n_runs}"
+            )
+
+    def should_create_session_summary(self, run_metrics: Optional["RunMetrics"] = None) -> bool:
+        """Return whether the current run is large enough to update the session summary."""
+        if self.token_limit is None:
+            log_debug("Session summary token gate disabled; creating summary whenever requested")
+            return True
+        if run_metrics is None:
+            log_info("Skipping session summary: no run metrics available for token-limit check")
+            return False
+
+        input_tokens = getattr(run_metrics, "input_tokens", 0) or 0
+        total_tokens = getattr(run_metrics, "total_tokens", 0) or 0
+        tokens = max(input_tokens, total_tokens)
+        threshold = int(self.token_limit * self.token_limit_ratio)
+
+        if tokens < threshold:
+            log_info(
+                f"Skipping session summary: token usage {tokens} < threshold {threshold} "
+                f"(limit={self.token_limit}, ratio={self.token_limit_ratio})"
+            )
+            return False
+
+        log_info(
+            f"Creating session summary: token usage {tokens} >= threshold {threshold} "
+            f"(limit={self.token_limit}, ratio={self.token_limit_ratio})"
+        )
+        return True
+
+    def compact_session_history(self, session: Union["AgentSession", "TeamSession"]) -> None:
+        """Keep only recent runs after older context has been summarized."""
+        if not self.compact_history_after_summary:
+            return
+        if session is None or not getattr(session, "runs", None):
+            return
+
+        original_run_count = len(session.runs)
+        session.runs = session.runs[-self.compact_history_keep_last_n_runs :]
+        log_info(
+            f"Compacted session history after summary; kept last {self.compact_history_keep_last_n_runs} run(s)"
+            f" out of {original_run_count}"
+        )
 
     def get_response_format(self, model: "Model") -> Union[Dict[str, Any], Type[BaseModel]]:  # type: ignore
         if model.supports_native_structured_outputs:
@@ -245,6 +304,9 @@ class SessionSummaryManager:
         run_metrics: Optional["RunMetrics"] = None,
     ) -> Optional[SessionSummary]:
         """Creates a summary of the session"""
+        if not self.should_create_session_summary(run_metrics):
+            return None
+
         log_debug("Creating session summary", center=True)
         self.model = get_model(self.model)
         if self.model is None:
@@ -272,6 +334,7 @@ class SessionSummaryManager:
         if session is not None and session_summary is not None:
             session.summary = session_summary
             self.summaries_updated = True
+            self.compact_session_history(session)
 
         return session_summary
 
@@ -281,6 +344,9 @@ class SessionSummaryManager:
         run_metrics: Optional["RunMetrics"] = None,
     ) -> Optional[SessionSummary]:
         """Creates a summary of the session"""
+        if not self.should_create_session_summary(run_metrics):
+            return None
+
         log_debug("Creating session summary", center=True)
         self.model = get_model(self.model)
         if self.model is None:
@@ -308,5 +374,6 @@ class SessionSummaryManager:
         if session is not None and session_summary is not None:
             session.summary = session_summary
             self.summaries_updated = True
+            self.compact_session_history(session)
 
         return session_summary

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -904,7 +904,7 @@ def _run_tasks_stream(
                     store_events=team.store_events,
                 )
             try:
-                team.session_summary_manager.create_session_summary(session=session)
+                team.session_summary_manager.create_session_summary(session=session, run_metrics=run_response.metrics)
             except Exception as e:
                 log_warning(f"Error in session summary creation: {str(e)}")
             if stream_events:
@@ -2777,7 +2777,9 @@ async def _arun_tasks_stream(
                     store_events=team.store_events,
                 )
             try:
-                await team.session_summary_manager.acreate_session_summary(session=team_session)
+                await team.session_summary_manager.acreate_session_summary(
+                    session=team_session, run_metrics=run_response.metrics
+                )
             except Exception as e:
                 log_warning(f"Error in session summary creation: {str(e)}")
             if stream_events:

--- a/libs/agno/tests/integration/managers/test_session_summary_manager.py
+++ b/libs/agno/tests/integration/managers/test_session_summary_manager.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from agno.db.sqlite import SqliteDb
+from agno.metrics import RunMetrics
 from agno.models.openai import OpenAIChat
 from agno.run.agent import Message, RunOutput
 from agno.run.team import TeamRunOutput
@@ -818,3 +819,48 @@ def test_session_summary_manager_rejects_zero_conversation_limit(model):
     """Test that SessionSummaryManager raises ValueError for zero conversation_limit."""
     with pytest.raises(ValueError, match="conversation_limit must be a positive integer"):
         SessionSummaryManager(model=model, conversation_limit=0)
+
+
+def test_session_summary_manager_skips_below_token_threshold(model):
+    """Test that token-gated summaries are skipped below the configured threshold."""
+    manager = SessionSummaryManager(model=model, token_limit=1000, token_limit_ratio=0.8)
+    metrics = RunMetrics(input_tokens=799, total_tokens=799)
+
+    assert manager.should_create_session_summary(metrics) is False
+
+
+def test_session_summary_manager_creates_at_token_threshold(model):
+    """Test that token-gated summaries run at the configured threshold."""
+    manager = SessionSummaryManager(model=model, token_limit=1000, token_limit_ratio=0.8)
+    metrics = RunMetrics(input_tokens=800, total_tokens=800)
+
+    assert manager.should_create_session_summary(metrics) is True
+
+
+def test_session_summary_manager_rejects_invalid_token_limit(model):
+    """Test that SessionSummaryManager raises ValueError for invalid token_limit."""
+    with pytest.raises(ValueError, match="token_limit must be a positive integer"):
+        SessionSummaryManager(model=model, token_limit=0)
+
+
+def test_session_summary_manager_rejects_invalid_token_limit_ratio(model):
+    """Test that SessionSummaryManager raises ValueError for invalid token_limit_ratio."""
+    with pytest.raises(ValueError, match="token_limit_ratio must be > 0 and <= 1"):
+        SessionSummaryManager(model=model, token_limit_ratio=0)
+
+
+def test_session_summary_manager_compacts_history_after_summary(model):
+    """Test that session history is compacted when configured."""
+    manager = SessionSummaryManager(model=model, compact_history_after_summary=True)
+    session = Mock()
+    session.runs = [Mock(run_id="run-1"), Mock(run_id="run-2")]
+
+    manager.compact_session_history(session)
+
+    assert [run.run_id for run in session.runs] == ["run-2"]
+
+
+def test_session_summary_manager_rejects_invalid_compact_history_keep_last_n_runs(model):
+    """Test that SessionSummaryManager raises ValueError for invalid compaction retention."""
+    with pytest.raises(ValueError, match="compact_history_keep_last_n_runs must be a positive integer"):
+        SessionSummaryManager(model=model, compact_history_keep_last_n_runs=0)


### PR DESCRIPTION
## Summary

This PR implements token-aware session summary creation and optional history compaction for Agno sessions.

It addresses [#8342](https://github.com/agno-agi/agno/issues/8342) and is related to the broader request in [#4952](https://github.com/agno-agi/agno/issues/4952).

Today, session summaries are created whenever the summary path runs, which makes them behave like per-run post-processing. That works for persistence, but it does not behave like context compaction. In long-running agent and team sessions, we typically want summaries to be created only when context usage becomes large enough to justify compaction.

This PR takes a narrower, upstream-friendly approach than [#4952](https://github.com/agno-agi/agno/issues/4952): instead of introducing a new top-level compaction API, it extends the existing `SessionSummaryManager` flow with token gating and optional history compaction.

This change makes session summaries threshold-aware by allowing `SessionSummaryManager` to evaluate the current run token usage before creating a summary. When the configured threshold is crossed, the summary is created and older session history can be compacted so the next run uses `summary + recent context` instead of replaying the entire conversation history.

This change also forwards `run_metrics` through the remaining team summary call sites so the same threshold-based behavior works consistently for both agents and teams.

## What this change adds

- `token_limit` support in `SessionSummaryManager`
- `token_limit_ratio` support so summary creation can trigger at a fraction of the configured limit
- optional session history compaction after summary creation
- forwarding of `run_metrics` through remaining team summary call sites so the same gating logic works consistently for both agents and teams
- tests for threshold behavior and compaction behavior

## How it works

The summary manager checks the run metrics and creates a summary only when:

```text
max(run_metrics.input_tokens, run_metrics.total_tokens) >= token_limit * token_limit_ratio
```

If the threshold is not reached, summary creation is skipped.

If the threshold is reached:

1. the session summary is created
2. the summary is stored on the session
3. older runs can be compacted, keeping only the most recent unsummarized context

This keeps the behavior aligned with token-aware context management instead of unconditional summary updates.

## Why this is useful

Agno already has token-aware compression via `CompressionManager`, but that only applies to tool-result messages. It does not compact full session history.

This PR fills that gap by making session summaries usable as a true context compaction mechanism for long-running sessions.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This PR is intentionally narrower than the broader design proposed in [#4952](https://github.com/agno-agi/agno/issues/4952). Instead of adding new top-level compaction APIs and session helper methods, it extends the existing session-summary flow with token gating and optional history compaction. This keeps the change smaller, easier to review, and directly addresses the recurring problem described in [#8342](https://github.com/agno-agi/agno/issues/8342).

---

## Additional Notes

This PR adds `token_limit`, `token_limit_ratio`, and optional history compaction behavior to `SessionSummaryManager`.

Summary creation now triggers only when:

```text
max(run_metrics.input_tokens, run_metrics.total_tokens) >= token_limit * token_limit_ratio
```

If configured, older runs are compacted after successful summary creation so subsequent runs can use `summary + recent context`.

Example runtime log from our testing:

```text
INFO Creating session summary: token usage 124463 >= threshold 80000 (limit=100000, ratio=0.8)
DEBUG ***************** Creating session summary *****************
INFO Compacted session history after summary; kept last 1 run(s) out of 1
```

Local verification:

- `python3 -m py_compile libs/agno/agno/session/summary.py libs/agno/agno/team/_run.py libs/agno/tests/integration/managers/test_session_summary_manager.py`