### PR TITLE
fix: enforce RBAC on /learnings + fix async_mongo None collection caching

### DIFF
--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -385,7 +385,7 @@ class AsyncMongoDb(AsyncBaseDb):
         reset_cache = self._should_reset_collection_cache()
 
         if table_type == "sessions":
-            if reset_cache or not hasattr(self, "session_collection"):
+            if reset_cache or getattr(self, "session_collection", None) is None:
                 if self.session_table_name is None:
                     raise ValueError("Session collection was not provided on initialization")
                 self.session_collection = await self._get_or_create_collection(
@@ -396,7 +396,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.session_collection
 
         if table_type == "memories":
-            if reset_cache or not hasattr(self, "memory_collection"):
+            if reset_cache or getattr(self, "memory_collection", None) is None:
                 if self.memory_table_name is None:
                     raise ValueError("Memory collection was not provided on initialization")
                 self.memory_collection = await self._get_or_create_collection(
@@ -407,7 +407,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.memory_collection
 
         if table_type == "metrics":
-            if reset_cache or not hasattr(self, "metrics_collection"):
+            if reset_cache or getattr(self, "metrics_collection", None) is None:
                 if self.metrics_table_name is None:
                     raise ValueError("Metrics collection was not provided on initialization")
                 self.metrics_collection = await self._get_or_create_collection(
@@ -418,7 +418,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.metrics_collection
 
         if table_type == "evals":
-            if reset_cache or not hasattr(self, "eval_collection"):
+            if reset_cache or getattr(self, "eval_collection", None) is None:
                 if self.eval_table_name is None:
                     raise ValueError("Eval collection was not provided on initialization")
                 self.eval_collection = await self._get_or_create_collection(
@@ -429,7 +429,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.eval_collection
 
         if table_type == "knowledge":
-            if reset_cache or not hasattr(self, "knowledge_collection"):
+            if reset_cache or getattr(self, "knowledge_collection", None) is None:
                 if self.knowledge_table_name is None:
                     raise ValueError("Knowledge collection was not provided on initialization")
                 self.knowledge_collection = await self._get_or_create_collection(
@@ -440,7 +440,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.knowledge_collection
 
         if table_type == "culture":
-            if reset_cache or not hasattr(self, "culture_collection"):
+            if reset_cache or getattr(self, "culture_collection", None) is None:
                 if self.culture_table_name is None:
                     raise ValueError("Culture collection was not provided on initialization")
                 self.culture_collection = await self._get_or_create_collection(
@@ -451,7 +451,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.culture_collection
 
         if table_type == "traces":
-            if reset_cache or not hasattr(self, "traces_collection"):
+            if reset_cache or getattr(self, "traces_collection", None) is None:
                 if self.trace_table_name is None:
                     raise ValueError("Traces collection was not provided on initialization")
                 self.traces_collection = await self._get_or_create_collection(
@@ -462,7 +462,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.traces_collection
 
         if table_type == "spans":
-            if reset_cache or not hasattr(self, "spans_collection"):
+            if reset_cache or getattr(self, "spans_collection", None) is None:
                 if self.span_table_name is None:
                     raise ValueError("Spans collection was not provided on initialization")
                 self.spans_collection = await self._get_or_create_collection(
@@ -473,7 +473,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.spans_collection
 
         if table_type == "learnings":
-            if reset_cache or not hasattr(self, "learnings_collection"):
+            if reset_cache or getattr(self, "learnings_collection", None) is None:
                 if self.learnings_table_name is None:
                     raise ValueError("Learnings collection was not provided on initialization")
                 self.learnings_collection = await self._get_or_create_collection(
@@ -484,7 +484,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.learnings_collection
 
         if table_type == "schedules":
-            if reset_cache or not hasattr(self, "schedules_collection"):
+            if reset_cache or getattr(self, "schedules_collection", None) is None:
                 if self.schedules_table_name is None:
                     raise ValueError("Schedules collection was not provided on initialization")
                 self.schedules_collection = await self._get_or_create_collection(
@@ -495,7 +495,7 @@ class AsyncMongoDb(AsyncBaseDb):
             return self.schedules_collection
 
         if table_type == "schedule_runs":
-            if reset_cache or not hasattr(self, "schedule_runs_collection"):
+            if reset_cache or getattr(self, "schedule_runs_collection", None) is None:
                 if self.schedule_runs_table_name is None:
                     raise ValueError("Schedule runs collection was not provided on initialization")
                 self.schedule_runs_collection = await self._get_or_create_collection(

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -55,6 +55,9 @@ class AgentOSScope(str, Enum):
     - memories:read - View memories
     - memories:write - Create and update memories
     - memories:delete - Delete memories
+    - learnings:read - View learnings
+    - learnings:write - Create and update learnings
+    - learnings:delete - Delete learnings
     - knowledge:read - View and search knowledge
     - knowledge:write - Add and update knowledge
     - knowledge:delete - Delete knowledge
@@ -439,6 +442,12 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "DELETE /memories": ["memories:delete"],
         "DELETE /memories/*": ["memories:delete"],
         "POST /optimize-memories": ["memories:write"],
+        # Learning endpoints
+        "GET /learnings": ["learnings:read"],
+        "GET /learnings/*": ["learnings:read"],
+        "POST /learnings": ["learnings:write"],
+        "PATCH /learnings/*": ["learnings:write"],
+        "DELETE /learnings/*": ["learnings:delete"],
         # Knowledge endpoints
         "GET /knowledge/content": ["knowledge:read"],
         "GET /knowledge/content/*": ["knowledge:read"],

--- a/libs/agno/tests/unit/db/test_async_mongo.py
+++ b/libs/agno/tests/unit/db/test_async_mongo.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 import pytest
 from pymongo import AsyncMongoClient
@@ -335,3 +335,27 @@ async def test_get_session_query_without_user_id():
 
     assert result is None
     mock_collection.find_one.assert_called_once_with({"session_id": "test-session-id"})
+
+
+@pytest.mark.asyncio
+async def test_get_collection_refetches_when_cached_none():
+    """Regression: a read with create_collection_if_not_found=False on a not-yet-created
+    collection must NOT cache None. Otherwise a GET before the first write would poison the
+    cache and every later write would be silently dropped (reproduced on the learnings path:
+    GET then POST saved nothing; POST first worked)."""
+    db = AsyncMongoDb(db_url="mongodb://localhost:27017", db_name="test_none_cache", learnings_collection="learnings")
+    sentinel = object()
+    db._should_reset_collection_cache = Mock(return_value=False)
+    db._get_or_create_collection = AsyncMock(side_effect=[None, sentinel])
+
+    # Stub the client property so nothing tries to connect.
+    with patch.object(type(db), "db_client", new_callable=PropertyMock, return_value=Mock()):
+        # 1) Read on a missing collection -> None, and must not be cached.
+        first = await db._get_collection("learnings", create_collection_if_not_found=False)
+        assert first is None
+
+        # 2) A subsequent write must re-fetch (and actually get the collection), not the cached None.
+        second = await db._get_collection("learnings", create_collection_if_not_found=True)
+
+    assert second is sentinel
+    assert db._get_or_create_collection.await_count == 2

--- a/libs/agno/tests/unit/os/test_scopes.py
+++ b/libs/agno/tests/unit/os/test_scopes.py
@@ -119,3 +119,34 @@ class TestDefaultScopeMappings:
         # Delete
         assert mappings["DELETE /components/*"] == ["components:delete"]
         assert mappings["DELETE /components/*/configs/*"] == ["components:delete"]
+
+    def test_learnings_endpoints_have_scope_mappings(self):
+        mappings = get_default_scope_mappings()
+        assert mappings["GET /learnings"] == ["learnings:read"]
+        assert mappings["GET /learnings/*"] == ["learnings:read"]
+        assert mappings["POST /learnings"] == ["learnings:write"]
+        assert mappings["PATCH /learnings/*"] == ["learnings:write"]
+        assert mappings["DELETE /learnings/*"] == ["learnings:delete"]
+
+
+class TestLearningsRouteScopeResolution:
+    """The learnings routes must not be left unmapped -- an unmapped route requires no scopes
+    and would let any authenticated token bypass RBAC. Verify every route (including the nested
+    /learnings/users and /learnings/users/{user_id}) resolves to a learnings scope."""
+
+    def _required(self, method, path):
+        from agno.os.middleware.jwt import JWTMiddleware
+
+        mw = JWTMiddleware.__new__(JWTMiddleware)
+        mw.scope_mappings = get_default_scope_mappings()
+        return mw._get_required_scopes(method, path)
+
+    def test_all_learnings_routes_require_a_learnings_scope(self):
+        assert self._required("GET", "/learnings") == ["learnings:read"]
+        assert self._required("GET", "/learnings/users") == ["learnings:read"]
+        assert self._required("GET", "/learnings/lrn-1") == ["learnings:read"]
+        assert self._required("POST", "/learnings") == ["learnings:write"]
+        assert self._required("PATCH", "/learnings/lrn-1") == ["learnings:write"]
+        assert self._required("DELETE", "/learnings/lrn-1") == ["learnings:delete"]
+        # Nested bulk-delete-by-user must also be gated (not left unmapped).
+        assert self._required("DELETE", "/learnings/users/priti@agno.com") == ["learnings:delete"]


### PR DESCRIPTION
## Summary

Closes the two high-severity review items from #7826 that the `/learnings/users` work (#8303) didn't cover. Targets `feat/learnings-crud-endpoints`.

### 1. RBAC bypass — `/learnings` routes weren't in the scope map

`get_default_scope_mappings()` had an entry for every domain **except** learnings, and `_get_required_scopes` returns `[]` (no scopes required → allow) for unmapped routes. So with RBAC enabled, **any authenticated token could hit every `/learnings` endpoint regardless of its scopes**, while `/memories`, `/sessions`, etc. enforced `domain:read/write/delete`.

- Added a learnings scope block: `GET → learnings:read`, `POST`/`PATCH → learnings:write`, `DELETE → learnings:delete`.
- `DELETE /learnings/*` also covers the nested `DELETE /learnings/users/{user_id}`; `GET /learnings/*` covers `/learnings/users` (verified via the middleware matcher).
- Documented `learnings:read/write/delete` in the `AgentOSScope` docstring.

### 2. async_mongo caches a missing collection as `None`

Each block in `_get_collection` cached whatever `_get_or_create_collection` returned — including `None` when the collection didn't exist yet and `create=False`. Because the guard was `not hasattr(self, "X_collection")`, the cached `None` stuck, so a **read before the first write** (the learnings read methods pass `create_collection_if_not_found=False`) made every later write resolve to `None` and get silently dropped.

Reproduced by the reviewer: *GET then POST saved nothing; POST first worked.*

- Changed the guard in **every** collection block to re-fetch when the cached value is `None` (`getattr(self, "X_collection", None) is None`). Collections that exist still cache after the first successful fetch; only the not-yet-created `None` case re-attempts. Only learnings triggers it today (it's the only path passing `create=False`), but the buggy pattern was identical in all 11 blocks.

## Tests

- `test_scopes.py`: assert the learnings mappings, and that every learnings route (including the nested delete-user path) resolves to a learnings scope via the real `_get_required_scopes` matcher.
- `test_async_mongo.py`: red/green regression — fails on the old `not hasattr` guard, passes with the re-fetch-on-None fix.

## Type of change

- [x] Bug fix

## Checklist

- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tests added/updated

## Additional Notes

- Targets `feat/learnings-crud-endpoints` (where #8303 was merged), not `main`.
- `validate.sh` reports one pre-existing unrelated mypy error in `libs/agno/agno/tools/sql.py`; not touched here.
