### PR TITLE
fix: preserve registered model params when reconstructing agents

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -762,7 +762,18 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
     if "model" in config:
         model_data = config["model"]
         if isinstance(model_data, dict) and "id" in model_data:
-            config["model"] = get_model_from_dict(model_data)
+            # Prefer the live instance from the registry: rebuilding from the serialized dict drops
+            # connection params (azure_endpoint, base_url, ...) and credentials that aren't persisted.
+            registered_model = (
+                registry.get_model(
+                    model_data["id"],
+                    provider=model_data.get("provider"),
+                    name=model_data.get("name"),
+                )
+                if registry is not None
+                else None
+            )
+            config["model"] = registered_model if registered_model is not None else get_model_from_dict(model_data)
         elif isinstance(model_data, str):
             config["model"] = get_model(model_data)
 

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -754,28 +754,13 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
     Returns:
         Agent: Reconstructed agent instance
     """
-    from agno.models.utils import get_model, get_model_from_dict
+    from agno.models.utils import resolve_model
 
     config = data.copy()
 
     # --- Handle Model reconstruction ---
     if "model" in config:
-        model_data = config["model"]
-        if isinstance(model_data, dict) and "id" in model_data:
-            # Prefer the live instance from the registry: rebuilding from the serialized dict drops
-            # connection params (azure_endpoint, base_url, ...) and credentials that aren't persisted.
-            registered_model = (
-                registry.get_model(
-                    model_data["id"],
-                    provider=model_data.get("provider"),
-                    name=model_data.get("name"),
-                )
-                if registry is not None
-                else None
-            )
-            config["model"] = registered_model if registered_model is not None else get_model_from_dict(model_data)
-        elif isinstance(model_data, str):
-            config["model"] = get_model(model_data)
+        config["model"] = resolve_model(config["model"], registry)
 
     # --- Handle reasoning_model reconstruction ---
     # TODO: implement reasoning model deserialization

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -1,8 +1,11 @@
 import importlib
 from collections import Counter
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union
 
 from agno.models.base import Model
+
+if TYPE_CHECKING:
+    from agno.registry.registry import Registry
 
 # Single source of truth for every supported model provider. One row per stable provider key:
 #   key -> (module, class_name, default_name, default_provider_display)
@@ -202,3 +205,29 @@ def get_model_from_dict(model_data: Dict[str, Any]) -> Optional[Model]:
 
     provider_key = _resolve_provider_key(model_data.get("provider"), model_data.get("name"))
     return _get_model_class(model_id, provider_key)
+
+
+def resolve_model(model_data: Any, registry: Optional["Registry"] = None) -> Any:
+    """Reconstruct a model from its serialized config, preferring a registered live instance.
+
+    Rebuilding from a serialized dict only round-trips ``id``/``name``/``provider`` (see
+    ``Model.to_dict``), so connection params like ``azure_endpoint``/``base_url`` and any
+    credentials are lost. When the model is present in the registry, its live, fully-configured
+    instance is reused; otherwise we fall back to rebuilding from the dict (or a ``provider:id``
+    string). Values that are neither a model dict nor a string are returned unchanged.
+
+    Shared by Agent and Team reconstruction so both resolve models identically.
+    """
+    if isinstance(model_data, dict) and "id" in model_data:
+        if registry is not None:
+            registered_model = registry.get_model(
+                model_data["id"],
+                provider=model_data.get("provider"),
+                name=model_data.get("name"),
+            )
+            if registered_model is not None:
+                return registered_model
+        return get_model_from_dict(model_data)
+    elif isinstance(model_data, str):
+        return get_model(model_data)
+    return model_data

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -245,6 +245,31 @@ class Registry:
             return next((db for db in self.dbs if db.id == db_id), None)
         return None
 
+    def get_model(self, model_id: str, provider: Optional[str] = None, name: Optional[str] = None) -> Optional[Model]:
+        """Get a registered model instance by id, disambiguating by provider/name when given.
+
+        Returns the live, fully-configured instance the user registered. Reconstructing a model
+        from its serialized config only round-trips ``id``/``name``/``provider`` (see
+        ``Model.to_dict``), so connection params like ``azure_endpoint``/``base_url`` and any
+        credentials are lost. Preferring the registered instance keeps those intact.
+
+        ``provider`` and ``name`` are matched only when supplied, so distinct provider classes that
+        share an id (e.g. OpenAIChat vs OpenAIResponses, or the Azure model classes -- all report
+        provider "Azure") resolve to the right instance. Returns None when nothing matches, letting
+        the caller fall back to rebuilding from the serialized dict.
+        """
+        if not self.models or not model_id:
+            return None
+        for model in self.models:
+            if getattr(model, "id", None) != model_id:
+                continue
+            if provider is not None and getattr(model, "provider", None) != provider:
+                continue
+            if name is not None and getattr(model, "name", None) != name:
+                continue
+            return model
+        return None
+
     def get_function(self, name: str) -> Optional[Callable]:
         return next((f for f in self.functions if f.__name__ == name), None)
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -751,7 +751,18 @@ def from_dict(
     if "model" in config:
         model_data = config["model"]
         if isinstance(model_data, dict) and "id" in model_data:
-            config["model"] = get_model_from_dict(model_data)
+            # Prefer the live instance from the registry: rebuilding from the serialized dict drops
+            # connection params (azure_endpoint, base_url, ...) and credentials that aren't persisted.
+            registered_model = (
+                registry.get_model(
+                    model_data["id"],
+                    provider=model_data.get("provider"),
+                    name=model_data.get("name"),
+                )
+                if registry is not None
+                else None
+            )
+            config["model"] = registered_model if registered_model is not None else get_model_from_dict(model_data)
         elif isinstance(model_data, str):
             config["model"] = get_model(model_data)
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -25,7 +25,7 @@ from agno.db.utils import resolve_db_from_config
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
 from agno.models.message import Message
-from agno.models.utils import get_model, get_model_from_dict
+from agno.models.utils import resolve_model
 from agno.registry.registry import Registry
 from agno.run.agent import RunOutput
 from agno.run.team import (
@@ -749,22 +749,7 @@ def from_dict(
 
     # --- Handle Model reconstruction ---
     if "model" in config:
-        model_data = config["model"]
-        if isinstance(model_data, dict) and "id" in model_data:
-            # Prefer the live instance from the registry: rebuilding from the serialized dict drops
-            # connection params (azure_endpoint, base_url, ...) and credentials that aren't persisted.
-            registered_model = (
-                registry.get_model(
-                    model_data["id"],
-                    provider=model_data.get("provider"),
-                    name=model_data.get("name"),
-                )
-                if registry is not None
-                else None
-            )
-            config["model"] = registered_model if registered_model is not None else get_model_from_dict(model_data)
-        elif isinstance(model_data, str):
-            config["model"] = get_model(model_data)
+        config["model"] = resolve_model(config["model"], registry)
 
     # --- Handle Members reconstruction ---
     members: Optional[List[Union[Agent, "Team"]]] = None

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -11,12 +11,14 @@ import pytest
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
 
+from agno.models.base import Model
 from agno.models.utils import (
     MODEL_PROVIDER_CLASSES,
     _canonical_provider_display,
     _get_model_class,
     _resolve_provider_key,
     get_model_from_dict,
+    resolve_model,
 )
 
 ALL_PROVIDER_KEYS = sorted(MODEL_PROVIDER_CLASSES)
@@ -171,6 +173,64 @@ def test_unsupported_provider_raises():
 def test_get_model_from_dict_requires_id():
     with pytest.raises(ValueError, match="missing an 'id'"):
         get_model_from_dict({"provider": "openai"})
+
+
+class _FakeRegistry:
+    """Minimal registry stub exposing get_model() the way Registry does."""
+
+    def __init__(self, model):
+        self._model = model
+
+    def get_model(self, model_id, provider=None, name=None):
+        if getattr(self._model, "id", None) != model_id:
+            return None
+        if provider is not None and getattr(self._model, "provider", None) != provider:
+            return None
+        if name is not None and getattr(self._model, "name", None) != name:
+            return None
+        return self._model
+
+
+def test_resolve_model_prefers_registry_instance():
+    """A dict that matches a registered model resolves to the live instance, not a rebuild."""
+
+    class _M:
+        id = "gpt-5.5"
+        provider = "OpenAI"
+        name = "OpenAIResponses"
+
+    live = _M()
+    registry = _FakeRegistry(live)
+
+    resolved = resolve_model({"id": "gpt-5.5", "provider": "OpenAI", "name": "OpenAIResponses"}, registry)
+    assert resolved is live
+
+
+def test_resolve_model_falls_back_to_dict_when_not_registered():
+    """When the registry has no match, resolve_model rebuilds from the dict (unchanged behavior)."""
+    registry = _FakeRegistry(None)
+    rebuilt = resolve_model({"id": "gpt-4o", "provider": "OpenAI", "name": "OpenAIResponses"}, registry)
+    assert isinstance(rebuilt, Model)
+    assert rebuilt.id == "gpt-4o"
+
+
+def test_resolve_model_without_registry_rebuilds_from_dict():
+    rebuilt = resolve_model({"id": "gpt-4o", "provider": "OpenAI", "name": "OpenAIResponses"})
+    assert isinstance(rebuilt, Model)
+    assert rebuilt.id == "gpt-4o"
+
+
+def test_resolve_model_from_string():
+    rebuilt = resolve_model("openai:gpt-4o")
+    assert isinstance(rebuilt, Model)
+    assert rebuilt.id == "gpt-4o"
+
+
+def test_resolve_model_passes_through_unhandled_values():
+    """Values that are neither a model dict nor a string are returned unchanged."""
+    sentinel = object()
+    assert resolve_model(sentinel) is sentinel
+    assert resolve_model({"no": "id"}) == {"no": "id"}
 
 
 # Abstract/intermediate Model subclasses that are not concrete providers and so must not appear

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -483,6 +483,56 @@ class TestRegistryIntegration:
         if agent.tools:
             assert len(agent.tools) == 1
 
+    def test_registry_preserves_model_connection_params(self):
+        """Reconstructing an agent reuses the registered model instance, keeping connection params.
+
+        Regression: a serialized model dict only round-trips id/name/provider, so rebuilding from it
+        drops azure_endpoint/base_url and credentials. The registry holds the live instance, so
+        from_dict should prefer it. See Model.to_dict / Registry.get_model.
+        """
+        from agno.agent.agent import Agent
+        from agno.models.azure import AzureOpenAI
+
+        model = AzureOpenAI(
+            id="gpt-4.1-mini",
+            api_version="2024-12-01-preview",
+            azure_endpoint="https://example.cognitiveservices.azure.com",
+        )
+        registry = Registry(models=[model])
+
+        # The stored config only carries the serialized model dict (id/name/provider).
+        config = {
+            "id": "test-agent",
+            "name": "Test Agent",
+            "model": model.to_dict(),
+        }
+        assert "azure_endpoint" not in config["model"]  # confirm the gap the fix bridges
+
+        agent = Agent.from_dict(config, registry=registry)
+
+        # The live, fully-configured instance is reused -- not a bare rebuild.
+        assert agent.model is model
+        assert agent.model.azure_endpoint == "https://example.cognitiveservices.azure.com"
+        assert agent.model.api_version == "2024-12-01-preview"
+
+    def test_from_dict_without_registry_rebuilds_bare_model(self):
+        """Without a registry, the model is still rebuilt from its dict (unchanged fallback)."""
+        from agno.agent.agent import Agent
+        from agno.models.azure import AzureOpenAI
+
+        config = {
+            "id": "test-agent",
+            "name": "Test Agent",
+            "model": {"id": "gpt-4.1-mini", "name": "AzureOpenAI", "provider": "Azure"},
+        }
+
+        agent = Agent.from_dict(config)
+
+        assert isinstance(agent.model, AzureOpenAI)
+        assert agent.model.id == "gpt-4.1-mini"
+        # No registered instance to source connection params from.
+        assert agent.model.azure_endpoint is None
+
     def test_registry_schema_with_agent(self):
         """Test registry schema lookup with agent config."""
         reg = Registry(schemas=[SampleInputSchema, SampleOutputSchema])
@@ -642,6 +692,61 @@ class TestGetDb:
 
         not_found2 = reg.get_db("TEST-DB")
         assert not_found2 is None
+
+
+# =============================================================================
+# get_model() Tests
+# =============================================================================
+
+
+class TestGetModel:
+    """Tests for Registry.get_model() method."""
+
+    def _model(self, id, provider, name):
+        m = MagicMock()
+        m.id = id
+        m.provider = provider
+        m.name = name
+        return m
+
+    def test_get_model_found_by_id(self):
+        """A single registered model is returned by id alone."""
+        model = self._model("gpt-4.1-mini", "Azure", "AzureOpenAI")
+        reg = Registry(models=[model])
+
+        assert reg.get_model("gpt-4.1-mini") is model
+
+    def test_get_model_not_found(self):
+        """An unknown id returns None so the caller can fall back to dict reconstruction."""
+        reg = Registry(models=[self._model("gpt-4.1-mini", "Azure", "AzureOpenAI")])
+
+        assert reg.get_model("does-not-exist") is None
+
+    def test_get_model_empty_registry(self, basic_registry):
+        """An empty registry returns None."""
+        assert basic_registry.get_model("gpt-4.1-mini") is None
+
+    def test_get_model_disambiguates_by_provider_and_name(self):
+        """Models sharing an id are disambiguated by provider/name (e.g. OpenAIChat vs Responses)."""
+        chat = self._model("gpt-5.5", "OpenAI", "OpenAIChat")
+        responses = self._model("gpt-5.5", "OpenAI", "OpenAIResponses")
+        reg = Registry(models=[chat, responses])
+
+        assert reg.get_model("gpt-5.5", provider="OpenAI", name="OpenAIChat") is chat
+        assert reg.get_model("gpt-5.5", provider="OpenAI", name="OpenAIResponses") is responses
+
+    def test_get_model_no_match_on_provider_returns_none(self):
+        """When provider is given and no registered model matches, None is returned."""
+        model = self._model("gpt-4.1-mini", "Azure", "AzureOpenAI")
+        reg = Registry(models=[model])
+
+        assert reg.get_model("gpt-4.1-mini", provider="OpenAI") is None
+
+    def test_get_model_empty_id(self):
+        """A falsy id returns None."""
+        reg = Registry(models=[self._model("gpt-4.1-mini", "Azure", "AzureOpenAI")])
+
+        assert reg.get_model("") is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

When an agent or team is reconstructed from its stored config (e.g. serving an AgentOS run for a DB-stored component), the model was rebuilt purely from its serialized dict. `Model.to_dict` only persists `id`/`name`/`provider`, so connection params such as `azure_endpoint`/`base_url` and any credentials were dropped on the rebuild.

The result: a user registers a fully-configured `AgnoAzureOpenAI(id=..., api_version=..., azure_endpoint=...)` on the `Registry`, but when the agent runs through AgentOS the reconstructed model has `azure_endpoint=None` and fails with:

```
Must provide one of the `base_url` or `azure_endpoint` arguments, or the AZURE_OPENAI_ENDPOINT environment variable
```

The `Registry` already holds the live, fully-configured model instance and is threaded into `from_dict` — it was being used to rehydrate tools and dbs, but the model branch ignored it entirely, and there was no `Registry.get_model()` to call.

### Changes

- **`registry/registry.py`** — add `Registry.get_model(model_id, provider=None, name=None)`, mirroring the existing `get_db`/`get_agent` lookups. Matches by `id` and optionally disambiguates by `provider`/`name` so distinct classes sharing an id resolve correctly (OpenAIChat vs OpenAIResponses; the three Azure model classes all report provider "Azure"). Returns `None` when nothing matches.
- **`agent/_storage.py`** and **`team/_storage.py`** — the model-dict branch now prefers the live registry instance (preserving connection params and credentials), falling back to the previous `get_model_from_dict` rebuild only when the model is not registered or no registry is present.

This is the credential-safe fix: it reuses the live instance rather than persisting `api_key`/endpoints to the DB.

### Notes

- Code-defined agents passed directly to `AgentOS(agents=[...])` are served from the in-memory list via `deep_copy()` and never hit `from_dict`, so they were never affected — this only matters for DB-stored components, which is exactly the failing case.
- `reasoning_model`/`parser_model` reconstruction are still `TODO` stubs in `_storage.py` and don't hit this path yet; they should get the same registry treatment once implemented.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added `TestGetModel` (lookup by id, provider/name disambiguation, no-match, empty registry, empty id) plus two integration cases on `TestRegistryIntegration`: the regression (Azure `azure_endpoint`/`api_version` survive a full `Agent.from_dict` round-trip via the registry) and the unchanged no-registry fallback. 112 registry tests + 154 related agent/team/registry-population tests pass.
