### PR TITLE
fix: POST /learnings derives the deterministic store id (no orphan/duplicate)

### DIFF
--- a/cookbook/05_agent_os/learnings/README.md
+++ b/cookbook/05_agent_os/learnings/README.md
@@ -73,3 +73,24 @@ through unscoped.
 - `workflow_id` is not exposed: workflows don't produce learnings directly —
   they go through their constituent agents/teams, which write `agent_id` or
   `team_id`.
+
+## Creating records (id derivation)
+
+The learning stores key their records by a deterministic id derived from the
+identity fields, not a random id. So `POST /learnings` derives the same id for
+the identity-keyed types, ensuring a record created via the API reconciles with
+what the agent reads and writes (no orphan, no duplicate):
+
+| `learning_type` | derived id |
+|---|---|
+| `user_profile` | `user_profile_{user_id}` |
+| `user_memory` | `memories_{user_id}` |
+| `session_context` | `session_context_{session_id}` |
+| `entity_memory` | `entity_{namespace}_{entity_type}_{entity_id}` |
+
+- Provide the required identity field(s) for these types, or the request is
+  rejected with `422`. If a record already exists for that identity, `POST`
+  returns `409` — use `PATCH` to update it.
+- Put the same identity fields inside `content` too (e.g. `user_id` for
+  `user_profile`), so the agent's store can deserialize the record.
+- Other types (e.g. `decision_log`) use a generated id, so a user can have many.

--- a/cookbook/05_agent_os/learnings/rest_api_learnings.py
+++ b/cookbook/05_agent_os/learnings/rest_api_learnings.py
@@ -29,6 +29,11 @@ def main():
     # =========================================================================
     # 1. Create a learning record
     # =========================================================================
+    # For the identity-keyed types (user_profile, user_memory, session_context,
+    # entity_memory) the record id is derived deterministically from the identity fields,
+    # so it reconciles with what the agent reads/writes. Include those identity fields in
+    # `content` too (e.g. user_id) so the agent can deserialize the record. Re-POSTing the
+    # same identity returns 409 -- use PATCH to update.
     print("=== Create Learning ===\n")
     resp = client.post(
         "/learnings",
@@ -37,6 +42,7 @@ def main():
             "namespace": "global",
             "user_id": "demo-user",
             "content": {
+                "user_id": "demo-user",
                 "name": "Yash",
                 "preferences": {"language": "Python", "tone": "concise"},
             },
@@ -134,15 +140,16 @@ def main():
     # 7. Delete a user and all of their learnings
     # =========================================================================
     # Seed a couple of records for a throwaway user, then remove the user and
-    # everything associated with them in one call.
+    # everything associated with them in one call. decision_log uses a generated id
+    # (not identity-keyed), so a user can have many of them.
     print("\n=== Delete Learning User ===\n")
-    for content in ({"note": "first"}, {"note": "second"}):
+    for note in ("first", "second"):
         client.post(
             "/learnings",
             json={
-                "learning_type": "user_memory",
+                "learning_type": "decision_log",
                 "user_id": "bulk-demo-user",
-                "content": content,
+                "content": {"note": note},
             },
         ).raise_for_status()
 

--- a/libs/agno/agno/learn/stores/entity_memory.py
+++ b/libs/agno/agno/learn/stores/entity_memory.py
@@ -39,11 +39,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from os import getenv
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from agno.learn.config import EntityMemoryConfig, LearningMode
 from agno.learn.schemas import EntityMemory
 from agno.learn.stores.protocol import LearningStore
+from agno.learn.utils import build_learning_id
 from agno.utils.log import (
     log_debug,
     log_warning,
@@ -3095,7 +3096,10 @@ class EntityMemoryStore(LearningStore):
         namespace: str,
     ) -> str:
         """Build unique DB ID for entity."""
-        return f"entity_{namespace}_{entity_type}_{entity_id}"
+        return cast(
+            str,
+            build_learning_id("entity_memory", entity_id=entity_id, entity_type=entity_type, namespace=namespace),
+        )
 
     def _format_entity_basic(self, entity: Any) -> str:
         """Basic entity formatting fallback."""

--- a/libs/agno/agno/learn/stores/session_context.py
+++ b/libs/agno/agno/learn/stores/session_context.py
@@ -29,12 +29,12 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from os import getenv
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from agno.learn.config import LearningMode, SessionContextConfig
 from agno.learn.schemas import SessionContext
 from agno.learn.stores.protocol import LearningStore
-from agno.learn.utils import from_dict_safe, to_dict_safe
+from agno.learn.utils import build_learning_id, from_dict_safe, to_dict_safe
 from agno.utils.log import (
     log_debug,
     log_warning,
@@ -649,7 +649,7 @@ class SessionContextStore(LearningStore):
 
     def _build_context_id(self, session_id: str) -> str:
         """Build a unique context ID."""
-        return f"session_context_{session_id}"
+        return cast(str, build_learning_id("session_context", session_id=session_id))
 
     def _format_context(self, context: Any) -> str:
         """Format context data for display in agent prompt."""

--- a/libs/agno/agno/learn/stores/user_memory.py
+++ b/libs/agno/agno/learn/stores/user_memory.py
@@ -28,12 +28,12 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from os import getenv
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 
 from agno.learn.config import LearningMode, UserMemoryConfig
 from agno.learn.schemas import Memories
 from agno.learn.stores.protocol import LearningStore
-from agno.learn.utils import from_dict_safe, to_dict_safe
+from agno.learn.utils import build_learning_id, from_dict_safe, to_dict_safe
 from agno.utils.log import (
     log_debug,
     log_warning,
@@ -932,7 +932,7 @@ class UserMemoryStore(LearningStore):
 
     def _build_memories_id(self, user_id: str) -> str:
         """Build a unique memories ID."""
-        return f"memories_{user_id}"
+        return cast(str, build_learning_id("user_memory", user_id=user_id))
 
     def _memories_to_list(self, memories: Optional[Any]) -> List[dict]:
         """Convert memories to list of memory dicts for prompt."""

--- a/libs/agno/agno/learn/stores/user_profile.py
+++ b/libs/agno/agno/learn/stores/user_profile.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 from agno.learn.config import LearningMode, UserProfileConfig
 from agno.learn.schemas import UserProfile
 from agno.learn.stores.protocol import LearningStore
-from agno.learn.utils import from_dict_safe, to_dict_safe
+from agno.learn.utils import build_learning_id, from_dict_safe, to_dict_safe
 from agno.utils.log import (
     log_debug,
     log_warning,
@@ -1018,7 +1018,7 @@ class UserProfileStore(LearningStore):
 
     def _build_profile_id(self, user_id: str) -> str:
         """Build a unique profile ID."""
-        return f"user_profile_{user_id}"
+        return cast(str, build_learning_id("user_profile", user_id=user_id))
 
     def _build_functions_for_model(self, tools: List[Callable]) -> List["Function"]:
         """Convert callables to Functions for model."""

--- a/libs/agno/agno/learn/utils.py
+++ b/libs/agno/agno/learn/utils.py
@@ -13,6 +13,49 @@ from typing import Any, Dict, List, Optional, Type, TypeVar
 
 T = TypeVar("T")
 
+# Default sharing namespace used by the learning stores when none is configured/provided.
+DEFAULT_LEARNING_NAMESPACE = "global"
+
+# Learning types whose records are keyed by a deterministic id derived from their identity
+# fields (see build_learning_id). Anything creating these must use that id, or the record
+# won't reconcile with the agent's store. Other types (e.g. decision_log) use a generated id.
+IDENTITY_KEYED_LEARNING_TYPES = frozenset({"user_profile", "user_memory", "session_context", "entity_memory"})
+
+
+def build_learning_id(
+    learning_type: str,
+    *,
+    user_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    entity_id: Optional[str] = None,
+    entity_type: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> Optional[str]:
+    """Deterministic primary key for the framework's identity-keyed learning stores.
+
+    The learning stores key each record in ``agno_learnings`` by an id derived from its
+    identity fields -- NOT a random uuid. So anything else writing to that table (e.g. the
+    REST create endpoint) must compute the same id, otherwise the record won't reconcile
+    with what the agent reads/writes and duplicate rows appear.
+
+    This is the single source of truth: the stores' ``_build_*_id`` helpers delegate here.
+
+    Returns ``None`` for learning types that do not use a deterministic id (e.g.
+    ``decision_log``, which keys each entry by its own uuid) or when the identity fields
+    required for the id are missing -- callers should fall back to a generated id then.
+    """
+    if learning_type == "user_profile":
+        return f"user_profile_{user_id}" if user_id else None
+    if learning_type == "user_memory":
+        return f"memories_{user_id}" if user_id else None
+    if learning_type == "session_context":
+        return f"session_context_{session_id}" if session_id else None
+    if learning_type == "entity_memory":
+        if entity_id and entity_type:
+            return f"entity_{namespace or DEFAULT_LEARNING_NAMESPACE}_{entity_type}_{entity_id}"
+        return None
+    return None
+
 
 def _safe_get(data: Any, key: str, default: Any = None) -> Any:
     """Safely get a key from dict-like data.

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -8,6 +8,7 @@ from fastapi import Depends, HTTPException, Path, Query, Request
 from fastapi.routing import APIRouter
 
 from agno.db.base import AsyncBaseDb, BaseDb
+from agno.learn.utils import IDENTITY_KEYED_LEARNING_TYPES, build_learning_id
 from agno.os.auth import get_authentication_dependency
 from agno.os.middleware.user_scope import get_scoped_user_id
 from agno.os.routers.learnings.schema import LearningCreate, LearningResponse, LearningUpdate, LearningUserStats
@@ -147,9 +148,13 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         operation_id="create_learning",
         summary="Create Learning",
         description=(
-            "Create a new learning record. For a scoped (non-admin) caller, the body's `user_id` "
-            "must either be omitted/null (creates a global / non-user-scoped record) or match the "
-            "caller. A mismatch is rejected with 403. Admins and unscoped callers may set any `user_id`."
+            "Create a new learning record. For the identity-keyed learning types (`user_profile`, "
+            "`user_memory`, `session_context`, `entity_memory`) the record id is derived "
+            "deterministically from the identity fields so it reconciles with what the agent "
+            "reads/writes — provide those fields (else 422), and if a record already exists the "
+            "request is rejected with 409 (use PATCH to update it). Other types get a generated id. "
+            "For a scoped (non-admin) caller, the body's `user_id` must be omitted/null or match the "
+            "caller (mismatch → 403); admins and unscoped callers may set any `user_id`."
         ),
     )
     async def create_learning(
@@ -167,9 +172,42 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         if isinstance(db, RemoteDb):
             raise HTTPException(status_code=501, detail="Learnings endpoints not supported on remote DBs")
 
-        learning_id = str(uuid4())
+        # The learning stores key their records by a deterministic id derived from the identity
+        # fields, not a random uuid. A POST must use that same id, otherwise the record is
+        # invisible to the agent (which reads/writes the deterministic id) and a duplicate row
+        # appears on the agent's next write. Derive it for the identity-keyed types; fall back to
+        # a uuid only for types that genuinely use generated ids (e.g. decision_log).
+        deterministic_id = build_learning_id(
+            body.learning_type,
+            user_id=body.user_id,
+            session_id=body.session_id,
+            entity_id=body.entity_id,
+            entity_type=body.entity_type,
+            namespace=body.namespace,
+        )
+        if body.learning_type in IDENTITY_KEYED_LEARNING_TYPES and deterministic_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"learning_type '{body.learning_type}' is keyed by its identity fields; provide the "
+                    "required field(s) (user_id, session_id, or entity_id + entity_type) so the record "
+                    "reconciles with the agent's store."
+                ),
+            )
+        learning_id = deterministic_id or str(uuid4())
+
         try:
             if isinstance(db, AsyncBaseDb):
+                # Identity-keyed record already exists -> don't silently overwrite agent-curated
+                # data; steer the caller to PATCH.
+                if deterministic_id is not None and await db.get_learning_by_id(learning_id) is not None:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"A '{body.learning_type}' learning already exists for this identity "
+                            f"(id '{learning_id}'). Use PATCH /learnings/{learning_id} to update it."
+                        ),
+                    )
                 await db.upsert_learning(
                     id=learning_id,
                     learning_type=body.learning_type,
@@ -186,6 +224,14 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 created = await db.get_learning_by_id(learning_id)
             else:
                 sync_db = cast(BaseDb, db)
+                if deterministic_id is not None and sync_db.get_learning_by_id(learning_id) is not None:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"A '{body.learning_type}' learning already exists for this identity "
+                            f"(id '{learning_id}'). Use PATCH /learnings/{learning_id} to update it."
+                        ),
+                    )
                 sync_db.upsert_learning(
                     id=learning_id,
                     learning_type=body.learning_type,

--- a/libs/agno/tests/unit/learn/test_build_learning_id.py
+++ b/libs/agno/tests/unit/learn/test_build_learning_id.py
@@ -1,0 +1,69 @@
+"""Tests for build_learning_id, the single source of truth for learning record PKs.
+
+The learning stores delegate their `_build_*_id` helpers here, so the REST create endpoint
+can compute the same deterministic id and records reconcile with what the agent reads/writes.
+"""
+
+from agno.learn.stores.entity_memory import EntityMemoryStore
+from agno.learn.stores.session_context import SessionContextStore
+from agno.learn.stores.user_memory import UserMemoryStore
+from agno.learn.stores.user_profile import UserProfileStore
+from agno.learn.utils import IDENTITY_KEYED_LEARNING_TYPES, build_learning_id
+
+
+class TestBuildLearningId:
+    def test_identity_keyed_types(self):
+        assert build_learning_id("user_profile", user_id="u1") == "user_profile_u1"
+        assert build_learning_id("user_memory", user_id="u1") == "memories_u1"
+        assert build_learning_id("session_context", session_id="s1") == "session_context_s1"
+        assert (
+            build_learning_id("entity_memory", entity_id="acme", entity_type="company") == "entity_global_company_acme"
+        )
+        assert (
+            build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user")
+            == "entity_user_company_acme"
+        )
+
+    def test_missing_identity_fields_returns_none(self):
+        assert build_learning_id("user_profile") is None
+        assert build_learning_id("user_memory") is None
+        assert build_learning_id("session_context") is None
+        assert build_learning_id("entity_memory", entity_id="acme") is None  # needs entity_type too
+
+    def test_non_identity_types_return_none(self):
+        assert build_learning_id("decision_log", user_id="u1") is None
+        assert build_learning_id("something_custom", user_id="u1") is None
+
+    def test_identity_keyed_set_matches_helper(self):
+        # Every type in the set must be derivable when its fields are present, and the
+        # decision_log (generated-id) type must not be in the set.
+        assert IDENTITY_KEYED_LEARNING_TYPES == {
+            "user_profile",
+            "user_memory",
+            "session_context",
+            "entity_memory",
+        }
+        assert "decision_log" not in IDENTITY_KEYED_LEARNING_TYPES
+
+
+class TestStoresDelegateToHelper:
+    """The stores' private id builders must produce exactly what build_learning_id returns,
+    so a REST create lands on the same row the agent uses."""
+
+    def test_user_profile_store(self):
+        store = UserProfileStore.__new__(UserProfileStore)
+        assert store._build_profile_id("u1") == build_learning_id("user_profile", user_id="u1")
+
+    def test_user_memory_store(self):
+        store = UserMemoryStore.__new__(UserMemoryStore)
+        assert store._build_memories_id("u1") == build_learning_id("user_memory", user_id="u1")
+
+    def test_session_context_store(self):
+        store = SessionContextStore.__new__(SessionContextStore)
+        assert store._build_context_id("s1") == build_learning_id("session_context", session_id="s1")
+
+    def test_entity_memory_store(self):
+        store = EntityMemoryStore.__new__(EntityMemoryStore)
+        assert store._build_entity_db_id("acme", "company", "global") == build_learning_id(
+            "entity_memory", entity_id="acme", entity_type="company", namespace="global"
+        )

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -191,28 +191,57 @@ class TestListLearningUsers:
 
 
 class TestCreateLearning:
-    def test_create_success(self, client, mock_db):
-        created = _make_learning(learning_id="new-id", content={"hello": "world"})
-        mock_db.get_learning_by_id = MagicMock(return_value=created)
+    def test_create_uses_deterministic_id_for_identity_keyed_type(self, client, mock_db):
+        created = _make_learning(learning_id="user_profile_user-1", content={"hello": "world"})
+        # existence check -> None (not present), then readback -> created
+        mock_db.get_learning_by_id = MagicMock(side_effect=[None, created])
         resp = client.post(
             "/learnings",
             json={"learning_type": "user_profile", "content": {"hello": "world"}, "user_id": "user-1"},
         )
         assert resp.status_code == 201
-        body = resp.json()
-        assert body["learning_type"] == "user_profile"
-        assert body["content"] == {"hello": "world"}
-        assert mock_db.upsert_learning.called
+        assert resp.json()["learning_id"] == "user_profile_user-1"
+        # Persisted under the deterministic id (reconciles with the agent's store), not a uuid.
+        assert mock_db.upsert_learning.call_args[1]["id"] == "user_profile_user-1"
 
-    def test_create_missing_required_field(self, client):
+    def test_create_conflict_when_identity_record_exists(self, client, mock_db):
+        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(learning_id="user_profile_user-1"))
+        resp = client.post(
+            "/learnings",
+            json={"learning_type": "user_profile", "content": {}, "user_id": "user-1"},
+        )
+        assert resp.status_code == 409
+        mock_db.upsert_learning.assert_not_called()
+
+    def test_create_identity_type_missing_field_is_422(self, client, mock_db):
+        # user_profile is keyed by user_id; without it the id can't be derived -> reject.
+        resp = client.post("/learnings", json={"learning_type": "user_profile", "content": {}})
+        assert resp.status_code == 422
+        mock_db.upsert_learning.assert_not_called()
+
+    def test_create_generated_id_for_non_identity_type(self, client, mock_db):
+        created = _make_learning(learning_id="generated", learning_type="decision_log")
+        mock_db.get_learning_by_id = MagicMock(return_value=created)
+        resp = client.post(
+            "/learnings",
+            json={"learning_type": "decision_log", "content": {"d": 1}, "user_id": "user-1"},
+        )
+        assert resp.status_code == 201
+        # decision_log uses a generated uuid; no existence pre-check (only the readback call).
+        assert mock_db.upsert_learning.called
+        upsert_id = mock_db.upsert_learning.call_args[1]["id"]
+        assert upsert_id not in ("decision_log_user-1",) and len(upsert_id) == 36
+
+    def test_create_missing_learning_type_is_422(self, client):
         resp = client.post("/learnings", json={"content": {}})
         assert resp.status_code == 422
 
     def test_create_failure_when_get_returns_none(self, client, mock_db):
-        mock_db.get_learning_by_id = MagicMock(return_value=None)
+        # identity record absent (None on existence) and readback also None -> 500
+        mock_db.get_learning_by_id = MagicMock(side_effect=[None, None])
         resp = client.post(
             "/learnings",
-            json={"learning_type": "user_profile", "content": {}},
+            json={"learning_type": "user_profile", "content": {}, "user_id": "user-1"},
         )
         assert resp.status_code == 500
 
@@ -391,7 +420,8 @@ class TestIDORScoping:
         assert kwargs["agent_id"] == "ag-1"
 
     def test_create_matching_user_id_allowed(self, jwt_client, mock_db):
-        mock_db.get_learning_by_id = MagicMock(return_value=_make_learning(user_id="user-A"))
+        # existence check -> None (not present), then readback -> created
+        mock_db.get_learning_by_id = MagicMock(side_effect=[None, _make_learning(user_id="user-A")])
         resp = jwt_client.post(
             "/learnings",
             json={"learning_type": "user_profile", "content": {}, "user_id": "user-A"},


### PR DESCRIPTION
## Summary

Fixes the high-severity issue from the #7826 review: `POST /learnings` minted a random `uuid4` for the primary key, but the learning stores key their records by a **deterministic id derived from the identity fields**. So a record created via the API never reconciled with what the agent reads/writes, and the agent's next save created a **duplicate row** for the same user (no unique constraint beyond the PK). End-to-end *"create a profile via API, then have the agent use it"* silently didn't work.

The deterministic schemes:

| `learning_type` | PK |
|---|---|
| `user_profile` | `user_profile_{user_id}` |
| `user_memory` | `memories_{user_id}` |
| `session_context` | `session_context_{session_id}` |
| `entity_memory` | `entity_{namespace}_{entity_type}_{entity_id}` |
| `decision_log` / other | generated uuid (append-style, not identity-keyed) |

## Changes

- **`build_learning_id()`** in `agno/learn/utils.py` — single source of truth for the deterministic ids. The four stores' `_build_*_id` helpers now **delegate** to it, so the router and stores can't drift (covered by a parity test).
- **`create_learning`** derives the id via `build_learning_id` for the identity-keyed types; uuid fallback for generated-id types.
  - Missing the required identity field(s) for an identity-keyed type → **422** (would otherwise orphan).
  - An identity record already exists → **409**, steering the caller to PATCH instead of silently overwriting agent-curated data.
- **Cookbook + README** — document the id derivation, include identity fields in `content` (so the agent's store can deserialize), and switch the multi-record bulk-delete demo to `decision_log` (which allows many records per user).

## Verification

End-to-end against a real SqliteDb: a REST-created `user_profile` is read by `UserProfileStore`, and the agent's subsequent `save()` updates the **same** row — one row, no duplicate. The full cookbook (`create → list → users → get → patch → delete → bulk delete-user`) runs green with the deterministic id.

## Tests

- `test_build_learning_id.py`: id values, missing-field/None cases, the identity-keyed set, and parity between each store's `_build_*_id` and `build_learning_id`.
- `test_learnings_router.py`: deterministic id on create, 409-on-exists, 422 missing-identity, generated id for non-identity types.

## Type of change

- [x] Bug fix

## Checklist

- [x] Ran format/validation scripts
- [x] Tests added/updated
- [x] Tested in a clean environment (live AgentOS + agent-store reconciliation)

## Additional Notes

- Targets `feat/learnings-crud-endpoints`.
- `validate.sh` reports one pre-existing unrelated mypy error in `libs/agno/agno/tools/sql.py`; not touched here.
