### PR TITLE
fix: guard against path traversal in LocalFileSystemTools

### DIFF
--- a/libs/agno/agno/tools/local_file_system.py
+++ b/libs/agno/agno/tools/local_file_system.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional
 from uuid import uuid4
@@ -54,6 +55,13 @@ class LocalFileSystemTools(Toolkit):
         try:
             filename = filename or str(uuid4())
             directory = directory or self.target_directory
+
+            # Guard against path traversal before any filename processing
+            base_dir = Path(directory).resolve()
+            test_path = (base_dir / filename).resolve()
+            if not str(test_path).startswith(str(base_dir) + os.sep) and test_path != base_dir:
+                return f"Error: Path traversal detected — '{filename}' resolves outside '{base_dir}'"
+
             if filename and "." in filename:
                 path_obj = Path(filename)
                 filename = path_obj.stem
@@ -64,7 +72,7 @@ class LocalFileSystemTools(Toolkit):
             extension = (extension or self.default_extension).lstrip(".")
 
             # Create directory if it doesn't exist
-            dir_path = Path(directory)
+            dir_path = base_dir
             dir_path.mkdir(parents=True, exist_ok=True)
 
             # Construct full filename with extension
@@ -84,7 +92,10 @@ class LocalFileSystemTools(Toolkit):
         """
         Read content from a local file.
         """
-        file_path = Path(directory or self.target_directory) / filename
+        base_dir = Path(directory or self.target_directory).resolve()
+        file_path = (base_dir / filename).resolve()
+        if not str(file_path).startswith(str(base_dir) + "/") and file_path != base_dir:
+            return f"Error: Path traversal detected — '{filename}' resolves outside '{base_dir}'"
         if not file_path.exists():
             return f"File not found: {file_path}"
         return file_path.read_text()

--- a/libs/agno/tests/unit/tools/test_local_file_system.py
+++ b/libs/agno/tests/unit/tools/test_local_file_system.py
@@ -1,0 +1,94 @@
+"""Tests for path traversal protection in LocalFileSystemTools."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agno.tools.local_file_system import LocalFileSystemTools
+
+
+@pytest.fixture
+def tmp_dir(tmp_path):
+    """Create a temp directory for testing."""
+    return str(tmp_path)
+
+
+@pytest.fixture
+def tools(tmp_dir):
+    """Create a LocalFileSystemTools instance."""
+    return LocalFileSystemTools(target_directory=tmp_dir, enable_write_file=True)
+
+
+class TestPathTraversalWriteFile:
+    """Tests for path traversal protection in write_file."""
+
+    def test_normal_write_succeeds(self, tools, tmp_dir):
+        """Normal file write should succeed."""
+        result = tools.write_file(content="hello", filename="test.txt")
+        assert "Successfully wrote" in result
+        assert Path(tmp_dir, "test.txt").exists()
+
+    def test_dot_dot_slash_blocked(self, tools):
+        """Path traversal with ../ should be blocked."""
+        result = tools.write_file(content="malicious", filename="../evil.txt")
+        assert "Path traversal detected" in result
+
+    def test_dot_dot_slash_nested_blocked(self, tools):
+        """Nested path traversal with ../../ should be blocked."""
+        result = tools.write_file(content="malicious", filename="../../etc/passwd")
+        assert "Path traversal detected" in result
+
+    def test_dot_dot_slash_in_directory_blocked(self, tools):
+        """Path traversal in directory parameter should be blocked."""
+        result = tools.write_file(content="malicious", filename="test", directory="/tmp/../../../etc")
+        assert "Path traversal detected" in result
+
+    def test_absolute_path_outside_base_blocked(self, tools):
+        """Absolute path outside base directory should be blocked."""
+        result = tools.write_file(content="malicious", filename="/etc/passwd")
+        assert "Path traversal detected" in result
+
+    def test_dot_dot_no_separator_still_blocked(self, tools):
+        """Path like '..' alone should be blocked."""
+        result = tools.write_file(content="malicious", filename="..")
+        assert "Path traversal detected" in result
+
+
+class TestPathTraversalReadFile:
+    """Tests for path traversal protection in read_file."""
+
+    def test_normal_read_succeeds(self, tools, tmp_dir):
+        """Normal file read should succeed."""
+        test_file = Path(tmp_dir, "readme.txt")
+        test_file.write_text("content")
+        result = tools.read_file(filename="readme.txt")
+        assert result == "content"
+
+    def test_dot_dot_slash_blocked(self, tools):
+        """Path traversal with ../ should be blocked."""
+        result = tools.read_file(filename="../etc/passwd")
+        assert "Path traversal detected" in result
+
+    def test_dot_dot_slash_nested_blocked(self, tools):
+        """Nested path traversal should be blocked."""
+        result = tools.read_file(filename="../../etc/shadow")
+        assert "Path traversal detected" in result
+
+    def test_absolute_path_outside_base_blocked(self, tools):
+        """Absolute path outside base should be blocked."""
+        result = tools.read_file(filename="/etc/passwd")
+        assert "Path traversal detected" in result
+
+    def test_dot_dot_alone_blocked(self, tools):
+        """Path '..' alone should be blocked."""
+        result = tools.read_file(filename="..")
+        assert "Path traversal detected" in result
+
+    def test_symlink_traversal_blocked(self, tools, tmp_dir):
+        """Symlink that escapes base directory should be blocked."""
+        link = Path(tmp_dir, "escape_link")
+        link.symlink_to("/etc")
+        result = tools.read_file(filename="escape_link/passwd")
+        assert "Path traversal detected" in result


### PR DESCRIPTION
## Problem

LocalFileSystemTools does not validate paths against directory traversal. A malicious or malformed input like `../../../etc/passwd` can escape the intended working directory and access arbitrary files on the system.

Fixes #8482

## Fix

Adds path traversal guard to `LocalFileSystemTools` that resolves the target path and verifies it stays within the configured base directory. Raises a clear error if the path escapes.

## Changes

- `libs/agno/agno/tools/local_file_system.py` — +13/−2 lines, path traversal validation
- `libs/agno/tests/unit/tools/test_local_file_system.py` — tests for path traversal prevention