### PR TITLE
feat: add frontend tools support to AG-UI interface

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/agentic_chat.py
+++ b/cookbook/05_agent_os/interfaces/agui/agentic_chat.py
@@ -2,12 +2,11 @@
 Agentic Chat — Dojo Demo
 ========================
 
-Frontend tool: change_background (external_execution)
-Backend tool: get_weather (renders as card via useRenderTool)
+Frontend tool: change_background — defined by Dojo via useFrontendTool, sent to backend
+    in run_input.tools, automatically converted to external_execution=True Functions
+Backend tool: get_weather — defined here, renders as card via useRenderTool on Dojo
 
-Dojo expects:
-- change_background(background: str) -> changes CSS background
-- get_weather(location: str) -> dict with city, temperature, humidity, wind_speed, conditions
+The agent only defines backend tools. Frontend tools come from the UI at runtime.
 """
 
 from agno.agent.agent import Agent
@@ -15,35 +14,65 @@ from agno.models.openai import OpenAIResponses
 from agno.tools import tool
 
 
-@tool(external_execution=True, external_execution_silent=True)
-def change_background(background: str) -> str:
-    """Change the background color of the chat. Can be anything that the CSS background attribute accepts. Regular colors, linear or radial gradients etc."""
-    return f"Background changed to {background}"
-
-
 @tool
 def get_weather(location: str) -> dict:
     """Get the current weather for a location."""
     data = {
-        "San Francisco": {"city": "San Francisco", "temperature": 18, "humidity": 65, "wind_speed": 12, "conditions": "Sunny"},
-        "New York": {"city": "New York", "temperature": 22, "humidity": 55, "wind_speed": 8, "conditions": "Cloudy"},
-        "Tokyo": {"city": "Tokyo", "temperature": 26, "humidity": 70, "wind_speed": 5, "conditions": "Rainy"},
-        "London": {"city": "London", "temperature": 15, "humidity": 80, "wind_speed": 15, "conditions": "Overcast"},
-        "Paris": {"city": "Paris", "temperature": 20, "humidity": 60, "wind_speed": 10, "conditions": "Partly cloudy"},
+        "San Francisco": {
+            "city": "San Francisco",
+            "temperature": 18,
+            "humidity": 65,
+            "wind_speed": 12,
+            "conditions": "Sunny",
+        },
+        "New York": {
+            "city": "New York",
+            "temperature": 22,
+            "humidity": 55,
+            "wind_speed": 8,
+            "conditions": "Cloudy",
+        },
+        "Tokyo": {
+            "city": "Tokyo",
+            "temperature": 26,
+            "humidity": 70,
+            "wind_speed": 5,
+            "conditions": "Rainy",
+        },
+        "London": {
+            "city": "London",
+            "temperature": 15,
+            "humidity": 80,
+            "wind_speed": 15,
+            "conditions": "Overcast",
+        },
+        "Paris": {
+            "city": "Paris",
+            "temperature": 20,
+            "humidity": 60,
+            "wind_speed": 10,
+            "conditions": "Partly cloudy",
+        },
     }
-    return data.get(location, {"city": location, "temperature": 20, "humidity": 60, "wind_speed": 10, "conditions": "Partly cloudy"})
+    return data.get(
+        location,
+        {
+            "city": location,
+            "temperature": 20,
+            "humidity": 60,
+            "wind_speed": 10,
+            "conditions": "Partly cloudy",
+        },
+    )
 
 
 agentic_chat_agent = Agent(
     name="agentic_chat",
     model=OpenAIResponses(id="gpt-5.5"),
-    tools=[change_background, get_weather],
-    instructions="""You are a helpful assistant with frontend and backend capabilities.
+    tools=[get_weather],
+    instructions="""You are a helpful assistant.
 
-Tools available:
-- change_background: Changes the page background. Accepts CSS values (colors, gradients). Only use when explicitly asked.
-- get_weather: Gets weather for a location. Returns temperature, humidity, wind speed, and conditions.
-
-Be helpful and use tools when appropriate.""",
+Use the tools available to help the user. The frontend may provide additional tools
+like change_background — use them when the user asks.""",
     markdown=True,
 )

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -1313,6 +1313,7 @@ def run_dispatch(
     output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
+    client_tools: Optional[List[Any]] = None,
     **kwargs: Any,
 ) -> Union[RunOutput, Iterator[Union[RunOutputEvent, RunOutput]]]:
     """Run the Agent and return the response."""
@@ -1408,6 +1409,10 @@ def run_dispatch(
         knowledge_filters_provided=knowledge_filters is not None,
         metadata_provided=metadata is not None,
     )
+
+    # Set client_tools on run_context for per-run additive tools (e.g., AG-UI frontend tools)
+    if client_tools:
+        run_context.client_tools = client_tools
 
     # Prepare arguments for the model (must be after run_context is fully initialized)
     response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
@@ -2760,6 +2765,7 @@ def arun_dispatch(  # type: ignore
     yield_run_output: Optional[bool] = None,
     debug_mode: Optional[bool] = None,
     background: bool = False,
+    client_tools: Optional[List[Any]] = None,
     **kwargs: Any,
 ) -> Union[RunOutput, AsyncIterator[RunOutputEvent]]:
     """Async Run the Agent and return the response."""
@@ -2859,6 +2865,10 @@ def arun_dispatch(  # type: ignore
         knowledge_filters_provided=knowledge_filters is not None,
         metadata_provided=metadata is not None,
     )
+
+    # Set client_tools on run_context for per-run additive tools (e.g., AG-UI frontend tools)
+    if client_tools:
+        run_context.client_tools = client_tools
 
     # Prepare arguments for the model (must be after run_context is fully initialized)
     response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
@@ -4135,6 +4145,7 @@ def acontinue_run_dispatch(  # type: ignore
     debug_mode: Optional[bool] = None,
     yield_run_output: bool = False,
     background: bool = False,
+    client_tools: Optional[List[Any]] = None,
     **kwargs,
 ) -> Union[RunOutput, AsyncIterator[Union[RunOutputEvent, RunOutput]]]:
     """Continue a previous run.
@@ -4240,6 +4251,10 @@ def acontinue_run_dispatch(  # type: ignore
         metadata_provided=metadata is not None,
     )
 
+
+    # Set client_tools on run_context for per-run additive tools (e.g., AG-UI frontend tools)
+    if client_tools:
+        run_context.client_tools = client_tools
     response_format = get_response_format(agent, run_context=run_context) if agent.parser_model is None else None
 
     if background:

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -125,8 +125,14 @@ def get_tools(
 
     # Merge per-run client tools into run_context.tools after factory resolution.
     # Creates new list to avoid mutating cached factory results.
+    # Base priority: run_context.tools (factory-resolved) > agent.tools (static)
     if run_context.client_tools:
-        base = run_context.tools if run_context.tools is not None else []
+        if run_context.tools is not None:
+            base = run_context.tools
+        elif isinstance(agent.tools, list):
+            base = agent.tools
+        else:
+            base = []
         run_context.tools = list(base) + list(run_context.client_tools)
         run_context.client_tools = None
 
@@ -236,8 +242,14 @@ async def aget_tools(
 
     # Merge per-run client tools into run_context.tools after factory resolution.
     # Creates new list to avoid mutating cached factory results.
+    # Base priority: run_context.tools (factory-resolved) > agent.tools (static)
     if run_context.client_tools:
-        base = run_context.tools if run_context.tools is not None else []
+        if run_context.tools is not None:
+            base = run_context.tools
+        elif isinstance(agent.tools, list):
+            base = agent.tools
+        else:
+            base = []
         run_context.tools = list(base) + list(run_context.client_tools)
         run_context.client_tools = None
 

--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -123,6 +123,13 @@ def get_tools(
     resolve_callable_tools(agent, run_context)
     resolve_callable_knowledge(agent, run_context)
 
+    # Merge per-run client tools into run_context.tools after factory resolution.
+    # Creates new list to avoid mutating cached factory results.
+    if run_context.client_tools:
+        base = run_context.tools if run_context.tools is not None else []
+        run_context.tools = list(base) + list(run_context.client_tools)
+        run_context.client_tools = None
+
     resolved_tools = get_resolved_tools(agent, run_context)
     resolved_knowledge = get_resolved_knowledge(agent, run_context)
 
@@ -226,6 +233,13 @@ async def aget_tools(
     # Resolve callable factories
     await aresolve_callable_tools(agent, run_context)
     await aresolve_callable_knowledge(agent, run_context)
+
+    # Merge per-run client tools into run_context.tools after factory resolution.
+    # Creates new list to avoid mutating cached factory results.
+    if run_context.client_tools:
+        base = run_context.tools if run_context.tools is not None else []
+        run_context.tools = list(base) + list(run_context.client_tools)
+        run_context.client_tools = None
 
     resolved_tools = get_resolved_tools(agent, run_context)
     resolved_knowledge = get_resolved_knowledge(agent, run_context)

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1357,6 +1357,7 @@ class Agent:
         metadata: Optional[Dict[str, Any]] = None,
         output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
         debug_mode: Optional[bool] = None,
+        client_tools: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> RunOutput: ...
 
@@ -1385,6 +1386,7 @@ class Agent:
         output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
         yield_run_output: bool = False,
         debug_mode: Optional[bool] = None,
+        client_tools: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> Iterator[Union[RunOutputEvent, RunOutput]]: ...
 
@@ -1412,6 +1414,7 @@ class Agent:
         output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
         yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
+        client_tools: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> Union[RunOutput, Iterator[Union[RunOutputEvent, RunOutput]]]:
         return _run.run_dispatch(
@@ -1437,6 +1440,7 @@ class Agent:
             output_schema=output_schema,
             yield_run_output=yield_run_output,
             debug_mode=debug_mode,
+            client_tools=client_tools,
             **kwargs,
         )
 
@@ -1465,6 +1469,7 @@ class Agent:
         output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
         debug_mode: Optional[bool] = None,
         background: bool = False,
+        client_tools: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> Coroutine[Any, Any, RunOutput]: ...
 
@@ -1492,6 +1497,7 @@ class Agent:
         output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None,
         yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
+        client_tools: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> AsyncIterator[Union[RunOutputEvent, RunOutput]]: ...
 
@@ -1520,6 +1526,7 @@ class Agent:
         yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         background: bool = False,
+        client_tools: Optional[List[Any]] = None,
         **kwargs: Any,
     ) -> Union[RunOutput, AsyncIterator[RunOutputEvent]]:
         return _run.arun_dispatch(
@@ -1546,6 +1553,7 @@ class Agent:
             yield_run_output=yield_run_output,
             debug_mode=debug_mode,
             background=background,
+            client_tools=client_tools,
             **kwargs,
         )
 
@@ -1699,6 +1707,7 @@ class Agent:
         debug_mode: Optional[bool] = None,
         yield_run_output: bool = False,
         background: bool = False,
+        client_tools: Optional[List[Any]] = None,
         **kwargs,
     ) -> Union[RunOutput, AsyncIterator[Union[RunOutputEvent, RunOutput]]]:
         return _run.acontinue_run_dispatch(
@@ -1724,6 +1733,7 @@ class Agent:
             debug_mode=debug_mode,
             yield_run_output=yield_run_output,
             background=background,
+            client_tools=client_tools,
             **kwargs,
         )
 

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -26,6 +26,7 @@ from ag_ui.core import (
 )
 
 from agno.os.interfaces.agui.state import StreamState
+from agno.os.interfaces.agui.utils import to_json_str
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunContentEvent, RunEvent
 from agno.run.base import BaseRunOutputEvent
@@ -190,13 +191,15 @@ def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     state.end_tool_call(tool.tool_call_id)
 
     if tool.result is not None:
+        content = to_json_str(tool.result)
         events.append(
             ToolCallResultEvent(
                 type=EventType.TOOL_CALL_RESULT,
                 tool_call_id=tool.tool_call_id,
-                content=str(tool.result),
+                content=content,
                 role="tool",
-                message_id=str(uuid.uuid4()),
+                # Use tool_call_id as message_id so frontend can link result to the tool call
+                message_id=tool.tool_call_id,
             )
         )
 

--- a/libs/agno/agno/os/interfaces/agui/input.py
+++ b/libs/agno/agno/os/interfaces/agui/input.py
@@ -5,9 +5,12 @@ from dataclasses import asdict, is_dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from ag_ui.core.types import Message as AGUIMessage
+from ag_ui.core.types import Tool as AGUITool
+from ag_ui.core.types import ToolMessage as AGUIToolMessage
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
+from agno.tools.function import Function
 from agno.utils.log import log_warning
 
 
@@ -163,3 +166,40 @@ def _decode_base64(value: str) -> Optional[bytes]:
     except Exception:
         log_warning("Failed to decode base64 content")
         return None
+
+
+def extract_tool_messages(messages: List[AGUIMessage]) -> List[AGUIToolMessage]:
+    """Return trailing tool-role messages, indicating a tool-resume request.
+
+    When AG-UI frontends resume a paused run (external_execution tools), they append
+    ToolMessages at the end of the history. If the tail of the list is entirely
+    tool-role messages, this is a resume — not a fresh user turn.
+    """
+    tool_msgs: List[AGUIToolMessage] = []
+    for msg in reversed(messages):
+        if msg.role == "tool":
+            tool_msgs.append(msg)  # type: ignore[arg-type]
+        else:
+            break
+    return list(reversed(tool_msgs))
+
+
+def agui_tools_to_external_functions(agui_tools: Optional[List[AGUITool]]) -> List[Function]:
+    """Convert AG-UI tool definitions to Agno Functions with external_execution=True.
+
+    Frontend tools execute in the browser, not on the server. Setting
+    external_execution=True tells the agent to pause after generating the tool call,
+    yielding control back to the frontend for execution.
+    """
+    if not agui_tools:
+        return []
+    return [
+        Function(
+            name=tool.name,
+            description=tool.description,
+            parameters=tool.parameters or {"type": "object", "properties": {}},
+            external_execution=True,
+            external_execution_silent=True,
+        )
+        for tool in agui_tools
+    ]

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -21,8 +21,17 @@ from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
-from agno.os.interfaces.agui.input import extract_context, extract_media, extract_user_input, validate_state
+from agno.models.response import ToolExecution
+from agno.os.interfaces.agui.input import (
+    agui_tools_to_external_functions,
+    extract_context,
+    extract_media,
+    extract_tool_messages,
+    extract_user_input,
+    validate_state,
+)
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
+from agno.run.requirement import RunRequirement
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
 
@@ -35,11 +44,6 @@ async def run_entity(
     run_id = run_input.run_id or str(uuid.uuid4())
 
     try:
-        # AG-UI frontends send full conversation history every request.
-        # Extract only the last user message — entity manages history via session DB.
-        user_input = extract_user_input(run_input.messages or [])
-        images, audio, videos, files = extract_media(run_input.messages or [])
-
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
         user_id = run_input.forwarded_props.get("user_id") if run_input.forwarded_props else None
@@ -54,20 +58,62 @@ async def run_entity(
             run_kwargs["dependencies"] = ui_deps
             run_kwargs["add_dependencies_to_context"] = True
 
-        response_stream = entity.arun(  # type: ignore
-            input=user_input,
-            session_id=run_input.thread_id,
-            stream=True,
-            stream_events=True,
-            user_id=user_id,
-            images=images or None,
-            audio=audio or None,
-            videos=videos or None,
-            files=files or None,
-            session_state=session_state,
-            run_id=run_id,
-            **run_kwargs,
-        )
+        # 1. Check for trailing tool messages (resume request from frontend tools)
+        tool_messages = extract_tool_messages(run_input.messages or [])
+
+        # Convert frontend tools for both fresh and resume paths
+        frontend_tools = agui_tools_to_external_functions(run_input.tools)
+
+        if tool_messages:
+            # Resume paused run with tool results
+            if run_input.run_id is None:
+                yield RunErrorEvent(
+                    type=EventType.RUN_ERROR,
+                    message="Cannot resume paused run: run_id not provided in request.",
+                )
+                return
+
+            requirements = [
+                RunRequirement(
+                    tool_execution=ToolExecution(
+                        tool_call_id=msg.tool_call_id,
+                        external_execution_required=True,
+                        result=msg.content or "",
+                    )
+                )
+                for msg in tool_messages
+            ]
+
+            response_stream = entity.acontinue_run(  # type: ignore
+                run_id=run_input.run_id,
+                session_id=run_input.thread_id,
+                stream=True,
+                stream_events=True,
+                user_id=user_id,
+                requirements=requirements,
+                client_tools=frontend_tools or None,
+                **run_kwargs,
+            )
+        else:
+            # 2. Fresh user turn — extract input and run
+            user_input = extract_user_input(run_input.messages or [])
+            images, audio, videos, files = extract_media(run_input.messages or [])
+
+            response_stream = entity.arun(  # type: ignore
+                input=user_input,
+                session_id=run_input.thread_id,
+                stream=True,
+                stream_events=True,
+                user_id=user_id,
+                images=images or None,
+                audio=audio or None,
+                videos=videos or None,
+                files=files or None,
+                session_state=session_state,
+                run_id=run_id,
+                client_tools=frontend_tools or None,
+                **run_kwargs,
+            )
 
         async for event in async_stream_agno_response_as_agui_events(
             response_stream=response_stream,  # type: ignore

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -3,19 +3,23 @@ import json
 
 
 def to_json_str(value: str) -> str:
-    # 1. Already valid JSON
+    # Tool results arrive as strings but may be Python repr format ("{'key': 'value'}")
+    # because base.py uses str(dict). Frontend needs valid JSON for JSON.parse().
+
+    # 1. Already valid JSON — pass through unchanged
     try:
         json.loads(value)
         return value
     except (json.JSONDecodeError, TypeError):
         pass
 
-    # 2. Python repr (dict/list/bool/None)
+    # 2. Python repr — parse with ast.literal_eval (safe, literals only), then serialize as JSON
+    # Handles: "{'a': 1}" → {"a": 1}, "True" → true, "None" → null
     try:
         obj = ast.literal_eval(value)
         return json.dumps(obj)
     except (ValueError, SyntaxError):
         pass
 
-    # 3. Plain string
+    # 3. Plain string — wrap as JSON string literal
     return json.dumps(value)

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -1,0 +1,27 @@
+import ast
+import json
+
+
+def to_json_str(value: str) -> str:
+    """Convert a string value to valid JSON for frontend parsing.
+
+    Tool results arrive as strings that may be Python repr format,
+    already valid JSON, or plain strings. This normalizes them to
+    valid JSON that JavaScript can JSON.parse().
+    """
+    # 1. Already valid JSON
+    try:
+        json.loads(value)
+        return value
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # 2. Python repr (dict/list/bool/None)
+    try:
+        obj = ast.literal_eval(value)
+        return json.dumps(obj)
+    except (ValueError, SyntaxError):
+        pass
+
+    # 3. Plain string
+    return json.dumps(value)

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -3,12 +3,6 @@ import json
 
 
 def to_json_str(value: str) -> str:
-    """Convert a string value to valid JSON for frontend parsing.
-
-    Tool results arrive as strings that may be Python repr format,
-    already valid JSON, or plain strings. This normalizes them to
-    valid JSON that JavaScript can JSON.parse().
-    """
     # 1. Already valid JSON
     try:
         json.loads(value)

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -38,6 +38,10 @@ class RunContext:
     knowledge: Optional[Any] = None
     members: Optional[List[Any]] = None
 
+    # Per-run additive tools from the client (e.g., AG-UI frontend tools)
+    # Merged AFTER agent.tools during tool resolution
+    client_tools: Optional[List[Any]] = None
+
 
 @dataclass
 class BaseRunOutputEvent:

--- a/libs/agno/tests/unit/app/test_agui_client_tools.py
+++ b/libs/agno/tests/unit/app/test_agui_client_tools.py
@@ -1,22 +1,17 @@
-"""Tests for AG-UI client_tools (frontend tools) support."""
-
-import pytest
-from ag_ui.core import EventType
-from ag_ui.core.types import Tool as AGUITool, ToolMessage, UserMessage
+from ag_ui.core.types import Tool as AGUITool
+from ag_ui.core.types import ToolMessage, UserMessage
 
 from agno.os.interfaces.agui.input import agui_tools_to_external_functions, extract_tool_messages
 from agno.tools.function import Function
 
 
 def test_extract_tool_messages_empty():
-    """No tool messages returns empty list."""
     messages = [UserMessage(id="u1", content="hello")]
     result = extract_tool_messages(messages)
     assert result == []
 
 
 def test_extract_tool_messages_trailing_tools():
-    """Trailing tool messages are extracted in order."""
     messages = [
         UserMessage(id="u1", content="hello"),
         ToolMessage(id="t1", tool_call_id="call_1", content="result 1"),
@@ -29,7 +24,6 @@ def test_extract_tool_messages_trailing_tools():
 
 
 def test_extract_tool_messages_non_trailing_ignored():
-    """Tool messages not at the end are NOT extracted (only trailing)."""
     messages = [
         ToolMessage(id="t1", tool_call_id="call_1", content="old result"),
         UserMessage(id="u1", content="follow up"),
@@ -39,13 +33,11 @@ def test_extract_tool_messages_non_trailing_ignored():
 
 
 def test_agui_tools_to_external_functions_empty():
-    """Empty tools list returns empty list."""
     assert agui_tools_to_external_functions(None) == []
     assert agui_tools_to_external_functions([]) == []
 
 
 def test_agui_tools_to_external_functions_converts():
-    """AG-UI tools are converted to Functions with external_execution=True."""
     agui_tools = [
         AGUITool(
             name="change_background",
@@ -63,13 +55,11 @@ def test_agui_tools_to_external_functions_converts():
     assert len(result) == 2
     assert all(isinstance(f, Function) for f in result)
 
-    # Check first tool
     assert result[0].name == "change_background"
     assert result[0].description == "Change the page background color"
     assert result[0].external_execution is True
     assert result[0].external_execution_silent is True
     assert result[0].parameters == {"type": "object", "properties": {"color": {"type": "string"}}}
 
-    # Check second tool (no parameters)
     assert result[1].name == "show_modal"
     assert result[1].parameters == {"type": "object", "properties": {}}

--- a/libs/agno/tests/unit/app/test_agui_client_tools.py
+++ b/libs/agno/tests/unit/app/test_agui_client_tools.py
@@ -1,0 +1,75 @@
+"""Tests for AG-UI client_tools (frontend tools) support."""
+
+import pytest
+from ag_ui.core import EventType
+from ag_ui.core.types import Tool as AGUITool, ToolMessage, UserMessage
+
+from agno.os.interfaces.agui.input import agui_tools_to_external_functions, extract_tool_messages
+from agno.tools.function import Function
+
+
+def test_extract_tool_messages_empty():
+    """No tool messages returns empty list."""
+    messages = [UserMessage(id="u1", content="hello")]
+    result = extract_tool_messages(messages)
+    assert result == []
+
+
+def test_extract_tool_messages_trailing_tools():
+    """Trailing tool messages are extracted in order."""
+    messages = [
+        UserMessage(id="u1", content="hello"),
+        ToolMessage(id="t1", tool_call_id="call_1", content="result 1"),
+        ToolMessage(id="t2", tool_call_id="call_2", content="result 2"),
+    ]
+    result = extract_tool_messages(messages)
+    assert len(result) == 2
+    assert result[0].tool_call_id == "call_1"
+    assert result[1].tool_call_id == "call_2"
+
+
+def test_extract_tool_messages_non_trailing_ignored():
+    """Tool messages not at the end are NOT extracted (only trailing)."""
+    messages = [
+        ToolMessage(id="t1", tool_call_id="call_1", content="old result"),
+        UserMessage(id="u1", content="follow up"),
+    ]
+    result = extract_tool_messages(messages)
+    assert result == []
+
+
+def test_agui_tools_to_external_functions_empty():
+    """Empty tools list returns empty list."""
+    assert agui_tools_to_external_functions(None) == []
+    assert agui_tools_to_external_functions([]) == []
+
+
+def test_agui_tools_to_external_functions_converts():
+    """AG-UI tools are converted to Functions with external_execution=True."""
+    agui_tools = [
+        AGUITool(
+            name="change_background",
+            description="Change the page background color",
+            parameters={"type": "object", "properties": {"color": {"type": "string"}}},
+        ),
+        AGUITool(
+            name="show_modal",
+            description="Show a modal dialog",
+        ),
+    ]
+
+    result = agui_tools_to_external_functions(agui_tools)
+
+    assert len(result) == 2
+    assert all(isinstance(f, Function) for f in result)
+
+    # Check first tool
+    assert result[0].name == "change_background"
+    assert result[0].description == "Change the page background color"
+    assert result[0].external_execution is True
+    assert result[0].external_execution_silent is True
+    assert result[0].parameters == {"type": "object", "properties": {"color": {"type": "string"}}}
+
+    # Check second tool (no parameters)
+    assert result[1].name == "show_modal"
+    assert result[1].parameters == {"type": "object", "properties": {}}

--- a/libs/agno/tests/unit/app/test_agui_client_tools.py
+++ b/libs/agno/tests/unit/app/test_agui_client_tools.py
@@ -2,10 +2,18 @@ from ag_ui.core.types import Tool as AGUITool
 from ag_ui.core.types import ToolMessage, UserMessage
 
 from agno.os.interfaces.agui.input import agui_tools_to_external_functions, extract_tool_messages
+from agno.os.interfaces.agui.utils import to_json_str
 from agno.tools.function import Function
 
 
-def test_extract_tool_messages_empty():
+# extract_tool_messages tests
+
+def test_extract_tool_messages_empty_list():
+    result = extract_tool_messages([])
+    assert result == []
+
+
+def test_extract_tool_messages_no_tools():
     messages = [UserMessage(id="u1", content="hello")]
     result = extract_tool_messages(messages)
     assert result == []
@@ -31,6 +39,52 @@ def test_extract_tool_messages_non_trailing_ignored():
     result = extract_tool_messages(messages)
     assert result == []
 
+
+def test_extract_tool_messages_all_tools():
+    messages = [
+        ToolMessage(id="t1", tool_call_id="call_1", content="result 1"),
+        ToolMessage(id="t2", tool_call_id="call_2", content="result 2"),
+    ]
+    result = extract_tool_messages(messages)
+    assert len(result) == 2
+    assert result[0].tool_call_id == "call_1"
+    assert result[1].tool_call_id == "call_2"
+
+
+def test_extract_tool_messages_only_trailing_block():
+    # Only the trailing contiguous tool block should be returned
+    messages = [
+        UserMessage(id="u1", content="first"),
+        ToolMessage(id="t1", tool_call_id="call_old", content="old"),
+        UserMessage(id="u2", content="second"),
+        ToolMessage(id="t2", tool_call_id="call_new", content="new"),
+    ]
+    result = extract_tool_messages(messages)
+    assert len(result) == 1
+    assert result[0].tool_call_id == "call_new"
+
+
+def test_extract_tool_messages_with_error():
+    messages = [
+        UserMessage(id="u1", content="hello"),
+        ToolMessage(id="t1", tool_call_id="call_1", content="", error="something failed"),
+    ]
+    result = extract_tool_messages(messages)
+    assert len(result) == 1
+    assert result[0].error == "something failed"
+
+
+def test_extract_tool_messages_empty_content():
+    messages = [
+        UserMessage(id="u1", content="hello"),
+        ToolMessage(id="t1", tool_call_id="call_1", content=""),
+    ]
+    result = extract_tool_messages(messages)
+    assert len(result) == 1
+    assert result[0].content == ""
+
+
+# agui_tools_to_external_functions tests
 
 def test_agui_tools_to_external_functions_empty():
     assert agui_tools_to_external_functions(None) == []
@@ -63,3 +117,112 @@ def test_agui_tools_to_external_functions_converts():
 
     assert result[1].name == "show_modal"
     assert result[1].parameters == {"type": "object", "properties": {}}
+
+
+def test_agui_tools_all_have_external_execution():
+    agui_tools = [
+        AGUITool(name="tool_1", description="First"),
+        AGUITool(name="tool_2", description="Second"),
+        AGUITool(name="tool_3", description="Third"),
+    ]
+    result = agui_tools_to_external_functions(agui_tools)
+
+    for func in result:
+        assert func.external_execution is True
+        assert func.external_execution_silent is True
+
+
+def test_agui_tools_no_entrypoint():
+    # Frontend tools execute in browser, not server - no entrypoint
+    agui_tools = [AGUITool(name="browser_tool", description="Runs in browser")]
+    result = agui_tools_to_external_functions(agui_tools)
+
+    assert result[0].entrypoint is None
+
+
+def test_agui_tools_empty_description():
+    # AGUITool requires description, test with empty string
+    agui_tools = [AGUITool(name="no_desc", description="")]
+    result = agui_tools_to_external_functions(agui_tools)
+
+    assert result[0].name == "no_desc"
+    assert result[0].description == ""
+
+
+def test_agui_tools_preserves_complex_schema():
+    complex_params = {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "count": {"type": "integer"},
+            "options": {
+                "type": "object",
+                "properties": {"enabled": {"type": "boolean"}},
+            },
+            "tags": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": ["name"],
+    }
+    agui_tools = [AGUITool(name="complex", description="Complex tool", parameters=complex_params)]
+    result = agui_tools_to_external_functions(agui_tools)
+
+    assert result[0].parameters == complex_params
+
+
+def test_agui_tools_preserves_order():
+    agui_tools = [
+        AGUITool(name="alpha", description="First"),
+        AGUITool(name="beta", description="Second"),
+        AGUITool(name="gamma", description="Third"),
+    ]
+    result = agui_tools_to_external_functions(agui_tools)
+
+    assert [f.name for f in result] == ["alpha", "beta", "gamma"]
+
+
+# to_json_str tests
+
+def test_to_json_str_valid_json_passthrough():
+    valid_json = '{"city": "Tokyo", "temp": 26}'
+    result = to_json_str(valid_json)
+    assert result == valid_json
+
+
+def test_to_json_str_python_repr_dict():
+    python_repr = "{'city': 'Tokyo', 'temp': 26}"
+    result = to_json_str(python_repr)
+    assert result == '{"city": "Tokyo", "temp": 26}'
+
+
+def test_to_json_str_python_repr_list():
+    python_repr = "[1, 2, 3]"
+    result = to_json_str(python_repr)
+    assert result == "[1, 2, 3]"
+
+
+def test_to_json_str_python_repr_bool():
+    assert to_json_str("True") == "true"
+    assert to_json_str("False") == "false"
+
+
+def test_to_json_str_python_repr_none():
+    assert to_json_str("None") == "null"
+
+
+def test_to_json_str_plain_string():
+    result = to_json_str("hello world")
+    assert result == '"hello world"'
+
+
+def test_to_json_str_nested_structure():
+    python_repr = "{'user': {'name': 'Bob', 'tags': ['a', 'b']}}"
+    result = to_json_str(python_repr)
+    assert result == '{"user": {"name": "Bob", "tags": ["a", "b"]}}'
+
+
+def test_to_json_str_empty_dict():
+    assert to_json_str("{}") == "{}"
+
+
+def test_to_json_str_empty_list():
+    assert to_json_str("[]") == "[]"


### PR DESCRIPTION
## Summary

Adds minimal support for frontend tools (external execution) in the AG-UI interface:

- **`extract_tool_messages()`** — Detects resume requests by scanning for trailing tool-role messages in the message history
- **`agui_tools_to_external_functions()`** — Converts AG-UI tool definitions to Agno `Function` objects with `external_execution=True`
- **Resume branch in `run_entity()`** — If tool messages are present, calls `acontinue_run()` with `RunRequirement` objects; otherwise calls `arun()` with frontend tools injected

### How it works

1. Frontend sends `tools` array with tool definitions (e.g., `useCopilotAction` from CopilotKit)
2. Agent sees these as external-execution functions and pauses after generating tool calls
3. Frontend executes the tools in the browser
4. Frontend sends resume request with tool results as trailing ToolMessages
5. Router detects the tool messages, builds `RunRequirement` list, calls `acontinue_run()`

Fixes #7801

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Format and validate: `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Changes don't introduce new type errors