### PR TITLE
fix: regenerated run inherits source events and has null duration

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3050,8 +3050,12 @@ def _fork_run(run_response: RunOutput, message_index: int) -> RunOutput:
     forked.forked_from_run_id = run_response.run_id
     forked.forked_from_message_index = message_index
     # Reset lineage-irrelevant accumulators so the fork reports its own work,
-    # not the parent's. Without this, token counts and durations double-count.
+    # not the parent's. Without this, token counts and durations double-count
+    # and the fork's RunCompleted event would carry the parent's transcript of
+    # events.
     forked.metrics = RunMetrics()
+    forked.metrics.start_timer()
+    forked.events = None
     forked.created_at = int(_time())
     _truncate_run_to_checkpoint(forked, message_index)
     return forked

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -6082,7 +6082,13 @@ def _fork_team_run(run_response: "TeamRunOutput", message_index: int) -> "TeamRu
     forked.run_id = str(uuid4())
     forked.forked_from_run_id = run_response.run_id
     forked.forked_from_message_index = message_index
+    # Reset lineage-irrelevant accumulators so the fork reports its own work,
+    # not the parent's. Without this, token counts and durations double-count
+    # and the fork's RunCompleted event would carry the parent's transcript of
+    # events.
     forked.metrics = RunMetrics()
+    forked.metrics.start_timer()
+    forked.events = None
     forked.created_at = int(_time())
 
     _truncate_team_run_to_checkpoint(forked, message_index)

--- a/libs/agno/tests/unit/agent/test_unified_continue.py
+++ b/libs/agno/tests/unit/agent/test_unified_continue.py
@@ -1298,6 +1298,43 @@ class TestForkMetricsReset:
         assert forked.created_at > old_t, "Fork should have a fresh created_at"
         assert original.created_at == old_t, "Parent's created_at must not be touched"
 
+    def test_fork_resets_events_to_none(self):
+        """The forked run should NOT inherit the parent's events transcript.
+        Without this reset, the regenerated run's RunCompleted event would
+        carry every event from the source run."""
+        from agno.run.agent import RunCompletedEvent
+
+        original = RunOutput(
+            run_id="origin",
+            session_id="s",
+            messages=[Message(role="user", content="q")],
+            events=[RunCompletedEvent(run_id="origin", session_id="s")],
+        )
+
+        forked = _fork_run(original, message_index=1)
+
+        assert forked.events is None, "Fork must start with no events"
+        # Parent untouched
+        assert original.events is not None and len(original.events) == 1
+
+    def test_fork_starts_metrics_timer(self):
+        """The fresh metrics object on a fork must have its timer started so
+        that ``stop_timer()`` at run end produces a non-None ``duration``.
+        Without this, RunCompleted on regenerate has duration=None."""
+        original = RunOutput(
+            run_id="origin",
+            session_id="s",
+            messages=[Message(role="user", content="q")],
+        )
+
+        forked = _fork_run(original, message_index=1)
+
+        # Internal contract: stop_timer needs a start to compute duration.
+        # Simulate the terminal-cleanup path and assert duration is populated.
+        forked.metrics.stop_timer()
+        assert forked.metrics.duration is not None
+        assert forked.metrics.duration >= 0
+
 
 # ---------------------------------------------------------------------------
 # Bug-fix tests: regenerate sugar normalizes to canonical params

--- a/libs/agno/tests/unit/team/test_team_checkpointing.py
+++ b/libs/agno/tests/unit/team/test_team_checkpointing.py
@@ -235,6 +235,33 @@ class TestTeamFork:
         # team's original metrics unchanged
         assert team.metrics.input_tokens == 500
 
+    def test_fork_resets_events_to_none(self):
+        """The forked team run should NOT inherit the parent's events
+        transcript — without this reset, the regenerated team run's
+        RunCompleted event would carry every event from the source."""
+        from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
+
+        team = self._build_team_with_members()
+        team.events = [TeamRunCompletedEvent(run_id=team.run_id, session_id=team.session_id)]
+
+        forked = team_run._fork_team_run(team, message_index=5)
+
+        assert forked.events is None
+        # Parent untouched
+        assert team.events is not None and len(team.events) == 1
+
+    def test_fork_starts_metrics_timer(self):
+        """The fork's fresh metrics object must have its timer started so
+        ``stop_timer()`` at run end yields a non-None ``duration``.
+        Without this, the regenerated team run's RunCompleted event has
+        duration=None."""
+        team = self._build_team_with_members()
+        forked = team_run._fork_team_run(team, message_index=5)
+
+        forked.metrics.stop_timer()
+        assert forked.metrics.duration is not None
+        assert forked.metrics.duration >= 0
+
     def test_fork_does_not_clone_members_or_reparent(self):
         """Members are out of scope for team fork (parity with agent surface
         for fallback / parser / followups). The forked team's


### PR DESCRIPTION
## Summary

Two bugs in the regenerate flow surfaced by the FE team:

1. **Events from the source run leak into the regenerated run.** When regenerate forks (and regenerate always forks), the fork helper deep-copied the source RunOutput including its `events` array. The regenerated run then accumulated *all* of the source's events plus its own, producing a corrupt transcript when viewed via `GET /sessions/{id}/runs`.

2. **Regenerated run's `RunCompleted` event has no `duration`.** `_fork_run` created a fresh `RunMetrics()` but never started its timer. `stop_timer()` at terminal cleanup was a no-op, so `metrics.duration` stayed `None`.

Both bugs sit in `_fork_run` (agent) and `_fork_team_run` (team), which regenerate always routes through (`_normalize_regenerate_params` always sets `fork=True`).

## Fix

In both fork helpers, immediately after assigning the fresh `RunMetrics`:

\`\`\`python
forked.metrics = RunMetrics()
forked.metrics.start_timer()   # so stop_timer() at run end has a baseline
forked.events = None           # don't carry the source's events
forked.created_at = int(_time())
\`\`\`

The pattern mirrors the existing reset of `metrics` and `created_at` — all three fields are "lineage-irrelevant accumulators" that should report only the fork's own work, not the parent's.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Tests

New unit tests in `test_unified_continue.py` and `test_team_checkpointing.py`:

- `test_fork_resets_events_to_none` — verifies the fork starts with no events and the parent's events are not mutated
- `test_fork_starts_metrics_timer` — calls `stop_timer()` on the fork's metrics and asserts `duration` is populated (not `None`)

Full agent + team unit suite: **982 passed, 1 skipped**.

## Verification (manual)

Before: `GET /sessions/{id}/runs` on a regenerated session returned a run whose `events` array contained both the source's events (`RunStarted` / `ModelRequestStarted` / ... / `RunCompleted` from source-run-id) and the regenerated run's events. Its `RunCompleted` had `input_tokens` / `output_tokens` / `cache_read_tokens` populated but no `duration`.

After: the regenerated run's events contain only its own events (`RunContinued` / `ModelRequestStarted` / ... / `RunCompleted` from regenerated-run-id) and `RunCompleted.metrics.duration` is set.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (\`./scripts/format.sh\` and \`./scripts/validate.sh\`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)