### PR TITLE
[fix] Avoid scheduler poll tight loop on transient errors

### DIFF
--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -416,7 +416,8 @@ class ScheduleExecutor:
                     params={"session_id": session_id},
                 )
             except Exception as exc:
-                log_warning(f"Poll request failed for run {run_id}: {exc}: {exc}")
+                log_warning(f"Poll request failed for run {run_id}: {exc}")
+                await asyncio.sleep(self.poll_interval)
                 continue
 
             if resp.status_code == 404:

--- a/libs/agno/tests/unit/scheduler/test_executor.py
+++ b/libs/agno/tests/unit/scheduler/test_executor.py
@@ -259,6 +259,23 @@ class TestExecutorPollRun:
         assert result["status"] == "success"
         assert call_count == 3
 
+    @pytest.mark.asyncio
+    @patch("agno.scheduler.executor.asyncio.sleep", new_callable=AsyncMock)
+    async def test_poll_request_exception_waits_before_retry(self, mock_sleep):
+        executor = ScheduleExecutor(base_url="http://localhost:8000", internal_service_token="tok", poll_interval=5)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json = MagicMock(return_value={"status": "COMPLETED"})
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=[RuntimeError("temporary outage"), mock_resp])
+
+        result = await executor._poll_run(mock_client, {}, "agents", "a1", "run-1", "sess-1", 60)
+
+        assert result["status"] == "success"
+        assert mock_client.request.await_count == 2
+        mock_sleep.assert_awaited_once_with(5)
+
 
 class TestExecutorExecute:
     """Test the full execute() flow with mocked DB and endpoint."""


### PR DESCRIPTION
## Summary

Fixes #8498 by making `ScheduleExecutor._poll_run()` wait for `poll_interval` before retrying when the run-status HTTP request raises a transient client exception.

The change also removes the duplicated exception text in the warning log and adds a regression test that verifies a failed poll request waits before retrying and then completes successfully.

(If applicable, issue number: #8498)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run locally:

- `uv run --with pytest --with pytest-asyncio --with httpx --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with fastapi --with PyJWT --with opentelemetry-sdk --with aiosqlite --with greenlet --with mcp -- python -m pytest libs/agno/tests/unit/scheduler -q` -> 76 passed, 2 skipped
- `uv run --with ruff==0.14.3 -- ruff format --check --config libs/agno/pyproject.toml libs/agno/agno/scheduler/executor.py libs/agno/tests/unit/scheduler/test_executor.py` -> passed
- `uv run --with ruff==0.14.3 -- ruff check --config libs/agno/pyproject.toml libs/agno/agno/scheduler/executor.py libs/agno/tests/unit/scheduler/test_executor.py` -> passed

I did not run the full `./scripts/format.sh` / `./scripts/validate.sh` path because resolving the full project test extras currently fails locally: `agno[a2a]` requires `httpx>=0.28.1`, while `agno[brave]` resolves through `brave-search<0.2.0` with `httpx>=0.25.2,<0.26.0` (and `brave-search==0.2.0` has invalid metadata). The targeted scheduler tests and ruff checks above cover this change.

This PR was generated with AI assistance and reviewed before submission.
