### PR TITLE
chore: release 2.6.16

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.6.15"
+version = "2.6.16"
 description = "The programming language for agentic software."
 requires-python = ">=3.7,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog 

## Improvements

- Support parallel-web >= 1.0 GA API in ParallelBackend — migrate web_search/web_extract to the top-level client and pin the floor to >=1.0