### PR TITLE
fix: parameterize ClickHouse delete_by_metadata to prevent SQL injection (#7866)

### DIFF
--- a/libs/agno/agno/vectordb/clickhouse/clickhousedb.py
+++ b/libs/agno/agno/vectordb/clickhouse/clickhousedb.py
@@ -683,15 +683,30 @@ class Clickhouse(VectorDb):
             log_debug(f"ClickHouse VectorDB : Deleting documents with metadata {metadata}")
             parameters = self._get_base_parameters()
 
-            # Build WHERE clause for metadata matching using proper ClickHouse JSON syntax
+            # Build WHERE clause for metadata matching using parameterized ClickHouse bindings
+            # to prevent SQL injection (fixes #7866)
             where_conditions = []
-            for key, value in metadata.items():
+            for i, (key, value) in enumerate(metadata.items()):
+                param_key = f"filter_key_{i}"
+                param_val = f"filter_val_{i}"
                 if isinstance(value, bool):
-                    where_conditions.append(f"JSONExtractBool(toString(filters), '{key}') = {str(value).lower()}")
+                    where_conditions.append(
+                        f"JSONExtractBool(toString(filters), {{{param_key}:String}}) = {{{param_val}:Bool}}"
+                    )
+                    parameters[param_key] = key
+                    parameters[param_val] = value
                 elif isinstance(value, (int, float)):
-                    where_conditions.append(f"JSONExtractFloat(toString(filters), '{key}') = {value}")
+                    where_conditions.append(
+                        f"JSONExtractFloat(toString(filters), {{{param_key}:String}}) = {{{param_val}:Float64}}"
+                    )
+                    parameters[param_key] = key
+                    parameters[param_val] = float(value)
                 else:
-                    where_conditions.append(f"JSONExtractString(toString(filters), '{key}') = '{value}'")
+                    where_conditions.append(
+                        f"JSONExtractString(toString(filters), {{{param_key}:String}}) = {{{param_val}:String}}"
+                    )
+                    parameters[param_key] = key
+                    parameters[param_val] = str(value)
 
             if not where_conditions:
                 return False

--- a/libs/agno/tests/unit/vectordb/test_clickhousedb.py
+++ b/libs/agno/tests/unit/vectordb/test_clickhousedb.py
@@ -517,26 +517,44 @@ def test_delete_by_name(mock_clickhouse):
 
 def test_delete_by_metadata(mock_clickhouse):
     """Test delete_by_metadata method."""
-    # Test successful deletion with simple metadata
+    # Test successful deletion with simple metadata (parameterized for SQL injection prevention)
     result = mock_clickhouse.delete_by_metadata({"type": "test"})
     assert result is True
 
-    # Verify the delete command was executed with proper WHERE clause
-    mock_clickhouse.client.command.assert_called_with(
-        "DELETE FROM {database_name:Identifier}.{table_name:Identifier} WHERE JSONExtractString(toString(filters), 'type') = 'test'",
-        parameters={"table_name": mock_clickhouse.table_name, "database_name": mock_clickhouse.database_name},
-    )
+    # Verify the delete command uses parameterized bindings, not raw interpolation
+    call_args = mock_clickhouse.client.command.call_args
+    query = call_args[0][0]
+    params = call_args[1]["parameters"]
+    assert "{filter_key_0:String}" in query
+    assert "{filter_val_0:String}" in query
+    assert params["filter_key_0"] == "type"
+    assert params["filter_val_0"] == "test"
+    # Ensure raw values are NOT in the query string
+    assert "'type'" not in query
+    assert "'test'" not in query
 
-    # Test deletion with complex metadata
+    # Test deletion with complex metadata (string + bool, parameterized)
     mock_clickhouse.client.command.reset_mock()
     result = mock_clickhouse.delete_by_metadata({"cuisine": "Thai", "spicy": True})
     assert result is True
 
-    # Verify the delete command was executed with multiple conditions
-    mock_clickhouse.client.command.assert_called_with(
-        "DELETE FROM {database_name:Identifier}.{table_name:Identifier} WHERE JSONExtractString(toString(filters), 'cuisine') = 'Thai' AND JSONExtractBool(toString(filters), 'spicy') = true",
-        parameters={"table_name": mock_clickhouse.table_name, "database_name": mock_clickhouse.database_name},
-    )
+    call_args = mock_clickhouse.client.command.call_args
+    query = call_args[0][0]
+    params = call_args[1]["parameters"]
+    # String condition
+    assert "{filter_key_0:String}" in query
+    assert "{filter_val_0:String}" in query
+    assert params["filter_key_0"] == "cuisine"
+    assert params["filter_val_0"] == "Thai"
+    # Bool condition
+    assert "{filter_key_1:String}" in query
+    assert "{filter_val_1:Bool}" in query
+    assert params["filter_key_1"] == "spicy"
+    assert params["filter_val_1"] is True
+    # Ensure raw values are NOT in the query string
+    assert "'cuisine'" not in query
+    assert "'Thai'" not in query
+    assert "'spicy'" not in query
 
     # Test deletion with empty metadata
     mock_clickhouse.client.command.reset_mock()


### PR DESCRIPTION
## Summary

Fixes a SQL injection vulnerability in `Clickhouse.delete_by_metadata()` where user-controlled metadata keys and values were directly interpolated into ClickHouse SQL DELETE statements via f-strings, allowing attackers to delete arbitrary data or extract information through error-based injection.

**Closes #7866**

## What Was Broken

The `delete_by_metadata` method in `libs/agno/agno/vectordb/clickhouse/clickhousedb.py` built its WHERE clause by directly interpolating metadata dict keys and values into raw SQL strings:

```python
# VULNERABLE — direct interpolation
where_conditions.append(f"JSONExtractString(toString(filters), '{key}') = '{value}'")
```

This allowed SQL injection via crafted metadata:
```python
# Deletes ALL rows (tautology injection)
db.delete_by_metadata({"source": "' OR '1'='1"})
# → WHERE ... = '' OR '1'='1'  (always true)
```

## What the Fix Does

Replaces direct f-string interpolation with ClickHouse's native `{name:Type}` parameter binding syntax — the same safe pattern already used by `delete_by_content_id()` and `update_metadata()` in the same file:

```python
# SAFE — parameterized binding
param_key = f"filter_key_{i}"
param_val = f"filter_val_{i}"
where_conditions.append(
    f"JSONExtractString(toString(filters), {{{param_key}:String}}) = {{{param_val}:String}}"
)
parameters[param_key] = key
parameters[param_val] = str(value)
```

Handles all value types with proper ClickHouse type annotations:
- `str` → `{param:String}`
- `bool` → `{param:Bool}`
- `int/float` → `{param:Float64}`

## Verification

### Test Results

```
libs/agno/tests/unit/vectordb/test_clickhousedb.py::test_delete_by_metadata PASSED
18 passed, 9 failed (async failures are pre-existing — missing pytest-asyncio)
```

### Injection Payload Verification

Tested 6 metadata configurations including SQL injection payloads:

| Input | Result |
|-------|--------|
| `{"source": "public"}` | ✓ Normal query, raw input NOT in template |
| `{"source": "' OR '1'='1"}` | ✓ Injection payload safely parameterized |
| `{"x') = '1' OR ('1": "1"}` | ✓ Key injection safely parameterized |
| `{"source": "public", "type": "medical"}` | ✓ Multiple conditions, both parameterized |
| `{"active": True}` | ✓ Bool value uses `{param:Bool}` binding |
| `{"score": 42}` | ✓ Numeric value uses `{param:Float64}` binding |

In all cases, raw user input does NOT appear in the query template — it is passed separately via ClickHouse's parameterized binding mechanism.

### Static Checks

- `ruff check`: All checks passed
- `ruff format --check`: 1 file already formatted
- `python3 -c "import ast; ast.parse(...)"`: Syntax OK

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code follows the existing patterns in the codebase
- [x] Self-reviewed the diff
- [x] Tests pass locally
- [x] No new warnings introduced

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
