### PR TITLE
chore: Release v2.6.15

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.6.14"
+version = "2.6.15"
 description = "The programming language for agentic software."
 requires-python = ">=3.7,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## New Features:

- Custom, Scoped, Identity-Aware MCP Tools: The AgentOS MCP server (served at /mcp) is now a real extension point, configured through a single `MCPServerConfig` object. You can register custom tools (plain callables or Agno @tool/Functions), scope the built-ins (enable_builtin_tools=False, or filter with include_tags/exclude_tags), inject the authenticated caller identity into a tool (declare user_id and AgentOS supplies the JWT subject while hiding it from the client schema), gate calls with a one-line authorize function, and opt into built-in DNS-rebinding protection via allowed_hosts/allowed_origins. All with data, no custom middleware classes. Fully backward compatible: without mcp_config, all built-in tools register exactly as before.

## Bug Fixes:

- Call-Site Dependencies Merge: Call-site dependencies passed to agent.run()/team.run() replaced the configured Agent.dependencies/Team.dependencies wholesale, which dropped prompt-template vars over interfaces that always pass call-site dependencies (e.g. Slack/WhatsApp). They now merge({**configured, **call_site}, call-site wins on conflict), matching how metadata/knowledge_filters already merge.