### PR TITLE
perf(models): cache run-output event type tuple instead of rebuilding it per streamed item

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -57,6 +57,15 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.timer import Timer
 from agno.utils.tools import get_function_call_for_tool_call, get_function_call_for_tool_execution
 
+# get_args() on these Union aliases returns their member event classes, which are
+# constant at runtime. Compute the combined tuple once at import time instead of
+# rebuilding it on every streamed item inside the function-call loops below.
+RUN_OUTPUT_EVENT_TYPES: tuple = (
+    tuple(get_args(RunOutputEvent))
+    + tuple(get_args(TeamRunOutputEvent))
+    + tuple(get_args(WorkflowRunOutputEvent))
+)
+
 
 @dataclass
 class MessageData:
@@ -2116,11 +2125,7 @@ class Model(ABC):
             try:
                 for item in function_execution_result.result:
                     # This function yields agent/team/workflow run events
-                    if (
-                        isinstance(item, tuple(get_args(RunOutputEvent)))
-                        or isinstance(item, tuple(get_args(TeamRunOutputEvent)))
-                        or isinstance(item, tuple(get_args(WorkflowRunOutputEvent)))
-                    ):
+                    if isinstance(item, RUN_OUTPUT_EVENT_TYPES):
                         # We only capture content events for output accumulation
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
@@ -2651,12 +2656,7 @@ class Model(ABC):
             try:
                 async for item in function_call.result:
                     # This function yields agent/team/workflow run events
-                    if isinstance(
-                        item,
-                        tuple(get_args(RunOutputEvent))
-                        + tuple(get_args(TeamRunOutputEvent))
-                        + tuple(get_args(WorkflowRunOutputEvent)),
-                    ):
+                    if isinstance(item, RUN_OUTPUT_EVENT_TYPES):
                         # We only capture content events
                         if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                             if item.content is not None and isinstance(item.content, BaseModel):
@@ -2789,12 +2789,7 @@ class Model(ABC):
                 try:
                     for item in function_call.result:
                         # This function yields agent/team/workflow run events
-                        if isinstance(
-                            item,
-                            tuple(get_args(RunOutputEvent))
-                            + tuple(get_args(TeamRunOutputEvent))
-                            + tuple(get_args(WorkflowRunOutputEvent)),
-                        ):
+                        if isinstance(item, RUN_OUTPUT_EVENT_TYPES):
                             # We only capture content events
                             if isinstance(item, RunContentEvent) or isinstance(item, TeamRunContentEvent):
                                 if item.content is not None and isinstance(item.content, BaseModel):


### PR DESCRIPTION
While reading through the function-call streaming path in `Model`, I noticed the run-output event type check gets rebuilt on every streamed item.

In `models/base.py` three loops (the sync and async function-call result handlers) do roughly this:

```python
for item in function_call.result:
    if isinstance(
        item,
        tuple(get_args(RunOutputEvent))
        + tuple(get_args(TeamRunOutputEvent))
        + tuple(get_args(WorkflowRunOutputEvent)),
    ):
        ...
```

`get_args()` on those `Union` aliases always returns the same member classes — they don't change at runtime — but here it's recomputed (plus a fresh tuple allocation) for every single item these generators yield. For a tool that streams a lot of events that's pure repeated work in a hot loop, repeated across three call sites.

I pulled the combined tuple out into a module-level constant computed once at import:

```python
RUN_OUTPUT_EVENT_TYPES: tuple = (
    tuple(get_args(RunOutputEvent))
    + tuple(get_args(TeamRunOutputEvent))
    + tuple(get_args(WorkflowRunOutputEvent))
)
```

and the three checks now just do `isinstance(item, RUN_OUTPUT_EVENT_TYPES)`.

Behavior is identical (same set of types is matched); it only removes the per-item `get_args()`/tuple work and some duplication. The diff is a net reduction in lines as well.

There are a few more `tuple(get_args(...))` checks elsewhere (e.g. `utils/pprint.py`, the `_response.py` modules). I kept this PR scoped to `models/base.py` since that's the hot streaming path — happy to do a follow-up for the others if you'd like.
