### PR TITLE
[fix] honor extended_cache_time for cache_tools and validate tools+system TTL order

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -598,9 +598,23 @@ class Claude(Model):
         return None
 
     def _apply_cache_tools(self, request_kwargs: Dict[str, Any]) -> None:
-        """Tag the last tool with cache_control when cache_tools is enabled."""
+        """Tag the last tool with cache_control when cache_tools is enabled.
+
+        Honors ``extended_cache_time`` so the tools breakpoint uses the same 1h TTL
+        as the system block. Anthropic renders cache breakpoints in ``tools`` ->
+        ``system`` -> ``messages`` order and rejects a longer-TTL block that follows
+        a shorter-TTL one, so the tools TTL must not be shorter than the system TTL.
+        """
         if self.cache_tools and "tools" in request_kwargs and request_kwargs["tools"]:
-            request_kwargs["tools"][-1]["cache_control"] = {"type": "ephemeral"}
+            cc: Dict[str, str] = {"type": "ephemeral"}
+            if self.extended_cache_time:
+                cc["ttl"] = "1h"
+            request_kwargs["tools"][-1]["cache_control"] = cc
+
+        # Defense in depth: validate the full tools -> system breakpoint sequence.
+        # The check inside _build_system sees system blocks only and cannot catch a
+        # 5m tools breakpoint placed before a 1h system breakpoint.
+        _validate_cache_ttl_order([*request_kwargs.get("tools", []), *request_kwargs.get("system", [])])
 
     def _build_system(self, system_message: str) -> List[Dict[str, Any]]:
         """Assemble the Anthropic ``system`` array.

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -423,9 +423,12 @@ def build_system_blocks(
 def _validate_cache_ttl_order(blocks: List[Dict[str, Any]]) -> None:
     """Validate that no 5m-cached block appears before a 1h-cached block.
 
-    Anthropic's prompt caching rejects requests where a longer-TTL cache entry
-    follows a shorter-TTL one in the cached prefix. Catch this at assembly
-    time with an actionable error rather than letting the API reject it.
+    Anthropic renders cache breakpoints in ``tools`` -> ``system`` -> ``messages``
+    order and rejects a request where a longer-TTL cache entry follows a
+    shorter-TTL one in that sequence. Pass the blocks in render order (e.g.
+    ``[*tools, *system]``) so a 5m tools breakpoint before a 1h system breakpoint
+    is caught here, at assembly time, with an actionable error rather than as an
+    opaque API 400.
     """
     seen_5m = False
     for block in blocks:
@@ -435,12 +438,15 @@ def _validate_cache_ttl_order(blocks: List[Dict[str, Any]]) -> None:
         if cc.get("ttl") == "1h":
             if seen_5m:
                 raise ValueError(
-                    "Invalid Anthropic cache TTL ordering: a 1h cached block cannot "
-                    "follow a 5m cached block. This usually means cache_system_prompt=True "
-                    "(so the agent-built block is cached at 5m by default) together with "
-                    "a SystemPromptBlock(ttl='1h'). Fix with one of:\n"
-                    "  - Claude(extended_cache_time=True) so the agent-built block is 1h too\n"
-                    "  - Change your block ttl to '5m' or None\n"
+                    "Invalid Anthropic cache TTL ordering: a 1h cached block cannot follow a "
+                    "5m cached block. Anthropic processes cache breakpoints in tools -> system "
+                    "-> messages order, so once a 5m breakpoint appears every later breakpoint "
+                    "must also be 5m. This usually means a 5m breakpoint (cache_tools=True, or "
+                    "cache_system_prompt=True which caches the agent-built block at 5m by "
+                    "default) precedes a 1h breakpoint (extended_cache_time=True or a "
+                    "SystemPromptBlock(ttl='1h')). Fix with one of:\n"
+                    "  - Claude(extended_cache_time=True) so all breakpoints use the 1h TTL\n"
+                    "  - Change the 1h block ttl to '5m' or None\n"
                     "  - Set cache_system_prompt=False to leave the agent-built block "
                     "uncached (custom blocks still cache per their own block.cache field)"
                 )

--- a/libs/agno/tests/unit/models/anthropic/test_cache_ttl_ordering.py
+++ b/libs/agno/tests/unit/models/anthropic/test_cache_ttl_ordering.py
@@ -1,0 +1,143 @@
+"""Unit tests for Anthropic cache_control TTL ordering across tools + system.
+
+Regression for: ``cache_tools=True`` together with ``extended_cache_time=True``
+produced a 5m tools cache breakpoint followed by a 1h system breakpoint. Anthropic
+renders cache breakpoints in ``tools`` -> ``system`` -> ``messages`` order and
+rejects a request where a longer-TTL block follows a shorter-TTL one, so every
+request 400'd. The fix makes the tools breakpoint honor ``extended_cache_time`` and
+validates the combined tools+system breakpoint order at assembly time.
+"""
+
+import pytest
+
+pytest.importorskip("anthropic")
+
+from agno.models.anthropic.claude import Claude as AnthropicClaude
+from agno.utils.models.claude import _validate_cache_ttl_order
+
+_TOOL = {"name": "noop", "description": "no-op", "input_schema": {"type": "object", "properties": {}}}
+
+
+def _breakpoints(request_kwargs):
+    """cache_control dicts in Anthropic render order: tools -> system -> messages."""
+    seq = [t["cache_control"] for t in request_kwargs.get("tools", []) if "cache_control" in t]
+    seq += [b["cache_control"] for b in request_kwargs.get("system", []) if "cache_control" in b]
+    return seq
+
+
+def _ttl(cc):
+    return cc.get("ttl", "5m")  # ephemeral with no ttl key == 5m default
+
+
+def _is_valid_order(ttls):
+    """Anthropic rule: a 1h breakpoint must not follow a 5m one in render order."""
+    seen_5m = False
+    for t in ttls:
+        if t == "1h" and seen_5m:
+            return False
+        if t == "5m":
+            seen_5m = True
+    return True
+
+
+def _anthropic_kwargs(**flags):
+    model = AnthropicClaude(id="claude-sonnet-4-6", **flags)
+    return model._prepare_request_kwargs(system_message="You are a helpful assistant.", tools=[dict(_TOOL)])
+
+
+# ---------------------------------------------------------------------------
+# Assembled-request behavior (AnthropicClaude)
+# ---------------------------------------------------------------------------
+
+
+def test_tools_ttl_matches_system_when_extended_cache_time():
+    """The reported failing combo must now produce a valid, uniform 1h TTL."""
+    seq = _breakpoints(_anthropic_kwargs(cache_tools=True, cache_system_prompt=True, extended_cache_time=True))
+    assert len(seq) == 2  # one tools breakpoint + one system breakpoint
+    assert all(cc == {"type": "ephemeral", "ttl": "1h"} for cc in seq)
+
+
+def test_tools_default_to_5m_without_extended_cache_time():
+    """Without extended_cache_time, tools stay at the default 5m (no ttl key)."""
+    request_kwargs = _anthropic_kwargs(cache_tools=True, cache_system_prompt=True, extended_cache_time=False)
+    assert request_kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        dict(cache_tools=True, cache_system_prompt=True, extended_cache_time=True),
+        dict(cache_tools=True, cache_system_prompt=True, extended_cache_time=False),
+        dict(cache_tools=True, cache_system_prompt=False, extended_cache_time=True),
+    ],
+)
+def test_breakpoint_ttls_are_valid_order(flags):
+    """No longer-TTL breakpoint may follow a shorter-TTL one in render order."""
+    ttls = [_ttl(cc) for cc in _breakpoints(_anthropic_kwargs(**flags))]
+    assert _is_valid_order(ttls), f"invalid TTL order {ttls} for {flags}"
+
+
+# ---------------------------------------------------------------------------
+# Validator (pure function, no model construction)
+# ---------------------------------------------------------------------------
+
+
+def test_validator_rejects_5m_tools_before_1h_system():
+    """The exact cross-section case that previously shipped a 400 must raise locally."""
+    with pytest.raises(ValueError, match="cache TTL ordering"):
+        _validate_cache_ttl_order(
+            [
+                {"name": "noop", "cache_control": {"type": "ephemeral"}},  # tools 5m
+                {"type": "text", "text": "x", "cache_control": {"type": "ephemeral", "ttl": "1h"}},  # system 1h
+            ]
+        )
+
+
+def test_validator_allows_1h_tools_before_1h_system():
+    _validate_cache_ttl_order(
+        [
+            {"name": "noop", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            {"type": "text", "text": "x", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+        ]
+    )
+
+
+def test_validator_allows_5m_everywhere():
+    _validate_cache_ttl_order(
+        [
+            {"name": "noop", "cache_control": {"type": "ephemeral"}},
+            {"type": "text", "text": "x", "cache_control": {"type": "ephemeral"}},
+        ]
+    )
+
+
+def test_validator_ignores_uncached_blocks():
+    """Blocks without cache_control don't count as a 5m breakpoint."""
+    _validate_cache_ttl_order(
+        [
+            {"name": "noop"},  # uncached tool
+            {"type": "text", "text": "x", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Subclasses inherit the fix (shared base _apply_cache_tools)
+# ---------------------------------------------------------------------------
+
+
+def test_vertexai_tools_honor_extended_cache_time():
+    from agno.models.vertexai.claude import Claude as VertexAIClaude
+
+    model = VertexAIClaude(cache_tools=True, cache_system_prompt=True, extended_cache_time=True)
+    request_kwargs = model._prepare_request_kwargs(system_message="You are a helpful assistant.", tools=[dict(_TOOL)])
+    assert request_kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_aws_tools_honor_extended_cache_time():
+    pytest.importorskip("boto3")
+    from agno.models.aws.claude import Claude as AwsClaude
+
+    model = AwsClaude(cache_tools=True, cache_system_prompt=True, extended_cache_time=True)
+    request_kwargs = model._prepare_request_kwargs(system_message="You are a helpful assistant.", tools=[dict(_TOOL)])
+    assert request_kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}


### PR DESCRIPTION
## Summary

`Claude._apply_cache_tools` tagged the tools cache breakpoint with a bare `{"type": "ephemeral"}` (the default 5m TTL) and ignored `extended_cache_time`, while the system block honored it (1h). Anthropic renders cache breakpoints in `tools` → `system` → `messages` order and rejects a longer-TTL block that follows a shorter-TTL one, so `cache_tools=True` + `extended_cache_time=True` produced a 5m tools breakpoint before a 1h system breakpoint and returned **400 on every request**:

```
system.0.cache_control.ttl: a ttl='1h' cache_control block must not come after a ttl='5m' cache_control block. Note that blocks are processed in the following order: `tools`, `system`, `messages`.
```

This PR:

- Makes `_apply_cache_tools` set `ttl="1h"` on the tools breakpoint when `extended_cache_time` is enabled (matching the system block).
- Validates the assembled `tools + system` breakpoint order inside `_apply_cache_tools`. The existing `_validate_cache_ttl_order` ran over system blocks only (called from `_build_system`, before tools were added), so it could not catch this cross-section mismatch. Remaining cases (e.g. `cache_tools=True` with a `SystemPromptBlock(ttl="1h")`) now raise a clear local error instead of an opaque API 400.
- Broadens the validator's error message to mention `cache_tools` and the `tools → system → messages` render order.

The fix lives in the base `Claude` class, so `anthropic` / `aws` / `azure` / `vertexai` all inherit it.

Fixes #8405

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Validation:** ran the `libs/agno/scripts` commands — `ruff format`, `ruff check`, and `mypy` — against the changed files; the new tests and the existing `tests/unit/models/anthropic` + `test_claude_request_params.py` suites pass.

**Relation to #8234:** a previous PR (#8234) implemented the tools-TTL half of this fix but was closed ("opened in error") with no linked issue. This PR re-lands that behavior, adds the cross-section validation that turns the remaining mismatches into a clear local error, includes tests, and links a tracking issue. No other open PR addresses this.

**Tests:** `libs/agno/tests/unit/models/anthropic/test_cache_ttl_ordering.py` asserts the assembled tools+system TTL order (including the previously-failing `cache_tools=True` + `extended_cache_time=True` combo) and the validator behavior; verified failing on the pre-fix source and passing after.
