### PR TITLE
[fix] CodingTools: block inline-code interpreter execution

### DIFF
--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -248,13 +248,39 @@ class CodingTools(Toolkit):
     # Shell operators that enable command chaining or substitution
     _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
 
+    # Interpreters that can execute arbitrary inline code/scripts supplied as an argument.
+    # When restricted, an allowlisted interpreter (e.g. python) combined with an inline-code
+    # flag (e.g. -c) becomes an arbitrary-code executor: the code runs outside the view of the
+    # command allowlist and the path-containment check (it can import os, open() any file, spawn
+    # subprocesses, reach the network, etc.). Blocking these flags keeps the approval decision
+    # aligned with what actually executes.
+    _INLINE_CODE_INTERPRETERS: dict = {
+        "python": {"-c"},
+        "python3": {"-c"},
+        "python2": {"-c"},
+        "pip": {"-c"},
+        "pip3": {"-c"},
+        "perl": {"-e", "-E"},
+        "ruby": {"-e"},
+        "node": {"-e", "--eval", "-p", "--print"},
+        "nodejs": {"-e", "--eval", "-p", "--print"},
+        "bash": {"-c"},
+        "sh": {"-c"},
+        "zsh": {"-c"},
+        "dash": {"-c"},
+        "ksh": {"-c"},
+        "php": {"-r"},
+    }
+
     def _check_command(self, command: str) -> Optional[str]:
         """Check if a shell command is safe to execute.
 
         When restrict_to_base_dir is True, this method:
         1. Blocks shell metacharacters that enable chaining/substitution.
         2. Validates the command name against the allowed_commands list (if set).
-        3. Checks that path-like tokens don't escape the base directory.
+        3. Blocks inline-code execution flags on known interpreters (e.g. ``python -c``),
+           which would otherwise smuggle arbitrary code past the allowlist and path checks.
+        4. Checks that path-like tokens don't escape the base directory.
 
         Returns an error message if a violation is found, None if safe.
         """
@@ -277,6 +303,22 @@ class CodingTools(Toolkit):
             cmd_base = Path(cmd).name  # Handle /usr/bin/python -> python
             if cmd_base not in self.allowed_commands:
                 return f"Error: Command '{cmd_base}' is not in the allowed commands list."
+
+        # Block inline-code execution flags (e.g. `python -c`, `bash -c`, `node -e`). Such a
+        # flag turns an allowlisted interpreter into an arbitrary-code executor whose effects the
+        # allowlist and path-containment checks below cannot inspect.
+        if tokens:
+            interpreter = Path(tokens[0]).name
+            inline_flags = self._INLINE_CODE_INTERPRETERS.get(interpreter)
+            if inline_flags is not None:
+                for token in tokens[1:]:
+                    # Match exact flags (`-c`) and glued long forms (`--eval=...`).
+                    flag = token.split("=", 1)[0]
+                    if token in inline_flags or flag in inline_flags:
+                        return (
+                            f"Error: Inline code execution ('{flag}') with '{interpreter}' is not "
+                            "allowed in restricted mode."
+                        )
 
         for i, token in enumerate(tokens):
             # Skip the command itself (already validated by allowlist above)

--- a/libs/agno/tests/unit/tools/test_coding_tools.py
+++ b/libs/agno/tests/unit/tools/test_coding_tools.py
@@ -669,6 +669,82 @@ def test_default_allowed_commands():
         assert "pytest" in tools.allowed_commands
 
 
+def test_run_shell_blocks_python_inline_code():
+    """Restricted mode must block `python -c` arbitrary code execution.
+
+    `python`/`python3` are in the default allowlist, so the command name and the
+    lexical path check on argument tokens both pass. The `-c` payload, however,
+    can import os, open files outside base_dir, and spawn subprocesses — none of
+    which the allowlist or path-containment check can inspect. It must be rejected
+    before reaching subprocess.run.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+
+        # Interpreter execution smuggling (the documented PoC shape, de-weaponized).
+        result = tools.run_shell('python3 -c "print(1)"')
+        assert "Error" in result
+        assert "restricted mode" in result
+
+        result = tools.run_shell('python -c "print(1)"')
+        assert "Error" in result
+        assert "restricted mode" in result
+
+        # Outside-base file access encoded inside the interpreter expression must
+        # also be rejected before execution (workspace-isolation regression).
+        outside_sentinel = str((base_dir.parent / "outside_secret.txt").resolve())
+        result = tools.run_shell(f"python3 -c \"open('{outside_sentinel}')\"")
+        assert "Error" in result
+        assert "restricted mode" in result
+
+
+def test_run_shell_blocks_other_interpreter_inline_code():
+    """Inline-code flags on other interpreters/shells must also be blocked."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        # Allow these interpreter names so the allowlist alone does not reject them;
+        # the inline-code guard is what must reject the dangerous invocation.
+        tools = CodingTools(
+            base_dir=base_dir,
+            allowed_commands=["python3", "bash", "sh", "node", "perl"],
+        )
+
+        for cmd in (
+            'bash -c "echo hi"',
+            'sh -c "echo hi"',
+            'node -e "1"',
+            'node --eval="1"',
+            'perl -e "1"',
+        ):
+            result = tools.run_shell(cmd)
+            assert "Error" in result, cmd
+            assert "restricted mode" in result, cmd
+
+
+def test_run_shell_inline_code_allowed_when_unrestricted():
+    """Inline-code execution remains available when restriction is disabled."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir, restrict_to_base_dir=False)
+
+        result = tools.run_shell("python3 -c \"print('works')\"")
+        assert "Exit code: 0" in result
+        assert "works" in result
+
+
+def test_run_shell_allows_python_script_invocation():
+    """Running a script file (not inline code) stays allowed in restricted mode."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+
+        (base_dir / "ok.py").write_text("print('script works')\n")
+        result = tools.run_shell("python3 ok.py")
+        assert "Exit code: 0" in result
+        assert "script works" in result
+
+
 # --- instruction generation tests ---
 
 


### PR DESCRIPTION
Fixes #8469

## Summary

Harden `CodingTools` restricted mode against inline-code interpreter execution that bypasses
both the command allowlist and the base-directory containment check.

`CodingTools` is enabled by default with `restrict_to_base_dir=True` and a default
`allowed_commands` list that includes interpreters (`python`, `python3`, `pip`, ...). In that
mode `run_shell` is registered without `requires_confirmation`, so the restricted-mode validator
`CodingTools._check_command` is the only gate before the command runs. That validator blocks
shell metacharacters, checks only the first token against the allowlist, skips flag tokens, and
applies a *lexical* path-containment check to argument tokens — it does not look inside
interpreter code.

As a result, an allowlisted interpreter invoked with an inline-code flag (e.g. `python3 -c "..."`)
passes every check, and `run_shell` then executes the command with `shell=True` in the base
directory. The inline program can import modules, open files outside the base directory, and spawn
subprocesses — defeating both the command allowlist (meant to limit *which* programs run) and the
workspace/base-dir boundary (meant to limit *which* files are touched). The same gap applies to
`bash -c`, `sh -c`, `node -e` / `node --eval=...`, `perl -e`, `ruby -e`, `php -r`, and `pip -c`.

This is an approval-vs-execution mismatch: the validator reasons about argv tokens while the sink
runs a Turing-complete interpreter program. The fix adds one check at the same decision point
(`_check_command`) so the approval now matches what actually executes.

Affected sites:

- `libs/agno/agno/tools/coding.py` — `CodingTools._check_command` (restricted-mode validator;
  the decision point this change extends).
- `libs/agno/agno/tools/coding.py` — `CodingTools.run_shell` (sink: calls
  `subprocess.run(command, shell=True, ..., cwd=str(self.base_dir))` on the unmodified,
  allowlist-approved command string).

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Security hardening (no behavior change for legitimate use).

**What changed**

- `libs/agno/agno/tools/coding.py`
  - Added `_INLINE_CODE_INTERPRETERS`, a map of interpreter basename -> its inline-code execution
    flags (`python`/`python3`/`python2`/`pip`/`pip3` -> `{-c}`;
    `bash`/`sh`/`zsh`/`dash`/`ksh` -> `{-c}`; `node`/`nodejs` -> `{-e, --eval, -p, --print}`;
    `perl` -> `{-e, -E}`; `ruby` -> `{-e}`; `php` -> `{-r}`).
  - In `_check_command` (restricted mode only, after the existing allowlist check): if the
    command's basename is a known interpreter and any later token is one of its inline-code flags
    — matching both `-c` and glued long forms like `--eval=...` — the command is rejected before
    `subprocess.run`. This mirrors the existing `_DANGEROUS_PATTERNS` block and reuses the same
    `shlex` parse, so the approval decision matches what actually executes.

- `libs/agno/tests/unit/tools/test_coding_tools.py`
  - Regression tests for blocked inline-code interpreters; an outside-base sentinel path encoded
    inside a `-c` expression (workspace-isolation regression); the unrestricted opt-out still
    allowing inline code; and a legitimate script-file invocation still working.

**Backward compatibility**

- No public API signatures changed.
- Only affects restricted mode (`restrict_to_base_dir=True`, the default). The documented opt-out
  `restrict_to_base_dir=False` continues to allow inline-code execution (verified by
  `test_run_shell_inline_code_allowed_when_unrestricted`).
- Running a *script file* (`python3 script.py`) remains allowed; only inline-code execution flags
  are rejected (verified by `test_run_shell_allows_python_script_invocation`).
- Shell-metacharacter blocking and path-containment behavior are unchanged.

**Test summary (fail-before / pass-after)**

- Before the fix (validator change reverted, tests present), the inline-code regression tests
  fail: `test_run_shell_blocks_python_inline_code` and
  `test_run_shell_blocks_other_interpreter_inline_code` fail because the payloads execute
  (`2 failed, 1 passed, 51 deselected`).
- After the fix, the full `tests/unit/tools/test_coding_tools.py` file passes (54 passed), and
  `ruff check` / `ruff format --check` are clean on the changed files.

**Security considerations / scope**

This change narrows the restricted-mode validator to close the inline-code bypass; it does not
attempt to sandbox in-workspace execution, which is the documented purpose of the toolkit (it
already warns that it can run arbitrary shell commands and needs human supervision). A model could
still ask an allowlisted interpreter to run a *script file* it first wrote inside `base_dir`; that
is in-workspace execution and out of scope for this boundary fix.
