### PR TITLE
feat: Add S3 upload support to file generation tool 

### DIFF
--- a/cookbook/91_tools/file_generation_s3_tools.py
+++ b/cookbook/91_tools/file_generation_s3_tools.py
@@ -62,6 +62,7 @@ def example_json_generation():
             if file.url:
                 print(f"File location: {file.url}")
     print()
+    return response
 
 
 def example_csv_generation():
@@ -77,6 +78,7 @@ def example_csv_generation():
             if file.url:
                 print(f"File location: {file.url}")
     print()
+    return response
 
 
 def example_pdf_generation():
@@ -98,7 +100,7 @@ def example_pdf_generation():
 def download_from_s3(response):
     """Download the generated files back from S3 to confirm they exist."""
     print("=== Downloading Generated Files from S3 ===")
-    if not response.files:
+    if response is None or not response.files:
         print("No files were generated.")
         return
     s3_client = boto3.client("s3", region_name=AWS_REGION)
@@ -127,6 +129,7 @@ def example_text_generation():
             if file.url:
                 print(f"File location: {file.url}")
     print()
+    return response
 
 
 def example_docx_generation():
@@ -142,6 +145,7 @@ def example_docx_generation():
             if file.url:
                 print(f"File location: {file.url}")
     print()
+    return response
 
 
 def example_html_generation():
@@ -157,6 +161,7 @@ def example_html_generation():
             if file.url:
                 print(f"File location: {file.url}")
     print()
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/91_tools/file_generation_s3_tools.py
+++ b/cookbook/91_tools/file_generation_s3_tools.py
@@ -1,0 +1,173 @@
+"""
+File Generation Tool with S3 Example
+This cookbook shows how to use the FileGenerationTool to generate various file types (JSON, CSV, PDF, TXT, DOCX, HTML)
+and save them to an AWS S3 bucket instead of (or in addition to) the local disk.
+
+Providing s3_bucket implies save_to_s3=True, mirroring how output_directory implies save_files.
+The S3 location (s3://bucket/key) is reported in the agent's response.
+
+Requires boto3 (`pip install boto3`) and AWS credentials available via environment variables,
+~/.aws config, or an IAM role. Set S3_BUCKET below to your own bucket name before running.
+"""
+
+from pathlib import Path
+
+import boto3
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.tools.file_generation import FileGenerationTools
+
+# Replace with your own bucket name.
+S3_BUCKET = "virusbucket1agno"
+S3_PREFIX = "generated/"
+AWS_REGION = "us-east-1"
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Providing s3_bucket enables S3 uploads (s3_prefix acts like a folder inside the bucket).
+# Credentials fall back to environment variables / ~/.aws config / IAM role when not passed.
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="tmp/test.db"),
+    tools=[
+        FileGenerationTools(
+            s3_bucket=S3_BUCKET, s3_prefix=S3_PREFIX, region_name=AWS_REGION
+        )
+    ],
+    debug_mode=True,
+    description="You are a helpful assistant that can generate files in various formats.",
+    instructions=[
+        "When asked to create files, use the appropriate file generation tools.",
+        "Always provide meaningful content and appropriate filenames.",
+        "Explain what you've created and where it was saved.",
+    ],
+    markdown=True,
+)
+
+
+def example_json_generation():
+    """Example: Generate a JSON file"""
+    print("=== JSON File Generation Example ===")
+    response = agent.run(
+        "Create a JSON file containing information about 3 fictional employees with name, position, department, and salary."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+
+
+def example_csv_generation():
+    """Example: Generate a CSV file"""
+    print("=== CSV File Generation Example ===")
+    response = agent.run(
+        "Create a CSV file with sales data for the last 6 months. Include columns for month, product, units_sold, and revenue."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+
+
+def example_pdf_generation():
+    """Example: Generate a PDF file"""
+    print("=== PDF File Generation Example ===")
+    response = agent.run(
+        "Create a PDF report about renewable energy trends in 2024. Include sections on solar, wind, and hydroelectric power."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+    return response
+
+
+def download_from_s3(response):
+    """Download the generated files back from S3 to confirm they exist."""
+    print("=== Downloading Generated Files from S3 ===")
+    if not response.files:
+        print("No files were generated.")
+        return
+    s3_client = boto3.client("s3", region_name=AWS_REGION)
+    Path("tmp").mkdir(parents=True, exist_ok=True)
+    for file in response.files:
+        # The S3 key mirrors the upload: prefix + the generated filename.
+        key = f"{S3_PREFIX}{file.filename}"
+        local_path = Path("tmp") / file.filename
+        s3_client.download_file(S3_BUCKET, key, str(local_path))
+        print(
+            f"Downloaded s3://{S3_BUCKET}/{key} -> {local_path} ({local_path.stat().st_size} bytes)"
+        )
+    print()
+
+
+def example_text_generation():
+    """Example: Generate a text file"""
+    print("=== Text File Generation Example ===")
+    response = agent.run(
+        "Create a text file with a list of best practices for remote work productivity."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+
+
+def example_docx_generation():
+    """Example: Generate a DOCX file"""
+    print("=== DOCX File Generation Example ===")
+    response = agent.run(
+        "Create a DOCX report about customer onboarding best practices. Include sections for welcome email, product tour, and success check-ins."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+
+
+def example_html_generation():
+    """Example: Generate an HTML file"""
+    print("=== HTML File Generation Example ===")
+    response = agent.run(
+        "Create an HTML landing page for a coffee shop. Include a heading, a short intro, and a list of three signature drinks."
+    )
+    print(response.content)
+    if response.files:
+        for file in response.files:
+            print(f"Generated file: {file.filename} ({file.size} bytes)")
+            if file.url:
+                print(f"File location: {file.url}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    print("File Generation Tool with S3 Cookbook Example")
+    print("=" * 50)
+
+    # 1. Generate a file and upload it to S3.
+    response = example_html_generation()
+    # 2. Download it back from S3 to confirm it exists.
+    download_from_s3(response)

--- a/cookbook/91_tools/file_generation_s3_tools.py
+++ b/cookbook/91_tools/file_generation_s3_tools.py
@@ -20,7 +20,7 @@ from agno.models.openai import OpenAIResponses
 from agno.tools.file_generation import FileGenerationTools
 
 # Replace with your own bucket name.
-S3_BUCKET = "virusbucket1agno"
+S3_BUCKET = "yourbucket"
 S3_PREFIX = "generated/"
 AWS_REGION = "us-east-1"
 

--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -35,6 +35,15 @@ except ImportError as e:
         f"python-docx not installed. DOCX generation will not be available. Install with: pip install python-docx: {str(e)}"
     )
 
+try:
+    import boto3
+
+    BOTO3_AVAILABLE = True
+except ImportError:
+    # boto3 is only required when uploading to S3. Keep it optional so users who
+    # only generate/save files locally are unaffected.
+    BOTO3_AVAILABLE = False
+
 
 class FileGenerationTools(Toolkit):
     def __init__(
@@ -47,6 +56,13 @@ class FileGenerationTools(Toolkit):
         enable_html_generation: bool = True,
         output_directory: Optional[str] = None,
         save_files: bool = False,
+        s3_bucket: Optional[str] = None,
+        s3_prefix: Optional[str] = None,
+        save_to_s3: bool = False,
+        region_name: Optional[str] = None,
+        aws_access_key_id: Optional[str] = None,
+        aws_secret_access_key: Optional[str] = None,
+        aws_session_token: Optional[str] = None,
         all: bool = False,
         **kwargs,
     ):
@@ -67,6 +83,31 @@ class FileGenerationTools(Toolkit):
             log_debug(f"Files will be saved to: {self.output_directory}")
         else:
             self.output_directory = None
+
+        # s3_bucket implies save_to_s3=True, mirroring how output_directory implies save_files.
+        # S3 saving is independent of local saving: either, both, or neither can be enabled.
+        self.save_to_s3 = save_to_s3 or (s3_bucket is not None)
+        self.s3_prefix = s3_prefix
+        self.s3_client: Optional[Any] = None
+
+        if self.save_to_s3:
+            if s3_bucket is None:
+                raise ValueError("s3_bucket is required when save_to_s3 is True.")
+            if not BOTO3_AVAILABLE:
+                raise ImportError("boto3 is required to save files to S3. Install it with `pip install boto3`.")
+            self.s3_bucket: Optional[str] = s3_bucket
+            # Unset credentials are passed as None so boto3 falls back to its default
+            # credential chain (environment variables, ~/.aws config, or IAM role).
+            self.s3_client = boto3.client(
+                "s3",
+                region_name=region_name,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token,
+            )
+            log_debug(f"Files will be uploaded to S3 bucket: {self.s3_bucket}")
+        else:
+            self.s3_bucket = None
 
         if enable_pdf_generation and not PDF_AVAILABLE:
             logger.warning("PDF generation requested but reportlab is not installed. Disabling PDF generation.")
@@ -110,6 +151,25 @@ class FileGenerationTools(Toolkit):
         log_debug(f"File saved to: {file_path}")
         return str(file_path), None
 
+    def _upload_file_to_s3(
+        self, content: Union[str, bytes], filename: str, mime_type: str
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Upload file content to the configured S3 bucket.
+
+        Returns:
+            Tuple of (s3_uri, error_message). If successful, error is None.
+        """
+        key = f"{self.s3_prefix.rstrip('/')}/{filename}" if self.s3_prefix else filename
+        body = content.encode("utf-8") if isinstance(content, str) else content
+        try:
+            self.s3_client.put_object(Bucket=self.s3_bucket, Key=key, Body=body, ContentType=mime_type)
+        except Exception as e:
+            log_warning(f"Failed to upload file to S3: {str(e)}")
+            return None, str(e)
+        s3_uri = f"s3://{self.s3_bucket}/{key}"
+        log_debug(f"File uploaded to: {s3_uri}")
+        return s3_uri, None
+
     def _create_file_artifact(
         self,
         content: Union[str, bytes],
@@ -139,6 +199,11 @@ class FileGenerationTools(Toolkit):
         if self.save_files and self.output_directory:
             file_path, file_path_error = self._save_file_to_disk(content, file_name)
 
+        s3_uri: Optional[str] = None
+        s3_error: Optional[str] = None
+        if self.save_to_s3 and self.s3_client:
+            s3_uri, s3_error = self._upload_file_to_s3(content_bytes, file_name, mime_type)
+
         file_artifact = File(
             id=str(uuid4()),
             content=content_bytes,
@@ -155,6 +220,10 @@ class FileGenerationTools(Toolkit):
             success_msg += f" → {file_path}"
         elif file_path_error:
             success_msg += f" (save failed: {file_path_error})"
+        if s3_uri:
+            success_msg += f" → uploaded to {s3_uri}"
+        elif s3_error:
+            success_msg += f" (S3 upload failed: {s3_error})"
 
         return ToolResult(content=success_msg, files=[file_artifact])
 

--- a/libs/agno/agno/tools/file_generation.py
+++ b/libs/agno/agno/tools/file_generation.py
@@ -159,6 +159,8 @@ class FileGenerationTools(Toolkit):
         Returns:
             Tuple of (s3_uri, error_message). If successful, error is None.
         """
+        if self.s3_client is None:
+            return None, "S3 client is not configured."
         key = f"{self.s3_prefix.rstrip('/')}/{filename}" if self.s3_prefix else filename
         body = content.encode("utf-8") if isinstance(content, str) else content
         try:


### PR DESCRIPTION
## Summary

Enable optional S3 uploads for FileGenerationTools and add a cookbook example. Detects boto3 availability, adds constructor options (s3_bucket, s3_prefix, save_to_s3, region_name, aws credentials), and initializes an S3 client (falling back to boto3's default credential chain). Implements _upload_file_to_s3 and wires S3 URIs/errors into file artifacts and success messages. Validates that s3_bucket is provided when saving to S3 and raises an informative ImportError if boto3 is missing. Also add cookbook/91_tools/file_generation_s3_tools.py demonstrating usage and download verification.
## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
