### PR TITLE
fix: restore legacy playground import

### DIFF
--- a/libs/agno/agno/playground/__init__.py
+++ b/libs/agno/agno/playground/__init__.py
@@ -1,0 +1,3 @@
+from agno.playground.playground import Playground, PlaygroundSettings
+
+__all__ = ["Playground", "PlaygroundSettings"]

--- a/libs/agno/agno/playground/playground.py
+++ b/libs/agno/agno/playground/playground.py
@@ -1,0 +1,42 @@
+from typing import Any, List, Optional
+
+from agno.playground.settings import PlaygroundSettings
+
+
+class Playground:
+    """Compatibility wrapper for the legacy Playground import path.
+
+    Playground was replaced by AgentOS. Importing this wrapper stays lightweight
+    for fresh installs, and constructing it delegates to AgentOS with the common
+    legacy constructor shape.
+    """
+
+    def __new__(
+        cls,
+        agents: Optional[List[Any]] = None,
+        teams: Optional[List[Any]] = None,
+        workflows: Optional[List[Any]] = None,
+        settings: Optional[PlaygroundSettings] = None,
+        api_app: Optional[Any] = None,
+        router: Optional[Any] = None,
+        **kwargs,
+    ):
+        from agno.os import AgentOS
+
+        settings = settings or PlaygroundSettings()
+        kwargs.setdefault("name", settings.title)
+
+        agent_os = AgentOS(
+            agents=agents,
+            teams=teams,
+            workflows=workflows,
+            settings=settings,
+            base_app=api_app,
+            **kwargs,
+        )
+        setattr(agent_os, "router", router)
+        setattr(agent_os, "api_app", agent_os.base_app)
+        return agent_os
+
+
+__all__ = ["Playground", "PlaygroundSettings"]

--- a/libs/agno/agno/playground/playground.py
+++ b/libs/agno/agno/playground/playground.py
@@ -22,15 +22,22 @@ class Playground:
         **kwargs,
     ):
         from agno.os import AgentOS
+        from agno.os.settings import AgnoAPISettings
 
         settings = settings or PlaygroundSettings()
-        kwargs.setdefault("name", settings.title)
+        name = kwargs.pop("name", None) or settings.title
 
         agent_os = AgentOS(
             agents=agents,
             teams=teams,
             workflows=workflows,
-            settings=settings,
+            settings=AgnoAPISettings(
+                env=settings.env,
+                docs_enabled=settings.docs_enabled,
+                os_security_key=settings.secret_key,
+                cors_origin_list=settings.cors_origin_list,
+            ),
+            name=name,
             base_app=api_app,
             **kwargs,
         )

--- a/libs/agno/agno/playground/settings.py
+++ b/libs/agno/agno/playground/settings.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings
+
+
+class PlaygroundSettings(BaseSettings):
+    """Backward-compatible settings for the legacy Playground API."""
+
+    env: str = "dev"
+    title: str = "agno-playground"
+    docs_enabled: bool = True
+    secret_key: Optional[str] = None
+    cors_origin_list: Optional[List[str]] = Field(default=None, validate_default=True)
+
+    @field_validator("env", mode="before")
+    def validate_playground_env(cls, env):
+        valid_runtime_envs = ["dev", "stg", "prd"]
+        if env not in valid_runtime_envs:
+            raise ValueError(f"Invalid Playground Env: {env}")
+        return env
+
+    @field_validator("cors_origin_list", mode="before")
+    def set_cors_origin_list(cls, cors_origin_list):
+        valid_cors = cors_origin_list or []
+        valid_cors.extend(
+            [
+                "http://localhost:3000",
+                "https://agno.com",
+                "https://www.agno.com",
+                "https://app.agno.com",
+                "https://os-stg.agno.com",
+                "https://os.agno.com",
+            ]
+        )
+        return valid_cors
+
+
+__all__ = ["PlaygroundSettings"]

--- a/libs/agno/tests/unit/os/test_playground_compat.py
+++ b/libs/agno/tests/unit/os/test_playground_compat.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+
+
+BLOCK_FASTAPI_SCRIPT = """
+import builtins
+
+original_import = builtins.__import__
+
+
+def block_fastapi(name, *args, **kwargs):
+    if name == "fastapi" or name.startswith("fastapi."):
+        raise ModuleNotFoundError("No module named 'fastapi'")
+    return original_import(name, *args, **kwargs)
+
+
+builtins.__import__ = block_fastapi
+from agno.playground import Playground, PlaygroundSettings
+assert Playground.__name__ == "Playground"
+assert PlaygroundSettings().title == "agno-playground"
+"""
+
+
+def test_playground_import_exports_legacy_names_without_agentos_dependencies():
+    result = subprocess.run(
+        [sys.executable, "-c", BLOCK_FASTAPI_SCRIPT],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_playground_submodule_import_exports_same_aliases():
+    from agno.playground import Playground, PlaygroundSettings
+    from agno.playground.playground import Playground as SubmodulePlayground
+    from agno.playground.playground import PlaygroundSettings as SubmodulePlaygroundSettings
+
+    assert SubmodulePlayground is Playground
+    assert SubmodulePlaygroundSettings is PlaygroundSettings


### PR DESCRIPTION
## Summary
- Restores the legacy `agno.playground` import path as a lightweight compatibility wrapper around AgentOS.
- Adds backward-compatible `PlaygroundSettings` defaults.
- Adds regression coverage for importing `Playground` without requiring AgentOS/FastAPI dependencies at import time.

## Test Plan
- RED check: temporarily removed `libs/agno/agno/playground` and confirmed the import regression fails with `ModuleNotFoundError`.
- `PYTHONDONTWRITEBYTECODE=1 python3 -c "import ast, pathlib; files=[...]; [ast.parse(pathlib.Path(p).read_text(), filename=p) for p in files]"`
- `PYTHONDONTWRITEBYTECODE=1 python3 /tmp/playground_import_check.py`

Note: full `pytest` via `uv run --project libs/agno ...` could not be installed locally because this Mac has ~146 MiB free and uv hit `No space left on device`.

Closes #7955