### PR TITLE
fix: preserve member tool events in parallel tasks

### DIFF
--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -797,12 +797,13 @@ def _get_task_management_tools(
         save_task_list(run_context.session_state, task_list)
 
         def _run_single_task(task_obj, member_agent):
-            """Run a single task in a thread. Returns (task_id, member_run_response, session_state_copy, error)."""
+            """Run a single task in a thread."""
             member_task_description = task_obj.description or task_obj.title
             member_agent_task, history = _setup_member_for_task(member_agent, member_task_description)
 
             use_agent_logger()
             member_session_state_copy = deepcopy(run_context.session_state)
+            member_events: List[Union[RunOutputEvent, TeamRunOutputEvent]] = []
 
             # Copy media lists per-thread to avoid concurrent mutation
             thread_images = list(_images)
@@ -814,31 +815,92 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_run_response = member_agent.run(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=thread_images,
-                    videos=thread_videos,
-                    audio=thread_audio,
-                    files=thread_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
+                if stream:
+                    member_stream = member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=thread_images,
+                        videos=thread_videos,
+                        audio=thread_audio,
+                        files=thread_files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
+                    member_run_response = None
+                    draining_after_cancel = False
+                    for event in member_stream:
+                        if isinstance(event, (TeamRunOutput, RunOutput)):
+                            member_run_response = event
+                            continue
+                        if isinstance(event, _MEMBER_TERMINAL_EVENT_TYPES):
+                            event.parent_run_id = event.parent_run_id or run_response.run_id
+                            member_events.append(event)
+                            if event.is_cancelled:
+                                draining_after_cancel = True
+                            continue
+                        if draining_after_cancel:
+                            continue
+                        try:
+                            if run_response.run_id is not None:
+                                raise_if_cancelled(run_response.run_id)
+                        except RunCancelledException:
+                            if member_run_id:
+                                _cascading_cancel_run(member_run_id)
+                            draining_after_cancel = True
+                            continue
+                        event.parent_run_id = event.parent_run_id or run_response.run_id
+                        member_events.append(event)
+                    if draining_after_cancel:
+                        raise RunCancelledException("")
+                else:
+                    member_run_response = member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=thread_images,
+                        videos=thread_videos,
+                        audio=thread_audio,
+                        files=thread_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
+                if member_run_response is not None:
+                    check_if_run_cancelled(member_run_response)
+                if run_response.run_id is not None:
+                    raise_if_cancelled(run_response.run_id)
+                return (
+                    task_obj.id,
+                    member_run_response,
+                    member_session_state_copy,
+                    member_agent_task,
+                    None,
+                    member_events,
                 )
-                return (task_obj.id, member_run_response, member_session_state_copy, member_agent_task, None)
             except RunCancelledException:
                 raise
             except Exception as e:
-                return (task_obj.id, None, member_session_state_copy, member_agent_task, e)
+                return (task_obj.id, None, member_session_state_copy, member_agent_task, e, member_events)
 
         results_text: List[str] = []
         modified_states: List[Dict[str, Any]] = []
@@ -852,9 +914,12 @@ def _get_task_management_tools(
             for future in as_completed(futures):
                 task_obj, member_agent = futures[future]
                 try:
-                    tid, member_run, state_copy, member_task, error = future.result()
+                    tid, member_run, state_copy, member_task, error, member_events = future.result()
                     if state_copy is not None:
                         modified_states.append(state_copy)
+
+                    for event in member_events:
+                        yield event
 
                     if error is not None:
                         task_obj.status = TaskStatus.failed
@@ -1009,6 +1074,7 @@ def _get_task_management_tools(
 
             use_agent_logger()
             member_session_state_copy = deepcopy(run_context.session_state)
+            member_events: List[Union[RunOutputEvent, TeamRunOutputEvent]] = []
 
             # Copy media lists to avoid concurrent mutation across coroutines
             task_images = list(_images)
@@ -1020,31 +1086,92 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_run_response = await member_agent.arun(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=task_images,
-                    videos=task_videos,
-                    audio=task_audio,
-                    files=task_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
+                if stream:
+                    member_stream = member_agent.arun(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=task_images,
+                        videos=task_videos,
+                        audio=task_audio,
+                        files=task_files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
+                    member_run_response = None
+                    draining_after_cancel = False
+                    async for event in member_stream:
+                        if isinstance(event, (TeamRunOutput, RunOutput)):
+                            member_run_response = event
+                            continue
+                        if isinstance(event, _MEMBER_TERMINAL_EVENT_TYPES):
+                            event.parent_run_id = event.parent_run_id or run_response.run_id
+                            member_events.append(event)
+                            if event.is_cancelled:
+                                draining_after_cancel = True
+                            continue
+                        if draining_after_cancel:
+                            continue
+                        try:
+                            if run_response.run_id is not None:
+                                raise_if_cancelled(run_response.run_id)
+                        except RunCancelledException:
+                            if member_run_id:
+                                await _acascading_cancel_run(member_run_id)
+                            draining_after_cancel = True
+                            continue
+                        event.parent_run_id = event.parent_run_id or run_response.run_id
+                        member_events.append(event)
+                    if draining_after_cancel:
+                        raise RunCancelledException("")
+                else:
+                    member_run_response = await member_agent.arun(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=task_images,
+                        videos=task_videos,
+                        audio=task_audio,
+                        files=task_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
+                if member_run_response is not None:
+                    check_if_run_cancelled(member_run_response)
+                if run_response.run_id is not None:
+                    raise_if_cancelled(run_response.run_id)
+                return (
+                    task_obj.id,
+                    member_run_response,
+                    member_session_state_copy,
+                    member_agent_task,
+                    None,
+                    member_events,
                 )
-                return (task_obj.id, member_run_response, member_session_state_copy, member_agent_task, None)
             except RunCancelledException:
                 raise
             except Exception as e:
-                return (task_obj.id, None, member_session_state_copy, member_agent_task, e)
+                return (task_obj.id, None, member_session_state_copy, member_agent_task, e, member_events)
 
         # Run all tasks concurrently
         gather_results = await asyncio.gather(
@@ -1072,9 +1199,12 @@ def _get_task_management_tools(
                 results_text.append(f"Task [{task_obj.id}] failed unexpectedly: {gather_result}")
                 continue
 
-            tid, member_run, state_copy, member_task, error = gather_result
+            tid, member_run, state_copy, member_task, error, member_events = gather_result
             if state_copy is not None:
                 modified_states.append(state_copy)
+
+            for event in member_events:
+                yield event
 
             if error is not None:
                 task_obj.status = TaskStatus.failed

--- a/libs/agno/tests/unit/team/test_parallel_task_streaming.py
+++ b/libs/agno/tests/unit/team/test_parallel_task_streaming.py
@@ -1,0 +1,89 @@
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.response import ToolExecution
+from agno.run import RunContext
+from agno.run.agent import RunOutput, ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.team import TeamRunOutput
+from agno.session import TeamSession
+from agno.team._task_tools import _get_task_management_tools
+from agno.team.task import TaskList
+from agno.team.team import Team
+
+
+def test_execute_tasks_parallel_forwards_member_tool_events() -> None:
+    worker = Agent(id="worker", name="Worker")
+    team = Team(name="Test Team", members=[worker], stream_member_events=True)
+    task_list = TaskList()
+    task = task_list.create_task("check weather", assignee="worker")
+    run_response = TeamRunOutput(run_id="team-run", session_id="session")
+    run_context = RunContext(run_id="team-run", session_id="session", session_state={})
+    session = TeamSession(session_id="session")
+
+    def fake_run(**kwargs):
+        assert kwargs["stream"] is True
+        assert kwargs["stream_events"] is True
+        yield ToolCallStartedEvent(tool=ToolExecution(tool_name="get_weather"))
+        yield ToolCallCompletedEvent(tool=ToolExecution(tool_name="get_weather"), content="sunny")
+        yield RunOutput(run_id=kwargs["run_id"], session_id="session", content="sunny")
+
+    worker.run = fake_run  # type: ignore[method-assign]
+
+    tools = _get_task_management_tools(
+        team=team,
+        task_list=task_list,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        team_run_context={},
+        stream=True,
+        stream_events=True,
+    )
+    execute_tasks_parallel = next(tool for tool in tools if tool.name == "execute_tasks_parallel")
+
+    events = list(execute_tasks_parallel.entrypoint(task_ids=[task.id]))  # type: ignore[misc]
+
+    assert any(isinstance(event, ToolCallStartedEvent) for event in events)
+    assert any(isinstance(event, ToolCallCompletedEvent) for event in events)
+    assert task.result == "sunny"
+
+
+@pytest.mark.asyncio
+async def test_aexecute_tasks_parallel_forwards_member_tool_events() -> None:
+    worker = Agent(id="worker", name="Worker")
+    team = Team(name="Test Team", members=[worker], stream_member_events=True)
+    task_list = TaskList()
+    task = task_list.create_task("check weather", assignee="worker")
+    run_response = TeamRunOutput(run_id="team-run", session_id="session")
+    run_context = RunContext(run_id="team-run", session_id="session", session_state={})
+    session = TeamSession(session_id="session")
+
+    async def fake_arun(**kwargs):
+        assert kwargs["stream"] is True
+        assert kwargs["stream_events"] is True
+        yield ToolCallStartedEvent(tool=ToolExecution(tool_name="get_weather"))
+        yield ToolCallCompletedEvent(tool=ToolExecution(tool_name="get_weather"), content="sunny")
+        yield RunOutput(run_id=kwargs["run_id"], session_id="session", content="sunny")
+
+    worker.arun = fake_arun  # type: ignore[method-assign]
+
+    tools = _get_task_management_tools(
+        team=team,
+        task_list=task_list,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        team_run_context={},
+        stream=True,
+        stream_events=True,
+        async_mode=True,
+    )
+    execute_tasks_parallel = next(tool for tool in tools if tool.name == "execute_tasks_parallel")
+
+    events = []
+    async for event in execute_tasks_parallel.entrypoint(task_ids=[task.id]):  # type: ignore[misc]
+        events.append(event)
+
+    assert any(isinstance(event, ToolCallStartedEvent) for event in events)
+    assert any(isinstance(event, ToolCallCompletedEvent) for event in events)
+    assert task.result == "sunny"


### PR DESCRIPTION
## Summary

Fixes #8356

`execute_tasks_parallel` was running member agents with `stream=False`, so member tool lifecycle events could not reach the team stream even when the parent run was streaming. This updates the sync and async parallel task paths to use the same member streaming setup as `execute_task` when streaming is active, collect those member events, and forward them before task completion updates.

Added unit coverage for both sync and async parallel task execution so `ToolCallStartedEvent` and `ToolCallCompletedEvent` are preserved.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Targeted checks run locally:

```text
$ uv run --no-sync pytest tests/unit/team/test_parallel_task_streaming.py tests/unit/team/test_team_run_regressions.py -q
14 passed in 0.88s
```

```text
$ uv run --no-sync ruff check agno/team/_task_tools.py tests/unit/team/test_parallel_task_streaming.py
All checks passed!

$ uv run --no-sync ruff format --check agno/team/_task_tools.py tests/unit/team/test_parallel_task_streaming.py
2 files already formatted
```

I used targeted checks because the broad optional `tests` extra currently fails dependency resolution on this Windows/Python 3.13 setup due an optional `agno[brave]` and `agno[a2a]` httpx conflict.