### PR TITLE
chore: apply formatting fixes missed by merged PRs

### DIFF
--- a/cookbook/05_agent_os/human_in_the_loop/workflow/condition_user_decision.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/condition_user_decision.py
@@ -11,7 +11,6 @@ from agno.workflow.condition import Condition
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/decision_tree.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/decision_tree.py
@@ -11,7 +11,6 @@ from agno.workflow.condition import Condition
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/dual_level_hitl.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/dual_level_hitl.py
@@ -20,7 +20,6 @@ from agno.tools import tool
 from agno.workflow.step import Step
 from agno.workflow.workflow import Workflow
 from rich.console import Console
-
 from workflow_db import db
 
 console = Console()

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/loop_confirmation.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/loop_confirmation.py
@@ -10,7 +10,6 @@ from agno.workflow.loop import Loop
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/main.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/main.py
@@ -5,7 +5,6 @@ Run all workflow human-in-the-loop examples from this directory in one AgentOS.
 """
 
 from agno.os import AgentOS
-
 from condition_user_decision import workflow as condition_user_decision_workflow
 from decision_tree import workflow as decision_tree_workflow
 from dual_level_hitl import travel_agent

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/output_review.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/output_review.py
@@ -10,7 +10,6 @@ from agno.workflow import HumanReview, OnReject
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/router_user_selection.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/router_user_selection.py
@@ -10,7 +10,6 @@ from agno.workflow.router import Router
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/step_confirmation.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/step_confirmation.py
@@ -10,7 +10,6 @@ from agno.workflow import OnReject
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/cookbook/05_agent_os/human_in_the_loop/workflow/step_user_input.py
+++ b/cookbook/05_agent_os/human_in_the_loop/workflow/step_user_input.py
@@ -18,7 +18,6 @@ from agno.os import AgentOS
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput, UserInputField
 from agno.workflow.workflow import Workflow
-
 from workflow_db import db
 
 

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -1217,9 +1217,7 @@ class StepRequirement:
             try:
                 requirement.set_user_input(validate=True, **requirement.user_input)
             except ValueError as e:
-                raise ValueError(
-                    f"Invalid user_input for step '{requirement.step_name}': {e}"
-                ) from e
+                raise ValueError(f"Invalid user_input for step '{requirement.step_name}': {e}") from e
         return requirement
 
 


### PR DESCRIPTION
## Summary

Running `./scripts/format.sh` on a clean `main` produces diffs in files that were merged without running the format script. This PR contains only those formatting fixes, so future PRs don't pick up unrelated diffs when they run the script:

- `libs/agno/agno/workflow/types.py` — `ruff format` collapses a multi-line `raise ValueError(...)` into one line (fits within the line length limit).
- 9 files under `cookbook/05_agent_os/human_in_the_loop/workflow/` — `ruff check --select I --fix` removes the blank line separating the local `from workflow_db import db` import from the preceding import block.

No functional changes — whitespace and import-sorting only.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verified in a clean worktree off `origin/main`:
- `./scripts/format.sh` produces exactly this diff and is idempotent afterwards.
- `./scripts/validate.sh` passes: ruff and mypy clean for `libs/agno` (875 files) and `libs/agno_infra` (117 files), ruff clean for `cookbook`, quickstart pattern check 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)