### PR TITLE
fix: gate legacy search_messages on user token in SlackContextProvider

### DIFF
--- a/cookbook/05_agent_os/interfaces/slack/channel_summarizer.py
+++ b/cookbook/05_agent_os/interfaces/slack/channel_summarizer.py
@@ -14,6 +14,10 @@ Key concepts:
 
 Slack scopes: app_mentions:read, assistant:write, chat:write, im:history,
              channels:history, channels:read, search:read, users:read
+
+Environment variables:
+    SLACK_TOKEN         Bot token (xoxb-) for standard Slack APIs
+    SLACK_USER_TOKEN    User token (xoxp-) required for search_messages
 """
 
 from agno.agent import Agent

--- a/cookbook/05_agent_os/interfaces/slack/research_assistant.py
+++ b/cookbook/05_agent_os/interfaces/slack/research_assistant.py
@@ -14,6 +14,10 @@ Key concepts:
 
 Slack scopes: app_mentions:read, assistant:write, chat:write, im:history,
              search:read, channels:history, users:read
+
+Environment variables:
+    SLACK_TOKEN         Bot token (xoxb-) for standard Slack APIs
+    SLACK_USER_TOKEN    User token (xoxp-) required for search_messages
 """
 
 from agno.agent import Agent

--- a/cookbook/05_agent_os/interfaces/slack/support_team.py
+++ b/cookbook/05_agent_os/interfaces/slack/support_team.py
@@ -13,6 +13,10 @@ Key concepts:
 
 Slack scopes: app_mentions:read, assistant:write, chat:write, im:history,
              search:read, channels:history
+
+Environment variables:
+    SLACK_TOKEN         Bot token (xoxb-) for standard Slack APIs
+    SLACK_USER_TOKEN    User token (xoxp-) required for search_messages
 """
 
 from agno.agent import Agent

--- a/cookbook/12_context/05_slack.py
+++ b/cookbook/12_context/05_slack.py
@@ -27,6 +27,7 @@ Requires:
 
     Optional:
     SLACK_TOKEN         (falls back here if SLACK_BOT_TOKEN isn't set)
+    SLACK_USER_TOKEN    (user token; xoxp-...) for search_messages API
     SLACK_WRITE_CHANNEL (e.g. `#agno-test`) — opt in to the write demo
 """
 

--- a/cookbook/12_context/06_slack_search_media.py
+++ b/cookbook/12_context/06_slack_search_media.py
@@ -4,9 +4,11 @@ Slack Search & Media Tools
 
 Demonstrates SlackContextProvider with:
 
-- **search_messages** — Search using the legacy API (works with user
-  tokens `xoxp-`). Both bot and assisted read agents now have this
-  enabled alongside `search_workspace`.
+- **search_messages** — Slack's legacy search API. It requires a user
+  token (`xoxp-`); a bot token (`xoxb-`) fails it with
+  `not_allowed_token_type`. The provider gates the tool on token type, so
+  it is registered on the read agents only when a user token is
+  configured.
 - **enable_media_tools** — Opt-in file handling:
   - `download_file` on read agents (fetch images/files for multimodal)
   - `upload_file` on write agent (post generated content)
@@ -17,12 +19,12 @@ when you want faster/cheaper tool calls but stronger reasoning on top.
 
 Requires:
     GOOGLE_API_KEY
-    SLACK_BOT_TOKEN  (xoxb-) — uses channel history, no search
-    SLACK_TOKEN      (xoxp-) — enables search_messages API
+    SLACK_BOT_TOKEN  (xoxb-) — channel history + threads, no free-text search
+    SLACK_TOKEN      (xoxp-) — additionally enables the search_messages API
 
-With a bot token, search_messages returns `not_allowed_token_type` and
-the agent falls back to get_channel_history. With a user token, both
-search methods are available.
+With a bot token the provider does not register search_messages; reads go
+through get_channel_history / get_thread. With a user token, search_messages
+is available alongside the deterministic read tools.
 
 Usage:
     python cookbook/12_context/06_slack_search_media.py

--- a/cookbook/12_context/06_slack_search_media.py
+++ b/cookbook/12_context/06_slack_search_media.py
@@ -4,11 +4,9 @@ Slack Search & Media Tools
 
 Demonstrates SlackContextProvider with:
 
-- **search_messages** — Slack's legacy search API. It requires a user
-  token (`xoxp-`); a bot token (`xoxb-`) fails it with
-  `not_allowed_token_type`. The provider gates the tool on user token
-  availability, so search_messages is registered only when SLACK_USER_TOKEN
-  is set (or the primary token is a user token).
+- **search_messages** — Search using the legacy API (works with user
+  tokens `xoxp-`). Both bot and assisted read agents now have this
+  enabled alongside `search_workspace`.
 - **enable_media_tools** — Opt-in file handling:
   - `download_file` on read agents (fetch images/files for multimodal)
   - `upload_file` on write agent (post generated content)
@@ -19,14 +17,14 @@ when you want faster/cheaper tool calls but stronger reasoning on top.
 
 Requires:
     GOOGLE_API_KEY
-    SLACK_BOT_TOKEN  (xoxb-) — channel history + threads, no free-text search
+    SLACK_BOT_TOKEN  (xoxb-) — uses channel history, no search
 
 Optional:
-    SLACK_USER_TOKEN (xoxp-) — enables the search_messages API
+    SLACK_USER_TOKEN (xoxp-) — enables search_messages API
 
-With only a bot token, reads go through get_channel_history / get_thread.
-With SLACK_USER_TOKEN set, search_messages is available alongside the
-deterministic read tools.
+With a bot token, search_messages returns `not_allowed_token_type` and
+the agent falls back to get_channel_history. With a user token, both
+search methods are available.
 
 Usage:
     python cookbook/12_context/06_slack_search_media.py

--- a/cookbook/12_context/06_slack_search_media.py
+++ b/cookbook/12_context/06_slack_search_media.py
@@ -6,9 +6,9 @@ Demonstrates SlackContextProvider with:
 
 - **search_messages** — Slack's legacy search API. It requires a user
   token (`xoxp-`); a bot token (`xoxb-`) fails it with
-  `not_allowed_token_type`. The provider gates the tool on token type, so
-  it is registered on the read agents only when a user token is
-  configured.
+  `not_allowed_token_type`. The provider gates the tool on user token
+  availability, so search_messages is registered only when SLACK_USER_TOKEN
+  is set (or the primary token is a user token).
 - **enable_media_tools** — Opt-in file handling:
   - `download_file` on read agents (fetch images/files for multimodal)
   - `upload_file` on write agent (post generated content)
@@ -20,11 +20,13 @@ when you want faster/cheaper tool calls but stronger reasoning on top.
 Requires:
     GOOGLE_API_KEY
     SLACK_BOT_TOKEN  (xoxb-) — channel history + threads, no free-text search
-    SLACK_TOKEN      (xoxp-) — additionally enables the search_messages API
 
-With a bot token the provider does not register search_messages; reads go
-through get_channel_history / get_thread. With a user token, search_messages
-is available alongside the deterministic read tools.
+Optional:
+    SLACK_USER_TOKEN (xoxp-) — enables the search_messages API
+
+With only a bot token, reads go through get_channel_history / get_thread.
+With SLACK_USER_TOKEN set, search_messages is available alongside the
+deterministic read tools.
 
 Usage:
     python cookbook/12_context/06_slack_search_media.py

--- a/cookbook/12_context/09_web_plus_slack.py
+++ b/cookbook/12_context/09_web_plus_slack.py
@@ -23,6 +23,9 @@ Requires:
     SLACK_BOT_TOKEN    (or SLACK_TOKEN fallback; scopes: channels:read,
                         channels:history, users:read)
     pip install parallel-web
+
+Optional:
+    SLACK_USER_TOKEN   (xoxp-) enables search_messages API
 """
 
 from __future__ import annotations

--- a/cookbook/91_tools/slack_tools.py
+++ b/cookbook/91_tools/slack_tools.py
@@ -1,4 +1,13 @@
-"""Run: pip install openai slack-sdk"""
+"""
+Slack Tools
+===========
+
+Environment variables:
+    SLACK_TOKEN         Bot token (xoxb-) for standard Slack APIs
+    SLACK_USER_TOKEN    User token (xoxp-) required for search_messages
+
+Run: pip install openai slack-sdk
+"""
 
 from agno.agent import Agent
 from agno.tools.slack import SlackTools

--- a/libs/agno/agno/context/slack/provider.py
+++ b/libs/agno/agno/context/slack/provider.py
@@ -63,7 +63,8 @@ class SlackContextProvider(ContextProvider):
 
         # Resolve user token from param, env, or primary token (backward compat)
         _user_token = user_token or getenv("SLACK_USER_TOKEN")
-        if not _user_token and self.token.startswith("xoxp-"):
+        if not _user_token and ("xoxp-" in self.token):
+            # Handles both xoxp-... and rotated xoxe.xoxp-... formats
             _user_token = self.token
         self._user_token = _user_token
         self._enable_search_messages = self._user_token is not None

--- a/libs/agno/agno/context/slack/provider.py
+++ b/libs/agno/agno/context/slack/provider.py
@@ -59,6 +59,11 @@ class SlackContextProvider(ContextProvider):
         self.token = token or getenv("SLACK_BOT_TOKEN") or getenv("SLACK_TOKEN")
         if not self.token:
             raise ValueError("SlackContextProvider: SLACK_BOT_TOKEN (or SLACK_TOKEN) is required")
+        # Slack's legacy ``search.messages`` API is user-token-only; a bot token
+        # (``xoxb-``) always fails it with ``not_allowed_token_type``. Gate the
+        # tool on token type so bot-token deployments never register a tool that
+        # cannot work, while user-token (``xoxp-``) deployments keep it.
+        self._is_user_token = self.token.startswith("xoxp-")
         self.read_instructions_text = read_instructions
         self.write_instructions_text = (
             write_instructions if write_instructions is not None else DEFAULT_SLACK_WRITE_INSTRUCTIONS
@@ -188,7 +193,7 @@ class SlackContextProvider(ContextProvider):
                 enable_download_file=self.enable_media_tools,
                 enable_list_channels=True,
                 enable_get_channel_history=True,
-                enable_search_messages=True,
+                enable_search_messages=self._is_user_token,
                 enable_search_workspace=False,
                 enable_get_thread=True,
                 enable_list_users=True,
@@ -207,7 +212,7 @@ class SlackContextProvider(ContextProvider):
                 enable_download_file=self.enable_media_tools,
                 enable_list_channels=True,
                 enable_get_channel_history=True,
-                enable_search_messages=True,
+                enable_search_messages=self._is_user_token,
                 enable_search_workspace=True,
                 enable_get_thread=True,
                 enable_list_users=True,
@@ -281,9 +286,11 @@ Workflow:
    recent messages in a specific channel, call
    `get_channel_history(channel)`. If they ask about a thread or a
    message with replies, call `get_thread(channel, ts)`.
-2. **Use search for broad reads.** `search_workspace(query)` uses Slack
-   interface permissions; `search_messages(query)` works with user tokens.
-   Try one, and if it fails or returns nothing relevant, try the other.
+2. **Use search for broad reads.** `search_workspace(query)` searches with
+   Slack interface permissions - use it for topic lookups, catch-up, and
+   summaries. `search_messages(query)` is only present with a user token;
+   when it is available, fall back to it if `search_workspace` returns
+   nothing relevant.
 3. **Shape search queries.** Include channel or topic hints from the
    user's request. Use Slack search filters when useful, e.g.
    `in:#agents`.
@@ -303,22 +310,26 @@ _SLACK_BOT_TOKEN_READ_INSTRUCTIONS = """\
 You answer questions by reading Slack with bot-token-compatible tools.
 
 Workflow:
-1. **Search first.** Use `search_messages(query)` to find messages across
-   accessible channels. Shape queries with channel or topic hints, e.g.
-   `in:#agents topic`.
-2. **Read known channels directly.** If the user provides a channel name
+1. **Read known channels directly.** If the user provides a channel name
    or ID, pass it straight to `get_channel_history(channel)`. The tool
    resolves names like `#agents` to IDs.
-3. **Discover only when needed.** Use `list_channels` only when the user
+2. **Discover only when needed.** Use `list_channels` only when the user
    did not name a channel. The bot must be a member of private channels.
-4. **Expand threads.** When a message has replies, call
+3. **Expand threads.** When a message has replies, call
    `get_thread(channel, ts)` for the full discussion. Pass the same
    channel name or ID you used for history.
-5. **Resolve names.** `get_user_info` / `list_users` turn Slack user IDs
+4. **Resolve names.** `get_user_info` / `list_users` turn Slack user IDs
    into display names. Don't invent a name when the ID doesn't resolve —
    report the raw user id instead.
-6. **Cite.** Every claim should point to channel + author + timestamp.
+5. **Cite.** Every claim should point to channel + author + timestamp.
    Quote message text verbatim; don't paraphrase.
+
+Free-text workspace search is not available on a bot token. There is no
+search tool on this path unless a user token (`xoxp-`) is configured, in
+which case `search_messages(query)` is available for broad topic lookups
+(shape queries with hints like `in:#agents topic`). Without it, read named
+channels directly; never claim a channel is empty just because you cannot
+search it.
 
 You are read-only. Never send messages, upload, or download. If the
 channel cannot be found or the bot is not a member, say so plainly.

--- a/libs/agno/agno/context/slack/provider.py
+++ b/libs/agno/agno/context/slack/provider.py
@@ -39,21 +39,7 @@ if TYPE_CHECKING:
 
 
 class SlackContextProvider(ContextProvider):
-    """Read + write access to a Slack workspace via two tools.
-
-    Token Configuration:
-        - ``token`` / ``SLACK_BOT_TOKEN``: Primary bot token (xoxb-) for all standard
-          Slack APIs (posting, reading channels, file operations). Required.
-        - ``user_token`` / ``SLACK_USER_TOKEN``: Optional user token (xoxp-) for the
-          legacy search.messages API. Only needed when deploying read agents that
-          require workspace search outside the Slack interface.
-
-    Search Methods:
-        - ``search_workspace``: Uses action_token from Slack interface events.
-          Works with bot token when running inside the Slack interface.
-        - ``search_messages``: Legacy API requiring a user token. Use when
-          search_workspace is unavailable (CLI, cron, external apps).
-    """
+    """Read + write access to a Slack workspace via two tools."""
 
     def __init__(
         self,
@@ -71,14 +57,11 @@ class SlackContextProvider(ContextProvider):
         write: bool = True,
     ) -> None:
         super().__init__(id=id, name=name, mode=mode, model=model, read=read, write=write)
-        # Primary token (bot) for all standard Slack APIs
         self.token = token or getenv("SLACK_BOT_TOKEN") or getenv("SLACK_TOKEN")
         if not self.token:
             raise ValueError("SlackContextProvider: SLACK_BOT_TOKEN (or SLACK_TOKEN) is required")
-        # User token for legacy search.messages API (optional)
         self._user_token = user_token or getenv("SLACK_USER_TOKEN")
-        # Enable search_messages when user token available OR primary token is a user token
-        self._has_legacy_search = bool(self._user_token) or self.token.startswith("xoxp-")
+        self._enable_search_messages = self._user_token is not None
         self.read_instructions_text = read_instructions
         self.write_instructions_text = (
             write_instructions if write_instructions is not None else DEFAULT_SLACK_WRITE_INSTRUCTIONS
@@ -209,7 +192,7 @@ class SlackContextProvider(ContextProvider):
                 enable_download_file=self.enable_media_tools,
                 enable_list_channels=True,
                 enable_get_channel_history=True,
-                enable_search_messages=self._has_legacy_search,
+                enable_search_messages=self._enable_search_messages,
                 enable_search_workspace=False,
                 enable_get_thread=True,
                 enable_list_users=True,
@@ -229,7 +212,7 @@ class SlackContextProvider(ContextProvider):
                 enable_download_file=self.enable_media_tools,
                 enable_list_channels=True,
                 enable_get_channel_history=True,
-                enable_search_messages=self._has_legacy_search,
+                enable_search_messages=self._enable_search_messages,
                 enable_search_workspace=True,
                 enable_get_thread=True,
                 enable_list_users=True,
@@ -303,11 +286,9 @@ Workflow:
    recent messages in a specific channel, call
    `get_channel_history(channel)`. If they ask about a thread or a
    message with replies, call `get_thread(channel, ts)`.
-2. **Use search for broad reads.** `search_workspace(query)` searches with
-   Slack interface permissions - use it for topic lookups, catch-up, and
-   summaries. `search_messages(query)` is only present with a user token;
-   when it is available, fall back to it if `search_workspace` returns
-   nothing relevant.
+2. **Use search for broad reads.** `search_workspace(query)` uses Slack
+   interface permissions; `search_messages(query)` works with user tokens.
+   Try one, and if it fails or returns nothing relevant, try the other.
 3. **Shape search queries.** Include channel or topic hints from the
    user's request. Use Slack search filters when useful, e.g.
    `in:#agents`.
@@ -327,26 +308,22 @@ _SLACK_BOT_TOKEN_READ_INSTRUCTIONS = """\
 You answer questions by reading Slack with bot-token-compatible tools.
 
 Workflow:
-1. **Read known channels directly.** If the user provides a channel name
+1. **Search first.** Use `search_messages(query)` to find messages across
+   accessible channels. Shape queries with channel or topic hints, e.g.
+   `in:#agents topic`.
+2. **Read known channels directly.** If the user provides a channel name
    or ID, pass it straight to `get_channel_history(channel)`. The tool
    resolves names like `#agents` to IDs.
-2. **Discover only when needed.** Use `list_channels` only when the user
+3. **Discover only when needed.** Use `list_channels` only when the user
    did not name a channel. The bot must be a member of private channels.
-3. **Expand threads.** When a message has replies, call
+4. **Expand threads.** When a message has replies, call
    `get_thread(channel, ts)` for the full discussion. Pass the same
    channel name or ID you used for history.
-4. **Resolve names.** `get_user_info` / `list_users` turn Slack user IDs
+5. **Resolve names.** `get_user_info` / `list_users` turn Slack user IDs
    into display names. Don't invent a name when the ID doesn't resolve —
    report the raw user id instead.
-5. **Cite.** Every claim should point to channel + author + timestamp.
+6. **Cite.** Every claim should point to channel + author + timestamp.
    Quote message text verbatim; don't paraphrase.
-
-Free-text workspace search is not available on a bot token. There is no
-search tool on this path unless a user token (`xoxp-`) is configured, in
-which case `search_messages(query)` is available for broad topic lookups
-(shape queries with hints like `in:#agents topic`). Without it, read named
-channels directly; never claim a channel is empty just because you cannot
-search it.
 
 You are read-only. Never send messages, upload, or download. If the
 channel cannot be found or the bot is not a member, say so plainly.

--- a/libs/agno/agno/context/slack/provider.py
+++ b/libs/agno/agno/context/slack/provider.py
@@ -60,7 +60,12 @@ class SlackContextProvider(ContextProvider):
         self.token = token or getenv("SLACK_BOT_TOKEN") or getenv("SLACK_TOKEN")
         if not self.token:
             raise ValueError("SlackContextProvider: SLACK_BOT_TOKEN (or SLACK_TOKEN) is required")
-        self._user_token = user_token or getenv("SLACK_USER_TOKEN")
+
+        # Resolve user token from param, env, or primary token (backward compat)
+        _user_token = user_token or getenv("SLACK_USER_TOKEN")
+        if not _user_token and self.token.startswith("xoxp-"):
+            _user_token = self.token
+        self._user_token = _user_token
         self._enable_search_messages = self._user_token is not None
         self.read_instructions_text = read_instructions
         self.write_instructions_text = (

--- a/libs/agno/agno/context/slack/provider.py
+++ b/libs/agno/agno/context/slack/provider.py
@@ -39,12 +39,27 @@ if TYPE_CHECKING:
 
 
 class SlackContextProvider(ContextProvider):
-    """Read + write access to a Slack workspace via two tools."""
+    """Read + write access to a Slack workspace via two tools.
+
+    Token Configuration:
+        - ``token`` / ``SLACK_BOT_TOKEN``: Primary bot token (xoxb-) for all standard
+          Slack APIs (posting, reading channels, file operations). Required.
+        - ``user_token`` / ``SLACK_USER_TOKEN``: Optional user token (xoxp-) for the
+          legacy search.messages API. Only needed when deploying read agents that
+          require workspace search outside the Slack interface.
+
+    Search Methods:
+        - ``search_workspace``: Uses action_token from Slack interface events.
+          Works with bot token when running inside the Slack interface.
+        - ``search_messages``: Legacy API requiring a user token. Use when
+          search_workspace is unavailable (CLI, cron, external apps).
+    """
 
     def __init__(
         self,
         *,
         token: str | None = None,
+        user_token: str | None = None,
         id: str = "slack",
         name: str = "Slack",
         read_instructions: str | None = None,
@@ -56,14 +71,14 @@ class SlackContextProvider(ContextProvider):
         write: bool = True,
     ) -> None:
         super().__init__(id=id, name=name, mode=mode, model=model, read=read, write=write)
+        # Primary token (bot) for all standard Slack APIs
         self.token = token or getenv("SLACK_BOT_TOKEN") or getenv("SLACK_TOKEN")
         if not self.token:
             raise ValueError("SlackContextProvider: SLACK_BOT_TOKEN (or SLACK_TOKEN) is required")
-        # Slack's legacy ``search.messages`` API is user-token-only; a bot token
-        # (``xoxb-``) always fails it with ``not_allowed_token_type``. Gate the
-        # tool on token type so bot-token deployments never register a tool that
-        # cannot work, while user-token (``xoxp-``) deployments keep it.
-        self._is_user_token = self.token.startswith("xoxp-")
+        # User token for legacy search.messages API (optional)
+        self._user_token = user_token or getenv("SLACK_USER_TOKEN")
+        # Enable search_messages when user token available OR primary token is a user token
+        self._has_legacy_search = bool(self._user_token) or self.token.startswith("xoxp-")
         self.read_instructions_text = read_instructions
         self.write_instructions_text = (
             write_instructions if write_instructions is not None else DEFAULT_SLACK_WRITE_INSTRUCTIONS
@@ -187,13 +202,14 @@ class SlackContextProvider(ContextProvider):
         if self._bot_read_tools is None:
             self._bot_read_tools = SlackTools(
                 token=self.token,
+                user_token=self._user_token,
                 enable_send_message=False,
                 enable_send_message_thread=False,
                 enable_upload_file=False,
                 enable_download_file=self.enable_media_tools,
                 enable_list_channels=True,
                 enable_get_channel_history=True,
-                enable_search_messages=self._is_user_token,
+                enable_search_messages=self._has_legacy_search,
                 enable_search_workspace=False,
                 enable_get_thread=True,
                 enable_list_users=True,
@@ -206,13 +222,14 @@ class SlackContextProvider(ContextProvider):
         if self._assisted_read_tools is None:
             self._assisted_read_tools = SlackTools(
                 token=self.token,
+                user_token=self._user_token,
                 enable_send_message=False,
                 enable_send_message_thread=False,
                 enable_upload_file=False,
                 enable_download_file=self.enable_media_tools,
                 enable_list_channels=True,
                 enable_get_channel_history=True,
-                enable_search_messages=self._is_user_token,
+                enable_search_messages=self._has_legacy_search,
                 enable_search_workspace=True,
                 enable_get_thread=True,
                 enable_list_users=True,

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -51,6 +51,7 @@ def attach_routes(
     workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
     reply_to_mentions_only: bool = True,
     token: Optional[str] = None,
+    user_token: Optional[str] = None,
     signing_secret: Optional[str] = None,
     streaming: bool = True,
     loading_messages: Optional[List[str]] = None,
@@ -78,7 +79,7 @@ def attach_routes(
     op_suffix = entity_name.lower().replace(" ", "_")
     entity_id = getattr(entity, "id", None) or entity_name
 
-    slack_tools = SlackTools(token=token, ssl=ssl, max_file_size=max_file_size)
+    slack_tools = SlackTools(token=token, user_token=user_token, ssl=ssl, max_file_size=max_file_size)
     bot_name_resolver = BotNameResolver()
     if entity is None:
         raise ValueError("attach_routes requires agent, team, or workflow")

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -188,7 +188,14 @@ class SlackTools(Toolkit):
         self.token: str = _token
         self.client = WebClient(token=self.token, ssl=ssl)
 
-        self._user_token: Optional[str] = user_token or getenv("SLACK_USER_TOKEN")
+        # 1. Resolve user token from param, env, or primary token (backward compat)
+        _user_token = user_token or getenv("SLACK_USER_TOKEN")
+        if not _user_token and _token.startswith("xoxp-"):
+            # Backward compat: primary token is a user token, use it for search
+            _user_token = _token
+        self._user_token: Optional[str] = _user_token
+
+        # 2. Create user client for search_messages if we have a user token
         self._user_client: Optional[WebClient] = (
             WebClient(token=self._user_token, ssl=ssl) if self._user_token else None
         )
@@ -224,7 +231,8 @@ class SlackTools(Toolkit):
         if enable_search_messages or all:
             if self._user_client:
                 tools.append(self.search_messages)
-            else:
+            elif enable_search_messages:
+                # Only warn when explicitly requested, not via all=True
                 log_warning("search_messages disabled: no user token (SLACK_USER_TOKEN) provided")
         if enable_search_workspace or all:
             tools.append(self.search_workspace)

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -158,11 +158,8 @@ class SlackTools(Toolkit):
         Initialize the SlackTools class.
 
         Args:
-            token (str): The Slack bot token (xoxb-). Defaults to SLACK_BOT_TOKEN or SLACK_TOKEN env var.
-                Used for all standard Slack APIs (posting, reading channels, file operations).
-            user_token (str): Optional Slack user token (xoxp-) for the legacy search.messages API.
-                Defaults to SLACK_USER_TOKEN env var. Only needed if enable_search_messages=True.
-                Bot tokens cannot use search.messages (Slack returns not_allowed_token_type).
+            token (str): The Slack API token. Defaults to the SLACK_TOKEN environment variable.
+            user_token (str): User token (xoxp-) for search_messages. Defaults to SLACK_USER_TOKEN env var.
             markdown (bool): Whether to enable Slack markdown formatting. Defaults to True.
             output_directory (str): Directory for saving downloaded files. Only used when save_downloads=True.
             save_downloads (bool): Whether to save downloaded files to disk. Defaults to False (base64 only).
@@ -172,9 +169,7 @@ class SlackTools(Toolkit):
             enable_get_channel_history (bool): Whether to enable the get_channel_history tool. Defaults to True.
             enable_upload_file (bool): Whether to enable the upload_file tool. Defaults to True.
             enable_download_file (bool): Whether to enable the download_file tool. Defaults to True.
-            enable_search_messages (bool): Whether to enable the search_messages tool (legacy API).
-                Requires a user token (xoxp-) via user_token param or SLACK_USER_TOKEN env var.
-                Defaults to False.
+            enable_search_messages (bool): Whether to enable the search_messages tool (legacy API). Defaults to False.
             enable_search_workspace (bool): Whether to enable the search_workspace tool (assistant.search.context API).
                 Requires search:read.public, search:read.files, and search:read.users bot scopes.
                 The action_token is read from run_context.metadata at call time. Defaults to False.
@@ -187,17 +182,16 @@ class SlackTools(Toolkit):
             max_file_size (int): Maximum file size in bytes for uploads and downloads. Defaults to 1GB.
             thread_message_limit (int): Maximum number of messages to fetch in get_thread. Defaults to 20.
         """
-        # Primary token (bot) for all standard APIs
-        _token = token or getenv("SLACK_BOT_TOKEN") or getenv("SLACK_TOKEN")
+        _token = token or getenv("SLACK_TOKEN")
         if not _token:
-            raise ValueError("SLACK_BOT_TOKEN (or SLACK_TOKEN) is not set")
+            raise ValueError("SLACK_TOKEN is not set")
         self.token: str = _token
         self.client = WebClient(token=self.token, ssl=ssl)
 
-        # User token for legacy search.messages API (optional)
-        _user_token = user_token or getenv("SLACK_USER_TOKEN")
-        self._user_token: Optional[str] = _user_token
-        self._user_client: Optional[WebClient] = WebClient(token=_user_token, ssl=ssl) if _user_token else None
+        self._user_token: Optional[str] = user_token or getenv("SLACK_USER_TOKEN")
+        self._user_client: Optional[WebClient] = (
+            WebClient(token=self._user_token, ssl=ssl) if self._user_token else None
+        )
         self.markdown = markdown
         self.max_file_size = max_file_size
         self.thread_message_limit = thread_message_limit
@@ -228,7 +222,10 @@ class SlackTools(Toolkit):
         if enable_download_file or all:
             tools.append(self.download_file)
         if enable_search_messages or all:
-            tools.append(self.search_messages)
+            if self._user_client:
+                tools.append(self.search_messages)
+            else:
+                log_warning("search_messages disabled: no user token (SLACK_USER_TOKEN) provided")
         if enable_search_workspace or all:
             tools.append(self.search_workspace)
         if enable_get_thread or all:
@@ -765,9 +762,7 @@ class SlackTools(Toolkit):
             return None
 
     def search_messages(self, query: str, limit: int = 20) -> str:
-        """Search messages across the Slack workspace using the legacy search.messages API.
-
-        Requires a user token (xoxp-). Bot tokens cannot use this API.
+        """Search messages across the Slack workspace.
 
         Args:
             query (str): The search query. Supports modifiers like from:@user, in:#channel, has:link, before:date, after:date.
@@ -776,13 +771,8 @@ class SlackTools(Toolkit):
         Returns:
             str: A JSON string containing the count and list of matching messages with text, user, channel, timestamp, and permalink.
         """
-        if not self._user_client:
-            return json.dumps({
-                "error": "search_messages requires a user token (xoxp-). "
-                "Set SLACK_USER_TOKEN or pass user_token to SlackTools."
-            })
         try:
-            response = self._user_client.search_messages(query=query, count=min(limit, 100))
+            response = self._user_client.search_messages(query=query, count=min(limit, 100))  # type: ignore[union-attr]
             message_results = cast(Dict[str, Any], response.get("messages") or {})
             matches = cast(List[Dict[str, Any]], message_results.get("matches") or [])
             messages = [

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -132,6 +132,7 @@ class SlackTools(Toolkit):
     def __init__(
         self,
         token: Optional[str] = None,
+        user_token: Optional[str] = None,
         markdown: bool = True,
         output_directory: Optional[str] = None,
         save_downloads: bool = False,
@@ -157,7 +158,11 @@ class SlackTools(Toolkit):
         Initialize the SlackTools class.
 
         Args:
-            token (str): The Slack API token. Defaults to the SLACK_TOKEN environment variable.
+            token (str): The Slack bot token (xoxb-). Defaults to SLACK_BOT_TOKEN or SLACK_TOKEN env var.
+                Used for all standard Slack APIs (posting, reading channels, file operations).
+            user_token (str): Optional Slack user token (xoxp-) for the legacy search.messages API.
+                Defaults to SLACK_USER_TOKEN env var. Only needed if enable_search_messages=True.
+                Bot tokens cannot use search.messages (Slack returns not_allowed_token_type).
             markdown (bool): Whether to enable Slack markdown formatting. Defaults to True.
             output_directory (str): Directory for saving downloaded files. Only used when save_downloads=True.
             save_downloads (bool): Whether to save downloaded files to disk. Defaults to False (base64 only).
@@ -167,7 +172,9 @@ class SlackTools(Toolkit):
             enable_get_channel_history (bool): Whether to enable the get_channel_history tool. Defaults to True.
             enable_upload_file (bool): Whether to enable the upload_file tool. Defaults to True.
             enable_download_file (bool): Whether to enable the download_file tool. Defaults to True.
-            enable_search_messages (bool): Whether to enable the search_messages tool (legacy API). Defaults to False.
+            enable_search_messages (bool): Whether to enable the search_messages tool (legacy API).
+                Requires a user token (xoxp-) via user_token param or SLACK_USER_TOKEN env var.
+                Defaults to False.
             enable_search_workspace (bool): Whether to enable the search_workspace tool (assistant.search.context API).
                 Requires search:read.public, search:read.files, and search:read.users bot scopes.
                 The action_token is read from run_context.metadata at call time. Defaults to False.
@@ -180,11 +187,17 @@ class SlackTools(Toolkit):
             max_file_size (int): Maximum file size in bytes for uploads and downloads. Defaults to 1GB.
             thread_message_limit (int): Maximum number of messages to fetch in get_thread. Defaults to 20.
         """
-        _token = token or getenv("SLACK_TOKEN")
+        # Primary token (bot) for all standard APIs
+        _token = token or getenv("SLACK_BOT_TOKEN") or getenv("SLACK_TOKEN")
         if not _token:
-            raise ValueError("SLACK_TOKEN is not set")
+            raise ValueError("SLACK_BOT_TOKEN (or SLACK_TOKEN) is not set")
         self.token: str = _token
         self.client = WebClient(token=self.token, ssl=ssl)
+
+        # User token for legacy search.messages API (optional)
+        _user_token = user_token or getenv("SLACK_USER_TOKEN")
+        self._user_token: Optional[str] = _user_token
+        self._user_client: Optional[WebClient] = WebClient(token=_user_token, ssl=ssl) if _user_token else None
         self.markdown = markdown
         self.max_file_size = max_file_size
         self.thread_message_limit = thread_message_limit
@@ -752,7 +765,9 @@ class SlackTools(Toolkit):
             return None
 
     def search_messages(self, query: str, limit: int = 20) -> str:
-        """Search messages across the Slack workspace.
+        """Search messages across the Slack workspace using the legacy search.messages API.
+
+        Requires a user token (xoxp-). Bot tokens cannot use this API.
 
         Args:
             query (str): The search query. Supports modifiers like from:@user, in:#channel, has:link, before:date, after:date.
@@ -761,8 +776,13 @@ class SlackTools(Toolkit):
         Returns:
             str: A JSON string containing the count and list of matching messages with text, user, channel, timestamp, and permalink.
         """
+        if not self._user_client:
+            return json.dumps({
+                "error": "search_messages requires a user token (xoxp-). "
+                "Set SLACK_USER_TOKEN or pass user_token to SlackTools."
+            })
         try:
-            response = self.client.search_messages(query=query, count=min(limit, 100))
+            response = self._user_client.search_messages(query=query, count=min(limit, 100))
             message_results = cast(Dict[str, Any], response.get("messages") or {})
             matches = cast(List[Dict[str, Any]], message_results.get("matches") or [])
             messages = [

--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -190,8 +190,9 @@ class SlackTools(Toolkit):
 
         # 1. Resolve user token from param, env, or primary token (backward compat)
         _user_token = user_token or getenv("SLACK_USER_TOKEN")
-        if not _user_token and _token.startswith("xoxp-"):
+        if not _user_token and ("xoxp-" in _token):
             # Backward compat: primary token is a user token, use it for search
+            # Handles both xoxp-... and rotated xoxe.xoxp-... formats
             _user_token = _token
         self._user_token: Optional[str] = _user_token
 

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -453,76 +453,23 @@ def test_slack_read_surfaces_are_split_by_mode():
 
 
 def test_slack_bot_token_without_user_token_excludes_search_messages():
-    """Without a user token, search_messages is not registered since bot tokens
-    cannot use Slack's legacy search.messages API."""
+    """Without a user token, search_messages should not be registered."""
     p = SlackContextProvider(token="xoxb-x")
+    bot_tools = p._ensure_bot_read_tools()
+    assisted_tools = p._ensure_assisted_read_tools()
 
-    assert "search_messages" not in p._ensure_bot_read_tools().functions
-    assert "search_messages" not in p._ensure_assisted_read_tools().functions
-
-
-def test_slack_user_token_env_enables_search_messages():
-    """When SLACK_USER_TOKEN is set, search_messages is registered even with
-    a bot token as the primary token."""
-    import os
-    from unittest.mock import patch
-
-    with patch.dict(os.environ, {"SLACK_USER_TOKEN": "xoxp-user"}):
-        p = SlackContextProvider(token="xoxb-x")
-
-        bot_tools = p._ensure_bot_read_tools()
-        assisted_tools = p._ensure_assisted_read_tools()
-
-        assert "search_messages" in bot_tools.functions
-        assert "search_messages" in assisted_tools.functions
-        assert "search_workspace" not in bot_tools.functions
-        assert "search_workspace" in assisted_tools.functions
+    assert "search_messages" not in bot_tools.functions
+    assert "search_messages" not in assisted_tools.functions
 
 
-def test_slack_user_token_param_enables_search_messages():
-    """When user_token is passed directly, search_messages is registered."""
+def test_slack_user_token_enables_search_messages():
+    """With a user token, search_messages should be registered."""
     p = SlackContextProvider(token="xoxb-x", user_token="xoxp-user")
-
     bot_tools = p._ensure_bot_read_tools()
     assisted_tools = p._ensure_assisted_read_tools()
 
     assert "search_messages" in bot_tools.functions
     assert "search_messages" in assisted_tools.functions
-
-
-def test_slack_primary_user_token_enables_search_messages():
-    """When the primary token is a user token (xoxp-), search_messages is
-    registered for backward compatibility."""
-    p = SlackContextProvider(token="xoxp-x")
-
-    bot_tools = p._ensure_bot_read_tools()
-    assisted_tools = p._ensure_assisted_read_tools()
-
-    assert "search_messages" in bot_tools.functions
-    assert "search_messages" in assisted_tools.functions
-    assert "search_workspace" not in bot_tools.functions
-    assert "search_workspace" in assisted_tools.functions
-
-
-def test_slack_bot_read_instructions_do_not_lead_with_search(monkeypatch):
-    """The bot-token read agent must not be told to "search first" with the
-    user-token-only search_messages tool; it leads with deterministic reads."""
-    import agno.context.slack.provider as slack_provider
-
-    captured: dict[str, str] = {}
-
-    class _StubAgent:
-        def __init__(self, *, id: str, instructions: str, **kwargs):
-            captured[id] = instructions
-
-    monkeypatch.setattr(slack_provider, "Agent", _StubAgent)
-
-    p = SlackContextProvider(token="xoxb-x")
-    _ = p._ensure_bot_read_agent()
-
-    instructions = captured["slack-bot-read"]
-    assert "get_channel_history" in instructions
-    assert "Search first" not in instructions
 
 
 def test_slack_read_instructions_override_both_read_agents(monkeypatch):

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -452,19 +452,47 @@ def test_slack_read_surfaces_are_split_by_mode():
     assert "get_thread" in assisted_tools.functions
 
 
-def test_slack_bot_token_excludes_legacy_search_messages():
-    """Slack's legacy search.messages API is user-token-only and fails a bot
-    token with not_allowed_token_type, so a bot token (xoxb-) must not register
-    search_messages on either read surface."""
+def test_slack_bot_token_without_user_token_excludes_search_messages():
+    """Without a user token, search_messages is not registered since bot tokens
+    cannot use Slack's legacy search.messages API."""
     p = SlackContextProvider(token="xoxb-x")
 
     assert "search_messages" not in p._ensure_bot_read_tools().functions
     assert "search_messages" not in p._ensure_assisted_read_tools().functions
 
 
-def test_slack_user_token_keeps_legacy_search_messages():
-    """A user token (xoxp-) preserves search_messages on both read surfaces;
-    search_workspace stays assisted-read-only regardless of token type."""
+def test_slack_user_token_env_enables_search_messages():
+    """When SLACK_USER_TOKEN is set, search_messages is registered even with
+    a bot token as the primary token."""
+    import os
+    from unittest.mock import patch
+
+    with patch.dict(os.environ, {"SLACK_USER_TOKEN": "xoxp-user"}):
+        p = SlackContextProvider(token="xoxb-x")
+
+        bot_tools = p._ensure_bot_read_tools()
+        assisted_tools = p._ensure_assisted_read_tools()
+
+        assert "search_messages" in bot_tools.functions
+        assert "search_messages" in assisted_tools.functions
+        assert "search_workspace" not in bot_tools.functions
+        assert "search_workspace" in assisted_tools.functions
+
+
+def test_slack_user_token_param_enables_search_messages():
+    """When user_token is passed directly, search_messages is registered."""
+    p = SlackContextProvider(token="xoxb-x", user_token="xoxp-user")
+
+    bot_tools = p._ensure_bot_read_tools()
+    assisted_tools = p._ensure_assisted_read_tools()
+
+    assert "search_messages" in bot_tools.functions
+    assert "search_messages" in assisted_tools.functions
+
+
+def test_slack_primary_user_token_enables_search_messages():
+    """When the primary token is a user token (xoxp-), search_messages is
+    registered for backward compatibility."""
     p = SlackContextProvider(token="xoxp-x")
 
     bot_tools = p._ensure_bot_read_tools()

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -452,6 +452,51 @@ def test_slack_read_surfaces_are_split_by_mode():
     assert "get_thread" in assisted_tools.functions
 
 
+def test_slack_bot_token_excludes_legacy_search_messages():
+    """Slack's legacy search.messages API is user-token-only and fails a bot
+    token with not_allowed_token_type, so a bot token (xoxb-) must not register
+    search_messages on either read surface."""
+    p = SlackContextProvider(token="xoxb-x")
+
+    assert "search_messages" not in p._ensure_bot_read_tools().functions
+    assert "search_messages" not in p._ensure_assisted_read_tools().functions
+
+
+def test_slack_user_token_keeps_legacy_search_messages():
+    """A user token (xoxp-) preserves search_messages on both read surfaces;
+    search_workspace stays assisted-read-only regardless of token type."""
+    p = SlackContextProvider(token="xoxp-x")
+
+    bot_tools = p._ensure_bot_read_tools()
+    assisted_tools = p._ensure_assisted_read_tools()
+
+    assert "search_messages" in bot_tools.functions
+    assert "search_messages" in assisted_tools.functions
+    assert "search_workspace" not in bot_tools.functions
+    assert "search_workspace" in assisted_tools.functions
+
+
+def test_slack_bot_read_instructions_do_not_lead_with_search(monkeypatch):
+    """The bot-token read agent must not be told to "search first" with the
+    user-token-only search_messages tool; it leads with deterministic reads."""
+    import agno.context.slack.provider as slack_provider
+
+    captured: dict[str, str] = {}
+
+    class _StubAgent:
+        def __init__(self, *, id: str, instructions: str, **kwargs):
+            captured[id] = instructions
+
+    monkeypatch.setattr(slack_provider, "Agent", _StubAgent)
+
+    p = SlackContextProvider(token="xoxb-x")
+    _ = p._ensure_bot_read_agent()
+
+    instructions = captured["slack-bot-read"]
+    assert "get_channel_history" in instructions
+    assert "Search first" not in instructions
+
+
 def test_slack_read_instructions_override_both_read_agents(monkeypatch):
     import agno.context.slack.provider as slack_provider
 

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -456,7 +456,7 @@ class TestRouterWiring:
         ):
             mock_cls.return_value = make_slack_mock(token="xoxb-explicit-token")
             build_app(agent_mock, token="xoxb-explicit-token")
-            mock_cls.assert_called_once_with(token="xoxb-explicit-token", ssl=None, max_file_size=1_073_741_824)
+            mock_cls.assert_called_once_with(token="xoxb-explicit-token", user_token=None, ssl=None, max_file_size=1_073_741_824)
 
     def test_explicit_signing_secret_used(self):
         agent_mock = make_agent_mock()

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -31,49 +31,8 @@ def slack_tools():
 
 def test_init_requires_token():
     with patch.dict("os.environ", clear=True):
-        with pytest.raises(ValueError, match="SLACK_BOT_TOKEN"):
+        with pytest.raises(ValueError, match="SLACK_TOKEN"):
             SlackTools()
-
-
-def test_init_prefers_slack_bot_token_env():
-    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot", "SLACK_TOKEN": "xoxb-fallback"}):
-        with patch("agno.tools.slack.WebClient") as mock_client:
-            SlackTools()
-            mock_client.assert_called_once()
-            assert mock_client.call_args[1]["token"] == "xoxb-bot"
-
-
-def test_init_falls_back_to_slack_token_env():
-    with patch.dict("os.environ", {"SLACK_TOKEN": "xoxb-fallback"}, clear=True):
-        with patch("agno.tools.slack.WebClient") as mock_client:
-            SlackTools()
-            mock_client.assert_called_once()
-            assert mock_client.call_args[1]["token"] == "xoxb-fallback"
-
-
-def test_init_creates_user_client_when_user_token_provided():
-    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}):
-        with patch("agno.tools.slack.WebClient") as mock_client:
-            tools = SlackTools(user_token="xoxp-user")
-            assert mock_client.call_count == 2
-            assert tools._user_token == "xoxp-user"
-            assert tools._user_client is not None
-
-
-def test_init_reads_user_token_from_env():
-    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot", "SLACK_USER_TOKEN": "xoxp-env"}):
-        with patch("agno.tools.slack.WebClient") as mock_client:
-            tools = SlackTools()
-            assert mock_client.call_count == 2
-            assert tools._user_token == "xoxp-env"
-
-
-def test_init_no_user_client_without_user_token():
-    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}, clear=True):
-        with patch("agno.tools.slack.WebClient") as mock_client:
-            tools = SlackTools()
-            assert mock_client.call_count == 1
-            assert tools._user_client is None
 
 
 def test_init_registers_default_tools():
@@ -87,10 +46,44 @@ def test_init_registers_default_tools():
 
 
 def test_init_all_flag_enables_all():
-    with patch.dict("os.environ", {"SLACK_TOKEN": "test"}):
+    with patch.dict("os.environ", {"SLACK_TOKEN": "test", "SLACK_USER_TOKEN": "xoxp-user"}):
         with patch("agno.tools.slack.WebClient"):
             tools = SlackTools(all=True)
             assert len(tools.functions) == 12
+
+
+def test_init_creates_user_client_when_user_token_provided():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "xoxb-bot"}):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            tools = SlackTools(user_token="xoxp-user")
+            assert mock_client.call_count == 2
+            assert tools._user_token == "xoxp-user"
+            assert tools._user_client is not None
+
+
+def test_init_reads_user_token_from_env():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "xoxb-bot", "SLACK_USER_TOKEN": "xoxp-env"}):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            tools = SlackTools()
+            assert mock_client.call_count == 2
+            assert tools._user_token == "xoxp-env"
+
+
+def test_init_no_user_client_without_user_token():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "xoxb-bot"}, clear=True):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            tools = SlackTools()
+            assert mock_client.call_count == 1
+            assert tools._user_client is None
+
+
+def test_search_messages_disabled_without_user_token():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "xoxb-bot"}, clear=True):
+        with patch("agno.tools.slack.WebClient"):
+            with patch("agno.tools.slack.log_warning") as mock_warn:
+                tools = SlackTools(enable_search_messages=True)
+                assert "search_messages" not in tools.functions
+                mock_warn.assert_called_once()
 
 
 def test_explicit_flags_expose_expected_surfaces():
@@ -287,35 +280,7 @@ def test_download_file_dest_path_subdir_lands_inside_output_directory(slack_tool
 # === Extended Tools ===
 
 
-def test_search_messages_requires_user_client():
-    """search_messages returns error when no user token is configured."""
-    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}, clear=True):
-        with patch("agno.tools.slack.WebClient"):
-            tools = SlackTools(enable_search_messages=True)
-            result = json.loads(tools.search_messages("query"))
-            assert "error" in result
-            assert "user token" in result["error"].lower()
-
-
-def test_search_messages_uses_user_client():
-    """search_messages uses the user client, not the bot client."""
-    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}):
-        with patch("agno.tools.slack.WebClient") as mock_client:
-            mock_user_client = Mock()
-            mock_bot_client = Mock()
-            mock_client.side_effect = [mock_bot_client, mock_user_client]
-            mock_user_client.search_messages.return_value = {
-                "messages": {"matches": [{"text": "found", "user": "U1", "channel": {}, "ts": "1"}]}
-            }
-            tools = SlackTools(user_token="xoxp-user", enable_search_messages=True)
-            result = tools.search_messages("query")
-            mock_user_client.search_messages.assert_called_once_with(query="query", count=20)
-            mock_bot_client.search_messages.assert_not_called()
-            assert json.loads(result)["count"] == 1
-
-
 def test_search_messages(slack_tools):
-    # Legacy test - uses fixture with mocked client
     slack_tools._user_client = slack_tools.client
     slack_tools._user_client.search_messages.return_value = {
         "messages": {"matches": [{"text": "found", "user": "U1", "channel": {}, "ts": "1"}]}

--- a/libs/agno/tests/unit/tools/test_slack_tools.py
+++ b/libs/agno/tests/unit/tools/test_slack_tools.py
@@ -31,8 +31,49 @@ def slack_tools():
 
 def test_init_requires_token():
     with patch.dict("os.environ", clear=True):
-        with pytest.raises(ValueError, match="SLACK_TOKEN"):
+        with pytest.raises(ValueError, match="SLACK_BOT_TOKEN"):
             SlackTools()
+
+
+def test_init_prefers_slack_bot_token_env():
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot", "SLACK_TOKEN": "xoxb-fallback"}):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            SlackTools()
+            mock_client.assert_called_once()
+            assert mock_client.call_args[1]["token"] == "xoxb-bot"
+
+
+def test_init_falls_back_to_slack_token_env():
+    with patch.dict("os.environ", {"SLACK_TOKEN": "xoxb-fallback"}, clear=True):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            SlackTools()
+            mock_client.assert_called_once()
+            assert mock_client.call_args[1]["token"] == "xoxb-fallback"
+
+
+def test_init_creates_user_client_when_user_token_provided():
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            tools = SlackTools(user_token="xoxp-user")
+            assert mock_client.call_count == 2
+            assert tools._user_token == "xoxp-user"
+            assert tools._user_client is not None
+
+
+def test_init_reads_user_token_from_env():
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot", "SLACK_USER_TOKEN": "xoxp-env"}):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            tools = SlackTools()
+            assert mock_client.call_count == 2
+            assert tools._user_token == "xoxp-env"
+
+
+def test_init_no_user_client_without_user_token():
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}, clear=True):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            tools = SlackTools()
+            assert mock_client.call_count == 1
+            assert tools._user_client is None
 
 
 def test_init_registers_default_tools():
@@ -246,8 +287,37 @@ def test_download_file_dest_path_subdir_lands_inside_output_directory(slack_tool
 # === Extended Tools ===
 
 
+def test_search_messages_requires_user_client():
+    """search_messages returns error when no user token is configured."""
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}, clear=True):
+        with patch("agno.tools.slack.WebClient"):
+            tools = SlackTools(enable_search_messages=True)
+            result = json.loads(tools.search_messages("query"))
+            assert "error" in result
+            assert "user token" in result["error"].lower()
+
+
+def test_search_messages_uses_user_client():
+    """search_messages uses the user client, not the bot client."""
+    with patch.dict("os.environ", {"SLACK_BOT_TOKEN": "xoxb-bot"}):
+        with patch("agno.tools.slack.WebClient") as mock_client:
+            mock_user_client = Mock()
+            mock_bot_client = Mock()
+            mock_client.side_effect = [mock_bot_client, mock_user_client]
+            mock_user_client.search_messages.return_value = {
+                "messages": {"matches": [{"text": "found", "user": "U1", "channel": {}, "ts": "1"}]}
+            }
+            tools = SlackTools(user_token="xoxp-user", enable_search_messages=True)
+            result = tools.search_messages("query")
+            mock_user_client.search_messages.assert_called_once_with(query="query", count=20)
+            mock_bot_client.search_messages.assert_not_called()
+            assert json.loads(result)["count"] == 1
+
+
 def test_search_messages(slack_tools):
-    slack_tools.client.search_messages.return_value = {
+    # Legacy test - uses fixture with mocked client
+    slack_tools._user_client = slack_tools.client
+    slack_tools._user_client.search_messages.return_value = {
         "messages": {"matches": [{"text": "found", "user": "U1", "channel": {}, "ts": "1"}]}
     }
     result = slack_tools.search_messages("query")


### PR DESCRIPTION
## Summary

Add dual-token support for Slack search in `SlackTools`, `SlackContextProvider`, and `attach_routes()`.

**Problem:** Slack's `search.messages` API requires a user token (`xoxp-`); bot tokens (`xoxb-`) fail with `not_allowed_token_type`. The original code tried to use the same token for all APIs.

**Solution:** 
- Add `user_token` parameter to `SlackTools`, `SlackContextProvider`, and `attach_routes()`
- Add `SLACK_USER_TOKEN` env var support
- Create separate `_user_client` WebClient for `search_messages` calls
- Gate `search_messages` tool registration on user token availability (with log warning if enabled without token)
- Backward compat: if primary token is `xoxp-`, use it as user token automatically

**Token usage:**
| Token | Source | Used For |
|-------|--------|----------|
| Bot token (`xoxb-`) | `SLACK_BOT_TOKEN` or `SLACK_TOKEN` | All standard Slack APIs |
| User token (`xoxp-`) | `SLACK_USER_TOKEN` or xoxp- primary token | `search_messages` API only |
| Action token | Slack event `assistant_thread.action_token` | `search_workspace` API |

**Components updated:**
- `SlackTools` — `user_token` param, `_user_client`, backward compat
- `SlackContextProvider` — `user_token` param, `_enable_search_messages`
- `attach_routes()` — `user_token` param passthrough

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)