### PR TITLE
[fix] Add request timeout to FinancialDatasetsTools

### DIFF
--- a/libs/agno/agno/tools/financial_datasets.py
+++ b/libs/agno/agno/tools/financial_datasets.py
@@ -11,12 +11,14 @@ class FinancialDatasetsTools(Toolkit):
     def __init__(
         self,
         api_key: Optional[str] = None,
+        timeout: int = 30,
         **kwargs,
     ):
         """Initialize the Financial Datasets Tools.
 
         Args:
             api_key: API key for Financial Datasets API (optional, can be set via environment variable)
+            timeout: Timeout for API requests in seconds.
         """
 
         self.api_key: Optional[str] = api_key or getenv("FINANCIAL_DATASETS_API_KEY")
@@ -26,6 +28,7 @@ class FinancialDatasetsTools(Toolkit):
             )
 
         self.base_url = "https://api.financialdatasets.ai"
+        self.timeout = timeout
 
         tools: List[Any] = [
             # Financial statements
@@ -73,7 +76,7 @@ class FinancialDatasetsTools(Toolkit):
         url = f"{self.base_url}/{endpoint}"
 
         try:
-            response = requests.get(url, headers=headers, params=params)
+            response = requests.get(url, headers=headers, params=params, timeout=self.timeout)
             response.raise_for_status()
             return response.text
         except requests.exceptions.RequestException as e:

--- a/libs/agno/tests/unit/tools/test_financial_datasets.py
+++ b/libs/agno/tests/unit/tools/test_financial_datasets.py
@@ -34,6 +34,13 @@ def test_init_with_provided_key():
     """Test initialization with explicitly provided API key."""
     tools = FinancialDatasetsTools(api_key="explicit_key")
     assert tools.api_key == "explicit_key"
+    assert tools.timeout == 30
+
+
+def test_init_with_custom_timeout():
+    """Test initialization with a custom request timeout."""
+    tools = FinancialDatasetsTools(api_key="explicit_key", timeout=7)
+    assert tools.timeout == 7
 
 
 @patch.dict(os.environ, {"FINANCIAL_DATASETS_API_KEY": "env_key"})
@@ -51,6 +58,26 @@ def test_init_without_key(mock_log_error):
         tools = FinancialDatasetsTools()
         assert tools.api_key is None
         mock_log_error.assert_called_once()
+
+
+@patch("requests.get")
+def test_make_request_uses_configured_timeout(mock_get):
+    """Test API requests use the configured timeout."""
+    mock_response = MagicMock()
+    mock_response.text = '{"status": "success"}'
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+    tools = FinancialDatasetsTools(api_key="explicit_key", timeout=5)
+
+    result = tools._make_request("prices", {"ticker": "AAPL"})
+
+    assert result == '{"status": "success"}'
+    mock_get.assert_called_once_with(
+        "https://api.financialdatasets.ai/prices",
+        headers={"X-API-KEY": "explicit_key"},
+        params={"ticker": "AAPL"},
+        timeout=5,
+    )
 
 
 # Financial Statements Endpoint Tests


### PR DESCRIPTION
## Summary
- Add a configurable request timeout to FinancialDatasetsTools.
- Pass the timeout to the shared Financial Datasets API request helper.
- Add unit coverage for default and custom timeout behavior.

Fixes #8434

## Testing
- pytest libs/agno/tests/unit/tools/test_financial_datasets.py
- ruff format libs/agno/agno/tools/financial_datasets.py libs/agno/tests/unit/tools/test_financial_datasets.py
- ruff check libs/agno/agno/tools/financial_datasets.py libs/agno/tests/unit/tools/test_financial_datasets.py

## Notes
- This PR was prepared with AI assistance.
- I could not use ./scripts/dev_setup.sh directly because this checkout path contains spaces/non-ASCII characters; I installed the documented dependencies into .venv manually and ran the targeted checks above.