### PR TITLE
fix: drop dead workflow_id from upsert_learning + learnings doc nits

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1706,7 +1706,6 @@ class AsyncBaseDb(ABC):
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
         team_id: Optional[str] = None,
-        workflow_id: Optional[str] = None,
         session_id: Optional[str] = None,
         namespace: Optional[str] = None,
         entity_id: Optional[str] = None,
@@ -1722,7 +1721,6 @@ class AsyncBaseDb(ABC):
             user_id: Associated user ID.
             agent_id: Associated agent ID.
             team_id: Associated team ID.
-            workflow_id: Associated workflow ID.
             session_id: Associated session ID.
             namespace: Namespace for scoping ('user', 'global', or custom).
             entity_id: Associated entity ID (for entity-specific learnings).

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -4443,7 +4443,6 @@ class PostgresDb(BaseDb):
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
         team_id: Optional[str] = None,
-        workflow_id: Optional[str] = None,
         session_id: Optional[str] = None,
         namespace: Optional[str] = None,
         entity_id: Optional[str] = None,
@@ -4459,7 +4458,6 @@ class PostgresDb(BaseDb):
             user_id: Associated user ID.
             agent_id: Associated agent ID.
             team_id: Associated team ID.
-            workflow_id: Associated workflow ID.
             session_id: Associated session ID.
             namespace: Namespace for scoping ('user', 'global', or custom).
             entity_id: Associated entity ID (for entity-specific learnings).
@@ -4481,7 +4479,6 @@ class PostgresDb(BaseDb):
                     user_id=user_id,
                     agent_id=agent_id,
                     team_id=team_id,
-                    workflow_id=workflow_id,
                     session_id=session_id,
                     entity_id=entity_id,
                     entity_type=entity_type,

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3120,7 +3120,6 @@ class AsyncSqliteDb(AsyncBaseDb):
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
         team_id: Optional[str] = None,
-        workflow_id: Optional[str] = None,
         session_id: Optional[str] = None,
         namespace: Optional[str] = None,
         entity_id: Optional[str] = None,
@@ -3136,7 +3135,6 @@ class AsyncSqliteDb(AsyncBaseDb):
             user_id: Associated user ID.
             agent_id: Associated agent ID.
             team_id: Associated team ID.
-            workflow_id: Associated workflow ID.
             session_id: Associated session ID.
             namespace: Namespace for scoping ('user', 'global', or custom).
             entity_id: Associated entity ID (for entity-specific learnings).
@@ -3158,7 +3156,6 @@ class AsyncSqliteDb(AsyncBaseDb):
                     user_id=user_id,
                     agent_id=agent_id,
                     team_id=team_id,
-                    workflow_id=workflow_id,
                     session_id=session_id,
                     entity_id=entity_id,
                     entity_type=entity_type,

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -4293,7 +4293,6 @@ class SqliteDb(BaseDb):
         user_id: Optional[str] = None,
         agent_id: Optional[str] = None,
         team_id: Optional[str] = None,
-        workflow_id: Optional[str] = None,
         session_id: Optional[str] = None,
         namespace: Optional[str] = None,
         entity_id: Optional[str] = None,
@@ -4309,7 +4308,6 @@ class SqliteDb(BaseDb):
             user_id: Associated user ID.
             agent_id: Associated agent ID.
             team_id: Associated team ID.
-            workflow_id: Associated workflow ID.
             session_id: Associated session ID.
             namespace: Namespace for scoping ('user', 'global', or custom).
             entity_id: Associated entity ID (for entity-specific learnings).
@@ -4331,7 +4329,6 @@ class SqliteDb(BaseDb):
                     user_id=user_id,
                     agent_id=agent_id,
                     team_id=team_id,
-                    workflow_id=workflow_id,
                     session_id=session_id,
                     entity_id=entity_id,
                     entity_type=entity_type,

--- a/libs/agno/agno/learn/schemas.py
+++ b/libs/agno/agno/learn/schemas.py
@@ -41,7 +41,14 @@ from agno.utils.log import log_debug
 
 
 def _utc_now_iso() -> str:
-    """UTC timestamp in ISO-8601 with a trailing Z (matches the rest of the learn module)."""
+    """UTC timestamp in ISO-8601 with a trailing Z (matches the rest of the learn module).
+
+    Note on time formats: these per-entry timestamps live *inside* ``content`` (on each
+    memory / fact / event / relationship) and are ISO-8601 strings. They are deliberately
+    distinct from the row-level ``created_at`` / ``updated_at`` columns of the
+    ``agno_learnings`` table, which are Unix-epoch integers. A consumer reading both the
+    record columns and the in-content entries should expect the two different formats.
+    """
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 

--- a/libs/agno/agno/os/routers/learnings/router.py
+++ b/libs/agno/agno/os/routers/learnings/router.py
@@ -76,11 +76,23 @@ def _attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBas
         entity_type: Optional[str] = Query(None, description="Filter by entity type"),
         limit: int = Query(100, ge=1, le=1000, description="Page size"),
         page: int = Query(1, ge=1, description="1-indexed page number"),
-        sort_by: Optional[str] = Query(None, description="Field to sort by (defaults to updated_at)"),
+        sort_by: Optional[str] = Query(
+            None,
+            description=(
+                "Field to sort by, e.g. `created_at` or `updated_at` (the default). "
+                "An unrecognised field is ignored (the default ordering is used)."
+            ),
+        ),
         sort_order: Optional[SortOrder] = Query(SortOrder.DESC, description="Sort order (asc or desc)"),
         db_id: Optional[str] = Query(None, description="Database ID to query"),
         table: Optional[str] = Query(None, description="The database table to use (requires db_id)"),
     ) -> PaginatedResponse[LearningResponse]:
+        # Scoping note: this router calls get_scoped_user_id + get_db directly rather than the
+        # shared resolve_db_and_scope helper. That helper returns the user_id to *silently* thread
+        # onto a read; these endpoints instead enforce a stricter contract -- an explicit user_id
+        # that mismatches the caller is rejected with 403 (list/create/users), single records leak
+        # nothing via 404 (get/patch/delete), and list adds include_global -- none of which the
+        # helper expresses. Keeping the calls explicit here is intentional.
         include_global = False
         scoped_user_id = get_scoped_user_id(request)
         if scoped_user_id is not None:


### PR DESCRIPTION
## Summary

Low-priority review follow-ups for the learnings CRUD work (#7826). Doc/clarity nits plus a signature cleanup — no behavior change to any endpoint.

Stacked on `feat/learnings-crud-endpoints` so the diff stays scoped to just these items.

### Changes

1. **Drop dead `workflow_id` from `upsert_learning`** (`db/base.py` async contract + `sqlite`, `async_sqlite`, `postgres` impls)
   This branch had added `workflow_id` only to the **async** `AsyncBaseDb.upsert_learning` signature; the sync `BaseDb` never had it, no caller passes it, and the API deliberately doesn't expose it.
   - Removing it from only the async base contract would have left `AsyncSqliteDb` (and the pre-existing sync `SqliteDb`/`PostgresDb` impls) with `workflow_id` still in **positional slot 7**, so a positional call against the updated signature would silently store `session_id` as `workflow_id`. (Thanks for the catch on the review.)
   - So `workflow_id` is dropped from **every** `upsert_learning` implementation, making all signatures uniform with the sync + async base methods. It was dead across the board (no caller passes it, no store writes it); the nullable `workflow_id` column simply stays unset — exactly as it already did on async Postgres. Verified no caller references it.

2. **Document the mixed timestamp formats** (`learn/schemas.py`)
   Expanded the `_utc_now_iso` docstring to call out that per-entry `created_at`/`updated_at` (on memories / facts / events / relationships, inside `content`) are ISO-8601 strings, deliberately distinct from the row-level `created_at`/`updated_at` columns of `agno_learnings`, which are Unix-epoch ints. Heads-up for consumers reading both.

3. **Document the intentional scoping-helper divergence** (`os/routers/learnings/router.py`)
   The router calls `get_scoped_user_id` + `get_db` directly instead of the shared `resolve_db_and_scope` helper. That's deliberate: the helper silently threads a `user_id` onto reads, whereas these endpoints enforce a stricter contract (403 on an explicit mismatched `user_id`, 404-no-leak on single records, `include_global` on list) that the helper can't express. Added a comment so it isn't "fixed" later.

4. **Document `sort_by` behavior on `GET /learnings`** (`os/routers/learnings/router.py`)
   `list_learnings` passes `sort_by` straight to `apply_sorting`, which safely ignores unrecognised fields (verified). Clarified this in the param description for parity with the explicit field set documented on `GET /learnings/users`. No validation/behavior change.

> Note (handled outside this PR): the **stale description on #7826** is being synced directly on that PR's body, not here.

## Type of change

- [x] Bug fix (positional-argument compatibility of `upsert_learning`)
- [x] Improvement (code cleanup / documentation)
- [ ] New feature
- [ ] Breaking change
- [ ] Model update

## Checklist

- [x] Adheres to style guidelines (`ruff format` + `ruff check` clean on touched files)
- [x] Self-review completed
- [x] No new mypy errors introduced (pre-existing tree errors unaffected)
- [x] Tests pass (`test_learnings_router.py`, `test_memories_schema.py`, memory upsert mocks — all green)
- [ ] New tests — n/a (doc/clarity + dead-param removal, covered by existing suite)

## Additional Notes

- No endpoint behavior changes. The `workflow_id` removal is a pure dead-parameter cleanup that also fixes a latent positional-argument hazard between the base contract and the sqlite/postgres implementations.