### PR TITLE
feat: round-trip non-secret model connection params through serialization

### DIFF
--- a/libs/agno/agno/models/azure/openai_chat.py
+++ b/libs/agno/agno/models/azure/openai_chat.py
@@ -1,7 +1,7 @@
 from copy import copy, deepcopy
 from dataclasses import dataclass
 from os import getenv
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional, Tuple
 
 import httpx
 
@@ -43,6 +43,10 @@ class AzureOpenAI(OpenAILike):
     provider: str = "Azure"
 
     supports_native_structured_outputs: bool = True
+
+    # Non-secret connection params to round-trip. Credentials (api_key, azure_ad_token) are
+    # intentionally excluded -- they must come from the env or a registered model instance.
+    _serializable_params: ClassVar[Tuple[str, ...]] = ("base_url", "api_version", "azure_endpoint", "azure_deployment")
 
     api_key: Optional[str] = None
     api_version: Optional[str] = "2024-10-21"

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    ClassVar,
     Dict,
     Iterator,
     List,
@@ -135,6 +136,13 @@ class Model(ABC):
     # Functional role of this model (e.g., MODEL, OUTPUT_MODEL, PARSER_MODEL).
     # Set by the agent during initialization; defaults to MODEL.
     model_type: ModelType = ModelType.MODEL
+
+    # Non-secret connection params that round-trip through ``to_dict``/``get_model_from_dict``
+    # (e.g. base_url, azure_endpoint). Reconstructing a model from its serialized config would
+    # otherwise drop these. Subclasses extend this tuple; NEVER list credentials (api_key, tokens)
+    # here -- those must stay out of the persisted config and come from the env or a registered
+    # model instance. Declared as a ClassVar so dataclass does not treat it as an instance field.
+    _serializable_params: ClassVar[Tuple[str, ...]] = ()
 
     # -*- Do not set the following attributes directly -*-
     # -*- Set them on the Agent instead -*-
@@ -432,6 +440,12 @@ class Model(ABC):
     def to_dict(self) -> Dict[str, Any]:
         fields = {"name", "id", "provider"}
         _dict = {field: getattr(self, field) for field in fields if getattr(self, field) is not None}
+        # Round-trip non-secret connection params so a reconstructed model keeps e.g. its
+        # base_url/azure_endpoint. Credentials are never listed in ``_serializable_params``.
+        for param in self._serializable_params:
+            value = getattr(self, param, None)
+            if value is not None:
+                _dict[param] = value
         return _dict
 
     def _remove_temporary_messages(self, messages: List[Message]) -> None:

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from os import getenv
-from typing import Any, Dict, Iterator, List, Literal, Optional, Type, Union
+from typing import Any, ClassVar, Dict, Iterator, List, Literal, Optional, Tuple, Type, Union
 from uuid import uuid4
 
 import httpx
@@ -42,6 +42,10 @@ class OpenAIChat(Model):
     name: str = "OpenAIChat"
     provider: str = "OpenAI"
     supports_native_structured_outputs: bool = True
+
+    # Non-secret connection param to round-trip; inherited by all OpenAI-compatible subclasses
+    # (OpenAILike and its providers). Subclasses needing more (e.g. Azure) extend this.
+    _serializable_params: ClassVar[Tuple[str, ...]] = ("base_url",)
     # If True, only collect metrics on the final streaming chunk (for providers with cumulative token counts)
     collect_metrics_on_completion: bool = False
 

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, Type, Union
+from typing import Any, AsyncIterator, ClassVar, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import httpx
 from pydantic import BaseModel
@@ -39,6 +39,9 @@ class OpenAIResponses(Model):
     name: str = "OpenAIResponses"
     provider: str = "OpenAI"
     supports_native_structured_outputs: bool = True
+
+    # Non-secret connection param to round-trip through to_dict/get_model_from_dict.
+    _serializable_params: ClassVar[Tuple[str, ...]] = ("base_url",)
 
     # Request parameters
     include: Optional[List[str]] = None

--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -137,7 +137,7 @@ def _resolve_provider_key(model_provider: Optional[str], model_name: Optional[st
     return provider_key
 
 
-def _get_model_class(model_id: str, model_provider: str) -> Model:
+def _get_model_class(model_id: str, model_provider: str, params: Optional[Dict[str, Any]] = None) -> Model:
     entry = MODEL_PROVIDER_CLASSES.get(model_provider)
     if entry is None:
         # Allow alias forms (e.g. "azure", "inceptionlabs") to resolve too.
@@ -149,7 +149,14 @@ def _get_model_class(model_id: str, model_provider: str) -> Model:
     module_path, class_name = entry
     module = importlib.import_module(module_path)
     model_class = getattr(module, class_name)
-    return model_class(id=model_id)
+
+    kwargs: Dict[str, Any] = {"id": model_id}
+    if params:
+        # Only pass connection params the class declares as serializable, so a serialized config
+        # can't inject arbitrary constructor kwargs (and credentials are never round-tripped).
+        allowed = set(getattr(model_class, "_serializable_params", ()))
+        kwargs.update({key: value for key, value in params.items() if key in allowed})
+    return model_class(**kwargs)
 
 
 def _parse_model_string(model_string: str) -> Model:
@@ -204,7 +211,10 @@ def get_model_from_dict(model_data: Dict[str, Any]) -> Optional[Model]:
         raise ValueError(f"Model data is missing an 'id': {model_data}")
 
     provider_key = _resolve_provider_key(model_data.get("provider"), model_data.get("name"))
-    return _get_model_class(model_id, provider_key)
+    # Forward any serialized connection params (base_url, azure_endpoint, ...) so the rebuilt
+    # model keeps them. _get_model_class filters to the class's declared serializable params.
+    params = {key: value for key, value in model_data.items() if key not in {"id", "name", "provider"}}
+    return _get_model_class(model_id, provider_key, params=params)
 
 
 def resolve_model(model_data: Any, registry: Optional["Registry"] = None) -> Any:
@@ -220,10 +230,14 @@ def resolve_model(model_data: Any, registry: Optional["Registry"] = None) -> Any
     """
     if isinstance(model_data, dict) and "id" in model_data:
         if registry is not None:
+            # Pass serialized connection params so the registry can disambiguate models that share
+            # an id but differ by endpoint (e.g. two Azure deployments of the same model).
+            params = {key: value for key, value in model_data.items() if key not in {"id", "name", "provider"}}
             registered_model = registry.get_model(
                 model_data["id"],
                 provider=model_data.get("provider"),
                 name=model_data.get("name"),
+                params=params or None,
             )
             if registered_model is not None:
                 return registered_model

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -20,14 +20,20 @@ if TYPE_CHECKING:
 
 
 def _model_identity(model: Model) -> tuple:
-    """Stable identity for catalog dedup: the provider class, display provider, and model id.
+    """Stable identity for catalog dedup: the provider class, display provider, id, and connection.
 
     The class (module + qualname) is included alongside the display ``provider`` string so that
     distinct classes sharing a provider string (e.g. OpenAIChat vs OpenAIResponses, or the Azure
     model classes -- all report provider "Azure") are not collapsed into a single catalog entry.
+
+    The non-secret connection params (``_serializable_params``: base_url, azure_endpoint, ...) are
+    folded in so two instances of the same class and id that point at *different* endpoints are kept
+    as distinct entries rather than collapsing -- otherwise a second deployment would be silently
+    dropped and requests routed to the first one's endpoint.
     """
     cls = type(model)
-    return (cls.__module__, cls.__qualname__, getattr(model, "provider", None), getattr(model, "id", None))
+    connection = tuple(getattr(model, param, None) for param in getattr(cls, "_serializable_params", ()))
+    return (cls.__module__, cls.__qualname__, getattr(model, "provider", None), getattr(model, "id", None), connection)
 
 
 @dataclass
@@ -245,21 +251,32 @@ class Registry:
             return next((db for db in self.dbs if db.id == db_id), None)
         return None
 
-    def get_model(self, model_id: str, provider: Optional[str] = None, name: Optional[str] = None) -> Optional[Model]:
-        """Get a registered model instance by id, disambiguating by provider/name when given.
+    def get_model(
+        self,
+        model_id: str,
+        provider: Optional[str] = None,
+        name: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Model]:
+        """Get a registered model instance by id, disambiguating by provider/name/connection params.
 
-        Returns the live, fully-configured instance the user registered. Reconstructing a model
-        from its serialized config only round-trips ``id``/``name``/``provider`` (see
-        ``Model.to_dict``), so connection params like ``azure_endpoint``/``base_url`` and any
-        credentials are lost. Preferring the registered instance keeps those intact.
+        Returns the live, fully-configured instance the user registered (preserving credentials and
+        any client state that cannot be rebuilt from serialized config).
 
         ``provider`` and ``name`` are matched only when supplied, so distinct provider classes that
         share an id (e.g. OpenAIChat vs OpenAIResponses, or the Azure model classes -- all report
-        provider "Azure") resolve to the right instance. Returns None when nothing matches, letting
-        the caller fall back to rebuilding from the serialized dict.
+        provider "Azure") resolve to the right instance. ``params`` carries serialized connection
+        fields (base_url, azure_endpoint, ...) and is matched too, so two deployments of the same
+        model at different endpoints resolve to the correct one.
+
+        Returns None when nothing matches. Also returns None (rather than guessing) when more than
+        one registered model matches and the candidates cannot be told apart -- falling back to a
+        rebuild is safer than silently routing to the wrong endpoint/account.
         """
         if not self.models or not model_id:
             return None
+        params = params or {}
+        matches = []
         for model in self.models:
             if getattr(model, "id", None) != model_id:
                 continue
@@ -267,8 +284,20 @@ class Registry:
                 continue
             if name is not None and getattr(model, "name", None) != name:
                 continue
-            return model
-        return None
+            if any(getattr(model, key, None) != value for key, value in params.items()):
+                continue
+            matches.append(model)
+
+        if not matches:
+            return None
+        if len(matches) > 1:
+            log_warning(
+                f"Registry: multiple registered models match id '{model_id}' and could not be "
+                "disambiguated from the serialized config; rebuilding instead of guessing. Give the "
+                "models distinct ids or connection params to resolve this."
+            )
+            return None
+        return matches[0]
 
     def get_function(self, name: str) -> Optional[Callable]:
         return next((f for f in self.functions if f.__name__ == name), None)

--- a/libs/agno/tests/unit/models/test_provider_resolution.py
+++ b/libs/agno/tests/unit/models/test_provider_resolution.py
@@ -47,6 +47,64 @@ def test_to_dict_round_trip_preserves_class(key):
     assert rebuilt.id == "test-id"
 
 
+def test_to_dict_serializes_non_secret_connection_params_not_credentials():
+    """to_dict round-trips declared connection params (azure_endpoint, ...) but never credentials."""
+    from agno.models.azure import AzureOpenAI
+
+    model = AzureOpenAI(
+        id="gpt-4.1-mini",
+        api_key="super-secret",
+        api_version="2024-12-01-preview",
+        azure_endpoint="https://example.cognitiveservices.azure.com",
+        azure_deployment="my-deployment",
+    )
+    data = model.to_dict()
+
+    assert data["azure_endpoint"] == "https://example.cognitiveservices.azure.com"
+    assert data["api_version"] == "2024-12-01-preview"
+    assert data["azure_deployment"] == "my-deployment"
+    # Credentials must never be persisted.
+    assert "api_key" not in data
+    assert "azure_ad_token" not in data
+
+
+def test_get_model_from_dict_recovers_connection_params():
+    """Rebuilding from a dict restores the non-secret connection params (self-healing fallback)."""
+    from agno.models.azure import AzureOpenAI
+
+    rebuilt = get_model_from_dict(
+        {
+            "id": "gpt-4.1-mini",
+            "name": "AzureOpenAI",
+            "provider": "Azure",
+            "azure_endpoint": "https://example.cognitiveservices.azure.com",
+            "api_version": "2024-12-01-preview",
+        }
+    )
+    assert isinstance(rebuilt, AzureOpenAI)
+    assert rebuilt.azure_endpoint == "https://example.cognitiveservices.azure.com"
+    assert rebuilt.api_version == "2024-12-01-preview"
+
+
+def test_get_model_from_dict_ignores_undeclared_params():
+    """Only fields a class declares serializable are passed to its constructor."""
+    from agno.models.openai import OpenAIResponses
+
+    # base_url is declared; a stray non-serializable field must be dropped, not injected.
+    rebuilt = get_model_from_dict(
+        {
+            "id": "gpt-5.5",
+            "name": "OpenAIResponses",
+            "provider": "OpenAI",
+            "base_url": "https://proxy.example.com/v1",
+            "api_key": "should-be-ignored",
+        }
+    )
+    assert isinstance(rebuilt, OpenAIResponses)
+    assert str(rebuilt.base_url) == "https://proxy.example.com/v1"
+    assert rebuilt.api_key != "should-be-ignored"
+
+
 @pytest.mark.parametrize("key", ALL_PROVIDER_KEYS)
 def test_canonical_provider_display_matches_class(key):
     """Drift guard: the provider-display override table matches what each class actually reports.
@@ -181,12 +239,14 @@ class _FakeRegistry:
     def __init__(self, model):
         self._model = model
 
-    def get_model(self, model_id, provider=None, name=None):
-        if getattr(self._model, "id", None) != model_id:
+    def get_model(self, model_id, provider=None, name=None, params=None):
+        if self._model is None or getattr(self._model, "id", None) != model_id:
             return None
         if provider is not None and getattr(self._model, "provider", None) != provider:
             return None
         if name is not None and getattr(self._model, "name", None) != name:
+            return None
+        if params and any(getattr(self._model, key, None) != value for key, value in params.items()):
             return None
         return self._model
 

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -486,9 +486,8 @@ class TestRegistryIntegration:
     def test_registry_preserves_model_connection_params(self):
         """Reconstructing an agent reuses the registered model instance, keeping connection params.
 
-        Regression: a serialized model dict only round-trips id/name/provider, so rebuilding from it
-        drops azure_endpoint/base_url and credentials. The registry holds the live instance, so
-        from_dict should prefer it. See Model.to_dict / Registry.get_model.
+        The registry holds the live, fully-configured instance (with credentials and client state),
+        so from_dict should prefer it over a rebuild. See Registry.get_model.
         """
         from agno.agent.agent import Agent
         from agno.models.azure import AzureOpenAI
@@ -500,13 +499,14 @@ class TestRegistryIntegration:
         )
         registry = Registry(models=[model])
 
-        # The stored config only carries the serialized model dict (id/name/provider).
         config = {
             "id": "test-agent",
             "name": "Test Agent",
             "model": model.to_dict(),
         }
-        assert "azure_endpoint" not in config["model"]  # confirm the gap the fix bridges
+        # Non-secret connection params now round-trip through to_dict ...
+        assert config["model"]["azure_endpoint"] == "https://example.cognitiveservices.azure.com"
+        assert "api_key" not in config["model"]  # ... but credentials never do.
 
         agent = Agent.from_dict(config, registry=registry)
 
@@ -515,23 +515,33 @@ class TestRegistryIntegration:
         assert agent.model.azure_endpoint == "https://example.cognitiveservices.azure.com"
         assert agent.model.api_version == "2024-12-01-preview"
 
-    def test_from_dict_without_registry_rebuilds_bare_model(self):
-        """Without a registry, the model is still rebuilt from its dict (unchanged fallback)."""
+    def test_from_dict_without_registry_recovers_connection_params(self):
+        """Without a registry, the model is rebuilt from its dict and now recovers non-secret params.
+
+        This is the self-healing fallback: even an agent that was never registered keeps its endpoint
+        because to_dict serializes it. Only credentials must come from env/registry.
+        """
         from agno.agent.agent import Agent
         from agno.models.azure import AzureOpenAI
 
         config = {
             "id": "test-agent",
             "name": "Test Agent",
-            "model": {"id": "gpt-4.1-mini", "name": "AzureOpenAI", "provider": "Azure"},
+            "model": {
+                "id": "gpt-4.1-mini",
+                "name": "AzureOpenAI",
+                "provider": "Azure",
+                "azure_endpoint": "https://example.cognitiveservices.azure.com",
+                "api_version": "2024-12-01-preview",
+            },
         }
 
         agent = Agent.from_dict(config)
 
         assert isinstance(agent.model, AzureOpenAI)
         assert agent.model.id == "gpt-4.1-mini"
-        # No registered instance to source connection params from.
-        assert agent.model.azure_endpoint is None
+        assert agent.model.azure_endpoint == "https://example.cognitiveservices.azure.com"
+        assert agent.model.api_version == "2024-12-01-preview"
 
     def test_registry_schema_with_agent(self):
         """Test registry schema lookup with agent config."""
@@ -747,6 +757,44 @@ class TestGetModel:
         reg = Registry(models=[self._model("gpt-4.1-mini", "Azure", "AzureOpenAI")])
 
         assert reg.get_model("") is None
+
+    def test_get_model_disambiguates_by_connection_params(self):
+        """Two deployments of the same model at different endpoints resolve by connection params."""
+        pytest.importorskip("openai")
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+        from agno.models.azure import AzureOpenAI
+
+        endpoint_a = "https://a.cognitiveservices.azure.com"
+        endpoint_b = "https://b.cognitiveservices.azure.com"
+        model_a = AzureOpenAI(id="gpt-4.1-mini", azure_endpoint=endpoint_a)
+        model_b = AzureOpenAI(id="gpt-4.1-mini", azure_endpoint=endpoint_b)
+        reg = Registry(models=[model_a, model_b])
+
+        resolved = reg.get_model(
+            "gpt-4.1-mini", provider="Azure", name="AzureOpenAI", params={"azure_endpoint": endpoint_b}
+        )
+        assert resolved is model_b
+
+    def test_get_model_declines_ambiguous_match(self, monkeypatch):
+        """When candidates can't be told apart, decline (return None) rather than guess an endpoint."""
+        pytest.importorskip("openai")
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+        import agno.registry.registry as registry_module
+        from agno.models.azure import AzureOpenAI
+
+        warnings = []
+        monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: warnings.append(msg))
+
+        reg = Registry(
+            models=[
+                AzureOpenAI(id="gpt-4.1-mini", azure_endpoint="https://a.cognitiveservices.azure.com"),
+                AzureOpenAI(id="gpt-4.1-mini", azure_endpoint="https://b.cognitiveservices.azure.com"),
+            ]
+        )
+
+        # No connection params to disambiguate the two registered deployments.
+        assert reg.get_model("gpt-4.1-mini", provider="Azure", name="AzureOpenAI") is None
+        assert warnings and "gpt-4.1-mini" in warnings[0]
 
 
 # =============================================================================
@@ -1142,6 +1190,36 @@ class TestAddModel:
         reg = Registry()
         reg.add_model(OpenAIResponses(id="gpt-5.4"))
         reg.add_model(OpenAIResponses(id="gpt-5.4"))  # genuine duplicate
+        assert len(reg.models) == 1
+
+    def test_keeps_same_class_id_different_endpoint(self):
+        """Same class and id but different endpoints are kept distinct, not collapsed.
+
+        Otherwise a second Azure deployment of the same model would be silently dropped and requests
+        routed to the first one's endpoint. See _model_identity.
+        """
+        pytest.importorskip("openai")
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+        from agno.models.azure import AzureOpenAI
+
+        reg = Registry()
+        reg.add_model(AzureOpenAI(id="gpt-4.1-mini", azure_endpoint="https://a.cognitiveservices.azure.com"))
+        reg.add_model(AzureOpenAI(id="gpt-4.1-mini", azure_endpoint="https://b.cognitiveservices.azure.com"))
+        assert len(reg.models) == 2
+        assert {m.azure_endpoint for m in reg.models} == {
+            "https://a.cognitiveservices.azure.com",
+            "https://b.cognitiveservices.azure.com",
+        }
+
+    def test_dedupes_same_class_id_and_endpoint(self):
+        """Same class, id and endpoint collapse as before -- they are interchangeable."""
+        pytest.importorskip("openai")
+        os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+        from agno.models.azure import AzureOpenAI
+
+        reg = Registry()
+        reg.add_model(AzureOpenAI(id="gpt-4.1-mini", azure_endpoint="https://a.cognitiveservices.azure.com"))
+        reg.add_model(AzureOpenAI(id="gpt-4.1-mini", azure_endpoint="https://a.cognitiveservices.azure.com"))
         assert len(reg.models) == 1
 
     def test_logs_debug_when_dropping_matching_model(self, monkeypatch):


### PR DESCRIPTION
## Summary

> Follow-up to #8476 (now merged). This PR's diff is only the additional serialization work.

#8476 made the registry preserve a model's connection params by reusing the live registered instance. This follow-up closes the two gaps that fix left open, with one unifying change: **serialize the non-secret connection params so they round-trip through the stored config.**

`Model.to_dict` only persisted `id`/`name`/`provider`, so rebuilding a model from its serialized config dropped `azure_endpoint`/`base_url`/`api_version`. And because `Registry` dedup keyed on `(class, provider, id)`, two deployments of the same model at different endpoints collapsed to one — so even with #8476, a second endpoint could be silently dropped and requests routed to the first.

### Changes

- **Per-class allowlist** — `Model._serializable_params` (a `ClassVar`, never credentials). Declared on `OpenAIChat`/`OpenAIResponses` (`base_url`) and `AzureOpenAI` (`base_url`, `api_version`, `azure_endpoint`, `azure_deployment`). Other providers opt in by setting it.
- **`Model.to_dict`** serializes those params; **`get_model_from_dict`** threads them back through the constructor, filtered to the class allowlist so a serialized config can't inject arbitrary kwargs. This makes the **no-registry fallback self-healing** for endpoint/version.
- **`_model_identity`** folds the connection params in, so different-endpoint models are kept as distinct registry entries instead of collapsing.
- **`Registry.get_model`** matches on connection params and **declines ambiguous matches** (returns `None` → safe rebuild) rather than guessing an endpoint.

This directly addresses the Codex P1 review comment on #8476 (multi-endpoint models cross-wiring) and makes the components-API flow robust even for DB-only agents that were never registered.

### What is intentionally NOT serialized

Credentials — `api_key`, `azure_ad_token`. These never enter the persisted config; they continue to come from the env or a registered live model instance. That is the whole reason the allowlist is opt-in per field rather than dumping the dataclass.

## Type of change

- [x] Improvement
- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

New tests:
- `to_dict` serializes connection params but not `api_key`/`azure_ad_token`; `get_model_from_dict` recovers them and ignores undeclared fields.
- `Agent.from_dict` without a registry now recovers endpoint/version (self-healing fallback); with a registry still reuses the live instance.
- `add_model` keeps same-class/same-id models with different endpoints distinct, and still dedupes identical ones.
- `Registry.get_model` disambiguates by connection params and declines (returns `None` + warns) when candidates are indistinguishable.

No cookbook added: this is a serialization-layer change with no new user-facing API surface. The 23 unrelated failures in `test_parse_tool_calls_name.py` seen locally are missing optional SDKs (groq/huggingface/cerebras/watsonx) in the dev venv, not regressions.

Follow-up still open: `reasoning_model`/`parser_model`/`output_model` reconstruction stubs in `_storage.py` should get the same `resolve_model` treatment.