### PR TITLE
fix: update ParallelTools for parallel-web >= 1.0 GA API

### DIFF
--- a/libs/agno/agno/tools/parallel.py
+++ b/libs/agno/agno/tools/parallel.py
@@ -40,8 +40,7 @@ class ParallelTools(Toolkit):
         all (bool): Enable all tools. Overrides individual flags when True. Default is False.
         max_results (int): Default maximum number of results for search operations. Default is 10.
         max_chars_per_result (int): Default maximum characters per result for search operations. Default is 10000.
-        beta_version (str): Beta API version header. Default is "search-extract-2025-10-10".
-        mode (Optional[str]): Default search mode. Options: "one-shot" or "agentic". Default is None.
+        mode (Optional[str]): Default search mode. Options: "turbo", "basic", or "advanced". Default is None (uses "advanced").
         include_domains (Optional[List[str]]): Default domains to restrict results to. Default is None.
         exclude_domains (Optional[List[str]]): Default domains to exclude from results. Default is None.
         max_age_seconds (Optional[int]): Default cache age threshold (minimum 600). Default is None.
@@ -63,7 +62,6 @@ class ParallelTools(Toolkit):
         all: bool = False,
         max_results: int = 10,
         max_chars_per_result: int = 10000,
-        beta_version: str = "search-extract-2025-10-10",
         mode: Optional[str] = None,
         include_domains: Optional[List[str]] = None,
         exclude_domains: Optional[List[str]] = None,
@@ -82,7 +80,6 @@ class ParallelTools(Toolkit):
 
         self.max_results = max_results
         self.max_chars_per_result = max_chars_per_result
-        self.beta_version = beta_version
         self.mode = mode
         self.include_domains = include_domains
         self.exclude_domains = exclude_domains
@@ -94,9 +91,7 @@ class ParallelTools(Toolkit):
         self.default_timeout = default_timeout
         self.default_output_schema = default_output_schema
 
-        self.parallel_client = ParallelClient(
-            api_key=self.api_key, default_headers={"parallel-beta": self.beta_version}
-        )
+        self.parallel_client = ParallelClient(api_key=self.api_key)
 
         tools: List[Any] = []
         if all or enable_search:
@@ -145,30 +140,28 @@ class ParallelTools(Toolkit):
             # Use instance defaults if not provided
             final_max_results = max_results if max_results is not None else self.max_results
 
-            search_params: Dict[str, Any] = {
-                "max_results": final_max_results,
-            }
+            search_params: Dict[str, Any] = {}
 
             # Add objective if provided
             if objective:
                 search_params["objective"] = objective
 
-            # Add search_queries if provided
+            # search_queries is required in GA API
             if search_queries:
                 search_params["search_queries"] = search_queries
+            elif objective:
+                search_params["search_queries"] = [objective]
 
-            # Add mode from constructor default
-            if self.mode:
-                search_params["mode"] = self.mode
+            # Add mode from constructor default (GA modes: turbo, basic, advanced)
+            search_params["mode"] = self.mode if self.mode else "advanced"
 
-            # Add excerpts configuration
-            excerpts_config: Dict[str, Any] = {}
+            # GA API: all config goes under advanced_settings
+            advanced_settings: Dict[str, Any] = {"max_results": final_max_results}
+
+            # Add excerpt_settings
             final_max_chars = max_chars_per_result if max_chars_per_result is not None else self.max_chars_per_result
             if final_max_chars is not None:
-                excerpts_config["max_chars_per_result"] = final_max_chars
-
-            if excerpts_config:
-                search_params["excerpts"] = excerpts_config
+                advanced_settings["excerpt_settings"] = {"max_chars_per_result": final_max_chars}
 
             # Add source_policy from constructor defaults
             source_policy: Dict[str, Any] = {}
@@ -176,9 +169,8 @@ class ParallelTools(Toolkit):
                 source_policy["include_domains"] = self.include_domains
             if self.exclude_domains:
                 source_policy["exclude_domains"] = self.exclude_domains
-
             if source_policy:
-                search_params["source_policy"] = source_policy
+                advanced_settings["source_policy"] = source_policy
 
             # Add fetch_policy from constructor defaults
             fetch_policy: Dict[str, Any] = {}
@@ -186,11 +178,12 @@ class ParallelTools(Toolkit):
                 fetch_policy["max_age_seconds"] = self.max_age_seconds
             if self.disable_cache_fallback is not None:
                 fetch_policy["disable_cache_fallback"] = self.disable_cache_fallback
-
             if fetch_policy:
-                search_params["fetch_policy"] = fetch_policy
+                advanced_settings["fetch_policy"] = fetch_policy
 
-            search_result = self.parallel_client.beta.search(**search_params)
+            search_params["advanced_settings"] = advanced_settings
+
+            search_result = self.parallel_client.search(**search_params)
 
             # Use model_dump() if available, otherwise convert to dict
             try:
@@ -207,7 +200,8 @@ class ParallelTools(Toolkit):
 
             if hasattr(search_result, "results") and search_result.results:
                 results_list: List[Dict[str, Any]] = []
-                for result in search_result.results:
+                # GA API doesn't support max_results param, so slice client-side
+                for result in search_result.results[:final_max_results]:
                     formatted_result: Dict[str, Any] = {
                         "title": getattr(result, "title", ""),
                         "url": getattr(result, "url", ""),
@@ -291,7 +285,7 @@ class ParallelTools(Toolkit):
             if fetch_policy:
                 extract_params["fetch_policy"] = fetch_policy
 
-            extract_result = self.parallel_client.beta.extract(**extract_params)
+            extract_result = self.parallel_client.extract(**extract_params)
 
             # Use model_dump() if available, otherwise convert to dict
             try:

--- a/libs/agno/agno/tools/parallel.py
+++ b/libs/agno/agno/tools/parallel.py
@@ -251,29 +251,32 @@ class ParallelTools(Toolkit):
             if not urls:
                 return json.dumps({"error": "Please provide at least one URL to extract"}, indent=2)
 
-            extract_params: Dict[str, Any] = {
-                "urls": urls,
-            }
+            extract_params: Dict[str, Any] = {"urls": urls}
 
-            # Add objective if provided
             if objective:
                 extract_params["objective"] = objective
 
-            # Add search_queries if provided
             if search_queries:
                 extract_params["search_queries"] = search_queries
 
-            # Add excerpts configuration
-            if excerpts and max_chars_per_excerpt is not None:
-                extract_params["excerpts"] = {"max_chars_per_result": max_chars_per_excerpt}
-            else:
-                extract_params["excerpts"] = excerpts
+            # GA API: all config goes under advanced_settings
+            advanced_settings: Dict[str, Any] = {}
 
-            # Add full_content configuration
-            if full_content and max_chars_for_full_content is not None:
-                extract_params["full_content"] = {"max_chars_per_result": max_chars_for_full_content}
-            else:
-                extract_params["full_content"] = full_content
+            # Add excerpt_settings (replaces top-level excerpts param)
+            if excerpts:
+                if max_chars_per_excerpt is not None:
+                    advanced_settings["excerpt_settings"] = {"max_chars_per_result": max_chars_per_excerpt}
+                else:
+                    final_max_chars = self.max_chars_per_result
+                    if final_max_chars is not None:
+                        advanced_settings["excerpt_settings"] = {"max_chars_per_result": final_max_chars}
+
+            # Add full_content (replaces top-level full_content param)
+            if full_content:
+                if max_chars_for_full_content is not None:
+                    advanced_settings["full_content"] = {"max_chars_per_result": max_chars_for_full_content}
+                else:
+                    advanced_settings["full_content"] = True
 
             # Add fetch_policy from constructor defaults
             fetch_policy: Dict[str, Any] = {}
@@ -281,9 +284,11 @@ class ParallelTools(Toolkit):
                 fetch_policy["max_age_seconds"] = self.max_age_seconds
             if self.disable_cache_fallback is not None:
                 fetch_policy["disable_cache_fallback"] = self.disable_cache_fallback
-
             if fetch_policy:
-                extract_params["fetch_policy"] = fetch_policy
+                advanced_settings["fetch_policy"] = fetch_policy
+
+            if advanced_settings:
+                extract_params["advanced_settings"] = advanced_settings
 
             extract_result = self.parallel_client.extract(**extract_params)
 

--- a/libs/agno/agno/tools/parallel.py
+++ b/libs/agno/agno/tools/parallel.py
@@ -137,33 +137,27 @@ class ParallelTools(Toolkit):
             if not objective and not search_queries:
                 return json.dumps({"error": "Please provide at least one of: objective or search_queries"}, indent=2)
 
-            # Use instance defaults if not provided
             final_max_results = max_results if max_results is not None else self.max_results
 
             search_params: Dict[str, Any] = {}
 
-            # Add objective if provided
             if objective:
                 search_params["objective"] = objective
 
-            # search_queries is required in GA API
+            # search_queries is required — auto-populate from objective if not provided
             if search_queries:
                 search_params["search_queries"] = search_queries
             elif objective:
                 search_params["search_queries"] = [objective]
 
-            # Add mode from constructor default (GA modes: turbo, basic, advanced)
             search_params["mode"] = self.mode if self.mode else "advanced"
 
-            # GA API: all config goes under advanced_settings
             advanced_settings: Dict[str, Any] = {"max_results": final_max_results}
 
-            # Add excerpt_settings
             final_max_chars = max_chars_per_result if max_chars_per_result is not None else self.max_chars_per_result
             if final_max_chars is not None:
                 advanced_settings["excerpt_settings"] = {"max_chars_per_result": final_max_chars}
 
-            # Add source_policy from constructor defaults
             source_policy: Dict[str, Any] = {}
             if self.include_domains:
                 source_policy["include_domains"] = self.include_domains
@@ -172,7 +166,6 @@ class ParallelTools(Toolkit):
             if source_policy:
                 advanced_settings["source_policy"] = source_policy
 
-            # Add fetch_policy from constructor defaults
             fetch_policy: Dict[str, Any] = {}
             if self.max_age_seconds is not None:
                 fetch_policy["max_age_seconds"] = self.max_age_seconds
@@ -185,14 +178,12 @@ class ParallelTools(Toolkit):
 
             search_result = self.parallel_client.search(**search_params)
 
-            # Use model_dump() if available, otherwise convert to dict
+            # Prefer SDK's model_dump() for complete response, fall back to manual formatting
             try:
                 if hasattr(search_result, "model_dump"):
                     return json.dumps(search_result.model_dump(), cls=CustomJSONEncoder)
             except Exception:
                 pass
-
-            # Manually format the results
             formatted_results: Dict[str, Any] = {
                 "search_id": getattr(search_result, "search_id", ""),
                 "results": [],
@@ -200,7 +191,6 @@ class ParallelTools(Toolkit):
 
             if hasattr(search_result, "results") and search_result.results:
                 results_list: List[Dict[str, Any]] = []
-                # GA API doesn't support max_results param, so slice client-side
                 for result in search_result.results[:final_max_results]:
                     formatted_result: Dict[str, Any] = {
                         "title": getattr(result, "title", ""),
@@ -257,22 +247,18 @@ class ParallelTools(Toolkit):
             if search_queries:
                 extract_params["search_queries"] = search_queries
 
-            # GA API: all config goes under advanced_settings
             advanced_settings: Dict[str, Any] = {}
 
-            # Add excerpt_settings if size limit specified
             final_excerpt_chars = max_chars_per_excerpt if max_chars_per_excerpt is not None else self.max_chars_per_result
             if final_excerpt_chars is not None:
                 advanced_settings["excerpt_settings"] = {"max_chars_per_result": final_excerpt_chars}
 
-            # Add full_content (replaces top-level full_content param)
             if full_content:
                 if max_chars_for_full_content is not None:
                     advanced_settings["full_content"] = {"max_chars_per_result": max_chars_for_full_content}
                 else:
                     advanced_settings["full_content"] = True
 
-            # Add fetch_policy from constructor defaults
             fetch_policy: Dict[str, Any] = {}
             if self.max_age_seconds is not None:
                 fetch_policy["max_age_seconds"] = self.max_age_seconds
@@ -286,14 +272,13 @@ class ParallelTools(Toolkit):
 
             extract_result = self.parallel_client.extract(**extract_params)
 
-            # Use model_dump() if available, otherwise convert to dict
+            # Prefer SDK's model_dump() for complete response, fall back to manual formatting
             try:
                 if hasattr(extract_result, "model_dump"):
                     return json.dumps(extract_result.model_dump(), cls=CustomJSONEncoder)
             except Exception:
                 pass
 
-            # Manually format the results
             formatted_results: Dict[str, Any] = {
                 "extract_id": getattr(extract_result, "extract_id", ""),
                 "results": [],

--- a/libs/agno/agno/tools/parallel.py
+++ b/libs/agno/agno/tools/parallel.py
@@ -228,7 +228,6 @@ class ParallelTools(Toolkit):
         urls: List[str],
         objective: Optional[str] = None,
         search_queries: Optional[List[str]] = None,
-        excerpts: bool = True,
         max_chars_per_excerpt: Optional[int] = None,
         full_content: bool = False,
         max_chars_for_full_content: Optional[int] = None,
@@ -239,8 +238,7 @@ class ParallelTools(Toolkit):
             urls (List[str]): List of public URLs to extract content from.
             objective (Optional[str]): Search focus to guide content extraction.
             search_queries (Optional[List[str]]): Keywords for targeting relevant content.
-            excerpts (bool): Include relevant text snippets.
-            max_chars_per_excerpt (Optional[int]): Upper bound on total characters per url. Only used when excerpts is True.
+            max_chars_per_excerpt (Optional[int]): Upper bound on characters per URL for excerpts.
             full_content (bool): Include complete page text.
             max_chars_for_full_content (Optional[int]): Limit on characters per url. Only used when full_content is True.
 
@@ -262,14 +260,10 @@ class ParallelTools(Toolkit):
             # GA API: all config goes under advanced_settings
             advanced_settings: Dict[str, Any] = {}
 
-            # Add excerpt_settings (replaces top-level excerpts param)
-            if excerpts:
-                if max_chars_per_excerpt is not None:
-                    advanced_settings["excerpt_settings"] = {"max_chars_per_result": max_chars_per_excerpt}
-                else:
-                    final_max_chars = self.max_chars_per_result
-                    if final_max_chars is not None:
-                        advanced_settings["excerpt_settings"] = {"max_chars_per_result": final_max_chars}
+            # Add excerpt_settings if size limit specified
+            final_excerpt_chars = max_chars_per_excerpt if max_chars_per_excerpt is not None else self.max_chars_per_result
+            if final_excerpt_chars is not None:
+                advanced_settings["excerpt_settings"] = {"max_chars_per_result": final_excerpt_chars}
 
             # Add full_content (replaces top-level full_content param)
             if full_content:
@@ -315,7 +309,7 @@ class ParallelTools(Toolkit):
                         "publish_date": getattr(result, "publish_date", ""),
                     }
 
-                    if excerpts and hasattr(result, "excerpts"):
+                    if hasattr(result, "excerpts"):
                         formatted_result["excerpts"] = result.excerpts
 
                     if full_content and hasattr(result, "full_content"):

--- a/libs/agno/tests/unit/tools/test_parallel_tools.py
+++ b/libs/agno/tests/unit/tools/test_parallel_tools.py
@@ -40,7 +40,7 @@ def test_parallel_search(parallel_tools):
         }
     )
 
-    parallel_tools.parallel_client.beta.search = Mock(return_value=mock_result)
+    parallel_tools.parallel_client.search = Mock(return_value=mock_result)
 
     # Execute test
     result = parallel_tools.parallel_search(objective="Test objective")
@@ -57,18 +57,33 @@ def test_parallel_search_with_queries(parallel_tools):
     mock_result = Mock()
     mock_result.model_dump = Mock(return_value={"search_id": "test-id", "results": []})
 
-    parallel_tools.parallel_client.beta.search = Mock(return_value=mock_result)
+    parallel_tools.parallel_client.search = Mock(return_value=mock_result)
 
     parallel_tools.parallel_search(objective="Test", search_queries=["query1", "query2"])
 
     # Verify search_queries was passed
-    call_args = parallel_tools.parallel_client.beta.search.call_args
+    call_args = parallel_tools.parallel_client.search.call_args
     assert call_args[1]["search_queries"] == ["query1", "query2"]
+
+
+def test_parallel_search_auto_populates_search_queries(parallel_tools):
+    """Test that search_queries is auto-populated from objective when not provided."""
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"search_id": "test-id", "results": []})
+
+    parallel_tools.parallel_client.search = Mock(return_value=mock_result)
+
+    parallel_tools.parallel_search(objective="Find AI trends")
+
+    # GA API requires search_queries — should be auto-populated from objective
+    call_args = parallel_tools.parallel_client.search.call_args
+    assert call_args[1]["search_queries"] == ["Find AI trends"]
+    assert call_args[1]["mode"] == "advanced"
 
 
 def test_parallel_search_error(parallel_tools):
     """Test parallel_search error handling."""
-    parallel_tools.parallel_client.beta.search = Mock(side_effect=Exception("API Error"))
+    parallel_tools.parallel_client.search = Mock(side_effect=Exception("API Error"))
 
     result = parallel_tools.parallel_search(objective="Test")
     result_dict = json.loads(result)
@@ -95,7 +110,7 @@ def test_parallel_extract(parallel_tools):
         }
     )
 
-    parallel_tools.parallel_client.beta.extract = Mock(return_value=mock_result)
+    parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
 
     # Execute test
     result = parallel_tools.parallel_extract(urls=["https://example.com"])
@@ -112,19 +127,19 @@ def test_parallel_extract_with_full_content(parallel_tools):
     mock_result = Mock()
     mock_result.model_dump = Mock(return_value={"extract_id": "test-id", "results": [], "errors": []})
 
-    parallel_tools.parallel_client.beta.extract = Mock(return_value=mock_result)
+    parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
 
     parallel_tools.parallel_extract(urls=["https://example.com"], excerpts=False, full_content=True)
 
     # Verify parameters
-    call_args = parallel_tools.parallel_client.beta.extract.call_args
+    call_args = parallel_tools.parallel_client.extract.call_args
     assert call_args[1]["excerpts"] is False
     assert call_args[1]["full_content"] is True
 
 
 def test_parallel_extract_error(parallel_tools):
     """Test parallel_extract error handling."""
-    parallel_tools.parallel_client.beta.extract = Mock(side_effect=Exception("API Error"))
+    parallel_tools.parallel_client.extract = Mock(side_effect=Exception("API Error"))
 
     result = parallel_tools.parallel_extract(urls=["https://example.com"])
     result_dict = json.loads(result)

--- a/libs/agno/tests/unit/tools/test_parallel_tools.py
+++ b/libs/agno/tests/unit/tools/test_parallel_tools.py
@@ -81,6 +81,22 @@ def test_parallel_search_auto_populates_search_queries(parallel_tools):
     assert call_args[1]["mode"] == "advanced"
 
 
+def test_parallel_search_advanced_settings_structure(parallel_tools):
+    """Test that search uses advanced_settings for max_results and excerpt_settings."""
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"search_id": "test-id", "results": []})
+
+    parallel_tools.parallel_client.search = Mock(return_value=mock_result)
+
+    parallel_tools.parallel_search(objective="Test", max_results=5, max_chars_per_result=3000)
+
+    # GA API: config goes under advanced_settings
+    call_args = parallel_tools.parallel_client.search.call_args
+    assert "advanced_settings" in call_args[1]
+    assert call_args[1]["advanced_settings"]["max_results"] == 5
+    assert call_args[1]["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 3000}
+
+
 def test_parallel_search_error(parallel_tools):
     """Test parallel_search error handling."""
     parallel_tools.parallel_client.search = Mock(side_effect=Exception("API Error"))
@@ -131,10 +147,31 @@ def test_parallel_extract_with_full_content(parallel_tools):
 
     parallel_tools.parallel_extract(urls=["https://example.com"], excerpts=False, full_content=True)
 
-    # Verify parameters
+    # Verify GA API structure: full_content goes under advanced_settings
     call_args = parallel_tools.parallel_client.extract.call_args
-    assert call_args[1]["excerpts"] is False
-    assert call_args[1]["full_content"] is True
+    assert "advanced_settings" in call_args[1]
+    assert call_args[1]["advanced_settings"]["full_content"] is True
+    # When excerpts=False, no excerpt_settings should be present
+    assert "excerpt_settings" not in call_args[1]["advanced_settings"]
+
+
+def test_parallel_extract_with_excerpts(parallel_tools):
+    """Test parallel_extract with excerpts uses advanced_settings."""
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"extract_id": "test-id", "results": [], "errors": []})
+
+    parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
+
+    parallel_tools.parallel_extract(
+        urls=["https://example.com"],
+        excerpts=True,
+        max_chars_per_excerpt=5000,
+    )
+
+    # GA API: excerpt_settings goes under advanced_settings
+    call_args = parallel_tools.parallel_client.extract.call_args
+    assert "advanced_settings" in call_args[1]
+    assert call_args[1]["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 5000}
 
 
 def test_parallel_extract_error(parallel_tools):

--- a/libs/agno/tests/unit/tools/test_parallel_tools.py
+++ b/libs/agno/tests/unit/tools/test_parallel_tools.py
@@ -145,18 +145,16 @@ def test_parallel_extract_with_full_content(parallel_tools):
 
     parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
 
-    parallel_tools.parallel_extract(urls=["https://example.com"], excerpts=False, full_content=True)
+    parallel_tools.parallel_extract(urls=["https://example.com"], full_content=True)
 
     # Verify GA API structure: full_content goes under advanced_settings
     call_args = parallel_tools.parallel_client.extract.call_args
     assert "advanced_settings" in call_args[1]
     assert call_args[1]["advanced_settings"]["full_content"] is True
-    # When excerpts=False, no excerpt_settings should be present
-    assert "excerpt_settings" not in call_args[1]["advanced_settings"]
 
 
-def test_parallel_extract_with_excerpts(parallel_tools):
-    """Test parallel_extract with excerpts uses advanced_settings."""
+def test_parallel_extract_with_excerpt_limit(parallel_tools):
+    """Test parallel_extract with max_chars_per_excerpt uses advanced_settings."""
     mock_result = Mock()
     mock_result.model_dump = Mock(return_value={"extract_id": "test-id", "results": [], "errors": []})
 
@@ -164,7 +162,6 @@ def test_parallel_extract_with_excerpts(parallel_tools):
 
     parallel_tools.parallel_extract(
         urls=["https://example.com"],
-        excerpts=True,
         max_chars_per_excerpt=5000,
     )
 

--- a/libs/agno/tests/unit/tools/test_parallel_tools.py
+++ b/libs/agno/tests/unit/tools/test_parallel_tools.py
@@ -1,5 +1,3 @@
-"""Unit tests for ParallelTools"""
-
 import json
 from unittest.mock import Mock, patch
 
@@ -10,283 +8,369 @@ from agno.tools.parallel import ParallelTools
 
 @pytest.fixture
 def mock_parallel_client():
-    """Mock Parallel client."""
     with patch("agno.tools.parallel.ParallelClient") as mock_client:
         yield mock_client
 
 
 @pytest.fixture
 def parallel_tools(mock_parallel_client):
-    """Create ParallelTools instance with mocked client."""
     with patch.dict("os.environ", {"PARALLEL_API_KEY": "test-api-key"}):
         return ParallelTools(api_key="test-api-key")
 
 
-def test_parallel_search(parallel_tools):
-    """Test parallel_search function."""
-    # Setup mock data
+# === Initialization ===
+
+
+def test_init_with_api_key(mock_parallel_client):
+    tools = ParallelTools(api_key="test-key")
+    assert tools.api_key == "test-key"
+
+
+def test_init_with_env_var(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "env-key"}):
+        tools = ParallelTools()
+        assert tools.api_key == "env-key"
+
+
+def test_init_registers_default_tools(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools()
+        names = list(tools.functions.keys())
+        assert "parallel_search" in names
+        assert "parallel_extract" in names
+        assert len(names) == 2
+
+
+def test_init_all_flag_enables_all(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(all=True)
+        names = list(tools.functions.keys())
+        assert "parallel_search" in names
+        assert "parallel_extract" in names
+        assert "create_task" in names
+        assert "create_monitor" in names
+        assert len(names) == 11
+
+
+def test_init_enable_task_flag(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(enable_task=True)
+        names = list(tools.functions.keys())
+        assert "create_task" in names
+        assert "get_task_status" in names
+        assert "get_task_result" in names
+        assert "create_monitor" not in names
+
+
+def test_init_enable_monitor_flag(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(enable_monitor=True)
+        names = list(tools.functions.keys())
+        assert "create_monitor" in names
+        assert "list_monitors" in names
+        assert "cancel_monitor" in names
+        assert "create_task" not in names
+
+
+def test_init_disable_defaults(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(enable_search=False, enable_extract=False)
+        assert len(tools.functions) == 0
+
+
+def test_init_stores_constructor_params(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(
+            max_results=20,
+            max_chars_per_result=5000,
+            mode="turbo",
+            include_domains=["example.com"],
+            exclude_domains=["spam.com"],
+        )
+        assert tools.max_results == 20
+        assert tools.max_chars_per_result == 5000
+        assert tools.mode == "turbo"
+        assert tools.include_domains == ["example.com"]
+        assert tools.exclude_domains == ["spam.com"]
+
+
+# === Search API ===
+
+
+def test_search_returns_results(parallel_tools):
     mock_result = Mock()
     mock_result.model_dump = Mock(
         return_value={
             "search_id": "test-search-id",
             "results": [
-                {
-                    "title": "Test Title",
-                    "url": "https://example.com",
-                    "publish_date": "2025-01-01",
-                    "excerpts": ["Test excerpt content"],
-                }
+                {"title": "Test", "url": "https://example.com", "excerpts": ["content"]}
             ],
         }
     )
-
     parallel_tools.parallel_client.search = Mock(return_value=mock_result)
 
-    # Execute test
-    result = parallel_tools.parallel_search(objective="Test objective")
-    result_dict = json.loads(result)
+    result = parallel_tools.parallel_search(objective="test query")
+    parsed = json.loads(result)
 
-    # Verify the result
-    assert result_dict["search_id"] == "test-search-id"
-    assert len(result_dict["results"]) == 1
-    assert result_dict["results"][0]["title"] == "Test Title"
+    assert parsed["search_id"] == "test-search-id"
+    assert len(parsed["results"]) == 1
 
 
-def test_parallel_search_with_queries(parallel_tools):
-    """Test parallel_search with search queries."""
+def test_search_requires_objective_or_queries(parallel_tools):
+    result = parallel_tools.parallel_search()
+    parsed = json.loads(result)
+
+    assert "error" in parsed
+    assert "objective or search_queries" in parsed["error"]
+
+
+def test_search_auto_populates_search_queries(parallel_tools):
     mock_result = Mock()
-    mock_result.model_dump = Mock(return_value={"search_id": "test-id", "results": []})
-
+    mock_result.model_dump = Mock(return_value={"search_id": "id", "results": []})
     parallel_tools.parallel_client.search = Mock(return_value=mock_result)
 
-    parallel_tools.parallel_search(objective="Test", search_queries=["query1", "query2"])
+    parallel_tools.parallel_search(objective="AI trends")
 
-    # Verify search_queries was passed
-    call_args = parallel_tools.parallel_client.search.call_args
-    assert call_args[1]["search_queries"] == ["query1", "query2"]
+    call_args = parallel_tools.parallel_client.search.call_args[1]
+    assert call_args["search_queries"] == ["AI trends"]
 
 
-def test_parallel_search_auto_populates_search_queries(parallel_tools):
-    """Test that search_queries is auto-populated from objective when not provided."""
+def test_search_passes_explicit_queries(parallel_tools):
     mock_result = Mock()
-    mock_result.model_dump = Mock(return_value={"search_id": "test-id", "results": []})
-
+    mock_result.model_dump = Mock(return_value={"search_id": "id", "results": []})
     parallel_tools.parallel_client.search = Mock(return_value=mock_result)
 
-    parallel_tools.parallel_search(objective="Find AI trends")
+    parallel_tools.parallel_search(objective="AI", search_queries=["query1", "query2"])
 
-    # GA API requires search_queries — should be auto-populated from objective
-    call_args = parallel_tools.parallel_client.search.call_args
-    assert call_args[1]["search_queries"] == ["Find AI trends"]
-    assert call_args[1]["mode"] == "advanced"
+    call_args = parallel_tools.parallel_client.search.call_args[1]
+    assert call_args["search_queries"] == ["query1", "query2"]
 
 
-def test_parallel_search_advanced_settings_structure(parallel_tools):
-    """Test that search uses advanced_settings for max_results and excerpt_settings."""
+def test_search_defaults_to_advanced_mode(parallel_tools):
     mock_result = Mock()
-    mock_result.model_dump = Mock(return_value={"search_id": "test-id", "results": []})
-
+    mock_result.model_dump = Mock(return_value={"search_id": "id", "results": []})
     parallel_tools.parallel_client.search = Mock(return_value=mock_result)
 
-    parallel_tools.parallel_search(objective="Test", max_results=5, max_chars_per_result=3000)
+    parallel_tools.parallel_search(objective="test")
 
-    # GA API: config goes under advanced_settings
-    call_args = parallel_tools.parallel_client.search.call_args
-    assert "advanced_settings" in call_args[1]
-    assert call_args[1]["advanced_settings"]["max_results"] == 5
-    assert call_args[1]["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 3000}
+    call_args = parallel_tools.parallel_client.search.call_args[1]
+    assert call_args["mode"] == "advanced"
 
 
-def test_parallel_search_error(parallel_tools):
-    """Test parallel_search error handling."""
+def test_search_uses_constructor_mode(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(mode="turbo")
+
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"search_id": "id", "results": []})
+    tools.parallel_client.search = Mock(return_value=mock_result)
+
+    tools.parallel_search(objective="test")
+
+    call_args = tools.parallel_client.search.call_args[1]
+    assert call_args["mode"] == "turbo"
+
+
+def test_search_advanced_settings_structure(parallel_tools):
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"search_id": "id", "results": []})
+    parallel_tools.parallel_client.search = Mock(return_value=mock_result)
+
+    parallel_tools.parallel_search(objective="test", max_results=5, max_chars_per_result=3000)
+
+    call_args = parallel_tools.parallel_client.search.call_args[1]
+    assert call_args["advanced_settings"]["max_results"] == 5
+    assert call_args["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 3000}
+
+
+def test_search_includes_domain_filters(mock_parallel_client):
+    with patch.dict("os.environ", {"PARALLEL_API_KEY": "test"}):
+        tools = ParallelTools(include_domains=["a.com"], exclude_domains=["b.com"])
+
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"search_id": "id", "results": []})
+    tools.parallel_client.search = Mock(return_value=mock_result)
+
+    tools.parallel_search(objective="test")
+
+    call_args = tools.parallel_client.search.call_args[1]
+    assert call_args["advanced_settings"]["source_policy"]["include_domains"] == ["a.com"]
+    assert call_args["advanced_settings"]["source_policy"]["exclude_domains"] == ["b.com"]
+
+
+def test_search_error_returns_json(parallel_tools):
     parallel_tools.parallel_client.search = Mock(side_effect=Exception("API Error"))
 
-    result = parallel_tools.parallel_search(objective="Test")
-    result_dict = json.loads(result)
+    result = parallel_tools.parallel_search(objective="test")
+    parsed = json.loads(result)
 
-    assert "error" in result_dict
-    assert "Search failed" in result_dict["error"]
+    assert "error" in parsed
+    assert "Search failed" in parsed["error"]
 
 
-def test_parallel_extract(parallel_tools):
-    """Test parallel_extract function."""
-    # Setup mock data
+# === Extract API ===
+
+
+def test_extract_returns_results(parallel_tools):
     mock_result = Mock()
     mock_result.model_dump = Mock(
         return_value={
-            "extract_id": "test-extract-id",
-            "results": [
-                {
-                    "url": "https://example.com",
-                    "title": "Test Title",
-                    "excerpts": ["Excerpt 1", "Excerpt 2"],
-                }
-            ],
+            "extract_id": "test-id",
+            "results": [{"url": "https://example.com", "title": "Test", "excerpts": ["content"]}],
             "errors": [],
         }
     )
-
     parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
 
-    # Execute test
     result = parallel_tools.parallel_extract(urls=["https://example.com"])
-    result_dict = json.loads(result)
+    parsed = json.loads(result)
 
-    # Verify the result
-    assert result_dict["extract_id"] == "test-extract-id"
-    assert len(result_dict["results"]) == 1
-    assert result_dict["results"][0]["url"] == "https://example.com"
+    assert parsed["extract_id"] == "test-id"
+    assert len(parsed["results"]) == 1
 
 
-def test_parallel_extract_with_full_content(parallel_tools):
-    """Test parallel_extract with full_content."""
+def test_extract_requires_urls(parallel_tools):
+    result = parallel_tools.parallel_extract(urls=[])
+    parsed = json.loads(result)
+
+    assert "error" in parsed
+    assert "URL" in parsed["error"]
+
+
+def test_extract_with_full_content(parallel_tools):
     mock_result = Mock()
-    mock_result.model_dump = Mock(return_value={"extract_id": "test-id", "results": [], "errors": []})
-
+    mock_result.model_dump = Mock(return_value={"extract_id": "id", "results": [], "errors": []})
     parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
 
     parallel_tools.parallel_extract(urls=["https://example.com"], full_content=True)
 
-    # Verify GA API structure: full_content goes under advanced_settings
-    call_args = parallel_tools.parallel_client.extract.call_args
-    assert "advanced_settings" in call_args[1]
-    assert call_args[1]["advanced_settings"]["full_content"] is True
+    call_args = parallel_tools.parallel_client.extract.call_args[1]
+    assert call_args["advanced_settings"]["full_content"] is True
 
 
-def test_parallel_extract_with_excerpt_limit(parallel_tools):
-    """Test parallel_extract with max_chars_per_excerpt uses advanced_settings."""
+def test_extract_with_full_content_limit(parallel_tools):
     mock_result = Mock()
-    mock_result.model_dump = Mock(return_value={"extract_id": "test-id", "results": [], "errors": []})
-
+    mock_result.model_dump = Mock(return_value={"extract_id": "id", "results": [], "errors": []})
     parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
 
     parallel_tools.parallel_extract(
-        urls=["https://example.com"],
-        max_chars_per_excerpt=5000,
+        urls=["https://example.com"], full_content=True, max_chars_for_full_content=5000
     )
 
-    # GA API: excerpt_settings goes under advanced_settings
-    call_args = parallel_tools.parallel_client.extract.call_args
-    assert "advanced_settings" in call_args[1]
-    assert call_args[1]["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 5000}
+    call_args = parallel_tools.parallel_client.extract.call_args[1]
+    assert call_args["advanced_settings"]["full_content"] == {"max_chars_per_result": 5000}
 
 
-def test_parallel_extract_error(parallel_tools):
-    """Test parallel_extract error handling."""
+def test_extract_with_excerpt_limit(parallel_tools):
+    mock_result = Mock()
+    mock_result.model_dump = Mock(return_value={"extract_id": "id", "results": [], "errors": []})
+    parallel_tools.parallel_client.extract = Mock(return_value=mock_result)
+
+    parallel_tools.parallel_extract(urls=["https://example.com"], max_chars_per_excerpt=3000)
+
+    call_args = parallel_tools.parallel_client.extract.call_args[1]
+    assert call_args["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 3000}
+
+
+def test_extract_error_returns_json(parallel_tools):
     parallel_tools.parallel_client.extract = Mock(side_effect=Exception("API Error"))
 
     result = parallel_tools.parallel_extract(urls=["https://example.com"])
-    result_dict = json.loads(result)
+    parsed = json.loads(result)
 
-    assert "error" in result_dict
-    assert "Extract failed" in result_dict["error"]
+    assert "error" in parsed
+    assert "Extract failed" in parsed["error"]
 
 
-# ---------------------------------------------------------------------------
-# Task API Tests
-# ---------------------------------------------------------------------------
+# === Task API ===
 
 
 @pytest.fixture
 def task_tools(mock_parallel_client):
-    """Create ParallelTools with Task API enabled."""
     with patch.dict("os.environ", {"PARALLEL_API_KEY": "test-api-key"}):
         return ParallelTools(api_key="test-api-key", enable_task=True)
 
 
-def test_create_task(task_tools):
-    """Test create_task function."""
-    mock_task_run = Mock()
-    mock_task_run.run_id = "test-run-id"
-    mock_task_run.status = "running"
-    mock_task_run.interaction_id = "test-interaction-id"
-    mock_task_run.processor = "base"
-    mock_task_run.is_active = True
+def test_create_task_returns_run_id(task_tools):
+    mock_run = Mock()
+    mock_run.run_id = "run-123"
+    mock_run.status = "queued"
+    mock_run.interaction_id = "int-456"
+    mock_run.processor = "base"
+    mock_run.is_active = True
+    task_tools.parallel_client.task_run.create = Mock(return_value=mock_run)
 
-    task_tools.parallel_client.task_run.create = Mock(return_value=mock_task_run)
+    result = task_tools.create_task(query="Research AI")
+    parsed = json.loads(result)
 
-    result = task_tools.create_task(query="Research AI trends")
-    result_dict = json.loads(result)
-
-    assert result_dict["run_id"] == "test-run-id"
-    assert result_dict["status"] == "running"
-    assert result_dict["is_active"] is True
-
-
-def test_get_task_result(task_tools):
-    """Test get_task_result function."""
-    mock_task_result = Mock()
-    mock_task_result.run.status = "completed"
-    mock_task_result.run.processor = "base"
-    mock_task_result.output.content = {"data": "result"}
-    mock_task_result.output.basis = []
-
-    task_tools.parallel_client.task_run.result = Mock(return_value=mock_task_result)
-
-    result = task_tools.get_task_result(run_id="test-run-id")
-    result_dict = json.loads(result)
-
-    assert result_dict["status"] == "completed"
-    assert result_dict["content"] == {"data": "result"}
+    assert parsed["run_id"] == "run-123"
+    assert parsed["status"] == "queued"
+    assert parsed["is_active"] is True
 
 
 def test_get_task_status(task_tools):
-    """Test get_task_status function."""
-    mock_task_run = Mock()
-    mock_task_run.run_id = "test-run-id"
-    mock_task_run.status = "running"
-    mock_task_run.processor = "base"
-    mock_task_run.is_active = True
-    mock_task_run.created_at = "2026-01-01T00:00:00Z"
-    mock_task_run.modified_at = "2026-01-01T00:01:00Z"
+    mock_run = Mock()
+    mock_run.run_id = "run-123"
+    mock_run.status = "running"
+    mock_run.processor = "base"
+    mock_run.is_active = True
+    mock_run.created_at = "2026-01-01T00:00:00Z"
+    mock_run.modified_at = "2026-01-01T00:01:00Z"
+    task_tools.parallel_client.task_run.retrieve = Mock(return_value=mock_run)
 
-    task_tools.parallel_client.task_run.retrieve = Mock(return_value=mock_task_run)
+    result = task_tools.get_task_status(run_id="run-123")
+    parsed = json.loads(result)
 
-    result = task_tools.get_task_status(run_id="test-run-id")
-    result_dict = json.loads(result)
-
-    assert result_dict["run_id"] == "test-run-id"
-    assert result_dict["status"] == "running"
-    assert result_dict["is_active"] is True
+    assert parsed["run_id"] == "run-123"
+    assert parsed["status"] == "running"
 
 
-# ---------------------------------------------------------------------------
-# Monitor API Tests
-# ---------------------------------------------------------------------------
+def test_get_task_result(task_tools):
+    mock_result = Mock()
+    mock_result.run.status = "completed"
+    mock_result.run.processor = "base"
+    mock_result.output.content = {"answer": "AI is transforming..."}
+    mock_result.output.basis = []
+    task_tools.parallel_client.task_run.result = Mock(return_value=mock_result)
+
+    result = task_tools.get_task_result(run_id="run-123")
+    parsed = json.loads(result)
+
+    assert parsed["status"] == "completed"
+    assert parsed["content"] == {"answer": "AI is transforming..."}
+
+
+# === Monitor API ===
 
 
 @pytest.fixture
 def monitor_tools(mock_parallel_client):
-    """Create ParallelTools with Monitor API enabled."""
     with patch.dict("os.environ", {"PARALLEL_API_KEY": "test-api-key"}):
         return ParallelTools(api_key="test-api-key", enable_monitor=True)
 
 
 def test_create_monitor(monitor_tools):
-    """Test create_monitor function."""
     mock_monitor = Mock()
-    mock_monitor.monitor_id = "test-monitor-id"
+    mock_monitor.monitor_id = "mon-123"
     mock_monitor.type = "event_stream"
     mock_monitor.status = "active"
     mock_monitor.frequency = "1d"
     mock_monitor.processor = "lite"
     mock_monitor.created_at = "2026-01-01T00:00:00Z"
     mock_monitor.last_run_at = None
-
     monitor_tools.parallel_client.monitor.create = Mock(return_value=mock_monitor)
 
     result = monitor_tools.create_monitor(query="AI funding news")
-    result_dict = json.loads(result)
+    parsed = json.loads(result)
 
-    assert result_dict["monitor_id"] == "test-monitor-id"
-    assert result_dict["status"] == "active"
-    assert result_dict["query"] == "AI funding news"
+    assert parsed["monitor_id"] == "mon-123"
+    assert parsed["status"] == "active"
+    assert parsed["query"] == "AI funding news"
 
 
 def test_list_monitors(monitor_tools):
-    """Test list_monitors function."""
     mock_monitor = Mock()
-    mock_monitor.monitor_id = "test-monitor-id"
+    mock_monitor.monitor_id = "mon-123"
     mock_monitor.type = "event_stream"
     mock_monitor.status = "active"
     mock_monitor.frequency = "1d"
@@ -299,21 +383,19 @@ def test_list_monitors(monitor_tools):
     mock_response = Mock()
     mock_response.monitors = [mock_monitor]
     mock_response.next_cursor = None
-
     monitor_tools.parallel_client.monitor.list = Mock(return_value=mock_response)
 
     result = monitor_tools.list_monitors()
-    result_dict = json.loads(result)
+    parsed = json.loads(result)
 
-    assert len(result_dict["monitors"]) == 1
-    assert result_dict["monitors"][0]["monitor_id"] == "test-monitor-id"
-    assert result_dict["has_more"] is False
+    assert len(parsed["monitors"]) == 1
+    assert parsed["monitors"][0]["monitor_id"] == "mon-123"
+    assert parsed["has_more"] is False
 
 
 def test_get_monitor(monitor_tools):
-    """Test get_monitor function."""
     mock_monitor = Mock()
-    mock_monitor.monitor_id = "test-monitor-id"
+    mock_monitor.monitor_id = "mon-123"
     mock_monitor.type = "event_stream"
     mock_monitor.status = "active"
     mock_monitor.frequency = "1d"
@@ -322,89 +404,76 @@ def test_get_monitor(monitor_tools):
     mock_monitor.last_run_at = None
     mock_monitor.settings = Mock()
     mock_monitor.settings.query = "Test query"
-
     monitor_tools.parallel_client.monitor.retrieve = Mock(return_value=mock_monitor)
 
-    result = monitor_tools.get_monitor(monitor_id="test-monitor-id")
-    result_dict = json.loads(result)
+    result = monitor_tools.get_monitor(monitor_id="mon-123")
+    parsed = json.loads(result)
 
-    assert result_dict["monitor_id"] == "test-monitor-id"
-    assert result_dict["status"] == "active"
-    assert result_dict["query"] == "Test query"
+    assert parsed["monitor_id"] == "mon-123"
+    assert parsed["query"] == "Test query"
 
 
 def test_update_monitor(monitor_tools):
-    """Test update_monitor function."""
     mock_monitor = Mock()
-    mock_monitor.monitor_id = "test-monitor-id"
+    mock_monitor.monitor_id = "mon-123"
     mock_monitor.type = "event_stream"
     mock_monitor.status = "active"
     mock_monitor.frequency = "1h"
     mock_monitor.processor = "lite"
     mock_monitor.settings = Mock()
     mock_monitor.settings.query = "Updated query"
-
     monitor_tools.parallel_client.monitor.update = Mock(return_value=mock_monitor)
 
-    result = monitor_tools.update_monitor(monitor_id="test-monitor-id", frequency="1h")
-    result_dict = json.loads(result)
+    result = monitor_tools.update_monitor(monitor_id="mon-123", frequency="1h")
+    parsed = json.loads(result)
 
-    assert result_dict["monitor_id"] == "test-monitor-id"
-    assert result_dict["frequency"] == "1h"
-    assert result_dict["updated"] is True
+    assert parsed["frequency"] == "1h"
+    assert parsed["updated"] is True
 
 
 def test_cancel_monitor(monitor_tools):
-    """Test cancel_monitor function."""
     mock_monitor = Mock()
-    mock_monitor.monitor_id = "test-monitor-id"
+    mock_monitor.monitor_id = "mon-123"
     mock_monitor.status = "cancelled"
-
     monitor_tools.parallel_client.monitor.cancel = Mock(return_value=mock_monitor)
 
-    result = monitor_tools.cancel_monitor(monitor_id="test-monitor-id")
-    result_dict = json.loads(result)
+    result = monitor_tools.cancel_monitor(monitor_id="mon-123")
+    parsed = json.loads(result)
 
-    assert result_dict["monitor_id"] == "test-monitor-id"
-    assert result_dict["status"] == "cancelled"
-    assert result_dict["cancelled"] is True
+    assert parsed["status"] == "cancelled"
+    assert parsed["cancelled"] is True
 
 
 def test_get_monitor_events(monitor_tools):
-    """Test get_monitor_events function."""
     mock_output = Mock()
-    mock_output.content = {"summary": "New AI funding announced"}
+    mock_output.content = {"summary": "New development"}
     mock_output.basis = []
 
     mock_event = Mock()
-    mock_event.event_id = "test-event-id"
+    mock_event.event_id = "evt-123"
     mock_event.event_type = "event_stream"
-    mock_event.event_group_id = "test-group-id"
+    mock_event.event_group_id = "grp-456"
     mock_event.event_date = "2026-01-01"
     mock_event.output = mock_output
 
     mock_response = Mock()
     mock_response.events = [mock_event]
     mock_response.next_cursor = None
-
     monitor_tools.parallel_client.monitor.events = Mock(return_value=mock_response)
 
-    result = monitor_tools.get_monitor_events(monitor_id="test-monitor-id")
-    result_dict = json.loads(result)
+    result = monitor_tools.get_monitor_events(monitor_id="mon-123")
+    parsed = json.loads(result)
 
-    assert len(result_dict["events"]) == 1
-    assert result_dict["events"][0]["event_type"] == "event_stream"
-    assert result_dict["events"][0]["event_date"] == "2026-01-01"
-    assert result_dict["events"][0]["content"] == {"summary": "New AI funding announced"}
-    assert result_dict["has_more"] is False
+    assert len(parsed["events"]) == 1
+    assert parsed["events"][0]["event_id"] == "evt-123"
+    assert parsed["has_more"] is False
 
 
 def test_get_monitor_events_error(monitor_tools):
-    """Test get_monitor_events error handling."""
     monitor_tools.parallel_client.monitor.events = Mock(side_effect=Exception("API Error"))
 
-    result = monitor_tools.get_monitor_events(monitor_id="test-monitor-id")
-    result_dict = json.loads(result)
+    result = monitor_tools.get_monitor_events(monitor_id="mon-123")
+    parsed = json.loads(result)
 
-    assert "error" in result_dict
-    assert "Get events failed" in result_dict["error"]
+    assert "error" in parsed
+    assert "Get events failed" in parsed["error"]


### PR DESCRIPTION
## Summary

Migrates `ParallelTools` to use the GA API surface (`client.search` / `client.extract`) instead of the removed beta endpoints (`client.beta.*`) in `parallel-web >= 1.0`.

**This is the companion fix to PR #8412**, which fixed `ParallelBackend` (context provider) but missed `ParallelTools` (toolkit).

Fixes #8283

## Changes

### API Migration
- Use `client.search()` and `client.extract()` directly (beta namespace removed in SDK 1.0)
- Move config params under `advanced_settings` (new GA structure):
  - `max_results`, `excerpt_settings`, `source_policy`, `fetch_policy`
- Auto-populate `search_queries` from `objective` when not provided (required in GA)
- Default mode changed to `advanced` (GA modes: `turbo`, `basic`, `advanced`)

### Breaking Changes
- **Removed `excerpts` param** from `parallel_extract()` — GA API always returns excerpts, no way to disable them. Use `max_chars_per_excerpt` to control size instead.
- **Removed `beta_version` param** — no longer needed for GA API

### Code Quality
- Clean up comments: keep WHY, remove WHAT
- Rewrite tests following codebase patterns (33 tests, up from 19)
  - Init tests (api_key, env var, enable flags)
  - Edge case tests (empty urls, missing params)
  - Constructor param tests (mode, domains)

## Verified Against

- **SDK version:** parallel-web 1.1.0 (latest GA)
- **Live tested:** Search, Extract, Task, Monitor APIs all working
- **Unit tests:** 33 passing

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (33 total)