### PR TITLE
fix: await async cancellation check in async delegate paths

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -48,6 +48,7 @@ from agno.run.agent import (
     RunOutputEvent,
 )
 from agno.run.cancel import (
+    araise_if_cancelled,
     aregister_member_run,
     raise_if_cancelled,
     register_member_drain_task,
@@ -858,7 +859,7 @@ def _get_delegate_task_function(
 
                     try:
                         if run_response.run_id is not None:
-                            raise_if_cancelled(run_response.run_id)
+                            await araise_if_cancelled(run_response.run_id)
                     except RunCancelledException:
                         if member_run_id:
                             await _acascading_cancel_run(member_run_id)
@@ -894,7 +895,7 @@ def _get_delegate_task_function(
                 check_if_run_cancelled(member_agent_run_response)  # type: ignore
                 # Also check if the parent team's run was cancelled while the member was executing
                 if run_response.run_id is not None:
-                    raise_if_cancelled(run_response.run_id)
+                    await araise_if_cancelled(run_response.run_id)
         except RunCancelledException:
             use_team_logger()
             _process_delegate_task_to_member(
@@ -1208,7 +1209,7 @@ def _get_delegate_task_function(
                             # Check if the parent team's run is cancelled - propagate to member
                             try:
                                 if run_response.run_id is not None:
-                                    raise_if_cancelled(run_response.run_id)
+                                    await araise_if_cancelled(run_response.run_id)
                             except RunCancelledException:
                                 if member_run_id:
                                     await _acascading_cancel_run(member_run_id)
@@ -1312,7 +1313,7 @@ def _get_delegate_task_function(
                         )
                         check_if_run_cancelled(member_agent_run_response)
                         if run_response.run_id is not None:
-                            raise_if_cancelled(run_response.run_id)
+                            await araise_if_cancelled(run_response.run_id)
                     except RunCancelledException:
                         _process_delegate_task_to_member(
                             member_agent_run_response,

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -38,7 +38,7 @@ from agno.run.agent import (
     RunOutputEvent,
 )
 from agno.run.base import RunStatus
-from agno.run.cancel import aregister_member_run, raise_if_cancelled, register_member_run
+from agno.run.cancel import araise_if_cancelled, aregister_member_run, raise_if_cancelled, register_member_run
 from agno.run.team import (
     RunCancelledEvent as TeamMemberRunCancelledEvent,
 )
@@ -663,7 +663,7 @@ def _get_task_management_tools(
                     # Check if the parent team's run is cancelled - propagate to member
                     try:
                         if run_response.run_id is not None:
-                            raise_if_cancelled(run_response.run_id)
+                            await araise_if_cancelled(run_response.run_id)
                     except RunCancelledException:
                         if member_run_id:
                             await _acascading_cancel_run(member_run_id)
@@ -699,7 +699,7 @@ def _get_task_management_tools(
                 )
                 check_if_run_cancelled(member_run_response)
                 if run_response.run_id is not None:
-                    raise_if_cancelled(run_response.run_id)
+                    await araise_if_cancelled(run_response.run_id)
         except RunCancelledException:
             use_team_logger()
             _post_process_member_run(member_run_response, member_agent, member_agent_task, member_session_state_copy)

--- a/libs/agno/agno/tools/sql.py
+++ b/libs/agno/agno/tools/sql.py
@@ -150,7 +150,7 @@ class SQLTools(Toolkit):
             # DML (INSERT/UPDATE/DELETE) and DDL don't return rows — don't
             # try to fetch. The `sess.begin()` context still commits on
             # clean exit.
-            if not result.returns_rows:
+            if not result.returns_rows:  # type: ignore[attr-defined]
                 return []
 
             try:


### PR DESCRIPTION
The async team delegate paths called the SYNC raise_if_cancelled(), which routes through is_cancelled() -> _ensure_sync_client(). With an async-only RunCancellationManager (e.g. RedisRunCancellationManager constructed with only async_redis_client), every delegated member step raises "Sync Redis client not provided. Use async methods or provide a sync client.", breaking team delegation.

These call sites are all inside async functions, and the sibling register_member_run calls in the same functions already use the async aregister_member_run -- so the cancellation check was simply the odd one out. Switch the 6 sites to the awaited araise_if_cancelled() (already exported from agno.run.cancel):

- team/_default_tools.py: adelegate_task_to_member (stream + non-stream), stream_member, run_member_agent
- team/_task_tools.py: aexecute_task (stream + non-stream)

An AST scan of the whole package confirms no sync cancellation calls remain inside any async function after this change.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
