### PR TITLE
feat: add CrwTools (fastCRW) toolkit

### DIFF
--- a/cookbook/91_tools/crw_tools.py
+++ b/cookbook/91_tools/crw_tools.py
@@ -1,0 +1,41 @@
+"""
+This is an example of how to use the CrwTools.
+
+fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or cloud).
+
+Prerequisites:
+- Create a fastCRW account and get an API key
+- Set the API key as an environment variable:
+    export CRW_API_KEY=<your-api-key>
+"""
+
+from agno.agent import Agent
+from agno.tools.crw import CrwTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+
+agent = Agent(
+    tools=[
+        CrwTools(
+            enable_scrape=False, enable_crawl=True, enable_search=True, poll_interval=2
+        )
+    ],
+    markdown=True,
+)
+
+# Should use search
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Search for the web for the latest on 'web scraping technologies'",
+        formats=["markdown", "links"],
+    )
+
+    # Should use crawl
+    agent.print_response("Summarize this https://docs.agno.com/introduction/")

--- a/libs/agno/agno/tools/crw.py
+++ b/libs/agno/agno/tools/crw.py
@@ -1,0 +1,154 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import log_error
+
+try:
+    # fastCRW is a Firecrawl-compatible web scraper (single Rust binary; self-host or
+    # cloud), so it reuses the official Firecrawl client pointed at the fastCRW base URL.
+    from firecrawl import FirecrawlApp  # type: ignore[attr-defined]
+    from firecrawl.types import ScrapeOptions
+except ImportError:
+    raise ImportError("`firecrawl-py` not installed. Please install using `pip install firecrawl-py`")
+
+
+class CustomJSONEncoder(json.JSONEncoder):
+    """Custom JSON encoder that handles non-serializable types by converting them to strings."""
+
+    def default(self, obj):
+        try:
+            return super().default(obj)
+        except TypeError:
+            return str(obj)
+
+
+class CrwTools(Toolkit):
+    """
+    fastCRW is a Firecrawl-compatible tool for scraping and crawling websites.
+
+    Args:
+        api_key (Optional[str]): The API key to use for the fastCRW app.
+        enable_scrape (bool): Enable website scraping functionality. Default is True.
+        enable_crawl (bool): Enable website crawling functionality. Default is False.
+        enable_mapping (bool): Enable website mapping functionality. Default is False.
+        enable_search (bool): Enable web search functionality. Default is False.
+        all (bool): Enable all tools. Overrides individual flags when True. Default is False.
+        formats (Optional[List[str]]): The formats to use for the fastCRW app.
+        limit (int): The maximum number of pages to crawl.
+        poll_interval (int): Polling interval for crawl operations.
+        search_params (Optional[Dict[str, Any]]): Parameters for search operations.
+        api_url (Optional[str]): The API URL to use for the fastCRW app. Defaults to the
+            managed cloud; point it at a self-hosted server for self-host deployments.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        enable_scrape: bool = True,
+        enable_crawl: bool = False,
+        enable_mapping: bool = False,
+        enable_search: bool = False,
+        all: bool = False,
+        formats: Optional[List[str]] = None,
+        limit: int = 10,
+        poll_interval: int = 30,
+        search_params: Optional[Dict[str, Any]] = None,
+        api_url: Optional[str] = "https://fastcrw.com/api",
+        **kwargs,
+    ):
+        self.api_key: Optional[str] = api_key or getenv("CRW_API_KEY")
+        if not self.api_key:
+            log_error("CRW_API_KEY not set. Please set the CRW_API_KEY environment variable.")
+
+        self.formats: Optional[List[str]] = formats
+        self.limit: int = limit
+        self.poll_interval: int = poll_interval
+        self.app: FirecrawlApp = FirecrawlApp(api_key=self.api_key, api_url=api_url)
+        self.search_params = search_params
+
+        tools: List[Any] = []
+        if all or enable_scrape:
+            tools.append(self.scrape_website)
+        if all or enable_crawl:
+            tools.append(self.crawl_website)
+        if all or enable_mapping:
+            tools.append(self.map_website)
+        if all or enable_search:
+            tools.append(self.search_web)
+
+        super().__init__(name="crw_tools", tools=tools, **kwargs)
+
+    def scrape_website(self, url: str) -> str:
+        """Use this function to scrape a website using fastCRW.
+
+        Args:
+            url (str): The URL to scrape.
+        """
+        params = {}
+        if self.formats:
+            params["formats"] = self.formats
+
+        scrape_result = self.app.scrape(url, **params)
+        return json.dumps(scrape_result.model_dump(), cls=CustomJSONEncoder)
+
+    def crawl_website(self, url: str, limit: Optional[int] = None) -> str:
+        """Use this function to Crawls a website using fastCRW.
+
+        Args:
+            url (str): The URL to crawl.
+            limit (int): The maximum number of pages to crawl
+
+        Returns:
+            The results of the crawling.
+        """
+        params: Dict[str, Any] = {}
+        if self.limit is not None:
+            params["limit"] = self.limit
+        elif limit is not None:
+            params["limit"] = limit
+        if self.formats:
+            params["scrape_options"] = ScrapeOptions(formats=self.formats)  # type: ignore
+
+        params["poll_interval"] = self.poll_interval
+
+        crawl_result = self.app.crawl(url, **params)
+        return json.dumps(crawl_result.model_dump(), cls=CustomJSONEncoder)
+
+    def map_website(self, url: str) -> str:
+        """Use this function to Map a website using fastCRW.
+
+        Args:
+            url (str): The URL to map.
+
+        """
+        map_result = self.app.map(url)
+        return json.dumps(map_result.model_dump(), cls=CustomJSONEncoder)
+
+    def search_web(self, query: str, limit: Optional[int] = None):
+        """Use this function to search for the web using fastCRW.
+
+        Args:
+            query (str): The query to search for.
+            limit (int): The maximum number of results to return.
+        """
+        params: Dict[str, Any] = {}
+        if self.limit is not None:
+            params["limit"] = self.limit
+        elif limit is not None:
+            params["limit"] = limit
+        if self.formats:
+            params["scrape_options"] = ScrapeOptions(formats=self.formats)  # type: ignore
+        if self.search_params:
+            params.update(self.search_params)
+
+        search_result = self.app.search(query, **params)
+
+        if hasattr(search_result, "success"):
+            if search_result.success:
+                return json.dumps(search_result.data, cls=CustomJSONEncoder)
+            else:
+                return f"Error searching with the fastCRW tool: {search_result.error}"
+        else:
+            return json.dumps(search_result.model_dump(), cls=CustomJSONEncoder)

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -123,6 +123,7 @@ you-com = []
 seltz = ["seltz>=0.2.0"]
 fal = ["fal_client"]
 firecrawl = ["firecrawl-py==3.4.0"]
+crw = ["firecrawl-py==3.4.0"]
 tavily = ["tavily-python"]
 crawl4ai = ["crawl4ai>=0.6.3"]
 github = ["PyGithub"]
@@ -255,6 +256,7 @@ tools = [
   "agno[newspaper]",
   "agno[youtube]",
   "agno[firecrawl]",
+  "agno[crw]",
   "agno[tavily]",
   # "agno[crawl4ai]",  # Temporarily disabled - depends on litellm which is compromised on PyPI (March 24, 2026)
   "agno[github]",

--- a/libs/agno/tests/unit/tools/test_crw.py
+++ b/libs/agno/tests/unit/tools/test_crw.py
@@ -1,0 +1,239 @@
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from firecrawl import FirecrawlApp  # noqa
+
+from agno.tools.crw import CrwTools
+
+TEST_API_KEY = os.environ.get("CRW_API_KEY", "test_api_key")
+TEST_API_URL = "https://fastcrw.com/api"
+
+
+@pytest.fixture
+def mock_crw():
+    """Create a mock FirecrawlApp instance."""
+    with patch("agno.tools.crw.FirecrawlApp") as mock_crw_cls:
+        mock_app = Mock()
+        mock_crw_cls.return_value = mock_app
+        return mock_app
+
+
+@pytest.fixture
+def crw_tools(mock_crw):
+    """Create a CrwTools instance with mocked dependencies."""
+    with patch.dict("os.environ", {"CRW_API_KEY": TEST_API_KEY}):
+        tools = CrwTools()
+        # Directly set the app to our mock to avoid initialization issues
+        tools.app = mock_crw
+        return tools
+
+
+def test_init_with_env_vars():
+    """Test initialization with environment variables."""
+    with patch("agno.tools.crw.FirecrawlApp"):
+        with patch.dict("os.environ", {"CRW_API_KEY": TEST_API_KEY}, clear=True):
+            tools = CrwTools()
+            assert tools.api_key == TEST_API_KEY
+            assert tools.formats is None
+            assert tools.limit == 10
+            assert tools.app is not None
+
+
+def test_init_with_params():
+    """Test initialization with parameters."""
+    with patch("agno.tools.crw.FirecrawlApp"):
+        tools = CrwTools(api_key="param_api_key", formats=["html", "text"], limit=5, api_url=TEST_API_URL)
+        assert tools.api_key == "param_api_key"
+        assert tools.formats == ["html", "text"]
+        assert tools.limit == 5
+        assert tools.app is not None
+
+
+def test_scrape_website(crw_tools, mock_crw):
+    """Test scrape_website method."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "url": "https://example.com",
+        "content": "Test content",
+        "status": "success",
+    }
+    mock_crw.scrape.return_value = mock_response
+
+    # Call the method
+    result = crw_tools.scrape_website("https://example.com")
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["url"] == "https://example.com"
+    assert result_data["content"] == "Test content"
+    assert result_data["status"] == "success"
+    mock_crw.scrape.assert_called_once_with("https://example.com")
+
+
+def test_scrape_website_with_formats(crw_tools, mock_crw):
+    """Test scrape_website method with formats."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "url": "https://example.com",
+        "content": "Test content",
+        "status": "success",
+    }
+    mock_crw.scrape.return_value = mock_response
+
+    # Set formats
+    crw_tools.formats = ["html", "text"]
+
+    # Call the method
+    result = crw_tools.scrape_website("https://example.com")
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["url"] == "https://example.com"
+    assert result_data["content"] == "Test content"
+    assert result_data["status"] == "success"
+    mock_crw.scrape.assert_called_once_with("https://example.com", formats=["html", "text"])
+
+
+def test_crawl_website(crw_tools, mock_crw):
+    """Test crawl_website method."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "url": "https://example.com",
+        "pages": ["page1", "page2"],
+        "status": "success",
+    }
+    mock_crw.crawl.return_value = mock_response
+
+    # Call the method
+    result = crw_tools.crawl_website("https://example.com")
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["url"] == "https://example.com"
+    assert result_data["pages"] == ["page1", "page2"]
+    assert result_data["status"] == "success"
+    mock_crw.crawl.assert_called_once_with("https://example.com", limit=10, poll_interval=30)
+
+
+def test_crawl_website_with_custom_limit(crw_tools, mock_crw):
+    """Test crawl_website method with custom limit."""
+    # Reset the default limit
+    crw_tools.limit = None
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "url": "https://example.com",
+        "pages": ["page1", "page2"],
+        "status": "success",
+    }
+    mock_crw.crawl.return_value = mock_response
+
+    # Call the method with custom limit
+    result = crw_tools.crawl_website("https://example.com", limit=5)
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["url"] == "https://example.com"
+    assert result_data["pages"] == ["page1", "page2"]
+    assert result_data["status"] == "success"
+    mock_crw.crawl.assert_called_once_with("https://example.com", limit=5, poll_interval=30)
+
+
+def test_map_website(crw_tools, mock_crw):
+    """Test map_website method."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "url": "https://example.com",
+        "sitemap": {"page1": ["link1", "link2"]},
+        "status": "success",
+    }
+    mock_crw.map.return_value = mock_response
+
+    # Call the method
+    result = crw_tools.map_website("https://example.com")
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["url"] == "https://example.com"
+    assert result_data["sitemap"] == {"page1": ["link1", "link2"]}
+    assert result_data["status"] == "success"
+    mock_crw.map.assert_called_once_with("https://example.com")
+
+
+def test_search(crw_tools, mock_crw):
+    """Test search method."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.success = True
+    mock_response.data = {"query": "test query", "results": ["result1", "result2"], "status": "success"}
+    mock_crw.search.return_value = mock_response
+
+    # Call the method
+    result = crw_tools.search_web("test query")
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["query"] == "test query"
+    assert result_data["results"] == ["result1", "result2"]
+    assert result_data["status"] == "success"
+    mock_crw.search.assert_called_once_with("test query", limit=10)
+
+
+def test_search_with_error(crw_tools, mock_crw):
+    """Test search method with error response."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.success = False
+    mock_response.error = "Search failed"
+    mock_crw.search.return_value = mock_response
+
+    # Call the method
+    result = crw_tools.search_web("test query")
+
+    # Verify results
+    assert result == "Error searching with the fastCRW tool: Search failed"
+    mock_crw.search.assert_called_once_with("test query", limit=10)
+
+
+def test_search_with_custom_params(crw_tools, mock_crw):
+    """Test search method with custom search parameters."""
+    # Setup mock response
+    mock_response = Mock()
+    mock_response.success = True
+    mock_response.data = {"query": "test query", "results": ["result1", "result2"], "status": "success"}
+    mock_crw.search.return_value = mock_response
+
+    # Set custom search parameters
+    crw_tools.search_params = {"language": "en", "region": "us"}
+
+    # Call the method
+    result = crw_tools.search_web("test query")
+    result_data = json.loads(result)
+
+    # Verify results
+    assert result_data["query"] == "test query"
+    assert result_data["results"] == ["result1", "result2"]
+    assert result_data["status"] == "success"
+    mock_crw.search.assert_called_once_with("test query", limit=10, language="en", region="us")
+
+
+def test_search_tool_response(crw_tools, mock_crw):
+    mock_response = Mock(spec=["model_dump"])
+    mock_response.model_dump.return_value = {
+        "query": "test query",
+        "results": ["result1", "result2"],
+    }
+    mock_crw.search.return_value = mock_response
+
+    result = crw_tools.search_web("test query")
+    result_data = json.loads(result)
+
+    assert result_data["query"] == "test query"
+    assert result_data["results"] == ["result1", "result2"]
+    mock_crw.search.assert_called_once_with("test query", limit=10)


### PR DESCRIPTION
closes #8392

## What
Adds **`CrwTools`**, a toolkit for scrape/crawl/map/search backed by [fastCRW](https://fastcrw.com), mirroring the existing `FirecrawlTools`.

## Why

**fastCRW is the only self-hostable scraping engine that ships the full capability in open source (AGPL).**

Three concrete differentiators:

1. **Runs 100% locally — no cloud-gated tiers.** Anti-bot/stealth, BYO-proxy + rotation, and JS rendering (Cloudflare JS-challenge handling, SPA rendering, automatic HTTP→headless→proxy fallback) all ship in the open core. Firecrawl's OSS omits its stealth engine (`fire-engine`) behind a cloud-only flag, so its self-hosted build falls back to plain fetch/Playwright and cannot reliably reach Cloudflare-protected or JS-heavy pages. fastCRW's self-host can.

2. **Faster and higher recall — verified on Firecrawl's own benchmark dataset.** fastCRW scores **63.74% truth-recall vs 56.04%** for Firecrawl, at a faster median latency (**p50 ~1.9 s vs ~2.3 s**). Delivered by a single ~8 MB Rust binary at ~6 MB RAM idle — no Redis, no worker fleet, no Playwright sidecar required.

3. **Search is built on top of SearXNG, not an alternative to it.** SearXNG is the metasearch aggregator underneath; crw adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), and category routing (research queries fan out to arxiv/semantic scholar/google scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer — all open-source (AGPL) and self-hostable with configurable engines.

Because fastCRW is Firecrawl-API-compatible, `CrwTools` reuses the official `firecrawl-py` client pointed at the fastCRW base URL — which is why this integration is a small additive diff rather than a new abstraction.

## Changes (additive only)
- `libs/agno/agno/tools/crw.py`: `CrwTools(Toolkit)` mirroring `firecrawl.py` exactly.
- `libs/agno/pyproject.toml`: optional extra.
- `libs/agno/tests/unit/tools/test_crw.py` + `cookbook/91_tools/crw_tools.py`.

## Config
`CRW_API_KEY` from https://fastcrw.com/dashboard (free tier); `api_url` overridable for self-host.

---
Happy to adjust — I maintain the integration and can provide free credits.
