### PR TITLE
feat: add PostgresRunCancellationManager for distributed multi-worker…

### DIFF
--- a/cookbook/02_agents/14_advanced/cancel_postgres_run.py
+++ b/cookbook/02_agents/14_advanced/cancel_postgres_run.py
@@ -1,0 +1,361 @@
+"""
+Multi-Process Run Cancellation with PostgreSQL
+===============================================
+
+Demonstrates the PRIMARY use case for PostgresRunCancellationManager:
+cancelling an agent run from a COMPLETELY SEPARATE PROCESS.
+
+The in-memory manager cannot solve this — its state exists only inside a
+single OS process. When you deploy multiple API workers (gunicorn, uvicorn),
+a cancel request may land on Worker B while the agent is running on Worker A.
+PostgreSQL acts as the shared cancellation bus between all workers.
+
+Scenario in this demo:
+  Process A (AgentWorker) — creates its own manager, runs the agent
+  Process B (Canceller)   — creates its own manager, same DB, cancels after a delay
+
+Both managers have completely separate in-process caches and engine pools.
+The only shared state is the ``t_run_cancel`` table in PostgreSQL.
+
+Two variants are shown:
+  sync_main()  — sync agent.run()  + sync   manager methods
+  async_main() — async agent.arun() + async manager methods (realistic for ASGI workers)
+
+Prerequisites:
+    uv pip install psycopg[binary] sqlalchemy
+
+    Set DATABASE_URL (psycopg async dialect):
+        export DATABASE_URL=postgresql+psycopg_async://ai:ai@host:port/db
+
+Usage:
+    DATABASE_URL=postgresql+psycopg_async://ai:ai@localhost:5532/ai \\
+        .venv/bin/python cookbook/02_agents/14_advanced/cancel_postgres_run.py
+"""
+
+import asyncio
+import multiprocessing
+import os
+import time
+
+# ---------------------------------------------------------------------------
+# Database URLs
+# ---------------------------------------------------------------------------
+
+ASYNC_DB_URL = os.environ["DATABASE_URL"]
+# Derive a sync URL from the async one (replace driver dialect suffix)
+SYNC_DB_URL = (
+    ASYNC_DB_URL.replace("+psycopg_async", "+psycopg")
+    .replace("+asyncpg", "")
+    .replace("+aiopg", "")
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fresh manager (called independently in each process)
+# ---------------------------------------------------------------------------
+
+
+def _build_manager():
+    """Create a PostgresRunCancellationManager with both async and sync engines.
+
+    Each OS process must build its own engines — SQLAlchemy connection pools
+    are not safe to share across fork boundaries.
+    """
+    from agno.run.cancellation_management.postgres_cancellation_manager import (
+        PostgresRunCancellationManager,
+    )
+    from sqlalchemy import create_engine
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    async_engine = create_async_engine(ASYNC_DB_URL, echo=False)
+    sync_engine = create_engine(SYNC_DB_URL, echo=False)
+    return PostgresRunCancellationManager(
+        async_engine=async_engine,
+        sync_engine=sync_engine,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Process A: run the agent
+# ---------------------------------------------------------------------------
+
+
+def worker_process(run_id_queue: multiprocessing.Queue) -> None:
+    """Agent worker — simulates one gunicorn/uvicorn worker handling a request."""
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+    from agno.run.agent import RunEvent
+    from agno.run.cancel import set_cancellation_manager
+
+    print("[Worker A] Starting — building its own Postgres manager...")
+    manager = _build_manager()
+    set_cancellation_manager(manager)
+
+    agent = Agent(
+        name="StoryAgent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="An agent that writes long, detailed stories.",
+    )
+
+    run_id_sent = False
+    for chunk in agent.run(
+        "Write a very long story about a sailor who discovers a mysterious island. "
+        "Include vivid descriptions of the landscape, mysterious creatures, "
+        "and the sailor's inner thoughts. Aim for at least 2000 words.",
+        stream=True,
+    ):
+        # Share run_id with the canceller process as soon as we have it
+        if not run_id_sent and chunk.run_id:
+            run_id_queue.put(chunk.run_id)
+            print(f"\n[Worker A] Run started: {chunk.run_id}")
+            run_id_sent = True
+
+        if chunk.event == RunEvent.run_content and chunk.content:
+            print(chunk.content, end="", flush=True)
+        elif chunk.event == RunEvent.run_cancelled:
+            print(f"\n[Worker A] Received cancellation signal for run {chunk.run_id}.")
+            print("[Worker A] Stopping cleanly.")
+            return
+
+    print("\n[Worker A] Run completed without cancellation.")
+
+
+# ---------------------------------------------------------------------------
+# Process B: cancel the run
+# ---------------------------------------------------------------------------
+
+
+def canceller_process(run_id_queue: multiprocessing.Queue, delay: int = 4) -> None:
+    """Canceller — simulates a DIFFERENT worker/service receiving a cancel API call."""
+    print(f"[Canceller B] Will cancel after {delay}s. Waiting for run_id...")
+
+    # Wait until Worker A puts the run_id in the queue
+    run_id = None
+    deadline = time.time() + 60
+    while run_id is None and time.time() < deadline:
+        try:
+            run_id = run_id_queue.get(timeout=1)
+        except Exception:
+            pass
+
+    if run_id is None:
+        print("[Canceller B] Timed out waiting for run_id. Exiting.")
+        return
+
+    # Wait for the configured delay before cancelling
+    elapsed = 0
+    while elapsed < delay:
+        time.sleep(1)
+        elapsed += 1
+        print(f"[Canceller B] {elapsed}/{delay}s elapsed, run_id={run_id}...")
+
+    print(f"\n[Canceller B] Sending cancel signal via PostgreSQL for run {run_id}...")
+
+    # Build a completely SEPARATE manager — different process, different cache,
+    # different engine pool. Only the database is shared.
+    manager = _build_manager()
+    was_registered = manager.cancel_run(run_id)
+
+    if was_registered:
+        print(
+            "[Canceller B] Cancellation written to DB. Worker A will detect it shortly."
+        )
+    else:
+        print(f"[Canceller B] Run {run_id} was not found (may have already completed).")
+
+    # Confirm the flag is visible from this independent process
+    active = manager.get_active_runs()
+    print(f"[Canceller B] Active runs seen from this process: {active}")
+
+
+# ---------------------------------------------------------------------------
+# Sync main
+# ---------------------------------------------------------------------------
+
+
+def sync_main() -> None:
+    print("Building Postgres manager in main process to create the table...")
+    manager = _build_manager()
+    manager.create_table()
+    print("t_run_cancel table is ready.")
+
+    print()
+    print("=" * 60)
+    print("Sync multi-process cancellation demo")
+    print("  Process A: runs the agent    (sync agent.run)")
+    print("  Process B: cancels after 4s  (sync manager.cancel_run)")
+    print("=" * 60)
+    print()
+
+    run_id_queue: multiprocessing.Queue = multiprocessing.Queue()
+
+    worker = multiprocessing.Process(
+        target=worker_process,
+        args=(run_id_queue,),
+        name="AgentWorker",
+    )
+    canceller = multiprocessing.Process(
+        target=canceller_process,
+        args=(run_id_queue, 4),
+        name="Canceller",
+    )
+
+    worker.start()
+    canceller.start()
+    worker.join()
+    canceller.join()
+
+    print()
+    print("=" * 60)
+    print("Both processes finished.")
+    active = manager.get_active_runs()
+    if active:
+        print(f"Stale runs still in DB: {active}")
+    else:
+        print("No stale runs in DB — cleanup was successful.")
+
+
+# ---------------------------------------------------------------------------
+# Async worker / canceller — realistic for ASGI (uvicorn/FastAPI) deployments
+# ---------------------------------------------------------------------------
+
+
+async def _async_worker(run_id_queue: multiprocessing.Queue) -> None:
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+    from agno.run.agent import RunEvent
+    from agno.run.cancel import set_cancellation_manager
+
+    print("[Worker A] Starting async — building its own Postgres manager...")
+    manager = _build_manager()
+    set_cancellation_manager(manager)
+
+    agent = Agent(
+        name="StoryAgent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="An agent that writes long, detailed stories.",
+    )
+
+    run_id_sent = False
+    async for chunk in agent.arun(
+        "Write a very long story about a sailor who discovers a mysterious island. "
+        "Include vivid descriptions of the landscape, mysterious creatures, "
+        "and the sailor's inner thoughts. Aim for at least 2000 words.",
+        stream=True,
+    ):
+        if not run_id_sent and chunk.run_id:
+            run_id_queue.put(chunk.run_id)
+            print(f"\n[Worker A] Run started: {chunk.run_id}")
+            run_id_sent = True
+
+        if chunk.event == RunEvent.run_content and chunk.content:
+            print(chunk.content, end="", flush=True)
+        elif chunk.event == RunEvent.run_cancelled:
+            print(f"\n[Worker A] Run {chunk.run_id} was cancelled (async).")
+            return
+
+    print("\n[Worker A] Run completed without cancellation.")
+
+
+async def _async_canceller(run_id_queue: multiprocessing.Queue, delay: int = 4) -> None:
+    print(f"[Canceller B] Will cancel after {delay}s. Waiting for run_id...")
+
+    run_id = None
+    deadline = time.time() + 60
+    while run_id is None and time.time() < deadline:
+        try:
+            run_id = run_id_queue.get_nowait()
+        except Exception:
+            await asyncio.sleep(1)
+
+    if run_id is None:
+        print("[Canceller B] Timed out waiting for run_id. Exiting.")
+        return
+
+    for i in range(1, delay + 1):
+        await asyncio.sleep(1)
+        print(f"[Canceller B] {i}/{delay}s elapsed, run_id={run_id}...")
+
+    print(f"\n[Canceller B] Sending async cancel signal for run {run_id}...")
+
+    manager = _build_manager()
+    was_registered = await manager.acancel_run(run_id)
+
+    if was_registered:
+        print("[Canceller B] Cancellation written to DB via acancel_run.")
+    else:
+        print(f"[Canceller B] Run {run_id} not found (may have completed).")
+
+    active = await manager.aget_active_runs()
+    print(f"[Canceller B] Active runs seen from this process: {active}")
+
+
+def _async_worker_process(run_id_queue: multiprocessing.Queue) -> None:
+    """Entry point for the worker subprocess (async version)."""
+    asyncio.run(_async_worker(run_id_queue))
+
+
+def _async_canceller_process(run_id_queue: multiprocessing.Queue, delay: int) -> None:
+    """Entry point for the canceller subprocess (async version)."""
+    asyncio.run(_async_canceller(run_id_queue, delay))
+
+
+# ---------------------------------------------------------------------------
+# Async main
+# ---------------------------------------------------------------------------
+
+
+def async_main() -> None:
+    print("Building Postgres manager in main process to create the table...")
+    manager = _build_manager()
+    manager.create_table()
+    print("t_run_cancel table is ready.")
+
+    print()
+    print("=" * 60)
+    print("Async multi-process cancellation demo")
+    print("  Process A: runs the agent    (async agent.arun)")
+    print("  Process B: cancels after 4s  (async manager.acancel_run)")
+    print("=" * 60)
+    print()
+
+    run_id_queue: multiprocessing.Queue = multiprocessing.Queue()
+
+    worker = multiprocessing.Process(
+        target=_async_worker_process,
+        args=(run_id_queue,),
+        name="AsyncAgentWorker",
+    )
+    canceller = multiprocessing.Process(
+        target=_async_canceller_process,
+        args=(run_id_queue, 4),
+        name="AsyncCanceller",
+    )
+
+    worker.start()
+    canceller.start()
+    worker.join()
+    canceller.join()
+
+    print()
+    print("=" * 60)
+    print("Both async processes finished.")
+    active = manager.get_active_runs()
+    if active:
+        print(f"Stale runs still in DB: {active}")
+    else:
+        print("No stale runs in DB — cleanup was successful.")
+
+
+if __name__ == "__main__":
+    # "spawn" avoids inheriting open DB connections from the parent process —
+    # matches how gunicorn/uvicorn workers are launched.
+    multiprocessing.set_start_method("spawn")
+
+    import sys
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else "sync"
+    if mode == "async":
+        async_main()
+    else:
+        sync_main()

--- a/cookbook/03_teams/14_run_control/cancel_postgres_run.py
+++ b/cookbook/03_teams/14_run_control/cancel_postgres_run.py
@@ -1,0 +1,402 @@
+"""
+Multi-Process Team Run Cancellation with PostgreSQL
+====================================================
+
+Demonstrates the PRIMARY use case for PostgresRunCancellationManager:
+cancelling a team run from a COMPLETELY SEPARATE PROCESS.
+
+The in-memory manager cannot solve this — its state exists only inside a
+single OS process. When you deploy multiple API workers (gunicorn, uvicorn),
+a cancel request may land on Worker B while the team is running on Worker A.
+PostgreSQL acts as the shared cancellation bus between all workers.
+
+Scenario in this demo:
+  Process A (TeamWorker) — creates its own manager, runs the team
+  Process B (Canceller)  — creates its own manager, same DB, cancels after a delay
+
+Both managers have completely separate in-process caches and engine pools.
+The only shared state is the ``t_run_cancel`` table in PostgreSQL.
+
+Two variants are shown:
+  sync_main()  — sync team.run()  + sync   manager methods
+  async_main() — async team.arun() + async manager methods (realistic for ASGI workers)
+
+Prerequisites:
+    uv pip install psycopg[binary] sqlalchemy
+
+    Set DATABASE_URL (psycopg async dialect):
+        export DATABASE_URL=postgresql+psycopg_async://ai:ai@host:port/db
+
+Usage:
+    DATABASE_URL=postgresql+psycopg_async://ai:ai@localhost:5532/ai \\
+        .venvs/demo/bin/python cookbook/03_teams/14_run_control/cancel_postgres_run.py
+
+    # Async variant:
+    DATABASE_URL=postgresql+psycopg_async://ai:ai@localhost:5532/ai \\
+        .venvs/demo/bin/python cookbook/03_teams/14_run_control/cancel_postgres_run.py async
+"""
+
+import asyncio
+import multiprocessing
+import os
+import time
+
+# ---------------------------------------------------------------------------
+# Database URLs
+# ---------------------------------------------------------------------------
+
+ASYNC_DB_URL = os.environ["DATABASE_URL"]
+# Derive a sync URL from the async one (replace driver dialect suffix)
+SYNC_DB_URL = (
+    ASYNC_DB_URL.replace("+psycopg_async", "+psycopg")
+    .replace("+asyncpg", "")
+    .replace("+aiopg", "")
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fresh manager (called independently in each process)
+# ---------------------------------------------------------------------------
+
+
+def _build_manager():
+    """Create a PostgresRunCancellationManager with both async and sync engines.
+
+    Each OS process must build its own engines — SQLAlchemy connection pools
+    are not safe to share across fork boundaries.
+    """
+    from agno.run.cancellation_management.postgres_cancellation_manager import (
+        PostgresRunCancellationManager,
+    )
+    from sqlalchemy import create_engine
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    async_engine = create_async_engine(ASYNC_DB_URL, echo=False)
+    sync_engine = create_engine(SYNC_DB_URL, echo=False)
+    return PostgresRunCancellationManager(
+        async_engine=async_engine,
+        sync_engine=sync_engine,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Process A: run the team
+# ---------------------------------------------------------------------------
+
+
+def worker_process(run_id_queue: multiprocessing.Queue) -> None:
+    """Team worker — simulates one gunicorn/uvicorn worker handling a request."""
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+    from agno.run.agent import RunEvent
+    from agno.run.cancel import set_cancellation_manager
+    from agno.run.team import TeamRunEvent
+    from agno.team import Team
+
+    print("[Worker A] Starting — building its own Postgres manager...")
+    manager = _build_manager()
+    set_cancellation_manager(manager)
+
+    storyteller = Agent(
+        name="StorytellerAgent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="An agent that writes creative, detailed stories.",
+    )
+    editor = Agent(
+        name="EditorAgent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="An agent that reviews and expands stories.",
+    )
+    team = Team(
+        name="StoryTeam",
+        members=[storyteller, editor],
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="A team that collaborates to write long, detailed stories.",
+    )
+
+    run_id_sent = False
+    for chunk in team.run(
+        "Write a very long story about a sailor who discovers a mysterious island. "
+        "Include vivid descriptions of the landscape, mysterious creatures, "
+        "and the sailor's inner thoughts. Aim for at least 2000 words.",
+        stream=True,
+    ):
+        # Share team run_id with the canceller process as soon as we have it
+        if not run_id_sent and chunk.run_id:
+            run_id_queue.put(chunk.run_id)
+            print(f"\n[Worker A] Team run started: {chunk.run_id}")
+            run_id_sent = True
+
+        if (
+            chunk.event in (TeamRunEvent.run_content, RunEvent.run_content)
+            and chunk.content
+        ):
+            print(chunk.content, end="", flush=True)
+        elif chunk.event == RunEvent.run_cancelled:
+            print(f"\n[Worker A] Member run cancelled: {chunk.run_id}")
+        elif chunk.event == TeamRunEvent.run_cancelled:
+            print(f"\n[Worker A] Team run cancelled: {chunk.run_id}. Stopping cleanly.")
+            return
+
+    print("\n[Worker A] Team run completed without cancellation.")
+
+
+# ---------------------------------------------------------------------------
+# Process B: cancel the run
+# ---------------------------------------------------------------------------
+
+
+def canceller_process(run_id_queue: multiprocessing.Queue, delay: int = 4) -> None:
+    """Canceller — simulates a DIFFERENT worker/service receiving a cancel API call."""
+    print(f"[Canceller B] Will cancel after {delay}s. Waiting for run_id...")
+
+    # Wait until Worker A puts the team run_id in the queue
+    run_id = None
+    deadline = time.time() + 60
+    while run_id is None and time.time() < deadline:
+        try:
+            run_id = run_id_queue.get(timeout=1)
+        except Exception:
+            pass
+
+    if run_id is None:
+        print("[Canceller B] Timed out waiting for run_id. Exiting.")
+        return
+
+    # Wait for the configured delay before cancelling
+    elapsed = 0
+    while elapsed < delay:
+        time.sleep(1)
+        elapsed += 1
+        print(f"[Canceller B] {elapsed}/{delay}s elapsed, run_id={run_id}...")
+
+    print(
+        f"\n[Canceller B] Sending cancel signal via PostgreSQL for team run {run_id}..."
+    )
+
+    # Build a completely SEPARATE manager — different process, different cache,
+    # different engine pool. Only the database is shared.
+    manager = _build_manager()
+    was_registered = manager.cancel_run(run_id)
+
+    if was_registered:
+        print(
+            "[Canceller B] Cancellation written to DB. Worker A will detect it shortly."
+        )
+    else:
+        print(f"[Canceller B] Run {run_id} was not found (may have already completed).")
+
+    # Confirm the flag is visible from this independent process
+    active = manager.get_active_runs()
+    print(f"[Canceller B] Active runs seen from this process: {active}")
+
+
+# ---------------------------------------------------------------------------
+# Sync main
+# ---------------------------------------------------------------------------
+
+
+def sync_main() -> None:
+    print("Building Postgres manager in main process to create the table...")
+    manager = _build_manager()
+    manager.create_table()
+    print("t_run_cancel table is ready.")
+
+    print()
+    print("=" * 60)
+    print("Sync multi-process team cancellation demo")
+    print("  Process A: runs the team     (sync team.run)")
+    print("  Process B: cancels after 16s  (sync manager.cancel_run)")
+    print("=" * 60)
+    print()
+
+    run_id_queue: multiprocessing.Queue = multiprocessing.Queue()
+
+    worker = multiprocessing.Process(
+        target=worker_process,
+        args=(run_id_queue,),
+        name="TeamWorker",
+    )
+    canceller = multiprocessing.Process(
+        target=canceller_process,
+        args=(run_id_queue, 16),
+        name="Canceller",
+    )
+
+    worker.start()
+    canceller.start()
+    worker.join()
+    canceller.join()
+
+    print()
+    print("=" * 60)
+    print("Both processes finished.")
+    active = manager.get_active_runs()
+    if active:
+        print(f"Stale runs still in DB: {active}")
+    else:
+        print("No stale runs in DB — cleanup was successful.")
+
+
+# ---------------------------------------------------------------------------
+# Async worker / canceller — realistic for ASGI (uvicorn/FastAPI) deployments
+# ---------------------------------------------------------------------------
+
+
+async def _async_worker(run_id_queue: multiprocessing.Queue) -> None:
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIResponses
+    from agno.run.agent import RunEvent
+    from agno.run.cancel import set_cancellation_manager
+    from agno.run.team import TeamRunEvent
+    from agno.team import Team
+
+    print("[Worker A] Starting async — building its own Postgres manager...")
+    manager = _build_manager()
+    set_cancellation_manager(manager)
+
+    storyteller = Agent(
+        name="StorytellerAgent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="An agent that writes creative, detailed stories.",
+    )
+    editor = Agent(
+        name="EditorAgent",
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="An agent that reviews and expands stories.",
+    )
+    team = Team(
+        name="StoryTeam",
+        members=[storyteller, editor],
+        model=OpenAIResponses(id="gpt-5.4"),
+        description="A team that collaborates to write long, detailed stories.",
+    )
+
+    run_id_sent = False
+    async for chunk in team.arun(
+        "Write a very long story about a sailor who discovers a mysterious island. "
+        "Include vivid descriptions of the landscape, mysterious creatures, "
+        "and the sailor's inner thoughts. Aim for at least 2000 words.",
+        stream=True,
+    ):
+        if not run_id_sent and chunk.run_id:
+            run_id_queue.put(chunk.run_id)
+            print(f"\n[Worker A] Team run started: {chunk.run_id}")
+            run_id_sent = True
+
+        if (
+            chunk.event in (TeamRunEvent.run_content, RunEvent.run_content)
+            and chunk.content
+        ):
+            print(chunk.content, end="", flush=True)
+        elif chunk.event == RunEvent.run_cancelled:
+            print(f"\n[Worker A] Member run cancelled (async): {chunk.run_id}")
+        elif chunk.event == TeamRunEvent.run_cancelled:
+            print(f"\n[Worker A] Team run cancelled (async): {chunk.run_id}.")
+            return
+
+    print("\n[Worker A] Team run completed without cancellation.")
+
+
+async def _async_canceller(run_id_queue: multiprocessing.Queue, delay: int = 4) -> None:
+    print(f"[Canceller B] Will cancel after {delay}s. Waiting for run_id...")
+
+    run_id = None
+    deadline = time.time() + 60
+    while run_id is None and time.time() < deadline:
+        try:
+            run_id = run_id_queue.get_nowait()
+        except Exception:
+            await asyncio.sleep(1)
+
+    if run_id is None:
+        print("[Canceller B] Timed out waiting for run_id. Exiting.")
+        return
+
+    for i in range(1, delay + 1):
+        await asyncio.sleep(1)
+        print(f"[Canceller B] {i}/{delay}s elapsed, run_id={run_id}...")
+
+    print(f"\n[Canceller B] Sending async cancel signal for team run {run_id}...")
+
+    manager = _build_manager()
+    was_registered = await manager.acancel_run(run_id)
+
+    if was_registered:
+        print("[Canceller B] Cancellation written to DB via acancel_run.")
+    else:
+        print(f"[Canceller B] Run {run_id} not found (may have completed).")
+
+    active = await manager.aget_active_runs()
+    print(f"[Canceller B] Active runs seen from this process: {active}")
+
+
+def _async_worker_process(run_id_queue: multiprocessing.Queue) -> None:
+    """Entry point for the worker subprocess (async version)."""
+    asyncio.run(_async_worker(run_id_queue))
+
+
+def _async_canceller_process(run_id_queue: multiprocessing.Queue, delay: int) -> None:
+    """Entry point for the canceller subprocess (async version)."""
+    asyncio.run(_async_canceller(run_id_queue, delay))
+
+
+# ---------------------------------------------------------------------------
+# Async main
+# ---------------------------------------------------------------------------
+
+
+def async_main() -> None:
+    print("Building Postgres manager in main process to create the table...")
+    manager = _build_manager()
+    manager.create_table()
+    print("t_run_cancel table is ready.")
+
+    print()
+    print("=" * 60)
+    print("Async multi-process team cancellation demo")
+    print("  Process A: runs the team     (async team.arun)")
+    print("  Process B: cancels after 16s  (async manager.acancel_run)")
+    print("=" * 60)
+    print()
+
+    run_id_queue: multiprocessing.Queue = multiprocessing.Queue()
+
+    worker = multiprocessing.Process(
+        target=_async_worker_process,
+        args=(run_id_queue,),
+        name="AsyncTeamWorker",
+    )
+    canceller = multiprocessing.Process(
+        target=_async_canceller_process,
+        args=(run_id_queue, 16),
+        name="AsyncCanceller",
+    )
+
+    worker.start()
+    canceller.start()
+    worker.join()
+    canceller.join()
+
+    print()
+    print("=" * 60)
+    print("Both async processes finished.")
+    active = manager.get_active_runs()
+    if active:
+        print(f"Stale runs still in DB: {active}")
+    else:
+        print("No stale runs in DB — cleanup was successful.")
+
+
+if __name__ == "__main__":
+    # "spawn" avoids inheriting open DB connections from the parent process —
+    # matches how gunicorn/uvicorn workers are launched.
+    multiprocessing.set_start_method("spawn")
+
+    import sys
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else "sync"
+    if mode == "async":
+        async_main()
+    else:
+        sync_main()

--- a/libs/agno/agno/run/cancellation_management/__init__.py
+++ b/libs/agno/agno/run/cancellation_management/__init__.py
@@ -1,9 +1,11 @@
 from agno.run.cancellation_management.base import BaseRunCancellationManager
 from agno.run.cancellation_management.in_memory_cancellation_manager import InMemoryRunCancellationManager
+from agno.run.cancellation_management.postgres_cancellation_manager import PostgresRunCancellationManager
 from agno.run.cancellation_management.redis_cancellation_manager import RedisRunCancellationManager
 
 __all__ = [
     "BaseRunCancellationManager",
     "InMemoryRunCancellationManager",
+    "PostgresRunCancellationManager",
     "RedisRunCancellationManager",
 ]

--- a/libs/agno/agno/run/cancellation_management/postgres_cancellation_manager.py
+++ b/libs/agno/agno/run/cancellation_management/postgres_cancellation_manager.py
@@ -1,0 +1,433 @@
+"""PostgreSQL-based run cancellation manager for multi-worker deployments."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import TYPE_CHECKING, Dict, Optional, Set
+
+from agno.exceptions import RunCancelledException
+from agno.run.cancellation_management.base import BaseRunCancellationManager
+from agno.utils.log import logger
+
+_sqlalchemy_available = True
+_sqlalchemy_import_error: Optional[str] = None
+
+try:
+    from sqlalchemy import text
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+    from sqlalchemy.orm import Session, sessionmaker
+except ImportError:
+    _sqlalchemy_available = False
+    _sqlalchemy_import_error = "`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`"
+    if TYPE_CHECKING:
+        from sqlalchemy import text
+        from sqlalchemy.engine import Engine
+        from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+        from sqlalchemy.orm import Session, sessionmaker
+    else:
+        text = object
+        Engine = object
+        AsyncEngine = object
+        AsyncSession = object
+        async_sessionmaker = object
+        Session = object
+        sessionmaker = object
+
+# TTL in seconds for caching a False (not-cancelled) result.
+# True (cancelled) results are cached indefinitely — the flag never reverts.
+_CACHE_TTL_SECONDS = 2.0
+
+# ---------------------------------------------------------------------------
+# DDL
+# ---------------------------------------------------------------------------
+
+_DDL_TABLE = """
+CREATE TABLE IF NOT EXISTS t_run_cancel (
+    run_id     VARCHAR(64)  PRIMARY KEY,
+    cancelled  SMALLINT     NOT NULL DEFAULT 0,
+    parent_id  VARCHAR(64)  NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+)
+"""
+_DDL_INDEX = (
+    "CREATE INDEX IF NOT EXISTS idx_t_run_cancel_parent_id ON t_run_cancel (parent_id) WHERE parent_id IS NOT NULL"
+)
+
+# ---------------------------------------------------------------------------
+# SQL statements
+# ---------------------------------------------------------------------------
+
+_SQL_REGISTER = "INSERT INTO t_run_cancel (run_id, cancelled) VALUES (:run_id, 0) ON CONFLICT (run_id) DO NOTHING"
+# xmax = 0  → fresh INSERT  (run was not previously registered)
+# xmax != 0 → DO UPDATE fired (run already existed, i.e. was registered)
+_SQL_CANCEL = (
+    "INSERT INTO t_run_cancel (run_id, cancelled) "
+    "VALUES (:run_id, 1) "
+    "ON CONFLICT (run_id) DO UPDATE SET cancelled = 1 "
+    "RETURNING (xmax = 0) AS is_inserted"
+)
+_SQL_IS_CANCELLED = "SELECT cancelled FROM t_run_cancel WHERE run_id = :run_id"
+_SQL_DELETE = "DELETE FROM t_run_cancel WHERE run_id = :run_id"
+_SQL_ALL_RUNS = "SELECT run_id, cancelled FROM t_run_cancel"
+_SQL_REGISTER_MEMBER = (
+    "INSERT INTO t_run_cancel (run_id, cancelled, parent_id) "
+    "VALUES (:run_id, 0, :parent_id) "
+    "ON CONFLICT (run_id) DO UPDATE SET parent_id = EXCLUDED.parent_id"
+)
+_SQL_GET_MEMBERS = "SELECT run_id FROM t_run_cancel WHERE parent_id = :parent_id"
+
+
+# ---------------------------------------------------------------------------
+# Cache entry
+# ---------------------------------------------------------------------------
+
+
+class _CacheEntry:
+    __slots__ = ("value", "expires_at")
+
+    def __init__(self, value: bool, ttl: float) -> None:
+        self.value = value
+        self.expires_at = time.monotonic() + ttl if not value else float("inf")
+
+    def is_valid(self) -> bool:
+        return time.monotonic() < self.expires_at
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+
+class PostgresRunCancellationManager(BaseRunCancellationManager):
+    """PostgreSQL-based cancellation manager for distributed, multi-worker deployments.
+
+    Stores run cancellation state in a single ``t_run_cancel`` table so that any
+    worker process can read and write cancellation flags without in-process state.
+
+    An in-process cache reduces database round-trips for hot ``is_cancelled``
+    check-points:
+
+    * ``cancelled=True``  — cached indefinitely (the flag never reverts).
+    * ``cancelled=False`` — cached for ``_CACHE_TTL_SECONDS`` seconds.
+
+    Team cancel-cascade is supported via the ``parent_id`` column, which stores
+    the team run's ``run_id`` on each member row.  No second table is needed::
+
+        run_id (PK) | cancelled | parent_id   | created_at
+        team-run-1  |     0     |    NULL     | ...   <- standalone / team run
+        member-run-1|     0     |  team-run-1 | ...   <- member run
+
+    Args:
+        async_engine: Async SQLAlchemy engine used by all async methods.
+        sync_engine:  Sync SQLAlchemy engine used by all sync methods.
+                      Optional if only async methods are used.
+    """
+
+    def __init__(
+        self,
+        async_engine: AsyncEngine,
+        sync_engine: Optional[Engine] = None,
+    ) -> None:
+        if not _sqlalchemy_available:
+            raise ImportError(_sqlalchemy_import_error)
+        super().__init__()
+        self._async_engine = async_engine
+        self._sync_engine = sync_engine
+        self._async_session_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+        self._sync_session_factory: Optional[sessionmaker] = (
+            sessionmaker(sync_engine, class_=Session, expire_on_commit=False)  # type: ignore[call-overload]
+            if sync_engine is not None
+            else None
+        )
+        # Async in-process cache protected by an asyncio.Lock.
+        self._cache: Dict[str, _CacheEntry] = {}
+        self._cache_lock = asyncio.Lock()
+        # Sync in-process cache protected by a threading.Lock.
+        self._sync_cache: Dict[str, _CacheEntry] = {}
+        self._sync_cache_lock = threading.Lock()
+
+    # ---------------------------------------------------------------------------
+    # Internal helpers
+    # ---------------------------------------------------------------------------
+
+    def _ensure_sync_session_factory(self) -> sessionmaker:
+        if self._sync_session_factory is None:
+            raise RuntimeError(
+                "Sync engine not provided. Pass `sync_engine` to "
+                "PostgresRunCancellationManager or use the async methods."
+            )
+        return self._sync_session_factory
+
+    # -- async cache --
+
+    async def _get_cache(self, run_id: str) -> Optional[bool]:
+        async with self._cache_lock:
+            entry = self._cache.get(run_id)
+            if entry and entry.is_valid():
+                return entry.value
+            if entry:
+                del self._cache[run_id]
+            return None
+
+    async def _set_cache(self, run_id: str, value: bool) -> None:
+        async with self._cache_lock:
+            self._cache[run_id] = _CacheEntry(value, _CACHE_TTL_SECONDS)
+
+    async def _evict_cache(self, run_id: str) -> None:
+        async with self._cache_lock:
+            self._cache.pop(run_id, None)
+
+    # -- sync cache --
+
+    def _get_sync_cache(self, run_id: str) -> Optional[bool]:
+        with self._sync_cache_lock:
+            entry = self._sync_cache.get(run_id)
+            if entry and entry.is_valid():
+                return entry.value
+            if entry:
+                del self._sync_cache[run_id]
+            return None
+
+    def _set_sync_cache(self, run_id: str, value: bool) -> None:
+        with self._sync_cache_lock:
+            self._sync_cache[run_id] = _CacheEntry(value, _CACHE_TTL_SECONDS)
+
+    def _evict_sync_cache(self, run_id: str) -> None:
+        with self._sync_cache_lock:
+            self._sync_cache.pop(run_id, None)
+
+    # ---------------------------------------------------------------------------
+    # Table creation (call once at application startup)
+    # ---------------------------------------------------------------------------
+
+    def create_table(self) -> None:
+        """Create ``t_run_cancel`` and its index if they do not yet exist."""
+        if self._sync_engine is not None:
+            with self._sync_engine.begin() as conn:
+                conn.execute(text(_DDL_TABLE))
+                conn.execute(text(_DDL_INDEX))
+        else:
+            with self._async_engine.sync_engine.begin() as conn:  # type: ignore[attr-defined]
+                conn.execute(text(_DDL_TABLE))
+                conn.execute(text(_DDL_INDEX))
+
+    async def acreate_table(self) -> None:
+        """Create ``t_run_cancel`` and its index if they do not yet exist (async)."""
+        async with self._async_engine.begin() as conn:
+            await conn.execute(text(_DDL_TABLE))
+            await conn.execute(text(_DDL_INDEX))
+
+    # ---------------------------------------------------------------------------
+    # register_run
+    # ---------------------------------------------------------------------------
+
+    def register_run(self, run_id: str) -> None:
+        """Register a new run as not cancelled.
+
+        Uses INSERT … ON CONFLICT DO NOTHING to preserve any existing
+        cancellation intent (cancel-before-start support).
+        """
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            session.execute(text(_SQL_REGISTER), {"run_id": run_id})
+            session.commit()
+
+    async def aregister_run(self, run_id: str) -> None:
+        """Register a new run as not cancelled (async version).
+
+        Uses INSERT … ON CONFLICT DO NOTHING to preserve any existing
+        cancellation intent (cancel-before-start support).
+        """
+        async with self._async_session_factory() as session:
+            await session.execute(text(_SQL_REGISTER), {"run_id": run_id})
+            await session.commit()
+
+    # ---------------------------------------------------------------------------
+    # cancel_run
+    # ---------------------------------------------------------------------------
+
+    def _log_cancel(self, run_id: str, was_registered: bool) -> None:
+        if was_registered:
+            logger.info(f"Run {run_id} marked for cancellation")
+        else:
+            logger.info(f"Run {run_id} not yet registered, storing cancellation intent")
+
+    def cancel_run(self, run_id: str) -> bool:
+        """Cancel a run by marking it as cancelled.
+
+        Always stores cancellation intent, even for runs not yet registered
+        (cancel-before-start support).
+
+        Returns:
+            bool: True if run was previously registered, False if storing
+            cancellation intent for an unregistered run.
+        """
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            result = session.execute(text(_SQL_CANCEL), {"run_id": run_id})
+            row = result.fetchone()
+            session.commit()
+        was_registered = not bool(row[0]) if row else False
+        self._set_sync_cache(run_id, True)
+        self._log_cancel(run_id, was_registered)
+        return was_registered
+
+    async def acancel_run(self, run_id: str) -> bool:
+        """Cancel a run by marking it as cancelled (async version).
+
+        Always stores cancellation intent, even for runs not yet registered
+        (cancel-before-start support).
+
+        Returns:
+            bool: True if run was previously registered, False if storing
+            cancellation intent for an unregistered run.
+        """
+        async with self._async_session_factory() as session:
+            result = await session.execute(text(_SQL_CANCEL), {"run_id": run_id})
+            row = result.fetchone()
+            await session.commit()
+        was_registered = not bool(row[0]) if row else False
+        await self._set_cache(run_id, True)
+        self._log_cancel(run_id, was_registered)
+        return was_registered
+
+    # ---------------------------------------------------------------------------
+    # is_cancelled
+    # ---------------------------------------------------------------------------
+
+    def is_cancelled(self, run_id: str) -> bool:
+        """Check if a run is cancelled."""
+        cached = self._get_sync_cache(run_id)
+        if cached is not None:
+            return cached
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            result = session.execute(text(_SQL_IS_CANCELLED), {"run_id": run_id})
+            row = result.fetchone()
+        value = bool(row[0]) if row else False
+        self._set_sync_cache(run_id, value)
+        return value
+
+    async def ais_cancelled(self, run_id: str) -> bool:
+        """Check if a run is cancelled (async version)."""
+        cached = await self._get_cache(run_id)
+        if cached is not None:
+            return cached
+        async with self._async_session_factory() as session:
+            result = await session.execute(text(_SQL_IS_CANCELLED), {"run_id": run_id})
+            row = result.fetchone()
+        value = bool(row[0]) if row else False
+        await self._set_cache(run_id, value)
+        return value
+
+    # ---------------------------------------------------------------------------
+    # cleanup_run
+    # ---------------------------------------------------------------------------
+
+    def cleanup_run(self, run_id: str) -> None:
+        """Remove a run from tracking (called when run completes)."""
+        self._evict_sync_cache(run_id)
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            session.execute(text(_SQL_DELETE), {"run_id": run_id})
+            session.commit()
+
+    async def acleanup_run(self, run_id: str) -> None:
+        """Remove a run from tracking (called when run completes) (async version)."""
+        await self._evict_cache(run_id)
+        async with self._async_session_factory() as session:
+            await session.execute(text(_SQL_DELETE), {"run_id": run_id})
+            await session.commit()
+
+    # ---------------------------------------------------------------------------
+    # raise_if_cancelled
+    # ---------------------------------------------------------------------------
+
+    def raise_if_cancelled(self, run_id: str) -> None:
+        """Check if a run should be cancelled and raise exception if so."""
+        if self.is_cancelled(run_id):
+            logger.info(f"Cancelling run {run_id}")
+            raise RunCancelledException(f"Run {run_id} was cancelled")
+
+    async def araise_if_cancelled(self, run_id: str) -> None:
+        """Check if a run should be cancelled and raise exception if so (async version)."""
+        if await self.ais_cancelled(run_id):
+            logger.info(f"Cancelling run {run_id}")
+            raise RunCancelledException(f"Run {run_id} was cancelled")
+
+    # ---------------------------------------------------------------------------
+    # get_active_runs
+    # ---------------------------------------------------------------------------
+
+    def get_active_runs(self) -> Dict[str, bool]:
+        """Get all currently tracked runs and their cancellation status."""
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            result = session.execute(text(_SQL_ALL_RUNS))
+            return {row[0]: bool(row[1]) for row in result.fetchall()}
+
+    async def aget_active_runs(self) -> Dict[str, bool]:
+        """Get all currently tracked runs and their cancellation status (async version)."""
+        async with self._async_session_factory() as session:
+            result = await session.execute(text(_SQL_ALL_RUNS))
+            return {row[0]: bool(row[1]) for row in result.fetchall()}
+
+    # ---------------------------------------------------------------------------
+    # Member-run tracking (team cancel-cascade)
+    #
+    # The parent_id column on each member row encodes the team → member mapping.
+    # No separate table is needed.  When a member run finishes, its row is deleted
+    # by acleanup_run (called from the agent's finally block), which removes both
+    # the cancellation state and the parent reference in one DELETE.
+    # ---------------------------------------------------------------------------
+
+    def register_member_run(self, team_run_id: str, member_run_id: str) -> None:
+        """Record that a member run belongs to a team run for cancel-cascade."""
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            session.execute(
+                text(_SQL_REGISTER_MEMBER),
+                {"run_id": member_run_id, "parent_id": team_run_id},
+            )
+            session.commit()
+
+    async def aregister_member_run(self, team_run_id: str, member_run_id: str) -> None:
+        """Record that a member run belongs to a team run for cancel-cascade (async version)."""
+        async with self._async_session_factory() as session:
+            await session.execute(
+                text(_SQL_REGISTER_MEMBER),
+                {"run_id": member_run_id, "parent_id": team_run_id},
+            )
+            await session.commit()
+
+    def get_member_run_ids(self, team_run_id: str) -> Set[str]:
+        """Return the in-flight member run_ids of a team run."""
+        sf = self._ensure_sync_session_factory()
+        with sf() as session:
+            result = session.execute(text(_SQL_GET_MEMBERS), {"parent_id": team_run_id})
+            return {row[0] for row in result.fetchall()}
+
+    async def aget_member_run_ids(self, team_run_id: str) -> Set[str]:
+        """Return the in-flight member run_ids of a team run (async version)."""
+        async with self._async_session_factory() as session:
+            result = await session.execute(text(_SQL_GET_MEMBERS), {"parent_id": team_run_id})
+            return {row[0] for row in result.fetchall()}
+
+    def cleanup_member_runs(self, team_run_id: str) -> None:
+        """Drop a team run's member mapping when the team run finishes.
+
+        Member rows are deleted individually by each agent's ``cleanup_run``
+        call (in the agent's finally block), so no additional work is needed here.
+        """
+        pass
+
+    async def acleanup_member_runs(self, team_run_id: str) -> None:
+        """Drop a team run's member mapping when the team run finishes (async version).
+
+        Member rows are deleted individually by each agent's ``acleanup_run``
+        call (in the agent's finally block), so no additional work is needed here.
+        """
+        pass


### PR DESCRIPTION
## Summary
Add `PostgresRunCancellationManager` — a PostgreSQL-backed run cancellation manager for distributed, multi-worker deployments.
The existing `InMemoryRunCancellationManager` and `RedisRunCancellationManager` are not suitable when Redis is unavailable. This implementation uses a single `t_run_cancel` table in PostgreSQL as a shared cancellation bus across all worker processes (gunicorn/uvicorn workers, Kubernetes pods, etc.).
Key design points:
- Both sync and async methods — mirrors the InMemory/Redis manager pattern exactly
- In-process cache: `True` cached indefinitely; `False` cached 2s to reduce DB round-trips
- Cancel-before-start via `ON CONFLICT DO UPDATE`
- Team cancel-cascade via `parent_id` column — no second table needed
- `xmax` trick to distinguish fresh INSERT from UPDATE without an extra SELECT
Closes #8360
## Additional Notes
**On tests:** `PostgresRunCancellationManager` implements the same interface as
`InMemoryRunCancellationManager` and `RedisRunCancellationManager`. The existing
integration tests in `libs/agno/tests/integration/agent/test_agent_run_cancellation.py`
and `libs/agno/tests/integration/teams/test_team_run_cancellation.py` cover the full
cancellation contract via `InMemoryRunCancellationManager`. A dedicated integration
test for `PostgresRunCancellationManager` requires a live PostgreSQL instance and
follows the exact same pattern — the two cookbook examples
(`cancel_postgres_run.py`) serve as runnable integration tests for this manager.
## Type of change
- [x] New feature
---
## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: `cookbook/02_agents/14_advanced/cancel_postgres_run.py` and `cookbook/03_teams/14_run_control/cancel_postgres_run.py`
- [x] Tested in clean environment
### Duplicate and AI-Generated PR Check
- [x] Confirmed no duplicate open PRs
- [x] This PR was AI-assisted (Cursor / Claude)