### PR TITLE
Fix-Issue-#8401-external_execution-tools-never-surfaced-in-Team-Runs-over-AG-UI

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -36,7 +36,7 @@ from agno.run.agent import ReasoningCompletedEvent as AgentReasoningCompletedEve
 from agno.run.agent import ReasoningContentDeltaEvent as AgentReasoningContentDeltaEvent
 from agno.run.agent import ReasoningStartedEvent as AgentReasoningStartedEvent
 from agno.run.agent import ReasoningStepEvent as AgentReasoningStepEvent
-from agno.run.agent import RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
+from agno.run.agent import RunContentEvent, RunEvent, RunOutputEvent
 from agno.run.team import ReasoningCompletedEvent as TeamReasoningCompletedEvent
 from agno.run.team import ReasoningContentDeltaEvent as TeamReasoningContentDeltaEvent
 from agno.run.team import ReasoningStartedEvent as TeamReasoningStartedEvent
@@ -556,8 +556,12 @@ def _create_completion_events(
         events_to_emit.append(end_message_event)
 
     # Emit external execution tools
-    if isinstance(chunk, RunPausedEvent):
-        external_tools = chunk.tools_awaiting_external_execution
+    is_paused = chunk.event in (RunEvent.run_paused, TeamRunEvent.run_paused)
+    if is_paused:
+        # Both agno.run.agent.RunPausedEvent and agno.run.team.RunPausedEvent expose `tools`,
+        # but only the agent-side class also has a `tools_awaiting_external_execution`
+        # property, so compute it directly from `tools` to cover both.
+        external_tools = [t for t in (getattr(chunk, "tools", None) or []) if t.external_execution_required]
         if external_tools:
             # First, emit an assistant message for external tool calls
             assistant_message_id = str(uuid.uuid4())

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -944,6 +944,77 @@ async def test_tool_call_without_result():
 
 
 @pytest.mark.asyncio
+async def test_agent_run_paused_external_execution_emits_tool_events():
+    """Test that an Agent RunPausedEvent with tools_awaiting_external_execution emits
+    synthetic TOOL_CALL_START/ARGS/END events for the AG-UI client to act on."""
+    from agno.models.response import ToolExecution
+    from agno.run.agent import RunPausedEvent
+
+    async def mock_stream_paused():
+        tool = ToolExecution(
+            tool_call_id="ext_1",
+            tool_name="send_notification",
+            tool_args={"message": "hello"},
+            external_execution_required=True,
+        )
+        yield RunPausedEvent(tools=[tool])
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream_paused(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+    assert EventType.TOOL_CALL_START in event_types
+    assert EventType.TOOL_CALL_ARGS in event_types
+    assert EventType.TOOL_CALL_END in event_types
+
+    start_event = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+    assert start_event.tool_call_id == "ext_1"
+    assert start_event.tool_call_name == "send_notification"
+
+    assert EventType.RUN_FINISHED in event_types
+
+
+@pytest.mark.asyncio
+async def test_team_run_paused_external_execution_emits_tool_events():
+    """Regression test: a Team RunPausedEvent must also surface
+    tools_awaiting_external_execution as synthetic TOOL_CALL_START/ARGS/END events.
+
+    Previously this branch was gated on `isinstance(chunk, agno.run.agent.RunPausedEvent)`,
+    which is never True for `agno.run.team.RunPausedEvent` (a sibling class, not a subclass
+    of the agent-side event), so this entire branch silently never fired for Team runs.
+    """
+    from agno.models.response import ToolExecution
+    from agno.run.team import RunPausedEvent as TeamRunPausedEvent
+
+    async def mock_stream_paused():
+        tool = ToolExecution(
+            tool_call_id="ext_team_1",
+            tool_name="send_notification",
+            tool_args={"message": "hello"},
+            external_execution_required=True,
+        )
+        yield TeamRunPausedEvent(tools=[tool])
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream_paused(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+    assert EventType.TOOL_CALL_START in event_types, (
+        "Team RunPausedEvent should emit TOOL_CALL_START for external execution tools"
+    )
+    assert EventType.TOOL_CALL_ARGS in event_types
+    assert EventType.TOOL_CALL_END in event_types
+
+    start_event = next(e for e in events if e.type == EventType.TOOL_CALL_START)
+    assert start_event.tool_call_id == "ext_team_1"
+    assert start_event.tool_call_name == "send_notification"
+
+    assert EventType.RUN_FINISHED in event_types
+
+
+@pytest.mark.asyncio
 async def test_mixed_content_and_tools_complex():
     """Complex test with interleaved content and tool calls (comprehensive scenario)"""
     from agno.models.response import ToolExecution


### PR DESCRIPTION
## Summary

`_create_completion_events` (`agno/os/interfaces/agui/utils.py`) gated its only HITL-handling
branch — emitting synthetic `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END` events for
tools awaiting external execution — on `isinstance(chunk, RunPausedEvent)`, where
`RunPausedEvent` was imported from `agno.run.agent`. `agno.run.team.RunPausedEvent` is a sibling
class (extends `BaseTeamRunEvent`, not `BaseAgentRunEvent`), so this check was always `False`
for Team runs. As a result, `AGUI(team=...)` never surfaced `external_execution_required` tools
to the client — the stream went straight to `RUN_FINISHED` with no signal to act on.

Changes:

- Replaced the `isinstance` check with a duck-typed `is_paused = chunk.event in
  (RunEvent.run_paused, TeamRunEvent.run_paused)`, using the `RunEvent` / `TeamRunEvent` enums
  already imported in this file.
- Computed `external_tools` directly from `chunk.tools` filtered by
  `t.external_execution_required`, instead of via the `tools_awaiting_external_execution`
  property — `agno.run.team.RunPausedEvent` doesn't define that property (only the agent-side
  `BaseAgentRunEvent` / `RunOutput` do), but both Agent and Team `RunPausedEvent` define a
  `tools: Optional[List[ToolExecution]]` field.
- Removed the now-unused `RunPausedEvent` import from `agno.run.agent`.
- Added two regression tests to `tests/unit/app/test_agui_app.py`:
  `test_agent_run_paused_external_execution_emits_tool_events` and
  `test_team_run_paused_external_execution_emits_tool_events` — the latter fails against the old
  `isinstance` check and passes with this fix.

Not yet filed as a GitHub issue — tracked locally as
`HITL over AGUI - Issue Draft 1 (Bug - Team RunPausedEvent).md`.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---
