### PR TITLE
fix(team): forward parallel task member events

### DIFF
--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -797,12 +797,13 @@ def _get_task_management_tools(
         save_task_list(run_context.session_state, task_list)
 
         def _run_single_task(task_obj, member_agent):
-            """Run a single task in a thread. Returns (task_id, member_run_response, session_state_copy, error)."""
+            """Run a single task in a thread."""
             member_task_description = task_obj.description or task_obj.title
             member_agent_task, history = _setup_member_for_task(member_agent, member_task_description)
 
             use_agent_logger()
             member_session_state_copy = deepcopy(run_context.session_state)
+            member_events: List[Union[RunOutputEvent, TeamRunOutputEvent]] = []
 
             # Copy media lists per-thread to avoid concurrent mutation
             thread_images = list(_images)
@@ -814,31 +815,88 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     register_member_run(run_response.run_id, member_run_id)
-                member_run_response = member_agent.run(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=thread_images,
-                    videos=thread_videos,
-                    audio=thread_audio,
-                    files=thread_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
+                if stream:
+                    member_run_response = None
+                    member_stream = member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=thread_images,
+                        videos=thread_videos,
+                        audio=thread_audio,
+                        files=thread_files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        metadata=run_context.metadata,
+                        add_session_state_to_context=add_session_state_to_context,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
+                    draining_after_cancel = False
+                    for event in member_stream:
+                        if isinstance(event, (TeamRunOutput, RunOutput)):
+                            member_run_response = event
+                            continue
+                        if isinstance(event, _MEMBER_TERMINAL_EVENT_TYPES):
+                            event.parent_run_id = event.parent_run_id or run_response.run_id
+                            member_events.append(event)
+                            if event.is_cancelled:
+                                draining_after_cancel = True
+                            continue
+                        if draining_after_cancel:
+                            continue
+                        try:
+                            if run_response.run_id is not None:
+                                raise_if_cancelled(run_response.run_id)
+                        except RunCancelledException:
+                            if member_run_id:
+                                _cascading_cancel_run(member_run_id)
+                            draining_after_cancel = True
+                            continue
+                        event.parent_run_id = event.parent_run_id or run_response.run_id
+                        member_events.append(event)
+                    if draining_after_cancel:
+                        raise RunCancelledException("")
+                else:
+                    member_run_response = member_agent.run(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=thread_images,
+                        videos=thread_videos,
+                        audio=thread_audio,
+                        files=thread_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
+                return (
+                    task_obj.id,
+                    member_run_response,
+                    member_session_state_copy,
+                    member_agent_task,
+                    None,
+                    member_events,
                 )
-                return (task_obj.id, member_run_response, member_session_state_copy, member_agent_task, None)
             except RunCancelledException:
                 raise
             except Exception as e:
-                return (task_obj.id, None, member_session_state_copy, member_agent_task, e)
+                return (task_obj.id, None, member_session_state_copy, member_agent_task, e, member_events)
 
         results_text: List[str] = []
         modified_states: List[Dict[str, Any]] = []
@@ -852,9 +910,12 @@ def _get_task_management_tools(
             for future in as_completed(futures):
                 task_obj, member_agent = futures[future]
                 try:
-                    tid, member_run, state_copy, member_task, error = future.result()
+                    tid, member_run, state_copy, member_task, error, member_events = future.result()
                     if state_copy is not None:
                         modified_states.append(state_copy)
+
+                    for event in member_events:
+                        yield event
 
                     if error is not None:
                         task_obj.status = TaskStatus.failed
@@ -1009,6 +1070,7 @@ def _get_task_management_tools(
 
             use_agent_logger()
             member_session_state_copy = deepcopy(run_context.session_state)
+            member_events: List[Union[RunOutputEvent, TeamRunOutputEvent]] = []
 
             # Copy media lists to avoid concurrent mutation across coroutines
             task_images = list(_images)
@@ -1020,31 +1082,88 @@ def _get_task_management_tools(
                 member_run_id = str(uuid4())
                 if run_response.run_id is not None:
                     await aregister_member_run(run_response.run_id, member_run_id)
-                member_run_response = await member_agent.arun(
-                    input=member_agent_task if not history else history,
-                    user_id=user_id,
-                    session_id=session.session_id,
-                    session_state=member_session_state_copy,
-                    images=task_images,
-                    videos=task_videos,
-                    audio=task_audio,
-                    files=task_files,
-                    stream=False,
-                    debug_mode=debug_mode,
-                    dependencies=run_context.dependencies,
-                    add_dependencies_to_context=add_dependencies_to_context,
-                    add_session_state_to_context=add_session_state_to_context,
-                    metadata=run_context.metadata,
-                    knowledge_filters=run_context.knowledge_filters
-                    if not member_agent.knowledge_filters and member_agent.knowledge
-                    else None,
-                    run_id=member_run_id,
+                if stream:
+                    member_run_response = None
+                    member_stream = member_agent.arun(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=task_images,
+                        videos=task_videos,
+                        audio=task_audio,
+                        files=task_files,
+                        stream=True,
+                        stream_events=stream_events or team.stream_member_events,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        metadata=run_context.metadata,
+                        add_session_state_to_context=add_session_state_to_context,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                        yield_run_output=True,
+                    )
+                    draining_after_cancel = False
+                    async for event in member_stream:
+                        if isinstance(event, (TeamRunOutput, RunOutput)):
+                            member_run_response = event
+                            continue
+                        if isinstance(event, _MEMBER_TERMINAL_EVENT_TYPES):
+                            event.parent_run_id = event.parent_run_id or run_response.run_id
+                            member_events.append(event)
+                            if event.is_cancelled:
+                                draining_after_cancel = True
+                            continue
+                        if draining_after_cancel:
+                            continue
+                        try:
+                            if run_response.run_id is not None:
+                                raise_if_cancelled(run_response.run_id)
+                        except RunCancelledException:
+                            if member_run_id:
+                                await _acascading_cancel_run(member_run_id)
+                            draining_after_cancel = True
+                            continue
+                        event.parent_run_id = event.parent_run_id or run_response.run_id
+                        member_events.append(event)
+                    if draining_after_cancel:
+                        raise RunCancelledException("")
+                else:
+                    member_run_response = await member_agent.arun(
+                        input=member_agent_task if not history else history,
+                        user_id=user_id,
+                        session_id=session.session_id,
+                        session_state=member_session_state_copy,
+                        images=task_images,
+                        videos=task_videos,
+                        audio=task_audio,
+                        files=task_files,
+                        stream=False,
+                        debug_mode=debug_mode,
+                        dependencies=run_context.dependencies,
+                        add_dependencies_to_context=add_dependencies_to_context,
+                        add_session_state_to_context=add_session_state_to_context,
+                        metadata=run_context.metadata,
+                        knowledge_filters=run_context.knowledge_filters
+                        if not member_agent.knowledge_filters and member_agent.knowledge
+                        else None,
+                        run_id=member_run_id,
+                    )
+                return (
+                    task_obj.id,
+                    member_run_response,
+                    member_session_state_copy,
+                    member_agent_task,
+                    None,
+                    member_events,
                 )
-                return (task_obj.id, member_run_response, member_session_state_copy, member_agent_task, None)
             except RunCancelledException:
                 raise
             except Exception as e:
-                return (task_obj.id, None, member_session_state_copy, member_agent_task, e)
+                return (task_obj.id, None, member_session_state_copy, member_agent_task, e, member_events)
 
         # Run all tasks concurrently
         gather_results = await asyncio.gather(
@@ -1072,9 +1191,12 @@ def _get_task_management_tools(
                 results_text.append(f"Task [{task_obj.id}] failed unexpectedly: {gather_result}")
                 continue
 
-            tid, member_run, state_copy, member_task, error = gather_result
+            tid, member_run, state_copy, member_task, error, member_events = gather_result
             if state_copy is not None:
                 modified_states.append(state_copy)
+
+            for event in member_events:
+                yield event
 
             if error is not None:
                 task_obj.status = TaskStatus.failed

--- a/libs/agno/tests/unit/team/test_task_tools_parallel_events.py
+++ b/libs/agno/tests/unit/team/test_task_tools_parallel_events.py
@@ -1,0 +1,120 @@
+from typing import Any
+
+import pytest
+
+from agno.agent import Agent
+from agno.models.response import ToolExecution
+from agno.run import RunContext, RunStatus
+from agno.run.agent import RunOutput, ToolCallCompletedEvent, ToolCallStartedEvent
+from agno.run.team import TeamRunOutput
+from agno.session import TeamSession
+from agno.team._task_tools import _get_task_management_tools
+from agno.team.task import TaskList
+from agno.team.team import Team
+
+
+def _build_parallel_tool(*, async_mode: bool = False):
+    member = Agent(name="Worker")
+    task_list = TaskList()
+    task = task_list.create_task(
+        title="Use worker tool",
+        description="Ask the worker to use its tool.",
+        assignee="worker",
+    )
+    run_context = RunContext(run_id="team-run", session_id="session", session_state={})
+    run_response = TeamRunOutput(run_id="team-run", session_id="session")
+    team = Team(name="Parallel Team", members=[member], stream_member_events=True, telemetry=False)
+    session = TeamSession(session_id="session")
+    tool_execution = ToolExecution(tool_call_id="call-1", tool_name="worker_tool", tool_args={"x": 1})
+
+    def _member_run_output(run_id: str | None) -> RunOutput:
+        return RunOutput(
+            run_id=run_id,
+            agent_name="Worker",
+            content="worker result",
+            tools=[tool_execution],
+            status=RunStatus.completed,
+            messages=[],
+        )
+
+    def fake_run(input: Any, *, stream: bool = False, run_id: str | None = None, **kwargs: Any):
+        if not stream:
+            return _member_run_output(run_id)
+
+        def _stream():
+            yield ToolCallStartedEvent(run_id=run_id, agent_name="Worker", tool=tool_execution)
+            yield ToolCallCompletedEvent(
+                run_id=run_id,
+                agent_name="Worker",
+                tool=tool_execution,
+                content="worker result",
+            )
+            yield _member_run_output(run_id)
+
+        return _stream()
+
+    def fake_arun(input: Any, *, stream: bool = False, run_id: str | None = None, **kwargs: Any):
+        if not stream:
+
+            async def _run_output():
+                return _member_run_output(run_id)
+
+            return _run_output()
+
+        async def _stream():
+            yield ToolCallStartedEvent(run_id=run_id, agent_name="Worker", tool=tool_execution)
+            yield ToolCallCompletedEvent(
+                run_id=run_id,
+                agent_name="Worker",
+                tool=tool_execution,
+                content="worker result",
+            )
+            yield _member_run_output(run_id)
+
+        return _stream()
+
+    member.run = fake_run  # type: ignore[method-assign]
+    member.arun = fake_arun  # type: ignore[method-assign]
+
+    tools = _get_task_management_tools(
+        team=team,
+        task_list=task_list,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        team_run_context={},
+        stream=True,
+        stream_events=True,
+        async_mode=async_mode,
+    )
+    execute_parallel = next(tool for tool in tools if tool.name == "execute_tasks_parallel")
+    return execute_parallel, task
+
+
+def _assert_member_tool_events_forwarded(events: list[Any]):
+    started_events = [event for event in events if isinstance(event, ToolCallStartedEvent)]
+    completed_events = [event for event in events if isinstance(event, ToolCallCompletedEvent)]
+
+    assert started_events
+    assert completed_events
+    assert started_events[0].parent_run_id == "team-run"
+    assert completed_events[0].parent_run_id == "team-run"
+
+
+def test_execute_tasks_parallel_forwards_member_tool_events():
+    execute_parallel, task = _build_parallel_tool()
+
+    events = list(execute_parallel.entrypoint(task_ids=[task.id]))
+
+    _assert_member_tool_events_forwarded(events)
+
+
+@pytest.mark.asyncio
+async def test_aexecute_tasks_parallel_forwards_member_tool_events():
+    execute_parallel, task = _build_parallel_tool(async_mode=True)
+
+    events = []
+    async for event in execute_parallel.entrypoint(task_ids=[task.id]):
+        events.append(event)
+
+    _assert_member_tool_events_forwarded(events)


### PR DESCRIPTION
## Summary

- stream member runs from `execute_tasks_parallel` when the parent team run is streaming
- forward member run events with the parent team run id before task completion handling
- add sync and async regression coverage for member tool-call events in parallel task execution

Fixes #8356

## Validation

- `python -m pytest libs/agno/tests/unit/team/test_task_tools_parallel_events.py -q`
- `python -m pytest libs/agno/tests/unit/team/test_team_run_regressions.py libs/agno/tests/unit/team/test_task_tools_parallel_events.py -q`
- `python -m ruff check libs/agno/agno/team/_task_tools.py libs/agno/tests/unit/team/test_task_tools_parallel_events.py`
- `python -m ruff format --check libs/agno/agno/team/_task_tools.py libs/agno/tests/unit/team/test_task_tools_parallel_events.py`
- `python -m py_compile libs/agno/agno/team/_task_tools.py libs/agno/tests/unit/team/test_task_tools_parallel_events.py`
- `git diff --check`

I also ran `python -m pytest libs/agno/tests/unit/team -q`; the new tests passed, with two existing unrelated failures in `test_team_config.py` around lazy `agno.db.postgres` / `agno.db.sqlite` module patching.