### PR TITLE
fix: expose run lineage in AgentOS schemas

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -1857,10 +1857,12 @@ class AgentOSClient:
         # Parse runs based on session type and run content
         runs: List[Union[RunSchema, TeamRunSchema, WorkflowRunSchema]] = []
         for run in data:
-            if run.get("workflow_id") is not None:
-                runs.append(WorkflowRunSchema.model_validate(run))
+            if run.get("agent_id") is not None:
+                runs.append(RunSchema.model_validate(run))
             elif run.get("team_id") is not None:
                 runs.append(TeamRunSchema.model_validate(run))
+            elif run.get("workflow_id") is not None:
+                runs.append(WorkflowRunSchema.model_validate(run))
             else:
                 runs.append(RunSchema.model_validate(run))
         return runs
@@ -1903,10 +1905,12 @@ class AgentOSClient:
         data = await self._aget(f"/sessions/{session_id}/runs/{run_id}", params=params, headers=headers)
 
         # Return appropriate schema based on run type
-        if data.get("workflow_id") is not None:
-            return WorkflowRunSchema.model_validate(data)
+        if data.get("agent_id") is not None:
+            return RunSchema.model_validate(data)
         elif data.get("team_id") is not None:
             return TeamRunSchema.model_validate(data)
+        elif data.get("workflow_id") is not None:
+            return WorkflowRunSchema.model_validate(data)
         else:
             return RunSchema.model_validate(data)
 

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -474,8 +474,11 @@ class WorkflowSessionDetailSchema(BaseModel):
 
 class RunSchema(BaseModel):
     run_id: str = Field(..., description="Unique identifier for the run")
+    session_id: Optional[str] = Field(None, description="Session ID associated with the run")
     parent_run_id: Optional[str] = Field(None, description="Parent run ID if this is a nested run")
     agent_id: Optional[str] = Field(None, description="Agent ID that executed this run")
+    workflow_id: Optional[str] = Field(None, description="Workflow ID if this run was executed as part of a workflow")
+    workflow_step_id: Optional[str] = Field(None, description="Workflow step ID associated with this run")
     user_id: Optional[str] = Field(None, description="User ID associated with the run")
     status: Optional[str] = Field(None, description="Run status (PENDING, RUNNING, COMPLETED, ERROR, etc.)")
     run_input: Optional[str] = Field(None, description="Input provided to the run")
@@ -501,6 +504,13 @@ class RunSchema(BaseModel):
     response_audio: Optional[dict] = Field(None, description="Audio response if generated")
     input_media: Optional[Dict[str, Any]] = Field(None, description="Input media attachments")
     followups: Optional[List[str]] = Field(None, description="Followup suggestions generated after the run")
+    last_checkpoint_at_message_index: Optional[int] = Field(
+        None, description="Message index for the most recent checkpoint written during this run"
+    )
+    forked_from_run_id: Optional[str] = Field(None, description="Source run ID this run was forked from")
+    forked_from_message_index: Optional[int] = Field(None, description="Source message index this run was forked from")
+    forked_from_session_id: Optional[str] = Field(None, description="Source session ID this run was forked from")
+    regenerated_from: Optional[str] = Field(None, description="Run ID this run was regenerated from")
 
     @classmethod
     def from_dict(cls, run_dict: Dict[str, Any]) -> "RunSchema":
@@ -509,8 +519,11 @@ class RunSchema(BaseModel):
 
         return cls(
             run_id=run_dict.get("run_id", ""),
+            session_id=run_dict.get("session_id"),
             parent_run_id=run_dict.get("parent_run_id", ""),
             agent_id=run_dict.get("agent_id", ""),
+            workflow_id=run_dict.get("workflow_id"),
+            workflow_step_id=run_dict.get("workflow_step_id"),
             user_id=run_dict.get("user_id", ""),
             status=run_dict.get("status"),
             run_input=run_input,
@@ -533,14 +546,22 @@ class RunSchema(BaseModel):
             response_audio=run_dict.get("response_audio", None),
             input_media=extract_input_media(run_dict),
             followups=run_dict.get("followups", None),
+            last_checkpoint_at_message_index=run_dict.get("last_checkpoint_at_message_index"),
+            forked_from_run_id=run_dict.get("forked_from_run_id"),
+            forked_from_message_index=run_dict.get("forked_from_message_index"),
+            forked_from_session_id=run_dict.get("forked_from_session_id"),
+            regenerated_from=run_dict.get("regenerated_from"),
             created_at=to_utc_datetime(run_dict.get("created_at")),
         )
 
 
 class TeamRunSchema(BaseModel):
     run_id: str = Field(..., description="Unique identifier for the team run")
+    session_id: Optional[str] = Field(None, description="Session ID associated with the run")
     parent_run_id: Optional[str] = Field(None, description="Parent run ID if this is a nested run")
     team_id: Optional[str] = Field(None, description="Team ID that executed this run")
+    user_id: Optional[str] = Field(None, description="User ID associated with the run")
+    workflow_step_id: Optional[str] = Field(None, description="Workflow step ID associated with this run")
     status: Optional[str] = Field(None, description="Run status (PENDING, RUNNING, COMPLETED, ERROR, etc.)")
     content: Optional[Union[str, dict]] = Field(None, description="Output content from the team run")
     reasoning_content: Optional[str] = Field(None, description="Reasoning content if reasoning was enabled")
@@ -565,6 +586,13 @@ class TeamRunSchema(BaseModel):
     files: Optional[List[dict]] = Field(None, description="Files included in the run")
     response_audio: Optional[dict] = Field(None, description="Audio response if generated")
     followups: Optional[List[str]] = Field(None, description="Followup suggestions generated after the run")
+    last_checkpoint_at_message_index: Optional[int] = Field(
+        None, description="Message index for the most recent checkpoint written during this run"
+    )
+    forked_from_run_id: Optional[str] = Field(None, description="Source run ID this run was forked from")
+    forked_from_message_index: Optional[int] = Field(None, description="Source message index this run was forked from")
+    forked_from_session_id: Optional[str] = Field(None, description="Source session ID this run was forked from")
+    regenerated_from: Optional[str] = Field(None, description="Run ID this run was regenerated from")
 
     @classmethod
     def from_dict(cls, run_dict: Dict[str, Any]) -> "TeamRunSchema":
@@ -572,8 +600,11 @@ class TeamRunSchema(BaseModel):
         run_response_format = "text" if run_dict.get("content_type", "str") == "str" else "json"
         return cls(
             run_id=run_dict.get("run_id", ""),
+            session_id=run_dict.get("session_id"),
             parent_run_id=run_dict.get("parent_run_id", ""),
             team_id=run_dict.get("team_id", ""),
+            user_id=run_dict.get("user_id", ""),
+            workflow_step_id=run_dict.get("workflow_step_id"),
             status=run_dict.get("status"),
             run_input=run_input,
             content=run_dict.get("content", ""),
@@ -596,6 +627,11 @@ class TeamRunSchema(BaseModel):
             response_audio=run_dict.get("response_audio", None),
             input_media=extract_input_media(run_dict),
             followups=run_dict.get("followups", None),
+            last_checkpoint_at_message_index=run_dict.get("last_checkpoint_at_message_index"),
+            forked_from_run_id=run_dict.get("forked_from_run_id"),
+            forked_from_message_index=run_dict.get("forked_from_message_index"),
+            forked_from_session_id=run_dict.get("forked_from_session_id"),
+            regenerated_from=run_dict.get("regenerated_from"),
         )
 
 

--- a/libs/agno/tests/unit/os/test_client.py
+++ b/libs/agno/tests/unit/os/test_client.py
@@ -407,6 +407,42 @@ async def test_get_session():
 
 
 @pytest.mark.asyncio
+async def test_get_session_runs_prefers_agent_schema_for_workflow_agent_runs():
+    """Agent run history can carry workflow_id without becoming WorkflowRunSchema."""
+    from agno.os.schema import RunSchema, WorkflowRunSchema
+
+    client = AgentOSClient(base_url="http://localhost:7777")
+    mock_data = [
+        {
+            "run_id": "run-123",
+            "session_id": "sess-123",
+            "agent_id": "agent-1",
+            "workflow_id": "workflow-1",
+            "workflow_step_id": "step-1",
+            "content": "done",
+            "last_checkpoint_at_message_index": 4,
+            "forked_from_run_id": "source-run",
+            "forked_from_message_index": 2,
+            "forked_from_session_id": "source-session",
+            "regenerated_from": "previous-run",
+        }
+    ]
+    with patch.object(client, "_aget", new_callable=AsyncMock) as mock_get:
+        mock_get.return_value = mock_data
+        runs = await client.get_session_runs("sess-123")
+
+        assert isinstance(runs[0], RunSchema)
+        assert not isinstance(runs[0], WorkflowRunSchema)
+        assert runs[0].workflow_id == "workflow-1"
+        assert runs[0].workflow_step_id == "step-1"
+        assert runs[0].last_checkpoint_at_message_index == 4
+        assert runs[0].forked_from_run_id == "source-run"
+        assert runs[0].forked_from_message_index == 2
+        assert runs[0].forked_from_session_id == "source-session"
+        assert runs[0].regenerated_from == "previous-run"
+
+
+@pytest.mark.asyncio
 async def test_delete_session():
     """Verify delete_session deletes a session."""
     client = AgentOSClient(base_url="http://localhost:7777")

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -226,32 +226,87 @@ def test_session_state_mutability():
 
 
 def test_api_schema_session_state():
-    """Test that API schemas include session_state."""
+    """Test that API schemas include session_state and run lineage fields."""
     from agno.os.schema import RunSchema, TeamRunSchema
     from agno.run.agent import RunOutput
     from agno.run.team import TeamRunOutput
 
     # Test RunSchema
-    run_output = RunOutput(run_id="test_123", session_state={"api_data": "value"})
+    run_output = RunOutput(
+        run_id="test_123",
+        session_id="session_123",
+        workflow_id="workflow_123",
+        workflow_step_id="step_123",
+        session_state={"api_data": "value"},
+        last_checkpoint_at_message_index=5,
+        forked_from_run_id="source_run_123",
+        forked_from_message_index=3,
+        forked_from_session_id="source_session_123",
+        regenerated_from="previous_run_123",
+    )
     run_dict = run_output.to_dict()
     api_schema = RunSchema.from_dict(run_dict)
     assert api_schema.session_state == {"api_data": "value"}
+    assert api_schema.session_id == "session_123"
+    assert api_schema.workflow_id == "workflow_123"
+    assert api_schema.workflow_step_id == "step_123"
+    assert api_schema.last_checkpoint_at_message_index == 5
+    assert api_schema.forked_from_run_id == "source_run_123"
+    assert api_schema.forked_from_message_index == 3
+    assert api_schema.forked_from_session_id == "source_session_123"
+    assert api_schema.regenerated_from == "previous_run_123"
 
     # Verify API response includes it
     api_response = api_schema.model_dump(exclude_none=True)
     assert "session_state" in api_response
     assert api_response["session_state"] == {"api_data": "value"}
+    assert api_response["session_id"] == "session_123"
+    assert api_response["workflow_id"] == "workflow_123"
+    assert api_response["workflow_step_id"] == "step_123"
+    assert api_response["last_checkpoint_at_message_index"] == 5
+    assert api_response["forked_from_run_id"] == "source_run_123"
+    assert api_response["forked_from_message_index"] == 3
+    assert api_response["forked_from_session_id"] == "source_session_123"
+    assert api_response["regenerated_from"] == "previous_run_123"
 
     # Test TeamRunSchema
-    team_output = TeamRunOutput(run_id="team_123", team_id="team_456", session_state={"team_api_data": "value"})
+    team_output = TeamRunOutput(
+        run_id="team_123",
+        team_id="team_456",
+        session_id="team_session_123",
+        user_id="user_123",
+        workflow_step_id="team_step_123",
+        session_state={"team_api_data": "value"},
+        last_checkpoint_at_message_index=8,
+        forked_from_run_id="source_team_run_123",
+        forked_from_message_index=6,
+        forked_from_session_id="source_team_session_123",
+        regenerated_from="previous_team_run_123",
+    )
     team_dict = team_output.to_dict()
     team_schema = TeamRunSchema.from_dict(team_dict)
     assert team_schema.session_state == {"team_api_data": "value"}
+    assert team_schema.session_id == "team_session_123"
+    assert team_schema.user_id == "user_123"
+    assert team_schema.workflow_step_id == "team_step_123"
+    assert team_schema.last_checkpoint_at_message_index == 8
+    assert team_schema.forked_from_run_id == "source_team_run_123"
+    assert team_schema.forked_from_message_index == 6
+    assert team_schema.forked_from_session_id == "source_team_session_123"
+    assert team_schema.regenerated_from == "previous_team_run_123"
 
     # Verify API response includes it
     team_api_response = team_schema.model_dump(exclude_none=True)
     assert "session_state" in team_api_response
     assert team_api_response["session_state"] == {"team_api_data": "value"}
+    assert team_api_response["session_id"] == "team_session_123"
+    assert team_api_response["user_id"] == "user_123"
+    assert team_api_response["workflow_step_id"] == "team_step_123"
+    assert team_api_response["last_checkpoint_at_message_index"] == 8
+    assert team_api_response["forked_from_run_id"] == "source_team_run_123"
+    assert team_api_response["forked_from_message_index"] == 6
+    assert team_api_response["forked_from_session_id"] == "source_team_session_123"
+    assert team_api_response["regenerated_from"] == "previous_team_run_123"
 
 
 def test_custom_event_subclass_serialization():


### PR DESCRIPTION
## Summary

Expose the run lineage and checkpoint fields already present on `RunOutput` / `TeamRunOutput` through the AgentOS history schemas:

- add `session_id`, workflow context IDs, checkpoint index, and fork/regenerate lineage fields to `RunSchema`
- add matching session/user/workflow-step/checkpoint/fork/regenerate fields to `TeamRunSchema`
- make the AgentOS client prefer agent/team identifiers before `workflow_id` when parsing session run history, so nested workflow agent runs remain `RunSchema`
- add regression coverage for schema serialization and client parsing

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation:

- `pytest libs/agno/tests/unit/run/test_run_events.py libs/agno/tests/unit/os/test_client.py -q` passed (`54 passed`)
- `ruff check libs/agno/agno/os/schema.py libs/agno/agno/client/os.py libs/agno/tests/unit/run/test_run_events.py libs/agno/tests/unit/os/test_client.py` passed
- `git diff --check` passed
- `./scripts/validate.sh` was run. It completed, with unrelated existing mypy errors printed under Google/AWS/AG-UI/parallel areas.
