### PR TITLE
feat: propagate nested-run metrics to the enclosing run [SDK-499]

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -37,12 +37,19 @@ from agno.exceptions import (
 )
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
+from agno.metrics import swap_nested_run_metrics_sink
 from agno.models.base import Model
 from agno.models.fallback import acall_model_with_fallback, call_model_with_fallback
 from agno.models.message import Message
 from agno.models.metrics import RunMetrics, merge_background_metrics
 from agno.models.response import ModelResponse, ToolExecution
 from agno.run import RunContext, RunStatus
+from agno.run._nested_metrics import (
+    arun_stream_with_metrics_scope,
+    arun_with_metrics_scope,
+    report_run_to_parent,
+    run_stream_with_metrics_scope,
+)
 from agno.run.agent import (
     RunCancelledEvent,
     RunCompletedEvent,
@@ -1433,24 +1440,30 @@ def run_dispatch(
             pre_session=agent_session,
             **kwargs,
         )
-        return response_iterator
+        return run_stream_with_metrics_scope(response_iterator, run_response, sink=run_response.metrics)
     else:
-        response = _run(
-            agent,
-            run_response=run_response,
-            run_context=run_context,
-            session_id=session_id,
-            user_id=user_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            response_format=response_format,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            pre_session=agent_session,
-            **kwargs,
-        )
-        return response
+        response = run_response
+        parent_sink = swap_nested_run_metrics_sink(run_response.metrics)
+        try:
+            response = _run(
+                agent,
+                run_response=run_response,
+                run_context=run_context,
+                session_id=session_id,
+                user_id=user_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                response_format=response_format,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                pre_session=agent_session,
+                **kwargs,
+            )
+            return response
+        finally:
+            swap_nested_run_metrics_sink(parent_sink)
+            report_run_to_parent(parent_sink, response)
 
 
 async def _arun(
@@ -1944,6 +1957,12 @@ async def _arun_background(
             agent_session.upsert_run(run=run_response)
             await asave_session(agent, session=agent_session)
 
+            # Detached run — nested runs report into this run's metrics, never
+            # to an enclosing run that may complete before this task does
+            if run_response.metrics is None:
+                run_response.metrics = RunMetrics()
+            swap_nested_run_metrics_sink(run_response.metrics)
+
             # Execute the actual run — _arun handles everything including
             # session persistence and cleanup
             await _arun(
@@ -2034,6 +2053,11 @@ async def _arun_background_stream(
         from agno.os.utils import format_sse_event_with_index
 
         try:
+            # Detached run — nested runs report into this run's metrics, never
+            # to an enclosing run that may complete before this task does
+            if run_response.metrics is None:
+                run_response.metrics = RunMetrics()
+            swap_nested_run_metrics_sink(run_response.metrics)
             async for event in _arun_stream(
                 agent,
                 run_response=run_response,
@@ -2896,38 +2920,46 @@ def arun_dispatch(  # type: ignore
 
     # Pass the new run_response to _arun
     if opts.stream:
-        return _arun_stream(  # type: ignore
-            agent,
-            run_response=run_response,
-            run_context=run_context,
-            user_id=user_id,
-            response_format=response_format,
-            stream_events=opts.stream_events,
-            yield_run_output=opts.yield_run_output,
-            session_id=session_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            pre_session=_pre_session,
-            **kwargs,
-        )  # type: ignore[assignment]
+        return arun_stream_with_metrics_scope(  # type: ignore[return-value]
+            _arun_stream(  # type: ignore
+                agent,
+                run_response=run_response,
+                run_context=run_context,
+                user_id=user_id,
+                response_format=response_format,
+                stream_events=opts.stream_events,
+                yield_run_output=opts.yield_run_output,
+                session_id=session_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                pre_session=_pre_session,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics,
+        )
     else:
-        return _arun(  # type: ignore
-            agent,
-            run_response=run_response,
-            run_context=run_context,
-            user_id=user_id,
-            response_format=response_format,
-            session_id=session_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            pre_session=_pre_session,
-            **kwargs,
+        return arun_with_metrics_scope(  # type: ignore[return-value]
+            _arun(  # type: ignore
+                agent,
+                run_response=run_response,
+                run_context=run_context,
+                user_id=user_id,
+                response_format=response_format,
+                session_id=session_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                pre_session=_pre_session,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics,
         )
 
 
@@ -3143,6 +3175,9 @@ def continue_run_dispatch(
     # Reset the run state
     run_response.status = RunStatus.running
 
+    if run_response.metrics is None:
+        run_response.metrics = RunMetrics()
+
     if opts.stream:
         response_iterator = _continue_run_stream(
             agent,
@@ -3159,22 +3194,28 @@ def continue_run_dispatch(
             background_tasks=background_tasks,
             **kwargs,
         )
-        return response_iterator
+        return run_stream_with_metrics_scope(response_iterator, run_response, sink=run_response.metrics)
     else:
-        response = _continue_run(
-            agent,
-            run_response=run_response,
-            run_messages=run_messages,
-            run_context=run_context,
-            tools=_tools,
-            user_id=user_id,
-            session=agent_session,
-            response_format=response_format,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
-        )
-        return response
+        response = run_response
+        parent_sink = swap_nested_run_metrics_sink(run_response.metrics)
+        try:
+            response = _continue_run(
+                agent,
+                run_response=run_response,
+                run_messages=run_messages,
+                run_context=run_context,
+                tools=_tools,
+                user_id=user_id,
+                session=agent_session,
+                response_format=response_format,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            )
+            return response
+        finally:
+            swap_nested_run_metrics_sink(parent_sink)
+            report_run_to_parent(parent_sink, response)
 
 
 def _continue_run(
@@ -3837,37 +3878,55 @@ def acontinue_run_dispatch(  # type: ignore
                 **kwargs,
             )
 
+    if run_response is not None and run_response.metrics is None:
+        run_response.metrics = RunMetrics()
+
+    # A run continued by run_id only yields its resolved output when
+    # yield_run_output is set — force it so the metrics scope can adopt the
+    # output, and swallow it again unless the caller asked for it
+    resolve_run_output = run_response is None and run_id is not None
+
     if opts.stream:
-        return _acontinue_run_stream(
-            agent,
-            run_response=run_response,
-            run_context=run_context,
-            updated_tools=updated_tools,
-            requirements=requirements,
+        return arun_stream_with_metrics_scope(
+            _acontinue_run_stream(
+                agent,
+                run_response=run_response,
+                run_context=run_context,
+                updated_tools=updated_tools,
+                requirements=requirements,
+                run_id=run_id,
+                user_id=user_id,
+                session_id=session_id,
+                response_format=response_format,
+                stream_events=opts.stream_events,
+                yield_run_output=opts.yield_run_output or resolve_run_output,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics if run_response is not None else None,
             run_id=run_id,
-            user_id=user_id,
-            session_id=session_id,
-            response_format=response_format,
-            stream_events=opts.stream_events,
-            yield_run_output=opts.yield_run_output,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
+            swallow_run_output=resolve_run_output and not opts.yield_run_output,
         )
     else:
-        return _acontinue_run(  # type: ignore
-            agent,
-            session_id=session_id,
-            run_response=run_response,
-            run_context=run_context,
-            updated_tools=updated_tools,
-            requirements=requirements,
-            run_id=run_id,
-            user_id=user_id,
-            response_format=response_format,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
+        return arun_with_metrics_scope(  # type: ignore[return-value]
+            _acontinue_run(  # type: ignore
+                agent,
+                session_id=session_id,
+                run_response=run_response,
+                run_context=run_context,
+                updated_tools=updated_tools,
+                requirements=requirements,
+                run_id=run_id,
+                user_id=user_id,
+                response_format=response_format,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics if run_response is not None else None,
         )
 
 
@@ -3926,6 +3985,9 @@ async def _acontinue_run_background_stream(
         from agno.os.utils import format_sse_event_with_index
 
         try:
+            # Detached run — never report metrics to an enclosing run that may
+            # complete before this task does
+            swap_nested_run_metrics_sink(None)
             async for event in _acontinue_run_stream(
                 agent,
                 run_response=run_response,
@@ -4151,6 +4213,13 @@ async def _acontinue_run(
                     raise ValueError("Either run_response or run_id must be provided.")
 
                 run_response = cast(RunOutput, run_response)
+
+                # Install this run's metrics sink so nested runs inside resumed
+                # tools report here. The dispatch wrapper restores the previous
+                # sink when this run finishes.
+                if run_response.metrics is None:
+                    run_response.metrics = RunMetrics()
+                swap_nested_run_metrics_sink(run_response.metrics)
 
                 # 5. Determine tools for model
                 agent.model = cast(Model, agent.model)
@@ -4552,6 +4621,13 @@ async def _acontinue_run_stream(
                     raise ValueError("Either run_response or run_id must be provided.")
 
                 run_response = cast(RunOutput, run_response)
+
+                # Install this run's metrics sink so nested runs inside resumed
+                # tools report here. The dispatch wrapper restores the previous
+                # sink when this run finishes.
+                if run_response.metrics is None:
+                    run_response.metrics = RunMetrics()
+                swap_nested_run_metrics_sink(run_response.metrics)
 
                 # 5. Determine tools for model
                 agent.model = cast(Model, agent.model)
@@ -5129,8 +5205,11 @@ def cleanup_and_store(
     # Add scrubbed RunOutput to Agent Session
     session.upsert_run(run=storage_copy)
 
-    # Calculate session metrics
-    update_session_metrics(agent, session=session, run_response=run_response)
+    # Calculate session metrics. Paused runs are skipped — the continued run
+    # accumulates the full run metrics exactly once when it finishes, so
+    # accumulating the partial metrics here would double count them.
+    if run_response.status != RunStatus.paused:
+        update_session_metrics(agent, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -5186,8 +5265,11 @@ async def acleanup_and_store(
     # Add scrubbed RunOutput to Agent Session
     session.upsert_run(run=storage_copy)
 
-    # Calculate session metrics
-    update_session_metrics(agent, session=session, run_response=run_response)
+    # Calculate session metrics. Paused runs are skipped — the continued run
+    # accumulates the full run metrics exactly once when it finishes, so
+    # accumulating the partial metrics here would double count them.
+    if run_response.status != RunStatus.paused:
+        update_session_metrics(agent, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:

--- a/libs/agno/agno/eval/accuracy.py
+++ b/libs/agno/agno/eval/accuracy.py
@@ -285,7 +285,12 @@ Remember: You must only compare the agent_output to the expected_output. The exp
     ) -> Optional[AccuracyEvaluation]:
         """Orchestrate the evaluation process."""
         try:
-            response = evaluator_agent.run(evaluation_input, stream=False)
+            # Shield the ambient metrics sink — eval metrics are accumulated
+            # explicitly below, so the nested run must not also report to it
+            from agno.run._nested_metrics import shielded_metrics_sink
+
+            with shielded_metrics_sink():
+                response = evaluator_agent.run(evaluation_input, stream=False)
 
             # Accumulate eval model metrics into the parent run_metrics
             if run_metrics is not None and response.metrics is not None:
@@ -318,7 +323,12 @@ Remember: You must only compare the agent_output to the expected_output. The exp
     ) -> Optional[AccuracyEvaluation]:
         """Orchestrate the evaluation process asynchronously."""
         try:
-            response = await evaluator_agent.arun(evaluation_input, stream=False)  # type: ignore[misc]
+            # Shield the ambient metrics sink — eval metrics are accumulated
+            # explicitly below, so the nested run must not also report to it
+            from agno.run._nested_metrics import shielded_metrics_sink
+
+            with shielded_metrics_sink():
+                response = await evaluator_agent.arun(evaluation_input, stream=False)  # type: ignore[misc]
 
             # Accumulate eval model metrics into the parent run_metrics
             if run_metrics is not None and response.metrics is not None:

--- a/libs/agno/agno/eval/agent_as_judge.py
+++ b/libs/agno/agno/eval/agent_as_judge.py
@@ -289,7 +289,12 @@ class AgentAsJudgeEval(BaseEval):
                 </output>
             """)
 
-            response = evaluator_agent.run(prompt, stream=False)
+            # Shield the ambient metrics sink — eval metrics are accumulated
+            # explicitly below, so the nested run must not also report to it
+            from agno.run._nested_metrics import shielded_metrics_sink
+
+            with shielded_metrics_sink():
+                response = evaluator_agent.run(prompt, stream=False)
 
             # Accumulate eval model metrics into the parent run_metrics
             if run_metrics is not None and response.metrics is not None:
@@ -354,7 +359,12 @@ class AgentAsJudgeEval(BaseEval):
                 </output>
             """)
 
-            response = await evaluator_agent.arun(prompt, stream=False)  # type: ignore[misc]
+            # Shield the ambient metrics sink — eval metrics are accumulated
+            # explicitly below, so the nested run must not also report to it
+            from agno.run._nested_metrics import shielded_metrics_sink
+
+            with shielded_metrics_sink():
+                response = await evaluator_agent.arun(prompt, stream=False)  # type: ignore[misc]
 
             # Accumulate eval model metrics into the parent run_metrics
             if run_metrics is not None and response.metrics is not None:

--- a/libs/agno/agno/metrics.py
+++ b/libs/agno/agno/metrics.py
@@ -1,3 +1,5 @@
+import threading
+from contextvars import ContextVar
 from dataclasses import asdict, dataclass
 from dataclasses import fields as dc_fields
 from enum import Enum
@@ -771,6 +773,65 @@ def accumulate_eval_metrics(
         run_metrics.additional_metrics["eval_duration"] = existing + eval_metrics.duration
 
 
+def accumulate_run_metrics(
+    run_metrics: RunMetrics,
+    other_metrics: RunMetrics,
+) -> None:
+    """Accumulate another run's metrics into run_metrics in place.
+
+    Sums token counts and cost, and merges per-model details by (provider, id).
+    Timing fields (timer, duration, time_to_first_token) are left untouched —
+    a nested run's wall time is already part of the parent's wall time.
+    """
+    metrics = run_metrics
+
+    # Accumulate top-level token counts
+    metrics.input_tokens += other_metrics.input_tokens
+    metrics.output_tokens += other_metrics.output_tokens
+    metrics.total_tokens += other_metrics.total_tokens
+    metrics.audio_input_tokens += other_metrics.audio_input_tokens
+    metrics.audio_output_tokens += other_metrics.audio_output_tokens
+    metrics.audio_total_tokens += other_metrics.audio_total_tokens
+    metrics.cache_read_tokens += other_metrics.cache_read_tokens
+    metrics.cache_write_tokens += other_metrics.cache_write_tokens
+    metrics.reasoning_tokens += other_metrics.reasoning_tokens
+
+    # Accumulate cost
+    if other_metrics.cost is not None:
+        metrics.cost = (metrics.cost or 0) + other_metrics.cost
+
+    # Merge per-model details
+    if other_metrics.details:
+        if metrics.details is None:
+            metrics.details = {}
+        for model_type, model_metrics_list in other_metrics.details.items():
+            if model_type not in metrics.details:
+                metrics.details[model_type] = []
+            for mm in model_metrics_list:
+                found = False
+                for existing in metrics.details[model_type]:
+                    if existing.provider == mm.provider and existing.id == mm.id:
+                        existing.accumulate(mm)
+                        found = True
+                        break
+                if not found:
+                    metrics.details[model_type].append(ModelMetrics.from_dict(mm.to_dict()))
+
+    # Merge additional_metrics (sum numeric values, keep latest for others)
+    if other_metrics.additional_metrics:
+        if metrics.additional_metrics is None:
+            metrics.additional_metrics = {}
+        for k, v in other_metrics.additional_metrics.items():
+            if (
+                k in metrics.additional_metrics
+                and isinstance(v, (int, float))
+                and isinstance(metrics.additional_metrics[k], (int, float))
+            ):
+                metrics.additional_metrics[k] += v
+            else:
+                metrics.additional_metrics[k] = v
+
+
 def merge_background_metrics(
     run_metrics: Optional[RunMetrics],
     background_metrics: "Sequence[Optional[RunMetrics]]",
@@ -788,51 +849,38 @@ def merge_background_metrics(
     for bg_metrics in background_metrics:
         if bg_metrics is None:
             continue
+        accumulate_run_metrics(run_metrics, bg_metrics)
 
-        metrics = run_metrics
 
-        # Accumulate top-level token counts
-        metrics.input_tokens += bg_metrics.input_tokens
-        metrics.output_tokens += bg_metrics.output_tokens
-        metrics.total_tokens += bg_metrics.total_tokens
-        metrics.audio_input_tokens += bg_metrics.audio_input_tokens
-        metrics.audio_output_tokens += bg_metrics.audio_output_tokens
-        metrics.audio_total_tokens += bg_metrics.audio_total_tokens
-        metrics.cache_read_tokens += bg_metrics.cache_read_tokens
-        metrics.cache_write_tokens += bg_metrics.cache_write_tokens
-        metrics.reasoning_tokens += bg_metrics.reasoning_tokens
+# ---------------------------------------------------------------------------
+# Nested-run metrics propagation
+# ---------------------------------------------------------------------------
 
-        # Accumulate cost
-        if bg_metrics.cost is not None:
-            metrics.cost = (metrics.cost or 0) + bg_metrics.cost
+_nested_run_metrics_sink: ContextVar[Optional[RunMetrics]] = ContextVar("_nested_run_metrics_sink", default=None)
 
-        # Merge per-model details
-        if bg_metrics.details:
-            if metrics.details is None:
-                metrics.details = {}
-            for model_type, model_metrics_list in bg_metrics.details.items():
-                if model_type not in metrics.details:
-                    metrics.details[model_type] = []
-                for mm in model_metrics_list:
-                    found = False
-                    for existing in metrics.details[model_type]:
-                        if existing.provider == mm.provider and existing.id == mm.id:
-                            existing.accumulate(mm)
-                            found = True
-                            break
-                    if not found:
-                        metrics.details[model_type].append(ModelMetrics.from_dict(mm.to_dict()))
+# Guards concurrent in-place accumulation into a shared sink (e.g. parallel
+# tool calls completing nested runs at the same time).
+_nested_run_metrics_lock = threading.Lock()
 
-        # Merge additional_metrics (sum numeric values, keep latest for others)
-        if bg_metrics.additional_metrics:
-            if metrics.additional_metrics is None:
-                metrics.additional_metrics = {}
-            for k, v in bg_metrics.additional_metrics.items():
-                if (
-                    k in metrics.additional_metrics
-                    and isinstance(v, (int, float))
-                    and isinstance(metrics.additional_metrics[k], (int, float))
-                ):
-                    metrics.additional_metrics[k] += v
-                else:
-                    metrics.additional_metrics[k] = v
+
+def get_nested_run_metrics_sink() -> Optional[RunMetrics]:
+    """Return the metrics sink of the enclosing run, if any.
+
+    See agno.run._nested_metrics for how runs install and report to the sink.
+    """
+    return _nested_run_metrics_sink.get()
+
+
+def swap_nested_run_metrics_sink(sink: Optional[RunMetrics]) -> Optional[RunMetrics]:
+    """Set the current metrics sink and return the previous one."""
+    previous = _nested_run_metrics_sink.get()
+    _nested_run_metrics_sink.set(sink)
+    return previous
+
+
+def report_metrics_to_sink(sink: Optional[RunMetrics], metrics: Optional[RunMetrics]) -> None:
+    """Report a completed nested run's total metrics into a parent sink."""
+    if sink is None or metrics is None or sink is metrics:
+        return
+    with _nested_run_metrics_lock:
+        accumulate_run_metrics(sink, metrics)

--- a/libs/agno/agno/reasoning/anthropic.py
+++ b/libs/agno/agno/reasoning/anthropic.py
@@ -65,6 +65,7 @@ def get_anthropic_reasoning(
 def get_anthropic_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Anthropic Claude model.
@@ -74,13 +75,16 @@ def get_anthropic_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
     redacted_reasoning_content: Optional[str] = None
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -88,7 +92,11 @@ def get_anthropic_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -144,6 +152,7 @@ async def aget_anthropic_reasoning(
 async def aget_anthropic_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Anthropic Claude model asynchronously.
@@ -153,13 +162,16 @@ async def aget_anthropic_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
     redacted_reasoning_content: Optional[str] = None
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -167,7 +179,11 @@ async def aget_anthropic_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/reasoning/azure_ai_foundry.py
+++ b/libs/agno/agno/reasoning/azure_ai_foundry.py
@@ -89,6 +89,7 @@ async def aget_ai_foundry_reasoning(
 def get_ai_foundry_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Azure AI Foundry model.
@@ -100,12 +101,15 @@ def get_ai_foundry_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -117,7 +121,11 @@ def get_ai_foundry_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -135,6 +143,7 @@ def get_ai_foundry_reasoning_stream(
 async def aget_ai_foundry_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Azure AI Foundry model asynchronously.
@@ -146,12 +155,15 @@ async def aget_ai_foundry_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -163,7 +175,11 @@ async def aget_ai_foundry_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/reasoning/deepseek.py
+++ b/libs/agno/agno/reasoning/deepseek.py
@@ -66,6 +66,7 @@ def get_deepseek_reasoning(
 def get_deepseek_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from DeepSeek model.
@@ -75,6 +76,7 @@ def get_deepseek_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     # Update system message role to "system"
@@ -85,7 +87,9 @@ def get_deepseek_reasoning_stream(
     reasoning_content: str = ""
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -93,7 +97,11 @@ def get_deepseek_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -145,6 +153,7 @@ async def aget_deepseek_reasoning(
 async def aget_deepseek_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from DeepSeek model asynchronously.
@@ -154,6 +163,7 @@ async def aget_deepseek_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     # Update system message role to "system"
@@ -164,7 +174,9 @@ async def aget_deepseek_reasoning_stream(
     reasoning_content: str = ""
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -172,7 +184,11 @@ async def aget_deepseek_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/reasoning/gemini.py
+++ b/libs/agno/agno/reasoning/gemini.py
@@ -99,6 +99,7 @@ async def aget_gemini_reasoning(
 def get_gemini_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Gemini model.
@@ -108,12 +109,15 @@ def get_gemini_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -121,7 +125,11 @@ def get_gemini_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -139,6 +147,7 @@ def get_gemini_reasoning_stream(
 async def aget_gemini_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Gemini model asynchronously.
@@ -148,12 +157,15 @@ async def aget_gemini_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -161,7 +173,11 @@ async def aget_gemini_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/reasoning/groq.py
+++ b/libs/agno/agno/reasoning/groq.py
@@ -98,6 +98,7 @@ async def aget_groq_reasoning(
 def get_groq_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Groq model.
@@ -109,6 +110,7 @@ def get_groq_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     # Update system message role to "system"
@@ -119,7 +121,9 @@ def get_groq_reasoning_stream(
     reasoning_content: str = ""
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -131,7 +135,11 @@ def get_groq_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -149,6 +157,7 @@ def get_groq_reasoning_stream(
 async def aget_groq_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Groq model asynchronously.
@@ -160,6 +169,7 @@ async def aget_groq_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     # Update system message role to "system"
@@ -170,7 +180,9 @@ async def aget_groq_reasoning_stream(
     reasoning_content: str = ""
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -182,7 +194,11 @@ async def aget_groq_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/reasoning/manager.py
+++ b/libs/agno/agno/reasoning/manager.py
@@ -28,6 +28,7 @@ from typing import (
 from agno.models.base import Model
 from agno.models.message import Message
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
+from agno.run._nested_metrics import shielded_metrics_sink
 from agno.run.base import RunContext
 from agno.run.messages import RunMessages
 from agno.tools import Toolkit
@@ -206,53 +207,57 @@ class ReasoningManager:
         run_metrics = self.config.run_metrics
 
         try:
-            if model_type == "deepseek":
-                from agno.reasoning.deepseek import get_deepseek_reasoning
+            # Shield the ambient metrics sink — the helpers below accumulate the
+            # reasoning run's metrics explicitly via accumulate_eval_metrics, so
+            # the nested run must not also report to it
+            with shielded_metrics_sink():
+                if model_type == "deepseek":
+                    from agno.reasoning.deepseek import get_deepseek_reasoning
 
-                log_debug("Starting DeepSeek Reasoning", center=True, symbol="=")
-                reasoning_message = get_deepseek_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting DeepSeek Reasoning", center=True, symbol="=")
+                    reasoning_message = get_deepseek_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "anthropic":
-                from agno.reasoning.anthropic import get_anthropic_reasoning
+                elif model_type == "anthropic":
+                    from agno.reasoning.anthropic import get_anthropic_reasoning
 
-                log_debug("Starting Anthropic Claude Reasoning", center=True, symbol="=")
-                reasoning_message = get_anthropic_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Anthropic Claude Reasoning", center=True, symbol="=")
+                    reasoning_message = get_anthropic_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "openai":
-                from agno.reasoning.openai import get_openai_reasoning
+                elif model_type == "openai":
+                    from agno.reasoning.openai import get_openai_reasoning
 
-                log_debug("Starting OpenAI Reasoning", center=True, symbol="=")
-                reasoning_message = get_openai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting OpenAI Reasoning", center=True, symbol="=")
+                    reasoning_message = get_openai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "groq":
-                from agno.reasoning.groq import get_groq_reasoning
+                elif model_type == "groq":
+                    from agno.reasoning.groq import get_groq_reasoning
 
-                log_debug("Starting Groq Reasoning", center=True, symbol="=")
-                reasoning_message = get_groq_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Groq Reasoning", center=True, symbol="=")
+                    reasoning_message = get_groq_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "ollama":
-                from agno.reasoning.ollama import get_ollama_reasoning
+                elif model_type == "ollama":
+                    from agno.reasoning.ollama import get_ollama_reasoning
 
-                log_debug("Starting Ollama Reasoning", center=True, symbol="=")
-                reasoning_message = get_ollama_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Ollama Reasoning", center=True, symbol="=")
+                    reasoning_message = get_ollama_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "ai_foundry":
-                from agno.reasoning.azure_ai_foundry import get_ai_foundry_reasoning
+                elif model_type == "ai_foundry":
+                    from agno.reasoning.azure_ai_foundry import get_ai_foundry_reasoning
 
-                log_debug("Starting Azure AI Foundry Reasoning", center=True, symbol="=")
-                reasoning_message = get_ai_foundry_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Azure AI Foundry Reasoning", center=True, symbol="=")
+                    reasoning_message = get_ai_foundry_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "gemini":
-                from agno.reasoning.gemini import get_gemini_reasoning
+                elif model_type == "gemini":
+                    from agno.reasoning.gemini import get_gemini_reasoning
 
-                log_debug("Starting Gemini Reasoning", center=True, symbol="=")
-                reasoning_message = get_gemini_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Gemini Reasoning", center=True, symbol="=")
+                    reasoning_message = get_gemini_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "vertexai":
-                from agno.reasoning.vertexai import get_vertexai_reasoning
+                elif model_type == "vertexai":
+                    from agno.reasoning.vertexai import get_vertexai_reasoning
 
-                log_debug("Starting VertexAI Reasoning", center=True, symbol="=")
-                reasoning_message = get_vertexai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting VertexAI Reasoning", center=True, symbol="=")
+                    reasoning_message = get_vertexai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
         except Exception as e:
             log_error(f"Reasoning error: {str(e)}")
@@ -282,53 +287,65 @@ class ReasoningManager:
         run_metrics = self.config.run_metrics
 
         try:
-            if model_type == "deepseek":
-                from agno.reasoning.deepseek import aget_deepseek_reasoning
+            # Shield the ambient metrics sink — the helpers below accumulate the
+            # reasoning run's metrics explicitly via accumulate_eval_metrics, so
+            # the nested run must not also report to it
+            with shielded_metrics_sink():
+                if model_type == "deepseek":
+                    from agno.reasoning.deepseek import aget_deepseek_reasoning
 
-                log_debug("Starting DeepSeek Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_deepseek_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting DeepSeek Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_deepseek_reasoning(
+                        reasoning_agent, messages, run_metrics=run_metrics
+                    )
 
-            elif model_type == "anthropic":
-                from agno.reasoning.anthropic import aget_anthropic_reasoning
+                elif model_type == "anthropic":
+                    from agno.reasoning.anthropic import aget_anthropic_reasoning
 
-                log_debug("Starting Anthropic Claude Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_anthropic_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Anthropic Claude Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_anthropic_reasoning(
+                        reasoning_agent, messages, run_metrics=run_metrics
+                    )
 
-            elif model_type == "openai":
-                from agno.reasoning.openai import aget_openai_reasoning
+                elif model_type == "openai":
+                    from agno.reasoning.openai import aget_openai_reasoning
 
-                log_debug("Starting OpenAI Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_openai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting OpenAI Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_openai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "groq":
-                from agno.reasoning.groq import aget_groq_reasoning
+                elif model_type == "groq":
+                    from agno.reasoning.groq import aget_groq_reasoning
 
-                log_debug("Starting Groq Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_groq_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Groq Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_groq_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "ollama":
-                from agno.reasoning.ollama import aget_ollama_reasoning
+                elif model_type == "ollama":
+                    from agno.reasoning.ollama import aget_ollama_reasoning
 
-                log_debug("Starting Ollama Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_ollama_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Ollama Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_ollama_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "ai_foundry":
-                from agno.reasoning.azure_ai_foundry import aget_ai_foundry_reasoning
+                elif model_type == "ai_foundry":
+                    from agno.reasoning.azure_ai_foundry import aget_ai_foundry_reasoning
 
-                log_debug("Starting Azure AI Foundry Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_ai_foundry_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Azure AI Foundry Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_ai_foundry_reasoning(
+                        reasoning_agent, messages, run_metrics=run_metrics
+                    )
 
-            elif model_type == "gemini":
-                from agno.reasoning.gemini import aget_gemini_reasoning
+                elif model_type == "gemini":
+                    from agno.reasoning.gemini import aget_gemini_reasoning
 
-                log_debug("Starting Gemini Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_gemini_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting Gemini Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_gemini_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
 
-            elif model_type == "vertexai":
-                from agno.reasoning.vertexai import aget_vertexai_reasoning
+                elif model_type == "vertexai":
+                    from agno.reasoning.vertexai import aget_vertexai_reasoning
 
-                log_debug("Starting VertexAI Reasoning", center=True, symbol="=")
-                reasoning_message = await aget_vertexai_reasoning(reasoning_agent, messages, run_metrics=run_metrics)
+                    log_debug("Starting VertexAI Reasoning", center=True, symbol="=")
+                    reasoning_message = await aget_vertexai_reasoning(
+                        reasoning_agent, messages, run_metrics=run_metrics
+                    )
 
         except Exception as e:
             log_error(f"Reasoning error: {str(e)}")
@@ -368,6 +385,7 @@ class ReasoningManager:
             return
 
         reasoning_agent = self._get_reasoning_agent(model)
+        run_metrics = self.config.run_metrics
 
         # Currently only DeepSeek and Anthropic support streaming
         if model_type == "deepseek":
@@ -375,7 +393,9 @@ class ReasoningManager:
 
             log_debug("Starting DeepSeek Reasoning (streaming)", center=True, symbol="=")
             final_message: Optional[Message] = None
-            for reasoning_delta, message in get_deepseek_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_deepseek_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -399,7 +419,9 @@ class ReasoningManager:
 
             log_debug("Starting Anthropic Claude Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_anthropic_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_anthropic_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -423,7 +445,9 @@ class ReasoningManager:
 
             log_debug("Starting Gemini Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_gemini_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_gemini_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -447,7 +471,9 @@ class ReasoningManager:
 
             log_debug("Starting OpenAI Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_openai_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_openai_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -471,7 +497,9 @@ class ReasoningManager:
 
             log_debug("Starting VertexAI Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_vertexai_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_vertexai_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -495,7 +523,9 @@ class ReasoningManager:
 
             log_debug("Starting Azure AI Foundry Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_ai_foundry_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_ai_foundry_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -519,7 +549,9 @@ class ReasoningManager:
 
             log_debug("Starting Groq Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_groq_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_groq_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -543,7 +575,9 @@ class ReasoningManager:
 
             log_debug("Starting Ollama Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            for reasoning_delta, message in get_ollama_reasoning_stream(reasoning_agent, messages):
+            for reasoning_delta, message in get_ollama_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -584,6 +618,7 @@ class ReasoningManager:
             return
 
         reasoning_agent = self._get_reasoning_agent(model)
+        run_metrics = self.config.run_metrics
 
         # Currently only DeepSeek and Anthropic support streaming
         if model_type == "deepseek":
@@ -591,7 +626,9 @@ class ReasoningManager:
 
             log_debug("Starting DeepSeek Reasoning (streaming)", center=True, symbol="=")
             final_message: Optional[Message] = None
-            async for reasoning_delta, message in aget_deepseek_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_deepseek_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -615,7 +652,9 @@ class ReasoningManager:
 
             log_debug("Starting Anthropic Claude Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_anthropic_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_anthropic_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -639,7 +678,9 @@ class ReasoningManager:
 
             log_debug("Starting Gemini Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_gemini_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_gemini_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -663,7 +704,9 @@ class ReasoningManager:
 
             log_debug("Starting OpenAI Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_openai_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_openai_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -687,7 +730,9 @@ class ReasoningManager:
 
             log_debug("Starting VertexAI Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_vertexai_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_vertexai_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -711,7 +756,9 @@ class ReasoningManager:
 
             log_debug("Starting Azure AI Foundry Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_ai_foundry_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_ai_foundry_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -735,7 +782,9 @@ class ReasoningManager:
 
             log_debug("Starting Groq Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_groq_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_groq_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -759,7 +808,9 @@ class ReasoningManager:
 
             log_debug("Starting Ollama Reasoning (streaming)", center=True, symbol="=")
             final_message = None
-            async for reasoning_delta, message in aget_ollama_reasoning_stream(reasoning_agent, messages):
+            async for reasoning_delta, message in aget_ollama_reasoning_stream(
+                reasoning_agent, messages, run_metrics=run_metrics
+            ):
                 if reasoning_delta is not None:
                     yield (reasoning_delta, None)
                 if message is not None:
@@ -830,7 +881,10 @@ class ReasoningManager:
         while next_action == NextAction.CONTINUE and step_count < self.config.max_steps:
             log_debug(f"Step {step_count}", center=True, symbol="=")
             try:
-                reasoning_agent_response: RunOutput = reasoning_agent.run(input=run_messages.get_input_messages())
+                # Shield the ambient metrics sink — reasoning metrics are accumulated
+                # explicitly below, so the nested run must not also report to it
+                with shielded_metrics_sink():
+                    reasoning_agent_response: RunOutput = reasoning_agent.run(input=run_messages.get_input_messages())
 
                 # Accumulate reasoning model metrics
                 if self.config.run_metrics is not None:
@@ -943,9 +997,12 @@ class ReasoningManager:
             log_debug(f"Step {step_count}", center=True, symbol="=")
             step_count += 1
             try:
-                reasoning_agent_response: RunOutput = await reasoning_agent.arun(  # type: ignore[misc]
-                    input=run_messages.get_input_messages()
-                )
+                # Shield the ambient metrics sink — reasoning metrics are accumulated
+                # explicitly below, so the nested run must not also report to it
+                with shielded_metrics_sink():
+                    reasoning_agent_response: RunOutput = await reasoning_agent.arun(  # type: ignore[misc]
+                        input=run_messages.get_input_messages()
+                    )
 
                 # Accumulate reasoning model metrics
                 if self.config.run_metrics is not None:

--- a/libs/agno/agno/reasoning/ollama.py
+++ b/libs/agno/agno/reasoning/ollama.py
@@ -89,6 +89,7 @@ async def aget_ollama_reasoning(
 def get_ollama_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Ollama model.
@@ -100,12 +101,15 @@ def get_ollama_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -117,7 +121,11 @@ def get_ollama_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -135,6 +143,7 @@ def get_ollama_reasoning_stream(
 async def aget_ollama_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from Ollama model asynchronously.
@@ -146,12 +155,15 @@ async def aget_ollama_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -163,7 +175,11 @@ async def aget_ollama_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/reasoning/openai.py
+++ b/libs/agno/agno/reasoning/openai.py
@@ -115,6 +115,7 @@ async def aget_openai_reasoning(
 def get_openai_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from OpenAI model.
@@ -126,6 +127,7 @@ def get_openai_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     # Update system message role to "system"
@@ -136,7 +138,9 @@ def get_openai_reasoning_stream(
     reasoning_content: str = ""
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -148,6 +152,11 @@ def get_openai_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
                     # Check for reasoning_content at completion (OpenAIResponses with reasoning_summary)
                     if hasattr(event, "reasoning_content") and event.reasoning_content:
                         # If we haven't accumulated any reasoning content yet, use this
@@ -171,6 +180,7 @@ def get_openai_reasoning_stream(
 async def aget_openai_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from OpenAI model asynchronously.
@@ -182,6 +192,7 @@ async def aget_openai_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     # Update system message role to "system"
@@ -192,7 +203,9 @@ async def aget_openai_reasoning_stream(
     reasoning_content: str = ""
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Check for reasoning_content attribute first (native reasoning)
@@ -204,6 +217,11 @@ async def aget_openai_reasoning_stream(
                         reasoning_content += event.content
                         yield (event.content, None)
                 elif event.event == RunEvent.run_completed:
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
                     # Check for reasoning_content at completion (OpenAIResponses with reasoning_summary)
                     if hasattr(event, "reasoning_content") and event.reasoning_content:
                         # If we haven't accumulated any reasoning content yet, use this

--- a/libs/agno/agno/reasoning/vertexai.py
+++ b/libs/agno/agno/reasoning/vertexai.py
@@ -98,6 +98,7 @@ async def aget_vertexai_reasoning(
 def get_vertexai_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> Iterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from VertexAI Claude model.
@@ -107,13 +108,16 @@ def get_vertexai_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import shielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
     redacted_reasoning_content: Optional[str] = None
 
     try:
-        for event in reasoning_agent.run(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        for event in shielded_stream(reasoning_agent.run(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -121,7 +125,11 @@ def get_vertexai_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return
@@ -140,6 +148,7 @@ def get_vertexai_reasoning_stream(
 async def aget_vertexai_reasoning_stream(
     reasoning_agent: "Agent",  # type: ignore  # noqa: F821
     messages: List[Message],
+    run_metrics: Optional["RunMetrics"] = None,
 ) -> AsyncIterator[Tuple[Optional[str], Optional[Message]]]:
     """
     Stream reasoning content from VertexAI Claude model asynchronously.
@@ -149,13 +158,16 @@ async def aget_vertexai_reasoning_stream(
         - During streaming: (reasoning_content_delta, None)
         - At the end: (None, final_message)
     """
+    from agno.run._nested_metrics import ashielded_stream
     from agno.run.agent import RunEvent
 
     reasoning_content: str = ""
     redacted_reasoning_content: Optional[str] = None
 
     try:
-        async for event in reasoning_agent.arun(input=messages, stream=True, stream_events=True):
+        # Reasoning metrics are accumulated explicitly below, so the reasoning
+        # run must not also report to the ambient metrics sink
+        async for event in ashielded_stream(reasoning_agent.arun(input=messages, stream=True, stream_events=True)):
             if hasattr(event, "event"):
                 if event.event == RunEvent.run_content:
                     # Stream reasoning content as it arrives
@@ -163,7 +175,11 @@ async def aget_vertexai_reasoning_stream(
                         reasoning_content += event.reasoning_content
                         yield (event.reasoning_content, None)
                 elif event.event == RunEvent.run_completed:
-                    pass
+                    # Accumulate reasoning agent metrics into the parent run_metrics
+                    if run_metrics is not None and hasattr(event, "metrics"):
+                        from agno.metrics import accumulate_eval_metrics
+
+                        accumulate_eval_metrics(event.metrics, run_metrics, prefix="reasoning")
     except Exception as e:
         log_warning(f"Reasoning error: {str(e)}")
         return

--- a/libs/agno/agno/run/_nested_metrics.py
+++ b/libs/agno/agno/run/_nested_metrics.py
@@ -1,0 +1,293 @@
+"""Plumbing for propagating nested-run metrics to the enclosing run.
+
+When an agent/team/workflow run is started from inside user code that belongs
+to another run — a custom tool, a tool hook, a pre/post hook or a custom
+workflow step function — its token metrics must roll up into the enclosing
+run so session metrics and AgentOS reflect the real cost of the run. The
+channel is a ContextVar in agno.metrics holding the enclosing run's RunMetrics
+collector (the "sink").
+
+The helpers here wrap run execution so the run's own sink is installed while
+its frames execute (restored per-resume for generators, so the sink never
+leaks into consumer contexts between yields) and the run's total metrics are
+reported to the enclosing sink exactly once, when the run reaches a terminal
+status or its stream is exhausted or closed. Paused runs do not report — the
+continued run reports the full metrics when it finishes. Framework-managed
+child runs (team members, workflow steps) are already aggregated through
+member_responses / step metrics, so those call sites shield the sink to avoid
+double counting.
+"""
+
+from contextlib import contextmanager
+from typing import Any, AsyncIterator, Coroutine, Iterator, List, Optional, TypeVar
+
+from agno.metrics import (
+    RunMetrics,
+    accumulate_run_metrics,
+    get_nested_run_metrics_sink,
+    report_metrics_to_sink,
+    swap_nested_run_metrics_sink,
+)
+from agno.run.agent import RunCompletedEvent, RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowCompletedEvent, WorkflowRunOutput
+
+T = TypeVar("T")
+
+_TERMINAL_STATUSES = (RunStatus.completed, RunStatus.error, RunStatus.cancelled)
+
+_RUN_OUTPUT_TYPES = (RunOutput, TeamRunOutput, WorkflowRunOutput)
+
+_COMPLETED_EVENT_TYPES = (RunCompletedEvent, TeamRunCompletedEvent, WorkflowCompletedEvent)
+
+
+def total_run_metrics(run_output: Any) -> Optional[RunMetrics]:
+    """Compute the total metrics a completed run should report to its parent.
+
+    - Workflow runs carry WorkflowMetrics: sum the per-step RunMetrics.
+    - Team runs: leader metrics plus all member responses, recursively.
+    - Agent runs: the run metrics as-is.
+    """
+    metrics = getattr(run_output, "metrics", None)
+
+    # WorkflowMetrics — aggregate the per-step breakdown
+    if metrics is not None and hasattr(metrics, "steps"):
+        # Workflow-agent runs already roll the executed steps up into the
+        # agent's own run metrics, so those are the full totals
+        workflow_agent_run = getattr(run_output, "workflow_agent_run", None)
+        if workflow_agent_run is not None and workflow_agent_run.metrics is not None:
+            return workflow_agent_run.metrics
+        total = RunMetrics()
+        for step_metrics in (metrics.steps or {}).values():
+            if step_metrics.metrics is not None:
+                accumulate_run_metrics(total, step_metrics.metrics)
+        return total
+
+    member_responses = getattr(run_output, "member_responses", None)
+    if member_responses:
+        total = RunMetrics()
+        if metrics is not None:
+            accumulate_run_metrics(total, metrics)
+            # Keep the team leader's timing — member runs happen within it
+            total.duration = metrics.duration
+            total.time_to_first_token = metrics.time_to_first_token
+        _accumulate_member_metrics(total, member_responses)
+        return total
+
+    return metrics
+
+
+def _accumulate_member_metrics(total: RunMetrics, member_responses: List[Any]) -> None:
+    for member_response in member_responses:
+        member_metrics = getattr(member_response, "metrics", None)
+        if member_metrics is not None:
+            accumulate_run_metrics(total, member_metrics)
+        nested_members = getattr(member_response, "member_responses", None)
+        if nested_members:
+            _accumulate_member_metrics(total, nested_members)
+
+
+def report_run_to_parent(parent_sink: Optional[RunMetrics], run_output: Any) -> None:
+    """Report a finished run's total metrics to the enclosing run's sink."""
+    if parent_sink is None or run_output is None:
+        return
+    # Paused runs report nothing — the continued run reports the full metrics.
+    if getattr(run_output, "status", None) == RunStatus.paused:
+        return
+    report_metrics_to_sink(parent_sink, total_run_metrics(run_output))
+
+
+def run_stream_with_metrics_scope(
+    stream: Iterator[T],
+    run_output: Any,
+    sink: Optional[RunMetrics],
+    run_id: Optional[str] = None,
+    swallow_run_output: bool = False,
+) -> Iterator[T]:
+    """Wrap a run's event stream so nested-run metrics propagate correctly.
+
+    The sink is installed only while the inner generator's frames execute and
+    restored before each event is yielded out. The run reports to the parent
+    sink as soon as it reaches a terminal status, so metrics survive consumers
+    that stop iterating after the completed event.
+
+    A run continued by run_id resolves the stored run inside its own frames, so
+    run_output is None at wrap time; pass run_id so the wrapper can adopt the
+    resolved output (or its completed event) from the stream without mistaking
+    a member's or nested run's output for this run's. Continue dispatchers force
+    yield_run_output so the resolved output reaches the wrapper, and set
+    swallow_run_output when the caller did not ask for it.
+    """
+    reported = False
+    parent_sink: Optional[RunMetrics] = None
+    completed_event: Any = None
+    # The run's frames may replace their own sink (e.g. a continued run installs
+    # its metrics once the stored run is resolved) — capture what they leave
+    # installed on each resume so it is re-installed on the next one.
+    current_sink = sink
+    try:
+        while True:
+            parent_sink = swap_nested_run_metrics_sink(current_sink)
+            try:
+                item = next(stream)
+            except StopIteration:
+                if not reported:
+                    reported = True
+                    report_run_to_parent(parent_sink, run_output if run_output is not None else completed_event)
+                return
+            finally:
+                current_sink = swap_nested_run_metrics_sink(parent_sink)
+            if run_output is None and getattr(item, "run_id", None) == run_id and run_id is not None:
+                if isinstance(item, _RUN_OUTPUT_TYPES):
+                    run_output = item
+                elif isinstance(item, _COMPLETED_EVENT_TYPES):
+                    # The resolved output is only yielded when yield_run_output is
+                    # set — keep the completed event as a fallback to report from
+                    completed_event = item
+            if not reported and getattr(run_output, "status", None) in _TERMINAL_STATUSES:
+                reported = True
+                report_run_to_parent(parent_sink, run_output)
+            if swallow_run_output and isinstance(item, _RUN_OUTPUT_TYPES) and item.run_id == run_id:
+                continue
+            yield item
+    finally:
+        if not reported:
+            report_run_to_parent(parent_sink, run_output if run_output is not None else completed_event)
+
+
+async def arun_stream_with_metrics_scope(
+    stream: AsyncIterator[T],
+    run_output: Any,
+    sink: Optional[RunMetrics],
+    run_id: Optional[str] = None,
+    swallow_run_output: bool = False,
+) -> AsyncIterator[T]:
+    """Async variant of run_stream_with_metrics_scope."""
+    reported = False
+    parent_sink: Optional[RunMetrics] = None
+    completed_event: Any = None
+    current_sink = sink
+    try:
+        while True:
+            parent_sink = swap_nested_run_metrics_sink(current_sink)
+            try:
+                item = await stream.__anext__()
+            except StopAsyncIteration:
+                if not reported:
+                    reported = True
+                    report_run_to_parent(parent_sink, run_output if run_output is not None else completed_event)
+                return
+            finally:
+                current_sink = swap_nested_run_metrics_sink(parent_sink)
+            if run_output is None and getattr(item, "run_id", None) == run_id and run_id is not None:
+                if isinstance(item, _RUN_OUTPUT_TYPES):
+                    run_output = item
+                elif isinstance(item, _COMPLETED_EVENT_TYPES):
+                    # The resolved output is only yielded when yield_run_output is
+                    # set — keep the completed event as a fallback to report from
+                    completed_event = item
+            if not reported and getattr(run_output, "status", None) in _TERMINAL_STATUSES:
+                reported = True
+                report_run_to_parent(parent_sink, run_output)
+            if swallow_run_output and isinstance(item, _RUN_OUTPUT_TYPES) and item.run_id == run_id:
+                continue
+            yield item
+    finally:
+        if not reported:
+            report_run_to_parent(parent_sink, run_output if run_output is not None else completed_event)
+
+
+async def arun_with_metrics_scope(coro: Coroutine[Any, Any, T], run_output: Any, sink: Optional[RunMetrics]) -> T:
+    """Await a non-streaming run with its metrics sink installed.
+
+    Reports the returned output (which may be a different object than
+    run_output, e.g. on cancellation) to the enclosing sink on the way out.
+    """
+    parent_sink = swap_nested_run_metrics_sink(sink)
+    result = None
+    try:
+        result = await coro
+        return result
+    finally:
+        swap_nested_run_metrics_sink(parent_sink)
+        report_run_to_parent(parent_sink, result if result is not None else run_output)
+
+
+def shielded_stream(stream: Iterator[T]) -> Iterator[T]:
+    """Consume a framework-managed child run's stream with the sink shielded.
+
+    Used where the parent already aggregates the child's metrics through its
+    own bookkeeping (team member responses), so the child must not also report
+    to the ambient sink.
+    """
+    while True:
+        parent_sink = swap_nested_run_metrics_sink(None)
+        try:
+            item = next(stream)
+        except StopIteration:
+            return
+        finally:
+            swap_nested_run_metrics_sink(parent_sink)
+        yield item
+
+
+async def ashielded_stream(stream: AsyncIterator[T]) -> AsyncIterator[T]:
+    """Async variant of shielded_stream."""
+    while True:
+        parent_sink = swap_nested_run_metrics_sink(None)
+        try:
+            item = await stream.__anext__()
+        except StopAsyncIteration:
+            return
+        finally:
+            swap_nested_run_metrics_sink(parent_sink)
+        yield item
+
+
+@contextmanager
+def shielded_metrics_sink():
+    """Hide the ambient metrics sink.
+
+    Used around framework-managed child runs whose metrics are aggregated
+    through other means (member responses, workflow step metrics).
+    """
+    parent_sink = swap_nested_run_metrics_sink(None)
+    try:
+        yield
+    finally:
+        # Restore only if our shield is still installed — a generator holding
+        # this context manager may be closed from a foreign context (e.g. an
+        # abandoned stream finalized in its consumer's context), where swapping
+        # would clobber that context's own sink.
+        if get_nested_run_metrics_sink() is None:
+            swap_nested_run_metrics_sink(parent_sink)
+
+
+@contextmanager
+def metrics_collection_sink():
+    """Install a fresh collection sink and yield it.
+
+    Used around custom workflow step functions: nested runs started inside the
+    function report into the yielded collector, which is then attached to the
+    step output.
+    """
+    collected = RunMetrics()
+    parent_sink = swap_nested_run_metrics_sink(collected)
+    try:
+        yield collected
+    finally:
+        # Restore only if our collector is still installed — a generator holding
+        # this context manager may be closed from a foreign context (e.g. an
+        # abandoned stream finalized in its consumer's context), where swapping
+        # would clobber that context's own sink.
+        if get_nested_run_metrics_sink() is collected:
+            swap_nested_run_metrics_sink(parent_sink)
+
+
+def has_token_metrics(metrics: Optional[RunMetrics]) -> bool:
+    """Whether a collector accumulated anything worth attaching."""
+    if metrics is None:
+        return False
+    return metrics.total_tokens > 0 or metrics.input_tokens > 0 or metrics.output_tokens > 0 or bool(metrics.details)

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -34,6 +34,7 @@ from agno.media import Audio, File, Image, Video
 from agno.memory import MemoryManager
 from agno.models.message import Message, MessageReferences
 from agno.run import RunContext
+from agno.run._nested_metrics import ashielded_stream, shielded_metrics_sink, shielded_stream
 from agno.run.agent import (
     RunCancelledEvent as AgentRunCancelledEvent,
 )
@@ -581,8 +582,10 @@ def _get_delegate_task_function(
 
                 scrub_run_output_for_storage(member_agent, run_response=member_agent_run_response)  # type: ignore[arg-type]
 
-            # Add the member run to the team session
-            session.upsert_run(member_agent_run_response)
+            # Add a shallow copy of the member run to the team session — save_session
+            # scrubs member_responses on stored runs, which must not reach the response
+            # attached to the team run's member_responses
+            session.upsert_run(copy(member_agent_run_response))
 
         # Update team session state
         merge_dictionaries(run_context.session_state, member_session_state_copy)  # type: ignore
@@ -622,28 +625,32 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_agent_run_response_stream = member_agent.run(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    # All members have the same session_id
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,  # Send a copy to the agent
-                    images=images,
-                    videos=videos,
-                    audio=audio,
-                    files=files,
-                    stream=True,
-                    stream_events=stream_events or team.stream_member_events,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    metadata=run_context.metadata,
-                    add_session_state_to_context=add_session_state_to_context,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                    yield_run_output=True,
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                member_agent_run_response_stream = shielded_stream(
+                    member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        # All members have the same session_id
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,  # Send a copy to the agent
+                        images=images,
+                        videos=videos,
+                        audio=audio,
+                        files=files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        metadata=run_context.metadata,
+                        add_session_state_to_context=add_session_state_to_context,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
                 )
                 draining_after_cancel = False
                 for member_agent_run_output_event in member_agent_run_response_stream:
@@ -683,27 +690,30 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_agent_run_response = member_agent.run(  # type: ignore
-                    input=member_agent_task if not history else history,  # type: ignore
-                    user_id=user_id,
-                    # All members have the same session_id
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,  # Send a copy to the agent
-                    images=images,
-                    videos=videos,
-                    audio=audio,
-                    files=files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                )
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                with shielded_metrics_sink():
+                    member_agent_run_response = member_agent.run(  # type: ignore
+                        input=member_agent_task if not history else history,  # type: ignore
+                        user_id=user_id,
+                        # All members have the same session_id
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,  # Send a copy to the agent
+                        images=images,
+                        videos=videos,
+                        audio=audio,
+                        files=files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
 
                 check_if_run_cancelled(member_agent_run_response)  # type: ignore
                 # Also check if the parent team's run was cancelled while the member was executing
@@ -809,28 +819,32 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_agent_run_response_stream = member_agent.arun(  # type: ignore
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    # All members have the same session_id
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,  # Send a copy to the agent
-                    images=images,
-                    videos=videos,
-                    audio=audio,
-                    files=files,
-                    stream=True,
-                    stream_events=stream_events or team.stream_member_events,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                    yield_run_output=True,
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                member_agent_run_response_stream = ashielded_stream(
+                    member_agent.arun(  # type: ignore
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        # All members have the same session_id
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,  # Send a copy to the agent
+                        images=images,
+                        videos=videos,
+                        audio=audio,
+                        files=files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
                 )
                 draining_after_cancel = False
                 async for member_agent_run_response_event in member_agent_run_response_stream:
@@ -870,27 +884,30 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_agent_run_response = await member_agent.arun(  # type: ignore
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    # All members have the same session_id
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,  # Send a copy to the agent
-                    images=images,
-                    videos=videos,
-                    audio=audio,
-                    files=files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                )
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                with shielded_metrics_sink():
+                    member_agent_run_response = await member_agent.arun(  # type: ignore
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        # All members have the same session_id
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,  # Send a copy to the agent
+                        images=images,
+                        videos=videos,
+                        audio=audio,
+                        files=files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
                 check_if_run_cancelled(member_agent_run_response)  # type: ignore
                 # Also check if the parent team's run was cancelled while the member was executing
                 if run_response.run_id is not None:
@@ -979,28 +996,32 @@ def _get_delegate_task_function(
                     member_run_id = str(uuid4())
                     if run_response.run_id is not None:
                         register_member_run(run_response.run_id, member_run_id)
-                    member_agent_run_response_stream = member_agent.run(
-                        input=member_agent_task if not history else history,
-                        user_id=user_id,
-                        # All members have the same session_id
-                        session_id=session.session_id,
-                        session_state=member_session_state_copy,  # Send a copy to the agent
-                        images=images,
-                        videos=videos,
-                        audio=audio,
-                        files=files,
-                        stream=True,
-                        stream_events=stream_events or team.stream_member_events,
-                        knowledge_filters=run_context.knowledge_filters
-                        if not member_agent.knowledge_filters and member_agent.knowledge
-                        else None,
-                        debug_mode=debug_mode,
-                        dependencies=run_context.dependencies,
-                        add_dependencies_to_context=add_dependencies_to_context,
-                        add_session_state_to_context=add_session_state_to_context,
-                        metadata=run_context.metadata,
-                        run_id=member_run_id,
-                        yield_run_output=True,
+                    # Member metrics are aggregated through member_responses, so the
+                    # member run must not also report to the ambient metrics sink
+                    member_agent_run_response_stream = shielded_stream(
+                        member_agent.run(
+                            input=member_agent_task if not history else history,
+                            user_id=user_id,
+                            # All members have the same session_id
+                            session_id=session.session_id,
+                            session_state=member_session_state_copy,  # Send a copy to the agent
+                            images=images,
+                            videos=videos,
+                            audio=audio,
+                            files=files,
+                            stream=True,
+                            stream_events=stream_events or team.stream_member_events,
+                            knowledge_filters=run_context.knowledge_filters
+                            if not member_agent.knowledge_filters and member_agent.knowledge
+                            else None,
+                            debug_mode=debug_mode,
+                            dependencies=run_context.dependencies,
+                            add_dependencies_to_context=add_dependencies_to_context,
+                            add_session_state_to_context=add_session_state_to_context,
+                            metadata=run_context.metadata,
+                            run_id=member_run_id,
+                            yield_run_output=True,
+                        )
                     )
                     draining_after_cancel = False
                     for member_agent_run_response_chunk in member_agent_run_response_stream:
@@ -1043,27 +1064,30 @@ def _get_delegate_task_function(
                     member_run_id = str(uuid4())
                     if run_response.run_id is not None:
                         register_member_run(run_response.run_id, member_run_id)
-                    member_agent_run_response = member_agent.run(  # type: ignore
-                        input=member_agent_task if not history else history,
-                        user_id=user_id,
-                        # All members have the same session_id
-                        session_id=session.session_id,
-                        session_state=member_session_state_copy,  # Send a copy to the agent
-                        images=images,
-                        videos=videos,
-                        audio=audio,
-                        files=files,
-                        stream=False,
-                        knowledge_filters=run_context.knowledge_filters
-                        if not member_agent.knowledge_filters and member_agent.knowledge
-                        else None,
-                        debug_mode=debug_mode,
-                        dependencies=run_context.dependencies,
-                        add_dependencies_to_context=add_dependencies_to_context,
-                        add_session_state_to_context=add_session_state_to_context,
-                        metadata=run_context.metadata,
-                        run_id=member_run_id,
-                    )
+                    # Member metrics are aggregated through member_responses, so the
+                    # member run must not also report to the ambient metrics sink
+                    with shielded_metrics_sink():
+                        member_agent_run_response = member_agent.run(  # type: ignore
+                            input=member_agent_task if not history else history,
+                            user_id=user_id,
+                            # All members have the same session_id
+                            session_id=session.session_id,
+                            session_state=member_session_state_copy,  # Send a copy to the agent
+                            images=images,
+                            videos=videos,
+                            audio=audio,
+                            files=files,
+                            stream=False,
+                            knowledge_filters=run_context.knowledge_filters
+                            if not member_agent.knowledge_filters and member_agent.knowledge
+                            else None,
+                            debug_mode=debug_mode,
+                            dependencies=run_context.dependencies,
+                            add_dependencies_to_context=add_dependencies_to_context,
+                            add_session_state_to_context=add_session_state_to_context,
+                            metadata=run_context.metadata,
+                            run_id=member_run_id,
+                        )
 
                     check_if_run_cancelled(member_agent_run_response)  # type: ignore
                     if run_response.run_id is not None:
@@ -1154,27 +1178,31 @@ def _get_delegate_task_function(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_stream = agent.arun(  # type: ignore
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,  # Send a copy to the agent
-                    images=images,
-                    videos=videos,
-                    audio=audio,
-                    files=files,
-                    stream=True,
-                    stream_events=stream_events or team.stream_member_events,
-                    debug_mode=debug_mode,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not agent.knowledge_filters and agent.knowledge
-                    else None,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    run_id=member_run_id,
-                    yield_run_output=True,
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                member_stream = ashielded_stream(
+                    agent.arun(  # type: ignore
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,  # Send a copy to the agent
+                        images=images,
+                        videos=videos,
+                        audio=audio,
+                        files=files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not agent.knowledge_filters and agent.knowledge
+                        else None,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
                 )
                 member_agent_run_response = None
                 try:
@@ -1288,28 +1316,31 @@ def _get_delegate_task_function(
                         member_run_id = str(uuid4())
                         if run_response.run_id is not None:
                             await aregister_member_run(run_response.run_id, member_run_id)
-                        member_agent_run_response = await member_agent.arun(
-                            input=member_agent_task if not history else history,
-                            user_id=user_id,
-                            # All members have the same session_id
-                            session_id=session.session_id,
-                            session_state=member_session_state_copy,  # Send a copy to the agent
-                            images=images,
-                            videos=videos,
-                            audio=audio,
-                            files=files,
-                            stream=False,
-                            stream_events=stream_events,
-                            debug_mode=debug_mode,
-                            knowledge_filters=run_context.knowledge_filters
-                            if not member_agent.knowledge_filters and member_agent.knowledge
-                            else None,
-                            dependencies=run_context.dependencies,
-                            add_dependencies_to_context=add_dependencies_to_context,
-                            add_session_state_to_context=add_session_state_to_context,
-                            metadata=run_context.metadata,
-                            run_id=member_run_id,
-                        )
+                        # Member metrics are aggregated through member_responses, so the
+                        # member run must not also report to the ambient metrics sink
+                        with shielded_metrics_sink():
+                            member_agent_run_response = await member_agent.arun(
+                                input=member_agent_task if not history else history,
+                                user_id=user_id,
+                                # All members have the same session_id
+                                session_id=session.session_id,
+                                session_state=member_session_state_copy,  # Send a copy to the agent
+                                images=images,
+                                videos=videos,
+                                audio=audio,
+                                files=files,
+                                stream=False,
+                                stream_events=stream_events,
+                                debug_mode=debug_mode,
+                                knowledge_filters=run_context.knowledge_filters
+                                if not member_agent.knowledge_filters and member_agent.knowledge
+                                else None,
+                                dependencies=run_context.dependencies,
+                                add_dependencies_to_context=add_dependencies_to_context,
+                                add_session_state_to_context=add_session_state_to_context,
+                                metadata=run_context.metadata,
+                                run_id=member_run_id,
+                            )
                         check_if_run_cancelled(member_agent_run_response)
                         if run_response.run_id is not None:
                             raise_if_cancelled(run_response.run_id)

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -30,12 +30,22 @@ from agno.exceptions import (
 )
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
+from agno.metrics import swap_nested_run_metrics_sink
 from agno.models.base import Model
 from agno.models.fallback import acall_model_with_fallback, call_model_with_fallback
 from agno.models.message import Message
 from agno.models.metrics import RunMetrics, merge_background_metrics
 from agno.models.response import ModelResponse, ToolExecution
 from agno.run import RunContext, RunStatus
+from agno.run._nested_metrics import (
+    arun_stream_with_metrics_scope,
+    arun_with_metrics_scope,
+    ashielded_stream,
+    report_run_to_parent,
+    run_stream_with_metrics_scope,
+    shielded_metrics_sink,
+    shielded_stream,
+)
 from agno.run.agent import (
     RunCancelledEvent as AgentRunCancelledEvent,
 )
@@ -2003,38 +2013,49 @@ def run_dispatch(
         raise
 
     if opts.stream:
-        return _run_stream(
-            team,
-            run_response=run_response,
-            run_context=run_context,
-            session=team_session,
-            user_id=user_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            response_format=response_format,
-            stream_events=opts.stream_events,
-            yield_run_output=opts.yield_run_output,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
-        )  # type: ignore
+        return run_stream_with_metrics_scope(  # type: ignore[return-value]
+            _run_stream(  # type: ignore
+                team,
+                run_response=run_response,
+                run_context=run_context,
+                session=team_session,
+                user_id=user_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                response_format=response_format,
+                stream_events=opts.stream_events,
+                yield_run_output=opts.yield_run_output,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics,
+        )
 
     else:
-        return _run(
-            team,
-            run_response=run_response,
-            run_context=run_context,
-            session=team_session,
-            user_id=user_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            response_format=response_format,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
-        )
+        response = run_response
+        parent_sink = swap_nested_run_metrics_sink(run_response.metrics)
+        try:
+            response = _run(
+                team,
+                run_response=run_response,
+                run_context=run_context,
+                session=team_session,
+                user_id=user_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                response_format=response_format,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            )
+            return response
+        finally:
+            swap_nested_run_metrics_sink(parent_sink)
+            report_run_to_parent(parent_sink, response)
 
 
 async def _arun_tasks(
@@ -3372,6 +3393,12 @@ async def _arun_background(
             team_session.upsert_run(run_response=run_response)
             await asave_session(team, session=team_session)
 
+            # Detached run — nested runs report into this run's metrics, never
+            # to an enclosing run that may complete before this task does
+            if run_response.metrics is None:
+                run_response.metrics = RunMetrics()
+            swap_nested_run_metrics_sink(run_response.metrics)
+
             # Execute the actual run — _arun handles everything including
             # session persistence and cleanup
             await _arun(
@@ -3459,6 +3486,11 @@ async def _arun_background_stream(
         from agno.os.utils import format_sse_event_with_index
 
         try:
+            # Detached run — nested runs report into this run's metrics, never
+            # to an enclosing run that may complete before this task does
+            if run_response.metrics is None:
+                run_response.metrics = RunMetrics()
+            swap_nested_run_metrics_sink(run_response.metrics)
             async for event in _arun_stream(
                 team,
                 run_response=run_response,
@@ -4237,36 +4269,44 @@ def arun_dispatch(  # type: ignore
         )
 
     if opts.stream:
-        return _arun_stream(
-            team,  # type: ignore
-            run_response=run_response,
-            run_context=run_context,
-            session_id=session_id,
-            user_id=user_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            response_format=response_format,
-            stream_events=opts.stream_events,
-            yield_run_output=opts.yield_run_output,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
+        return arun_stream_with_metrics_scope(  # type: ignore[return-value]
+            _arun_stream(
+                team,  # type: ignore
+                run_response=run_response,
+                run_context=run_context,
+                session_id=session_id,
+                user_id=user_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                response_format=response_format,
+                stream_events=opts.stream_events,
+                yield_run_output=opts.yield_run_output,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics,
         )
     else:
-        return _arun(
-            team,  # type: ignore
-            run_response=run_response,
-            run_context=run_context,
-            session_id=session_id,
-            user_id=user_id,
-            add_history_to_context=opts.add_history_to_context,
-            add_dependencies_to_context=opts.add_dependencies_to_context,
-            add_session_state_to_context=opts.add_session_state_to_context,
-            response_format=response_format,
-            debug_mode=debug_mode,
-            background_tasks=background_tasks,
-            **kwargs,
+        return arun_with_metrics_scope(  # type: ignore[return-value]
+            _arun(
+                team,  # type: ignore
+                run_response=run_response,
+                run_context=run_context,
+                session_id=session_id,
+                user_id=user_id,
+                add_history_to_context=opts.add_history_to_context,
+                add_dependencies_to_context=opts.add_dependencies_to_context,
+                add_session_state_to_context=opts.add_session_state_to_context,
+                response_format=response_format,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                **kwargs,
+            ),
+            run_response,
+            sink=run_response.metrics,
         )
 
 
@@ -4419,8 +4459,11 @@ def _cleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics
-    update_session_metrics(team, session=session, run_response=run_response)
+    # Calculate session metrics. Paused runs are skipped — the continued run
+    # accumulates the full run metrics exactly once when it finishes, so
+    # accumulating the partial metrics here would double count them.
+    if run_response.status != RunStatus.paused:
+        update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -4468,8 +4511,11 @@ async def _acleanup_and_store(
     # Add scrubbed RunOutput to Team Session
     session.upsert_run(run_response=storage_copy)
 
-    # Calculate session metrics
-    update_session_metrics(team, session=session, run_response=run_response)
+    # Calculate session metrics. Paused runs are skipped — the continued run
+    # accumulates the full run metrics exactly once when it finishes, so
+    # accumulating the partial metrics here would double count them.
+    if run_response.status != RunStatus.paused:
+        update_session_metrics(team, session=session, run_response=run_response)
 
     # Update session state before saving the session
     if run_context is not None and run_context.session_state is not None:
@@ -5138,6 +5184,8 @@ def _route_requirements_to_members(
     Returns:
         List of member result strings.
     """
+    import copy
+
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
@@ -5197,19 +5245,23 @@ def _route_requirements_to_members(
                 updated_map = {t.tool_call_id: t for t in updated_tools}
                 member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
 
-            member_response = member.continue_run(
-                run_response=member_run_output,  # type: ignore[arg-type]
-                session_id=session.session_id,
-                **member_continue_kwargs,
-            )
+            # Member metrics are aggregated through member_responses, so the
+            # member run must not also report to the ambient metrics sink
+            with shielded_metrics_sink():
+                member_response = member.continue_run(
+                    run_response=member_run_output,  # type: ignore[arg-type]
+                    session_id=session.session_id,
+                    **member_continue_kwargs,
+                )
         else:
             # Fallback: use run_id (requires DB or cached session)
-            member_response = member.continue_run(  # type: ignore[arg-type]
-                run_id=member_run_id,
-                requirements=reqs,
-                session_id=session.session_id,
-                **member_continue_kwargs,
-            )
+            with shielded_metrics_sink():
+                member_response = member.continue_run(  # type: ignore[arg-type]
+                    run_id=member_run_id,
+                    requirements=reqs,
+                    session_id=session.session_id,
+                    **member_continue_kwargs,
+                )
 
         # Check if member is still paused (chained HITL)
         if getattr(member_response, "is_paused", False):
@@ -5218,8 +5270,18 @@ def _route_requirements_to_members(
             _propagate_member_pause(run_response, member, member_response)
         else:
             # Update the member's run in the team session so its status is persisted
-            # (member agents skip save_session when team_id is set)
-            session.upsert_run(member_response)
+            # (member agents skip save_session when team_id is set). Persist a
+            # shallow copy of the member run — save_session scrubs member_responses on
+            # stored runs, which must not reach the response attached to the team run's
+            # member_responses
+            session.upsert_run(copy.copy(member_response))
+
+            # Re-attach the member run to member_responses so session metrics and
+            # upward reports include it. After a process restart the paused member
+            # output is resolved from session.runs and is no longer present there.
+            existing_member_run_ids = {getattr(r, "run_id", None) for r in (run_response.member_responses or [])}
+            if getattr(member_response, "run_id", None) not in existing_member_run_ids:
+                run_response.add_member_run(member_response)
 
             content = getattr(member_response, "content", None) or "Task completed"
             member_results.append(f"[{member.name or member_id}]: {content}")
@@ -5253,6 +5315,8 @@ def _route_requirements_to_members_stream(
     Yields:
         Member streaming events (RunOutputEvent, TeamRunOutputEvent).
     """
+    import copy
+
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
@@ -5305,23 +5369,29 @@ def _route_requirements_to_members_stream(
                 updated_map = {t.tool_call_id: t for t in updated_tools}
                 member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
 
-            member_response_stream = member.continue_run(  # type: ignore[call-overload]
-                run_response=member_run_output,  # type: ignore[arg-type]
-                session_id=session.session_id,
-                stream=True,
-                stream_events=stream_events or team.stream_member_events,
-                yield_run_output=True,
-                **member_continue_kwargs,
+            # Member metrics are aggregated through member_responses, so the
+            # member run must not also report to the ambient metrics sink
+            member_response_stream = shielded_stream(
+                member.continue_run(  # type: ignore[call-overload]
+                    run_response=member_run_output,  # type: ignore[arg-type]
+                    session_id=session.session_id,
+                    stream=True,
+                    stream_events=stream_events or team.stream_member_events,
+                    yield_run_output=True,
+                    **member_continue_kwargs,
+                )
             )
         else:
-            member_response_stream = member.continue_run(  # type: ignore[call-overload]
-                run_id=member_run_id,
-                requirements=reqs,
-                session_id=session.session_id,
-                stream=True,
-                stream_events=stream_events or team.stream_member_events,
-                yield_run_output=True,
-                **member_continue_kwargs,
+            member_response_stream = shielded_stream(
+                member.continue_run(  # type: ignore[call-overload]
+                    run_id=member_run_id,
+                    requirements=reqs,
+                    session_id=session.session_id,
+                    stream=True,
+                    stream_events=stream_events or team.stream_member_events,
+                    yield_run_output=True,
+                    **member_continue_kwargs,
+                )
             )
 
         # Iterate the member's streaming response — yield intermediate events,
@@ -5354,7 +5424,18 @@ def _route_requirements_to_members_stream(
 
             _propagate_member_pause(run_response, member, member_response)
         else:
-            session.upsert_run(member_response)
+            # Persist a shallow copy of the member run — save_session scrubs
+            # member_responses on stored runs, which must not reach the response
+            # attached to the team run's member_responses
+            session.upsert_run(copy.copy(member_response))
+
+            # Re-attach the member run to member_responses so session metrics and
+            # upward reports include it. After a process restart the paused member
+            # output is resolved from session.runs and is no longer present there.
+            existing_member_run_ids = {getattr(r, "run_id", None) for r in (run_response.member_responses or [])}
+            if getattr(member_response, "run_id", None) not in existing_member_run_ids:
+                run_response.add_member_run(member_response)
+
             content = getattr(member_response, "content", None) or "Task completed"
             member_results.append(f"[{member.name or member_id}]: {content}")
 
@@ -5376,6 +5457,8 @@ async def _aroute_requirements_to_members(
     Returns:
         List of member result strings.
     """
+    import copy
+
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
@@ -5429,18 +5512,22 @@ async def _aroute_requirements_to_members(
                 updated_map = {t.tool_call_id: t for t in updated_tools}
                 member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
 
-            member_response = await member.acontinue_run(  # type: ignore[misc]
-                run_response=member_run_output,  # type: ignore[arg-type]
-                session_id=session.session_id,
-                **member_continue_kwargs,
-            )
+            # Member metrics are aggregated through member_responses, so the
+            # member run must not also report to the ambient metrics sink
+            with shielded_metrics_sink():
+                member_response = await member.acontinue_run(  # type: ignore[misc]
+                    run_response=member_run_output,  # type: ignore[arg-type]
+                    session_id=session.session_id,
+                    **member_continue_kwargs,
+                )
         else:
-            member_response = await member.acontinue_run(  # type: ignore[misc]
-                run_id=member_run_id,
-                requirements=reqs,
-                session_id=session.session_id,
-                **member_continue_kwargs,
-            )
+            with shielded_metrics_sink():
+                member_response = await member.acontinue_run(  # type: ignore[misc]
+                    run_id=member_run_id,
+                    requirements=reqs,
+                    session_id=session.session_id,
+                    **member_continue_kwargs,
+                )
 
         # Clear _member_run_response references to allow GC of the member RunOutput
         for req in reqs:
@@ -5453,8 +5540,18 @@ async def _aroute_requirements_to_members(
             return None
         else:
             # Update the member's run in the team session so its status is persisted
-            # (member agents skip save_session when team_id is set, so we do it here)
-            session.upsert_run(member_response)
+            # (member agents skip save_session when team_id is set, so we do it here). Persist a
+            # shallow copy of the member run — save_session scrubs member_responses on
+            # stored runs, which must not reach the response attached to the team run's
+            # member_responses
+            session.upsert_run(copy.copy(member_response))
+
+            # Re-attach the member run to member_responses so session metrics and
+            # upward reports include it. After a process restart the paused member
+            # output is resolved from session.runs and is no longer present there.
+            existing_member_run_ids = {getattr(r, "run_id", None) for r in (run_response.member_responses or [])}
+            if getattr(member_response, "run_id", None) not in existing_member_run_ids:
+                run_response.add_member_run(member_response)
 
             content = getattr(member_response, "content", None) or "Task completed"
             return f"[{member.name or member_id}]: {content}"
@@ -5496,6 +5593,8 @@ async def _aroute_requirements_to_members_stream(
     Yields:
         Member streaming events (RunOutputEvent, TeamRunOutputEvent).
     """
+    import copy
+
     from agno.run.requirement import RunRequirement
     from agno.team._tools import _find_member_route_by_id
 
@@ -5548,23 +5647,29 @@ async def _aroute_requirements_to_members_stream(
                 updated_map = {t.tool_call_id: t for t in updated_tools}
                 member_run_output.tools = [updated_map.get(t.tool_call_id, t) for t in member_run_output.tools]
 
-            member_response_stream = member.acontinue_run(  # type: ignore[call-overload]
-                run_response=member_run_output,  # type: ignore[arg-type]
-                session_id=session.session_id,
-                stream=True,
-                stream_events=stream_events or team.stream_member_events,
-                yield_run_output=True,
-                **member_continue_kwargs,
+            # Member metrics are aggregated through member_responses, so the
+            # member run must not also report to the ambient metrics sink
+            member_response_stream = ashielded_stream(
+                member.acontinue_run(  # type: ignore[call-overload]
+                    run_response=member_run_output,  # type: ignore[arg-type]
+                    session_id=session.session_id,
+                    stream=True,
+                    stream_events=stream_events or team.stream_member_events,
+                    yield_run_output=True,
+                    **member_continue_kwargs,
+                )
             )
         else:
-            member_response_stream = member.acontinue_run(  # type: ignore[call-overload]
-                run_id=member_run_id,
-                requirements=reqs,
-                session_id=session.session_id,
-                stream=True,
-                stream_events=stream_events or team.stream_member_events,
-                yield_run_output=True,
-                **member_continue_kwargs,
+            member_response_stream = ashielded_stream(
+                member.acontinue_run(  # type: ignore[call-overload]
+                    run_id=member_run_id,
+                    requirements=reqs,
+                    session_id=session.session_id,
+                    stream=True,
+                    stream_events=stream_events or team.stream_member_events,
+                    yield_run_output=True,
+                    **member_continue_kwargs,
+                )
             )
 
         # Iterate the member's async streaming response — yield intermediate events,
@@ -5597,7 +5702,18 @@ async def _aroute_requirements_to_members_stream(
 
             _propagate_member_pause(run_response, member, member_response)
         else:
-            session.upsert_run(member_response)
+            # Persist a shallow copy of the member run — save_session scrubs
+            # member_responses on stored runs, which must not reach the response
+            # attached to the team run's member_responses
+            session.upsert_run(copy.copy(member_response))
+
+            # Re-attach the member run to member_responses so session metrics and
+            # upward reports include it. After a process restart the paused member
+            # output is resolved from session.runs and is no longer present there.
+            existing_member_run_ids = {getattr(r, "run_id", None) for r in (run_response.member_responses or [])}
+            if getattr(member_response, "run_id", None) not in existing_member_run_ids:
+                run_response.add_member_run(member_response)
+
             content = getattr(member_response, "content", None) or "Task completed"
             member_results.append(f"[{member.name or member_id}]: {content}")
 
@@ -6332,6 +6448,13 @@ def _continue_run(
 
     register_run(run_response.run_id)  # type: ignore
 
+    # Install this run's metrics sink so nested runs inside resumed tools report
+    # here. The public continue_run scope restores the previous sink when this
+    # run finishes.
+    if run_response.metrics is None:
+        run_response.metrics = RunMetrics()
+    swap_nested_run_metrics_sink(run_response.metrics)
+
     # Emit RunContinued event (matching streaming variant behaviour)
     handle_event(
         create_team_run_continued_event(run_response),
@@ -6514,6 +6637,14 @@ def _continue_run_stream(
     from agno.utils.events import create_team_run_continued_event
 
     register_run(run_response.run_id)  # type: ignore
+
+    # Install this run's metrics sink so nested runs inside resumed tools report
+    # here. These generator frames run after the dispatch-scope install has been
+    # restored, so the sink must be re-installed from inside them; the public
+    # continue_run scope restores the previous sink between yields.
+    if run_response.metrics is None:
+        run_response.metrics = RunMetrics()
+    swap_nested_run_metrics_sink(run_response.metrics)
 
     try:
         num_attempts = team.retries + 1
@@ -6824,6 +6955,9 @@ async def _acontinue_run_background_stream(
         from agno.os.utils import format_sse_event_with_index
 
         try:
+            # Detached run — never report metrics to an enclosing run that may
+            # complete before this task does
+            swap_nested_run_metrics_sink(None)
             async for event in _acontinue_run_stream(
                 team,
                 run_response=run_response,
@@ -7103,6 +7237,13 @@ async def _acontinue_run(
 
                 if run_response.status == RunStatus.cancelled:
                     raise ValueError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+
+                # Install this run's metrics sink so nested runs inside resumed
+                # tools report here. The public acontinue_run scope restores the
+                # previous sink when this run finishes.
+                if run_response.metrics is None:
+                    run_response.metrics = RunMetrics()
+                swap_nested_run_metrics_sink(run_response.metrics)
 
                 # Save old requirements before overwriting — needed for member-level approval fields
                 old_requirements = run_response.requirements
@@ -7469,6 +7610,13 @@ async def _acontinue_run_stream(
 
                 if run_response.status == RunStatus.cancelled:
                     raise ValueError(f"Cannot continue run {run_response.run_id}: run is cancelled")
+
+                # Install this run's metrics sink so nested runs inside resumed
+                # tools report here. The public acontinue_run scope restores the
+                # previous sink between yields.
+                if run_response.metrics is None:
+                    run_response.metrics = RunMetrics()
+                swap_nested_run_metrics_sink(run_response.metrics)
 
                 # Save old requirements before overwriting — needed for member-level approval fields
                 old_requirements = run_response.requirements

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from agno.team.team import Team
 
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import (
     Any,
     AsyncIterator,
@@ -24,6 +24,7 @@ from agno.agent import Agent
 from agno.exceptions import RunCancelledException
 from agno.media import Audio, File, Image, Video
 from agno.run import RunContext
+from agno.run._nested_metrics import ashielded_stream, shielded_metrics_sink, shielded_stream
 from agno.run.agent import (
     RunCancelledEvent as AgentRunCancelledEvent,
 )
@@ -389,7 +390,10 @@ def _get_task_management_tools(
                 from agno.agent._run import scrub_run_output_for_storage
 
                 scrub_run_output_for_storage(member_agent, run_response=member_run_response)  # type: ignore[arg-type]
-            session.upsert_run(member_run_response)
+            # Add a shallow copy of the member run to the team session — save_session
+            # scrubs member_responses on stored runs, which must not reach the response
+            # attached to the team run's member_responses
+            session.upsert_run(copy(member_run_response))
 
         if run_context.session_state is not None and member_session_state_copy is not None and not skip_session_merge:
             merge_dictionaries(run_context.session_state, member_session_state_copy)
@@ -446,27 +450,31 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_stream = member_agent.run(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=_images,
-                    videos=_videos,
-                    audio=_audio,
-                    files=_files,
-                    stream=True,
-                    stream_events=stream_events or team.stream_member_events,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    metadata=run_context.metadata,
-                    add_session_state_to_context=add_session_state_to_context,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                    yield_run_output=True,
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                member_stream = shielded_stream(
+                    member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=_images,
+                        videos=_videos,
+                        audio=_audio,
+                        files=_files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        metadata=run_context.metadata,
+                        add_session_state_to_context=add_session_state_to_context,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
                 )
                 draining_after_cancel = False
                 for event in member_stream:
@@ -498,26 +506,29 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_run_response = member_agent.run(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=_images,
-                    videos=_videos,
-                    audio=_audio,
-                    files=_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                )
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                with shielded_metrics_sink():
+                    member_run_response = member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=_images,
+                        videos=_videos,
+                        audio=_audio,
+                        files=_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
                 check_if_run_cancelled(member_run_response)
                 if run_response.run_id is not None:
                     raise_if_cancelled(run_response.run_id)
@@ -625,27 +636,31 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_stream = member_agent.arun(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=_images,
-                    videos=_videos,
-                    audio=_audio,
-                    files=_files,
-                    stream=True,
-                    stream_events=stream_events or team.stream_member_events,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    metadata=run_context.metadata,
-                    add_session_state_to_context=add_session_state_to_context,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                    yield_run_output=True,
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                member_stream = ashielded_stream(
+                    member_agent.arun(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=_images,
+                        videos=_videos,
+                        audio=_audio,
+                        files=_files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        metadata=run_context.metadata,
+                        add_session_state_to_context=add_session_state_to_context,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
                 )
                 draining_after_cancel = False
                 async for event in member_stream:
@@ -677,26 +692,29 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_run_response = await member_agent.arun(  # type: ignore[misc]
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=_images,
-                    videos=_videos,
-                    audio=_audio,
-                    files=_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                )
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                with shielded_metrics_sink():
+                    member_run_response = await member_agent.arun(  # type: ignore[misc]
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=_images,
+                        videos=_videos,
+                        audio=_audio,
+                        files=_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
                 check_if_run_cancelled(member_run_response)
                 if run_response.run_id is not None:
                     raise_if_cancelled(run_response.run_id)
@@ -814,26 +832,29 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_run_response = member_agent.run(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=thread_images,
-                    videos=thread_videos,
-                    audio=thread_audio,
-                    files=thread_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                )
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                with shielded_metrics_sink():
+                    member_run_response = member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=thread_images,
+                        videos=thread_videos,
+                        audio=thread_audio,
+                        files=thread_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
                 return (task_obj.id, member_run_response, member_session_state_copy, member_agent_task, None)
             except RunCancelledException:
                 raise
@@ -1020,26 +1041,29 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_run_response = await member_agent.arun(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=task_images,
-                    videos=task_videos,
-                    audio=task_audio,
-                    files=task_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
-                )
+                # Member metrics are aggregated through member_responses, so the
+                # member run must not also report to the ambient metrics sink
+                with shielded_metrics_sink():
+                    member_run_response = await member_agent.arun(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=task_images,
+                        videos=task_videos,
+                        audio=task_audio,
+                        files=task_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
                 return (task_obj.id, member_run_response, member_session_state_copy, member_agent_task, None)
             except RunCancelledException:
                 raise

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -16,6 +16,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
     overload,
 )
 
@@ -31,7 +32,7 @@ from agno.knowledge.protocol import KnowledgeProtocol
 from agno.learn.machine import LearningMachine
 from agno.media import Audio, File, Image, Video
 from agno.memory import MemoryManager
-from agno.metrics import SessionMetrics
+from agno.metrics import SessionMetrics, swap_nested_run_metrics_sink
 from agno.models.base import Model
 from agno.models.fallback import FallbackConfig
 from agno.models.message import Message
@@ -39,6 +40,12 @@ from agno.models.metrics import RunMetrics
 from agno.models.response import ModelResponse
 from agno.registry.registry import Registry
 from agno.run import RunContext, RunStatus
+from agno.run._nested_metrics import (
+    arun_stream_with_metrics_scope,
+    arun_with_metrics_scope,
+    report_run_to_parent,
+    run_stream_with_metrics_scope,
+)
 from agno.run.agent import RunEvent, RunOutput, RunOutputEvent
 from agno.run.team import (
     TeamRunEvent,
@@ -1020,22 +1027,49 @@ class Team:
         yield_run_output: bool = False,
         **kwargs,
     ) -> Union[TeamRunOutput, Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]]:
-        return _run.continue_run_dispatch(
-            self,
-            run_response=run_response,
+        if run_response is not None and run_response.metrics is None:
+            run_response.metrics = RunMetrics()
+        sink = run_response.metrics if run_response is not None else None
+        # A run continued by run_id only yields its resolved output when
+        # yield_run_output is set — force it so the metrics scope can adopt the
+        # output, and swallow it again unless the caller asked for it
+        resolve_run_output = run_response is None and run_id is not None
+
+        result = None
+        parent_sink = swap_nested_run_metrics_sink(sink)
+        try:
+            result = _run.continue_run_dispatch(
+                self,
+                run_response=run_response,
+                run_id=run_id,
+                requirements=requirements,
+                stream=stream,
+                stream_events=stream_events,
+                user_id=user_id,
+                session_id=session_id,
+                run_context=run_context,
+                knowledge_filters=knowledge_filters,
+                dependencies=dependencies,
+                metadata=metadata,
+                debug_mode=debug_mode,
+                yield_run_output=yield_run_output or resolve_run_output,
+                **kwargs,
+            )
+        finally:
+            swap_nested_run_metrics_sink(parent_sink)
+            # A dispatch that raises still reports the partial run, matching the
+            # dispatch-level scopes. Streams report through the scope wrapper below.
+            if result is None:
+                report_run_to_parent(parent_sink, run_response)
+        if isinstance(result, TeamRunOutput):
+            report_run_to_parent(parent_sink, result)
+            return result
+        return run_stream_with_metrics_scope(
+            result,
+            run_response,
+            sink=sink,
             run_id=run_id,
-            requirements=requirements,
-            stream=stream,
-            stream_events=stream_events,
-            user_id=user_id,
-            session_id=session_id,
-            run_context=run_context,
-            knowledge_filters=knowledge_filters,
-            dependencies=dependencies,
-            metadata=metadata,
-            debug_mode=debug_mode,
-            yield_run_output=yield_run_output,
-            **kwargs,
+            swallow_run_output=resolve_run_output and not yield_run_output,
         )
 
     @overload
@@ -1093,7 +1127,15 @@ class Team:
         background: bool = False,
         **kwargs: Any,
     ) -> Union[TeamRunOutput, AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]]:
-        return _run.acontinue_run_dispatch(
+        if run_response is not None and run_response.metrics is None:
+            run_response.metrics = RunMetrics()
+        sink = run_response.metrics if run_response is not None else None
+        # A run continued by run_id only yields its resolved output when
+        # yield_run_output is set — force it so the metrics scope can adopt the
+        # output, and swallow it again unless the caller asked for it
+        resolve_run_output = run_response is None and run_id is not None
+
+        result = _run.acontinue_run_dispatch(
             self,
             run_response=run_response,
             run_id=run_id,
@@ -1107,9 +1149,23 @@ class Team:
             dependencies=dependencies,
             metadata=metadata,
             debug_mode=debug_mode,
-            yield_run_output=yield_run_output,
+            yield_run_output=yield_run_output or resolve_run_output,
             background=background,
             **kwargs,
+        )
+        if background:
+            # Detached run — the background producer shields its own metrics sink
+            return result
+        if hasattr(result, "__anext__"):
+            return arun_stream_with_metrics_scope(
+                cast(AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]], result),
+                run_response,
+                sink=sink,
+                run_id=run_id,
+                swallow_run_output=resolve_run_output and not yield_run_output,
+            )
+        return arun_with_metrics_scope(  # type: ignore[return-value]
+            cast(Coroutine[Any, Any, TeamRunOutput], result), run_response, sink=sink
         )
 
     def _handle_model_response_chunk(

--- a/libs/agno/agno/workflow/agent.py
+++ b/libs/agno/agno/workflow/agent.py
@@ -3,8 +3,15 @@
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from agno.agent import Agent
+from agno.metrics import swap_nested_run_metrics_sink
 from agno.models.base import Model
 from agno.run import RunContext
+from agno.run._nested_metrics import (
+    arun_stream_with_metrics_scope,
+    arun_with_metrics_scope,
+    report_run_to_parent,
+    run_stream_with_metrics_scope,
+)
 
 if TYPE_CHECKING:
     from agno.os.managers import WebSocketHandler
@@ -147,14 +154,21 @@ Guidelines:
             )
 
             # ===== EXECUTION LOGIC (Based on streaming mode) =====
+            # Steps report through StepOutput metrics, so the workflow shields the
+            # ambient sink (sink=None) and reports its aggregated step metrics to the
+            # workflow agent's run (mirrors the Workflow.run dispatch scope).
             if stream:
                 final_content = ""
-                for event in workflow._execute_stream(
-                    session=session_from_db,
-                    run_context=run_context,
-                    execution_input=workflow_execution_input,
-                    workflow_run_response=workflow_run_response,
-                    stream_events=True,
+                for event in run_stream_with_metrics_scope(
+                    workflow._execute_stream(
+                        session=session_from_db,
+                        run_context=run_context,
+                        execution_input=workflow_execution_input,
+                        workflow_run_response=workflow_run_response,
+                        stream_events=True,
+                    ),
+                    workflow_run_response,
+                    sink=None,
                 ):
                     yield event
 
@@ -167,12 +181,18 @@ Guidelines:
                 return final_content
             else:
                 # NON-STREAMING MODE: Execute synchronously
-                result = workflow._execute(
-                    session=session_from_db,
-                    execution_input=workflow_execution_input,
-                    workflow_run_response=workflow_run_response,
-                    run_context=run_context,
-                )
+                result = workflow_run_response
+                parent_sink = swap_nested_run_metrics_sink(None)
+                try:
+                    result = workflow._execute(
+                        session=session_from_db,
+                        execution_input=workflow_execution_input,
+                        workflow_run_response=workflow_run_response,
+                        run_context=run_context,
+                    )
+                finally:
+                    swap_nested_run_metrics_sink(parent_sink)
+                    report_run_to_parent(parent_sink, result)
 
                 if isinstance(result.content, str):
                     return result.content
@@ -261,16 +281,23 @@ Guidelines:
                 files=execution_input.files,
             )
 
+            # Steps report through StepOutput metrics, so the workflow shields the
+            # ambient sink (sink=None) and reports its aggregated step metrics to the
+            # workflow agent's run (mirrors the Workflow.arun dispatch scope).
             if stream:
                 final_content = ""
-                async for event in workflow._aexecute_stream(
-                    session_id=session_from_db.session_id,
-                    user_id=session_from_db.user_id,
-                    execution_input=workflow_execution_input,
-                    workflow_run_response=workflow_run_response,
-                    run_context=run_context,
-                    stream_events=True,
-                    websocket_handler=websocket_handler,
+                async for event in arun_stream_with_metrics_scope(
+                    workflow._aexecute_stream(
+                        session_id=session_from_db.session_id,
+                        user_id=session_from_db.user_id,
+                        execution_input=workflow_execution_input,
+                        workflow_run_response=workflow_run_response,
+                        run_context=run_context,
+                        stream_events=True,
+                        websocket_handler=websocket_handler,
+                    ),
+                    workflow_run_response,
+                    sink=None,
                 ):
                     yield event
 
@@ -281,12 +308,16 @@ Guidelines:
 
                 yield final_content
             else:
-                result = await workflow._aexecute(
-                    session_id=session_from_db.session_id,
-                    user_id=session_from_db.user_id,
-                    execution_input=workflow_execution_input,
-                    workflow_run_response=workflow_run_response,
-                    run_context=run_context,
+                result = await arun_with_metrics_scope(
+                    workflow._aexecute(
+                        session_id=session_from_db.session_id,
+                        user_id=session_from_db.user_id,
+                        execution_input=workflow_execution_input,
+                        workflow_run_response=workflow_run_response,
+                        run_context=run_context,
+                    ),
+                    workflow_run_response,
+                    sink=None,
                 )
 
                 if isinstance(result.content, str):

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -18,6 +18,7 @@ from agno.models.message import Message
 from agno.models.metrics import RunMetrics
 from agno.registry import Registry
 from agno.run import RunContext
+from agno.run._nested_metrics import has_token_metrics, metrics_collection_sink, total_run_metrics
 from agno.run.agent import (
     RunCancelledEvent as AgentRunCancelledEvent,
 )
@@ -686,9 +687,13 @@ class Step:
             raise ValueError("No executor configured")
 
     def _extract_metrics_from_response(self, response: Union[RunOutput, TeamRunOutput]) -> Optional[RunMetrics]:
-        """Extract metrics from agent or team response"""
+        """Extract metrics from agent or team response.
+
+        For team responses this includes member metrics, which live on
+        member_responses rather than the team's own run metrics.
+        """
         if hasattr(response, "metrics") and response.metrics:
-            return response.metrics
+            return total_run_metrics(response)
         return None
 
     def _call_custom_function(
@@ -769,74 +774,78 @@ class Step:
                 if self._executor_type == "function":
                     if _is_async_callable(self.active_executor) or _is_async_generator_function(self.active_executor):
                         raise ValueError("Cannot use async function with synchronous execution")
-                    if _is_generator_function(self.active_executor):
-                        content = ""
-                        final_response = None
-                        try:
-                            for chunk in self._call_custom_function(
-                                self.active_executor,
+                    # Nested agent/team/workflow runs started inside the function
+                    # report their metrics into the collection sink
+                    with metrics_collection_sink() as collected_metrics:
+                        if _is_generator_function(self.active_executor):
+                            content = ""
+                            final_response = None
+                            try:
+                                for chunk in self._call_custom_function(
+                                    self.active_executor,
+                                    step_input,
+                                    session_state_copy,  # type: ignore[arg-type]
+                                    run_context,
+                                ):  # type: ignore
+                                    if isinstance(chunk, (BaseRunOutputEvent)):
+                                        if (
+                                            isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
+                                            and chunk.content is not None
+                                        ):
+                                            # Its a regular chunk of content
+                                            if isinstance(chunk.content, str):
+                                                content += chunk.content
+                                            # Its the BaseModel object, set it as the content. Replace any previous content.
+                                            # There should be no previous str content at this point
+                                            elif isinstance(chunk.content, BaseModel):
+                                                content = chunk.content  # type: ignore[assignment]
+                                            else:
+                                                # Case when parse_response is False and the content is a dict
+                                                content += str(chunk.content)
+                                    elif isinstance(chunk, (RunOutput, TeamRunOutput)):
+                                        # This is the final response from the agent/team
+                                        content = chunk.content  # type: ignore[assignment]
+                                    # If the chunk is a StepOutput, use it as the final response
+                                    elif isinstance(chunk, StepOutput):
+                                        final_response = chunk
+                                        break
+                                    # Non Agent/Team data structure that was yielded
+                                    else:
+                                        content += str(chunk)
+
+                            except StopIteration as e:
+                                if hasattr(e, "value") and isinstance(e.value, StepOutput):
+                                    final_response = e.value
+
+                            # Merge session_state changes back
+                            if run_context is None and session_state is not None:
+                                merge_dictionaries(session_state, session_state_copy)
+
+                            if final_response is not None:
+                                response = final_response
+                            else:
+                                response = StepOutput(content=content)
+                        else:
+                            # Execute function with signature inspection for session_state support
+                            result = self._call_custom_function(
+                                self.active_executor,  # type: ignore[arg-type]
                                 step_input,
-                                session_state_copy,  # type: ignore[arg-type]
+                                session_state_copy,
                                 run_context,
-                            ):  # type: ignore
-                                if isinstance(chunk, (BaseRunOutputEvent)):
-                                    if (
-                                        isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
-                                        and chunk.content is not None
-                                    ):
-                                        # Its a regular chunk of content
-                                        if isinstance(chunk.content, str):
-                                            content += chunk.content
-                                        # Its the BaseModel object, set it as the content. Replace any previous content.
-                                        # There should be no previous str content at this point
-                                        elif isinstance(chunk.content, BaseModel):
-                                            content = chunk.content  # type: ignore[assignment]
-                                        else:
-                                            # Case when parse_response is False and the content is a dict
-                                            content += str(chunk.content)
-                                elif isinstance(chunk, (RunOutput, TeamRunOutput)):
-                                    # This is the final response from the agent/team
-                                    content = chunk.content  # type: ignore[assignment]
-                                # If the chunk is a StepOutput, use it as the final response
-                                elif isinstance(chunk, StepOutput):
-                                    final_response = chunk
-                                    break
-                                # Non Agent/Team data structure that was yielded
-                                else:
-                                    content += str(chunk)
+                            )
 
-                        except StopIteration as e:
-                            if hasattr(e, "value") and isinstance(e.value, StepOutput):
-                                final_response = e.value
+                            # Merge session_state changes back
+                            if run_context is None and session_state is not None:
+                                merge_dictionaries(session_state, session_state_copy)
 
-                        # Merge session_state changes back
-                        if run_context is None and session_state is not None:
-                            merge_dictionaries(session_state, session_state_copy)
-
-                        if final_response is not None:
-                            response = final_response
-                        else:
-                            response = StepOutput(content=content)
-                    else:
-                        # Execute function with signature inspection for session_state support
-                        result = self._call_custom_function(
-                            self.active_executor,  # type: ignore[arg-type]
-                            step_input,
-                            session_state_copy,
-                            run_context,
-                        )
-
-                        # Merge session_state changes back
-                        if run_context is None and session_state is not None:
-                            merge_dictionaries(session_state, session_state_copy)
-
-                        # If function returns StepOutput, use it directly
-                        if isinstance(result, StepOutput):
-                            response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            response = StepOutput(content=result.content)
-                        else:
-                            response = StepOutput(content=str(result))
+                            # If function returns StepOutput, use it directly
+                            if isinstance(result, StepOutput):
+                                response = result
+                            elif isinstance(result, (RunOutput, TeamRunOutput)):
+                                response = StepOutput(content=result.content)
+                            else:
+                                response = StepOutput(content=str(result))
+                    self._attach_function_step_metrics(response, collected_metrics)
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -1108,71 +1117,75 @@ class Step:
                     log_debug(f"Executing function executor for step: {self.name}")
                     if _is_async_callable(self.active_executor) or _is_async_generator_function(self.active_executor):
                         raise ValueError("Cannot use async function with synchronous execution")
-                    if _is_generator_function(self.active_executor):
-                        log_debug("Function returned iterable, streaming events")
-                        content = ""
-                        try:
-                            iterator = self._call_custom_function(
-                                self.active_executor,
+                    # Nested agent/team/workflow runs started inside the function
+                    # report their metrics into the collection sink
+                    with metrics_collection_sink() as collected_metrics:
+                        if _is_generator_function(self.active_executor):
+                            log_debug("Function returned iterable, streaming events")
+                            content = ""
+                            try:
+                                iterator = self._call_custom_function(
+                                    self.active_executor,
+                                    step_input,
+                                    session_state_copy,
+                                    run_context,
+                                )
+                                for event in iterator:  # type: ignore
+                                    if isinstance(event, (BaseRunOutputEvent)):
+                                        if (
+                                            isinstance(event, (RunContentEvent, TeamRunContentEvent))
+                                            and event.content is not None
+                                        ):
+                                            if isinstance(event.content, str):
+                                                content += event.content
+                                            elif isinstance(event.content, BaseModel):
+                                                content = event.content  # type: ignore[assignment]
+                                            else:
+                                                content = str(event.content)
+                                        # Only yield executor events if stream_executor_events is True
+                                        if stream_executor_events or isinstance(event, _EXECUTOR_TERMINAL_EVENT_TYPES):
+                                            enriched_event = self._enrich_event_with_context(
+                                                event, workflow_run_response, step_index
+                                            )
+                                            yield enriched_event  # type: ignore[misc]
+                                    elif isinstance(event, (RunOutput, TeamRunOutput)):
+                                        content = event.content  # type: ignore[assignment]
+                                    elif isinstance(event, StepOutput):
+                                        final_response = event
+                                        break
+                                    else:
+                                        content += str(event)
+
+                                # Merge session_state changes back
+                                if run_context is None and session_state is not None:
+                                    merge_dictionaries(session_state, session_state_copy)
+
+                                if not final_response:
+                                    final_response = StepOutput(content=content)
+                            except StopIteration as e:
+                                if hasattr(e, "value") and isinstance(e.value, StepOutput):
+                                    final_response = e.value
+
+                        else:
+                            result = self._call_custom_function(
+                                self.active_executor,  # type: ignore[arg-type]
                                 step_input,
                                 session_state_copy,
                                 run_context,
                             )
-                            for event in iterator:  # type: ignore
-                                if isinstance(event, (BaseRunOutputEvent)):
-                                    if (
-                                        isinstance(event, (RunContentEvent, TeamRunContentEvent))
-                                        and event.content is not None
-                                    ):
-                                        if isinstance(event.content, str):
-                                            content += event.content
-                                        elif isinstance(event.content, BaseModel):
-                                            content = event.content  # type: ignore[assignment]
-                                        else:
-                                            content = str(event.content)
-                                    # Only yield executor events if stream_executor_events is True
-                                    if stream_executor_events or isinstance(event, _EXECUTOR_TERMINAL_EVENT_TYPES):
-                                        enriched_event = self._enrich_event_with_context(
-                                            event, workflow_run_response, step_index
-                                        )
-                                        yield enriched_event  # type: ignore[misc]
-                                elif isinstance(event, (RunOutput, TeamRunOutput)):
-                                    content = event.content  # type: ignore[assignment]
-                                elif isinstance(event, StepOutput):
-                                    final_response = event
-                                    break
-                                else:
-                                    content += str(event)
 
                             # Merge session_state changes back
                             if run_context is None and session_state is not None:
                                 merge_dictionaries(session_state, session_state_copy)
 
-                            if not final_response:
-                                final_response = StepOutput(content=content)
-                        except StopIteration as e:
-                            if hasattr(e, "value") and isinstance(e.value, StepOutput):
-                                final_response = e.value
-
-                    else:
-                        result = self._call_custom_function(
-                            self.active_executor,  # type: ignore[arg-type]
-                            step_input,
-                            session_state_copy,
-                            run_context,
-                        )
-
-                        # Merge session_state changes back
-                        if run_context is None and session_state is not None:
-                            merge_dictionaries(session_state, session_state_copy)
-
-                        if isinstance(result, StepOutput):
-                            final_response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            final_response = StepOutput(content=result.content)
-                        else:
-                            final_response = StepOutput(content=str(result))
-                        log_debug("Function returned non-iterable, created StepOutput")
+                            if isinstance(result, StepOutput):
+                                final_response = result
+                            elif isinstance(result, (RunOutput, TeamRunOutput)):
+                                final_response = StepOutput(content=result.content)
+                            else:
+                                final_response = StepOutput(content=str(result))
+                            log_debug("Function returned non-iterable, created StepOutput")
+                    self._attach_function_step_metrics(final_response, collected_metrics)
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -1410,48 +1423,23 @@ class Step:
         for attempt in range(self.max_retries + 1):
             try:
                 if self._executor_type == "function":
-                    if _is_generator_function(self.active_executor) or _is_async_generator_function(
-                        self.active_executor
-                    ):
-                        content = ""
-                        final_response = None
-                        try:
-                            if _is_generator_function(self.active_executor):
-                                iterator = self._call_custom_function(
-                                    self.active_executor,
-                                    step_input,
-                                    session_state_copy,
-                                    run_context,
-                                )
-                                for chunk in iterator:  # type: ignore
-                                    if isinstance(chunk, (BaseRunOutputEvent)):
-                                        if (
-                                            isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
-                                            and chunk.content is not None
-                                        ):
-                                            if isinstance(chunk.content, str):
-                                                content += chunk.content
-                                            elif isinstance(chunk.content, BaseModel):
-                                                content = chunk.content  # type: ignore[assignment]
-                                            else:
-                                                content = str(chunk.content)
-                                    elif isinstance(chunk, (RunOutput, TeamRunOutput)):
-                                        content = chunk.content  # type: ignore[assignment]
-                                    elif isinstance(chunk, StepOutput):
-                                        final_response = chunk
-                                        break
-                                    else:
-                                        content += str(chunk)
-
-                            else:
-                                if _is_async_generator_function(self.active_executor):
-                                    iterator = await self._acall_custom_function(
+                    # Nested agent/team/workflow runs started inside the function
+                    # report their metrics into the collection sink
+                    with metrics_collection_sink() as collected_metrics:
+                        if _is_generator_function(self.active_executor) or _is_async_generator_function(
+                            self.active_executor
+                        ):
+                            content = ""
+                            final_response = None
+                            try:
+                                if _is_generator_function(self.active_executor):
+                                    iterator = self._call_custom_function(
                                         self.active_executor,
                                         step_input,
                                         session_state_copy,
                                         run_context,
                                     )
-                                    async for chunk in iterator:  # type: ignore
+                                    for chunk in iterator:  # type: ignore
                                         if isinstance(chunk, (BaseRunOutputEvent)):
                                             if (
                                                 isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
@@ -1471,45 +1459,74 @@ class Step:
                                         else:
                                             content += str(chunk)
 
-                        except StopIteration as e:
-                            if hasattr(e, "value") and isinstance(e.value, StepOutput):
-                                final_response = e.value
+                                else:
+                                    if _is_async_generator_function(self.active_executor):
+                                        iterator = await self._acall_custom_function(
+                                            self.active_executor,
+                                            step_input,
+                                            session_state_copy,
+                                            run_context,
+                                        )
+                                        async for chunk in iterator:  # type: ignore
+                                            if isinstance(chunk, (BaseRunOutputEvent)):
+                                                if (
+                                                    isinstance(chunk, (RunContentEvent, TeamRunContentEvent))
+                                                    and chunk.content is not None
+                                                ):
+                                                    if isinstance(chunk.content, str):
+                                                        content += chunk.content
+                                                    elif isinstance(chunk.content, BaseModel):
+                                                        content = chunk.content  # type: ignore[assignment]
+                                                    else:
+                                                        content = str(chunk.content)
+                                            elif isinstance(chunk, (RunOutput, TeamRunOutput)):
+                                                content = chunk.content  # type: ignore[assignment]
+                                            elif isinstance(chunk, StepOutput):
+                                                final_response = chunk
+                                                break
+                                            else:
+                                                content += str(chunk)
 
-                        # Merge session_state changes back
-                        if run_context is None and session_state is not None:
-                            merge_dictionaries(session_state, session_state_copy)
+                            except StopIteration as e:
+                                if hasattr(e, "value") and isinstance(e.value, StepOutput):
+                                    final_response = e.value
 
-                        if final_response is not None:
-                            response = final_response
+                            # Merge session_state changes back
+                            if run_context is None and session_state is not None:
+                                merge_dictionaries(session_state, session_state_copy)
+
+                            if final_response is not None:
+                                response = final_response
+                            else:
+                                response = StepOutput(content=content)
                         else:
-                            response = StepOutput(content=content)
-                    else:
-                        if _is_async_callable(self.active_executor):
-                            result = await self._acall_custom_function(
-                                self.active_executor,
-                                step_input,
-                                session_state_copy,
-                                run_context,
-                            )
-                        else:
-                            result = self._call_custom_function(
-                                self.active_executor,  # type: ignore[arg-type]
-                                step_input,
-                                session_state_copy,
-                                run_context,
-                            )
+                            if _is_async_callable(self.active_executor):
+                                result = await self._acall_custom_function(
+                                    self.active_executor,
+                                    step_input,
+                                    session_state_copy,
+                                    run_context,
+                                )
+                            else:
+                                result = self._call_custom_function(
+                                    self.active_executor,  # type: ignore[arg-type]
+                                    step_input,
+                                    session_state_copy,
+                                    run_context,
+                                )
 
-                        # Merge session_state changes back
-                        if run_context is None and session_state is not None:
-                            merge_dictionaries(session_state, session_state_copy)
+                            # Merge session_state changes back
+                            if run_context is None and session_state is not None:
+                                merge_dictionaries(session_state, session_state_copy)
 
-                        # If function returns StepOutput, use it directly
-                        if isinstance(result, StepOutput):
-                            response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            response = StepOutput(content=result.content)
-                        else:
-                            response = StepOutput(content=str(result))
+                            # If function returns StepOutput, use it directly
+                            if isinstance(result, StepOutput):
+                                response = result
+                            elif isinstance(result, (RunOutput, TeamRunOutput)):
+                                response = StepOutput(content=result.content)
+                            else:
+                                response = StepOutput(content=str(result))
+                    self._attach_function_step_metrics(response, collected_metrics)
 
                 else:
                     # For agents and teams, prepare message with context
@@ -1711,116 +1728,120 @@ class Step:
                 if self._executor_type == "function":
                     log_debug(f"Executing async function executor for step: {self.name}")
 
-                    # Check if the function is an async generator
-                    if _is_async_generator_function(self.active_executor):
-                        content = ""
-                        # It's an async generator - iterate over it
-                        iterator = await self._acall_custom_function(
-                            self.active_executor,
-                            step_input,
-                            session_state_copy,
-                            run_context,
-                        )
-                        async for event in iterator:  # type: ignore
-                            if isinstance(event, (BaseRunOutputEvent)):
-                                if (
-                                    isinstance(event, (RunContentEvent, TeamRunContentEvent))
-                                    and event.content is not None
-                                ):
-                                    if isinstance(event.content, str):
-                                        content += event.content
-                                    elif isinstance(event.content, BaseModel):
-                                        content = event.content  # type: ignore[assignment]
-                                    else:
-                                        content = str(event.content)
+                    # Nested agent/team/workflow runs started inside the function
+                    # report their metrics into the collection sink
+                    with metrics_collection_sink() as collected_metrics:
+                        # Check if the function is an async generator
+                        if _is_async_generator_function(self.active_executor):
+                            content = ""
+                            # It's an async generator - iterate over it
+                            iterator = await self._acall_custom_function(
+                                self.active_executor,
+                                step_input,
+                                session_state_copy,
+                                run_context,
+                            )
+                            async for event in iterator:  # type: ignore
+                                if isinstance(event, (BaseRunOutputEvent)):
+                                    if (
+                                        isinstance(event, (RunContentEvent, TeamRunContentEvent))
+                                        and event.content is not None
+                                    ):
+                                        if isinstance(event.content, str):
+                                            content += event.content
+                                        elif isinstance(event.content, BaseModel):
+                                            content = event.content  # type: ignore[assignment]
+                                        else:
+                                            content = str(event.content)
 
-                                # Only yield executor events if stream_executor_events is True
-                                if stream_executor_events or isinstance(event, _EXECUTOR_TERMINAL_EVENT_TYPES):
-                                    enriched_event = self._enrich_event_with_context(
-                                        event, workflow_run_response, step_index
-                                    )
-                                    yield enriched_event  # type: ignore[misc]
-                            elif isinstance(event, (RunOutput, TeamRunOutput)):
-                                content = event.content  # type: ignore[assignment]
-                            elif isinstance(event, StepOutput):
-                                final_response = event
-                                break
-                            else:
-                                content += str(event)
-                        if not final_response:
-                            final_response = StepOutput(content=content)
-                    elif _is_async_callable(self.active_executor):
-                        # It's a regular async function - await it
-                        result = await self._acall_custom_function(
-                            self.active_executor,
-                            step_input,
-                            session_state_copy,
-                            run_context,
-                        )
-                        if isinstance(result, StepOutput):
-                            final_response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            final_response = StepOutput(content=result.content)
-                        else:
-                            final_response = StepOutput(content=str(result))
-                    elif _is_generator_function(self.active_executor):
-                        content = ""
-                        # It's a regular generator function - iterate over it
-                        iterator = self._call_custom_function(
-                            self.active_executor,
-                            step_input,
-                            session_state_copy,
-                            run_context,
-                        )
-                        for event in iterator:  # type: ignore
-                            if isinstance(event, (BaseRunOutputEvent)):
-                                if (
-                                    isinstance(event, (RunContentEvent, TeamRunContentEvent))
-                                    and event.content is not None
-                                ):
-                                    if isinstance(event.content, str):
-                                        content += event.content
-                                    elif isinstance(event.content, BaseModel):
-                                        content = event.content  # type: ignore[assignment]
-                                    else:
-                                        content = str(event.content)
-
-                                # Only yield executor events if stream_executor_events is True
-                                if stream_executor_events or isinstance(event, _EXECUTOR_TERMINAL_EVENT_TYPES):
-                                    enriched_event = self._enrich_event_with_context(
-                                        event, workflow_run_response, step_index
-                                    )
-                                    yield enriched_event  # type: ignore[misc]
-                            elif isinstance(event, (RunOutput, TeamRunOutput)):
-                                content = event.content  # type: ignore[assignment]
-                            elif isinstance(event, StepOutput):
-                                final_response = event
-                                break
-                            else:
-                                if isinstance(content, str):
-                                    content += str(event)
+                                    # Only yield executor events if stream_executor_events is True
+                                    if stream_executor_events or isinstance(event, _EXECUTOR_TERMINAL_EVENT_TYPES):
+                                        enriched_event = self._enrich_event_with_context(
+                                            event, workflow_run_response, step_index
+                                        )
+                                        yield enriched_event  # type: ignore[misc]
+                                elif isinstance(event, (RunOutput, TeamRunOutput)):
+                                    content = event.content  # type: ignore[assignment]
+                                elif isinstance(event, StepOutput):
+                                    final_response = event
+                                    break
                                 else:
-                                    content = str(event)
-                        if not final_response:
-                            final_response = StepOutput(content=content)
-                    else:
-                        # It's a regular function - call it directly
-                        result = self._call_custom_function(
-                            self.active_executor,  # type: ignore[arg-type]
-                            step_input,
-                            session_state_copy,
-                            run_context,
-                        )
-                        if isinstance(result, StepOutput):
-                            final_response = result
-                        elif isinstance(result, (RunOutput, TeamRunOutput)):
-                            final_response = StepOutput(content=result.content)
-                        else:
-                            final_response = StepOutput(content=str(result))
+                                    content += str(event)
+                            if not final_response:
+                                final_response = StepOutput(content=content)
+                        elif _is_async_callable(self.active_executor):
+                            # It's a regular async function - await it
+                            result = await self._acall_custom_function(
+                                self.active_executor,
+                                step_input,
+                                session_state_copy,
+                                run_context,
+                            )
+                            if isinstance(result, StepOutput):
+                                final_response = result
+                            elif isinstance(result, (RunOutput, TeamRunOutput)):
+                                final_response = StepOutput(content=result.content)
+                            else:
+                                final_response = StepOutput(content=str(result))
+                        elif _is_generator_function(self.active_executor):
+                            content = ""
+                            # It's a regular generator function - iterate over it
+                            iterator = self._call_custom_function(
+                                self.active_executor,
+                                step_input,
+                                session_state_copy,
+                                run_context,
+                            )
+                            for event in iterator:  # type: ignore
+                                if isinstance(event, (BaseRunOutputEvent)):
+                                    if (
+                                        isinstance(event, (RunContentEvent, TeamRunContentEvent))
+                                        and event.content is not None
+                                    ):
+                                        if isinstance(event.content, str):
+                                            content += event.content
+                                        elif isinstance(event.content, BaseModel):
+                                            content = event.content  # type: ignore[assignment]
+                                        else:
+                                            content = str(event.content)
 
-                    # Merge session_state changes back
-                    if run_context is None and session_state is not None:
-                        merge_dictionaries(session_state, session_state_copy)
+                                    # Only yield executor events if stream_executor_events is True
+                                    if stream_executor_events or isinstance(event, _EXECUTOR_TERMINAL_EVENT_TYPES):
+                                        enriched_event = self._enrich_event_with_context(
+                                            event, workflow_run_response, step_index
+                                        )
+                                        yield enriched_event  # type: ignore[misc]
+                                elif isinstance(event, (RunOutput, TeamRunOutput)):
+                                    content = event.content  # type: ignore[assignment]
+                                elif isinstance(event, StepOutput):
+                                    final_response = event
+                                    break
+                                else:
+                                    if isinstance(content, str):
+                                        content += str(event)
+                                    else:
+                                        content = str(event)
+                            if not final_response:
+                                final_response = StepOutput(content=content)
+                        else:
+                            # It's a regular function - call it directly
+                            result = self._call_custom_function(
+                                self.active_executor,  # type: ignore[arg-type]
+                                step_input,
+                                session_state_copy,
+                                run_context,
+                            )
+                            if isinstance(result, StepOutput):
+                                final_response = result
+                            elif isinstance(result, (RunOutput, TeamRunOutput)):
+                                final_response = StepOutput(content=result.content)
+                            else:
+                                final_response = StepOutput(content=str(result))
+
+                        # Merge session_state changes back
+                        if run_context is None and session_state is not None:
+                            merge_dictionaries(session_state, session_state_copy)
+                    self._attach_function_step_metrics(final_response, collected_metrics)
                 else:
                     # For agents and teams, prepare message with context
                     message = self._prepare_message(
@@ -2300,6 +2321,21 @@ class Step:
                     if isinstance(s, StepOutput):
                         nested_steps.append(s)
         return nested_steps
+
+    @staticmethod
+    def _attach_function_step_metrics(step_output: Optional[StepOutput], collected_metrics: RunMetrics) -> None:
+        """Attach metrics collected from nested runs inside a custom function step.
+
+        Nested agent/team/workflow runs started inside the function report into the
+        collection sink; their totals land on the StepOutput so workflow metrics
+        aggregation picks them up. Explicit user-set metrics take precedence.
+        """
+        if step_output is None or not has_token_metrics(collected_metrics):
+            return
+        if step_output.metrics is None:
+            step_output.metrics = collected_metrics
+        else:
+            log_debug("StepOutput already has metrics set, skipping collected nested-run metrics")
 
     @staticmethod
     def _aggregate_workflow_metrics(workflow_metrics: Any) -> Optional[RunMetrics]:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -32,10 +32,19 @@ from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
 from agno.db.utils import resolve_db_from_config
 from agno.exceptions import InputCheckError, OutputCheckError, RunCancelledException
 from agno.media import Audio, File, Image, Video
+from agno.metrics import swap_nested_run_metrics_sink
 from agno.models.message import Message
 from agno.models.metrics import RunMetrics, SessionMetrics
 from agno.registry import Registry
 from agno.run import RunContext, RunStatus
+from agno.run._nested_metrics import (
+    arun_stream_with_metrics_scope,
+    arun_with_metrics_scope,
+    has_token_metrics,
+    metrics_collection_sink,
+    report_run_to_parent,
+    run_stream_with_metrics_scope,
+)
 from agno.run.agent import (
     RunCancelledEvent as AgentRunCancelledEvent,
 )
@@ -1934,32 +1943,71 @@ class Workflow:
             else:
                 return len(self.steps)
 
+    def _attach_callable_workflow_metrics(
+        self, workflow_run_response: WorkflowRunOutput, collected_metrics: RunMetrics
+    ) -> None:
+        """Attach metrics collected from nested runs inside a callable workflow.
+
+        Callable workflows have no Step objects, so nested agent/team/workflow runs
+        started inside the callable are recorded as a single function step in the
+        workflow metrics.
+        """
+        if not has_token_metrics(collected_metrics):
+            return
+        executor_name = getattr(self.steps, "__name__", "workflow_function")
+        if workflow_run_response.metrics is None:
+            workflow_run_response.metrics = WorkflowMetrics(steps={})
+        workflow_run_response.metrics.steps[executor_name] = StepMetrics(
+            step_name=executor_name,
+            executor_type="function",
+            executor_name=executor_name,
+            metrics=collected_metrics,
+        )
+
     def _aggregate_workflow_metrics(
         self,
         step_results: List[Union[StepOutput, List[StepOutput]]],
         current_workflow_metrics: Optional[WorkflowMetrics] = None,
     ) -> WorkflowMetrics:
         """Aggregate metrics from all step responses into structured workflow metrics"""
-        steps_dict = {}
+        steps_dict: Dict[str, StepMetrics] = {}
 
         def process_step_output(step_output: StepOutput):
             """Process a single step output for metrics"""
 
-            # If this step has nested steps, process them recursively
-            if hasattr(step_output, "steps") and step_output.steps:
+            # Only collect metrics from steps that actually have metrics. Containers
+            # (parallel etc.) and nested workflows carry aggregates of their children,
+            # which are collected through the recursion below instead.
+            collected = (
+                step_output.step_name is not None
+                and step_output.metrics is not None
+                and step_output.executor_type in ["agent", "team", "function"]
+            )
+
+            # If this step has nested steps and was not collected itself, process
+            # them recursively — collecting both would count the children twice
+            if not collected and hasattr(step_output, "steps") and step_output.steps:
                 for nested_step in step_output.steps:
                     process_step_output(nested_step)
 
-            # Only collect metrics from steps that actually have metrics (actual agents/teams)
-            if (
-                step_output.step_name and step_output.metrics and step_output.executor_type in ["agent", "team"]
-            ):  # Only include actual executors
-                step_metrics = StepMetrics(
-                    step_name=step_output.step_name,
-                    executor_type=step_output.executor_type or "unknown",
-                    executor_name=step_output.executor_name or "unknown",
-                    metrics=step_output.metrics,
-                )
+            # Only include actual executors
+            if collected and step_output.step_name and step_output.metrics:
+                existing_step_metrics = steps_dict.get(step_output.step_name)
+                if existing_step_metrics is not None and existing_step_metrics.metrics is not None:
+                    # Same step executed more than once (e.g. loop iterations) — sum the metrics
+                    step_metrics = StepMetrics(
+                        step_name=step_output.step_name,
+                        executor_type=step_output.executor_type or "unknown",
+                        executor_name=step_output.executor_name or "unknown",
+                        metrics=existing_step_metrics.metrics + step_output.metrics,
+                    )
+                else:
+                    step_metrics = StepMetrics(
+                        step_name=step_output.step_name,
+                        executor_type=step_output.executor_type or "unknown",
+                        executor_name=step_output.executor_name or "unknown",
+                        metrics=step_output.metrics,
+                    )
                 steps_dict[step_output.step_name] = step_metrics
 
         # Process all step results
@@ -2037,23 +2085,32 @@ class Workflow:
 
         if callable(self.steps):
             try:
-                if iscoroutinefunction(self.steps) or isasyncgenfunction(self.steps):
-                    raise ValueError("Cannot use async function with synchronous execution")
-                elif isgeneratorfunction(self.steps):
-                    content = ""
-                    for chunk in self.steps(self, execution_input, **kwargs):
-                        # Check for cancellation while consuming generator
+                # Nested agent/team/workflow runs started inside the callable report
+                # their metrics into the collection sink
+                with metrics_collection_sink() as collected_metrics:
+                    if iscoroutinefunction(self.steps) or isasyncgenfunction(self.steps):
+                        raise ValueError("Cannot use async function with synchronous execution")
+                    elif isgeneratorfunction(self.steps):
+                        content = ""
+                        for chunk in self.steps(self, execution_input, **kwargs):
+                            # Check for cancellation while consuming generator
+                            raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                            if (
+                                hasattr(chunk, "content")
+                                and chunk.content is not None
+                                and isinstance(chunk.content, str)
+                            ):
+                                content += chunk.content
+                            else:
+                                content += str(chunk)
+                        workflow_run_response.content = content
+                    else:
+                        # Execute the workflow with the custom executor
                         raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                        if hasattr(chunk, "content") and chunk.content is not None and isinstance(chunk.content, str):
-                            content += chunk.content
-                        else:
-                            content += str(chunk)
-                    workflow_run_response.content = content
-                else:
-                    # Execute the workflow with the custom executor
-                    raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    workflow_run_response.content = self._call_custom_function(self.steps, execution_input, **kwargs)  # type: ignore[arg-type]
-
+                        workflow_run_response.content = self._call_custom_function(
+                            self.steps, execution_input, **kwargs
+                        )  # type: ignore[arg-type]
+                self._attach_callable_workflow_metrics(workflow_run_response, collected_metrics)
                 workflow_run_response.status = RunStatus.completed
             except RunCancelledException as e:
                 logger.info(f"Workflow run {workflow_run_response.run_id} was cancelled")
@@ -2388,22 +2445,32 @@ class Workflow:
 
         if callable(self.steps):
             try:
-                if iscoroutinefunction(self.steps) or isasyncgenfunction(self.steps):
-                    raise ValueError("Cannot use async function with synchronous execution")
-                elif isgeneratorfunction(self.steps):
-                    content = ""
-                    for chunk in self._call_custom_function(self.steps, execution_input, **kwargs):  # type: ignore[arg-type]
+                # Nested agent/team/workflow runs started inside the callable report
+                # their metrics into the collection sink
+                with metrics_collection_sink() as collected_metrics:
+                    if iscoroutinefunction(self.steps) or isasyncgenfunction(self.steps):
+                        raise ValueError("Cannot use async function with synchronous execution")
+                    elif isgeneratorfunction(self.steps):
+                        content = ""
+                        for chunk in self._call_custom_function(self.steps, execution_input, **kwargs):  # type: ignore[arg-type]
+                            raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                            # Update the run_response with the content from the result
+                            if (
+                                hasattr(chunk, "content")
+                                and chunk.content is not None
+                                and isinstance(chunk.content, str)
+                            ):
+                                content += chunk.content
+                                yield chunk
+                            else:
+                                content += str(chunk)
+                        workflow_run_response.content = content
+                    else:
                         raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                        # Update the run_response with the content from the result
-                        if hasattr(chunk, "content") and chunk.content is not None and isinstance(chunk.content, str):
-                            content += chunk.content
-                            yield chunk
-                        else:
-                            content += str(chunk)
-                    workflow_run_response.content = content
-                else:
-                    raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    workflow_run_response.content = self._call_custom_function(self.steps, execution_input, **kwargs)
+                        workflow_run_response.content = self._call_custom_function(
+                            self.steps, execution_input, **kwargs
+                        )
+                self._attach_callable_workflow_metrics(workflow_run_response, collected_metrics)
                 workflow_run_response.status = RunStatus.completed
             except RunCancelledException as e:
                 logger.info(f"Workflow run {workflow_run_response.run_id} was cancelled during streaming")
@@ -3059,31 +3126,45 @@ class Workflow:
             content = ""
 
             try:
-                if iscoroutinefunction(self.steps):  # type: ignore
-                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    workflow_run_response.content = await self._acall_custom_function(
-                        self.steps, execution_input, **kwargs
-                    )
-                elif isgeneratorfunction(self.steps):
-                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    for chunk in self.steps(self, execution_input, **kwargs):  # type: ignore[arg-type]
-                        if hasattr(chunk, "content") and chunk.content is not None and isinstance(chunk.content, str):
-                            content += chunk.content
-                        else:
-                            content += str(chunk)
-                    workflow_run_response.content = content
-                elif isasyncgenfunction(self.steps):  # type: ignore
-                    async_gen = await self._acall_custom_function(self.steps, execution_input, **kwargs)
-                    async for chunk in async_gen:
+                # Nested agent/team/workflow runs started inside the callable report
+                # their metrics into the collection sink
+                with metrics_collection_sink() as collected_metrics:
+                    if iscoroutinefunction(self.steps):  # type: ignore
                         await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                        if hasattr(chunk, "content") and chunk.content is not None and isinstance(chunk.content, str):
-                            content += chunk.content
-                        else:
-                            content += str(chunk)
-                    workflow_run_response.content = content
-                else:
-                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    workflow_run_response.content = self._call_custom_function(self.steps, execution_input, **kwargs)
+                        workflow_run_response.content = await self._acall_custom_function(
+                            self.steps, execution_input, **kwargs
+                        )
+                    elif isgeneratorfunction(self.steps):
+                        await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                        for chunk in self.steps(self, execution_input, **kwargs):  # type: ignore[arg-type]
+                            if (
+                                hasattr(chunk, "content")
+                                and chunk.content is not None
+                                and isinstance(chunk.content, str)
+                            ):
+                                content += chunk.content
+                            else:
+                                content += str(chunk)
+                        workflow_run_response.content = content
+                    elif isasyncgenfunction(self.steps):  # type: ignore
+                        async_gen = await self._acall_custom_function(self.steps, execution_input, **kwargs)
+                        async for chunk in async_gen:
+                            await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                            if (
+                                hasattr(chunk, "content")
+                                and chunk.content is not None
+                                and isinstance(chunk.content, str)
+                            ):
+                                content += chunk.content
+                            else:
+                                content += str(chunk)
+                        workflow_run_response.content = content
+                    else:
+                        await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                        workflow_run_response.content = self._call_custom_function(
+                            self.steps, execution_input, **kwargs
+                        )
+                self._attach_callable_workflow_metrics(workflow_run_response, collected_metrics)
                 workflow_run_response.status = RunStatus.completed
             except (RunCancelledException, asyncio.CancelledError, KeyboardInterrupt) as e:
                 # Persistence happens below after the if/else; just mark cancelled and fall through
@@ -3426,35 +3507,47 @@ class Workflow:
 
         if callable(self.steps):
             try:
-                if iscoroutinefunction(self.steps):  # type: ignore
-                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    workflow_run_response.content = await self._acall_custom_function(
-                        self.steps, execution_input, **kwargs
-                    )
-                elif isgeneratorfunction(self.steps):
-                    content = ""
-                    for chunk in self.steps(self, execution_input, **kwargs):  # type: ignore[arg-type]
+                # Nested agent/team/workflow runs started inside the callable report
+                # their metrics into the collection sink
+                with metrics_collection_sink() as collected_metrics:
+                    if iscoroutinefunction(self.steps):  # type: ignore
                         await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                        if hasattr(chunk, "content") and chunk.content is not None and isinstance(chunk.content, str):
-                            content += chunk.content
-                            yield chunk
-                        else:
-                            content += str(chunk)
-                    workflow_run_response.content = content
-                elif isasyncgenfunction(self.steps):  # type: ignore
-                    content = ""
-                    async_gen = await self._acall_custom_function(self.steps, execution_input, **kwargs)
-                    async for chunk in async_gen:
+                        workflow_run_response.content = await self._acall_custom_function(
+                            self.steps, execution_input, **kwargs
+                        )
+                    elif isgeneratorfunction(self.steps):
+                        content = ""
+                        for chunk in self.steps(self, execution_input, **kwargs):  # type: ignore[arg-type]
+                            await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                            if (
+                                hasattr(chunk, "content")
+                                and chunk.content is not None
+                                and isinstance(chunk.content, str)
+                            ):
+                                content += chunk.content
+                                yield chunk
+                            else:
+                                content += str(chunk)
+                        workflow_run_response.content = content
+                    elif isasyncgenfunction(self.steps):  # type: ignore
+                        content = ""
+                        async_gen = await self._acall_custom_function(self.steps, execution_input, **kwargs)
+                        async for chunk in async_gen:
+                            await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+                            if (
+                                hasattr(chunk, "content")
+                                and chunk.content is not None
+                                and isinstance(chunk.content, str)
+                            ):
+                                content += chunk.content
+                                yield chunk
+                            else:
+                                content += str(chunk)
+                        workflow_run_response.content = content
+                    else:
                         await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                        if hasattr(chunk, "content") and chunk.content is not None and isinstance(chunk.content, str):
-                            content += chunk.content
-                            yield chunk
-                        else:
-                            content += str(chunk)
-                    workflow_run_response.content = content
-                else:
-                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
-                    workflow_run_response.content = self.steps(self, execution_input, **kwargs)
+                        workflow_run_response.content = self.steps(self, execution_input, **kwargs)
+                self._attach_callable_workflow_metrics(workflow_run_response, collected_metrics)
                 workflow_run_response.status = RunStatus.completed
             except RunCancelledException as e:
                 logger.info(f"Workflow run {workflow_run_response.run_id} was cancelled during streaming")
@@ -4161,6 +4254,10 @@ class Workflow:
         async def execute_workflow_background():
             """Simple background execution"""
             try:
+                # Detached run — never report metrics to an enclosing run that may
+                # complete before this task does
+                swap_nested_run_metrics_sink(None)
+
                 # Update status to RUNNING and save
                 workflow_run_response.status = RunStatus.running
                 if self._has_async_db():
@@ -4294,6 +4391,10 @@ class Workflow:
         async def execute_workflow_background_stream():
             """Background execution with streaming and WebSocket broadcasting"""
             try:
+                # Detached run — never report metrics to an enclosing run that may
+                # complete before this task does
+                swap_nested_run_metrics_sink(None)
+
                 if self.agent is not None:
                     result = self._aexecute_workflow_agent(
                         user_input=input,  # type: ignore
@@ -4462,6 +4563,10 @@ class Workflow:
             # that _handle_event just assigned.
 
             try:
+                # Detached run — never report metrics to an enclosing run that may
+                # complete before this task does
+                swap_nested_run_metrics_sink(None)
+
                 if self.agent is not None:
                     result = self._aexecute_workflow_agent(
                         user_input=input,  # type: ignore
@@ -5822,24 +5927,37 @@ class Workflow:
             start_index = paused_step_index
 
         if stream:
-            return self._continue_execute_stream(
-                session=session,
-                execution_input=execution_input,
-                workflow_run_response=run_response,
-                run_context=run_context,
-                start_step_index=start_index,
-                stream_events=stream_events or False,
-                **kwargs,
+            # Steps report through StepOutput metrics, so the workflow shields the
+            # ambient sink (sink=None) and reports its aggregated step metrics upward.
+            return run_stream_with_metrics_scope(
+                self._continue_execute_stream(
+                    session=session,
+                    execution_input=execution_input,
+                    workflow_run_response=run_response,
+                    run_context=run_context,
+                    start_step_index=start_index,
+                    stream_events=stream_events or False,
+                    **kwargs,
+                ),
+                run_response,
+                sink=None,
             )
         else:
-            return self._continue_execute(
-                session=session,
-                execution_input=execution_input,
-                workflow_run_response=run_response,
-                run_context=run_context,
-                start_step_index=start_index,
-                **kwargs,
-            )
+            response = run_response
+            parent_sink = swap_nested_run_metrics_sink(None)
+            try:
+                response = self._continue_execute(
+                    session=session,
+                    execution_input=execution_input,
+                    workflow_run_response=run_response,
+                    run_context=run_context,
+                    start_step_index=start_index,
+                    **kwargs,
+                )
+                return response
+            finally:
+                swap_nested_run_metrics_sink(parent_sink)
+                report_run_to_parent(parent_sink, response)
 
     def _continue_execute(
         self,
@@ -7753,23 +7871,33 @@ class Workflow:
             start_index = paused_step_index
 
         if stream:
-            return self._acontinue_execute_stream(
-                session=session,
-                execution_input=execution_input,
-                workflow_run_response=run_response,
-                run_context=run_context,
-                start_step_index=start_index,
-                stream_events=stream_events or False,
-                **kwargs,
+            # Steps report through StepOutput metrics, so the workflow shields the
+            # ambient sink (sink=None) and reports its aggregated step metrics upward.
+            return arun_stream_with_metrics_scope(
+                self._acontinue_execute_stream(
+                    session=session,
+                    execution_input=execution_input,
+                    workflow_run_response=run_response,
+                    run_context=run_context,
+                    start_step_index=start_index,
+                    stream_events=stream_events or False,
+                    **kwargs,
+                ),
+                run_response,
+                sink=None,
             )
         else:
-            return await self._acontinue_execute(
-                session=session,
-                execution_input=execution_input,
-                workflow_run_response=run_response,
-                run_context=run_context,
-                start_step_index=start_index,
-                **kwargs,
+            return await arun_with_metrics_scope(
+                self._acontinue_execute(
+                    session=session,
+                    execution_input=execution_input,
+                    workflow_run_response=run_response,
+                    run_context=run_context,
+                    start_step_index=start_index,
+                    **kwargs,
+                ),
+                run_response,
+                sink=None,
             )
 
     async def _acontinue_execute(
@@ -9249,28 +9377,41 @@ class Workflow:
         workflow_run_response.metrics.start_timer()
 
         if stream:
-            return self._execute_stream(
-                session=workflow_session,
-                execution_input=inputs,  # type: ignore[arg-type]
-                workflow_run_response=workflow_run_response,
-                stream_events=stream_events,
-                run_context=run_context,
-                background_tasks=background_tasks,
-                add_dependencies_to_context=resolved["add_dependencies_to_context"],
-                add_session_state_to_context=resolved["add_session_state_to_context"],
-                **kwargs,
+            # Steps report through StepOutput metrics, so the workflow shields the
+            # ambient sink (sink=None) and reports its aggregated step metrics upward.
+            return run_stream_with_metrics_scope(
+                self._execute_stream(
+                    session=workflow_session,
+                    execution_input=inputs,  # type: ignore[arg-type]
+                    workflow_run_response=workflow_run_response,
+                    stream_events=stream_events,
+                    run_context=run_context,
+                    background_tasks=background_tasks,
+                    add_dependencies_to_context=resolved["add_dependencies_to_context"],
+                    add_session_state_to_context=resolved["add_session_state_to_context"],
+                    **kwargs,
+                ),
+                workflow_run_response,
+                sink=None,
             )
         else:
-            return self._execute(
-                session=workflow_session,
-                execution_input=inputs,  # type: ignore[arg-type]
-                workflow_run_response=workflow_run_response,
-                run_context=run_context,
-                background_tasks=background_tasks,
-                add_dependencies_to_context=resolved["add_dependencies_to_context"],
-                add_session_state_to_context=resolved["add_session_state_to_context"],
-                **kwargs,
-            )
+            response = workflow_run_response
+            parent_sink = swap_nested_run_metrics_sink(None)
+            try:
+                response = self._execute(
+                    session=workflow_session,
+                    execution_input=inputs,  # type: ignore[arg-type]
+                    workflow_run_response=workflow_run_response,
+                    run_context=run_context,
+                    background_tasks=background_tasks,
+                    add_dependencies_to_context=resolved["add_dependencies_to_context"],
+                    add_session_state_to_context=resolved["add_session_state_to_context"],
+                    **kwargs,
+                )
+                return response
+            finally:
+                swap_nested_run_metrics_sink(parent_sink)
+                report_run_to_parent(parent_sink, response)
 
     @overload
     async def arun(
@@ -9513,35 +9654,45 @@ class Workflow:
         workflow_run_response.metrics.start_timer()
 
         if stream:
-            return self._aexecute_stream(  # type: ignore
-                execution_input=inputs,
-                workflow_run_response=workflow_run_response,
-                session_id=session_id,
-                user_id=user_id,
-                stream_events=stream_events,
-                websocket=websocket,
-                files=files,
-                session_state=session_state,
-                run_context=run_context,
-                background_tasks=background_tasks,
-                add_dependencies_to_context=resolved["add_dependencies_to_context"],
-                add_session_state_to_context=resolved["add_session_state_to_context"],
-                **kwargs,
+            # Steps report through StepOutput metrics, so the workflow shields the
+            # ambient sink (sink=None) and reports its aggregated step metrics upward.
+            return arun_stream_with_metrics_scope(  # type: ignore[return-value]
+                self._aexecute_stream(  # type: ignore
+                    execution_input=inputs,
+                    workflow_run_response=workflow_run_response,
+                    session_id=session_id,
+                    user_id=user_id,
+                    stream_events=stream_events,
+                    websocket=websocket,
+                    files=files,
+                    session_state=session_state,
+                    run_context=run_context,
+                    background_tasks=background_tasks,
+                    add_dependencies_to_context=resolved["add_dependencies_to_context"],
+                    add_session_state_to_context=resolved["add_session_state_to_context"],
+                    **kwargs,
+                ),
+                workflow_run_response,
+                sink=None,
             )
         else:
-            return self._aexecute(  # type: ignore
-                execution_input=inputs,
-                workflow_run_response=workflow_run_response,
-                session_id=session_id,
-                user_id=user_id,
-                websocket=websocket,
-                files=files,
-                session_state=session_state,
-                run_context=run_context,
-                background_tasks=background_tasks,
-                add_dependencies_to_context=resolved["add_dependencies_to_context"],
-                add_session_state_to_context=resolved["add_session_state_to_context"],
-                **kwargs,
+            return arun_with_metrics_scope(  # type: ignore[return-value]
+                self._aexecute(  # type: ignore
+                    execution_input=inputs,
+                    workflow_run_response=workflow_run_response,
+                    session_id=session_id,
+                    user_id=user_id,
+                    websocket=websocket,
+                    files=files,
+                    session_state=session_state,
+                    run_context=run_context,
+                    background_tasks=background_tasks,
+                    add_dependencies_to_context=resolved["add_dependencies_to_context"],
+                    add_session_state_to_context=resolved["add_session_state_to_context"],
+                    **kwargs,
+                ),
+                workflow_run_response,
+                sink=None,
             )
 
     def _prepare_steps(self):

--- a/libs/agno/tests/integration/agent/test_nested_run_metrics.py
+++ b/libs/agno/tests/integration/agent/test_nested_run_metrics.py
@@ -1,0 +1,180 @@
+"""Tests for nested-run metrics propagation: agent/team/workflow runs started
+inside custom tools must roll up into the parent run's metrics."""
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.run.agent import RunOutput
+from agno.team import Team
+
+
+def _own_usage(run_output: RunOutput) -> int:
+    return sum(
+        m.metrics.total_tokens for m in (run_output.messages or []) if m.role == "assistant" and m.metrics is not None
+    )
+
+
+def _make_ask_specialist(nested_run_tokens):
+    def ask_specialist(question: str) -> str:
+        """Ask the specialist agent a question.
+
+        Args:
+            question: The question for the specialist.
+        """
+        specialist = Agent(model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.")
+        result = specialist.run(question)
+        nested_run_tokens.append(result.metrics.total_tokens)
+        return str(result.content)
+
+    return ask_specialist
+
+
+def _make_aask_specialist(nested_run_tokens):
+    async def aask_specialist(question: str) -> str:
+        """Ask the specialist agent a question.
+
+        Args:
+            question: The question for the specialist.
+        """
+        specialist = Agent(model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.")
+        result = await specialist.arun(question)
+        nested_run_tokens.append(result.metrics.total_tokens)
+        return str(result.content)
+
+    return aask_specialist
+
+
+def _assert_propagated(run_output: RunOutput, nested_run_tokens):
+    nested = sum(nested_run_tokens)
+    assert nested > 0, "nested run did not execute"
+    assert run_output.metrics.total_tokens == _own_usage(run_output) + nested
+
+
+def test_nested_agent_in_tool():
+    nested_run_tokens = []
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[_make_ask_specialist(nested_run_tokens)],
+        instructions="Use the ask_specialist tool to answer. Then reply in 3 words.",
+    )
+    response = agent.run("What is the capital of France? Use your tool.")
+    _assert_propagated(response, nested_run_tokens)
+
+
+def test_nested_agent_in_tool_stream():
+    nested_run_tokens = []
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[_make_ask_specialist(nested_run_tokens)],
+        instructions="Use the ask_specialist tool to answer. Then reply in 3 words.",
+    )
+    response = None
+    for event in agent.run("What is the capital of Japan? Use your tool.", stream=True, yield_run_output=True):
+        if isinstance(event, RunOutput):
+            response = event
+    _assert_propagated(response, nested_run_tokens)
+
+
+@pytest.mark.asyncio
+async def test_nested_agent_in_tool_async():
+    nested_run_tokens = []
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[_make_aask_specialist(nested_run_tokens)],
+        instructions="Use the aask_specialist tool to answer. Then reply in 3 words.",
+    )
+    response = await agent.arun("What is the capital of Italy? Use your tool.")
+    _assert_propagated(response, nested_run_tokens)
+
+
+@pytest.mark.asyncio
+async def test_nested_agent_in_tool_async_stream():
+    nested_run_tokens = []
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[_make_aask_specialist(nested_run_tokens)],
+        instructions="Use the aask_specialist tool to answer. Then reply in 3 words.",
+    )
+    response = None
+    async for event in agent.arun("What is the capital of Spain? Use your tool.", stream=True, yield_run_output=True):
+        if isinstance(event, RunOutput):
+            response = event
+    _assert_propagated(response, nested_run_tokens)
+
+
+def test_nested_team_in_tool():
+    """A team run inside a tool reports leader + member metrics to the parent."""
+    nested_run_tokens = []
+
+    def consult_team(question: str) -> str:
+        """Consult the research team.
+
+        Args:
+            question: The question for the team.
+        """
+        member = Agent(name="M1", model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.")
+        nested_team = Team(
+            name="NestedTeam",
+            model=OpenAIChat(id="gpt-4o-mini"),
+            members=[member],
+            instructions="You MUST always delegate the task to member M1. Never answer directly.",
+        )
+        result = nested_team.run(question)
+        leader_tokens = result.metrics.total_tokens if result.metrics else 0
+        member_tokens = sum(r.metrics.total_tokens for r in (result.member_responses or []) if r.metrics)
+        nested_run_tokens.append(leader_tokens + member_tokens)
+        return str(result.content)
+
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[consult_team],
+        instructions="Use the consult_team tool, then reply in 3 words.",
+    )
+    response = agent.run("What color is the sky? Use your tool.")
+    _assert_propagated(response, nested_run_tokens)
+
+
+@pytest.mark.asyncio
+async def test_background_run_includes_nested_metrics(shared_db):
+    """A detached background run collects nested-run metrics into its own run."""
+    import asyncio
+
+    from agno.run.base import RunStatus
+
+    nested_run_tokens = []
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[_make_ask_specialist(nested_run_tokens)],
+        instructions="Use the ask_specialist tool to answer. Then reply in 3 words.",
+        db=shared_db,
+    )
+    handle = await agent.arun("What is the capital of Brazil? Use your tool.", background=True)
+
+    response = None
+    for _ in range(60):
+        await asyncio.sleep(2)
+        polled = await agent.aget_run_output(run_id=handle.run_id, session_id=handle.session_id)
+        if polled is not None and polled.status in (RunStatus.completed, RunStatus.error):
+            response = polled
+            break
+
+    assert response is not None and response.status == RunStatus.completed
+    _assert_propagated(response, nested_run_tokens)
+
+
+def test_nested_run_metrics_in_session_metrics(shared_db):
+    """Session metrics include the nested run's tokens exactly once."""
+    nested_run_tokens = []
+    agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[_make_ask_specialist(nested_run_tokens)],
+        instructions="Use the ask_specialist tool to answer. Then reply in 3 words.",
+        db=shared_db,
+    )
+    response = agent.run("What is the capital of Kenya? Use your tool.")
+    _assert_propagated(response, nested_run_tokens)
+
+    session = agent.get_session(session_id=response.session_id)
+    session_metrics = session.session_data.get("session_metrics", {})
+    assert session_metrics.get("total_tokens") == response.metrics.total_tokens

--- a/libs/agno/tests/integration/teams/test_nested_run_metrics.py
+++ b/libs/agno/tests/integration/teams/test_nested_run_metrics.py
@@ -1,0 +1,121 @@
+"""Tests for nested-run metrics propagation in teams: a workflow streamed from
+inside a team's custom tool must roll up into the team's run and session
+metrics."""
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.run.team import TeamRunOutput
+from agno.team import Team
+from agno.tools import tool
+from agno.workflow import Step, Workflow
+
+
+@pytest.mark.asyncio
+async def test_workflow_in_team_tool_stream(shared_db):
+    inner_workflow = Workflow(
+        name="doc-workflow",
+        steps=[
+            Step(
+                name="summarize",
+                agent=Agent(name="Summarizer", model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words."),
+            ),
+        ],
+    )
+
+    async def process_documents(task: str):
+        """Process documents through the internal workflow.
+
+        Args:
+            task: What to process.
+        """
+        async for event in inner_workflow.arun(input=task, stream=True, stream_events=True):
+            yield event
+
+    team = Team(
+        name="DocTeam",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[Agent(name="Helper", model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.")],
+        tools=[process_documents],
+        instructions="Call process_documents with the user's request. Then reply in 5 words.",
+        db=shared_db,
+    )
+
+    response = await team.arun("Summarize: the sky is blue.")
+
+    leader_own = sum(
+        m.metrics.total_tokens for m in (response.messages or []) if m.role == "assistant" and m.metrics is not None
+    )
+    member_total = sum(r.metrics.total_tokens for r in (response.member_responses or []) if r.metrics)
+    workflow_total = response.metrics.total_tokens - leader_own
+
+    # The nested workflow's tokens must be part of the team run metrics
+    assert workflow_total > 0
+
+    # Session metrics count the run (including nested workflow) and members exactly once
+    session = team.get_session(session_id=response.session_id)
+    session_metrics = session.session_data.get("session_metrics", {})
+    assert session_metrics.get("total_tokens") == response.metrics.total_tokens + member_total
+
+
+def test_nested_run_in_continued_team_stream_by_run_id(shared_db):
+    """A nested agent run by a tool during a streamed HITL continuation (by
+    run_id) must roll up into the continued run's metrics."""
+    nested_run_tokens = []
+
+    @tool(requires_confirmation=True)
+    def get_order_status(order_id: str) -> str:
+        """Get the status of an order.
+
+        Args:
+            order_id: The order id.
+        """
+        return "Order is shipped."
+
+    def ask_specialist(question: str) -> str:
+        """Ask the specialist a question. Call this after get_order_status.
+
+        Args:
+            question: The question.
+        """
+        specialist = Agent(model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.")
+        result = specialist.run(question)
+        nested_run_tokens.append(result.metrics.total_tokens)
+        return str(result.content)
+
+    team = Team(
+        name="OrderTeam",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[],
+        tools=[get_order_status, ask_specialist],
+        instructions=(
+            "Use get_order_status first. After it returns, you MUST ask the specialist "
+            "for the delivery outlook using the ask_specialist tool. Then answer in one sentence."
+        ),
+        db=shared_db,
+    )
+
+    run_output = team.run("What is the status of order 42 and its delivery outlook?")
+    assert run_output.is_paused
+    for req in run_output.requirements or []:
+        if req.tool_execution is not None:
+            req.tool_execution.confirmed = True
+
+    response = None
+    for event in team.continue_run(
+        run_id=run_output.run_id,
+        requirements=run_output.requirements,
+        session_id=run_output.session_id,
+        stream=True,
+        yield_run_output=True,
+    ):
+        if isinstance(event, TeamRunOutput):
+            response = event
+
+    nested = sum(nested_run_tokens)
+    own = sum(
+        m.metrics.total_tokens for m in (response.messages or []) if m.role == "assistant" and m.metrics is not None
+    )
+    assert nested > 0, "nested run did not execute"
+    assert response.metrics.total_tokens == own + nested

--- a/libs/agno/tests/integration/workflows/test_nested_run_metrics.py
+++ b/libs/agno/tests/integration/workflows/test_nested_run_metrics.py
@@ -1,0 +1,161 @@
+"""Tests for nested-run metrics in workflows: custom function steps running
+agents, loop iteration sums, nested workflows, and team steps."""
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.team import Team
+from agno.workflow import Loop, Step, Workflow
+from agno.workflow.types import StepInput, StepOutput
+
+nested_agent = Agent(name="Nested", model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.")
+
+
+def _make_fn_step(nested_run_tokens):
+    def fn_step(step_input: StepInput) -> StepOutput:
+        result = nested_agent.run("Say one word.")
+        nested_run_tokens.append(result.metrics.total_tokens)
+        return StepOutput(content=str(result.content))
+
+    return fn_step
+
+
+def _make_async_fn_step(nested_run_tokens):
+    async def async_fn_step(step_input: StepInput) -> StepOutput:
+        result = await nested_agent.arun("Say two words.")
+        nested_run_tokens.append(result.metrics.total_tokens)
+        return StepOutput(content=str(result.content))
+
+    return async_fn_step
+
+
+def _workflow_total(run_output) -> int:
+    if run_output.metrics and run_output.metrics.steps:
+        return sum(s.metrics.total_tokens for s in run_output.metrics.steps.values() if s.metrics)
+    return 0
+
+
+def test_function_step_nested_agent(shared_db):
+    nested_run_tokens = []
+    workflow = Workflow(name="wf-fn", steps=[Step(name="fn", executor=_make_fn_step(nested_run_tokens))], db=shared_db)
+    response = workflow.run(input="x")
+
+    expected = sum(nested_run_tokens)
+    assert expected > 0
+    assert _workflow_total(response) == expected
+
+    # The function step's StepOutput carries the collected metrics
+    assert response.metrics.steps["fn"].executor_type == "function"
+
+    # Session metrics include the function step's nested tokens
+    session = workflow.get_session(session_id=response.session_id)
+    session_metrics = session.session_data.get("session_metrics", {})
+    assert session_metrics.get("total_tokens") == expected
+
+
+@pytest.mark.asyncio
+async def test_async_function_step_nested_agent():
+    nested_run_tokens = []
+    workflow = Workflow(name="wf-afn", steps=[Step(name="afn", executor=_make_async_fn_step(nested_run_tokens))])
+    response = await workflow.arun(input="x")
+
+    expected = sum(nested_run_tokens)
+    assert expected > 0
+    assert _workflow_total(response) == expected
+
+
+def test_callable_workflow_nested_agent(shared_db):
+    """Callable workflows have no Step objects — nested runs are collected and
+    recorded as a single function step in the workflow metrics."""
+    nested_run_tokens = []
+
+    def callable_steps(workflow, execution_input) -> str:
+        result = nested_agent.run("Say one word.")
+        nested_run_tokens.append(result.metrics.total_tokens)
+        return str(result.content)
+
+    workflow = Workflow(name="wf-callable", steps=callable_steps, db=shared_db)
+    response = workflow.run(input="x")
+
+    expected = sum(nested_run_tokens)
+    assert expected > 0
+    assert _workflow_total(response) == expected
+    assert response.metrics.steps["callable_steps"].executor_type == "function"
+
+    # Session metrics include the callable's nested tokens
+    session = workflow.get_session(session_id=response.session_id)
+    session_metrics = session.session_data.get("session_metrics", {})
+    assert session_metrics.get("total_tokens") == expected
+
+
+def test_loop_function_step_metrics_sum():
+    """Loop iterations of the same step must sum, not overwrite."""
+    nested_run_tokens = []
+    workflow = Workflow(
+        name="wf-loop",
+        steps=[
+            Loop(
+                name="loop",
+                steps=[Step(name="fn", executor=_make_fn_step(nested_run_tokens))],
+                end_condition=lambda outputs: len(nested_run_tokens) >= 2,
+                max_iterations=2,
+            )
+        ],
+    )
+    response = workflow.run(input="x")
+
+    assert len(nested_run_tokens) == 2
+    assert _workflow_total(response) == sum(nested_run_tokens)
+
+
+def test_nested_workflow_no_double_count():
+    nested_run_tokens = []
+    inner = Workflow(
+        name="inner",
+        steps=[
+            Step(
+                name="inner-agent",
+                agent=Agent(name="InnerAgent", model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 2 words."),
+            ),
+        ],
+    )
+    outer = Workflow(
+        name="outer",
+        steps=[Step(name="nested-wf", workflow=inner), Step(name="fn", executor=_make_fn_step(nested_run_tokens))],
+    )
+    response = outer.run(input="x")
+
+    inner_agent_tokens = 0
+    for step_result in response.step_results:
+        for nested in step_result.steps or []:
+            if nested.step_name == "inner-agent" and nested.metrics:
+                inner_agent_tokens += nested.metrics.total_tokens
+
+    assert inner_agent_tokens > 0
+    assert _workflow_total(response) == inner_agent_tokens + sum(nested_run_tokens)
+
+
+@pytest.mark.asyncio
+async def test_team_step_includes_member_metrics():
+    member_tokens = []
+
+    def member_hook(run_output) -> None:
+        if run_output.metrics is not None:
+            member_tokens.append(run_output.metrics.total_tokens)
+
+    member = Agent(
+        name="M1", model=OpenAIChat(id="gpt-4o-mini"), instructions="Answer in 3 words.", post_hooks=[member_hook]
+    )
+    team = Team(
+        name="StepTeam",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        members=[member],
+        instructions="You MUST always delegate the task to member M1. Never answer directly.",
+    )
+    workflow = Workflow(name="wf-team", steps=[Step(name="team-step", team=team)])
+    response = await workflow.arun(input="Say hello.")
+
+    # Member tokens are part of the team step metrics (not just the leader's)
+    assert sum(member_tokens) > 0
+    assert _workflow_total(response) > sum(member_tokens)

--- a/libs/agno/tests/unit/run/test_nested_metrics.py
+++ b/libs/agno/tests/unit/run/test_nested_metrics.py
@@ -1,0 +1,280 @@
+"""Unit tests for the nested-run metrics sink machinery (no API calls)."""
+
+import pytest
+
+from agno.metrics import (
+    ModelMetrics,
+    RunMetrics,
+    get_nested_run_metrics_sink,
+    report_metrics_to_sink,
+    swap_nested_run_metrics_sink,
+)
+from agno.run._nested_metrics import (
+    arun_stream_with_metrics_scope,
+    has_token_metrics,
+    metrics_collection_sink,
+    report_run_to_parent,
+    run_stream_with_metrics_scope,
+    shielded_metrics_sink,
+    total_run_metrics,
+)
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+
+
+@pytest.fixture(autouse=True)
+def _reset_sink():
+    """Isolate from sink leaks of unrelated tests sharing this context."""
+    swap_nested_run_metrics_sink(None)
+    yield
+    swap_nested_run_metrics_sink(None)
+
+
+def _metrics(total: int, duration: float = 1.0) -> RunMetrics:
+    return RunMetrics(
+        input_tokens=total // 2,
+        output_tokens=total - total // 2,
+        total_tokens=total,
+        duration=duration,
+        details={"model": [ModelMetrics(id="m1", provider="p", total_tokens=total)]},
+    )
+
+
+def test_report_merges_tokens_but_not_timing():
+    parent = RunMetrics(total_tokens=15, duration=1.0)
+    child = _metrics(150, duration=99.0)
+    child.cost = 0.5
+    report_metrics_to_sink(parent, child)
+    assert parent.total_tokens == 165
+    assert parent.duration == 1.0
+    assert parent.cost == 0.5
+    assert parent.details["model"][0].total_tokens == 150
+
+
+def test_report_to_self_is_a_noop():
+    metrics = _metrics(10)
+    report_metrics_to_sink(metrics, metrics)
+    assert metrics.total_tokens == 10
+
+
+def test_sink_swap_and_shield():
+    parent = RunMetrics()
+    previous = swap_nested_run_metrics_sink(parent)
+    assert previous is None
+    try:
+        with shielded_metrics_sink():
+            assert get_nested_run_metrics_sink() is None
+        assert get_nested_run_metrics_sink() is parent
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+
+def test_collection_sink_collects_reports():
+    with metrics_collection_sink() as collected:
+        report_metrics_to_sink(get_nested_run_metrics_sink(), _metrics(150))
+    assert collected.total_tokens == 150
+    assert has_token_metrics(collected)
+    assert get_nested_run_metrics_sink() is None
+
+
+def test_paused_runs_do_not_report():
+    run_output = RunOutput(run_id="r1", metrics=_metrics(42))
+    run_output.status = RunStatus.paused
+    sink = RunMetrics()
+    report_run_to_parent(sink, run_output)
+    assert sink.total_tokens == 0
+    run_output.status = RunStatus.completed
+    report_run_to_parent(sink, run_output)
+    assert sink.total_tokens == 42
+
+
+def test_total_run_metrics_includes_members():
+    class FakeOutput:
+        pass
+
+    team_output = FakeOutput()
+    team_output.metrics = _metrics(10, duration=2.5)
+    member = FakeOutput()
+    member.metrics = _metrics(20)
+    member.member_responses = None
+    team_output.member_responses = [member]
+
+    total = total_run_metrics(team_output)
+    assert total.total_tokens == 30
+    assert total.duration == 2.5
+
+
+def test_stream_scope_reports_once_and_restores_sink():
+    run_output = RunOutput(run_id="r2", metrics=_metrics(7))
+    outer = RunMetrics()
+
+    def stream():
+        yield "a"
+        run_output.status = RunStatus.completed
+        yield "b"
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        events = []
+        for event in run_stream_with_metrics_scope(stream(), run_output, sink=run_output.metrics):
+            events.append(event)
+            # The sink never leaks into the consumer context between yields
+            assert get_nested_run_metrics_sink() is outer
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    assert events == ["a", "b"]
+    assert outer.total_tokens == 7
+
+
+def test_stream_scope_reports_on_early_break():
+    run_output = RunOutput(run_id="r3", metrics=_metrics(9))
+    outer = RunMetrics()
+
+    def stream():
+        run_output.status = RunStatus.completed
+        yield "completed-event"
+        yield "never-consumed"
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        for _ in run_stream_with_metrics_scope(stream(), run_output, sink=run_output.metrics):
+            break
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    assert outer.total_tokens == 9
+
+
+def test_stream_scope_picks_up_resolved_run_output():
+    """A run continued by run_id starts with no run_output; the wrapper picks up
+    the resolved output from the stream and reports it on completion."""
+    resolved = RunOutput(run_id="r6", metrics=_metrics(13))
+    outer = RunMetrics()
+
+    def stream():
+        yield "event"
+        resolved.status = RunStatus.completed
+        yield resolved
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        for _ in run_stream_with_metrics_scope(stream(), None, sink=None, run_id="r6"):
+            pass
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    assert outer.total_tokens == 13
+
+
+def test_stream_scope_reports_own_completed_event_without_run_output():
+    """Without yield_run_output the resolved output is never yielded — the
+    wrapper falls back to the run's own completed event."""
+    from agno.run.agent import RunCompletedEvent
+
+    outer = RunMetrics()
+
+    def stream():
+        yield "event"
+        yield RunCompletedEvent(run_id="r7", metrics=_metrics(17))
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        for _ in run_stream_with_metrics_scope(stream(), None, sink=None, run_id="r7"):
+            pass
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    assert outer.total_tokens == 17
+
+
+def test_stream_scope_ignores_foreign_outputs_and_events():
+    """Member or nested-run outputs and completed events flowing through a
+    by-run_id continue stream must not be adopted as this run's output."""
+    from agno.run.agent import RunCompletedEvent
+
+    outer = RunMetrics()
+    foreign_output = RunOutput(run_id="member-1", metrics=_metrics(100))
+    foreign_output.status = RunStatus.completed
+
+    def stream():
+        yield RunCompletedEvent(run_id="member-1", metrics=_metrics(100))
+        yield foreign_output
+        yield RunCompletedEvent(run_id="r8", metrics=_metrics(21))
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        for _ in run_stream_with_metrics_scope(stream(), None, sink=None, run_id="r8"):
+            pass
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    # Only the run's own completed event is reported — never the member's
+    assert outer.total_tokens == 21
+
+
+def test_stream_scope_preserves_inner_sink_replacement():
+    """A continued run installs its own sink mid-stream; the per-resume swap keeps it."""
+    resolved_metrics = RunMetrics()
+    run_output = RunOutput(run_id="r4", metrics=resolved_metrics)
+    outer = RunMetrics()
+
+    def stream():
+        # Mimic a continued run resolving its stored run and installing its sink
+        swap_nested_run_metrics_sink(resolved_metrics)
+        yield "a"
+        # Nested run reporting inside the run's frames lands on the resolved sink
+        report_metrics_to_sink(get_nested_run_metrics_sink(), _metrics(5))
+        run_output.status = RunStatus.completed
+        yield "b"
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        for _ in run_stream_with_metrics_scope(stream(), run_output, sink=None):
+            assert get_nested_run_metrics_sink() is outer
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    assert resolved_metrics.total_tokens == 5
+    # The run reported its (resolved) metrics to the outer sink on completion
+    assert outer.total_tokens == 5
+
+
+def test_collection_sink_close_in_foreign_context_does_not_clobber():
+    """Closing a generator holding a collection sink from a consumer context must
+    not overwrite the consumer's own sink."""
+
+    def gen():
+        with metrics_collection_sink():
+            yield "a"
+            yield "b"
+
+    iterator = gen()
+    next(iterator)  # enter the with block; the collector leaks into this context
+    consumer_sink = RunMetrics()
+    swap_nested_run_metrics_sink(consumer_sink)
+    try:
+        iterator.close()  # finalized while the consumer's sink is installed
+        assert get_nested_run_metrics_sink() is consumer_sink
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+
+@pytest.mark.asyncio
+async def test_async_stream_scope_reports_once():
+    run_output = RunOutput(run_id="r5", metrics=_metrics(11))
+    outer = RunMetrics()
+
+    async def astream():
+        yield "a"
+        run_output.status = RunStatus.completed
+        yield "b"
+
+    swap_nested_run_metrics_sink(outer)
+    try:
+        async for _ in arun_stream_with_metrics_scope(astream(), run_output, sink=run_output.metrics):
+            assert get_nested_run_metrics_sink() is outer
+    finally:
+        swap_nested_run_metrics_sink(None)
+
+    assert outer.total_tokens == 11


### PR DESCRIPTION
## Summary

Token metrics from agent/team/workflow runs that are started **inside** another run — a custom tool, a tool/pre/post hook, a custom workflow step function, or a callable workflow — were not propagated to the enclosing run. As a result `RunOutput.metrics`, session metrics, and AgentOS undercounted the true token usage 

This PR makes those nested-run tokens roll up into the enclosing run.

**Mechanism.** An ambient `ContextVar` "sink" in `agno.metrics` holds the enclosing run's `RunMetrics`. Each run installs its own sink while its frames execute and reports its total to the enclosing sink **exactly once** on completion — across sync/async, stream/non-stream, and run/continue/background dispatches. Framework-managed children (team members, workflow steps) are **shielded** so they are not double counted, since those are already aggregated via `member_responses` / step metrics. Timing fields are never summed (a nested run's wall time is already inside the parent's).

Issue number: #6861

While implementing this, a few **pre-existing** metrics bugs were found and fixed:
- Loop step metrics overwrote instead of summing across iterations.
- Team steps inside workflows dropped member tokens (leader-only).
- HITL pause/continue double-counted pre-pause tokens in session metrics.
- Streamed native reasoning tokens were not counted at all.
- Reasoning / eval evaluator runs would double-count with the new sink (now shielded; explicit accumulation remains the single counter).
- Cross-process team HITL resume lost member tokens.
- Saving a team session scrubbed `member_responses` on the live run output.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes