### PR TITLE
[chore] Fix typos: guardails → guardrails in agent and team _run.py

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -1323,7 +1323,7 @@ def run_dispatch(
     # Validate input against input_schema if provided
     validated_input = validate_input(input, agent.input_schema)
 
-    # Normalise hook & guardails
+    # Normalise hook & guardrails
     if not agent._hooks_normalised:
         if agent.pre_hooks:
             agent.pre_hooks = normalize_pre_hooks(agent.pre_hooks)  # type: ignore
@@ -2753,10 +2753,10 @@ def arun_dispatch(  # type: ignore
 
         background_tasks: BackgroundTasks = background_tasks  # type: ignore
 
-    # 2. Validate input against input_schema if provided
+    # Validate input against input_schema if provided
     validated_input = validate_input(input, agent.input_schema)
 
-    # Normalise hooks & guardails
+    # Normalise hooks & guardrails
     if not agent._hooks_normalised:
         if agent.pre_hooks:
             agent.pre_hooks = normalize_pre_hooks(agent.pre_hooks, async_mode=True)  # type: ignore

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -1892,7 +1892,7 @@ def run_dispatch(
         # Register run for cancellation tracking (after validation succeeds)
         register_run(run_id)  # type: ignore
 
-        # Normalise hook & guardails
+        # Normalise hook & guardrails
         if not team._hooks_normalised:
             if team.pre_hooks:
                 team.pre_hooks = normalize_pre_hooks(team.pre_hooks)  # type: ignore
@@ -4124,7 +4124,7 @@ def arun_dispatch(  # type: ignore
     # Validate input against input_schema if provided
     validated_input = validate_input(input, team.input_schema)
 
-    # Normalise hook & guardails
+    # Normalise hook & guardrails
     if not team._hooks_normalised:
         if team.pre_hooks:
             team.pre_hooks = normalize_pre_hooks(team.pre_hooks, async_mode=True)  # type: ignore


### PR DESCRIPTION
fixes #8505

## Summary

Fixes a typo in comment annotations across two files: `guardails` → `guardrails`.

Also removes an inconsistent `2.` numbering prefix from a comment in `arun_dispatch` that had no adjacent numbered siblings.

**Files changed:**
- `libs/agno/agno/agent/_run.py` — 3 fixes (lines 1326, 2756, 2759)
- `libs/agno/agno/team/_run.py` — 2 fixes (lines 1895, 4127)

## Type of change

- [x] Bug fix (non-functional typo in comments)
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (not applicable — comment-only change, no behavior impact)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)