### PR TITLE
fix: prevent MCP tool param collision with framework-injected args

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -950,6 +950,17 @@ class FunctionCall(BaseModel):
         except Exception:
             pass
 
+        # Remove any framework-injected args that conflict with LLM-provided tool arguments.
+        # This prevents "got multiple values for keyword argument" when an MCP tool (or any
+        # tool) has a parameter whose name matches a framework-injected name such as 'agent',
+        # 'team', or 'run_context'.  The LLM-provided value takes priority because the tool
+        # signature expects the user-facing value, not the framework object.
+        # See issue #6760.
+        if self.arguments:
+            for key in list(entrypoint_args.keys()):
+                if key in self.arguments:
+                    del entrypoint_args[key]
+
         return entrypoint_args
 
     def _build_hook_args(self, hook: Callable, name: str, func: Callable, args: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
Closes #6760

When using MCPTools with MCP servers whose tools have parameters named `agent` or `team` (e.g. Linear's MCP server), all tool calls fail with `TypeError: got multiple values for keyword argument 'team'`. This is because `_build_entrypoint_args()` injects `team=<agno Team object>` into the call, which then collides with the LLM-provided `team="Engineering"` when both are unpacked together.

Fix: strip any framework-injected key from `entrypoint_args` that is already present in `self.arguments` (the LLM-provided values). One place, 9 lines, all code paths covered.