### PR TITLE
fix: use validate=True in File.from_base64 to prevent text content corruption

### DIFF
--- a/libs/agno/agno/media.py
+++ b/libs/agno/agno/media.py
@@ -469,7 +469,7 @@ class File(BaseModel):
         import base64
 
         try:
-            content_bytes = base64.b64decode(base64_content)
+            content_bytes = base64.b64decode(base64_content, validate=True)
         except Exception:
             # If not valid base64, it might be plain text content (text/csv, text/plain, etc.)
             # which is stored as UTF-8 strings, not base64

--- a/libs/agno/tests/unit/utils/test_media_reconstruction.py
+++ b/libs/agno/tests/unit/utils/test_media_reconstruction.py
@@ -398,3 +398,26 @@ def test_session_persistence_simulation():
     # Both images should have valid content
     assert retrieved_input_1.images[0].content == original_content
     assert retrieved_input_2.images[0].content == second_content
+
+
+def test_reconstruct_file_from_plain_text():
+    """Test that plain text content (csv/txt/json) is preserved byte-for-byte.
+
+    Regression test for https://github.com/agno-agi/agno/issues/8451:
+    base64.b64decode without validate=True silently corrupts plain text
+    by discarding non-alphabet characters and decoding the remainder.
+    """
+    # CSV content — the exact case from the issue
+    csv_text = "col_a,col_b,col_c\n1,x,y\n2,x,y\n3,x,y\n4,x,y\n"
+    restored = File.from_base64(csv_text, mime_type="text/csv", filename="data.csv")
+    assert restored.content == csv_text.encode("utf-8")
+
+    # JSON content
+    json_text = '{"key": "value", "items": [1, 2, 3]}'
+    restored_json = File.from_base64(json_text, mime_type="application/json")
+    assert restored_json.content == json_text.encode("utf-8")
+
+    # Markdown with special characters
+    md_text = "# Title\n\nSome **bold** and *italic* text.\n- item 1\n- item 2\n"
+    restored_md = File.from_base64(md_text, mime_type="text/markdown")
+    assert restored_md.content == md_text.encode("utf-8")


### PR DESCRIPTION
## Summary

Fixes #8451

`File.from_base64()` silently corrupts plain-text file content (csv/txt/json/md/xml) when rebuilding a `File` from persisted session history. The root cause is `base64.b64decode` called without `validate=True`, which does not raise on plain text — it silently discards non-alphabet characters and decodes the remainder into garbage. The UTF-8 fallback never runs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## What changed

`libs/agno/agno/media.py`: Added `validate=True` to the `base64.b64decode()` call in `File.from_base64()`. This makes the decoder raise `binascii.Error` on non-base64 input, so the fallback path correctly encodes plain text as UTF-8.

## Verification

```python
from agno.media import File

text = "col_a,col_b,col_c\n1,x,y\n2,x,y\n3,x,y\n4,x,y\n"
restored = File.from_base64(text, mime_type="text/csv", filename="data.csv")
assert restored.content == text.encode("utf-8")  # PASS
```

- All 19 existing `test_media_reconstruction` tests pass
- Added regression test `test_reconstruct_file_from_plain_text` covering CSV, JSON, and Markdown
- `./scripts/format.sh` and `./scripts/validate.sh` both pass

## Notes

The same `b64decode` without `validate=True` pattern exists in `Image.from_base64`, `Audio.from_base64`, and `Video.from_base64`. Those classes primarily handle binary content where corruption is less likely to manifest, but the same fix could be applied for consistency.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: N/A (bug fix, no new patterns)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

PR #8021 adds error logging to silent except blocks in media.py but does not fix the underlying corruption. This PR fixes the root cause.