### PR TITLE
[fix] Add timeout and status handling to HackerNewsTools

### DIFF
--- a/libs/agno/agno/tools/hackernews.py
+++ b/libs/agno/agno/tools/hackernews.py
@@ -12,14 +12,21 @@ class HackerNewsTools(Toolkit):
     HackerNews is a tool for getting top stories from Hacker News.
 
     Args:
+        timeout (int): Request timeout in seconds. Default is 30.
         enable_get_top_stories (bool): Enable getting top stories from Hacker News. Default is True.
         enable_get_user_details (bool): Enable getting user details from Hacker News. Default is True.
         all (bool): Enable all tools. Overrides individual flags when True. Default is False.
     """
 
     def __init__(
-        self, enable_get_top_stories: bool = True, enable_get_user_details: bool = True, all: bool = False, **kwargs
+        self,
+        timeout: int = 30,
+        enable_get_top_stories: bool = True,
+        enable_get_user_details: bool = True,
+        all: bool = False,
+        **kwargs,
     ):
+        self.timeout = timeout
         tools: List[Any] = []
         if all or enable_get_top_stories:
             tools.append(self.get_top_hackernews_stories)
@@ -27,6 +34,11 @@ class HackerNewsTools(Toolkit):
             tools.append(self.get_user_details)
 
         super().__init__(name="hackers_news", tools=tools, **kwargs)
+
+    def _get_json(self, url: str) -> Any:
+        response = httpx.get(url, timeout=self.timeout)
+        response.raise_for_status()
+        return response.json()
 
     def get_top_hackernews_stories(self, num_stories: int = 10) -> str:
         """Use this function to get top stories from Hacker News.
@@ -41,14 +53,12 @@ class HackerNewsTools(Toolkit):
         try:
             log_debug(f"Getting top {num_stories} stories from Hacker News")
             # Fetch top story IDs
-            response = httpx.get("https://hacker-news.firebaseio.com/v0/topstories.json")
-            story_ids = response.json()
+            story_ids = self._get_json("https://hacker-news.firebaseio.com/v0/topstories.json")
 
             # Fetch story details
             stories = []
             for story_id in story_ids[:num_stories]:
-                story_response = httpx.get(f"https://hacker-news.firebaseio.com/v0/item/{story_id}.json")
-                story = story_response.json()
+                story = self._get_json(f"https://hacker-news.firebaseio.com/v0/item/{story_id}.json")
                 if story is None:
                     continue
                 story["username"] = story.get("by", "unknown")
@@ -70,7 +80,7 @@ class HackerNewsTools(Toolkit):
 
         try:
             log_debug(f"Getting details for user: {username}")
-            user = httpx.get(f"https://hacker-news.firebaseio.com/v0/user/{username}.json").json()
+            user = self._get_json(f"https://hacker-news.firebaseio.com/v0/user/{username}.json")
             user_details = {
                 "id": user.get("user_id"),
                 "karma": user.get("karma"),

--- a/libs/agno/tests/unit/tools/test_hackernews.py
+++ b/libs/agno/tests/unit/tools/test_hackernews.py
@@ -80,6 +80,11 @@ class TestHackerNewsToolsInitialization:
         tools = HackerNewsTools()
         assert tools.name == "hackers_news"
 
+    def test_initialization_with_custom_timeout(self):
+        """Test initialization with custom request timeout."""
+        tools = HackerNewsTools(timeout=7)
+        assert tools.timeout == 7
+
 
 class TestGetTopHackerNewsStories:
     """Tests for get_top_hackernews_stories method."""
@@ -93,7 +98,7 @@ class TestGetTopHackerNewsStories:
             {"id": 11111, "title": "Story 3", "by": "user3", "url": "https://example3.com"},
         ]
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -114,6 +119,25 @@ class TestGetTopHackerNewsStories:
         assert stories[1]["title"] == "Story 2"
         assert stories[2]["title"] == "Story 3"
 
+    def test_get_top_stories_uses_configured_timeout(self):
+        """Test top stories requests use the configured timeout."""
+        tools = HackerNewsTools(timeout=7)
+
+        def mock_get(url, **kwargs):
+            response = MagicMock()
+            if "topstories" in url:
+                response.json.return_value = [12345]
+            else:
+                response.json.return_value = {"id": 12345, "title": "Story 1", "by": "user1"}
+            return response
+
+        with patch("agno.tools.hackernews.httpx.get", side_effect=mock_get) as mock_http_get:
+            tools.get_top_hackernews_stories(num_stories=1)
+
+        assert mock_http_get.call_count == 2
+        for call in mock_http_get.call_args_list:
+            assert call.kwargs["timeout"] == 7
+
     def test_get_top_stories_custom_count(self, hackernews_tools):
         """Test getting top stories with custom count."""
         mock_story_ids = [1, 2, 3, 4, 5]
@@ -122,7 +146,7 @@ class TestGetTopHackerNewsStories:
             2: {"id": 2, "title": "Story 2", "by": "user2"},
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -142,7 +166,7 @@ class TestGetTopHackerNewsStories:
         mock_story_ids = [12345]
         mock_story = {"id": 12345, "title": "Test Story", "by": "testuser", "score": 100}
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -160,7 +184,7 @@ class TestGetTopHackerNewsStories:
     def test_get_top_stories_empty_response(self, hackernews_tools):
         """Test handling of empty story list."""
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             response.json.return_value = []
             return response
@@ -188,7 +212,7 @@ class TestGetTopHackerNewsStories:
             67890: {"id": 67890, "title": "Story 2", "by": "user2"},
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -210,7 +234,7 @@ class TestGetTopHackerNewsStories:
         mock_story_ids = [12345]
         mock_story = {"id": 12345, "title": "Job Posting", "type": "job", "url": "https://example.com"}
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -238,7 +262,7 @@ class TestGetTopHackerNewsStories:
             "type": "story",
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -384,7 +408,7 @@ class TestEdgeCases:
         """Test requesting zero stories."""
         mock_story_ids = [1, 2, 3]
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             response.json.return_value = mock_story_ids
             return response
@@ -403,7 +427,7 @@ class TestEdgeCases:
             2: {"id": 2, "title": "Story 2", "by": "user2"},
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -446,7 +470,7 @@ class TestEdgeCases:
             "score": 5000,
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids


### PR DESCRIPTION
## Summary

Adds a configurable request timeout to `HackerNewsTools` and centralizes Hacker News API fetches through a helper that calls `raise_for_status()` before parsing JSON.

Fixes #8397

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` and `ruff check` on changed files; `./scripts/dev_setup.sh` is not path-safe when the checkout path contains spaces)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated

---

## Additional Notes

Validation performed:

- `pytest libs/agno/tests/unit/tools/test_hackernews.py::TestHackerNewsToolsInitialization::test_initialization_with_custom_timeout libs/agno/tests/unit/tools/test_hackernews.py::TestGetTopHackerNewsStories::test_get_top_stories_uses_configured_timeout`
- `pytest libs/agno/tests/unit/tools/test_hackernews.py`
- `ruff format libs/agno/agno/tools/hackernews.py libs/agno/tests/unit/tools/test_hackernews.py`
- `ruff check libs/agno/agno/tools/hackernews.py libs/agno/tests/unit/tools/test_hackernews.py`