### PR TITLE
fix: include JSON instructions in followup prompt for json_object providers

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1719,16 +1719,26 @@ def _get_followups_response_format(model: Model) -> Optional[Union[Dict, Type[Ba
 
 
 def _build_followup_messages(
-    response_content: Any, num_suggestions: int, user_message: Optional[str] = None
+    response_content: Any,
+    num_suggestions: int,
+    user_message: Optional[str] = None,
+    response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
 ) -> List[Message]:
     """Build the messages for the followups model call."""
     import json
+
+    from agno.utils.prompts import get_json_output_prompt
 
     system_prompt = (
         "Based on the user's message and the assistant's response below, generate follow-up suggestions. "
         "Each suggestion should be a short action-oriented prompt (5-10 words). "
         "Cover different angles: dig deeper, practical next step, or alternative perspective."
     )
+
+    # json_object-only providers (e.g. DeepSeek) require the word "json" in the prompt
+    # and an example of the expected shape when response_format={"type": "json_object"}
+    if isinstance(response_format, dict) and response_format.get("type") == "json_object":
+        system_prompt += "\n\n" + get_json_output_prompt(Followups)  # type: ignore
 
     # Stringify content if needed
     if isinstance(response_content, str):
@@ -1804,7 +1814,9 @@ def generate_followups(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, agent.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = model.response(
@@ -1833,7 +1845,9 @@ async def agenerate_followups(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, agent.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = await model.aresponse(
@@ -1871,7 +1885,9 @@ def generate_followups_stream(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, agent.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = model.response(
@@ -1917,7 +1933,9 @@ async def agenerate_followups_stream(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, agent.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, agent.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = await model.aresponse(

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -1755,7 +1755,9 @@ def generate_team_followups(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, team.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, team.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = model.response(
@@ -1787,7 +1789,9 @@ async def agenerate_team_followups(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, team.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, team.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = await model.aresponse(
@@ -1828,7 +1832,9 @@ def generate_team_followups_stream(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, team.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, team.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = model.response(
@@ -1877,7 +1883,9 @@ async def agenerate_team_followups_stream(
 
     response_format = _get_followups_response_format(model)
     user_message = run_response.input.input_content_string() if run_response.input else None
-    messages = _build_followup_messages(run_response.content, team.num_followups, user_message=user_message)
+    messages = _build_followup_messages(
+        run_response.content, team.num_followups, user_message=user_message, response_format=response_format
+    )
 
     try:
         model_response: ModelResponse = await model.aresponse(

--- a/libs/agno/tests/unit/agent/test_followup_messages.py
+++ b/libs/agno/tests/unit/agent/test_followup_messages.py
@@ -1,0 +1,70 @@
+"""Tests for followup message construction.
+
+Regression tests for https://github.com/agno-agi/agno/issues/8355:
+json_object-only providers (e.g. DeepSeek) require the word "json" in the
+prompt when response_format={"type": "json_object"} is used. The followup
+system prompt must satisfy this and describe the expected JSON shape.
+"""
+
+from agno.agent._response import _build_followup_messages, _get_followups_response_format
+from agno.run.agent import Followups
+
+
+class _FakeModel:
+    """Minimal stand-in exposing the capability flags read by _get_followups_response_format."""
+
+    def __init__(self, native: bool = False, json_schema: bool = False):
+        self.supports_native_structured_outputs = native
+        self.supports_json_schema_outputs = json_schema
+
+
+def test_followup_messages_default_structure():
+    """Without json_object mode, messages keep the original system/user structure."""
+    messages = _build_followup_messages("Paris is the capital of France.", 3, user_message="Capital of France?")
+
+    assert len(messages) == 2
+    assert messages[0].role == "system"
+    assert messages[1].role == "user"
+    assert "Capital of France?" in messages[1].content
+    assert "Generate exactly 3 follow-up suggestions." in messages[1].content
+
+
+def test_followup_messages_json_object_mode_contains_json():
+    """json_object mode must include the word "json" and the expected fields in the prompt.
+
+    DeepSeek (and OpenAI JSON mode) reject requests with response_format
+    {"type": "json_object"} unless the prompt contains the word "json".
+    """
+    messages = _build_followup_messages(
+        "Paris is the capital of France.",
+        3,
+        user_message="Capital of France?",
+        response_format={"type": "json_object"},
+    )
+
+    system_content = messages[0].content
+    assert "json" in system_content.lower()
+    # The prompt should also describe the expected shape so the model emits
+    # {"suggestions": [...]} that _parse_followups_response can validate.
+    assert "suggestions" in system_content
+
+
+def test_followup_messages_structured_output_mode_unchanged():
+    """Schema-aware response formats do not need the JSON instructions appended."""
+    for response_format in (
+        Followups,
+        {"type": "json_schema", "json_schema": {"name": "Followups", "schema": Followups.model_json_schema()}},
+    ):
+        messages = _build_followup_messages(
+            "Paris is the capital of France.",
+            3,
+            response_format=response_format,
+        )
+        assert "<json_fields>" not in messages[0].content
+
+
+def test_get_followups_response_format_fallback_to_json_object():
+    """Models without structured/json-schema output support fall back to json_object."""
+    assert _get_followups_response_format(_FakeModel()) == {"type": "json_object"}
+    assert _get_followups_response_format(_FakeModel(native=True)) is Followups
+    assert _get_followups_response_format(_FakeModel(json_schema=True))["type"] == "json_schema"


### PR DESCRIPTION
## Summary

When `followups=True` is used with a model that falls back to `response_format={"type": "json_object"}` (e.g. DeepSeek, which supports neither native structured outputs nor json_schema outputs), every followup call fails with a provider 400 error:

```
Prompt must contain the word 'json' in some form to use 'response_format' of type 'json_object'.
```

The followup system prompt built by `_build_followup_messages` did not contain the word "json", which OpenAI-compatible JSON mode requires ([DeepSeek docs](https://api-docs.deepseek.com/guides/json_mode)). It also never told the model the expected `{"suggestions": [...]}` shape, so even providers that don't enforce the rule had no schema guidance in this mode.

(Issue number: fixes #8355)

**Changes:**
- `_build_followup_messages` accepts the already-computed `response_format`; when it is `{"type": "json_object"}`, the standard `get_json_output_prompt(Followups)` block is appended to the system prompt — the same convention used in `_messages.py` for `use_json_mode`.
- All 8 call sites (agent + team, sync/async, streaming/non-streaming) pass `response_format` through.
- Prompts for native structured outputs and json_schema modes are unchanged.
- Added unit tests in `tests/unit/agent/test_followup_messages.py` covering json_object mode, structured-output modes, and the `_get_followups_response_format` fallback.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Similar PR:** #7875 touches the same prompt but adds the JSON instruction unconditionally for all response formats, has no linked issue, and no tests (flagged by triage and marked stale since May 27). This PR scopes the JSON instructions to json_object mode only, links the issue, reuses the existing `get_json_output_prompt` helper, and includes regression tests.

**AI disclosure:** implemented with Claude Code under my direction and review.

**Validation:** new tests fail on `main` (prompt contains no "json") and pass with this change; `mypy` (872 files) and `ruff` clean.
