### PR TITLE
fix: emit reasoning events for streamed reasoning content

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1051,6 +1051,8 @@ def handle_model_response_stream(
 
     reasoning_state = {
         "reasoning_started": False,
+        "reasoning_content_streamed": False,
+        "reasoning_completed": False,
         "reasoning_time_taken": 0.0,
     }
     model_response = ModelResponse(content="")
@@ -1181,6 +1183,21 @@ def handle_model_response_stream(
                 events_to_skip=agent.events_to_skip,  # type: ignore
                 store_events=agent.store_events,
             )
+        elif (
+            reasoning_state["reasoning_content_streamed"]
+            and not reasoning_state["reasoning_completed"]
+            and run_response.reasoning_content
+        ):
+            yield handle_event(  # type: ignore
+                create_reasoning_completed_event(
+                    from_run_response=run_response,
+                    content=run_response.reasoning_content,
+                    content_type="str",
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,  # type: ignore
+                store_events=agent.store_events,
+            )
 
     # Update the run_response audio if streaming
     if model_response.audio is not None:
@@ -1202,6 +1219,8 @@ async def ahandle_model_response_stream(
 
     reasoning_state = {
         "reasoning_started": False,
+        "reasoning_content_streamed": False,
+        "reasoning_completed": False,
         "reasoning_time_taken": 0.0,
     }
     model_response = ModelResponse(content="")
@@ -1334,6 +1353,21 @@ async def ahandle_model_response_stream(
                 events_to_skip=agent.events_to_skip,  # type: ignore
                 store_events=agent.store_events,
             )
+        elif (
+            reasoning_state["reasoning_content_streamed"]
+            and not reasoning_state["reasoning_completed"]
+            and run_response.reasoning_content
+        ):
+            yield handle_event(  # type: ignore
+                create_reasoning_completed_event(
+                    from_run_response=run_response,
+                    content=run_response.reasoning_content,
+                    content_type="str",
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,  # type: ignore
+                store_events=agent.store_events,
+            )
 
     # Update the run_response audio if streaming
     if model_response.audio is not None:
@@ -1415,6 +1449,30 @@ def handle_model_response_chunk(
                     model_response.reasoning_content += model_response_event.redacted_reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
 
+            reasoning_content_delta = (
+                model_response_event.reasoning_content or model_response_event.redacted_reasoning_content
+            )
+            if stream_events and reasoning_content_delta and reasoning_state is not None:
+                if not reasoning_state["reasoning_started"]:
+                    yield handle_event(  # type: ignore
+                        create_reasoning_started_event(from_run_response=run_response),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
+                    reasoning_state["reasoning_started"] = True
+
+                reasoning_state["reasoning_content_streamed"] = True
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_content_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data
@@ -1422,6 +1480,26 @@ def handle_model_response_chunk(
             # Handle citations (one chunk)
             if model_response_event.citations is not None:
                 run_response.citations = model_response_event.citations
+
+            if (
+                stream_events
+                and reasoning_state is not None
+                and reasoning_state["reasoning_content_streamed"]
+                and not reasoning_state["reasoning_completed"]
+                and model_response_event.content not in (None, "")
+                and run_response.reasoning_content
+            ):
+                yield handle_event(  # type: ignore
+                    create_reasoning_completed_event(
+                        from_run_response=run_response,
+                        content=run_response.reasoning_content,
+                        content_type="str",
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+                reasoning_state["reasoning_completed"] = True
 
             # Only yield if we have content to show
             if content_type != "str":
@@ -1437,10 +1515,15 @@ def handle_model_response_chunk(
                 )
             elif (
                 model_response_event.content is not None
-                or model_response_event.reasoning_content is not None
-                or model_response_event.redacted_reasoning_content is not None
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
+                or (
+                    not stream_events
+                    and (
+                        model_response_event.reasoning_content is not None
+                        or model_response_event.redacted_reasoning_content is not None
+                    )
+                )
             ):
                 yield handle_event(  # type: ignore
                     create_run_output_content_event(

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1529,8 +1529,10 @@ def handle_model_response_chunk(
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
-                        redacted_reasoning_content=model_response_event.redacted_reasoning_content,
+                        reasoning_content=(model_response_event.reasoning_content if not stream_events else None),
+                        redacted_reasoning_content=(
+                            model_response_event.redacted_reasoning_content if not stream_events else None
+                        ),
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,
                     ),

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -8,7 +8,10 @@ from unittest.mock import patch
 
 import pytest
 
+from agno.agent import Agent
+from agno.models.base import Model
 from agno.models.message import Message
+from agno.models.response import ModelResponse
 from agno.reasoning.step import ReasoningStep, ReasoningSteps
 from agno.run.agent import RunEvent
 
@@ -139,6 +142,73 @@ def test_deepseek_stream_yields_tuples():
 
     assert "reasoning_agent" in params
     assert "messages" in params
+
+
+def test_openai_stream_yields_reasoning_content_deltas():
+    """Test OpenAI reasoning stream yields RunContent.reasoning_content chunks."""
+    from agno.reasoning.openai import get_openai_reasoning_stream
+    from agno.run.agent import RunCompletedEvent, RunContentEvent
+
+    class MockReasoningAgent:
+        def run(self, *args, **kwargs):
+            yield RunContentEvent(reasoning_content="The user ")
+            yield RunContentEvent(reasoning_content="asked a question.")
+            yield RunCompletedEvent()
+
+    results = list(get_openai_reasoning_stream(MockReasoningAgent(), messages=[]))
+
+    assert results[0] == ("The user ", None)
+    assert results[1] == ("asked a question.", None)
+    assert results[2][0] is None
+    assert results[2][1] is not None
+    assert results[2][1].reasoning_content == "The user asked a question."
+
+
+def test_agent_stream_emits_reasoning_events_for_model_reasoning_content():
+    """Test model-streamed reasoning_content is emitted as reasoning events."""
+
+    class ReasoningContentModel(Model):
+        id: str = "reasoning-content-model"
+        name: str = "ReasoningContentModel"
+
+        def invoke(self, *args, **kwargs):
+            return ModelResponse(content="Done")
+
+        async def ainvoke(self, *args, **kwargs):
+            return ModelResponse(content="Done")
+
+        def invoke_stream(self, *args, **kwargs):
+            yield ModelResponse(reasoning_content="The user ")
+            yield ModelResponse(reasoning_content="asked a question.")
+            yield ModelResponse(content="Done")
+
+        async def ainvoke_stream(self, *args, **kwargs):
+            yield ModelResponse(reasoning_content="The user ")
+            yield ModelResponse(reasoning_content="asked a question.")
+            yield ModelResponse(content="Done")
+
+        def _parse_provider_response(self, response, **kwargs):
+            return ModelResponse(content=response)
+
+        def _parse_provider_response_delta(self, response):
+            return ModelResponse(content=response)
+
+    agent = Agent(model=ReasoningContentModel(id="reasoning-content-model", name="ReasoningContentModel"))
+
+    events = list(agent.run("Hi", stream=True, stream_events=True))
+    event_types = [event.event for event in events]
+    reasoning_deltas = [event.reasoning_content for event in events if event.event == RunEvent.reasoning_content_delta]
+    completed_event = next(event for event in events if event.event == RunEvent.reasoning_completed)
+    run_content_events = [event for event in events if event.event == RunEvent.run_content]
+    final_event = events[-1]
+
+    assert RunEvent.reasoning_started in event_types
+    assert reasoning_deltas == ["The user ", "asked a question."]
+    assert completed_event.content == "The user asked a question."
+    assert completed_event.content_type == "str"
+    assert [event.content for event in run_content_events] == ["Done"]
+    assert event_types.index(RunEvent.reasoning_completed) < event_types.index(RunEvent.run_content)
+    assert final_event.reasoning_content == "The user asked a question."
 
 
 # ============================================================================

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -211,6 +211,47 @@ def test_agent_stream_emits_reasoning_events_for_model_reasoning_content():
     assert final_event.reasoning_content == "The user asked a question."
 
 
+def test_agent_stream_preserves_content_when_reasoning_and_content_share_chunk():
+    """Test mixed reasoning/content chunks emit both event types without duplication."""
+
+    class MixedReasoningContentModel(Model):
+        id: str = "mixed-reasoning-content-model"
+        name: str = "MixedReasoningContentModel"
+
+        def invoke(self, *args, **kwargs):
+            return ModelResponse(content="Done")
+
+        async def ainvoke(self, *args, **kwargs):
+            return ModelResponse(content="Done")
+
+        def invoke_stream(self, *args, **kwargs):
+            yield ModelResponse(reasoning_content="Think first. ", content="Done")
+
+        async def ainvoke_stream(self, *args, **kwargs):
+            yield ModelResponse(reasoning_content="Think first. ", content="Done")
+
+        def _parse_provider_response(self, response, **kwargs):
+            return ModelResponse(content=response)
+
+        def _parse_provider_response_delta(self, response):
+            return ModelResponse(content=response)
+
+    agent = Agent(
+        model=MixedReasoningContentModel(id="mixed-reasoning-content-model", name="MixedReasoningContentModel")
+    )
+
+    events = list(agent.run("Hi", stream=True, stream_events=True))
+    reasoning_deltas = [event for event in events if event.event == RunEvent.reasoning_content_delta]
+    run_content_events = [event for event in events if event.event == RunEvent.run_content]
+    final_event = events[-1]
+
+    assert [event.reasoning_content for event in reasoning_deltas] == ["Think first. "]
+    assert [event.content for event in run_content_events] == ["Done"]
+    assert all(not event.reasoning_content for event in run_content_events)
+    assert final_event.content == "Done"
+    assert final_event.reasoning_content == "Think first. "
+
+
 # ============================================================================
 # Mock-based streaming tests
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes #8400.

This PR normalizes streamed `ModelResponse.reasoning_content` into Agno reasoning events.

Previously, models that streamed reasoning content through `ModelResponse.reasoning_content` only exposed it through `RunContent.reasoning_content`, so `/runs` and `/agui` did not receive complete native reasoning event streams.

This change emits:

- `ReasoningStarted`
- `ReasoningContentDelta`
- `ReasoningCompleted`

for streamed reasoning content.

## Behavior

The resulting event order is:

```text
RunStarted
ModelRequestStarted
ReasoningStarted
ReasoningContentDelta*
ReasoningCompleted
RunContent*
RunCompleted
```

`RunCompleted.reasoning_content` still contains the accumulated reasoning content.

## Why

This keeps streamed reasoning content aligned with Agno's existing reasoning event contract and gives downstream interfaces, including AG-UI, a complete reasoning stream to convert.

Without this normalization, `/runs` may contain reasoning text only inside `RunContent.reasoning_content`, and `/agui` may miss `REASONING_MESSAGE_CONTENT` events because it relies on Agno reasoning events.

## Tests

```bash
python -m pytest libs/agno/tests/unit/reasoning/test_reasoning_checkers.py libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
ruff check libs/agno/agno/agent/_response.py libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
```