### PR TITLE
[fix] Add request timeout to OpenWeatherTools

### DIFF
--- a/libs/agno/agno/tools/openweather.py
+++ b/libs/agno/agno/tools/openweather.py
@@ -18,6 +18,7 @@ class OpenWeatherTools(Toolkit):
     Args:
         api_key (Optional[str]): OpenWeatherMap API key. If not provided, will try to get from OPENWEATHER_API_KEY env var.
         units (str): Units of measurement. Options are 'standard', 'metric', and 'imperial'. Default is 'metric'.
+        timeout (int): Request timeout in seconds. Default is 30.
         enable_current_weather (bool): Enable current weather function. Default is True.
         enable_forecast (bool): Enable forecast function. Default is True.
         enable_air_pollution (bool): Enable air pollution function. Default is True.
@@ -29,6 +30,7 @@ class OpenWeatherTools(Toolkit):
         self,
         api_key: Optional[str] = None,
         units: str = "metric",
+        timeout: int = 30,
         enable_current_weather: bool = True,
         enable_forecast: bool = True,
         enable_air_pollution: bool = True,
@@ -43,6 +45,7 @@ class OpenWeatherTools(Toolkit):
             )
 
         self.units = units
+        self.timeout = timeout
         self.base_url = "https://api.openweathermap.org/data/2.5"
         self.geo_url = "https://api.openweathermap.org/geo/1.0"
 
@@ -70,7 +73,7 @@ class OpenWeatherTools(Toolkit):
         """
         try:
             params["appid"] = self.api_key
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=self.timeout)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/libs/agno/tests/unit/tools/test_openweather.py
+++ b/libs/agno/tests/unit/tools/test_openweather.py
@@ -205,6 +205,25 @@ def test_error_handling(openweather_tools, mock_openweather_api):
     assert "Connection error" in result_data["error"]
 
 
+def test_make_request_uses_configured_timeout(mock_openweather_api):
+    """Test API requests use the configured timeout."""
+    mock_response = Mock()
+    mock_response.json.return_value = {"ok": True}
+    mock_response.raise_for_status.return_value = None
+    mock_openweather_api.return_value = mock_response
+
+    with patch.dict("os.environ", {"OPENWEATHER_API_KEY": "test_api_key"}):
+        tools = OpenWeatherTools(timeout=12)
+
+    tools._make_request("https://api.openweathermap.org/data/2.5/weather", {"lat": 1, "lon": 2})
+
+    mock_openweather_api.assert_called_once_with(
+        "https://api.openweathermap.org/data/2.5/weather",
+        params={"lat": 1, "lon": 2, "appid": "test_api_key"},
+        timeout=12,
+    )
+
+
 def test_geocode_location_empty_result(openweather_tools, mock_openweather_api):
     """Test geocode location with empty result."""
     mock_response = Mock()


### PR DESCRIPTION
## Summary

Adds a configurable request timeout to `OpenWeatherTools` and passes it to the shared OpenWeatherMap request helper.

Fixes #8396

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` and `ruff check` on changed files; `./scripts/dev_setup.sh` is not path-safe when the checkout path contains spaces)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated

---

## Additional Notes

Validation performed:

- `pytest libs/agno/tests/unit/tools/test_openweather.py::test_make_request_uses_configured_timeout`
- `pytest libs/agno/tests/unit/tools/test_openweather.py`
- `ruff format libs/agno/agno/tools/openweather.py libs/agno/tests/unit/tools/test_openweather.py`
- `ruff check libs/agno/agno/tools/openweather.py libs/agno/tests/unit/tools/test_openweather.py`