### PR TITLE
[fix] Add request timeout to UnsplashTools

### DIFF
--- a/libs/agno/agno/tools/unsplash.py
+++ b/libs/agno/agno/tools/unsplash.py
@@ -48,6 +48,7 @@ class UnsplashTools(Toolkit):
         enable_get_random_photo: bool = True,
         enable_download_photo: bool = False,
         all: bool = False,
+        timeout: int = 30,
         **kwargs: Any,
     ):
         """Initialize the Unsplash toolkit.
@@ -60,6 +61,7 @@ class UnsplashTools(Toolkit):
             enable_get_random_photo: Enable the get_random_photo tool. Default: True.
             enable_download_photo: Enable the download_photo tool. Default: False.
             all: Enable all tools. Default: False.
+            timeout: Timeout for Unsplash API requests in seconds. Default: 30.
             **kwargs: Additional arguments passed to the Toolkit base class.
         """
         self.access_key = access_key or getenv("UNSPLASH_ACCESS_KEY")
@@ -67,6 +69,7 @@ class UnsplashTools(Toolkit):
             logger.warning("No Unsplash API key provided. Set UNSPLASH_ACCESS_KEY environment variable.")
 
         self.base_url = "https://api.unsplash.com"
+        self.timeout = timeout
 
         tools: List[Any] = []
         if all or enable_search_photos:
@@ -103,7 +106,7 @@ class UnsplashTools(Toolkit):
         }
 
         request = Request(url, headers=headers)
-        with urlopen(request) as response:
+        with urlopen(request, timeout=self.timeout) as response:
             return json.loads(response.read().decode())
 
     def _format_photo(self, photo: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/agno/tests/unit/tools/test_unsplash.py
+++ b/libs/agno/tests/unit/tools/test_unsplash.py
@@ -95,6 +95,12 @@ class TestUnsplashToolsInit:
         """Test initialization with provided API key."""
         tools = UnsplashTools(access_key="provided_key")
         assert tools.access_key == "provided_key"
+        assert tools.timeout == 30
+
+    def test_init_with_custom_timeout(self):
+        """Test initialization with a custom request timeout."""
+        tools = UnsplashTools(access_key="provided_key", timeout=5)
+        assert tools.timeout == 5
 
     def test_init_without_api_key_logs_warning(self):
         """Test initialization without API key logs a warning."""
@@ -483,6 +489,16 @@ class TestMakeRequest:
         assert "/test?" in call_args.full_url
         assert "param1=value1" in call_args.full_url
         assert "param2=value2" in call_args.full_url
+        assert mock_urlopen.call_args.kwargs["timeout"] == 30
+
+    def test_make_request_uses_configured_timeout(self, mock_urlopen):
+        """Test request uses the configured timeout."""
+        mock_urlopen.return_value = create_mock_response({"test": "data"})
+        tools = UnsplashTools(access_key="provided_key", timeout=5)
+
+        tools._make_request("/test")
+
+        assert mock_urlopen.call_args.kwargs["timeout"] == 5
 
     def test_make_request_includes_auth_header(self, unsplash_tools, mock_urlopen):
         """Test request includes authorization header."""


### PR DESCRIPTION
## Summary
- Add a configurable request timeout to UnsplashTools.
- Pass the timeout to urllib.request.urlopen in the shared request helper.
- Add unit coverage for default and custom timeout behavior.

Fixes #8437

## Testing
- pytest libs/agno/tests/unit/tools/test_unsplash.py
- ruff format libs/agno/agno/tools/unsplash.py libs/agno/tests/unit/tools/test_unsplash.py
- ruff check libs/agno/agno/tools/unsplash.py libs/agno/tests/unit/tools/test_unsplash.py

## Notes
- This PR was prepared with AI assistance.
- I could not use ./scripts/dev_setup.sh directly because this checkout path contains spaces/non-ASCII characters; I installed the documented dependencies into .venv manually and ran the targeted checks above.