### PR TITLE
chore: avoid leaking telemetry URL in OS launch debug log

### DIFF
--- a/libs/agno/agno/api/os.py
+++ b/libs/agno/agno/api/os.py
@@ -6,12 +6,12 @@ from agno.utils.log import log_debug
 
 def log_os_telemetry(launch: OSLaunch) -> None:
     """Telemetry recording for OS launches"""
-    with api.Client() as api_client:
-        try:
+    try:
+        with api.Client() as api_client:
             response = api_client.post(
                 ApiRoutes.AGENT_OS_LAUNCH,
                 json=launch.model_dump(exclude_none=True),
             )
             response.raise_for_status()
-        except Exception as e:
-            log_debug(f"Could not register OS launch for telemetry: {e}")
+    except Exception as e:
+        log_debug(f"Could not register OS launch for telemetry: {type(e).__name__}")


### PR DESCRIPTION
## Summary

The OS launch telemetry call in `agno/api/os.py` logged the full exception via `f"...: {e}"`. When `response.raise_for_status()` raises `httpx.HTTPStatusError`, `str(e)` embeds the request URL — so users running with debug logging saw output like:

```
DEBUG Could not register OS launch for telemetry: Server error '502 Bad Gateway'
for url 'https://os-api.agno.com/telemetry/os'
For more information check:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502
```


This leaks the internal telemetry endpoint into user-visible logs and adds noise.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
