### PR TITLE
fix: resilient DB component loading, provider round-trip, and catalog dedup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,17 +98,27 @@ Make sure all tests pass before submitting your pull request. If you add new fea
 4. If the Model provider does not support the OpenAI API spec:
    - Reach out to us on [Discord](https://discord.gg/4MtYHHrgA8) or open an issue to discuss the best way to integrate your LLM provider.
    - Checkout [`agno/models/anthropic/claude.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/models/anthropic/claude.py) or [`agno/models/cohere/chat.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/models/cohere/chat.py) for inspiration.
-5. Add your model provider to `libs/agno/agno/models/utils.py`:
-   - Add a new `elif` clause in the `get_model()` function with your provider name
-   - Use the provider name that matches your module directory (e.g., "meta" for `models/meta/`)
-   - Import and return your Model class with the provided `model_id`
-   - This enables users to use the string format: `model="yourprovider:model-name"`
-   - Example:
+5. Register your model provider in `libs/agno/agno/models/utils.py`:
+   - Add an entry to the `MODEL_PROVIDER_CLASSES` dict mapping a stable provider key to the
+     `(module, class_name)` that implements it. This is the single source of truth used both for
+     the string format (`model="yourprovider:model-name"`) and for rebuilding a model saved to the
+     database. Use a lowercase, hyphenated key, typically matching your module directory (e.g.
+     `"meta"` for `models/meta/`, `"openai-chat"` for the chat variant).
      ```python
-     elif provider == "yourprovider":
-         from agno.models.yourprovider import YourModel
-         return YourModel(id=model_id)
+     "yourprovider": ("agno.models.yourprovider", "YourModel"),
      ```
+   - Models are reconstructed from their serialized `(provider, name)` pair (see
+     `get_model_from_dict` / `_resolve_provider_key`). Two extra maps keep that lossless; update
+     them only if your class needs them:
+     - `_PROVIDER_ALIASES`: add an entry if your class's display `provider` string, lowercased,
+       does not already equal your key (e.g. provider `"InceptionLabs"` -> key `"inception"`).
+     - `_NAME_TO_PROVIDER_KEY` and `_PROVIDER_DISPLAY_OVERRIDES`: add entries only if your class
+       shares a display `provider` string with another class (so the serialized `name` is needed
+       to tell them apart, as with `OpenAIChat` vs `OpenAIResponses`, both reporting `"OpenAI"`).
+   - CI enforces this: `test_every_model_subclass_is_registered` statically discovers every
+     concrete `Model` subclass and fails if one is missing from `MODEL_PROVIDER_CLASSES`. If your
+     class is an abstract base rather than a user-selectable provider, add it to that test's
+     allowlist instead.
 6. Add a recipe for using your Model provider under `cookbook/models/<your_model>`.
    - Checkout [`agno/cookbook/90_models/aws/claude`](https://github.com/agno-agi/agno/tree/main/cookbook/90_models/aws/claude) for an example.
    - Show both the model class and string syntax in your examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,26 +99,25 @@ Make sure all tests pass before submitting your pull request. If you add new fea
    - Reach out to us on [Discord](https://discord.gg/4MtYHHrgA8) or open an issue to discuss the best way to integrate your LLM provider.
    - Checkout [`agno/models/anthropic/claude.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/models/anthropic/claude.py) or [`agno/models/cohere/chat.py`](https://github.com/agno-agi/agno/blob/main/libs/agno/agno/models/cohere/chat.py) for inspiration.
 5. Register your model provider in `libs/agno/agno/models/utils.py`:
-   - Add an entry to the `MODEL_PROVIDER_CLASSES` dict mapping a stable provider key to the
-     `(module, class_name)` that implements it. This is the single source of truth used both for
-     the string format (`model="yourprovider:model-name"`) and for rebuilding a model saved to the
-     database. Use a lowercase, hyphenated key, typically matching your module directory (e.g.
-     `"meta"` for `models/meta/`, `"openai-chat"` for the chat variant).
+   - Add exactly one row to the `_PROVIDERS` table, keyed by a stable provider key, with the value
+     `(module, class_name, default_name, default_provider)`. `default_name` and `default_provider`
+     are your class's default `name` and (lowercased) `provider` attributes. This single table is
+     the source of truth: the construction registry (`MODEL_PROVIDER_CLASSES`) and the
+     `(provider, name)` resolution indices are all derived from it, so you do not edit any other
+     map. Use a lowercase, hyphenated key, typically matching your module directory (e.g. `"meta"`
+     for `models/meta/`, `"openai-chat"` for the chat variant).
      ```python
-     "yourprovider": ("agno.models.yourprovider", "YourModel"),
+     "yourprovider": ("agno.models.yourprovider", "YourModel", "YourModel", "yourprovider"),
      ```
-   - Models are reconstructed from their serialized `(provider, name)` pair (see
-     `get_model_from_dict` / `_resolve_provider_key`). Two extra maps keep that lossless; update
-     them only if your class needs them:
-     - `_PROVIDER_ALIASES`: add an entry if your class's display `provider` string, lowercased,
-       does not already equal your key (e.g. provider `"InceptionLabs"` -> key `"inception"`).
-     - `_NAME_TO_PROVIDER_KEY` and `_PROVIDER_DISPLAY_OVERRIDES`: add entries only if your class
-       shares a display `provider` string with another class (so the serialized `name` is needed
-       to tell them apart, as with `OpenAIChat` vs `OpenAIResponses`, both reporting `"OpenAI"`).
-   - CI enforces this: `test_every_model_subclass_is_registered` statically discovers every
-     concrete `Model` subclass and fails if one is missing from `MODEL_PROVIDER_CLASSES`. If your
-     class is an abstract base rather than a user-selectable provider, add it to that test's
-     allowlist instead.
+   - This covers both the string format (`model="yourprovider:model-name"`) and rebuilding a model
+     saved to the database. If your class shares a display `provider` string with another class
+     (e.g. an OpenAI-compatible provider reporting `"openai"`), the serialized `name` you list is
+     what tells them apart; if its display string differs from the key (e.g. `"inceptionlabs"` vs
+     key `"inception"`), the alias is derived automatically. Only the default key for an ambiguous
+     display string (e.g. `"azure"` -> AzureOpenAI) lives in `_AMBIGUOUS_PROVIDER_DEFAULTS`.
+   - CI enforces registration: `test_every_model_subclass_is_registered` statically discovers every
+     concrete `Model` subclass and fails if one is missing. If your class is an abstract base rather
+     than a user-selectable provider, add it to that test's allowlist instead.
 6. Add a recipe for using your Model provider under `cookbook/models/<your_model>`.
    - Checkout [`agno/cookbook/90_models/aws/claude`](https://github.com/agno-agi/agno/tree/main/cookbook/90_models/aws/claude) for an example.
    - Show both the model class and string syntax in your examples

--- a/cookbook/93_components/agent_os_registry.py
+++ b/cookbook/93_components/agent_os_registry.py
@@ -8,6 +8,7 @@ Demonstrates configuring AgentOS with a Registry and serving the app.
 from agno.agent.agent import Agent
 from agno.db.postgres import PostgresDb
 from agno.models.anthropic import Claude
+from agno.models.azure import AzureOpenAI
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
 from agno.registry import Registry
@@ -34,6 +35,7 @@ registry = Registry(
         OpenAIChat(id="gpt-5-mini"),
         OpenAIChat(id="gpt-5"),
         Claude(id="claude-sonnet-4-5"),
+        AzureOpenAI(id="gpt-5-mini"),
     ],
     dbs=[db],
 )

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -754,7 +754,7 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
     Returns:
         Agent: Reconstructed agent instance
     """
-    from agno.models.utils import get_model
+    from agno.models.utils import get_model, get_model_from_dict
 
     config = data.copy()
 
@@ -762,7 +762,7 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
     if "model" in config:
         model_data = config["model"]
         if isinstance(model_data, dict) and "id" in model_data:
-            config["model"] = get_model(f"{model_data['provider']}:{model_data['id']}")
+            config["model"] = get_model_from_dict(model_data)
         elif isinstance(model_data, str):
             config["model"] = get_model(model_data)
 

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1716,18 +1716,23 @@ def get_agents(
             component_type=ComponentType.AGENT, exclude_component_ids=exclude_component_ids
         )
         for component in components:
-            config = db.get_config(component_id=component["component_id"])
-            if config is not None:
-                agent_config = config.get("config")
-                if agent_config is not None:
-                    component_id = component["component_id"]
-                    if "id" not in agent_config:
-                        agent_config["id"] = component_id
-                    agent = Agent.from_dict(agent_config, registry=registry)
-                    agent.id = component_id
-                    agent._version = component.get("current_version")
-                    agent._stage = config.get("stage")
-                    agents.append(agent)
+            try:
+                config = db.get_config(component_id=component["component_id"])
+                if config is not None:
+                    agent_config = config.get("config")
+                    if agent_config is not None:
+                        component_id = component["component_id"]
+                        if "id" not in agent_config:
+                            agent_config["id"] = component_id
+                        agent = Agent.from_dict(agent_config, registry=registry)
+                        agent.id = component_id
+                        agent._version = component.get("current_version")
+                        agent._stage = config.get("stage")
+                        agents.append(agent)
+            except Exception as e:
+                component_id = component.get("component_id", "unknown")
+                log_error(f"Error loading Agent {component_id} from database: {str(e)}")
+                continue
         return agents
 
     except Exception as e:

--- a/libs/agno/agno/models/litellm/litellm_openai.py
+++ b/libs/agno/agno/models/litellm/litellm_openai.py
@@ -19,7 +19,7 @@ class LiteLLMOpenAI(OpenAILike):
     """
 
     id: str = "gpt-4o"
-    name: str = "LiteLLM"
+    name: str = "LiteLLMOpenAI"
     provider: str = "LiteLLM"
 
     api_key: Optional[str] = field(default_factory=lambda: getenv("LITELLM_API_KEY"))

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -196,10 +196,12 @@ def _resolve_provider_key(model_provider: Optional[str], model_name: Optional[st
     provider_key = provider if provider in MODEL_PROVIDER_CLASSES else _PROVIDER_ALIASES.get(provider)
     name_key = _NAME_TO_PROVIDER_KEY.get(model_name) if model_name else None
 
-    # Provider string is unknown (e.g. CometAPI's post-init "CometAPI (<id>)" when name is absent,
-    # or a custom provider): the name is the only reliable signal left.
     if provider_key is None:
-        return name_key or provider
+        # An empty provider string (older data, or a model whose provider was never set) leaves the
+        # name as the only signal. A non-empty but unrecognized provider stays authoritative so an
+        # unsupported/custom provider is rejected by _get_model_class rather than being silently
+        # re-routed to a built-in class by a colliding name.
+        return (name_key or provider) if not provider else provider
 
     # Otherwise trust the name only when its class reports this same provider string.
     if name_key is not None and _canonical_provider_display(name_key) == provider:

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -148,21 +148,63 @@ _PROVIDER_ALIASES: Dict[str, str] = {
 }
 
 
+# The lowercased display `provider` string each key's class reports, listed only where it differs
+# from the key itself (most keys equal their provider string). Several distinct classes share a
+# provider string -- e.g. OpenAIResponses, OpenAIChat, and OpenAI-compatible providers like
+# CometAPI all report "OpenAI" -- so this is what tells whether a serialized `name` legitimately
+# belongs to the serialized provider.
+_PROVIDER_DISPLAY_OVERRIDES: Dict[str, str] = {
+    "openai-chat": "openai",
+    "openai-responses": "openai",
+    "cometapi": "openai",
+    "google-interactions": "google",
+    "openrouter-responses": "openrouter",
+    "azure-openai": "azure",
+    "azure-ai-foundry": "azure",
+    "azure-foundry-claude": "azurefoundry",
+    "aws-bedrock": "awsbedrock",
+    "aws-claude": "awsbedrock",
+    "ollama-responses": "ollama",
+    "litellm-openai": "litellm",
+    "cerebras-openai": "cerebrasopenai",
+    "inception": "inceptionlabs",
+    "llama-cpp": "llamacpp",
+    "meta": "llama",
+    "llama-openai": "llamaopenai",
+    "vertexai-claude": "vertexai",
+    "xiaomi": "xiaomi mimo",
+    "open-responses": "openresponses",
+    "tuning-engines": "tuning engines",
+}
+
+
+def _canonical_provider_display(key: str) -> str:
+    """The lowercased display `provider` string a given provider key's class reports."""
+    return _PROVIDER_DISPLAY_OVERRIDES.get(key, key)
+
+
 def _resolve_provider_key(model_provider: Optional[str], model_name: Optional[str] = None) -> str:
     """Resolve a serialized (provider, name) pair to a stable provider key.
 
-    `name` is preferred because it disambiguates providers that share a display `provider`
-    string (e.g. Azure). Falls back to the provider string and known aliases.
+    The provider string is authoritative. `name` is used only to disambiguate among classes that
+    report the same display `provider` (e.g. AzureOpenAI vs AzureAIFoundry, or OpenAIResponses vs
+    the OpenAI-compatible CometAPI). A `name` whose class reports a different provider is treated
+    as a user-supplied label and ignored, so e.g. OpenAIChat(name="Gemini") still resolves to
+    OpenAI rather than Google.
     """
-    if model_name and model_name in _NAME_TO_PROVIDER_KEY:
-        return _NAME_TO_PROVIDER_KEY[model_name]
-
     provider = (model_provider or "").strip().lower()
-    if provider in MODEL_PROVIDER_CLASSES:
-        return provider
-    if provider in _PROVIDER_ALIASES:
-        return _PROVIDER_ALIASES[provider]
-    return provider
+    provider_key = provider if provider in MODEL_PROVIDER_CLASSES else _PROVIDER_ALIASES.get(provider)
+    name_key = _NAME_TO_PROVIDER_KEY.get(model_name) if model_name else None
+
+    # Provider string is unknown (e.g. CometAPI's post-init "CometAPI (<id>)" when name is absent,
+    # or a custom provider): the name is the only reliable signal left.
+    if provider_key is None:
+        return name_key or provider
+
+    # Otherwise trust the name only when its class reports this same provider string.
+    if name_key is not None and _canonical_provider_display(name_key) == provider:
+        return name_key
+    return provider_key
 
 
 def _get_model_class(model_id: str, model_provider: str) -> Model:

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -1,186 +1,111 @@
 import importlib
+from collections import Counter
 from typing import Any, Dict, Optional, Tuple, Union
 
 from agno.models.base import Model
 
-# Single source of truth mapping a stable provider key to the (module, class name) that
-# implements it. `_get_model_class` constructs from this and the round-trip resolver below
-# maps a serialized model back to the correct key. Add new providers here only.
-MODEL_PROVIDER_CLASSES: Dict[str, Tuple[str, str]] = {
-    "aimlapi": ("agno.models.aimlapi", "AIMLAPI"),
-    "anthropic": ("agno.models.anthropic", "Claude"),
-    "aws-bedrock": ("agno.models.aws", "AwsBedrock"),
-    "aws-claude": ("agno.models.aws", "Claude"),
-    "azure-ai-foundry": ("agno.models.azure", "AzureAIFoundry"),
-    "azure-foundry-claude": ("agno.models.azure", "AzureFoundryClaude"),
-    "azure-openai": ("agno.models.azure", "AzureOpenAI"),
-    "cerebras": ("agno.models.cerebras", "Cerebras"),
-    "cerebras-openai": ("agno.models.cerebras", "CerebrasOpenAI"),
-    "cohere": ("agno.models.cohere", "Cohere"),
-    "cometapi": ("agno.models.cometapi", "CometAPI"),
-    "cloudflare": ("agno.models.cloudflare", "Cloudflare"),
-    "dashscope": ("agno.models.dashscope", "DashScope"),
-    "deepinfra": ("agno.models.deepinfra", "DeepInfra"),
-    "deepseek": ("agno.models.deepseek", "DeepSeek"),
-    "fireworks": ("agno.models.fireworks", "Fireworks"),
-    "google": ("agno.models.google", "Gemini"),
-    "google-interactions": ("agno.models.google", "GeminiInteractions"),
-    "groq": ("agno.models.groq", "Groq"),
-    "huggingface": ("agno.models.huggingface", "HuggingFace"),
-    "ibm": ("agno.models.ibm", "WatsonX"),
-    "inception": ("agno.models.inception", "Inception"),
-    "internlm": ("agno.models.internlm", "InternLM"),
-    "langdb": ("agno.models.langdb", "LangDB"),
-    "litellm": ("agno.models.litellm", "LiteLLM"),
-    "litellm-openai": ("agno.models.litellm", "LiteLLMOpenAI"),
-    "llama-cpp": ("agno.models.llama_cpp", "LlamaCpp"),
-    "llama-openai": ("agno.models.meta", "LlamaOpenAI"),
-    "lmstudio": ("agno.models.lmstudio", "LMStudio"),
-    "meta": ("agno.models.meta", "Llama"),
-    "minimax": ("agno.models.minimax", "MiniMax"),
-    "mistral": ("agno.models.mistral", "MistralChat"),
-    "moonshot": ("agno.models.moonshot", "MoonShot"),
-    "n1n": ("agno.models.n1n", "N1N"),
-    "nebius": ("agno.models.nebius", "Nebius"),
-    "neosantara": ("agno.models.neosantara", "Neosantara"),
-    "nexus": ("agno.models.nexus", "Nexus"),
-    "nvidia": ("agno.models.nvidia", "Nvidia"),
-    "ollama": ("agno.models.ollama", "Ollama"),
-    "ollama-responses": ("agno.models.ollama", "OllamaResponses"),
-    "openai": ("agno.models.openai", "OpenAIResponses"),
-    "openai-chat": ("agno.models.openai", "OpenAIChat"),
-    "openai-responses": ("agno.models.openai", "OpenAIResponses"),
-    "open-responses": ("agno.models.openai", "OpenResponses"),
-    "openrouter": ("agno.models.openrouter", "OpenRouter"),
-    "openrouter-responses": ("agno.models.openrouter", "OpenRouterResponses"),
-    "perplexity": ("agno.models.perplexity", "Perplexity"),
-    "portkey": ("agno.models.portkey", "Portkey"),
-    "requesty": ("agno.models.requesty", "Requesty"),
-    "sambanova": ("agno.models.sambanova", "Sambanova"),
-    "siliconflow": ("agno.models.siliconflow", "Siliconflow"),
-    "together": ("agno.models.together", "Together"),
-    "tuning-engines": ("agno.models.tuning_engines", "TuningEngines"),
-    "vercel": ("agno.models.vercel", "V0"),
-    "vertexai-claude": ("agno.models.vertexai.claude", "Claude"),
-    "vllm": ("agno.models.vllm", "VLLM"),
-    "xai": ("agno.models.xai", "xAI"),
-    "xiaomi": ("agno.models.xiaomi", "MiMo"),
+# Single source of truth for every supported model provider. One row per stable provider key:
+#   key -> (module, class_name, default_name, default_provider_display)
+# `default_name` and `default_provider_display` are the class's default `name` and (lowercased)
+# `provider` attributes. The construction registry and the (provider, name) resolution indices
+# below are all derived from this table, so adding a provider means adding exactly one row here.
+_PROVIDERS: Dict[str, Tuple[str, str, str, str]] = {
+    "aimlapi": ("agno.models.aimlapi", "AIMLAPI", "AIMLAPI", "aimlapi"),
+    "anthropic": ("agno.models.anthropic", "Claude", "Claude", "anthropic"),
+    "aws-bedrock": ("agno.models.aws", "AwsBedrock", "AwsBedrock", "awsbedrock"),
+    "aws-claude": ("agno.models.aws", "Claude", "AwsBedrockAnthropicClaude", "awsbedrock"),
+    "azure-ai-foundry": ("agno.models.azure", "AzureAIFoundry", "AzureAIFoundry", "azure"),
+    "azure-foundry-claude": ("agno.models.azure", "AzureFoundryClaude", "AzureFoundryClaude", "azurefoundry"),
+    "azure-openai": ("agno.models.azure", "AzureOpenAI", "AzureOpenAI", "azure"),
+    "cerebras": ("agno.models.cerebras", "Cerebras", "Cerebras", "cerebras"),
+    "cerebras-openai": ("agno.models.cerebras", "CerebrasOpenAI", "CerebrasOpenAI", "cerebrasopenai"),
+    "cohere": ("agno.models.cohere", "Cohere", "cohere", "cohere"),
+    "cometapi": ("agno.models.cometapi", "CometAPI", "CometAPI", "openai"),
+    "cloudflare": ("agno.models.cloudflare", "Cloudflare", "Cloudflare", "cloudflare"),
+    "dashscope": ("agno.models.dashscope", "DashScope", "Qwen", "dashscope"),
+    "deepinfra": ("agno.models.deepinfra", "DeepInfra", "DeepInfra", "deepinfra"),
+    "deepseek": ("agno.models.deepseek", "DeepSeek", "DeepSeek", "deepseek"),
+    "fireworks": ("agno.models.fireworks", "Fireworks", "Fireworks", "fireworks"),
+    "google": ("agno.models.google", "Gemini", "Gemini", "google"),
+    "google-interactions": ("agno.models.google", "GeminiInteractions", "GeminiInteractions", "google"),
+    "groq": ("agno.models.groq", "Groq", "Groq", "groq"),
+    "huggingface": ("agno.models.huggingface", "HuggingFace", "HuggingFace", "huggingface"),
+    "ibm": ("agno.models.ibm", "WatsonX", "WatsonX", "ibm"),
+    "inception": ("agno.models.inception", "Inception", "Inception", "inceptionlabs"),
+    "internlm": ("agno.models.internlm", "InternLM", "InternLM", "internlm"),
+    "langdb": ("agno.models.langdb", "LangDB", "LangDB", "langdb"),
+    "litellm": ("agno.models.litellm", "LiteLLM", "LiteLLM", "litellm"),
+    "litellm-openai": ("agno.models.litellm", "LiteLLMOpenAI", "LiteLLMOpenAI", "litellm"),
+    "llama-cpp": ("agno.models.llama_cpp", "LlamaCpp", "LlamaCpp", "llamacpp"),
+    "llama-openai": ("agno.models.meta", "LlamaOpenAI", "LlamaOpenAI", "llamaopenai"),
+    "lmstudio": ("agno.models.lmstudio", "LMStudio", "LMStudio", "lmstudio"),
+    "meta": ("agno.models.meta", "Llama", "Llama", "llama"),
+    "minimax": ("agno.models.minimax", "MiniMax", "MiniMax", "minimax"),
+    "mistral": ("agno.models.mistral", "MistralChat", "MistralChat", "mistral"),
+    "moonshot": ("agno.models.moonshot", "MoonShot", "Moonshot", "moonshot"),
+    "n1n": ("agno.models.n1n", "N1N", "N1N", "n1n"),
+    "nebius": ("agno.models.nebius", "Nebius", "Nebius", "nebius"),
+    "neosantara": ("agno.models.neosantara", "Neosantara", "Neosantara", "neosantara"),
+    "nexus": ("agno.models.nexus", "Nexus", "Nexus", "nexus"),
+    "nvidia": ("agno.models.nvidia", "Nvidia", "Nvidia", "nvidia"),
+    "ollama": ("agno.models.ollama", "Ollama", "Ollama", "ollama"),
+    "ollama-responses": ("agno.models.ollama", "OllamaResponses", "OllamaResponses", "ollama"),
+    "openai": ("agno.models.openai", "OpenAIResponses", "OpenAIResponses", "openai"),
+    "openai-chat": ("agno.models.openai", "OpenAIChat", "OpenAIChat", "openai"),
+    "openai-responses": ("agno.models.openai", "OpenAIResponses", "OpenAIResponses", "openai"),
+    "open-responses": ("agno.models.openai", "OpenResponses", "OpenResponses", "openresponses"),
+    "openrouter": ("agno.models.openrouter", "OpenRouter", "OpenRouter", "openrouter"),
+    "openrouter-responses": ("agno.models.openrouter", "OpenRouterResponses", "OpenRouterResponses", "openrouter"),
+    "perplexity": ("agno.models.perplexity", "Perplexity", "Perplexity", "perplexity"),
+    "portkey": ("agno.models.portkey", "Portkey", "Portkey", "portkey"),
+    "requesty": ("agno.models.requesty", "Requesty", "Requesty", "requesty"),
+    "sambanova": ("agno.models.sambanova", "Sambanova", "Sambanova", "sambanova"),
+    "siliconflow": ("agno.models.siliconflow", "Siliconflow", "Siliconflow", "siliconflow"),
+    "together": ("agno.models.together", "Together", "Together", "together"),
+    "tuning-engines": ("agno.models.tuning_engines", "TuningEngines", "Tuning Engines", "tuning engines"),
+    "vercel": ("agno.models.vercel", "V0", "v0", "vercel"),
+    "vertexai-claude": ("agno.models.vertexai.claude", "Claude", "Claude", "vertexai"),
+    "vllm": ("agno.models.vllm", "VLLM", "VLLM", "vllm"),
+    "xai": ("agno.models.xai", "xAI", "xAI", "xai"),
+    "xiaomi": ("agno.models.xiaomi", "MiMo", "MiMo", "xiaomi mimo"),
 }
 
-# Maps a serialized model `name` (the per-class default name attribute) to its provider key.
-# `name` is the most specific discriminator and is needed when two providers share the same
-# display `provider` string (e.g. all Azure models report provider "Azure"). Names that are
-# shared across classes (e.g. "Claude", "LiteLLM") are intentionally omitted here and fall back
-# to provider-based resolution.
+# key -> (module, class_name): the construction registry consumed by `_get_model_class`, the
+# CONTRIBUTING guide, and the registry-drift test.
+MODEL_PROVIDER_CLASSES: Dict[str, Tuple[str, str]] = {key: (mod, cls) for key, (mod, cls, _n, _p) in _PROVIDERS.items()}
+
+# key -> lowercased display `provider` string the class reports.
+_KEY_TO_PROVIDER: Dict[str, str] = {key: prov for key, (_m, _c, _n, prov) in _PROVIDERS.items()}
+
+# Serialized `name` -> key, but only for names that identify exactly one provider. Names shared
+# across classes (e.g. "Claude") are ambiguous and omitted, so those fall back to the provider.
+_name_counts = Counter(name for (_m, _c, name, _p) in _PROVIDERS.values())
 _NAME_TO_PROVIDER_KEY: Dict[str, str] = {
-    "AIMLAPI": "aimlapi",
-    "AwsBedrock": "aws-bedrock",
-    "AwsBedrockAnthropicClaude": "aws-claude",
-    "AzureAIFoundry": "azure-ai-foundry",
-    "AzureFoundryClaude": "azure-foundry-claude",
-    "AzureOpenAI": "azure-openai",
-    "Cerebras": "cerebras",
-    "CerebrasOpenAI": "cerebras-openai",
-    "Cloudflare": "cloudflare",
-    "CometAPI": "cometapi",
-    "cohere": "cohere",
-    "Qwen": "dashscope",
-    "DeepInfra": "deepinfra",
-    "DeepSeek": "deepseek",
-    "Fireworks": "fireworks",
-    "Gemini": "google",
-    "GeminiInteractions": "google-interactions",
-    "Groq": "groq",
-    "HuggingFace": "huggingface",
-    "WatsonX": "ibm",
-    "Inception": "inception",
-    "InternLM": "internlm",
-    "LangDB": "langdb",
-    "LiteLLMOpenAI": "litellm-openai",
-    "LlamaCpp": "llama-cpp",
-    "LMStudio": "lmstudio",
-    "Llama": "meta",
-    "LlamaOpenAI": "llama-openai",
-    "MiniMax": "minimax",
-    "MistralChat": "mistral",
-    "Moonshot": "moonshot",
-    "N1N": "n1n",
-    "Nebius": "nebius",
-    "Neosantara": "neosantara",
-    "Nexus": "nexus",
-    "Nvidia": "nvidia",
-    "Ollama": "ollama",
-    "OllamaResponses": "ollama-responses",
-    "OpenAIChat": "openai-chat",
-    "OpenAIResponses": "openai-responses",
-    "OpenResponses": "open-responses",
-    "OpenRouter": "openrouter",
-    "OpenRouterResponses": "openrouter-responses",
-    "Perplexity": "perplexity",
-    "Portkey": "portkey",
-    "Requesty": "requesty",
-    "Sambanova": "sambanova",
-    "Siliconflow": "siliconflow",
-    "Together": "together",
-    "Tuning Engines": "tuning-engines",
-    "v0": "vercel",
-    "VLLM": "vllm",
-    "xAI": "xai",
-    "MiMo": "xiaomi",
+    name: key for key, (_m, _c, name, _p) in _PROVIDERS.items() if _name_counts[name] == 1
 }
 
-# Maps a lowercased serialized `provider` display string to its provider key, for providers
-# whose display string does not already equal a key. Used as a fallback when `name` is missing
-# or shared. Keeps the string form (e.g. "azure:gpt-4o") working too.
-_PROVIDER_ALIASES: Dict[str, str] = {
-    "awsbedrock": "aws-bedrock",
-    "azure": "azure-openai",
-    "azurefoundry": "azure-foundry-claude",
-    "cerebrasopenai": "cerebras-openai",
-    "inceptionlabs": "inception",
-    "llama": "meta",
-    "llamacpp": "llama-cpp",
-    "llamaopenai": "llama-openai",
-    "openresponses": "open-responses",
-    "tuning engines": "tuning-engines",
-    "vertexai": "vertexai-claude",
-    "xiaomi mimo": "xiaomi",
-}
+# Default key for a display `provider` string that is not itself a key. Where several classes
+# share such a string (e.g. "azure" -> AzureOpenAI/AzureAIFoundry), the default is the variant
+# used when `name` does not disambiguate.
+_AMBIGUOUS_PROVIDER_DEFAULTS: Dict[str, str] = {"azure": "azure-openai", "awsbedrock": "aws-bedrock"}
 
 
-# The lowercased display `provider` string each key's class reports, listed only where it differs
-# from the key itself (most keys equal their provider string). Several distinct classes share a
-# provider string -- e.g. OpenAIResponses, OpenAIChat, and OpenAI-compatible providers like
-# CometAPI all report "OpenAI" -- so this is what tells whether a serialized `name` legitimately
-# belongs to the serialized provider.
-_PROVIDER_DISPLAY_OVERRIDES: Dict[str, str] = {
-    "openai-chat": "openai",
-    "openai-responses": "openai",
-    "cometapi": "openai",
-    "google-interactions": "google",
-    "openrouter-responses": "openrouter",
-    "azure-openai": "azure",
-    "azure-ai-foundry": "azure",
-    "azure-foundry-claude": "azurefoundry",
-    "aws-bedrock": "awsbedrock",
-    "aws-claude": "awsbedrock",
-    "ollama-responses": "ollama",
-    "litellm-openai": "litellm",
-    "cerebras-openai": "cerebrasopenai",
-    "inception": "inceptionlabs",
-    "llama-cpp": "llamacpp",
-    "meta": "llama",
-    "llama-openai": "llamaopenai",
-    "vertexai-claude": "vertexai",
-    "xiaomi": "xiaomi mimo",
-    "open-responses": "openresponses",
-    "tuning-engines": "tuning engines",
-}
+def _build_provider_to_key() -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for key, (_m, _c, _n, prov) in _PROVIDERS.items():
+        if prov not in MODEL_PROVIDER_CLASSES:  # display strings that already equal a key resolve directly
+            mapping.setdefault(prov, key)
+    mapping.update(_AMBIGUOUS_PROVIDER_DEFAULTS)
+    return mapping
+
+
+# Display `provider` string -> key, used as a fallback when `name` is missing or shared.
+_PROVIDER_TO_KEY: Dict[str, str] = _build_provider_to_key()
 
 
 def _canonical_provider_display(key: str) -> str:
     """The lowercased display `provider` string a given provider key's class reports."""
-    return _PROVIDER_DISPLAY_OVERRIDES.get(key, key)
+    return _KEY_TO_PROVIDER.get(key, key)
 
 
 def _resolve_provider_key(model_provider: Optional[str], model_name: Optional[str] = None) -> str:
@@ -193,7 +118,7 @@ def _resolve_provider_key(model_provider: Optional[str], model_name: Optional[st
     OpenAI rather than Google.
     """
     provider = (model_provider or "").strip().lower()
-    provider_key = provider if provider in MODEL_PROVIDER_CLASSES else _PROVIDER_ALIASES.get(provider)
+    provider_key = provider if provider in MODEL_PROVIDER_CLASSES else _PROVIDER_TO_KEY.get(provider)
     name_key = _NAME_TO_PROVIDER_KEY.get(model_name) if model_name else None
 
     if provider_key is None:

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -59,6 +59,7 @@ MODEL_PROVIDER_CLASSES: Dict[str, Tuple[str, str]] = {
     "sambanova": ("agno.models.sambanova", "Sambanova"),
     "siliconflow": ("agno.models.siliconflow", "Siliconflow"),
     "together": ("agno.models.together", "Together"),
+    "tuning-engines": ("agno.models.tuning_engines", "TuningEngines"),
     "vercel": ("agno.models.vercel", "V0"),
     "vertexai-claude": ("agno.models.vertexai.claude", "Claude"),
     "vllm": ("agno.models.vllm", "VLLM"),
@@ -121,6 +122,7 @@ _NAME_TO_PROVIDER_KEY: Dict[str, str] = {
     "Sambanova": "sambanova",
     "Siliconflow": "siliconflow",
     "Together": "together",
+    "Tuning Engines": "tuning-engines",
     "v0": "vercel",
     "VLLM": "vllm",
     "xAI": "xai",
@@ -140,6 +142,7 @@ _PROVIDER_ALIASES: Dict[str, str] = {
     "llamacpp": "llama-cpp",
     "llamaopenai": "llama-openai",
     "openresponses": "open-responses",
+    "tuning engines": "tuning-engines",
     "vertexai": "vertexai-claude",
     "xiaomi mimo": "xiaomi",
 }

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -1,281 +1,180 @@
-from typing import Optional, Union
+import importlib
+from typing import Any, Dict, Optional, Tuple, Union
 
 from agno.models.base import Model
 
+# Single source of truth mapping a stable provider key to the (module, class name) that
+# implements it. `_get_model_class` constructs from this and the round-trip resolver below
+# maps a serialized model back to the correct key. Add new providers here only.
+MODEL_PROVIDER_CLASSES: Dict[str, Tuple[str, str]] = {
+    "aimlapi": ("agno.models.aimlapi", "AIMLAPI"),
+    "anthropic": ("agno.models.anthropic", "Claude"),
+    "aws-bedrock": ("agno.models.aws", "AwsBedrock"),
+    "aws-claude": ("agno.models.aws", "Claude"),
+    "azure-ai-foundry": ("agno.models.azure", "AzureAIFoundry"),
+    "azure-foundry-claude": ("agno.models.azure", "AzureFoundryClaude"),
+    "azure-openai": ("agno.models.azure", "AzureOpenAI"),
+    "cerebras": ("agno.models.cerebras", "Cerebras"),
+    "cerebras-openai": ("agno.models.cerebras", "CerebrasOpenAI"),
+    "cohere": ("agno.models.cohere", "Cohere"),
+    "cometapi": ("agno.models.cometapi", "CometAPI"),
+    "cloudflare": ("agno.models.cloudflare", "Cloudflare"),
+    "dashscope": ("agno.models.dashscope", "DashScope"),
+    "deepinfra": ("agno.models.deepinfra", "DeepInfra"),
+    "deepseek": ("agno.models.deepseek", "DeepSeek"),
+    "fireworks": ("agno.models.fireworks", "Fireworks"),
+    "google": ("agno.models.google", "Gemini"),
+    "google-interactions": ("agno.models.google", "GeminiInteractions"),
+    "groq": ("agno.models.groq", "Groq"),
+    "huggingface": ("agno.models.huggingface", "HuggingFace"),
+    "ibm": ("agno.models.ibm", "WatsonX"),
+    "inception": ("agno.models.inception", "Inception"),
+    "internlm": ("agno.models.internlm", "InternLM"),
+    "langdb": ("agno.models.langdb", "LangDB"),
+    "litellm": ("agno.models.litellm", "LiteLLM"),
+    "litellm-openai": ("agno.models.litellm", "LiteLLMOpenAI"),
+    "llama-cpp": ("agno.models.llama_cpp", "LlamaCpp"),
+    "llama-openai": ("agno.models.meta", "LlamaOpenAI"),
+    "lmstudio": ("agno.models.lmstudio", "LMStudio"),
+    "meta": ("agno.models.meta", "Llama"),
+    "minimax": ("agno.models.minimax", "MiniMax"),
+    "mistral": ("agno.models.mistral", "MistralChat"),
+    "moonshot": ("agno.models.moonshot", "MoonShot"),
+    "n1n": ("agno.models.n1n", "N1N"),
+    "nebius": ("agno.models.nebius", "Nebius"),
+    "neosantara": ("agno.models.neosantara", "Neosantara"),
+    "nexus": ("agno.models.nexus", "Nexus"),
+    "nvidia": ("agno.models.nvidia", "Nvidia"),
+    "ollama": ("agno.models.ollama", "Ollama"),
+    "ollama-responses": ("agno.models.ollama", "OllamaResponses"),
+    "openai": ("agno.models.openai", "OpenAIResponses"),
+    "openai-chat": ("agno.models.openai", "OpenAIChat"),
+    "openai-responses": ("agno.models.openai", "OpenAIResponses"),
+    "open-responses": ("agno.models.openai", "OpenResponses"),
+    "openrouter": ("agno.models.openrouter", "OpenRouter"),
+    "openrouter-responses": ("agno.models.openrouter", "OpenRouterResponses"),
+    "perplexity": ("agno.models.perplexity", "Perplexity"),
+    "portkey": ("agno.models.portkey", "Portkey"),
+    "requesty": ("agno.models.requesty", "Requesty"),
+    "sambanova": ("agno.models.sambanova", "Sambanova"),
+    "siliconflow": ("agno.models.siliconflow", "Siliconflow"),
+    "together": ("agno.models.together", "Together"),
+    "vercel": ("agno.models.vercel", "V0"),
+    "vertexai-claude": ("agno.models.vertexai.claude", "Claude"),
+    "vllm": ("agno.models.vllm", "VLLM"),
+    "xai": ("agno.models.xai", "xAI"),
+    "xiaomi": ("agno.models.xiaomi", "MiMo"),
+}
+
+# Maps a serialized model `name` (the per-class default name attribute) to its provider key.
+# `name` is the most specific discriminator and is needed when two providers share the same
+# display `provider` string (e.g. all Azure models report provider "Azure"). Names that are
+# shared across classes (e.g. "Claude", "LiteLLM") are intentionally omitted here and fall back
+# to provider-based resolution.
+_NAME_TO_PROVIDER_KEY: Dict[str, str] = {
+    "AIMLAPI": "aimlapi",
+    "AwsBedrock": "aws-bedrock",
+    "AwsBedrockAnthropicClaude": "aws-claude",
+    "AzureAIFoundry": "azure-ai-foundry",
+    "AzureFoundryClaude": "azure-foundry-claude",
+    "AzureOpenAI": "azure-openai",
+    "Cerebras": "cerebras",
+    "CerebrasOpenAI": "cerebras-openai",
+    "Cloudflare": "cloudflare",
+    "CometAPI": "cometapi",
+    "cohere": "cohere",
+    "Qwen": "dashscope",
+    "DeepInfra": "deepinfra",
+    "DeepSeek": "deepseek",
+    "Fireworks": "fireworks",
+    "Gemini": "google",
+    "GeminiInteractions": "google-interactions",
+    "Groq": "groq",
+    "HuggingFace": "huggingface",
+    "WatsonX": "ibm",
+    "Inception": "inception",
+    "InternLM": "internlm",
+    "LangDB": "langdb",
+    "LiteLLMOpenAI": "litellm-openai",
+    "LlamaCpp": "llama-cpp",
+    "LMStudio": "lmstudio",
+    "Llama": "meta",
+    "LlamaOpenAI": "llama-openai",
+    "MiniMax": "minimax",
+    "MistralChat": "mistral",
+    "Moonshot": "moonshot",
+    "N1N": "n1n",
+    "Nebius": "nebius",
+    "Neosantara": "neosantara",
+    "Nexus": "nexus",
+    "Nvidia": "nvidia",
+    "Ollama": "ollama",
+    "OllamaResponses": "ollama-responses",
+    "OpenAIChat": "openai-chat",
+    "OpenAIResponses": "openai-responses",
+    "OpenResponses": "open-responses",
+    "OpenRouter": "openrouter",
+    "OpenRouterResponses": "openrouter-responses",
+    "Perplexity": "perplexity",
+    "Portkey": "portkey",
+    "Requesty": "requesty",
+    "Sambanova": "sambanova",
+    "Siliconflow": "siliconflow",
+    "Together": "together",
+    "v0": "vercel",
+    "VLLM": "vllm",
+    "xAI": "xai",
+    "MiMo": "xiaomi",
+}
+
+# Maps a lowercased serialized `provider` display string to its provider key, for providers
+# whose display string does not already equal a key. Used as a fallback when `name` is missing
+# or shared. Keeps the string form (e.g. "azure:gpt-4o") working too.
+_PROVIDER_ALIASES: Dict[str, str] = {
+    "awsbedrock": "aws-bedrock",
+    "azure": "azure-openai",
+    "azurefoundry": "azure-foundry-claude",
+    "cerebrasopenai": "cerebras-openai",
+    "inceptionlabs": "inception",
+    "llama": "meta",
+    "llamacpp": "llama-cpp",
+    "llamaopenai": "llama-openai",
+    "openresponses": "open-responses",
+    "vertexai": "vertexai-claude",
+    "xiaomi mimo": "xiaomi",
+}
+
+
+def _resolve_provider_key(model_provider: Optional[str], model_name: Optional[str] = None) -> str:
+    """Resolve a serialized (provider, name) pair to a stable provider key.
+
+    `name` is preferred because it disambiguates providers that share a display `provider`
+    string (e.g. Azure). Falls back to the provider string and known aliases.
+    """
+    if model_name and model_name in _NAME_TO_PROVIDER_KEY:
+        return _NAME_TO_PROVIDER_KEY[model_name]
+
+    provider = (model_provider or "").strip().lower()
+    if provider in MODEL_PROVIDER_CLASSES:
+        return provider
+    if provider in _PROVIDER_ALIASES:
+        return _PROVIDER_ALIASES[provider]
+    return provider
+
 
 def _get_model_class(model_id: str, model_provider: str) -> Model:
-    if model_provider == "aimlapi":
-        from agno.models.aimlapi import AIMLAPI
-
-        return AIMLAPI(id=model_id)
-
-    elif model_provider == "anthropic":
-        from agno.models.anthropic import Claude
-
-        return Claude(id=model_id)
-
-    elif model_provider == "aws-bedrock":
-        from agno.models.aws import AwsBedrock
-
-        return AwsBedrock(id=model_id)
-
-    elif model_provider == "aws-claude":
-        from agno.models.aws import Claude as AWSClaude
-
-        return AWSClaude(id=model_id)
-
-    elif model_provider == "azure-ai-foundry":
-        from agno.models.azure import AzureAIFoundry
-
-        return AzureAIFoundry(id=model_id)
-
-    elif model_provider == "azure-foundry-claude":
-        from agno.models.azure import AzureFoundryClaude
-
-        return AzureFoundryClaude(id=model_id)
-
-    elif model_provider == "azure-openai":
-        from agno.models.azure import AzureOpenAI
-
-        return AzureOpenAI(id=model_id)
-
-    elif model_provider == "cerebras":
-        from agno.models.cerebras import Cerebras
-
-        return Cerebras(id=model_id)
-
-    elif model_provider == "cerebras-openai":
-        from agno.models.cerebras import CerebrasOpenAI
-
-        return CerebrasOpenAI(id=model_id)
-
-    elif model_provider == "cohere":
-        from agno.models.cohere import Cohere
-
-        return Cohere(id=model_id)
-
-    elif model_provider == "cometapi":
-        from agno.models.cometapi import CometAPI
-
-        return CometAPI(id=model_id)
-
-    elif model_provider == "cloudflare":
-        from agno.models.cloudflare import Cloudflare
-
-        return Cloudflare(id=model_id)
-
-    elif model_provider == "dashscope":
-        from agno.models.dashscope import DashScope
-
-        return DashScope(id=model_id)
-
-    elif model_provider == "deepinfra":
-        from agno.models.deepinfra import DeepInfra
-
-        return DeepInfra(id=model_id)
-
-    elif model_provider == "deepseek":
-        from agno.models.deepseek import DeepSeek
-
-        return DeepSeek(id=model_id)
-
-    elif model_provider == "fireworks":
-        from agno.models.fireworks import Fireworks
-
-        return Fireworks(id=model_id)
-
-    elif model_provider == "google":
-        from agno.models.google import Gemini
-
-        return Gemini(id=model_id)
-
-    elif model_provider == "google-interactions":
-        from agno.models.google import GeminiInteractions
-
-        return GeminiInteractions(id=model_id)
-
-    elif model_provider == "groq":
-        from agno.models.groq import Groq
-
-        return Groq(id=model_id)
-
-    elif model_provider == "huggingface":
-        from agno.models.huggingface import HuggingFace
-
-        return HuggingFace(id=model_id)
-
-    elif model_provider == "ibm":
-        from agno.models.ibm import WatsonX
-
-        return WatsonX(id=model_id)
-
-    elif model_provider == "inception":
-        from agno.models.inception import Inception
-
-        return Inception(id=model_id)
-
-    elif model_provider == "internlm":
-        from agno.models.internlm import InternLM
-
-        return InternLM(id=model_id)
-
-    elif model_provider == "langdb":
-        from agno.models.langdb import LangDB
-
-        return LangDB(id=model_id)
-
-    elif model_provider == "litellm":
-        from agno.models.litellm import LiteLLM
-
-        return LiteLLM(id=model_id)
-
-    elif model_provider == "litellm-openai":
-        from agno.models.litellm import LiteLLMOpenAI
-
-        return LiteLLMOpenAI(id=model_id)
-
-    elif model_provider == "llama-cpp":
-        from agno.models.llama_cpp import LlamaCpp
-
-        return LlamaCpp(id=model_id)
-
-    elif model_provider == "llama-openai":
-        from agno.models.meta import LlamaOpenAI
-
-        return LlamaOpenAI(id=model_id)
-
-    elif model_provider == "lmstudio":
-        from agno.models.lmstudio import LMStudio
-
-        return LMStudio(id=model_id)
-
-    elif model_provider == "meta":
-        from agno.models.meta import Llama
-
-        return Llama(id=model_id)
-
-    elif model_provider == "minimax":
-        from agno.models.minimax import MiniMax
-
-        return MiniMax(id=model_id)
-
-    elif model_provider == "mistral":
-        from agno.models.mistral import MistralChat
-
-        return MistralChat(id=model_id)
-
-    elif model_provider == "moonshot":
-        from agno.models.moonshot import MoonShot
-
-        return MoonShot(id=model_id)
-
-    elif model_provider == "xiaomi":
-        from agno.models.xiaomi import MiMo
-
-        return MiMo(id=model_id)
-
-    elif model_provider == "n1n":
-        from agno.models.n1n import N1N
-
-        return N1N(id=model_id)
-
-    elif model_provider == "nebius":
-        from agno.models.nebius import Nebius
-
-        return Nebius(id=model_id)
-
-    elif model_provider == "neosantara":
-        from agno.models.neosantara import Neosantara
-
-        return Neosantara(id=model_id)
-
-    elif model_provider == "nexus":
-        from agno.models.nexus import Nexus
-
-        return Nexus(id=model_id)
-
-    elif model_provider == "nvidia":
-        from agno.models.nvidia import Nvidia
-
-        return Nvidia(id=model_id)
-
-    elif model_provider == "ollama":
-        from agno.models.ollama import Ollama
-
-        return Ollama(id=model_id)
-
-    elif model_provider == "openai":
-        from agno.models.openai import OpenAIResponses
-
-        return OpenAIResponses(id=model_id)
-
-    elif model_provider == "openai-chat":
-        from agno.models.openai import OpenAIChat
-
-        return OpenAIChat(id=model_id)
-
-    elif model_provider == "openai-responses":
-        from agno.models.openai import OpenAIResponses
-
-        return OpenAIResponses(id=model_id)
-
-    elif model_provider == "openrouter":
-        from agno.models.openrouter import OpenRouter
-
-        return OpenRouter(id=model_id)
-
-    elif model_provider == "perplexity":
-        from agno.models.perplexity import Perplexity
-
-        return Perplexity(id=model_id)
-
-    elif model_provider == "portkey":
-        from agno.models.portkey import Portkey
-
-        return Portkey(id=model_id)
-
-    elif model_provider == "requesty":
-        from agno.models.requesty import Requesty
-
-        return Requesty(id=model_id)
-
-    elif model_provider == "sambanova":
-        from agno.models.sambanova import Sambanova
-
-        return Sambanova(id=model_id)
-
-    elif model_provider == "siliconflow":
-        from agno.models.siliconflow import Siliconflow
-
-        return Siliconflow(id=model_id)
-
-    elif model_provider == "together":
-        from agno.models.together import Together
-
-        return Together(id=model_id)
-
-    elif model_provider == "vercel":
-        from agno.models.vercel import V0
-
-        return V0(id=model_id)
-
-    elif model_provider == "vertexai-claude":
-        from agno.models.vertexai.claude import Claude as VertexAIClaude
-
-        return VertexAIClaude(id=model_id)
-
-    elif model_provider == "vllm":
-        from agno.models.vllm import VLLM
-
-        return VLLM(id=model_id)
-
-    elif model_provider == "xai":
-        from agno.models.xai import xAI
-
-        return xAI(id=model_id)
-
-    else:
+    entry = MODEL_PROVIDER_CLASSES.get(model_provider)
+    if entry is None:
+        # Allow alias forms (e.g. "azure", "inceptionlabs") to resolve too.
+        resolved = _resolve_provider_key(model_provider)
+        entry = MODEL_PROVIDER_CLASSES.get(resolved)
+    if entry is None:
         raise ValueError(f"Model provider '{model_provider}' is not supported.")
+
+    module_path, class_name = entry
+    module = importlib.import_module(module_path)
+    model_class = getattr(module, class_name)
+    return model_class(id=model_id)
 
 
 def _parse_model_string(model_string: str) -> Model:
@@ -302,7 +201,7 @@ def _parse_model_string(model_string: str) -> Model:
             f"Invalid model string format: '{model_string}'. Model strings should be in format '<provider>:<model_id>' e.g. 'openai:gpt-4o'"
         )
 
-    return _get_model_class(model_id, model_provider)
+    return _get_model_class(model_id, _resolve_provider_key(model_provider))
 
 
 def get_model(model: Union[Model, str, None]) -> Optional[Model]:
@@ -314,3 +213,20 @@ def get_model(model: Union[Model, str, None]) -> Optional[Model]:
         return _parse_model_string(model)
     else:
         raise ValueError("Model must be a Model instance, string, or None")
+
+
+def get_model_from_dict(model_data: Dict[str, Any]) -> Optional[Model]:
+    """Reconstruct a Model from its serialized dict (as produced by ``Model.to_dict``).
+
+    Uses both the serialized ``provider`` and ``name`` to resolve the exact provider class,
+    which is required for providers that share a display ``provider`` string (e.g. Azure).
+    """
+    if not isinstance(model_data, dict):
+        raise ValueError("Model data must be a dictionary")
+
+    model_id = model_data.get("id")
+    if not model_id:
+        raise ValueError(f"Model data is missing an 'id': {model_data}")
+
+    provider_key = _resolve_provider_key(model_data.get("provider"), model_data.get("name"))
+    return _get_model_class(model_id, provider_key)

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -19,6 +19,17 @@ if TYPE_CHECKING:
     from agno.team import Team
 
 
+def _model_identity(model: Model) -> tuple:
+    """Stable identity for catalog dedup: the provider class, display provider, and model id.
+
+    The class (module + qualname) is included alongside the display ``provider`` string so that
+    distinct classes sharing a provider string (e.g. OpenAIChat vs OpenAIResponses, or the Azure
+    model classes -- all report provider "Azure") are not collapsed into a single catalog entry.
+    """
+    cls = type(model)
+    return (cls.__module__, cls.__qualname__, getattr(model, "provider", None), getattr(model, "id", None))
+
+
 @dataclass
 class Registry:
     """
@@ -79,15 +90,18 @@ class Registry:
         return func
 
     def add_model(self, model: Any) -> None:
-        """Add a model unless an equivalent one (same provider and id) is already present.
+        """Add a model unless an equivalent one (same provider class and id) is already present.
 
-        Models that share a provider and id are interchangeable catalog entries,
-        so duplicates are collapsed. Non-Model values (e.g. plain string ids) are ignored.
+        Models of the same class that share an id are interchangeable catalog entries, so
+        duplicates are collapsed. Models of different classes are kept separate even when their
+        display ``provider`` string and id match -- e.g. ``OpenAIChat`` vs ``OpenAIResponses``
+        (both report provider "OpenAI") or the three distinct Azure model classes (all report
+        provider "Azure"). Non-Model values (e.g. plain string ids) are ignored.
         """
         if not isinstance(model, Model):
             return
-        key = (getattr(model, "provider", None), getattr(model, "id", None))
-        if any((getattr(m, "provider", None), getattr(m, "id", None)) == key for m in self.models):
+        key = _model_identity(model)
+        if any(_model_identity(m) == key for m in self.models):
             return
         self.models.append(model)
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -25,7 +25,7 @@ from agno.db.utils import resolve_db_from_config
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
 from agno.models.message import Message
-from agno.models.utils import get_model
+from agno.models.utils import get_model, get_model_from_dict
 from agno.registry.registry import Registry
 from agno.run.agent import RunOutput
 from agno.run.team import (
@@ -751,7 +751,7 @@ def from_dict(
     if "model" in config:
         model_data = config["model"]
         if isinstance(model_data, dict) and "id" in model_data:
-            config["model"] = get_model(f"{model_data['provider']}:{model_data['id']}")
+            config["model"] = get_model_from_dict(model_data)
         elif isinstance(model_data, str):
             config["model"] = get_model(model_data)
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1783,17 +1783,21 @@ def get_teams(
         )
         for component in components:
             component_id = component["component_id"]
-            config = db.get_config(component_id=component_id)
-            if config is not None:
-                team_config = config.get("config")
-                if team_config is not None:
-                    if "id" not in team_config:
-                        team_config["id"] = component_id
-                    team = Team.from_dict(team_config, db=db, registry=registry)
-                    team.id = component_id
-                    team._version = component.get("current_version")
-                    team._stage = config.get("stage")
-                    teams.append(team)
+            try:
+                config = db.get_config(component_id=component_id)
+                if config is not None:
+                    team_config = config.get("config")
+                    if team_config is not None:
+                        if "id" not in team_config:
+                            team_config["id"] = component_id
+                        team = Team.from_dict(team_config, db=db, registry=registry)
+                        team.id = component_id
+                        team._version = component.get("current_version")
+                        team._stage = config.get("stage")
+                        teams.append(team)
+            except Exception as e:
+                log_error(f"Error loading Team {component_id} from database: {str(e)}")
+                continue
         return teams
 
     except Exception as e:

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -125,7 +125,9 @@ def test_resolve_provider_aliases(provider, name, expected_key):
         ("Anthropic", "OpenAIChat", "anthropic"),
         # Within-family disambiguation still works (these share a display provider string).
         ("OpenAI", "OpenAIChat", "openai-chat"),
-        ("OpenAI", "OpenAIResponses", "openai-responses"),
+        # "OpenAIResponses" is the default name for both the "openai" and "openai-responses" keys
+        # (same class), so it resolves to the canonical "openai" key -- still the OpenAIResponses class.
+        ("OpenAI", "OpenAIResponses", "openai"),
         ("Azure", "AzureAIFoundry", "azure-ai-foundry"),
     ],
 )

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -19,51 +19,39 @@ from agno.models.utils import (
     get_model_from_dict,
 )
 
-# Providers whose model classes require an optional SDK at construction time. We cannot
-# instantiate them in the base test environment, so they are covered by the
-# resolution-only test below using their known serialized (provider, name) pairs.
-SDK_GATED_KEYS = {
-    "anthropic",  # anthropic SDK (not in the base .[dev] extras)
-    "aws-bedrock",
-    "aws-claude",
-    "azure-ai-foundry",
-    "azure-foundry-claude",  # anthropic SDK
-    "cerebras",
-    "cerebras-openai",
-    "cohere",
-    "groq",
-    "huggingface",
-    "ibm",
-    "litellm",
-    "litellm-openai",
-    "llama-openai",
-    "meta",
-    "mistral",
-    "ollama",
-    "ollama-responses",
-    "portkey",
-    "vertexai-claude",  # anthropic SDK
-}
-
-CONSTRUCTABLE_KEYS = [k for k in MODEL_PROVIDER_CLASSES if k not in SDK_GATED_KEYS]
+ALL_PROVIDER_KEYS = sorted(MODEL_PROVIDER_CLASSES)
 
 
-@pytest.mark.parametrize("key", CONSTRUCTABLE_KEYS)
+def _construct_or_skip(key):
+    """Construct a provider's model, or skip if its optional SDK is not installed.
+
+    The base test env (the ``dev`` extra) ships only the ``openai`` SDK, while the demo env ships
+    all of them. Skipping on ImportError keeps these tests correct in any environment instead of
+    hardcoding which providers are installable; resolution itself (no construction) is covered for
+    every provider by the parametrized resolution tests below.
+    """
+    try:
+        return _get_model_class("test-id", key)
+    except ImportError as e:
+        pytest.skip(f"optional SDK for '{key}' not installed: {e}")
+
+
+@pytest.mark.parametrize("key", ALL_PROVIDER_KEYS)
 def test_to_dict_round_trip_preserves_class(key):
-    """Every constructable provider rebuilds as the same class through to_dict/from_dict."""
-    model = _get_model_class("test-id", key)
+    """Every installable provider rebuilds as the same class through to_dict/from_dict."""
+    model = _construct_or_skip(key)
     rebuilt = get_model_from_dict(model.to_dict())
     assert type(rebuilt) is type(model)
     assert rebuilt.id == "test-id"
 
 
-@pytest.mark.parametrize("key", CONSTRUCTABLE_KEYS)
+@pytest.mark.parametrize("key", ALL_PROVIDER_KEYS)
 def test_canonical_provider_display_matches_class(key):
     """Drift guard: the provider-display override table matches what each class actually reports.
 
     Keeps name-vs-provider disambiguation correct if a provider's display string ever changes.
     """
-    model = _get_model_class("test-id", key)
+    model = _construct_or_skip(key)
     assert _canonical_provider_display(key) == (model.provider or "").strip().lower()
 
 

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -96,6 +96,9 @@ def test_resolve_sdk_gated_providers(provider, name, expected_key):
         ("Xiaomi MiMo", None, "xiaomi"),
         # CometAPI sets provider to "CometAPI (<id>)" via post-init; name still resolves it.
         ("CometAPI (gpt-x)", "CometAPI", "cometapi"),
+        # Tuning Engines: provider/name carry a space; both the name and string paths resolve.
+        ("Tuning Engines", "Tuning Engines", "tuning-engines"),
+        ("Tuning Engines", None, "tuning-engines"),
         # Plain providers whose display string already equals the key.
         ("openai", None, "openai"),
         ("anthropic", None, "anthropic"),
@@ -113,3 +116,103 @@ def test_unsupported_provider_raises():
 def test_get_model_from_dict_requires_id():
     with pytest.raises(ValueError, match="missing an 'id'"):
         get_model_from_dict({"provider": "openai"})
+
+
+# Abstract/intermediate Model subclasses that are not concrete providers and so must not appear
+# in MODEL_PROVIDER_CLASSES. Add a class here only after a deliberate decision that it is not a
+# user-selectable provider. Keyed by (defining_module, class_name).
+_NON_PROVIDER_MODEL_CLASSES = {("agno.models.openai.like", "OpenAILike")}
+
+
+def _models_root():
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[3] / "agno" / "models"
+    assert root.is_dir(), f"models root not found: {root}"
+    return root
+
+
+def _module_name(path, root):
+    name = ".".join(path.relative_to(root.parents[1]).with_suffix("").parts)
+    return name[: -len(".__init__")] if name.endswith(".__init__") else name
+
+
+def _discover_model_subclasses(root):
+    """Statically find every concrete Model subclass under agno/models, without importing.
+
+    Parses the source with ``ast`` so SDK-gated providers (whose modules fail to import without
+    their optional dependency) are still discovered. Returns a set of (defining_module, class).
+    """
+    import ast
+
+    # (defining_module, class_name) -> [base names]
+    class_bases: dict = {}
+    for path in root.rglob("*.py"):
+        if path.name == "__init__.py":
+            continue  # __init__ only re-exports; concrete classes live in submodules
+        module = _module_name(path, root)
+        for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+            if isinstance(node, ast.ClassDef):
+                bases = [
+                    b.id if isinstance(b, ast.Name) else b.attr
+                    for b in node.bases
+                    if isinstance(b, (ast.Name, ast.Attribute))
+                ]
+                class_bases[(module, node.name)] = bases
+
+    # Transitively mark every class whose base chain reaches Model (matched by class name, since
+    # bases are often imported under aliases and cannot be resolved without importing).
+    rooted = {"Model"}
+    changed = True
+    while changed:
+        changed = False
+        for (_module, name), bases in class_bases.items():
+            if name not in rooted and any(b in rooted for b in bases):
+                rooted.add(name)
+                changed = True
+
+    return {(module, name) for (module, name), bases in class_bases.items() if name != "Model" and name in rooted}
+
+
+def _registered_defining_classes(root):
+    """Resolve every MODEL_PROVIDER_CLASSES entry to the (defining_module, class) it points at.
+
+    The registry references the re-exporting package and that package's exported name (e.g.
+    ``("agno.models.azure", "AzureFoundryClaude")``), while the class is defined in a submodule
+    under its own name (``agno.models.azure.claude.Claude``). Parse each package __init__ to
+    follow ``from <mod> import <name> as <alias>`` re-exports back to the definition.
+    """
+    import ast
+
+    # (package_module, exported_name) -> (source_module, source_name)
+    reexports: dict = {}
+    for path in root.rglob("__init__.py"):
+        package = _module_name(path, root)
+        for node in ast.walk(ast.parse(path.read_text(), filename=str(path))):
+            if isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                for alias in node.names:
+                    reexports[(package, alias.asname or alias.name)] = (node.module, alias.name)
+
+    resolved = set()
+    for reg_module, reg_class in MODEL_PROVIDER_CLASSES.values():
+        resolved.add(reexports.get((reg_module, reg_class), (reg_module, reg_class)))
+    return resolved
+
+
+def test_every_model_subclass_is_registered():
+    """Guard against drift: every concrete provider on disk must be in MODEL_PROVIDER_CLASSES.
+
+    CI fails on the same PR that adds a new Model subclass without a registry entry, so the
+    registry stays the single source of truth without per-provider runtime wiring.
+    """
+    root = _models_root()
+    discovered = _discover_model_subclasses(root)
+    covered = _registered_defining_classes(root) | _NON_PROVIDER_MODEL_CLASSES
+
+    missing = sorted(f"{name} ({module})" for (module, name) in discovered - covered)
+    assert not missing, (
+        "Model subclasses missing from MODEL_PROVIDER_CLASSES: "
+        + ", ".join(missing)
+        + ". Add each to the registry in agno/models/utils.py (or to the test allowlist if it is "
+        "not a user-selectable provider)."
+    )

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -1,0 +1,115 @@
+"""Tests for provider-key resolution used when reconstructing models from a serialized dict.
+
+These guard the round-trip ``Model.to_dict() -> get_model_from_dict()`` so that a model loaded
+from the database (e.g. the components table) rebuilds as the correct provider class, and so a
+single unsupported/misconfigured provider no longer needs special-casing per call site.
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+
+from agno.models.utils import (
+    MODEL_PROVIDER_CLASSES,
+    _get_model_class,
+    _resolve_provider_key,
+    get_model_from_dict,
+)
+
+# Providers whose model classes require an optional SDK at construction time. We cannot
+# instantiate them in the base test environment, so they are covered by the
+# resolution-only test below using their known serialized (provider, name) pairs.
+SDK_GATED_KEYS = {
+    "aws-bedrock",
+    "aws-claude",
+    "azure-ai-foundry",
+    "cerebras",
+    "cerebras-openai",
+    "cohere",
+    "groq",
+    "huggingface",
+    "ibm",
+    "litellm",
+    "litellm-openai",
+    "llama-openai",
+    "meta",
+    "mistral",
+    "ollama",
+    "ollama-responses",
+    "portkey",
+}
+
+CONSTRUCTABLE_KEYS = [k for k in MODEL_PROVIDER_CLASSES if k not in SDK_GATED_KEYS]
+
+
+@pytest.mark.parametrize("key", CONSTRUCTABLE_KEYS)
+def test_to_dict_round_trip_preserves_class(key):
+    """Every constructable provider rebuilds as the same class through to_dict/from_dict."""
+    model = _get_model_class("test-id", key)
+    rebuilt = get_model_from_dict(model.to_dict())
+    assert type(rebuilt) is type(model)
+    assert rebuilt.id == "test-id"
+
+
+@pytest.mark.parametrize(
+    "provider, name, expected_key",
+    [
+        # The crash from the components table: Azure models all report provider "Azure".
+        ("Azure", "AzureOpenAI", "azure-openai"),
+        ("Azure", "AzureAIFoundry", "azure-ai-foundry"),
+        ("AzureFoundry", "AzureFoundryClaude", "azure-foundry-claude"),
+        # SDK-gated providers, validated via their serialized (provider, name) pairs.
+        ("AwsBedrock", "AwsBedrock", "aws-bedrock"),
+        ("AwsBedrock", "AwsBedrockAnthropicClaude", "aws-claude"),
+        ("Cerebras", "Cerebras", "cerebras"),
+        ("CerebrasOpenAI", "CerebrasOpenAI", "cerebras-openai"),
+        ("Cohere", "cohere", "cohere"),
+        ("Groq", "Groq", "groq"),
+        ("HuggingFace", "HuggingFace", "huggingface"),
+        ("IBM", "WatsonX", "ibm"),
+        ("LiteLLM", "LiteLLM", "litellm"),
+        ("LiteLLM", "LiteLLMOpenAI", "litellm-openai"),
+        ("Llama", "Llama", "meta"),
+        ("LlamaOpenAI", "LlamaOpenAI", "llama-openai"),
+        ("Mistral", "MistralChat", "mistral"),
+        ("Ollama", "Ollama", "ollama"),
+        ("Ollama", "OllamaResponses", "ollama-responses"),
+        ("Portkey", "Portkey", "portkey"),
+    ],
+)
+def test_resolve_sdk_gated_providers(provider, name, expected_key):
+    assert _resolve_provider_key(provider, name) == expected_key
+
+
+@pytest.mark.parametrize(
+    "provider, name, expected_key",
+    [
+        # Display-string providers that differ from the registry key resolve via alias,
+        # including the legacy/string path where no name is serialized.
+        ("Azure", None, "azure-openai"),
+        ("azure", None, "azure-openai"),
+        ("InceptionLabs", None, "inception"),
+        ("VertexAI", None, "vertexai-claude"),
+        ("LlamaCpp", None, "llama-cpp"),
+        ("Xiaomi MiMo", None, "xiaomi"),
+        # CometAPI sets provider to "CometAPI (<id>)" via post-init; name still resolves it.
+        ("CometAPI (gpt-x)", "CometAPI", "cometapi"),
+        # Plain providers whose display string already equals the key.
+        ("openai", None, "openai"),
+        ("anthropic", None, "anthropic"),
+    ],
+)
+def test_resolve_provider_aliases(provider, name, expected_key):
+    assert _resolve_provider_key(provider, name) == expected_key
+
+
+def test_unsupported_provider_raises():
+    with pytest.raises(ValueError, match="is not supported"):
+        _get_model_class("some-id", "definitely-not-a-provider")
+
+
+def test_get_model_from_dict_requires_id():
+    with pytest.raises(ValueError, match="missing an 'id'"):
+        get_model_from_dict({"provider": "openai"})

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -13,6 +13,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
 
 from agno.models.utils import (
     MODEL_PROVIDER_CLASSES,
+    _canonical_provider_display,
     _get_model_class,
     _resolve_provider_key,
     get_model_from_dict,
@@ -51,6 +52,16 @@ def test_to_dict_round_trip_preserves_class(key):
     rebuilt = get_model_from_dict(model.to_dict())
     assert type(rebuilt) is type(model)
     assert rebuilt.id == "test-id"
+
+
+@pytest.mark.parametrize("key", CONSTRUCTABLE_KEYS)
+def test_canonical_provider_display_matches_class(key):
+    """Drift guard: the provider-display override table matches what each class actually reports.
+
+    Keeps name-vs-provider disambiguation correct if a provider's display string ever changes.
+    """
+    model = _get_model_class("test-id", key)
+    assert _canonical_provider_display(key) == (model.provider or "").strip().lower()
 
 
 @pytest.mark.parametrize(
@@ -106,6 +117,32 @@ def test_resolve_sdk_gated_providers(provider, name, expected_key):
 )
 def test_resolve_provider_aliases(provider, name, expected_key):
     assert _resolve_provider_key(provider, name) == expected_key
+
+
+@pytest.mark.parametrize(
+    "provider, name, expected_key",
+    [
+        # A user-supplied name that collides with another provider's default name must NOT
+        # override the provider string. The name only disambiguates within the same family.
+        ("OpenAI", "Gemini", "openai"),
+        ("OpenAI", "Groq", "openai"),
+        ("Groq", "Gemini", "groq"),
+        ("Anthropic", "OpenAIChat", "anthropic"),
+        # Within-family disambiguation still works (these share a display provider string).
+        ("OpenAI", "OpenAIChat", "openai-chat"),
+        ("OpenAI", "OpenAIResponses", "openai-responses"),
+        ("Azure", "AzureAIFoundry", "azure-ai-foundry"),
+    ],
+)
+def test_name_does_not_override_conflicting_provider(provider, name, expected_key):
+    assert _resolve_provider_key(provider, name) == expected_key
+
+
+def test_user_named_model_reconstructs_correct_provider():
+    """Regression: OpenAIChat(name="Gemini") must not rebuild as the Google Gemini class."""
+    rebuilt = get_model_from_dict({"provider": "OpenAI", "name": "Gemini", "id": "gpt-4o"})
+    assert type(rebuilt).__name__ != "Gemini"
+    assert rebuilt.provider == "OpenAI"
 
 
 def test_unsupported_provider_raises():

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -135,6 +135,7 @@ def test_name_does_not_override_conflicting_provider(provider, name, expected_ke
 
 def test_user_named_model_reconstructs_correct_provider():
     """Regression: OpenAIChat(name="Gemini") must not rebuild as the Google Gemini class."""
+    pytest.importorskip("openai")  # openai is an optional extra, not a base dependency
     rebuilt = get_model_from_dict({"provider": "OpenAI", "name": "Gemini", "id": "gpt-4o"})
     assert type(rebuilt).__name__ != "Gemini"
     assert rebuilt.provider == "OpenAI"

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -23,9 +23,11 @@ from agno.models.utils import (
 # instantiate them in the base test environment, so they are covered by the
 # resolution-only test below using their known serialized (provider, name) pairs.
 SDK_GATED_KEYS = {
+    "anthropic",  # anthropic SDK (not in the base .[dev] extras)
     "aws-bedrock",
     "aws-claude",
     "azure-ai-foundry",
+    "azure-foundry-claude",  # anthropic SDK
     "cerebras",
     "cerebras-openai",
     "cohere",
@@ -40,6 +42,7 @@ SDK_GATED_KEYS = {
     "ollama",
     "ollama-responses",
     "portkey",
+    "vertexai-claude",  # anthropic SDK
 }
 
 CONSTRUCTABLE_KEYS = [k for k in MODEL_PROVIDER_CLASSES if k not in SDK_GATED_KEYS]
@@ -88,6 +91,10 @@ def test_canonical_provider_display_matches_class(key):
         ("Ollama", "Ollama", "ollama"),
         ("Ollama", "OllamaResponses", "ollama-responses"),
         ("Portkey", "Portkey", "portkey"),
+        # Anthropic-backed providers (anthropic SDK not in base test env).
+        ("Anthropic", "Claude", "anthropic"),
+        ("AzureFoundry", "AzureFoundryClaude", "azure-foundry-claude"),
+        ("VertexAI", "Claude", "vertexai-claude"),
     ],
 )
 def test_resolve_sdk_gated_providers(provider, name, expected_key):
@@ -105,8 +112,8 @@ def test_resolve_sdk_gated_providers(provider, name, expected_key):
         ("VertexAI", None, "vertexai-claude"),
         ("LlamaCpp", None, "llama-cpp"),
         ("Xiaomi MiMo", None, "xiaomi"),
-        # CometAPI sets provider to "CometAPI (<id>)" via post-init; name still resolves it.
-        ("CometAPI (gpt-x)", "CometAPI", "cometapi"),
+        # CometAPI inherits provider "OpenAI" from OpenAILike; its name disambiguates it.
+        ("OpenAI", "CometAPI", "cometapi"),
         # Tuning Engines: provider/name carry a space; both the name and string paths resolve.
         ("Tuning Engines", "Tuning Engines", "tuning-engines"),
         ("Tuning Engines", None, "tuning-engines"),
@@ -143,6 +150,26 @@ def test_user_named_model_reconstructs_correct_provider():
     rebuilt = get_model_from_dict({"provider": "OpenAI", "name": "Gemini", "id": "gpt-4o"})
     assert type(rebuilt).__name__ != "Gemini"
     assert rebuilt.provider == "OpenAI"
+
+
+@pytest.mark.parametrize(
+    "provider, name",
+    [
+        ("my-gateway", "Gemini"),  # unknown provider must not be re-routed by a colliding name
+        ("totally-custom", "OpenAIChat"),
+    ],
+)
+def test_unrecognized_provider_not_overridden_by_name(provider, name):
+    """A non-empty unsupported provider stays authoritative and is rejected, not name-routed."""
+    assert _resolve_provider_key(provider, name) == provider
+    with pytest.raises(ValueError, match="is not supported"):
+        get_model_from_dict({"provider": provider, "name": name, "id": "x"})
+
+
+def test_empty_provider_falls_back_to_name():
+    """With no provider string, the serialized name is the only signal and is used."""
+    assert _resolve_provider_key("", "Groq") == "groq"
+    assert _resolve_provider_key(None, "OpenAIChat") == "openai-chat"
 
 
 def test_unsupported_provider_raises():

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -8,6 +8,7 @@ Tests cover:
 - get_schema() for retrieving schemas by name
 """
 
+import os
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -1007,6 +1008,34 @@ class TestAddModel:
         reg.add_model(_model("m", provider="openai"))
         reg.add_model(_model("m", provider="azure"))
         assert len(reg.models) == 2
+
+    def test_keeps_distinct_classes_sharing_provider_and_id(self):
+        """Different classes that report the same provider string and id are not collapsed.
+
+        OpenAIChat and OpenAIResponses both report provider "OpenAI" but are genuinely different
+        integrations (Chat Completions vs Responses API); the three Azure model classes likewise
+        all report provider "Azure".
+        """
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+        from agno.models.openai.chat import OpenAIChat
+        from agno.models.openai.responses import OpenAIResponses
+
+        reg = Registry()
+        reg.add_model(OpenAIChat(id="gpt-5.4"))
+        reg.add_model(OpenAIResponses(id="gpt-5.4"))
+        assert len(reg.models) == 2
+        assert {type(m).__name__ for m in reg.models} == {"OpenAIChat", "OpenAIResponses"}
+        # Both report the same display provider, confirming the class is what disambiguates.
+        assert {m.provider for m in reg.models} == {"OpenAI"}
+
+    def test_dedupes_same_class_provider_and_id(self):
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+        from agno.models.openai.responses import OpenAIResponses
+
+        reg = Registry()
+        reg.add_model(OpenAIResponses(id="gpt-5.4"))
+        reg.add_model(OpenAIResponses(id="gpt-5.4"))  # genuine duplicate
+        assert len(reg.models) == 1
 
     def test_ignores_non_model(self):
         reg = Registry()

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -1016,6 +1016,7 @@ class TestAddModel:
         integrations (Chat Completions vs Responses API); the three Azure model classes likewise
         all report provider "Azure".
         """
+        pytest.importorskip("openai")  # openai is an optional extra, not a base dependency
         os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
         from agno.models.openai.chat import OpenAIChat
         from agno.models.openai.responses import OpenAIResponses
@@ -1029,6 +1030,7 @@ class TestAddModel:
         assert {m.provider for m in reg.models} == {"OpenAI"}
 
     def test_dedupes_same_class_provider_and_id(self):
+        pytest.importorskip("openai")  # openai is an optional extra, not a base dependency
         os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
         from agno.models.openai.responses import OpenAIResponses
 


### PR DESCRIPTION
## Summary

Fixes around loading agents/teams/models from the database (the components table) and registering them in the studio catalog. Found while debugging a startup where a single Azure-backed agent took down the whole load.

### 1. Per-component load resilience

`get_agents` and `get_teams` wrapped the entire component loop in one `try/except`, so a single bad component (e.g. an unsupported model provider) threw out of the loop and the handler returned `[]` — silently dropping **every** agent/team, not just the broken one. `get_workflows` already isolated each component; agents and teams now do the same (`try/except … continue` per component). One bad component is logged (`Error loading Agent <id> from database: ...`) and skipped; the rest load normally. The outer `try/except` is retained to guard the `list_components()` call itself.

### 2. Model provider round-trip (the `'azure' is not supported` crash)

`Model.to_dict()` serializes the human-readable display `provider` string (e.g. `"Azure"`, `"OpenAI"`, `"InceptionLabs"`), but deserialization fed that straight into `_get_model_class`, which keys on stable registry strings (`azure-openai`, `openai-chat`, `inception`). Any mismatch raised `Model provider '<x>' is not supported.` Azure is the worst case: three classes all report `"Azure"`/`"AzureFoundry"`, so the display string alone cannot identify which one.

Fix:
- Introduced a single source-of-truth registry (`MODEL_PROVIDER_CLASSES`) mapping each provider key to its `(module, class)`, replacing the long if/elif chain.
- Added a resolver that maps the serialized `(provider, name)` pair back to the canonical key. `name` is the precise discriminator (it tells `AzureOpenAI` apart from `AzureAIFoundry`); a provider-alias map handles the legacy string path with no `name`.
- Added `get_model_from_dict()`, now used by both `Agent.from_dict` and `Team.from_dict`.
- Added the missing `ollama-responses` / `openrouter-responses` / `open-responses` keys and made `LiteLLMOpenAI.name` unique so those round-trip to the correct class.

This also fixes pre-existing **silent** wrong-class round-trips (`OpenAIChat` → `OpenAIResponses`, `GeminiInteractions` → `Gemini`, etc.). No `to_dict`/API/test contract changes — the fix lives entirely in deserialization, so it is backward-compatible with rows already in the database.

### 3. Catalog dedup collapsing distinct classes

`Registry.add_model` deduped on `(provider, id)` using the display `provider` string, so `OpenAIChat` and `OpenAIResponses` (both report `"OpenAI"`), or the three Azure classes (all `"Azure"`), collapsed into a single catalog entry when they shared an id — silently dropping a genuinely different integration. The dedup key now also includes the model class (`module` + `qualname`), so distinct classes stay separate while true duplicates (same class + provider + id) still collapse. The display `provider` is kept in the key, so existing behavior is preserved as a strict superset.

> Note: when two *genuinely different* providers (e.g. OpenAI + xAI) share a model id, the backend already returns them as separate models; any visual bundling there is frontend grouping (it keys on the display name, which is the id) and is out of scope for this PR.

### 4. Register the `TuningEngines` provider + drift guard

`TuningEngines` is a real OpenAI-compatible provider (its own provider string, API key, base URL, and auth) that was never in the deserialization registry, nor the old if/elif chain. Any agent/team configured with it failed to load with `Model provider 'tuning engines' is not supported`. Registered it (`tuning-engines`) so it round-trips.

To stop this class of gap recurring, added `test_every_model_subclass_is_registered`: a **static AST walk** of `agno/models/**` that finds every concrete `Model` subclass *without importing* (so the 12 SDK-gated providers, whose modules fail to import without their optional dependency, are still covered) and asserts each is present in `MODEL_PROVIDER_CLASSES`. Re-export aliases are resolved by parsing each package `__init__` so the registry's exported names (e.g. `AzureFoundryClaude`) match the defining classes (`azure/claude.py` `Claude`). CI now fails on the same PR that adds an unregistered provider, keeping the registry the single source of truth with no per-provider runtime wiring. `OpenAILike` (the abstract base) is the sole allowlist entry.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tests:
- `libs/agno/tests/unit/models/test_provider_resolution.py` round-trips every provider in the registry (drift guard so the maps can't fall out of sync), targeted resolution cases for the SDK-gated and ambiguous providers, and the AST meta-test above.
- New `TestAddModel` cases cover distinct classes sharing a provider string + id (`OpenAIChat` vs `OpenAIResponses`) and genuine same-class duplicates.
- `cookbook/93_components/agent_os_registry.py` now registers an Azure model and a second model sharing id `gpt-5-mini`, exercising fixes 2 and 3.

`format.sh` and `validate.sh` are clean; the affected unit suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)