### PR TITLE
[fix] Add request timeout to WhatsAppTools

### DIFF
--- a/libs/agno/agno/tools/whatsapp.py
+++ b/libs/agno/agno/tools/whatsapp.py
@@ -48,6 +48,7 @@ class WhatsAppTools(Toolkit):
         enable_send_location: bool = False,
         enable_send_reaction: bool = False,
         all: bool = False,
+        timeout: int = 30,
         **kwargs,
     ):
         self.access_token = access_token or getenv("WHATSAPP_ACCESS_TOKEN")
@@ -64,6 +65,7 @@ class WhatsAppTools(Toolkit):
         self.default_recipient = recipient_waid or getenv("WHATSAPP_RECIPIENT_WAID")
         self.version = version or getenv("WHATSAPP_VERSION", "v22.0")
         self.base_url = "https://graph.facebook.com"
+        self.timeout = timeout
 
         # Register only enabled tools to keep the agent's tool list focused
         tools: List[Any] = []
@@ -101,7 +103,7 @@ class WhatsAppTools(Toolkit):
 
     def _send_message(self, data: Dict[str, Any]) -> Dict[str, Any]:
         # Raise on 4xx/5xx with parsed error body for better diagnostics
-        response = httpx.post(self._get_messages_url(), headers=self._get_headers(), json=data)
+        response = httpx.post(self._get_messages_url(), headers=self._get_headers(), json=data, timeout=self.timeout)
         if response.status_code >= 400:
             error_body = (
                 response.json()

--- a/libs/agno/tests/unit/tools/test_whatsapp_tools.py
+++ b/libs/agno/tests/unit/tools/test_whatsapp_tools.py
@@ -46,6 +46,7 @@ def test_init_registers_default_tools():
         names = [f.name for f in tools.functions.values()]
         assert "send_text_message" in names
         assert "send_template_message" in names
+        assert tools.timeout == 30
         assert len(names) == 2
 
 
@@ -73,6 +74,23 @@ def test_send_text_message(whatsapp_tools):
     parsed = json.loads(result)
     assert parsed["ok"] is True
     assert parsed["message_id"] == "wamid.test123"
+    assert whatsapp_tools._mock_httpx.post.call_args.kwargs["timeout"] == 30
+
+
+def test_send_message_uses_configured_timeout():
+    with patch.dict("os.environ", ENV):
+        with patch("agno.tools.whatsapp.httpx") as mock_httpx:
+            mock_response = Mock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"messages": [{"id": "wamid.test123"}]}
+            mock_httpx.post.return_value = mock_response
+            tools = WhatsAppTools(all=True, recipient_waid="+1234567890", timeout=5)
+
+            result = tools.send_text_message(text="Hello")
+
+            parsed = json.loads(result)
+            assert parsed["ok"] is True
+            assert mock_httpx.post.call_args.kwargs["timeout"] == 5
 
 
 def test_send_text_message_default_recipient(whatsapp_tools):


### PR DESCRIPTION
## Summary
- Add a configurable request timeout to WhatsAppTools.
- Pass the timeout through the shared WhatsApp message send helper.
- Add unit coverage for default and custom timeout behavior.

Fixes #8436

## Testing
- pytest libs/agno/tests/unit/tools/test_whatsapp_tools.py
- ruff format libs/agno/agno/tools/whatsapp.py libs/agno/tests/unit/tools/test_whatsapp_tools.py
- ruff check libs/agno/agno/tools/whatsapp.py libs/agno/tests/unit/tools/test_whatsapp_tools.py

## Notes
- This PR was prepared with AI assistance.
- I could not use ./scripts/dev_setup.sh directly because this checkout path contains spaces/non-ASCII characters; I installed the documented dependencies into .venv manually and ran the targeted checks above.