### PR TITLE
fix: update ParallelBackend for parallel-web >= 1.0 GA API

### DIFF
--- a/cookbook/12_context/03_web_parallel.py
+++ b/cookbook/12_context/03_web_parallel.py
@@ -2,8 +2,8 @@
 Web Context Provider with Parallel
 ==================================
 
-`ParallelBackend` speaks directly to Parallel's beta web API via the
-`parallel-web` SDK. Two tools: `web_search(objective)` returns
+`ParallelBackend` speaks directly to Parallel's web API via the
+`parallel-web` SDK (>= 1.0). Two tools: `web_search(objective)` returns
 URL + excerpt pairs for a natural-language objective; `web_extract(url)`
 fetches full-page content.
 

--- a/cookbook/12_context/README.md
+++ b/cookbook/12_context/README.md
@@ -23,7 +23,7 @@ Providers ship in this package:
 | `WorkspaceContextProvider` | Local project workspace | `query_<id>` (read-only `Workspace` sub-agent with project-aware excludes) |
 | `WebContextProvider` + `ExaMCPBackend` | Web via Exa's public MCP server (keyless / keyed) | `query_<id>` (search + fetch sub-agent) |
 | `WebContextProvider` + `ExaBackend` | Web via Exa's direct SDK | `query_<id>` (search + fetch sub-agent) |
-| `WebContextProvider` + `ParallelBackend` | Web via Parallel's beta API | `query_<id>` (search + fetch sub-agent) |
+| `WebContextProvider` + `ParallelBackend` | Web via Parallel's direct SDK | `query_<id>` (search + fetch sub-agent) |
 | `WebContextProvider` + `ParallelMCPBackend` | Web via Parallel's public MCP server (keyless / keyed) | `query_<id>` (search + fetch sub-agent) |
 | `DatabaseContextProvider` | Any SQL database (SQLAlchemy) | `query_<id>`, `update_<id>` (separate read/write sub-agents) |
 | `SlackContextProvider` | A Slack workspace | `query_<id>`, `update_<id>` (separate read/write sub-agents; writer only gets `send_message` + the lookup tools it needs) |
@@ -43,7 +43,7 @@ All read+write providers (`WikiContextProvider`, `DatabaseContextProvider`, `Sla
 | `00_filesystem.py` | Browse local files via `FilesystemContextProvider` |
 | `01_web_exa.py` | Web research via Exa's direct SDK (needs `EXA_API_KEY`) |
 | `02_web_exa_mcp.py` | Web research via Exa's keyless public MCP endpoint |
-| `03_web_parallel.py` | Web research via Parallel's beta API |
+| `03_web_parallel.py` | Web research via Parallel's direct SDK |
 | `04_database_read_write.py` | Read + write a SQLite DB; end-to-end round trip |
 | `05_slack.py` | Slack workspace: read channels (always) + optional post via `SLACK_WRITE_CHANNEL` |
 | `06_mcp_server.py` | Wrap an MCP server; explicit `asetup` / `aclose` lifecycle |

--- a/libs/agno/agno/context/web/parallel.py
+++ b/libs/agno/agno/context/web/parallel.py
@@ -25,7 +25,11 @@ _MAX_EXTRACT_CHARS = 50_000
 
 
 class ParallelBackend(ContextBackend):
-    """Backend for `WebContextProvider` backed by Parallel's beta API."""
+    """Backend for `WebContextProvider` backed by Parallel's web API.
+
+    Targets the GA top-level client surface (`client.search` / `client.extract`)
+    in `parallel-web` >= 1.0, not the pre-1.0 `client.beta.*` endpoints.
+    """
 
     def __init__(self, *, api_key: str | None = None) -> None:
         self.api_key: str = api_key if api_key else getenv("PARALLEL_API_KEY", "")
@@ -63,8 +67,10 @@ class ParallelBackend(ContextBackend):
             if not backend.api_key:
                 return json.dumps({"error": "PARALLEL_API_KEY not configured"})
             try:
-                out = await backend._get_client().beta.search(
-                    objective=objective, max_results=max_results, mode="agentic"
+                out = await backend._get_client().search(
+                    search_queries=[objective],
+                    objective=objective,
+                    mode="advanced",
                 )
             except Exception as exc:
                 log_error(f"web_search failed: {exc}")
@@ -93,7 +99,10 @@ class ParallelBackend(ContextBackend):
             if not backend.api_key:
                 return json.dumps({"error": "PARALLEL_API_KEY not configured"})
             try:
-                result = await backend._get_client().beta.extract(urls=[url], full_content=True)
+                result = await backend._get_client().extract(
+                    urls=[url],
+                    advanced_settings={"full_content": {"max_chars_per_result": _MAX_EXTRACT_CHARS}},
+                )
             except Exception as exc:
                 log_error(f"web_extract failed for {url}: {exc}")
                 return json.dumps({"error": f"{type(exc).__name__}: {exc}"})

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -138,7 +138,7 @@ memori = ["memori>=3.0.5"]
 newspaper = ["newspaper4k", "lxml_html_clean"]
 notion = ["notion-client"]
 opencv = ["opencv-python"]
-parallel = ["parallel-web"]
+parallel = ["parallel-web>=1.0"]
 psycopg = ["psycopg-binary", "psycopg"]
 redshift = ["redshift-connector"]
 reportlab = ["reportlab"]
@@ -393,7 +393,7 @@ demo = [
     "opentelemetry-api",
     "opentelemetry-sdk",
     "pandas",
-    "parallel-web",
+    "parallel-web>=1.0",
     "pgvector",
     "pillow",
     "psycopg[binary]",

--- a/libs/agno/tests/unit/context/test_parallel_backend.py
+++ b/libs/agno/tests/unit/context/test_parallel_backend.py
@@ -1,0 +1,169 @@
+"""Unit tests for ``ParallelBackend`` (direct ``parallel-web`` SDK backend).
+
+These don't hit Parallel. They mock the async client and assert that:
+
+- ``web_search`` calls the GA top-level ``client.search`` with the new kwargs
+  (``search_queries``/``objective``/``mode``) and slices results client-side.
+- ``web_extract`` calls the GA top-level ``client.extract`` with the new
+  ``advanced_settings={"full_content": {"max_chars_per_result": N}}`` shape.
+- The JSON output shape is unchanged from the pre-1.0 backend.
+
+The backend caches its client in ``_client``; setting it directly short-circuits
+the lazy ``from parallel import AsyncParallel`` import so no SDK call is made.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agno.context.web.parallel import _MAX_EXTRACT_CHARS, ParallelBackend
+
+
+def _tools(backend: ParallelBackend) -> dict:
+    """Return the backend's tools keyed by name."""
+    return {t.name: t for t in backend.get_tools()}
+
+
+def _search_result(url: str, title: str, excerpts: list[str]):
+    return SimpleNamespace(url=url, title=title, excerpts=excerpts)
+
+
+# ---------------------------------------------------------------------------
+# Status / config
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_backend_missing_api_key_fails_status(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    b = ParallelBackend()
+    status = b.status()
+    assert status.ok is False
+    assert "PARALLEL_API_KEY" in status.detail
+
+
+def test_parallel_backend_exposes_search_and_extract_tools():
+    b = ParallelBackend(api_key="x")
+    assert sorted(_tools(b)) == ["web_extract", "web_search"]
+
+
+@pytest.mark.asyncio
+async def test_web_search_without_api_key_returns_error(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    b = ParallelBackend()
+    out = json.loads(await _tools(b)["web_search"].entrypoint(objective="anything"))
+    assert out == {"error": "PARALLEL_API_KEY not configured"}
+
+
+# ---------------------------------------------------------------------------
+# web_search — GA top-level client.search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_web_search_calls_ga_search_with_new_kwargs_and_shape():
+    b = ParallelBackend(api_key="x")
+
+    # 10 results back; the tool must slice to max_results client-side. The
+    # first result carries >5 excerpts to confirm the [:5] cap survives.
+    results = [
+        _search_result(
+            f"https://example.com/{i}",
+            f"Title {i}",
+            [f"excerpt {i}.{j}" for j in range(7)],
+        )
+        for i in range(10)
+    ]
+    fake_search = AsyncMock(return_value=SimpleNamespace(results=results))
+    b._client = SimpleNamespace(search=fake_search)
+
+    raw = await _tools(b)["web_search"].entrypoint(objective="find the thing", max_results=3)
+    out = json.loads(raw)
+
+    # New GA surface: top-level client.search with search_queries + objective + mode.
+    fake_search.assert_awaited_once_with(
+        search_queries=["find the thing"],
+        objective="find the thing",
+        mode="advanced",
+    )
+
+    # JSON shape unchanged: results: [{url, title, excerpts: [...]}, ...]
+    assert list(out) == ["results"]
+    assert len(out["results"]) == 3  # sliced client-side to max_results
+    assert out["results"][0] == {
+        "url": "https://example.com/0",
+        "title": "Title 0",
+        "excerpts": ["excerpt 0.0", "excerpt 0.1", "excerpt 0.2", "excerpt 0.3", "excerpt 0.4"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_web_search_handles_empty_results():
+    b = ParallelBackend(api_key="x")
+    b._client = SimpleNamespace(search=AsyncMock(return_value=SimpleNamespace(results=None)))
+    out = json.loads(await _tools(b)["web_search"].entrypoint(objective="nothing"))
+    assert out == {"results": []}
+
+
+@pytest.mark.asyncio
+async def test_web_search_returns_error_on_client_exception():
+    b = ParallelBackend(api_key="x")
+    b._client = SimpleNamespace(search=AsyncMock(side_effect=RuntimeError("boom")))
+    out = json.loads(await _tools(b)["web_search"].entrypoint(objective="x"))
+    assert out["error"] == "RuntimeError: boom"
+
+
+# ---------------------------------------------------------------------------
+# web_extract — GA top-level client.extract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_web_extract_calls_ga_extract_with_advanced_settings_and_shape():
+    b = ParallelBackend(api_key="x")
+
+    extract_result = SimpleNamespace(results=[SimpleNamespace(full_content="full page body")])
+    fake_extract = AsyncMock(return_value=extract_result)
+    b._client = SimpleNamespace(extract=fake_extract)
+
+    raw = await _tools(b)["web_extract"].entrypoint(url="https://example.com/page")
+    out = json.loads(raw)
+
+    # New GA surface: advanced_settings.full_content.max_chars_per_result, not full_content=True.
+    fake_extract.assert_awaited_once_with(
+        urls=["https://example.com/page"],
+        advanced_settings={"full_content": {"max_chars_per_result": _MAX_EXTRACT_CHARS}},
+    )
+
+    # JSON shape unchanged: {url, content}.
+    assert out == {"url": "https://example.com/page", "content": "full page body"}
+
+
+@pytest.mark.asyncio
+async def test_web_extract_truncates_content_to_max_chars():
+    b = ParallelBackend(api_key="x")
+    body = "a" * (_MAX_EXTRACT_CHARS + 1000)
+    extract_result = SimpleNamespace(results=[SimpleNamespace(full_content=body)])
+    b._client = SimpleNamespace(extract=AsyncMock(return_value=extract_result))
+
+    out = json.loads(await _tools(b)["web_extract"].entrypoint(url="https://example.com"))
+    assert len(out["content"]) == _MAX_EXTRACT_CHARS
+
+
+@pytest.mark.asyncio
+async def test_web_extract_handles_empty_results():
+    b = ParallelBackend(api_key="x")
+    b._client = SimpleNamespace(extract=AsyncMock(return_value=SimpleNamespace(results=[])))
+    out = json.loads(await _tools(b)["web_extract"].entrypoint(url="https://example.com"))
+    assert out == {"url": "https://example.com", "content": ""}
+
+
+@pytest.mark.asyncio
+async def test_web_extract_returns_error_on_client_exception():
+    b = ParallelBackend(api_key="x")
+    b._client = SimpleNamespace(extract=AsyncMock(side_effect=ValueError("nope")))
+    out = json.loads(await _tools(b)["web_extract"].entrypoint(url="https://example.com"))
+    assert out["error"] == "ValueError: nope"


### PR DESCRIPTION
## Summary

`ParallelBackend` (`agno/context/web/parallel.py`) targeted the pre-1.0 **beta** surface of the `parallel-web` SDK. `parallel-web` 1.0 reshaped the client and `search`/`extract` moved off `client.beta` to the top-level client, so every call crashed against any modern release (validated on 1.1.0):

```
AttributeError: 'AsyncBetaResource' object has no attribute 'search'
```

This moves both tools to the GA top-level API and pins the floor at `>=1.0`.

**Changes**

- **`web_search`**: `client.beta.search(objective=..., max_results=..., mode="agentic")` → `client.search(search_queries=[objective], objective=objective, mode="advanced")`. The GA API has no `max_results` and dropped the old `agentic`/`one-shot`/`fast` modes, so results are still sliced to `max_results` client-side.
- **`web_extract`**: `client.beta.extract(urls=[url], full_content=True)` → `client.extract(urls=[url], advanced_settings={"full_content": {"max_chars_per_result": _MAX_EXTRACT_CHARS}})`.
- Response shapes are **unchanged** (`SearchResult.results[*].url/title/excerpts`, `ExtractResponse.results[0].full_content`), so the two `@tool` signatures, docstrings, and JSON output are identical.
- Bumped the `parallel-web` floor to `>=1.0` in both the `parallel` extra and the `demo` dependency group.
- Refreshed the class docstring (was "Parallel's beta API") and the cookbook/README wording.
- Added `libs/agno/tests/unit/context/test_parallel_backend.py` (10 tests) mocking the async client: asserts `client.search`/`client.extract` are awaited with the new kwargs, client-side `max_results` slicing, 5-excerpt cap, content truncation, and unchanged JSON shape — plus missing-key and client-exception paths.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verified against the live `parallel-web` 1.1.0 client in `.venvs/demo`: both new call sites `bind()` cleanly against the real method signatures, and the SDK's own `search` docstring confirms `mode` ∈ `turbo|basic|advanced` (default `advanced`) and links the legacy `/v1beta/search` migration guide. `_MAX_EXTRACT_CHARS` maps to the real `FullContentSettingsParam.max_chars_per_result`.

New tests: 10/10 pass in the demo venv; full context suite (98 tests, incl. these) passes in `.venv`. `mypy`/`ruff` clean on the changed files (the 8 mypy errors `validate.sh` reports are pre-existing, in unrelated `tools/*` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)