### PR TITLE
fix: avoid Chat suffix for OpenAILike providers

### DIFF
--- a/libs/agno/agno/models/openai/like.py
+++ b/libs/agno/agno/models/openai/like.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from agno.models.base import Model
 from agno.models.openai.chat import OpenAIChat
 
 
@@ -25,3 +26,6 @@ class OpenAILike(OpenAIChat):
         "assistant": "assistant",
         "tool": "tool",
     }
+
+    def get_provider(self) -> str:
+        return Model.get_provider(self)

--- a/libs/agno/tests/unit/models/test_model_helpers.py
+++ b/libs/agno/tests/unit/models/test_model_helpers.py
@@ -21,6 +21,7 @@ from agno.exceptions import AgentRunException
 from agno.models.base import _handle_agent_exception
 from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
+from agno.models.openai.like import OpenAILike
 from agno.models.response import ModelResponse
 
 
@@ -111,6 +112,11 @@ class TestGetProvider:
     def test_get_provider_returns_openai_default(self, model):
         """OpenAIChat defaults provider to 'OpenAI'."""
         assert model.get_provider() == "OpenAI Chat"
+
+    def test_openai_like_returns_provider_without_chat_suffix(self):
+        """OpenAILike returns the provider without the OpenAIChat suffix."""
+        model = OpenAILike(id="compatible-model", provider="CompatibleProvider")
+        assert model.get_provider() == "CompatibleProvider"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #8427.

`OpenAILike` currently inherits `OpenAIChat.get_provider()`, which appends `" Chat"` to the provider name. That suffix is useful for the concrete OpenAI Chat model class, but it is not needed for OpenAI-compatible providers using `OpenAILike`.

This PR:

- overrides `OpenAILike.get_provider()` to use the base `Model.get_provider()` behavior
- keeps `OpenAIChat.get_provider()` unchanged
- adds a regression test showing `OpenAILike` returns the configured provider without the `Chat` suffix

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed with the project virtual environment active:

- `./scripts/format.sh`
- `./scripts/validate.sh`
- `pytest tests/unit/models/test_model_helpers.py::TestGetProvider`

Duplicate check notes:

- Searched open issues and PRs for `OpenAILike get_provider Chat suffix` and `OpenAIChat OpenAILike provider`.
- Found no open PR that addresses this provider label suffix issue. Existing OpenAILike-related results were about request parameter compatibility or tool-call handling, not provider naming.