### PR TITLE
[fix] Add request timeouts to ZoomTools

### DIFF
--- a/libs/agno/agno/tools/zoom.py
+++ b/libs/agno/agno/tools/zoom.py
@@ -16,6 +16,7 @@ class ZoomTools(Toolkit):
         account_id: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,
+        timeout: int = 30,
         **kwargs,
     ):
         """
@@ -25,12 +26,14 @@ class ZoomTools(Toolkit):
             account_id (str): The Zoom account ID for authentication. If not provided, will use ZOOM_ACCOUNT_ID env var.
             client_id (str): The client ID for authentication. If not provided, will use ZOOM_CLIENT_ID env var.
             client_secret (str): The client secret for authentication. If not provided, will use ZOOM_CLIENT_SECRET env var.
+            timeout (int): The timeout for Zoom API requests in seconds. Defaults to 30.
             name (str): The name of the tool. Defaults to "zoom_tool".
         """
         # Get credentials from env vars if not provided
         self.account_id = account_id or getenv("ZOOM_ACCOUNT_ID")
         self.client_id = client_id or getenv("ZOOM_CLIENT_ID")
         self.client_secret = client_secret or getenv("ZOOM_CLIENT_SECRET")
+        self.timeout = timeout
         self.__access_token = None  # Made private
         self.__token_expiry = None  # Track token expiration
 
@@ -77,7 +80,7 @@ class ZoomTools(Toolkit):
                 "account_id": self.account_id,
             }
 
-            response = requests.post("https://zoom.us/oauth/token", headers=headers, data=data)
+            response = requests.post("https://zoom.us/oauth/token", headers=headers, data=data, timeout=self.timeout)
             response.raise_for_status()
 
             token_data = response.json()
@@ -134,7 +137,7 @@ class ZoomTools(Toolkit):
         }
 
         try:
-            response = requests.post(url, json=data, headers=headers)
+            response = requests.post(url, json=data, headers=headers, timeout=self.timeout)
             response.raise_for_status()
             meeting_info = response.json()
 
@@ -174,7 +177,7 @@ class ZoomTools(Toolkit):
         params = {"type": "upcoming", "page_size": str(30)}
 
         try:
-            response = requests.get(url, headers=headers, params=params)  # type: ignore
+            response = requests.get(url, headers=headers, params=params, timeout=self.timeout)  # type: ignore
             response.raise_for_status()
             meetings = response.json()
 
@@ -213,7 +216,7 @@ class ZoomTools(Toolkit):
         params = {"type": type}
 
         try:
-            response = requests.get(url, headers=headers, params=params)
+            response = requests.get(url, headers=headers, params=params, timeout=self.timeout)
             response.raise_for_status()
             meetings = response.json()
 
@@ -266,7 +269,7 @@ class ZoomTools(Toolkit):
                     logger.warning("Invalid TTL value. Must be between 0 and 604800 seconds.")
 
         try:
-            response = requests.get(url, headers=headers, params=params)
+            response = requests.get(url, headers=headers, params=params, timeout=self.timeout)
             response.raise_for_status()
             recordings = response.json()
 
@@ -313,7 +316,7 @@ class ZoomTools(Toolkit):
         params = {"schedule_for_reminder": schedule_for_reminder}
 
         try:
-            response = requests.delete(url, headers=headers, params=params)
+            response = requests.delete(url, headers=headers, params=params, timeout=self.timeout)
             response.raise_for_status()
 
             # Zoom returns 204 No Content for successful deletion
@@ -349,7 +352,7 @@ class ZoomTools(Toolkit):
         headers = {"Authorization": f"Bearer {token}"}
 
         try:
-            response = requests.get(url, headers=headers)
+            response = requests.get(url, headers=headers, timeout=self.timeout)
             response.raise_for_status()
             meeting_info = response.json()
 

--- a/libs/agno/tests/unit/tools/test_zoom_tools.py
+++ b/libs/agno/tests/unit/tools/test_zoom_tools.py
@@ -40,6 +40,18 @@ def test_init_with_credentials():
     assert tool.account_id == "test_account_id"
     assert tool.client_id == "test_client_id"
     assert tool.client_secret == "test_client_secret"
+    assert tool.timeout == 30
+
+
+def test_init_with_custom_timeout():
+    """Test initialization with a custom request timeout"""
+    tool = ZoomTools(
+        account_id="test_account_id",
+        client_id="test_client_id",
+        client_secret="test_client_secret",
+        timeout=7,
+    )
+    assert tool.timeout == 7
 
 
 @patch.dict(
@@ -75,6 +87,7 @@ def test_get_access_token_success(zoom_tools, mock_token_response):
         assert kwargs["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
         assert kwargs["data"]["grant_type"] == "account_credentials"
         assert kwargs["data"]["account_id"] == "test_account_id"
+        assert kwargs["timeout"] == 30
 
 
 def test_get_access_token_reuse(zoom_tools, mock_token_response):
@@ -168,6 +181,7 @@ def test_schedule_meeting_success(zoom_tools):
         assert result_data["meeting_id"] == 123456789
         assert result_data["topic"] == "Test Meeting"
         assert result_data["join_url"] == "https://zoom.us/j/123456789"
+        assert mock_post.call_args.kwargs["timeout"] == 30
 
 
 def test_get_meeting_success(zoom_tools):
@@ -194,6 +208,7 @@ def test_get_meeting_success(zoom_tools):
         assert result_data["meeting_id"] == "123456789"
         assert result_data["topic"] == "Test Meeting"
         assert result_data["join_url"] == "https://zoom.us/j/123456789"
+        assert mock_get.call_args.kwargs["timeout"] == 30
 
 
 def test_get_upcoming_meetings_success(zoom_tools):
@@ -228,6 +243,7 @@ def test_get_upcoming_meetings_success(zoom_tools):
         assert len(result_data["meetings"]) == 2
         assert result_data["meetings"][0]["id"] == 123456789
         assert result_data["meetings"][1]["id"] == 987654321
+        assert mock_get.call_args.kwargs["timeout"] == 30
 
 
 def test_list_meetings_success(zoom_tools):
@@ -265,6 +281,7 @@ def test_list_meetings_success(zoom_tools):
         assert len(result_data["meetings"]) == 2
         assert result_data["meetings"][0]["id"] == 123456789
         assert result_data["meetings"][1]["topic"] == "Scheduled Meeting 2"
+        assert mock_get.call_args.kwargs["timeout"] == 30
 
 
 def test_get_meeting_recordings_success(zoom_tools):
@@ -309,6 +326,7 @@ def test_get_meeting_recordings_success(zoom_tools):
         assert len(result_data["recording_files"]) == 2
         assert result_data["recording_files"][0]["recording_type"] == "shared_screen_with_speaker_view"
         assert result_data["recording_files"][1]["recording_type"] == "audio_only"
+        assert mock_get.call_args.kwargs["timeout"] == 30
 
 
 def test_delete_meeting_success(zoom_tools):
@@ -331,6 +349,7 @@ def test_delete_meeting_success(zoom_tools):
         args, kwargs = mock_delete.call_args
         assert args[0] == "https://api.zoom.us/v2/meetings/123456789"
         assert kwargs["headers"]["Authorization"] == "Bearer test_token"
+        assert kwargs["timeout"] == 30
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add a configurable request timeout to ZoomTools.
- Apply the timeout to OAuth token generation and all Zoom API get/post/delete calls.
- Extend unit tests to verify default and custom timeout behavior.

Fixes #8432

## Testing
- pytest libs/agno/tests/unit/tools/test_zoom_tools.py
- ruff format libs/agno/agno/tools/zoom.py libs/agno/tests/unit/tools/test_zoom_tools.py
- ruff check libs/agno/agno/tools/zoom.py libs/agno/tests/unit/tools/test_zoom_tools.py

## Notes
- This PR was prepared with AI assistance.
- I could not use ./scripts/dev_setup.sh directly because this checkout path contains spaces/non-ASCII characters; I installed the documented dependencies into .venv manually and ran the targeted checks above.