### PR TITLE
chore: update model guidance to gpt-5.5

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -13,10 +13,10 @@ Documentation:
 Basic Agent (start here):
 ```python
 from agno.agent import Agent
-from agno.models.openai import OpenAIChat
+from agno.models.openai import OpenAIResponses
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     instructions="You are a helpful assistant",
     markdown=True,
 )
@@ -28,7 +28,7 @@ Agent with Tools:
 from agno.tools.websearch import WebSearchTools
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     tools=[WebSearchTools()],
     instructions="Search the web for information",
 )
@@ -71,18 +71,18 @@ from agno.team.team import Team
 
 web_agent = Agent(
     name="Researcher",
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     tools=[WebSearchTools()],
 )
 
 writer_agent = Agent(
     name="Writer",
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
 )
 
 team = Team(
     members=[web_agent, writer_agent],
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     instructions="Research and write articles",
 )
 ```
@@ -125,7 +125,7 @@ knowledge = Knowledge(
 )
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     knowledge=knowledge,
     search_knowledge=True,  # Critical: enables agentic RAG
     instructions="Use knowledge base, cite sources"
@@ -135,7 +135,7 @@ agent = Agent(
 Chat History:
 ```python
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     db=SqliteDb(db_file="tmp/agents.db"),
     user_id="user-123",
     add_history_to_context=True,  # Adds previous messages
@@ -152,7 +152,7 @@ class Result(BaseModel):
     findings: list[str]
 
 agent = Agent(
-    model=OpenAIChat(id="gpt-4o"),
+    model=OpenAIResponses(id="gpt-5.5"),
     output_schema=Result,
 )
 result: Result = agent.run(query).content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ gh api repos/agno-agi/agno/pulls/<PR_NUMBER> -X PATCH -f body="$(cat /path/to/bo
 - Don't push code without running `./scripts/format.sh` and `./scripts/validate.sh`
 - Don't submit a PR without a detailed PR description. Always follow the PR template provided in `.github/pull_request_template.md`.
 - Don't use `OpenAIChat` in cookbooks or examples — use `OpenAIResponses` instead
-- Don't use `gpt-4o` or `gpt-4o-mini` in cookbooks or examples — use `gpt-5.4` instead
+- Don't use `gpt-4o` or `gpt-4o-mini` in cookbooks or examples — use `gpt-5.5` instead
 
 ---
 


### PR DESCRIPTION
## Summary

CLAUDE.md's "Don't" section still pointed cookbook authors at `gpt-5.4`, but the current cookbooks have standardized on `gpt-5.5` (50 uses across `cookbook/08_learning/` and `cookbook/01_demo/`, the most recently refreshed folders). This PR updates the guidance and fixes the same staleness in `.cursorrules`:

- **CLAUDE.md**: "use `gpt-5.4` instead" → "use `gpt-5.5` instead"
- **.cursorrules**: all 8 example snippets used `OpenAIChat(id="gpt-4o")` — both the banned model *and* the banned class per CLAUDE.md's own rules. Updated to `OpenAIResponses(id="gpt-5.5")` (matching the import convention used in the cookbooks).

Checked but intentionally not changed:
- `.github/` CI prompts: no stale model references found.
- The 2 remaining `gpt-5.2` mentions in `cookbook/08_learning/TEST_LOG.md` are historical test-log records (one documents the gpt-5.2 → gpt-5.5 migration itself), so they were left as-is.
- Older cookbook folders (e.g. `90_models/`, `02_agents/`) still use `gpt-5.2`/`gpt-5.4` widely (~830 references); migrating those is out of scope for this guidance-only chore.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [x] Other: docs/tooling guidance chore

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

No runtime code changes — only `CLAUDE.md` and `.cursorrules`. Both format and validate scripts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)