### PR TITLE
fix: apply self.timeout to BrightDataTools HTTP calls; add timeout to ClickUpTools

### DIFF
--- a/libs/agno/agno/tools/brightdata.py
+++ b/libs/agno/agno/tools/brightdata.py
@@ -82,7 +82,7 @@ class BrightDataTools(Toolkit):
             if self.verbose:
                 log_info(f"[Bright Data] Request: {payload['url']}")
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout)
 
             if response.status_code != 200:
                 raise Exception(f"Failed to scrape: {response.status_code} - {response.text}")
@@ -147,7 +147,7 @@ class BrightDataTools(Toolkit):
                 "data_format": "screenshot",
             }
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout)
 
             if response.status_code != 200:
                 raise Exception(f"Error {response.status_code}: {response.text}")
@@ -327,6 +327,7 @@ class BrightDataTools(Toolkit):
                 params={"dataset_id": dataset_id, "include_errors": "true"},
                 headers=self.headers,
                 json=[request_data],
+                timeout=self.timeout,
             )
 
             trigger_data = trigger_response.json()
@@ -346,6 +347,7 @@ class BrightDataTools(Toolkit):
                         f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
                         params={"format": "json"},
                         headers=self.headers,
+                        timeout=30,
                     )
 
                     snapshot_data = snapshot_response.json()

--- a/libs/agno/agno/tools/brightdata.py
+++ b/libs/agno/agno/tools/brightdata.py
@@ -347,6 +347,7 @@ class BrightDataTools(Toolkit):
                         f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
                         params={"format": "json"},
                         headers=self.headers,
+                        # Per-poll cap; self.timeout via max_attempts controls total polling budget
                         timeout=30,
                     )
 

--- a/libs/agno/agno/tools/clickup.py
+++ b/libs/agno/agno/tools/clickup.py
@@ -47,7 +47,7 @@ class ClickUpTools(Toolkit):
         """Make a request to the ClickUp API."""
         url = f"{self.base_url}/{endpoint}"
         try:
-            response = requests.request(method=method, url=url, headers=self.headers, params=params, json=data)
+            response = requests.request(method=method, url=url, headers=self.headers, params=params, json=data, timeout=30)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/libs/agno/tests/unit/tools/test_brightdata.py
+++ b/libs/agno/tests/unit/tools/test_brightdata.py
@@ -93,8 +93,69 @@ def test_make_request_success(brightdata_tools, mock_requests):
 
     assert result == "Success response"
     mock_requests.post.assert_called_once_with(
-        brightdata_tools.endpoint, headers=brightdata_tools.headers, data=json.dumps(payload)
+        brightdata_tools.endpoint, headers=brightdata_tools.headers, data=json.dumps(payload), timeout=brightdata_tools.timeout
     )
+
+
+def test_make_request_forwards_timeout(mock_requests):
+    """Test that _make_request forwards self.timeout to requests.post."""
+    tools = BrightDataTools(api_key="test_key", timeout=42)
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = "ok"
+    mock_requests.post.return_value = mock_response
+
+    tools._make_request({"url": "https://example.com"})
+
+    _, kwargs = mock_requests.post.call_args
+    assert kwargs["timeout"] == 42
+
+
+def test_get_screenshot_forwards_timeout(mock_requests):
+    """Test that get_screenshot forwards self.timeout to requests.post."""
+    tools = BrightDataTools(api_key="test_key", timeout=15)
+    agent = Mock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = b"fake_png"
+    mock_requests.post.return_value = mock_response
+
+    tools.get_screenshot(agent, "https://example.com")
+
+    _, kwargs = mock_requests.post.call_args
+    assert kwargs["timeout"] == 15
+
+
+def test_web_data_feed_trigger_forwards_timeout(mock_requests):
+    """Test that web_data_feed trigger request forwards self.timeout."""
+    tools = BrightDataTools(api_key="test_key", timeout=30)
+    mock_trigger = Mock()
+    mock_trigger.json.return_value = {"snapshot_id": "snap123"}
+    mock_snapshot = Mock()
+    mock_snapshot.json.return_value = {"data": "result"}
+    mock_requests.post.return_value = mock_trigger
+    mock_requests.get.return_value = mock_snapshot
+
+    tools.web_data_feed("amazon_product", "https://amazon.com/dp/B001")
+
+    _, kwargs = mock_requests.post.call_args
+    assert kwargs["timeout"] == 30
+
+
+def test_web_data_feed_polling_uses_fixed_timeout(mock_requests):
+    """Test that web_data_feed polling GET uses a fixed per-poll timeout of 30 s."""
+    tools = BrightDataTools(api_key="test_key", timeout=600)
+    mock_trigger = Mock()
+    mock_trigger.json.return_value = {"snapshot_id": "snap123"}
+    mock_snapshot = Mock()
+    mock_snapshot.json.return_value = {"data": "result"}
+    mock_requests.post.return_value = mock_trigger
+    mock_requests.get.return_value = mock_snapshot
+
+    tools.web_data_feed("amazon_product", "https://amazon.com/dp/B001")
+
+    _, kwargs = mock_requests.get.call_args
+    assert kwargs["timeout"] == 30
 
 
 def test_make_request_failure(brightdata_tools, mock_requests):

--- a/libs/agno/tests/unit/tools/test_clickup.py
+++ b/libs/agno/tests/unit/tools/test_clickup.py
@@ -1,0 +1,89 @@
+"""Unit tests for ClickUpTools class."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.tools.clickup import ClickUpTools
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    monkeypatch.setenv("CLICKUP_API_KEY", "test_api_key")
+    monkeypatch.setenv("MASTER_SPACE_ID", "test_space_id")
+
+
+@pytest.fixture
+def clickup_tools(mock_env):
+    return ClickUpTools()
+
+
+@pytest.fixture
+def mock_requests():
+    with patch("agno.tools.clickup.requests") as m:
+        yield m
+
+
+def _ok_response(json_data):
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = json_data
+    return resp
+
+
+class TestClickUpToolsInit:
+    def test_init_with_explicit_credentials(self):
+        tools = ClickUpTools(api_key="key", master_space_id="space")
+        assert tools.api_key == "key"
+        assert tools.master_space_id == "space"
+
+    def test_init_missing_api_key(self, monkeypatch):
+        monkeypatch.delenv("CLICKUP_API_KEY", raising=False)
+        monkeypatch.setenv("MASTER_SPACE_ID", "space")
+        with pytest.raises(ValueError, match="CLICKUP_API_KEY"):
+            ClickUpTools()
+
+    def test_init_missing_space_id(self, monkeypatch):
+        monkeypatch.setenv("CLICKUP_API_KEY", "key")
+        monkeypatch.delenv("MASTER_SPACE_ID", raising=False)
+        with pytest.raises(ValueError, match="MASTER_SPACE_ID"):
+            ClickUpTools()
+
+
+class TestClickUpMakeRequest:
+    def test_make_request_includes_timeout(self, clickup_tools, mock_requests):
+        """_make_request must pass timeout=30 to requests.request."""
+        mock_requests.request.return_value = _ok_response({"ok": True})
+
+        clickup_tools._make_request("GET", "team/space/123/space")
+
+        _, kwargs = mock_requests.request.call_args
+        assert kwargs.get("timeout") == 30
+
+    def test_make_request_returns_json(self, clickup_tools, mock_requests):
+        mock_requests.request.return_value = _ok_response({"spaces": []})
+
+        result = clickup_tools._make_request("GET", "team/space/123/space")
+
+        assert result == {"spaces": []}
+
+    def test_make_request_handles_error(self, clickup_tools, mock_requests):
+        import requests as req_lib
+
+        mock_requests.request.side_effect = req_lib.exceptions.ConnectionError("refused")
+        mock_requests.exceptions.RequestException = req_lib.exceptions.RequestException
+
+        result = clickup_tools._make_request("GET", "team/space/123/space")
+
+        assert "error" in result
+
+
+class TestClickUpListSpaces:
+    def test_list_spaces_uses_timeout(self, clickup_tools, mock_requests):
+        """list_spaces must route through _make_request, which uses timeout=30."""
+        mock_requests.request.return_value = _ok_response({"spaces": [{"id": "1", "name": "Dev"}]})
+
+        clickup_tools.list_spaces()
+
+        _, kwargs = mock_requests.request.call_args
+        assert kwargs.get("timeout") == 30


### PR DESCRIPTION
Fixes #8496

## Summary

- **BrightDataTools**: `__init__` accepts a configurable `timeout` parameter (default 600 s, documented as *"Timeout in seconds for operations"*) but none of the four HTTP call sites forwarded it — the user-supplied value was silently ignored. Fixed all four sites:
  - `_make_request()` — `requests.post(..., timeout=self.timeout)`
  - `get_screenshot()` — `requests.post(..., timeout=self.timeout)`
  - `web_data_feed()` trigger request — `requests.post(..., timeout=self.timeout)`
  - `web_data_feed()` polling GET — `requests.get(..., timeout=30)` (per-poll cap; `self.timeout` already controls the overall polling loop via `max_attempts`)

- **ClickUpTools**: the central `_make_request()` helper (used by all 7 ClickUp operations — `list_tasks`, `create_task`, `get_task`, `update_task`, `delete_task`, `list_spaces`, `list_lists`) had no `timeout` argument at all, so any ClickUp API call could hang indefinitely. Added `timeout=30`.

## Why this matters

Without timeouts, a slow or unresponsive upstream API stalls the calling thread/process forever. Both issues would be especially painful in long-running agent loops where a single hung HTTP call blocks the entire agent.

## Tests

- Updated `test_brightdata.py`: fixed `test_make_request_success` to expect `timeout=` in the call, and added four targeted tests verifying each HTTP call site forwards the correct timeout value.
- Added `test_clickup.py`: covers init validation (missing credentials) and verifies `_make_request` passes `timeout=30` to `requests.request`.