### PR TITLE
[fix] avoid mutable defaults in tools and PDF reader

### DIFF
--- a/libs/agno/agno/knowledge/reader/pdf_reader.py
+++ b/libs/agno/agno/knowledge/reader/pdf_reader.py
@@ -96,7 +96,7 @@ async def _async_ocr_reader(page: Any) -> str:
 
 def _clean_page_numbers(
     page_content_list: List[str],
-    extra_content: List[str] = [],
+    extra_content: Optional[List[str]] = None,
     page_start_numbering_format: str = PAGE_START_NUMBERING_FORMAT_DEFAULT,
     page_end_numbering_format: str = PAGE_END_NUMBERING_FORMAT_DEFAULT,
 ) -> Tuple[List[str], Optional[int]]:
@@ -123,6 +123,9 @@ def _clean_page_numbers(
         - If page numbers are found, the function will add formatted page numbers to each page's content if `page_start_numbering_format` or
           `page_end_numbering_format` is provided.
     """
+    if extra_content is None:
+        extra_content = []
+
     assert len(extra_content) == 0 or len(extra_content) == len(page_content_list), (
         "Please provide an equally sized list of extra content if provided."
     )

--- a/libs/agno/agno/tools/mcp_toolbox.py
+++ b/libs/agno/agno/tools/mcp_toolbox.py
@@ -102,11 +102,14 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
 
     def _handle_auth_params(
         self,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
     ):
         """handle authentication parameters for toolbox-core client"""
+        if auth_token_getters is None:
+            auth_token_getters = {}
+
         if auth_tokens:
             if auth_token_getters:
                 warn(
@@ -137,19 +140,19 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_tool(
         self,
         tool_name: str,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
     ) -> Function:
         """Loads the tool with the given tool name from the Toolbox service.
 
         Args:
             tool_name (str): The name of the tool to load.
-            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to {}.
+            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens.
             auth_tokens (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
             auth_headers (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
-            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values. Defaults to {}.
+            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values.
 
         Raises:
             RuntimeError: If the tool is not found in the MCP functions registry.
@@ -162,6 +165,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
             auth_tokens=auth_tokens,
             auth_headers=auth_headers,
         )
+        if bound_params is None:
+            bound_params = {}
 
         core_sync_tool = await self.__core_client.load_tool(
             name=tool_name,
@@ -177,20 +182,20 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_toolset(
         self,
         toolset_name: Optional[str] = None,
-        auth_token_getters: dict[str, Callable[[], str]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
         auth_tokens: Optional[dict[str, Callable[[], str]]] = None,
         auth_headers: Optional[dict[str, Callable[[], str]]] = None,
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Loads tools from the configured toolset.
 
         Args:
             toolset_name (Optional[str], optional): The name of the toolset to load. Defaults to None.
-            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to {}.
+            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens.
             auth_tokens (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
             auth_headers (Optional[dict[str, Callable[[], str]]], optional): Deprecated. Use `auth_token_getters` instead.
-            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values. Defaults to {}.
+            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values.
             strict (bool, optional): If True, raises an error if *any* loaded tool instance fails
                 to utilize all of the given parameters or auth tokens. (if any
                 provided). If False (default), raises an error only if a
@@ -205,6 +210,8 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
             auth_tokens=auth_tokens,
             auth_headers=auth_headers,
         )
+        if bound_params is None:
+            bound_params = {}
 
         core_sync_tools = await self.__core_client.load_toolset(
             name=toolset_name,
@@ -224,16 +231,16 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
     async def load_multiple_toolsets(
         self,
         toolset_names: List[str],
-        auth_token_getters: dict[str, Callable[[], str]] = {},
-        bound_params: dict[str, Union[Any, Callable[[], Any]]] = {},
+        auth_token_getters: Optional[dict[str, Callable[[], str]]] = None,
+        bound_params: Optional[dict[str, Union[Any, Callable[[], Any]]]] = None,
         strict: bool = False,
     ) -> List[Function]:
         """Load tools from multiple toolsets.
 
         Args:
             toolset_names (List[str]): A list of toolset names to load.
-            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens. Defaults to {}.
-            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values. Defaults to {}.
+            auth_token_getters (dict[str, Callable[[], str]], optional): A mapping of authentication source names to functions that retrieve ID tokens.
+            bound_params (dict[str, Union[Any, Callable[[], Any]]], optional): A mapping of parameter names to their bound values.
             strict (bool, optional): If True, raises an error if *any* loaded tool instance fails to utilize all of the given parameters or auth tokens. Defaults to False.
 
         Returns:

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -12,12 +12,12 @@ class Searxng(Toolkit):
     def __init__(
         self,
         host: str,
-        engines: List[str] = [],
+        engines: Optional[List[str]] = None,
         fixed_max_results: Optional[int] = None,
         **kwargs,
     ):
         self.host = host
-        self.engines = engines
+        self.engines = [] if engines is None else engines
         self.fixed_max_results = fixed_max_results
 
         tools: List[Any] = [

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -17,7 +17,7 @@ class Toolkit:
     def __init__(
         self,
         name: str = "toolkit",
-        tools: Sequence[Union[Callable[..., Any], Function]] = [],
+        tools: Optional[Sequence[Union[Callable[..., Any], Function]]] = None,
         async_tools: Optional[Sequence[tuple[Callable[..., Any], str]]] = None,
         instructions: Optional[str] = None,
         add_instructions: bool = False,
@@ -54,7 +54,7 @@ class Toolkit:
             show_result_tools (Optional[List[str]]): List of function names whose results should be shown.
         """
         self.name: str = name
-        self.tools: Sequence[Union[Callable[..., Any], Function]] = tools
+        self.tools: Sequence[Union[Callable[..., Any], Function]] = [] if tools is None else tools
         self._async_tools: Sequence[tuple[Callable[..., Any], str]] = async_tools or []
         # Functions dict - used by agent.run() and agent.print_response()
         self.functions: Dict[str, Function] = OrderedDict()
@@ -70,7 +70,7 @@ class Toolkit:
         self.show_result_tools: list[str] = show_result_tools or []
 
         self._check_tools_filters(
-            available_tools=[self._get_tool_name(tool) for tool in tools],
+            available_tools=[self._get_tool_name(tool) for tool in self.tools],
             include_tools=include_tools,
             exclude_tools=exclude_tools,
         )

--- a/libs/agno/tests/unit/reader/test_pdf_reader.py
+++ b/libs/agno/tests/unit/reader/test_pdf_reader.py
@@ -301,6 +301,15 @@ def test_clean_page_numbers_untrustable(p_nr_format):
     assert not clean_content[0].endswith(p_nr_format["end"].format(page_nr=2))
 
 
+def test_clean_page_numbers_default_extra_content_is_not_shared():
+    """Calls without extra_content should each receive an independent empty list."""
+    first_content, _ = _clean_page_numbers(["6 first page"])
+    second_content, _ = _clean_page_numbers(["6 second page"])
+
+    assert first_content == ["6 first page"]
+    assert second_content == ["6 second page"]
+
+
 def _create_encrypted_pdf_with_empty_password() -> BytesIO:
     from pypdf import PdfWriter
 

--- a/libs/agno/tests/unit/tools/test_mcp_toolbox.py
+++ b/libs/agno/tests/unit/tools/test_mcp_toolbox.py
@@ -1,0 +1,80 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def mcp_toolbox_module(monkeypatch):
+    """Import MCPToolbox with a lightweight toolbox_core stub."""
+    toolbox_core = types.ModuleType("toolbox_core")
+    toolbox_core.ToolboxClient = object
+    monkeypatch.setitem(sys.modules, "toolbox_core", toolbox_core)
+
+    import agno.tools.mcp_toolbox as mcp_toolbox
+
+    return importlib.reload(mcp_toolbox)
+
+
+def test_handle_auth_params_default_getters_are_not_shared(mcp_toolbox_module):
+    toolbox = object.__new__(mcp_toolbox_module.MCPToolbox)
+
+    first_getters = toolbox._handle_auth_params()
+    first_getters["token"] = lambda: "first"
+    second_getters = toolbox._handle_auth_params()
+
+    assert second_getters == {}
+
+
+@pytest.mark.asyncio
+async def test_load_tool_default_dicts_are_not_shared(mcp_toolbox_module):
+    class FakeCoreClient:
+        def __init__(self):
+            self.calls = []
+
+        async def load_tool(self, name, auth_token_getters, bound_params):
+            self.calls.append((dict(auth_token_getters), dict(bound_params), auth_token_getters, bound_params))
+            auth_token_getters["token"] = lambda: "mutated"
+            bound_params["limit"] = 10
+            return SimpleNamespace(_name=name)
+
+    toolbox = object.__new__(mcp_toolbox_module.MCPToolbox)
+    toolbox.functions = {"search": object()}
+    toolbox._MCPToolbox__core_client = FakeCoreClient()
+
+    await toolbox.load_tool("search")
+    await toolbox.load_tool("search")
+
+    first_call, second_call = toolbox._MCPToolbox__core_client.calls
+    assert first_call[:2] == ({}, {})
+    assert second_call[:2] == ({}, {})
+    assert first_call[2] is not second_call[2]
+    assert first_call[3] is not second_call[3]
+
+
+@pytest.mark.asyncio
+async def test_load_toolset_default_dicts_are_not_shared(mcp_toolbox_module):
+    class FakeCoreClient:
+        def __init__(self):
+            self.calls = []
+
+        async def load_toolset(self, name, auth_token_getters, bound_params, strict):
+            self.calls.append((dict(auth_token_getters), dict(bound_params), auth_token_getters, bound_params))
+            auth_token_getters["token"] = lambda: "mutated"
+            bound_params["limit"] = 10
+            return [SimpleNamespace(_name="search")]
+
+    toolbox = object.__new__(mcp_toolbox_module.MCPToolbox)
+    toolbox.functions = {"search": object()}
+    toolbox._MCPToolbox__core_client = FakeCoreClient()
+
+    await toolbox.load_toolset("default")
+    await toolbox.load_toolset("default")
+
+    first_call, second_call = toolbox._MCPToolbox__core_client.calls
+    assert first_call[:2] == ({}, {})
+    assert second_call[:2] == ({}, {})
+    assert first_call[2] is not second_call[2]
+    assert first_call[3] is not second_call[3]

--- a/libs/agno/tests/unit/tools/test_searxng.py
+++ b/libs/agno/tests/unit/tools/test_searxng.py
@@ -160,6 +160,16 @@ def test_searxng_initialization():
     )  # All 8 tools: search, image_search, it_search, map_search, music_search, news_search, science_search, video_search
 
 
+def test_searxng_default_engines_are_not_shared():
+    """Default engine lists should not leak mutations between instances."""
+    searxng_a = Searxng(host="http://localhost:53153")
+    searxng_b = Searxng(host="http://localhost:53153")
+
+    searxng_a.engines.append("google")
+
+    assert searxng_b.engines == []
+
+
 @pytest.mark.parametrize(
     "category,method_name",
     [

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -60,6 +60,16 @@ def test_toolkit_initialization():
     assert toolkit.add_instructions is False
 
 
+def test_toolkit_default_tools_are_not_shared():
+    """Default tool lists should not leak mutations between toolkit instances."""
+    toolkit_a = Toolkit(name="toolkit_a")
+    toolkit_b = Toolkit(name="toolkit_b")
+
+    toolkit_a.tools.append(example_func)
+
+    assert toolkit_b.tools == []
+
+
 def test_toolkit_with_tools_initialization(basic_toolkit):
     """Test toolkit initialization with tools."""
     assert basic_toolkit.name == "basic_toolkit"


### PR DESCRIPTION
## Summary

Fixes #8155 by replacing mutable list/dict defaults with `None` sentinels in:

- `Toolkit.__init__`
- `Searxng.__init__`
- `MCPToolbox` auth/bound parameter helpers
- `_clean_page_numbers`

This keeps the existing call behavior while ensuring omitted defaults get fresh containers per instance/call.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This PR was prepared with AI assistance and reviewed/verified locally.

I did not run the full repository scripts; validation run locally in a fresh `.venv`:

- `python -m pytest libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/tools/test_mcp_toolbox.py -q`
- `python -m pytest libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/tools/test_mcp_toolbox.py libs/agno/tests/unit/reader/test_pdf_reader.py -k "clean_page_numbers or sanitize_pdf_text" -q`
- `python -m ruff check libs/agno/agno/tools/toolkit.py libs/agno/agno/tools/searxng.py libs/agno/agno/tools/mcp_toolbox.py libs/agno/agno/knowledge/reader/pdf_reader.py libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/tools/test_mcp_toolbox.py libs/agno/tests/unit/reader/test_pdf_reader.py`
- `python -m ruff format --check libs/agno/agno/tools/toolkit.py libs/agno/agno/tools/searxng.py libs/agno/agno/tools/mcp_toolbox.py libs/agno/agno/knowledge/reader/pdf_reader.py libs/agno/tests/unit/tools/test_toolkit.py libs/agno/tests/unit/tools/test_searxng.py libs/agno/tests/unit/tools/test_mcp_toolbox.py libs/agno/tests/unit/reader/test_pdf_reader.py`
