### PR TITLE
Emit reasoning deltas for streamed model reasoning content

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1423,6 +1423,20 @@ def handle_model_response_chunk(
             if model_response_event.citations is not None:
                 run_response.citations = model_response_event.citations
 
+            reasoning_content_delta = model_response_event.reasoning_content if stream_events else None
+            if reasoning_content_delta:
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_content_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
+            run_content_reasoning_content = None if reasoning_content_delta else model_response_event.reasoning_content
+
             # Only yield if we have content to show
             if content_type != "str":
                 yield handle_event(  # type: ignore
@@ -1437,7 +1451,7 @@ def handle_model_response_chunk(
                 )
             elif (
                 model_response_event.content is not None
-                or model_response_event.reasoning_content is not None
+                or run_content_reasoning_content is not None
                 or model_response_event.redacted_reasoning_content is not None
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
@@ -1446,7 +1460,7 @@ def handle_model_response_chunk(
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
+                        reasoning_content=run_content_reasoning_content,
                         redacted_reasoning_content=model_response_event.redacted_reasoning_content,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,

--- a/libs/agno/tests/unit/agent/test_model_reasoning_content_events.py
+++ b/libs/agno/tests/unit/agent/test_model_reasoning_content_events.py
@@ -1,0 +1,88 @@
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import ReasoningContentDeltaEvent, RunContentEvent
+
+
+class StreamingReasoningModel(Model):
+    def __init__(self):
+        super().__init__(id="openai-compatible-reasoner", name="openai-compatible-reasoner", provider="test")
+        self.instructions = None
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse(content="Hello", role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield ModelResponse(reasoning_content="The user", role="assistant")
+        yield ModelResponse(reasoning_content=" said", role="assistant")
+        yield ModelResponse(content="Hello", role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        for event in self.invoke_stream(*args, **kwargs):
+            yield event
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self.invoke()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse()
+
+
+def test_streamed_model_reasoning_content_emits_reasoning_delta_events():
+    agent = Agent(model=StreamingReasoningModel())
+
+    events = list(agent.run("Say hello", stream=True, stream_events=True))
+
+    reasoning_deltas = [event for event in events if isinstance(event, ReasoningContentDeltaEvent)]
+    assert [event.reasoning_content for event in reasoning_deltas] == ["The user", " said"]
+
+    reasoning_run_content = [
+        event for event in events if isinstance(event, RunContentEvent) and event.reasoning_content
+    ]
+    assert reasoning_run_content == []
+
+    content_events = [event for event in events if isinstance(event, RunContentEvent) and event.content]
+    assert [event.content for event in content_events] == ["Hello"]
+
+
+@pytest.mark.asyncio
+async def test_async_streamed_model_reasoning_content_emits_reasoning_delta_events():
+    agent = Agent(model=StreamingReasoningModel())
+
+    events = []
+    async for event in agent.arun("Say hello", stream=True, stream_events=True):
+        events.append(event)
+
+    reasoning_deltas = [event for event in events if isinstance(event, ReasoningContentDeltaEvent)]
+    assert [event.reasoning_content for event in reasoning_deltas] == ["The user", " said"]
+
+    reasoning_run_content = [
+        event for event in events if isinstance(event, RunContentEvent) and event.reasoning_content
+    ]
+    assert reasoning_run_content == []
+
+    content_events = [event for event in events if isinstance(event, RunContentEvent) and event.content]
+    assert [event.content for event in content_events] == ["Hello"]


### PR DESCRIPTION
## Summary

Fixes #8400.

This updates streamed model response handling so chunks that carry `ModelResponse.reasoning_content` are emitted through Agno's native `ReasoningContentDelta` event pipeline instead of being exposed as ordinary `RunContent` reasoning fields.

## Root cause

OpenAI-compatible providers can stream reasoning text in fields such as `reasoning_content`. The OpenAI-compatible model layer already parses those fields into `ModelResponse.reasoning_content`, but the agent streaming response handler forwarded those chunks as `RunContent` events. AG-UI consumes native reasoning delta events, so the reasoning message content was missing downstream.

## Changes

- Emit `ReasoningContentDeltaEvent` for streamed model reasoning chunks when `stream_events=True`.
- Avoid duplicating the same reasoning chunk on the corresponding `RunContent` event.
- Add offline sync and async regression coverage using a fake streaming model, without requiring an external API key.

## Validation

- `python -m ruff check libs\agno\agno\agent\_response.py libs\agno\tests\unit\agent\test_model_reasoning_content_events.py`
- `python -m ruff format --check libs\agno\agno\agent\_response.py libs\agno\tests\unit\agent\test_model_reasoning_content_events.py`
- `python -m pytest libs\agno\tests\unit\agent\test_model_reasoning_content_events.py libs\agno\tests\unit\reasoning\test_reasoning_streaming.py libs\agno\tests\unit\agent\test_store_media_run_output.py -q`
- `python -m pytest libs\agno\tests\unit\app\test_agui_app.py::test_reasoning_content_delta_streaming libs\agno\tests\unit\app\test_agui_app.py::test_reasoning_auto_start -q`
- `python -m py_compile libs\agno\agno\agent\_response.py libs\agno\tests\unit\agent\test_model_reasoning_content_events.py`
- `git diff --check`