### PR TITLE
chore: release 2.6.17

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.6.16"
+version = "2.6.17"
 description = "The programming language for agentic software."
 requires-python = ">=3.7,<4"
 readme = "README.md"

--- a/libs/agno/tests/integration/agent/test_output_model.py
+++ b/libs/agno/tests/integration/agent/test_output_model.py
@@ -6,7 +6,7 @@ from agno.run.agent import IntermediateRunContentEvent, RunContentEvent
 
 def test_claude_with_openai_output_model():
     park_agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),  # Main model to generate the content
+        model=Claude(id="claude-sonnet-4-5-20250929"),  # Main model to generate the content
         description="You are an expert on national parks and provide concise guides.",
         output_model=OpenAIChat(id="gpt-4o"),  # Model to parse the output
         telemetry=False,
@@ -29,7 +29,7 @@ def test_openai_with_claude_output_model():
     park_agent = Agent(
         model=OpenAIChat(id="gpt-4o"),  # Main model to generate the content
         description="You are an expert on national parks and provide concise guides.",
-        output_model=Claude(id="claude-sonnet-4-20250514"),  # Model to parse the output
+        output_model=Claude(id="claude-sonnet-4-5-20250929"),  # Model to parse the output
         telemetry=False,
     )
 
@@ -50,7 +50,7 @@ async def test_openai_with_claude_output_model_async():
     park_agent = Agent(
         model=OpenAIChat(id="gpt-4o"),  # Main model to generate the content
         description="You are an expert on national parks and provide concise guides.",
-        output_model=Claude(id="claude-sonnet-4-20250514"),  # Model to parse the output
+        output_model=Claude(id="claude-sonnet-4-5-20250929"),  # Model to parse the output
         telemetry=False,
     )
 
@@ -69,7 +69,7 @@ async def test_openai_with_claude_output_model_async():
 
 def test_claude_with_openai_output_model_stream(shared_db):
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),  # Main model to generate the content
+        model=Claude(id="claude-sonnet-4-5-20250929"),  # Main model to generate the content
         db=shared_db,
         description="You are an expert on national parks and provide concise guides.",
         output_model=OpenAIChat(id="gpt-4o"),  # Model to parse the output
@@ -119,7 +119,7 @@ async def test_openai_with_claude_output_model_stream_async(shared_db):
         model=OpenAIChat(id="gpt-4o"),  # Main model to generate the content
         db=shared_db,
         description="You are an expert on national parks and provide concise guides.",
-        output_model=Claude(id="claude-sonnet-4-20250514"),  # Model to parse the output
+        output_model=Claude(id="claude-sonnet-4-5-20250929"),  # Model to parse the output
         stream_events=True,
         telemetry=False,
     )

--- a/libs/agno/tests/integration/agent/test_parser_model.py
+++ b/libs/agno/tests/integration/agent/test_parser_model.py
@@ -20,7 +20,7 @@ class ParkGuide(BaseModel):
 
 def test_claude_with_openai_parser_model():
     park_agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),  # Main model to generate the content
+        model=Claude(id="claude-sonnet-4-5-20250929"),  # Main model to generate the content
         description="You are an expert on national parks and provide concise guides.",
         output_schema=ParkGuide,
         parser_model=OpenAIChat(id="gpt-4o"),  # Model to parse the output
@@ -48,7 +48,7 @@ def test_openai_with_claude_parser_model():
         model=OpenAIChat(id="gpt-4o"),  # Main model to generate the content
         description="You are an expert on national parks and provide concise guides.",
         output_schema=ParkGuide,
-        parser_model=Claude(id="claude-sonnet-4-20250514"),  # Model to parse the output
+        parser_model=Claude(id="claude-sonnet-4-5-20250929"),  # Model to parse the output
     )
 
     response = park_agent.run("Tell me about Yosemite National Park.")
@@ -99,7 +99,7 @@ def test_parser_model_stream(shared_db):
         description="You are an expert on national parks and provide concise guides.",
         output_schema=ParkGuide,
         db=shared_db,
-        parser_model=Claude(id="claude-sonnet-4-20250514"),  # Model to parse the output
+        parser_model=Claude(id="claude-sonnet-4-5-20250929"),  # Model to parse the output
     )
 
     response = park_agent.run("Tell me about Yosemite National Park.", stream=True)

--- a/libs/agno/tests/integration/models/anthropic/test_basic.py
+++ b/libs/agno/tests/integration/models/anthropic/test_basic.py
@@ -9,7 +9,7 @@ from agno.models.anthropic import Claude
 @pytest.fixture(scope="module")
 def claude_model():
     """Fixture that provides a Claude model and reuses it across all tests in the module."""
-    return Claude(id="claude-sonnet-4-20250514")
+    return Claude(id="claude-sonnet-4-5-20250929")
 
 
 def _assert_metrics(response: RunOutput):

--- a/libs/agno/tests/integration/models/anthropic/test_betas.py
+++ b/libs/agno/tests/integration/models/anthropic/test_betas.py
@@ -58,13 +58,13 @@ def mock_anthropic_client():
 @pytest.fixture(scope="module")
 def claude_model():
     """Fixture that provides a Claude model and reuses it across all tests in the module."""
-    return Claude(id="claude-sonnet-4-20250514", betas=["context-1m-2025-08-07"])
+    return Claude(id="claude-sonnet-4-5-20250929", betas=["context-1m-2025-08-07"])
 
 
 def test_betas_parameter_in_request_params():
     """Test that betas parameter is included in request params when provided."""
     betas = ["context-1m-2025-08-07", "custom-beta-feature"]
-    model = Claude(id="claude-sonnet-4-20250514", betas=betas)
+    model = Claude(id="claude-sonnet-4-5-20250929", betas=betas)
 
     request_params = model.get_request_params()
 
@@ -74,7 +74,7 @@ def test_betas_parameter_in_request_params():
 
 def test_no_betas_parameter_when_not_provided():
     """Test that betas parameter is not included when not provided."""
-    model = Claude(id="claude-sonnet-4-20250514")
+    model = Claude(id="claude-sonnet-4-5-20250929")
 
     request_params = model.get_request_params()
 
@@ -83,14 +83,14 @@ def test_no_betas_parameter_when_not_provided():
 
 def test_has_beta_features_with_betas():
     """Test that _has_beta_features returns True when betas are provided."""
-    model = Claude(id="claude-sonnet-4-20250514", betas=["context-1m-2025-08-07"])
+    model = Claude(id="claude-sonnet-4-5-20250929", betas=["context-1m-2025-08-07"])
 
     assert model._has_beta_features() is True
 
 
 def test_has_beta_features_without_betas():
     """Test that _has_beta_features returns False when no beta features are enabled."""
-    model = Claude(id="claude-sonnet-4-20250514")
+    model = Claude(id="claude-sonnet-4-5-20250929")
 
     # Should return False when no beta features are enabled
     assert model._has_beta_features() is False
@@ -99,7 +99,7 @@ def test_has_beta_features_without_betas():
 def test_beta_client_used_when_betas_provided(mock_anthropic_client):
     """Test that beta client is used when betas parameter is provided."""
     betas = ["context-1m-2025-08-07"]
-    model = Claude(id="claude-sonnet-4-20250514", betas=betas)
+    model = Claude(id="claude-sonnet-4-5-20250929", betas=betas)
     agent = Agent(model=model, telemetry=False)
 
     # Run the agent
@@ -119,7 +119,7 @@ def test_beta_client_used_when_betas_provided(mock_anthropic_client):
 
 def test_regular_client_used_without_betas(mock_anthropic_client):
     """Test that regular client is used when no betas are provided."""
-    model = Claude(id="claude-sonnet-4-20250514")
+    model = Claude(id="claude-sonnet-4-5-20250929")
     agent = Agent(model=model, telemetry=False)
 
     # Run the agent
@@ -139,7 +139,7 @@ def test_regular_client_used_without_betas(mock_anthropic_client):
 def test_multiple_betas():
     """Test that multiple beta features can be specified."""
     betas = ["context-1m-2025-08-07", "feature-a", "feature-b"]
-    model = Claude(id="claude-sonnet-4-20250514", betas=betas)
+    model = Claude(id="claude-sonnet-4-5-20250929", betas=betas)
 
     request_params = model.get_request_params()
 
@@ -151,7 +151,7 @@ def test_betas_with_skills():
     """Test that betas work alongside skills configuration."""
     betas = ["custom-beta"]
     model = Claude(
-        id="claude-sonnet-4-20250514",
+        id="claude-sonnet-4-5-20250929",
         betas=betas,
         skills=[{"type": "anthropic", "skill_id": "pptx", "version": "latest"}],
     )
@@ -203,7 +203,7 @@ async def test_async_beta_client_used_when_betas_provided():
         mock_async_client_class.return_value = mock_async_client
 
         betas = ["context-1m-2025-08-07"]
-        model = Claude(id="claude-sonnet-4-20250514", betas=betas)
+        model = Claude(id="claude-sonnet-4-5-20250929", betas=betas)
         agent = Agent(model=model, telemetry=False)
 
         # Run the agent asynchronously
@@ -253,6 +253,6 @@ async def test_betas_with_real_client_async(claude_model):
 
     # Verify the model was set correctly
     assert response.model is not None, "Response model should not be None"
-    assert response.model == "claude-sonnet-4-20250514" or response.model.startswith("claude-"), (
+    assert response.model == "claude-sonnet-4-5-20250929" or response.model.startswith("claude-"), (
         f"Expected Claude model, got {response.model}"
     )

--- a/libs/agno/tests/integration/models/anthropic/test_multimodal.py
+++ b/libs/agno/tests/integration/models/anthropic/test_multimodal.py
@@ -4,7 +4,7 @@ from agno.models.anthropic import Claude
 
 
 def test_image_input(image_path):
-    agent = Agent(model=Claude(id="claude-sonnet-4-20250514"), markdown=True, telemetry=False)
+    agent = Agent(model=Claude(id="claude-sonnet-4-5-20250929"), markdown=True, telemetry=False)
 
     response = agent.run(
         "Tell me about this image.",
@@ -18,7 +18,7 @@ def test_image_input(image_path):
 
 def test_file_upload():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         markdown=True,
     )
 

--- a/libs/agno/tests/integration/models/anthropic/test_thinking.py
+++ b/libs/agno/tests/integration/models/anthropic/test_thinking.py
@@ -16,7 +16,7 @@ def _get_thinking_agent(**kwargs):
     """Create an agent with thinking enabled using consistent settings."""
     default_config = {
         "model": Claude(
-            id="claude-sonnet-4-20250514",
+            id="claude-sonnet-4-5-20250929",
             thinking={"type": "enabled", "budget_tokens": 1024},
         ),
         "markdown": True,
@@ -30,7 +30,7 @@ def _get_interleaved_thinking_agent(**kwargs):
     """Create an agent with interleaved thinking enabled using Claude 4."""
     default_config = {
         "model": Claude(
-            id="claude-sonnet-4-20250514",
+            id="claude-sonnet-4-5-20250929",
             thinking={"type": "enabled", "budget_tokens": 2048},
             betas=["interleaved-thinking-2025-05-14"],
         ),
@@ -158,7 +158,7 @@ async def test_thinking_with_storage():
     """Test that thinking content is stored and retrievable."""
     with tempfile.TemporaryDirectory() as storage_dir:
         agent = Agent(
-            model=Claude(id="claude-sonnet-4-20250514", thinking={"type": "enabled", "budget_tokens": 1024}),
+            model=Claude(id="claude-sonnet-4-5-20250929", thinking={"type": "enabled", "budget_tokens": 1024}),
             db=JsonDb(db_path=storage_dir, session_table="test_session"),
             user_id="test_user",
             session_id="test_session",
@@ -200,7 +200,7 @@ async def test_thinking_with_streaming_storage():
     """Test thinking content with streaming and storage."""
     with tempfile.TemporaryDirectory() as storage_dir:
         agent = Agent(
-            model=Claude(id="claude-sonnet-4-20250514", thinking={"type": "enabled", "budget_tokens": 1024}),
+            model=Claude(id="claude-sonnet-4-5-20250929", thinking={"type": "enabled", "budget_tokens": 1024}),
             db=JsonDb(db_path=storage_dir, session_table="test_session_stream"),
             user_id="test_user_stream",
             session_id="test_session_stream",
@@ -329,7 +329,7 @@ async def test_interleaved_thinking_with_storage():
     with tempfile.TemporaryDirectory() as storage_dir:
         agent = Agent(
             model=Claude(
-                id="claude-sonnet-4-20250514",
+                id="claude-sonnet-4-5-20250929",
                 thinking={"type": "enabled", "budget_tokens": 2048},
                 betas=["interleaved-thinking-2025-05-14"],
             ),
@@ -375,7 +375,7 @@ async def test_interleaved_thinking_streaming_with_storage():
     with tempfile.TemporaryDirectory() as storage_dir:
         agent = Agent(
             model=Claude(
-                id="claude-sonnet-4-20250514",
+                id="claude-sonnet-4-5-20250929",
                 thinking={"type": "enabled", "budget_tokens": 2048},
                 betas=["interleaved-thinking-2025-05-14"],
             ),
@@ -436,8 +436,8 @@ def test_interleaved_thinking_vs_regular_thinking():
     assert interleaved_response.content is not None
 
     # Verify the models are different
-    assert regular_agent.model.id == "claude-sonnet-4-20250514"  # type: ignore
-    assert interleaved_agent.model.id == "claude-sonnet-4-20250514"  # type: ignore
+    assert regular_agent.model.id == "claude-sonnet-4-5-20250929"  # type: ignore
+    assert interleaved_agent.model.id == "claude-sonnet-4-5-20250929"  # type: ignore
 
     # Verify the headers are different
     assert not hasattr(regular_agent.model, "default_headers") or regular_agent.model.default_headers is None  # type: ignore
@@ -451,9 +451,9 @@ def test_interleaved_thinking_vs_regular_thinking():
 def _get_reasoning_streaming_agent(**kwargs):
     """Create an agent with reasoning_model for streaming reasoning tests."""
     default_config = {
-        "model": Claude(id="claude-sonnet-4-20250514"),
+        "model": Claude(id="claude-sonnet-4-5-20250929"),
         "reasoning_model": Claude(
-            id="claude-sonnet-4-20250514",
+            id="claude-sonnet-4-5-20250929",
             thinking={"type": "enabled", "budget_tokens": 1024},
         ),
         "instructions": "You are an expert problem-solving assistant. Think step by step.",

--- a/libs/agno/tests/integration/models/anthropic/test_tool_use.py
+++ b/libs/agno/tests/integration/models/anthropic/test_tool_use.py
@@ -11,7 +11,7 @@ from agno.tools.yfinance import YFinanceTools
 
 def test_tool_use():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -28,7 +28,7 @@ def test_tool_use():
 
 def test_tool_use_stream():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -55,7 +55,7 @@ def test_tool_use_stream():
 @pytest.mark.asyncio
 async def test_async_tool_use():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -73,7 +73,7 @@ async def test_async_tool_use():
 @pytest.mark.asyncio
 async def test_async_tool_use_stream():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -99,7 +99,7 @@ async def test_async_tool_use_stream():
 
 def test_tool_use_tool_call_limit():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[
             YFinanceTools(
                 enable_stock_price=True,
@@ -125,7 +125,7 @@ def test_tool_use_tool_call_limit():
 
 def test_tool_use_with_content():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -143,7 +143,7 @@ def test_tool_use_with_content():
 
 def test_parallel_tool_calls():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -164,7 +164,7 @@ def test_parallel_tool_calls():
 
 def test_multiple_tool_calls():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[YFinanceTools(cache_results=True), WebSearchTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -191,7 +191,7 @@ def test_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[get_the_weather_in_tokyo],
         markdown=True,
         telemetry=False,
@@ -220,7 +220,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,
@@ -247,7 +247,7 @@ def test_tool_call_pydantic_parameters():
         return f"Researching {request.topic}"
 
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[research_topic],
         markdown=True,
         telemetry=False,
@@ -264,7 +264,7 @@ def test_tool_call_pydantic_parameters():
 
 def test_tool_call_list_parameters():
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514"),
+        model=Claude(id="claude-sonnet-4-5-20250929"),
         tools=[ExaTools()],
         instructions="Use a single tool call if possible",
         markdown=True,

--- a/libs/agno/tests/integration/teams/test_team_with_output_model.py
+++ b/libs/agno/tests/integration/teams/test_team_with_output_model.py
@@ -5,7 +5,7 @@ from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 from agno.team import Team
 
 agent = Agent(
-    model=Claude(id="claude-sonnet-4-20250514"),
+    model=Claude(id="claude-sonnet-4-5-20250929"),
     description="You are an expert on national parks and provide concise guides.",
     output_model=OpenAIChat(id="gpt-4o"),
     telemetry=False,


### PR DESCRIPTION
# Changelog

## Improvements

- **Resilient DB Component Loading**: Isolate each agent/team load so one bad component is skipped instead of dropping all, fix model provider round-trip on deserialization, register `TuningEngines`, and dedupe the catalog by model class. (#8461)
- **Structural Registry Tool Dedup**: Dedupe re-instantiated toolkits by `(type, name, function set)` so they collapse instead of accumulating duplicate registry entries. (#8450)

## Bug Fixes

- **ParallelTools GA API**: Migrate to the parallel-web >= 1.0 GA surface. (#8453)
- **Slack Search Dual-Token Support**: Support a user token (`xoxp-`) for `search_messages`, which bot tokens can't call. (#8411)
- **Slack HITL Required-Approval DB Gate**: Resolve the DB approval record on approve/reject so `required` rows aren't orphaned. (#8386)