### PR TITLE
fix: scope entity memory ids by user

### DIFF
--- a/libs/agno/agno/learn/stores/entity_memory.py
+++ b/libs/agno/agno/learn/stores/entity_memory.py
@@ -1650,8 +1650,18 @@ class EntityMemoryStore(LearningStore):
             return None
 
         effective_namespace = namespace or self.config.namespace
+        if effective_namespace == "user" and not user_id:
+            log_warning("EntityMemoryStore.get: namespace='user' requires user_id")
+            return None
 
         try:
+            if effective_namespace == "user":
+                scoped_id = self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id=user_id)
+                db = cast(BaseDb, self.db)
+                result_by_id = db.get_learning_by_id(scoped_id)
+                if result_by_id and result_by_id.get("content"):
+                    return self.schema.from_dict(result_by_id["content"])
+
             result = self.db.get_learning(
                 learning_type=self.learning_type,
                 entity_id=entity_id,
@@ -1681,9 +1691,19 @@ class EntityMemoryStore(LearningStore):
             return None
 
         effective_namespace = namespace or self.config.namespace
+        if effective_namespace == "user" and not user_id:
+            log_warning("EntityMemoryStore.aget: namespace='user' requires user_id")
+            return None
 
         try:
             if isinstance(self.db, AsyncBaseDb):
+                if effective_namespace == "user":
+                    scoped_id = self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id=user_id)
+                    async_db = cast(AsyncBaseDb, self.db)
+                    result_by_id = await async_db.get_learning_by_id(scoped_id)
+                    if result_by_id and result_by_id.get("content"):
+                        return self.schema.from_dict(result_by_id["content"])
+
                 result = await self.db.get_learning(
                     learning_type=self.learning_type,
                     entity_id=entity_id,
@@ -1692,6 +1712,13 @@ class EntityMemoryStore(LearningStore):
                     user_id=user_id if effective_namespace == "user" else None,
                 )
             else:
+                if effective_namespace == "user":
+                    scoped_id = self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id=user_id)
+                    db = cast(BaseDb, self.db)
+                    result_by_id = db.get_learning_by_id(scoped_id)
+                    if result_by_id and result_by_id.get("content"):
+                        return self.schema.from_dict(result_by_id["content"])
+
                 result = self.db.get_learning(
                     learning_type=self.learning_type,
                     entity_id=entity_id,
@@ -1737,6 +1764,9 @@ class EntityMemoryStore(LearningStore):
             return []
 
         effective_namespace = namespace or self.config.namespace
+        if effective_namespace == "user" and not user_id:
+            log_warning("EntityMemoryStore.search: namespace='user' requires user_id")
+            return []
 
         try:
             results = self.db.get_learnings(
@@ -1780,6 +1810,9 @@ class EntityMemoryStore(LearningStore):
             return []
 
         effective_namespace = namespace or self.config.namespace
+        if effective_namespace == "user" and not user_id:
+            log_warning("EntityMemoryStore.asearch: namespace='user' requires user_id")
+            return []
 
         try:
             if isinstance(self.db, AsyncBaseDb):
@@ -1941,7 +1974,7 @@ class EntityMemoryStore(LearningStore):
             )
 
             self.db.upsert_learning(
-                id=self._build_entity_db_id(entity_id, entity_type, effective_namespace),
+                id=self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id=user_id),
                 learning_type=self.learning_type,
                 entity_id=entity_id,
                 entity_type=entity_type,
@@ -2013,7 +2046,7 @@ class EntityMemoryStore(LearningStore):
 
             if isinstance(self.db, AsyncBaseDb):
                 await self.db.upsert_learning(
-                    id=self._build_entity_db_id(entity_id, entity_type, effective_namespace),
+                    id=self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id=user_id),
                     learning_type=self.learning_type,
                     entity_id=entity_id,
                     entity_type=entity_type,
@@ -2025,7 +2058,7 @@ class EntityMemoryStore(LearningStore):
                 )
             else:
                 self.db.upsert_learning(
-                    id=self._build_entity_db_id(entity_id, entity_type, effective_namespace),
+                    id=self._build_entity_db_id(entity_id, entity_type, effective_namespace, user_id=user_id),
                     learning_type=self.learning_type,
                     entity_id=entity_id,
                     entity_type=entity_type,
@@ -2563,7 +2596,7 @@ class EntityMemoryStore(LearningStore):
                 return False
 
             self.db.upsert_learning(
-                id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace),
+                id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace, user_id=user_id),
                 learning_type=self.learning_type,
                 entity_id=entity.entity_id,
                 entity_type=entity.entity_type,
@@ -2601,7 +2634,9 @@ class EntityMemoryStore(LearningStore):
 
             if isinstance(self.db, AsyncBaseDb):
                 await self.db.upsert_learning(
-                    id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace),
+                    id=self._build_entity_db_id(
+                        entity.entity_id, entity.entity_type, effective_namespace, user_id=user_id
+                    ),
                     learning_type=self.learning_type,
                     entity_id=entity.entity_id,
                     entity_type=entity.entity_type,
@@ -2613,7 +2648,9 @@ class EntityMemoryStore(LearningStore):
                 )
             else:
                 self.db.upsert_learning(
-                    id=self._build_entity_db_id(entity.entity_id, entity.entity_type, effective_namespace),
+                    id=self._build_entity_db_id(
+                        entity.entity_id, entity.entity_type, effective_namespace, user_id=user_id
+                    ),
                     learning_type=self.learning_type,
                     entity_id=entity.entity_id,
                     entity_type=entity.entity_type,
@@ -3094,11 +3131,14 @@ class EntityMemoryStore(LearningStore):
         entity_id: str,
         entity_type: str,
         namespace: str,
+        user_id: Optional[str] = None,
     ) -> str:
         """Build unique DB ID for entity."""
         return cast(
             str,
-            build_learning_id("entity_memory", entity_id=entity_id, entity_type=entity_type, namespace=namespace),
+            build_learning_id(
+                "entity_memory", entity_id=entity_id, entity_type=entity_type, namespace=namespace, user_id=user_id
+            ),
         )
 
     def _format_entity_basic(self, entity: Any) -> str:

--- a/libs/agno/agno/learn/utils.py
+++ b/libs/agno/agno/learn/utils.py
@@ -52,6 +52,8 @@ def build_learning_id(
         return f"session_context_{session_id}" if session_id else None
     if learning_type == "entity_memory":
         if entity_id and entity_type:
+            if namespace == "user":
+                return f"entity_user_{user_id}_{entity_type}_{entity_id}" if user_id else None
             return f"entity_{namespace or DEFAULT_LEARNING_NAMESPACE}_{entity_type}_{entity_id}"
         return None
     return None

--- a/libs/agno/tests/unit/learn/test_build_learning_id.py
+++ b/libs/agno/tests/unit/learn/test_build_learning_id.py
@@ -4,6 +4,10 @@ The learning stores delegate their `_build_*_id` helpers here, so the REST creat
 can compute the same deterministic id and records reconcile with what the agent reads/writes.
 """
 
+import asyncio
+from unittest.mock import MagicMock
+
+from agno.learn.config import EntityMemoryConfig
 from agno.learn.stores.entity_memory import EntityMemoryStore
 from agno.learn.stores.session_context import SessionContextStore
 from agno.learn.stores.user_memory import UserMemoryStore
@@ -20,8 +24,8 @@ class TestBuildLearningId:
             build_learning_id("entity_memory", entity_id="acme", entity_type="company") == "entity_global_company_acme"
         )
         assert (
-            build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user")
-            == "entity_user_company_acme"
+            build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user", user_id="u1")
+            == "entity_user_u1_company_acme"
         )
 
     def test_missing_identity_fields_returns_none(self):
@@ -29,6 +33,7 @@ class TestBuildLearningId:
         assert build_learning_id("user_memory") is None
         assert build_learning_id("session_context") is None
         assert build_learning_id("entity_memory", entity_id="acme") is None  # needs entity_type too
+        assert build_learning_id("entity_memory", entity_id="acme", entity_type="company", namespace="user") is None
 
     def test_non_identity_types_return_none(self):
         assert build_learning_id("decision_log", user_id="u1") is None
@@ -67,3 +72,83 @@ class TestStoresDelegateToHelper:
         assert store._build_entity_db_id("acme", "company", "global") == build_learning_id(
             "entity_memory", entity_id="acme", entity_type="company", namespace="global"
         )
+        assert store._build_entity_db_id("acme", "company", "user", user_id="u1") == build_learning_id(
+            "entity_memory", entity_id="acme", entity_type="company", namespace="user", user_id="u1"
+        )
+
+
+class TestEntityMemoryTenantScopedIds:
+    def test_user_namespace_includes_user_id_in_entity_learning_id(self):
+        db = MagicMock()
+        db.get_learning_by_id.return_value = None
+        db.get_learning.return_value = None
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+
+        assert store.create_entity(entity_id="john_smith", entity_type="person", name="John Smith", user_id="user-a")
+        assert store.create_entity(entity_id="john_smith", entity_type="person", name="John Smith", user_id="user-b")
+
+        upsert_ids = [call.kwargs["id"] for call in db.upsert_learning.call_args_list]
+        assert upsert_ids == ["entity_user_user-a_person_john_smith", "entity_user_user-b_person_john_smith"]
+        assert len(set(upsert_ids)) == 2
+
+    def test_user_namespace_get_requires_user_id(self):
+        db = MagicMock()
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+
+        assert store.get(entity_id="john_smith", entity_type="person") is None
+        db.get_learning_by_id.assert_not_called()
+        db.get_learning.assert_not_called()
+
+    def test_user_namespace_search_requires_user_id(self):
+        db = MagicMock()
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+
+        assert store.search(query="john") == []
+        db.get_learnings.assert_not_called()
+
+    def test_user_namespace_async_get_and_search_require_user_id(self):
+        db = MagicMock()
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+
+        assert asyncio.run(store.aget(entity_id="john_smith", entity_type="person")) is None
+        assert asyncio.run(store.asearch(query="john")) == []
+        db.get_learning_by_id.assert_not_called()
+        db.get_learning.assert_not_called()
+        db.get_learnings.assert_not_called()
+
+    def test_user_namespace_get_prefers_scoped_id_over_legacy_filtered_lookup(self):
+        db = MagicMock()
+        scoped_entity = EntityMemoryStore().schema(
+            entity_id="john_smith", entity_type="person", name="Scoped John", user_id="user-a", namespace="user"
+        )
+        db.get_learning_by_id.return_value = {"content": scoped_entity.to_dict()}
+        db.get_learning.return_value = {
+            "content": {"entity_id": "john_smith", "entity_type": "person", "name": "Legacy John"}
+        }
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+
+        entity = store.get(entity_id="john_smith", entity_type="person", user_id="user-a")
+
+        assert entity is not None
+        assert entity.name == "Scoped John"
+        db.get_learning_by_id.assert_called_once_with("entity_user_user-a_person_john_smith")
+        db.get_learning.assert_not_called()
+
+    def test_user_namespace_mutation_without_user_id_does_not_read_or_write(self):
+        db = MagicMock()
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+
+        assert not store.update_entity(entity_id="john_smith", entity_type="person", name="John Smith")
+        db.get_learning_by_id.assert_not_called()
+        db.get_learning.assert_not_called()
+        db.upsert_learning.assert_not_called()
+
+    def test_saving_user_namespace_entity_does_not_delete_potentially_foreign_legacy_id(self):
+        db = MagicMock()
+        store = EntityMemoryStore(config=EntityMemoryConfig(db=db, namespace="user"))
+        entity = store.schema(entity_id="john_smith", entity_type="person", name="John Smith", user_id="user-a")
+
+        assert store._save_entity(entity=entity, user_id="user-a", namespace="user")
+
+        assert db.upsert_learning.call_args.kwargs["id"] == "entity_user_user-a_person_john_smith"
+        db.delete_learning.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #8334.

- Scopes entity memory learning IDs by `user_id` when `namespace="user"`, preventing cross-user upsert collisions on the `learning_id` primary key.
- Requires `user_id` for user-scoped entity memory reads/searches so a missing tenant cannot silently fall back to shared behavior.
- Looks up the new scoped ID first, then falls back to the existing filtered lookup so legacy rows remain readable without deleting potentially foreign legacy IDs.
- Adds regression coverage for tenant-scoped IDs, missing-user guards, scoped-ID reads, and legacy-row safety.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Focused verification run:

```bash
.venv/bin/python -m pytest libs/agno/tests/unit/learn/test_build_learning_id.py -q
.venv/bin/python -m pytest libs/agno/tests/unit/learn -q
.venv/bin/ruff format --check libs/agno/agno/learn/stores/entity_memory.py libs/agno/agno/learn/utils.py libs/agno/tests/unit/learn/test_build_learning_id.py
.venv/bin/ruff check libs/agno/agno/learn/stores/entity_memory.py libs/agno/agno/learn/utils.py libs/agno/tests/unit/learn/test_build_learning_id.py
```

I did not run the full `./scripts/validate.sh` in this lane; this is a focused security/data-isolation fix with targeted unit coverage.
