### PR TITLE
[fix] Add request timeout to BitbucketTools

### DIFF
--- a/libs/agno/agno/tools/bitbucket.py
+++ b/libs/agno/agno/tools/bitbucket.py
@@ -19,6 +19,7 @@ class BitbucketTools(Toolkit):
         workspace: Optional[str] = None,
         repo_slug: Optional[str] = None,
         api_version: str = "2.0",
+        timeout: int = 30,
         **kwargs,
     ):
         self.username = username or getenv("BITBUCKET_USERNAME")
@@ -34,6 +35,7 @@ class BitbucketTools(Toolkit):
         )
         self.workspace = workspace
         self.repo_slug = repo_slug
+        self.timeout = timeout
 
         if not (self.username and self.auth_password):
             raise ValueError("Username and password or token are required")
@@ -74,7 +76,7 @@ class BitbucketTools(Toolkit):
         data: Optional[Dict[str, Any]] = None,
     ) -> Union[str, Dict[str, Any]]:
         url = f"{self.base_url}{endpoint}"
-        response = requests.request(method, url, headers=self.headers, json=data, params=params)
+        response = requests.request(method, url, headers=self.headers, json=data, params=params, timeout=self.timeout)
         response.raise_for_status()
         encoding_type = response.headers.get("Content-Type", "application/json")
         if encoding_type.startswith("application/json"):

--- a/libs/agno/tests/unit/tools/test_bitbucket.py
+++ b/libs/agno/tests/unit/tools/test_bitbucket.py
@@ -44,6 +44,7 @@ class TestBitbucketTools:
         assert tools.auth_password == "test_password"
         assert tools.server_url == "api.bitbucket.org"
         assert tools.api_version == "2.0"
+        assert tools.timeout == 30
         assert "Basic" in tools.headers["Authorization"]
 
     def test_init_with_custom_params(self, mock_env_vars):
@@ -55,6 +56,7 @@ class TestBitbucketTools:
             username="custom_user",
             password="custom_password",
             api_version="2.1",
+            timeout=7,
         )
 
         assert tools.workspace == "custom_workspace"
@@ -63,6 +65,7 @@ class TestBitbucketTools:
         assert tools.auth_password == "custom_password"
         assert tools.server_url == "custom.bitbucket.com"
         assert tools.api_version == "2.1"
+        assert tools.timeout == 7
 
     def test_init_with_token_priority(self, mock_env_vars):
         """Test that token takes priority over password."""
@@ -109,6 +112,21 @@ class TestBitbucketTools:
 
         assert result == {"test": "data"}
         mock_request.assert_called_once()
+        assert mock_request.call_args.kwargs["timeout"] == 30
+
+    @patch("requests.request")
+    def test_make_request_uses_custom_timeout(self, mock_request, mock_env_vars):
+        """Test _make_request passes the configured timeout."""
+        mock_response = MagicMock()
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"test": "data"}
+        mock_response.text = '{"test": "data"}'
+        mock_request.return_value = mock_response
+        bitbucket_tools = BitbucketTools(workspace="test_workspace", repo_slug="test_repo", timeout=5)
+
+        bitbucket_tools._make_request("GET", "/test")
+
+        assert mock_request.call_args.kwargs["timeout"] == 5
 
     @patch("requests.request")
     def test_make_request_text_response(self, mock_request, bitbucket_tools):


### PR DESCRIPTION
## Summary
- Add a configurable request timeout to BitbucketTools.
- Pass the timeout through the shared _make_request helper so all Bitbucket API calls are bounded.
- Add unit coverage for default and custom timeout behavior.

Fixes #8433

## Testing
- pytest libs/agno/tests/unit/tools/test_bitbucket.py
- ruff format libs/agno/agno/tools/bitbucket.py libs/agno/tests/unit/tools/test_bitbucket.py
- ruff check libs/agno/agno/tools/bitbucket.py libs/agno/tests/unit/tools/test_bitbucket.py

## Notes
- This PR was prepared with AI assistance.
- I could not use ./scripts/dev_setup.sh directly because this checkout path contains spaces/non-ASCII characters; I installed the documented dependencies into .venv manually and ran the targeted checks above.