### PR TITLE
fix: surface DB errors on learnings router methods (no false 204 on bulk delete)

### DIFF
--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -3234,8 +3234,8 @@ class AsyncMongoDb(AsyncBaseDb):
             return int(result.deleted_count or 0)
 
         except Exception as e:
-            log_debug(f"Error deleting user learnings: {e}")
-            return 0
+            log_error(f"Error deleting user learnings: {e}")
+            raise e
 
     async def get_learnings(
         self,
@@ -3318,8 +3318,8 @@ class AsyncMongoDb(AsyncBaseDb):
             result.pop("_id", None)
             return result
         except Exception as e:
-            log_debug(f"Error getting learning by id: {e}")
-            return None
+            log_error(f"Error getting learning by id: {e}")
+            raise e
 
     async def list_learnings(
         self,
@@ -3382,8 +3382,8 @@ class AsyncMongoDb(AsyncBaseDb):
             return learnings, int(total_count)
 
         except Exception as e:
-            log_debug(f"Error listing learnings: {e}")
-            return [], 0
+            log_error(f"Error listing learnings: {e}")
+            raise e
 
     async def get_learnings_user_stats(
         self,

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3047,8 +3047,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 return getattr(result, "rowcount", 0) or 0
 
         except Exception as e:
-            log_debug(f"Error deleting user learnings: {e}")
-            return 0
+            log_error(f"Error deleting user learnings: {e}")
+            raise e
 
     async def get_learnings(
         self,
@@ -3126,8 +3126,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
         except Exception as e:
-            log_debug(f"Error getting learning by id: {e}")
-            return None
+            log_error(f"Error getting learning by id: {e}")
+            raise e
 
     async def list_learnings(
         self,
@@ -3183,8 +3183,8 @@ class AsyncPostgresDb(AsyncBaseDb):
                 return [dict(row._mapping) for row in rows], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error listing learnings: {e}")
-            return [], 0
+            log_error(f"Error listing learnings: {e}")
+            raise e
 
     async def get_learnings_user_stats(
         self,

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4542,8 +4542,8 @@ class PostgresDb(BaseDb):
                 return result.rowcount or 0
 
         except Exception as e:
-            log_debug(f"Error deleting user learnings: {e}")
-            return 0
+            log_error(f"Error deleting user learnings: {e}")
+            raise e
 
     def get_learnings(
         self,
@@ -4623,8 +4623,8 @@ class PostgresDb(BaseDb):
                 result = sess.execute(select(table).where(table.c.learning_id == id)).fetchone()
                 return dict(result._mapping) if result else None
         except Exception as e:
-            log_debug(f"Error getting learning by id: {e}")
-            return None
+            log_error(f"Error getting learning by id: {e}")
+            raise e
 
     def list_learnings(
         self,
@@ -4678,8 +4678,8 @@ class PostgresDb(BaseDb):
                 return [dict(row._mapping) for row in result], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error listing learnings: {e}")
-            return [], 0
+            log_error(f"Error listing learnings: {e}")
+            raise e
 
     def get_learnings_user_stats(
         self,

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3219,8 +3219,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return getattr(result, "rowcount", 0) or 0
 
         except Exception as e:
-            log_debug(f"Error deleting user learnings: {e}")
-            return 0
+            log_error(f"Error deleting user learnings: {e}")
+            raise e
 
     async def get_learnings(
         self,
@@ -3302,8 +3302,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 row = result.fetchone()
                 return dict(row._mapping) if row else None
         except Exception as e:
-            log_debug(f"Error getting learning by id: {e}")
-            return None
+            log_error(f"Error getting learning by id: {e}")
+            raise e
 
     async def list_learnings(
         self,
@@ -3359,8 +3359,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return [dict(row._mapping) for row in results], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error listing learnings: {e}")
-            return [], 0
+            log_error(f"Error listing learnings: {e}")
+            raise e
 
     async def get_learnings_user_stats(
         self,

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4392,8 +4392,8 @@ class SqliteDb(BaseDb):
                 return result.rowcount or 0
 
         except Exception as e:
-            log_debug(f"Error deleting user learnings: {e}")
-            return 0
+            log_error(f"Error deleting user learnings: {e}")
+            raise e
 
     def get_learnings(
         self,
@@ -4473,8 +4473,8 @@ class SqliteDb(BaseDb):
                 result = sess.execute(select(table).where(table.c.learning_id == id)).fetchone()
                 return dict(result._mapping) if result else None
         except Exception as e:
-            log_debug(f"Error getting learning by id: {e}")
-            return None
+            log_error(f"Error getting learning by id: {e}")
+            raise e
 
     def list_learnings(
         self,
@@ -4528,8 +4528,8 @@ class SqliteDb(BaseDb):
                 return [dict(row._mapping) for row in results], int(total_count)
 
         except Exception as e:
-            log_debug(f"Error listing learnings: {e}")
-            return [], 0
+            log_error(f"Error listing learnings: {e}")
+            raise e
 
     def get_learnings_user_stats(
         self,

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -129,6 +129,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 )
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to list learnings: {e}")
 
         total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
         return PaginatedResponse(
@@ -248,6 +250,10 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 created = sync_db.get_learning_by_id(learning_id)
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except HTTPException:
+            raise  # e.g. the 409 conflict above
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to create learning: {e}")
 
         if created is None:
             raise HTTPException(status_code=500, detail="Failed to create learning")
@@ -369,6 +375,9 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 cast(BaseDb, db).delete_user_learnings(user_id, learning_type=learning_type)
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except Exception as e:
+            # Don't report a destructive bulk delete as a success (204) when it failed.
+            raise HTTPException(status_code=500, detail=f"Failed to delete user learnings: {e}")
 
     @router.get(
         "/learnings/{learning_id}",
@@ -457,6 +466,8 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
                 updated = sync_db.get_learning_by_id(learning_id)
         except NotImplementedError:
             raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to update learning: {e}")
 
         if updated is None:
             raise HTTPException(status_code=500, detail="Failed to update learning")
@@ -519,6 +530,9 @@ async def _fetch_learning(db: Union[BaseDb, AsyncBaseDb, RemoteDb], learning_id:
             record = cast(BaseDb, db).get_learning_by_id(learning_id)
     except NotImplementedError:
         raise HTTPException(status_code=501, detail="Learnings not supported by the configured database")
+    except Exception as e:
+        # A DB error is not "not found" -- surface it rather than emit a misleading 404.
+        raise HTTPException(status_code=500, detail=f"Failed to fetch learning: {e}")
     if record is None:
         raise HTTPException(status_code=404, detail="Learning not found")
     return record

--- a/libs/agno/tests/unit/os/routers/test_learnings_router.py
+++ b/libs/agno/tests/unit/os/routers/test_learnings_router.py
@@ -96,6 +96,12 @@ class TestListLearnings:
         resp = client.get("/learnings")
         assert resp.status_code == 501
 
+    def test_db_error_returns_500(self, client, mock_db):
+        # A DB error must surface as 500, not a misleading empty 200 page.
+        mock_db.list_learnings.side_effect = RuntimeError("boom")
+        resp = client.get("/learnings")
+        assert resp.status_code == 500
+
     def test_default_sort_passed_through(self, client, mock_db):
         client.get("/learnings")
         kwargs = mock_db.list_learnings.call_args[1]
@@ -258,6 +264,12 @@ class TestGetLearning:
         resp = client.get("/learnings/nope")
         assert resp.status_code == 404
 
+    def test_db_error_returns_500_not_404(self, client, mock_db):
+        # A DB error is not "not found" -- surface it as 500, not a misleading 404.
+        mock_db.get_learning_by_id = MagicMock(side_effect=RuntimeError("boom"))
+        resp = client.get("/learnings/lrn-1")
+        assert resp.status_code == 500
+
 
 class TestUpdateLearning:
     def test_update_replaces_content(self, client, mock_db):
@@ -355,6 +367,12 @@ class TestDeleteLearningUser:
         mock_db.delete_user_learnings.side_effect = NotImplementedError
         resp = client.delete("/learnings/users/user-1")
         assert resp.status_code == 501
+
+    def test_db_error_returns_500_not_false_204(self, client, mock_db):
+        # The destructive bulk delete must NOT report success when the DB call fails.
+        mock_db.delete_user_learnings.side_effect = RuntimeError("boom")
+        resp = client.delete("/learnings/users/user-1")
+        assert resp.status_code == 500
 
 
 class TestIDORScoping:


### PR DESCRIPTION
## Summary

Fixes the medium-severity issue from the #7826 review: the learnings router methods swallowed DB errors, so failures were reported as success/empty — most dangerously, a failed **destructive** `DELETE /learnings/users/{user_id}` returned `204` (the caller believes a user's learnings were wiped when they weren't).

The five new methods were inconsistent: `get_learnings_user_stats` raised (router → 500), while `get_learning_by_id`, `list_learnings`, and `delete_user_learnings` swallowed (→ misleading 404 / empty 200 / false 204).

## The convention

**Router-facing learning methods raise on error; agent-facing methods swallow.**

- `get_learning_by_id`, `list_learnings`, `get_learnings_user_stats`, `delete_user_learnings` are only called by the REST router → they now `log_error` + `raise` on failure, and the router turns that into a structured **500**.
- `get_learnings` / `get_learning` are called by the agent's stores → they keep swallowing, per the learn module's explicit "never crash the agent" rule.

That's the principled split (not arbitrary), and it makes all four router-facing methods consistent with `get_learnings_user_stats`.

## Changes

- DB adapters (postgres, async_postgres, sqlite, async_sqlite, async_mongo): `get_learning_by_id` / `list_learnings` / `delete_user_learnings` now `log_error` + `raise` instead of returning `None` / `([], 0)` / `0`.
- Router: added `except Exception → 500` to the list / create / patch / delete-user paths and `_fetch_learning` (so a DB error during a single-record read is a 500, not a misleading 404). `create_learning` re-raises its inner 409.

Normal results are unchanged — a missing row, an empty page, or "0 deleted" are not errors, so only genuine exceptions raise (verified against a live SqliteDb).

## Tests

`test_learnings_router.py`: DB-error → 500 for list and single-record GET, and — the key case — the destructive `DELETE /learnings/users/{user_id}` asserts **500, not a false 204**.

## Type of change

- [x] Bug fix

## Additional Notes

- Targets `feat/learnings-crud-endpoints`.
- `validate.sh` reports one pre-existing unrelated mypy error in `libs/agno/agno/tools/sql.py`; not touched here.
