### PR TITLE
feat: surface workflow progress over AG-UI via native STATE + STEP

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/TEST_LOG.md
+++ b/cookbook/05_agent_os/interfaces/agui/TEST_LOG.md
@@ -75,3 +75,26 @@
 **Description:** Structured Output.
 
 ---
+
+### workflow_progress.py
+
+**Status:** PASS
+
+**Description:** Native-first workflow progress over AG-UI -- a sequential Workflow (research -> analyze -> summarize) whose live progress renders from `state.workflow_progress.steps` ({name, status, step_index, output}) via STATE_SNAPSHOT/STATE_DELTA + native STEP_STARTED/FINISHED, with ZERO structural CustomEvent. The "simple case" unlocked by the native-first rework.
+
+**Result:** Verified end-to-end. The sequential workflow's progress renders live from `state.workflow_progress.steps` in the AG-UI Dojo (agentic_generative_ui feature, via useCoAgentStateRender) -- the panel fills research -> analyze -> summarize to 3/3 Complete -- with no custom-event handling on the client. Raw SSE confirms the wire: STATE carries workflow_progress.steps, native STEP fires, zero structural CustomEvent.
+
+**Verification:**
+- Unit: 98 agui interface tests pass (workflow + router + state_events); 5/5 key mutations re-proven (custom_event exclusion, _finalize_run re-inject, mark_completed promotion, strip on BOTH save paths, enum-driven RAW coverage); cheat-detector clean; ruff clean; mypy 0 introduced (base-comparison vs #8364). (DONE)
+- Core: 410 workflow tests pass (7 pre-existing skips) -- transient strip non-regressing on save/load. (DONE)
+- Raw SSE (4.1): POST /agui -> 2 STATE_SNAPSHOT, 7 STATE_DELTA, 3 STEP_STARTED, 3 STEP_FINISHED, CUSTOM=0; workflow_progress.steps on the wire. (DONE -- PASS)
+- Live render (4.2): state.workflow_progress.steps renders and updates in the Dojo; 3/3 Complete observed (screenshot on file). (DONE -- PASS)
+- Robustness (4.3): loop/parallel/condition/router/nested populate the flat steps[] with no structural CUSTOM/RAW; step_error -> "error" (no RUN_ERROR); cancel -> "cancelled"; pause -> "paused"; no-state baseline emits a leading STATE_SNAPSHOT (real-engine unit tests). Concurrency isolation: two sessions run concurrently with no progress bleed. (DONE -- PASS)
+- A/B (4.4): agent/team AG-UI paths unchanged -- 15 router + state_events tests pass. (DONE -- PASS)
+
+**Known gaps (honest):**
+- Postgres not run live -- the transient strip is backend-agnostic by construction (pops the key before the DB driver in both save_session/asave_session); verified on sqlite sync + async, not Postgres.
+- Topology grouping (parallel/loop/condition/router rendered flat, not nested) deferred to the follow-up.
+- Interactive pause/resume (HITL) deferred; pause shows as a status label only.
+
+---

--- a/cookbook/05_agent_os/interfaces/agui/workflow_progress.py
+++ b/cookbook/05_agent_os/interfaces/agui/workflow_progress.py
@@ -1,0 +1,77 @@
+"""
+Workflow Progress (native AG-UI STATE)
+======================================
+
+A simple SEQUENTIAL workflow whose live progress renders out of the box in any
+AG-UI client -- no custom event handling required. As each step runs, the AG-UI
+interface maintains a flat ``state.workflow_progress.steps`` list (each entry:
+name, status, step_index, output) via STATE_SNAPSHOT/STATE_DELTA -- the one AG-UI
+channel that auto-renders -- plus native STEP_STARTED/STEP_FINISHED for protocol
+consistency. No structural CustomEvent is emitted.
+
+This is the "simple case" the native-first rework unlocks: point CopilotKit / the
+Dojo at POST /agui and render ``state.workflow_progress.steps`` with
+``useCoAgentStateRender`` -- the same pattern the ``agentic_generative_ui`` example
+uses for ``state.steps``. A sample render component ships with this feature (see the
+PR description).
+
+Run:
+    .venvs/demo/bin/python cookbook/05_agent_os/interfaces/agui/workflow_progress.py
+then point an AG-UI client at http://localhost:9001/agui.
+"""
+
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.workflow.step import Step
+from agno.workflow.workflow import Workflow
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+MODEL_ID = "gpt-5.5"
+PORT = 9001
+
+researcher = Agent(
+    name="Researcher",
+    model=OpenAIResponses(id=MODEL_ID),
+    instructions="Research the topic and return three concise factual bullets.",
+    markdown=True,
+)
+analyst = Agent(
+    name="Analyst",
+    model=OpenAIResponses(id=MODEL_ID),
+    instructions="Analyze the research and state the single most important insight.",
+    markdown=True,
+)
+summarizer = Agent(
+    name="Summarizer",
+    model=OpenAIResponses(id=MODEL_ID),
+    instructions="Write a one-paragraph summary for a busy reader.",
+    markdown=True,
+)
+
+# Three named steps run in order. Each step's start/finish updates
+# state.workflow_progress.steps, so an AG-UI client renders live progress.
+progress_workflow = Workflow(
+    name="Research Pipeline",
+    description="Research, analyze, then summarize -- a simple sequential workflow.",
+    steps=[
+        Step(name="research", agent=researcher),
+        Step(name="analyze", agent=analyst),
+        Step(name="summarize", agent=summarizer),
+    ],
+)
+
+# Setup your AgentOS app
+agent_os = AgentOS(
+    workflows=[progress_workflow],
+    interfaces=[AGUI(workflow=progress_workflow)],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    # reload=False keeps a single serving process (set reload=True for auto-reload during development).
+    agent_os.serve(app="workflow_progress:app", reload=False, port=PORT)

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -10,6 +10,7 @@ from agno.os.interfaces.agui.router import attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
 from agno.team.remote import RemoteTeam
+from agno.workflow import RemoteWorkflow, Workflow
 
 
 class AGUI(BaseInterface):
@@ -21,6 +22,7 @@ class AGUI(BaseInterface):
         self,
         agent: Optional[Union[Agent, RemoteAgent]] = None,
         team: Optional[Union[Team, RemoteTeam]] = None,
+        workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
     ):
@@ -30,20 +32,25 @@ class AGUI(BaseInterface):
         Args:
             agent: The agent to expose via AG-UI
             team: The team to expose via AG-UI
+            workflow: The workflow to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
         """
         self.agent = agent
         self.team = team
+        self.workflow = workflow
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
 
-        if not (self.agent or self.team):
-            raise ValueError("AGUI requires an agent or a team")
+        provided = [entity for entity in (self.agent, self.team, self.workflow) if entity is not None]
+        if not provided:
+            raise ValueError("AGUI requires an agent, team, or workflow")
+        if len(provided) > 1:
+            raise ValueError("AGUI accepts exactly one of agent, team, or workflow")
 
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team, workflow=self.workflow)
 
         return self.router

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -25,12 +25,14 @@ from ag_ui.core import (
     ToolCallStartEvent,
 )
 
+from agno.os.interfaces.agui import workflow_handlers, workflow_progress
 from agno.os.interfaces.agui.state import StreamState
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunContentEvent, RunEvent
 from agno.run.base import BaseRunOutputEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunEvent
+from agno.run.workflow import WorkflowRunEvent
 from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
@@ -118,6 +120,7 @@ def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEv
         )
 
     if content:
+        state.streamed_any_text = True
         events.append(
             TextMessageContentEvent(
                 type=EventType.TEXT_MESSAGE_CONTENT,
@@ -308,7 +311,8 @@ def on_unknown_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
     return [RawEvent(type=EventType.RAW, event=raw_dict, source="agno")]
 
 
-def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+def _close_open_streams(state: StreamState) -> List[BaseEvent]:
+    """Close any open reasoning session, active tool calls, and text message."""
     events: List[BaseEvent] = []
 
     # Close orphaned reasoning session
@@ -330,6 +334,13 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
         events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
         state.close_text_message()
 
+    return events
+
+
+def _finalize_run(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Emit external-execution tool calls for paused runs, the final state snapshot, and RUN_FINISHED."""
+    events: List[BaseEvent] = []
+
     # Emit external execution tools for paused runs
     from agno.run.agent import RunPausedEvent
 
@@ -347,6 +358,7 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
 
             content = getattr(chunk, "content", None)
             if content:
+                state.streamed_any_text = True
                 events.append(
                     TextMessageContentEvent(
                         type=EventType.TEXT_MESSAGE_CONTENT,
@@ -384,10 +396,19 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
     if state.run_state is not None:
         authoritative_state = getattr(chunk, "session_state", None)
         final_state = authoritative_state if authoritative_state is not None else state.run_state
+        # workflow_progress is transient: stripped from session_state before the DB save, and the
+        # engine's authoritative session_state may not carry it. Re-inject the tracked progress so
+        # the final snapshot doesn't blank the steps the deltas already rendered.
+        if state.workflow_progress is not None:
+            final_state = {**final_state, "workflow_progress": state.workflow_progress}
         events.append(StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(final_state)))
 
     events.append(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=state.thread_id, run_id=state.run_id))
     return events
+
+
+def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    return _close_open_streams(state) + _finalize_run(chunk, state)
 
 
 def _normalize_event(event: str) -> str:
@@ -407,6 +428,16 @@ HANDLERS: Dict[str, EventHandler] = {
     RunEvent.custom_event.value: on_custom_event,
 }
 
+# Workflow structural events -> native STATE workflow_progress (+ native STEP at step
+# boundaries). custom_event is excluded so the author's own event keeps its CustomEvent
+# passthrough via the RunEvent.custom_event registration above (same wire value "CustomEvent").
+HANDLERS.update(
+    {
+        value: workflow_progress.progress_handler
+        for value in workflow_handlers.STRUCTURAL_EVENT_VALUES - {WorkflowRunEvent.custom_event.value}
+    }
+)
+
 # Terminal events that trigger completion handling
 _COMPLETION_EVENTS = frozenset(
     {
@@ -414,6 +445,8 @@ _COMPLETION_EVENTS = frozenset(
         RunEvent.run_paused.value,
         TeamRunEvent.run_completed.value,
         TeamRunEvent.run_paused.value,
+        WorkflowRunEvent.workflow_completed.value,
+        WorkflowRunEvent.workflow_error.value,
     }
 )
 
@@ -444,5 +477,15 @@ def process_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEve
 
 
 def process_completion(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
-    """Process completion event (run_completed/run_paused) and return cleanup events."""
-    return on_run_completed(chunk, state)
+    """Process a terminal event (run or workflow) and return cleanup events."""
+    if not workflow_handlers.is_workflow_terminal(chunk):
+        return on_run_completed(chunk, state)
+
+    # Workflow terminal: close open streams, emit the workflow-specific events,
+    # and finalize only for completed (error ends on RunErrorEvent, no finish).
+    events = _close_open_streams(state)
+    events += workflow_handlers.workflow_completion_events(chunk, state)
+    if workflow_handlers.is_workflow_completed(chunk):
+        workflow_progress.mark_completed(state)
+        events += _finalize_run(chunk, state)
+    return events

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -2,7 +2,7 @@ import copy
 import uuid
 from typing import AsyncIterator, Optional, Union
 
-from agno.utils.log import log_error
+from agno.utils.log import log_error, log_info
 
 try:
     from ag_ui.core import (
@@ -17,7 +17,7 @@ try:
 except ImportError as e:
     raise ImportError("`ag_ui` not installed. Please install it with `pip install -U ag-ui-protocol`") from e
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
@@ -25,13 +25,14 @@ from agno.os.interfaces.agui.input import extract_context, extract_media, extrac
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+from agno.workflow import RemoteWorkflow, Workflow
 
 
 async def run_entity(
-    entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
+    entity: Union[Agent, RemoteAgent, Team, RemoteTeam, Workflow, RemoteWorkflow],
     run_input: RunAgentInput,
 ) -> AsyncIterator[BaseEvent]:
-    """Shared handler for running an Agent or Team with AG-UI input/output mapping."""
+    """Shared handler for running an Agent, Team, or Workflow with AG-UI input/output mapping."""
     run_id = run_input.run_id or str(uuid.uuid4())
 
     try:
@@ -83,18 +84,26 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
 ) -> APIRouter:
-    if agent is None and team is None:
-        raise ValueError("Either agent or team must be provided.")
+    if agent is None and team is None and workflow is None:
+        raise ValueError("Either agent, team, or workflow must be provided.")
 
-    entity = agent or team
+    entity = agent or team or workflow
     encoder = EventEncoder()
 
     @router.post("/agui", name="run_agent")
-    async def run_agent_agui(run_input: RunAgentInput):
+    async def run_agent_agui(request: Request, run_input: RunAgentInput):
         async def event_generator():
             async for event in run_entity(entity, run_input):  # type: ignore
+                # Workflows fan out many steps; stop streaming if the client
+                # disconnected, to avoid burning tokens on output nobody sees.
+                if workflow is not None and await request.is_disconnected():
+                    log_info(f"AGUI client disconnected; stopping workflow stream for run_id={run_input.run_id}")
+                    break
                 yield encoder.encode(event)
 
         return StreamingResponse(

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -34,6 +34,23 @@ class StreamState:
     reasoning_message_id: Optional[str] = None
     reasoning_step_count: int = 0
 
+    # Sticky "did any assistant text reach the wire this run" flag. Set on the
+    # first non-empty streamed content and NEVER reset, so workflow completion can
+    # tell a streamed final (suppress the recap) from one that never streamed
+    # (e.g. stream_executor_events=False -> emit). Sticky, not per-message: an
+    # empty content chunk reopening a message after a tool must not clear it.
+    streamed_any_text: bool = False
+
+    # Workflow cancellation marker. Set when a WorkflowCancelledEvent is seen so
+    # the trailing WorkflowCompletedEvent (content = cancel reason, not an answer)
+    # is suppressed instead of rendered as the assistant's reply.
+    cancelled: bool = False
+
+    # Reference to the live workflow_progress dict (also stored under
+    # run_state["workflow_progress"]). Kept separately so the final snapshot can
+    # re-inject progress even after the DB-save strip pops the key from run_state.
+    workflow_progress: Optional[Dict[str, Any]] = None
+
     # State delta tracking
     _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
 

--- a/libs/agno/agno/os/interfaces/agui/workflow_handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/workflow_handlers.py
@@ -1,0 +1,143 @@
+"""Workflow-specific event handling for the AG-UI interface.
+
+A streaming workflow re-emits its inner agent/team events (content, tool calls,
+reasoning), which the standard handlers already translate — so this module only
+covers what is workflow-specific: identifying the structural events (routed to
+CustomEvents via on_custom_event in handlers.py) and resolving the terminal
+events (completed / error) at completion time. Cancellation is intentionally
+NOT terminal here: it mirrors the agent/team path (a non-error marker surfaced
+as a CustomEvent, plus a clean RUN_FINISHED).
+"""
+
+import json
+import uuid
+from typing import Any, List, Optional
+
+from ag_ui.core import (
+    BaseEvent,
+    EventType,
+    RunErrorEvent,
+    TextMessageContentEvent,
+    TextMessageEndEvent,
+    TextMessageStartEvent,
+)
+
+from agno.os.interfaces.agui.state import StreamState
+from agno.run.base import BaseRunOutputEvent
+from agno.run.workflow import WorkflowRunEvent
+from agno.workflow.types import StepType
+
+# Terminal workflow events that the stream gate routes to process_completion.
+# workflow_cancelled is deliberately excluded — it is surfaced as a structural
+# CustomEvent and the run finalizes cleanly, matching the agent/team path.
+_WORKFLOW_TERMINAL_VALUES = frozenset(
+    {
+        WorkflowRunEvent.workflow_completed.value,
+        WorkflowRunEvent.workflow_error.value,
+    }
+)
+
+# Every other WorkflowRunEvent value — surfaced to clients as CustomEvents so
+# the workflow's structure (steps, routers, loops, ...) carries through as data.
+STRUCTURAL_EVENT_VALUES = frozenset(e.value for e in WorkflowRunEvent) - _WORKFLOW_TERMINAL_VALUES
+
+
+def _event_value(chunk: BaseRunOutputEvent) -> str:
+    event = getattr(chunk, "event", None)
+    if event is None:
+        return ""
+    return event.value if hasattr(event, "value") else str(event)
+
+
+def is_workflow_terminal(chunk: BaseRunOutputEvent) -> bool:
+    """True for workflow_completed / workflow_error (handled at completion)."""
+    return _event_value(chunk) in _WORKFLOW_TERMINAL_VALUES
+
+
+def is_workflow_completed(chunk: BaseRunOutputEvent) -> bool:
+    """True only for workflow_completed (soft-terminal: the run still finalizes)."""
+    return _event_value(chunk) == WorkflowRunEvent.workflow_completed.value
+
+
+def _new_text_message(text: str) -> List[BaseEvent]:
+    """Build a fresh assistant TextMessage triplet (START / CONTENT / END)."""
+    message_id = str(uuid.uuid4())
+    return [
+        TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id, role="assistant"),
+        TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=text),
+        TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=message_id),
+    ]
+
+
+def _leaf_streamed(node: Any) -> Optional[bool]:
+    """Descend Router/Steps/Condition containers to the final leaf and report
+    whether it streamed. None = uncertain (Parallel/Loop fan-out, an unexpected
+    non-StepOutput node, or unknown executor) -> the caller emits (drop-safe).
+    A non-StepOutput (e.g. a nested list) has no step_type/steps/executor_type, so
+    it falls through every getattr to the drop-safe None below."""
+    if getattr(node, "step_type", None) in (StepType.PARALLEL, StepType.LOOP):  # fan-out: no single final leaf
+        return None
+    sub = getattr(node, "steps", None)
+    if sub:  # Router/Steps/Condition container -> descend the spine to its final leaf
+        return _leaf_streamed(sub[-1])
+    executor = getattr(node, "executor_type", None)
+    if executor in ("agent", "team"):
+        return True
+    if executor == "function":
+        return False
+    return None
+
+
+def _final_leaf_streamed(chunk: BaseRunOutputEvent) -> Optional[bool]:
+    """True iff the workflow's final answer already streamed (agent/team leaf)."""
+    results = getattr(chunk, "step_results", None)
+    if not results:
+        return None
+    return _leaf_streamed(results[-1])
+
+
+def _render_content(content: Any) -> str:
+    """Render the final answer as text: str as-is, list/dict as JSON, scalars via
+    str(). default=str keeps json.dumps from crashing on non-serializable values."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (list, dict)):
+        return json.dumps(content, default=str)
+    return str(content)
+
+
+def workflow_completion_events(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Build the workflow-specific terminal events.
+
+    The caller (process_completion) prepends stream cleanup and, for the
+    completed case, appends the run finalizer (RUN_FINISHED). A workflow error
+    is AG-UI-terminal: it ends on RunErrorEvent with no RUN_FINISHED following.
+    """
+    if _event_value(chunk) == WorkflowRunEvent.workflow_error.value:
+        error = getattr(chunk, "error", None) or "Workflow error occurred"
+        return [RunErrorEvent(type=EventType.RUN_ERROR, message=str(error))]
+
+    # Cancellation: the WorkflowCancelledEvent marker already surfaced as a
+    # CustomEvent; the trailing WorkflowCompletedEvent.content is the cancel
+    # REASON, not an answer (workflow.py:2865/2877). Never render it.
+    if state.cancelled:
+        return []
+
+    content = getattr(chunk, "content", None)
+    if content is None:
+        return []
+    rendered = _render_content(content)
+    if not rendered.strip():
+        return []
+
+    # Provenance (descend-to-leaf): suppress the completion recap ONLY when the
+    # final answer is an agent/team leaf AND content actually reached the wire.
+    # With stream_executor_events=False the agent's answer lands in .content with
+    # an agent leaf but never streams (streamed_any_text stays False) -> emit, so
+    # it is never silently dropped. A function leaf, or any uncertain shape
+    # (Parallel/Loop fan-out, missing/nested provenance), also emits -- which may
+    # rarely DUPLICATE a streamed answer. Deliberate drop-safe bias: a rare
+    # duplicate beats a dropped answer.
+    if _final_leaf_streamed(chunk) and state.streamed_any_text:
+        return []
+    return _new_text_message(rendered)

--- a/libs/agno/agno/os/interfaces/agui/workflow_progress.py
+++ b/libs/agno/agno/os/interfaces/agui/workflow_progress.py
@@ -1,0 +1,138 @@
+"""Workflow structural events -> native AG-UI STATE (workflow_progress) + STEP.
+
+A workflow's structural WorkflowRunEvents (started, step_*, loop/parallel/condition/
+router_*, pause/continue, cancelled) surface as a flat steps[] progress object in
+shared STATE -- the one channel the default AG-UI client auto-renders -- plus native
+STEP_STARTED/STEP_FINISHED at flat step boundaries (emitted for protocol consistency;
+they render nothing themselves). No CustomEvent: the author's own custom_event keeps
+its passthrough via the RunEvent.custom_event handler.
+
+v1 is intentionally FLAT: container events (loop/parallel/condition/router) are no-ops
+here -- their inner steps emit their own step_started/completed and populate the list.
+Grouping the topology is a deferred follow-up. Pause/cancel surface as a status only;
+interactive resume is out of scope.
+"""
+
+import copy
+from typing import Any, List, Optional
+
+from ag_ui.core import (
+    BaseEvent,
+    EventType,
+    StateDeltaEvent,
+    StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
+)
+
+from agno.os.interfaces.agui.state import StreamState
+from agno.os.interfaces.agui.workflow_handlers import _event_value, _render_content
+from agno.run.base import BaseRunOutputEvent
+from agno.run.workflow import WorkflowRunEvent
+
+_E = WorkflowRunEvent
+_MAX_OUTPUT = 500  # cap step output stored in STATE so deltas stay small
+
+_PAUSE_STEP = frozenset({_E.step_paused.value, _E.step_executor_paused.value, _E.step_output_review.value})
+_PAUSE_WORKFLOW = frozenset({_E.workflow_paused.value, _E.router_paused.value})
+_CONTINUE = frozenset({_E.step_continued.value, _E.step_executor_continued.value})
+
+
+def _progress(state: StreamState) -> dict:
+    if state.run_state is None:
+        state.run_state = {}
+    return state.run_state.setdefault("workflow_progress", {"status": "running", "steps": []})
+
+
+def _baseline(state: StreamState) -> List[BaseEvent]:
+    """First touch with no caller-supplied state: router.py emitted no initial snapshot
+    and stream.py set no delta baseline -> establish one here so the workflow_progress
+    deltas below have a reference to diff against."""
+    if state.run_state is not None:
+        return []
+    state.run_state = {}
+    state.set_state_snapshot(state.run_state)
+    return [StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=copy.deepcopy(state.run_state))]
+
+
+def _emit_delta(state: StreamState) -> List[BaseEvent]:
+    if state.run_state is None:
+        return []
+    ops = state.compute_state_delta(state.run_state)
+    if not ops:
+        return []
+    state.set_state_snapshot(state.run_state)
+    return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=ops)]
+
+
+def _short(content: Any) -> Optional[str]:
+    if content is None:
+        return None
+    text = _render_content(content)
+    return text[:_MAX_OUTPUT] if text else None
+
+
+def _open_step(steps: List[dict], index: Any) -> Optional[dict]:
+    """Most recent not-yet-finished entry for this step_index (loops reuse indices)."""
+    for step in reversed(steps):
+        if step["step_index"] == index and step["status"] in ("running", "paused"):
+            return step
+    return None
+
+
+def mark_completed(state: StreamState) -> None:
+    """Promote a still-running workflow to 'completed' at terminal time. Never clobbers a
+    'cancelled' / 'error' / 'paused' status already set by a structural event."""
+    progress = state.workflow_progress
+    if progress is not None and progress.get("status") == "running":
+        progress["status"] = "completed"
+
+
+def progress_handler(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    """Map one structural WorkflowRunEvent to a workflow_progress mutation (+ STEP)."""
+    events = _baseline(state)
+    value = _event_value(chunk)
+    progress = _progress(state)
+    state.workflow_progress = progress
+    steps = progress["steps"]
+    name = getattr(chunk, "step_name", None)
+    raw_index = getattr(chunk, "step_index", None)
+    index = list(raw_index) if isinstance(raw_index, tuple) else raw_index
+
+    if value == _E.step_started.value:
+        steps.append({"name": name, "status": "running", "step_index": index, "output": None})
+        if name:
+            events.append(StepStartedEvent(type=EventType.STEP_STARTED, step_name=name))
+    elif value == _E.step_completed.value:
+        step = _open_step(steps, index)
+        if step is not None:
+            step.update(status="completed", output=_short(getattr(chunk, "content", None)))
+        if name:
+            events.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name=name))
+    elif value == _E.step_output.value:
+        step = _open_step(steps, index)
+        if step is not None:
+            step["output"] = _short(getattr(chunk, "content", None))
+    elif value == _E.step_error.value:
+        step = _open_step(steps, index)
+        if step is not None:
+            step.update(status="error", output=_short(getattr(chunk, "error", None)))
+        if name:
+            events.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name=name))
+    elif value in _PAUSE_STEP:
+        step = _open_step(steps, index)
+        if step is not None:
+            step["status"] = "paused"
+    elif value in _PAUSE_WORKFLOW:
+        progress["status"] = "paused"
+    elif value in _CONTINUE:
+        step = _open_step(steps, index)
+        if step is not None:
+            step["status"] = "running"
+    elif value == _E.workflow_cancelled.value:
+        progress["status"] = "cancelled"
+        state.cancelled = True
+    # workflow_started initialises progress above; container/agent events are no-ops
+    # (their inner step_started/completed populate the flat list).
+
+    return events + _emit_delta(state)

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1416,6 +1416,7 @@ class Workflow:
                 session.session_data["session_state"].pop("run_id", None)
                 session.session_data["session_state"].pop("session_id", None)
                 session.session_data["session_state"].pop("workflow_name", None)
+                session.session_data["session_state"].pop("workflow_progress", None)
 
             if self._has_async_db():
                 result = await self._aupsert_session(session=session)  # type: ignore
@@ -1442,6 +1443,7 @@ class Workflow:
                 session.session_data["session_state"].pop("run_id", None)
                 session.session_data["session_state"].pop("session_id", None)
                 session.session_data["session_state"].pop("workflow_name", None)
+                session.session_data["session_state"].pop("workflow_progress", None)
 
             result = self._upsert_session(session=session)
             if result is None:

--- a/libs/agno/tests/unit/os/interfaces/test_agui_workflow.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_workflow.py
@@ -1,0 +1,887 @@
+"""Workflow -> AG-UI event translation.
+
+Workflows stream their inner agent/team content through the shared handlers;
+every structural WorkflowRunEvent (except the author's own custom_event) is
+surfaced natively -- as a flat steps[] progress object in shared STATE
+(STATE_SNAPSHOT/STATE_DELTA) plus native STEP_STARTED/STEP_FINISHED at step
+boundaries -- with ZERO CustomEvent. The terminals (completed / error) resolve at
+completion; cancellation/pause surface as a STATE status, never an error.
+
+Tests feed REAL agno event classes through the in-process
+`async_stream_agno_response_as_agui_events` entrypoint (the harness already used
+in this file) and assert the EXACT ordered AG-UI events. Structural-event coverage
+is driven off the real `STRUCTURAL_EVENT_VALUES` / event registry so a new
+WorkflowRunEvent auto-joins and coverage cannot silently drift.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from ag_ui.core import EventType, RunStartedEvent
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+from agno.os.interfaces.agui.agui import AGUI
+from agno.os.interfaces.agui.handlers import HANDLERS, on_custom_event
+from agno.os.interfaces.agui.router import run_entity
+from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
+from agno.os.interfaces.agui.workflow_handlers import STRUCTURAL_EVENT_VALUES, _final_leaf_streamed
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import (
+    ReasoningCompletedEvent,
+    ReasoningStartedEvent,
+    ReasoningStepEvent,
+    RunContentEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
+from agno.run.team import RunContentEvent as TeamRunContentEvent
+from agno.run.workflow import (
+    WORKFLOW_RUN_EVENT_TYPE_REGISTRY,
+    StepCompletedEvent,
+    StepErrorEvent,
+    StepOutputEvent,
+    StepStartedEvent,
+    WorkflowCancelledEvent,
+    WorkflowCompletedEvent,
+    WorkflowErrorEvent,
+    WorkflowPausedEvent,
+    WorkflowRunEvent,
+    WorkflowStartedEvent,
+)
+from agno.workflow.types import StepOutput, StepType
+
+ET = EventType
+
+
+def _stream(*chunks):
+    """Adapt a list of real event instances into the async stream the entrypoint consumes."""
+
+    async def gen():
+        for chunk in chunks:
+            yield chunk
+
+    return gen()
+
+
+async def _collect(stream):
+    return [event async for event in async_stream_agno_response_as_agui_events(stream, "t1", "r1")]
+
+
+def _types(events):
+    return [e.type for e in events]
+
+
+def _deltas(events):
+    return [e.delta for e in events if e.type == ET.TEXT_MESSAGE_CONTENT]
+
+
+# ====== AGUI construction ======
+
+
+def test_agui_accepts_workflow():
+    workflow = MagicMock()
+    assert AGUI(workflow=workflow).workflow is workflow
+
+
+def test_agui_requires_an_entity():
+    with pytest.raises(ValueError):
+        AGUI()
+
+
+def test_agui_rejects_multiple_entities():
+    with pytest.raises(ValueError):
+        AGUI(agent=MagicMock(), workflow=MagicMock())
+
+
+# ====== run_entity passthrough ======
+
+
+class _CaptureKwargsWorkflow:
+    def __init__(self):
+        self.captured_kwargs: dict = {}
+
+    async def arun(self, **kwargs):
+        self.captured_kwargs = kwargs
+        return
+        yield
+
+
+class _FakeRunInput:
+    def __init__(self):
+        self.messages = [MagicMock(role="user", content="hi")]
+        self.thread_id = "t1"
+        self.run_id = "r1"
+        self.forwarded_props = None
+        self.state = None
+        self.context = []  # real RunAgentInput field; run_entity reads it via extract_context
+
+
+@pytest.mark.asyncio
+async def test_run_entity_passes_streaming_kwargs_to_workflow():
+    workflow = _CaptureKwargsWorkflow()
+    async for _ in run_entity(workflow, _FakeRunInput()):
+        pass
+    assert workflow.captured_kwargs.get("stream") is True
+    assert workflow.captured_kwargs.get("stream_events") is True
+
+
+# ====== Completion gate: the two failure modes are DROP and DUPLICATE ======
+
+
+@pytest.mark.asyncio
+async def test_streamed_final_answer_is_not_re_emitted():
+    # Inner content streamed; completion content equals it -> no duplicate.
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="the answer"),
+            WorkflowCompletedEvent(
+                content="the answer",
+                step_results=[StepOutput(content="the answer", executor_type="agent", step_type=StepType.STEP)],
+                workflow_name="wf",
+            ),
+        )
+    )
+    assert _types(events) == [ET.TEXT_MESSAGE_START, ET.TEXT_MESSAGE_CONTENT, ET.TEXT_MESSAGE_END, ET.RUN_FINISHED]
+    assert _deltas(events).count("the answer") == 1
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_final_answer_is_emitted_once():
+    # Nothing streamed (e.g. a function step); the final answer lives only in
+    # WorkflowCompletedEvent.content and must be emitted exactly once.
+    events = await _collect(_stream(WorkflowCompletedEvent(content="final answer", workflow_name="wf")))
+    assert _types(events) == [ET.TEXT_MESSAGE_START, ET.TEXT_MESSAGE_CONTENT, ET.TEXT_MESSAGE_END, ET.RUN_FINISHED]
+    assert _deltas(events) == ["final answer"]
+
+
+@pytest.mark.asyncio
+async def test_non_streamed_final_after_a_streamed_step_is_not_dropped():
+    # An earlier step streamed; the final answer is non-streamed and different.
+    # It must NOT be dropped just because something streamed earlier.
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="research notes"),
+            WorkflowCompletedEvent(content="FINAL ANSWER", workflow_name="wf"),
+        )
+    )
+    assert _types(events) == [
+        ET.TEXT_MESSAGE_START,
+        ET.TEXT_MESSAGE_CONTENT,
+        ET.TEXT_MESSAGE_END,
+        ET.TEXT_MESSAGE_START,
+        ET.TEXT_MESSAGE_CONTENT,
+        ET.TEXT_MESSAGE_END,
+        ET.RUN_FINISHED,
+    ]
+    deltas = _deltas(events)
+    assert "research notes" in deltas
+    assert deltas.count("FINAL ANSWER") == 1
+
+
+# ====== Terminals ======
+
+
+@pytest.mark.asyncio
+async def test_workflow_error_is_terminal_run_error_with_no_finish():
+    # Gate CONTRACT (defensive): a terminal workflow_error -> RUN_ERROR, no
+    # RUN_FINISHED. In the real async-streaming engine this branch is NOT hit:
+    # generic errors raise (run_entity emits RUN_ERROR, see next test) and
+    # validation errors get overwritten by a trailing WorkflowCompletedEvent. Kept
+    # because it is the correct, cheap translation if a terminal error arrives.
+    events = await _collect(_stream(WorkflowErrorEvent(error="boom", workflow_name="wf")))
+    assert _types(events) == [ET.RUN_ERROR]
+    assert events[0].message == "boom"
+
+
+@pytest.mark.asyncio
+async def test_raising_workflow_stream_surfaces_single_run_error_via_run_entity():
+    # Real production error path (workflow.py:2903): the engine yields a
+    # WorkflowErrorEvent then RAISES; the raise preempts the completion gate, so
+    # run_entity's except (router.py:74) emits exactly one RUN_ERROR. (A raising
+    # function STEP does NOT reach here -- step errors are skipped and rendered as
+    # "Step skipped due to error: ..."; RUN_ERROR needs an escape from the stream.)
+    class _RaisingWorkflow:
+        async def arun(self, **kwargs):
+            yield WorkflowErrorEvent(error="engine exploded", workflow_name="wf")
+            raise RuntimeError("engine exploded")
+
+    events = [e async for e in run_entity(_RaisingWorkflow(), _FakeRunInput())]
+    types = [e.type for e in events]
+    assert types.count(ET.RUN_ERROR) == 1
+    assert types[-1] == ET.RUN_ERROR
+    assert "engine exploded" in next(e for e in events if e.type == ET.RUN_ERROR).message
+
+
+# ====== Structural event registry (gate STRUCTURAL_EVENT_VALUES vs event classes) ======
+
+
+def test_only_condition_paused_lacks_an_event_class():
+    # Guard the one documented gap so it cannot widen silently: agno defines
+    # WorkflowRunEvent.condition_paused but ships no event class for it (absent
+    # from the registry and the Union, so it is never emitted). The handler still
+    # covers it defensively (asserted above). If another value loses its class —
+    # or condition_paused gains one — this fails and we revisit.
+    missing = STRUCTURAL_EVENT_VALUES - set(WORKFLOW_RUN_EVENT_TYPE_REGISTRY)
+    assert missing == {WorkflowRunEvent.condition_paused.value}
+
+
+# ====== Inner agent/team events reuse the shared handlers (no workflow dup) ======
+
+
+@pytest.mark.asyncio
+async def test_inner_tool_call_streams_through_shared_handlers():
+    tool = MagicMock()
+    tool.tool_call_id = "call_1"
+    tool.tool_name = "search"
+    tool.tool_args = {"q": "agno"}
+    tool.result = "found"
+    events = await _collect(
+        _stream(
+            ToolCallStartedEvent(tool=tool),
+            ToolCallCompletedEvent(tool=tool),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert _types(events) == [
+        ET.TEXT_MESSAGE_START,
+        ET.TEXT_MESSAGE_END,
+        ET.TOOL_CALL_START,
+        ET.TOOL_CALL_ARGS,
+        ET.TOOL_CALL_END,
+        ET.TOOL_CALL_RESULT,
+        ET.RUN_FINISHED,
+    ]
+    start = next(e for e in events if e.type == ET.TOOL_CALL_START)
+    assert start.tool_call_id == "call_1"
+    assert start.tool_call_name == "search"
+    args = next(e for e in events if e.type == ET.TOOL_CALL_ARGS)
+    assert args.delta == json.dumps({"q": "agno"})
+
+
+@pytest.mark.asyncio
+async def test_inner_reasoning_streams_through_shared_handlers():
+    events = await _collect(
+        _stream(
+            ReasoningStartedEvent(),
+            ReasoningStepEvent(content=ReasoningStep(title="Plan", reasoning="thinking")),
+            ReasoningCompletedEvent(),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert _types(events) == [
+        ET.REASONING_START,
+        ET.REASONING_MESSAGE_START,
+        ET.REASONING_MESSAGE_CONTENT,
+        ET.REASONING_MESSAGE_END,
+        ET.REASONING_END,
+        ET.RUN_FINISHED,
+    ]
+    content = next(e for e in events if e.type == ET.REASONING_MESSAGE_CONTENT)
+    assert "Plan" in content.delta
+
+
+@pytest.mark.asyncio
+async def test_inner_team_content_streams_through_shared_handlers():
+    events = await _collect(
+        _stream(
+            TeamRunContentEvent(content="team answer"),
+            WorkflowCompletedEvent(
+                content="team answer",
+                step_results=[StepOutput(content="team answer", executor_type="team", step_type=StepType.STEP)],
+                workflow_name="wf",
+            ),
+        )
+    )
+    assert _types(events) == [ET.TEXT_MESSAGE_START, ET.TEXT_MESSAGE_CONTENT, ET.TEXT_MESSAGE_END, ET.RUN_FINISHED]
+    assert _deltas(events) == ["team answer"]
+
+
+# ====== Client disconnect stops the workflow stream ======
+
+
+@pytest.mark.asyncio
+async def test_workflow_stream_stops_on_client_disconnect():
+    from fastapi import APIRouter
+
+    from agno.os.interfaces.agui import router as agui_router
+
+    async def fake_run_entity(entity, run_input):
+        for _ in range(5):
+            yield RunStartedEvent(type=ET.RUN_STARTED, thread_id="t1", run_id="r1")
+
+    request = MagicMock()
+    # Connected for the first two events, then disconnected -> break before #3.
+    request.is_disconnected = AsyncMock(side_effect=[False, False, True])
+
+    r = APIRouter()
+    with patch.object(agui_router, "run_entity", fake_run_entity):
+        agui_router.attach_routes(r, workflow=MagicMock())
+        endpoint = next(route.endpoint for route in r.routes if getattr(route, "path", "") == "/agui")
+        response = await endpoint(request, MagicMock(run_id="r1"))
+        chunks = [chunk async for chunk in response.body_iterator]
+
+    assert len(chunks) == 2  # stopped at disconnect, not all 5
+
+
+# ====== Completion-gate reproductions (drop / duplicate / short-suffix) ======
+# Each drives the real async_stream entrypoint with production event sequences.
+# Synthetic WorkflowCompletedEvents carry realistic step_results so the descend-to-leaf
+# provenance gate is genuinely exercised.
+
+
+@pytest.mark.parametrize("value, expected", [(42, "42"), ([1, 2, 3], "[1, 2, 3]")])
+@pytest.mark.asyncio
+async def test_non_string_function_final_is_rendered_not_dropped(value, expected):
+    # #2: a function final step returns a non-string; the engine keeps it raw in
+    # WorkflowCompletedEvent.content. Must render (str for scalars, json.dumps for
+    # list/dict), never drop (int -> get_text_from_message=="") or crash (list).
+    events = await _collect(
+        _stream(
+            WorkflowCompletedEvent(
+                content=value,
+                step_results=[StepOutput(content=value, executor_type="function", step_type=StepType.STEP)],
+                workflow_name="wf",
+            )
+        )
+    )
+    assert _deltas(events) == [expected]
+
+
+@pytest.mark.asyncio
+async def test_streamed_agent_final_after_tool_is_not_duplicated():
+    # #7: an agent streams "part A. ", a tool closes the message, "part B." opens a
+    # new one; completion consolidates "part A. part B.". The final leaf is an agent
+    # (it streamed) -> the consolidation recap must be suppressed (no duplicate).
+    tool = MagicMock()
+    tool.tool_call_id = "t1"
+    tool.tool_name = "x"
+    tool.tool_args = {}
+    tool.result = "ok"
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="part A. "),
+            ToolCallStartedEvent(tool=tool),
+            ToolCallCompletedEvent(tool=tool),
+            RunContentEvent(content="part B."),
+            WorkflowCompletedEvent(
+                content="part A. part B.",
+                step_results=[StepOutput(content="part A. part B.", executor_type="agent", step_type=StepType.STEP)],
+                workflow_name="wf",
+            ),
+        )
+    )
+    deltas = _deltas(events)
+    assert deltas.count("part A. part B.") == 0
+    assert "part A. " in deltas
+    assert "part B." in deltas
+
+
+@pytest.mark.asyncio
+async def test_streamed_final_then_empty_post_tool_chunk_is_not_duplicated():
+    # C3: the final agent streams "FINAL", calls a tool (closing the message), then
+    # emits an EMPTY / reasoning-only RunContentEvent (content=None) after the tool
+    # -- which reopens a message. The answer already streamed, so the completion
+    # recap must be suppressed; a per-message "streamed" signal would be reset by
+    # the empty reopen and wrongly re-emit it (duplicate).
+    tool = MagicMock()
+    tool.tool_call_id = "t1"
+    tool.tool_name = "x"
+    tool.tool_args = {}
+    tool.result = "ok"
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="FINAL"),
+            ToolCallStartedEvent(tool=tool),
+            ToolCallCompletedEvent(tool=tool),
+            RunContentEvent(content=None),
+            WorkflowCompletedEvent(
+                content="FINAL",
+                step_results=[StepOutput(content="FINAL", executor_type="agent", step_type=StepType.STEP)],
+                workflow_name="wf",
+            ),
+        )
+    )
+    assert _deltas(events).count("FINAL") == 1
+
+
+@pytest.mark.asyncio
+async def test_short_non_streamed_final_is_not_dropped_by_suffix_match():
+    # #4: an earlier step streamed "The result is 42"; the FINAL step is a function
+    # returning "42" (a suffix of the streamed text). endswith dropped it; the
+    # function-leaf provenance emits it.
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="The result is 42"),
+            WorkflowCompletedEvent(
+                content="42",
+                step_results=[StepOutput(content="42", executor_type="function", step_type=StepType.STEP)],
+                workflow_name="wf",
+            ),
+        )
+    )
+    assert "42" in _deltas(events)
+
+
+@pytest.mark.asyncio
+async def test_agent_final_not_streamed_is_emitted_not_dropped():
+    # C1: stream_executor_events=False -- the agent's content lands in the
+    # completion (leaf executor_type="agent") but NOTHING streamed to AG-UI.
+    # Suppressing on the agent leaf alone silently DROPS the answer; the gate must
+    # emit it (suppress only when something actually streamed).
+    events = await _collect(
+        _stream(
+            WorkflowCompletedEvent(
+                content="agent answer",
+                step_results=[StepOutput(content="agent answer", executor_type="agent", step_type=StepType.STEP)],
+                workflow_name="wf",
+            )
+        )
+    )
+    assert _deltas(events) == ["agent answer"]
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_final_content_is_not_emitted():
+    # A final whose content renders to whitespace must not emit a junk TextMessage.
+    events = await _collect(
+        _stream(
+            WorkflowCompletedEvent(
+                content="   ",
+                step_results=[StepOutput(content="   ", executor_type="function", step_type=StepType.STEP)],
+                workflow_name="wf",
+            )
+        )
+    )
+    assert _deltas(events) == []
+    assert not any(e.type == ET.TEXT_MESSAGE_START for e in events)
+
+
+# ====== Provenance-shape matrix: descend-to-leaf decision per workflow shape ======
+# True = final answer streamed (agent/team leaf) -> suppress recap.
+# False = not streamed (function leaf) -> emit. None = uncertain -> emit (drop-safe).
+
+
+def _so(executor_type, content="answer", step_type=StepType.STEP, steps=None):
+    return StepOutput(content=content, executor_type=executor_type, step_type=step_type, steps=steps)
+
+
+@pytest.mark.parametrize(
+    "label, step_results, expected",
+    [
+        ("function", [_so("function")], False),
+        ("multi-step function", [_so("function"), _so("function")], False),
+        ("router->function", [_so(None, step_type=StepType.ROUTER, steps=[_so("function")])], False),
+        ("router->agent", [_so(None, step_type=StepType.ROUTER, steps=[_so("agent")])], True),
+        (
+            "router->steps->agent (nested spine)",
+            [_so(None, step_type=StepType.ROUTER, steps=[_so(None, step_type=StepType.STEPS, steps=[_so("agent")])])],
+            True,
+        ),
+        ("agent", [_so("agent")], True),
+        ("team", [_so("team")], True),
+        (
+            "parallel fan-out",
+            [_so("parallel", step_type=StepType.PARALLEL, steps=[_so("function"), _so("function")])],
+            None,
+        ),
+        ("loop fan-out", [_so("loop", step_type=StepType.LOOP, steps=[_so("agent")])], None),
+        ("missing provenance", [], None),
+        ("nested list (defensive)", [[_so("function")]], None),
+    ],
+)
+def test_final_leaf_provenance_matrix(label, step_results, expected):
+    chunk = WorkflowCompletedEvent(content="x", step_results=step_results, workflow_name="wf")
+    assert _final_leaf_streamed(chunk) is expected
+
+
+@pytest.mark.asyncio
+async def test_router_function_leaf_emits_completion():
+    # cookbook small-talk branch: Router -> chat (function). Non-streamed -> emit.
+    rr = [_so(None, content="Hi there", step_type=StepType.ROUTER, steps=[_so("function", content="Hi there")])]
+    events = await _collect(_stream(WorkflowCompletedEvent(content="Hi there", step_results=rr, workflow_name="wf")))
+    assert _deltas(events) == ["Hi there"]
+
+
+@pytest.mark.asyncio
+async def test_router_agent_leaf_suppresses_completion():
+    # cookbook research branch: Router -> [research, summarize] agents. Streamed -> suppress.
+    rr = [
+        _so(
+            None,
+            content="final summary",
+            step_type=StepType.ROUTER,
+            steps=[_so("agent", content="research"), _so("agent", content="final summary")],
+        )
+    ]
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="final summary"),
+            WorkflowCompletedEvent(content="final summary", step_results=rr, workflow_name="wf"),
+        )
+    )
+    assert _deltas(events).count("final summary") == 1
+
+
+# ====== Real-engine C1 regression: stream_executor_events=False must not drop ======
+
+
+class _StubModel(Model):
+    """Offline model that yields a fixed assistant response (no network)."""
+
+    def invoke(self, *args, **kwargs):
+        return ModelResponse(role="assistant", content="stub answer")
+
+    async def ainvoke(self, *args, **kwargs):
+        return ModelResponse(role="assistant", content="stub answer")
+
+    def invoke_stream(self, *args, **kwargs):
+        yield ModelResponse(role="assistant", content="stub answer")
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        yield ModelResponse(role="assistant", content="stub answer")
+
+    def _parse_provider_response(self, response, **kwargs):
+        return response
+
+    def _parse_provider_response_delta(self, response):
+        return response
+
+
+@pytest.mark.parametrize("n_steps", [1, 2])
+@pytest.mark.asyncio
+async def test_stream_executor_events_false_delivers_final_answer_once(n_steps):
+    # C1 regression, REAL engine: with stream_executor_events=False the agent's
+    # content is filtered from the stream (nothing reaches the wire) but lands in
+    # the completion with an agent leaf. The gate must deliver it exactly once,
+    # across single- AND multi-step workflows (last_streamed_text stays empty).
+    from agno.agent.agent import Agent
+    from agno.workflow.step import Step
+    from agno.workflow.workflow import Workflow
+
+    steps = [Step(name="s%d" % i, agent=Agent(name="A%d" % i, model=_StubModel(id="stub"))) for i in range(n_steps)]
+    wf = Workflow(name="w", steps=steps, stream_executor_events=False)
+    events = [e async for e in run_entity(wf, _FakeRunInput())]
+    assert _deltas(events).count("stub answer") == 1
+    assert any(e.type == ET.RUN_FINISHED for e in events)
+
+
+# ====== Step B: structural events -> native STATE workflow_progress + STEP ======
+# Native-first: every structural WorkflowRunEvent (except the author's own custom_event)
+# maps to a workflow_progress mutation (+ native STEP at step boundaries) -- zero
+# CustomEvent. These assert on the emitted STATE/STEP events and the steps[] shape
+# carried in the final STATE_SNAPSHOT.
+
+_STRUCTURAL_WITH_CLASS = sorted(STRUCTURAL_EVENT_VALUES & set(WORKFLOW_RUN_EVENT_TYPE_REGISTRY))
+
+
+def _final_state(events):
+    snaps = [e for e in events if e.type == ET.STATE_SNAPSHOT]
+    return snaps[-1].snapshot if snaps else None
+
+
+def _steps(events):
+    return (_final_state(events) or {}).get("workflow_progress", {}).get("steps", [])
+
+
+def _wf_status(events):
+    return (_final_state(events) or {}).get("workflow_progress", {}).get("status")
+
+
+# ---- completeness gate: no structural event falls through to RAW ----
+
+
+@pytest.mark.parametrize("event_value", _STRUCTURAL_WITH_CLASS)
+@pytest.mark.asyncio
+async def test_no_structural_event_falls_through_to_raw(event_value):
+    # Every structural value (driven off the registry) must have a native handler --
+    # none may reach on_unknown_event/RAW. The author's own custom_event is the one
+    # legitimate CustomEvent passthrough.
+    instance = WORKFLOW_RUN_EVENT_TYPE_REGISTRY[event_value]()
+    events = await _collect(_stream(instance, WorkflowCompletedEvent(content=None, workflow_name="wf")))
+    if event_value == WorkflowRunEvent.custom_event.value:
+        assert any(e.type == ET.CUSTOM for e in events)
+    else:
+        assert not any(e.type == ET.RAW for e in events)
+        assert not any(e.type == ET.CUSTOM for e in events)
+
+
+def test_structural_events_route_to_progress_handler():
+    # Every structural value except custom_event routes to the native progress handler;
+    # custom_event keeps the CustomEvent passthrough (base RunEvent.custom_event registration).
+    from agno.os.interfaces.agui import workflow_progress
+
+    custom = WorkflowRunEvent.custom_event.value
+    for value in STRUCTURAL_EVENT_VALUES:
+        expected = on_custom_event if value == custom else workflow_progress.progress_handler
+        assert HANDLERS.get(value) is expected
+
+
+# ---- step lifecycle -> STATE + STEP ----
+
+
+@pytest.mark.asyncio
+async def test_step_started_appends_running_entry_and_emits_step_started():
+    events = await _collect(
+        _stream(
+            StepStartedEvent(step_name="research", step_index=0),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert any(e.type == ET.STEP_STARTED and e.step_name == "research" for e in events)
+    assert _steps(events) == [{"name": "research", "status": "running", "step_index": 0, "output": None}]
+
+
+@pytest.mark.asyncio
+async def test_step_completed_flips_to_completed_with_output_and_step_finished():
+    events = await _collect(
+        _stream(
+            StepStartedEvent(step_name="research", step_index=0),
+            StepCompletedEvent(step_name="research", step_index=0, content="three facts"),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert any(e.type == ET.STEP_FINISHED and e.step_name == "research" for e in events)
+    assert _steps(events)[0]["status"] == "completed"
+    assert _steps(events)[0]["output"] == "three facts"
+
+
+@pytest.mark.asyncio
+async def test_step_output_sets_output_without_step_finished():
+    events = await _collect(
+        _stream(
+            StepStartedEvent(step_name="s", step_index=0),
+            StepOutputEvent(step_name="s", step_index=0, step_output=StepOutput(content="partial")),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert _steps(events)[0]["output"] == "partial"
+    assert not any(e.type == ET.STEP_FINISHED for e in events)
+
+
+@pytest.mark.asyncio
+async def test_step_error_sets_error_status_not_run_error():
+    events = await _collect(
+        _stream(
+            StepStartedEvent(step_name="s", step_index=0),
+            StepErrorEvent(step_name="s", step_index=0, error="boom"),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert _steps(events)[0]["status"] == "error"
+    assert _steps(events)[0]["output"] == "boom"
+    assert any(e.type == ET.STEP_FINISHED for e in events)
+    assert not any(e.type == ET.RUN_ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_workflow_started_initialises_progress():
+    events = await _collect(
+        _stream(
+            WorkflowStartedEvent(workflow_name="wf"),
+            StepStartedEvent(step_name="s", step_index=0),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert "workflow_progress" in (_final_state(events) or {})
+    assert _steps(events)
+
+
+@pytest.mark.asyncio
+async def test_step_event_between_chunks_emits_step_and_state_not_custom():
+    # A structural event between two streamed content chunks emits STEP + STATE_DELTA
+    # (NOT CustomEvent) and does not close the open text message; the final answer
+    # (already streamed) is not duplicated.
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="step one. "),
+            StepStartedEvent(step_name="s1", step_index=0),
+            StepCompletedEvent(step_name="s1", step_index=0, content="step one. "),
+            RunContentEvent(content="step two final."),
+            WorkflowCompletedEvent(
+                content="step two final.",
+                step_results=[StepOutput(content="step two final.", executor_type="agent", step_type=StepType.STEP)],
+                workflow_name="wf",
+            ),
+        )
+    )
+    assert not any(e.type == ET.CUSTOM for e in events)
+    assert any(e.type == ET.STEP_STARTED for e in events)
+    assert any(e.type == ET.STEP_FINISHED for e in events)
+    assert any(e.type == ET.STATE_DELTA for e in events)
+    deltas = _deltas(events)
+    assert "step one. " in deltas and "step two final." in deltas
+    assert deltas.count("step two final.") == 1
+
+
+# ---- cancel / pause -> STATE status, never RUN_ERROR, never CustomEvent ----
+
+
+@pytest.mark.asyncio
+async def test_workflow_cancelled_sets_status_not_custom():
+    events = await _collect(_stream(WorkflowCancelledEvent(reason="user stop", workflow_name="wf")))
+    assert not any(e.type == ET.CUSTOM for e in events)
+    assert not any(e.type == ET.RUN_ERROR for e in events)
+    assert any(e.type == ET.RUN_FINISHED for e in events)
+    assert _wf_status(events) == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancel_reason_not_rendered_as_answer():
+    # Real cancel sequence: partial content streams, then WorkflowCancelled(content=reason),
+    # then WorkflowCompleted(content=reason). The reason must NOT render as the answer
+    # (progress_handler sets state.cancelled, which the completion gate honors).
+    reason = "Operation cancelled by user"
+    events = await _collect(
+        _stream(
+            RunContentEvent(content="partial answer so far"),
+            WorkflowCancelledEvent(reason=reason, content=reason, workflow_name="wf"),
+            WorkflowCompletedEvent(content=reason, step_results=[], workflow_name="wf"),
+        )
+    )
+    deltas = _deltas(events)
+    assert "partial answer so far" in deltas
+    assert reason not in deltas
+    assert _wf_status(events) == "cancelled"
+    assert not any(e.type == ET.RUN_ERROR for e in events)
+
+
+@pytest.mark.asyncio
+async def test_workflow_paused_sets_status_not_custom():
+    events = await _collect(_stream(WorkflowPausedEvent(workflow_name="wf")))
+    assert not any(e.type == ET.CUSTOM for e in events)
+    assert not any(e.type == ET.RUN_ERROR for e in events)
+    assert _wf_status(events) == "paused"
+    assert any(e.type == ET.RUN_FINISHED for e in events)
+
+
+# ---- baseline without caller state ----
+
+
+@pytest.mark.asyncio
+async def test_baseline_snapshot_emitted_without_user_state():
+    # _collect runs with run_state=None (no caller state). The first structural event
+    # must establish a STATE baseline (snapshot) so the subsequent deltas apply.
+    events = await _collect(
+        _stream(
+            WorkflowStartedEvent(workflow_name="wf"),
+            StepStartedEvent(step_name="s", step_index=0),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    types = _types(events)
+    # the baseline SNAPSHOT must precede the first DELTA (it establishes the diff reference);
+    # without it the first STATE event would be a delta and the only snapshot the terminal one.
+    assert ET.STATE_SNAPSHOT in types and ET.STATE_DELTA in types
+    assert types.index(ET.STATE_SNAPSHOT) < types.index(ET.STATE_DELTA)
+    assert "workflow_progress" in (_final_state(events) or {})
+
+
+@pytest.mark.asyncio
+async def test_final_snapshot_status_completed_and_steps_survive():
+    events = await _collect(
+        _stream(
+            StepStartedEvent(step_name="s", step_index=0),
+            StepCompletedEvent(step_name="s", step_index=0, content="done"),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert _wf_status(events) == "completed"
+    assert _steps(events)[0]["name"] == "s"
+    assert _steps(events)[0]["status"] == "completed"
+
+
+# ---- custom_event: the author's own event keeps its CustomEvent passthrough ----
+
+
+@pytest.mark.asyncio
+async def test_custom_event_keeps_custom_passthrough():
+    from agno.run.workflow import CustomEvent as WorkflowCustomEvent
+
+    events = await _collect(
+        _stream(
+            WorkflowCustomEvent(name="my_event", data={"x": 1}),
+            WorkflowCompletedEvent(content=None, workflow_name="wf"),
+        )
+    )
+    assert len([e for e in events if e.type == ET.CUSTOM]) == 1
+
+
+# ---- real engine: container shapes produce a populated FLAT list (no CUSTOM/RAW) ----
+
+
+def _stub_step(name):
+    from agno.agent.agent import Agent
+    from agno.workflow.step import Step
+
+    return Step(name=name, agent=Agent(name=name, model=_StubModel(id="stub")))
+
+
+@pytest.mark.parametrize("shape", ["loop", "parallel", "condition", "router", "nested"])
+@pytest.mark.asyncio
+async def test_real_engine_container_populates_flat_steps(shape):
+    from agno.workflow.condition import Condition
+    from agno.workflow.loop import Loop
+    from agno.workflow.parallel import Parallel
+    from agno.workflow.router import Router
+    from agno.workflow.workflow import Workflow
+
+    s = _stub_step
+    if shape == "loop":
+        steps = [Loop(steps=[s("ls")], max_iterations=2, name="loop")]
+    elif shape == "parallel":
+        steps = [Parallel(s("p1"), s("p2"), name="par")]
+    elif shape == "condition":
+        steps = [Condition(name="cond", evaluator=lambda *a, **k: True, steps=[s("cs")])]
+    elif shape == "router":
+        rs = s("rs")
+        steps = [Router(name="router", selector=lambda *a, **k: [rs], choices=[rs])]
+    else:  # nested: a loop inside a parallel
+        steps = [Parallel(s("p1"), Loop(steps=[s("ls")], max_iterations=2, name="inner_loop"), name="par")]
+
+    wf = Workflow(name="w", steps=steps)
+    events = [e async for e in run_entity(wf, _FakeRunInput())]
+    assert not any(e.type == ET.CUSTOM for e in events)
+    # Inner-agent lifecycle events (RunStarted, ModelRequest*, ...) RAW via the shared
+    # handlers (pre-existing, all entities). Assert no WORKFLOW STRUCTURAL event falls to RAW
+    # (the per-event guarantee is proven exhaustively by test_no_structural_event_falls_through_to_raw).
+    structural = {e.value for e in WorkflowRunEvent}
+    raw_structural = [
+        e for e in events if e.type == ET.RAW and isinstance(e.event, dict) and e.event.get("event") in structural
+    ]
+    assert raw_structural == []
+    steps_out = _steps(events)
+    assert len(steps_out) >= 1  # inner steps populate the flat list
+    assert all(set(st.keys()) == {"name", "status", "step_index", "output"} for st in steps_out)
+
+
+# ---- pulled-forward (flag #1): DB-backed workflow keeps progress in the final snapshot ----
+
+
+@pytest.mark.asyncio
+async def test_db_backed_workflow_keeps_progress_in_final_snapshot(tmp_path):
+    # Client passes session_state + the workflow has a DB -> save_session strips the
+    # transient keys (incl. workflow_progress) at persist time. workflow_progress must
+    # STILL be present in the final AG-UI STATE_SNAPSHOT (the strip is for the DB only).
+    from agno.db.sqlite import SqliteDb
+    from agno.workflow.workflow import Workflow
+
+    wf = Workflow(name="w", db=SqliteDb(db_file=str(tmp_path / "wf.db")), steps=[_stub_step("s")])
+    ri = _FakeRunInput()
+    ri.state = {"client_key": "client_value"}  # client-passed session_state (aliased into the run)
+    events = [e async for e in run_entity(wf, ri)]
+    final = _final_state(events) or {}
+    # (a) the wire's final snapshot KEEPS workflow_progress (re-inject survives the save-time strip)
+    assert "workflow_progress" in final
+    assert final["workflow_progress"]["steps"]
+    # (b) the persisted DB session does NOT carry workflow_progress: when the client passes
+    # session_state it is aliased into the saved session, so the save-time transient strip
+    # (workflow.py save_session/asave_session) removes workflow_progress before persist, while
+    # the re-inject keeps it on the wire. Regression guard for the strip + re-inject pair.
+    saved = wf.get_session(session_id=ri.thread_id)
+    persisted = (saved.session_data or {}).get("session_state", {}) if saved is not None else {}
+    assert saved is not None and "workflow_progress" not in persisted


### PR DESCRIPTION
## Summary

Surface a **Workflow's live progress to AG-UI clients using only native AG-UI mechanisms** — a flat `state.workflow_progress` object emitted via `STATE_SNAPSHOT`/`STATE_DELTA`, plus native `STEP_STARTED`/`STEP_FINISHED` — so progress renders **out of the box** (e.g. CopilotKit `useCoAgentStateRender`), with **no structural `CustomEvent`**.

Stacked on **`himanshu/agui-utils-split` (#8364)** — please review/merge that first.

### Why native-first (the key finding)

AG-UI's **only auto-rendering structured channel is STATE**. In the default client, `CUSTOM` / `RAW` / `STEP_*` are subscriber-only no-ops, and `STEP_STARTED`/`STEP_FINISHED` carry just `step_name` — **they render nothing on their own**. So to make workflow progress visible *without* bespoke client code, the progress has to live in shared **STATE**. We still emit native `STEP_*` at step boundaries (protocol consistency / for subscribers), but **STATE is the visible channel**. This mirrors the `agentic_generative_ui` pattern (`state.steps`) that 7+ AG-UI integrations already render.

## Architecture

`state.workflow_progress`:

```jsonc
{
  "status": "running" | "completed" | "paused" | "cancelled",
  "steps": [
    { "name": str, "status": "running"|"completed"|"error"|"paused",
      "step_index": int | [int,...], "output": str | null }
  ]
}
```

Structural `WorkflowRunEvent`s map to mutations (in `os/interfaces/agui/workflow_progress.py`):

- `step_started` → append `{running}` (+ `STEP_STARTED`)
- `step_completed` → `completed` + `output` (+ `STEP_FINISHED`)
- `step_output` → update `output`
- `step_error` → `error` + `output` (+ `STEP_FINISHED`, **not** `RUN_ERROR`)
- pause family → `paused`; continue → `running`; `workflow_cancelled` → `cancelled`
- container events (loop / parallel / condition / router) → **no-ops**; their inner steps populate the flat list
- `mark_completed` promotes `running` → `completed` at terminal time, **never clobbering** an already-set `cancelled`/`error`/`paused`

## Key Decisions

1. **STATE over CUSTOM** — the native-first choice (the only auto-rendering channel). Precedent in-repo: the Slack interface already models a `{title, status}` task-card in shared state (`libs/agno/agno/os/interfaces/slack/state.py:17-30`).

2. **Pattern A transient strip — the only change outside the agui interface (+2 core lines in `libs/agno/agno/workflow/workflow.py`).** `workflow_progress` is transient `session_state`: popped before the DB save in **both** `save_session` and `asave_session`, immediately beside the existing transient strips (`workflow_id`, `current_session_id`/`current_user_id`/`current_run_id`, `run_id`, `session_id`, `workflow_name`). It is then **re-injected into the final `STATE_SNAPSHOT`** (`handlers._finalize_run`) so the steps the deltas already rendered are not blanked by the engine's `session_state` reset. (Left uncommented to match the 7 sibling pops, which carry no per-line comments.)

3. **`workflow_handlers.py` is a byte-identical port from #8164** (the completion/answer gate), kept identical so #8164 can later rebase cleanly on top. **Port-exception:** its module docstring predates this native-first rework and reads slightly stale relative to this PR — kept verbatim *on purpose* to preserve the byte-identical port, not overlooked.

## Out of Scope / Follow-ups

- **Topology grouping** (loop/parallel/condition/router rendered *flat*, not nested) — deferred.
- **Interactive HITL pause/resume** — deferred; pause surfaces as a status label only.
- **ACTIVITY-channel placement** — researched (it would auto-position progress in the message stream without a custom `messageView`), deferred: it buys ordering only, still needs a client-registered renderer, and gives no control over appearance.
- **#8164 (`feat/workflow-agui-interface`, frozen @ `2fae6a39b`)** becomes the advanced/custom layer, rebased on top of this PR.
- **Observation (not changed here):** this cookbook uses `gpt-5.5` per `CLAUDE.md`; sibling cookbooks in the dir use `gpt-5.4` (from #8376). A dir-wide model bump is a separate change.

## Verification log — 2026-06-22

- **Unit:** 98 agui interface tests pass (workflow + router + state_events).
- **Mutation:** 5/5 key guards re-proven to fail-on-break — `custom_event` exclusion, `_finalize_run` re-inject, `mark_completed` promotion, strip on **both** save paths, enum-driven RAW coverage; cheat-detector clean.
- **Core:** 410 workflow tests pass (7 pre-existing skips) — strip non-regressing on save/load.
- **Static:** ruff check + format clean; **mypy 0 introduced** (base-comparison vs #8364 — the only 2 errors are pre-existing and identical at base).
- **Live (raw SSE):** `POST /agui` → 2 `STATE_SNAPSHOT`, 7 `STATE_DELTA`, 3 `STEP_STARTED`, 3 `STEP_FINISHED`, **`CUSTOM`=0**, `workflow_progress.steps` on the wire.
- **Live (Dojo render):** `state.workflow_progress.steps` renders and fills research → analyze → summarize to **3/3 Complete** in CopilotKit (`agentic_generative_ui`, `useCoAgentStateRender`) — screenshot on file.
- **A/B:** agent/team AG-UI paths unchanged (15 router + state_events tests).
- **Concurrency:** two sessions run concurrently with no progress bleed.
- **Honest gaps:** Postgres not run live (the strip is backend-agnostic by construction — pops before the DB driver in both save paths; verified on sqlite sync + async). Topology + HITL deferred as above.

---

## Type of change

- [x] New feature

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation tooling — `ruff check`, `ruff format --check`, and `mypy` on the changed files (clean; 0 mypy errors introduced vs base)
- [x] Self-review completed
- [x] Documentation updated (module docstrings on the new modules; cookbook + TEST_LOG)
- [x] Examples and guides: added `cookbook/05_agent_os/interfaces/agui/workflow_progress.py`
- [x] Tested in clean environment (worktree pinned to #8364; import-path gate verified)
- [x] Tests added/updated — `test_agui_workflow.py` (98 agui tests; mutation-proven)

### Duplicate and AI-Generated PR Check

- [x] Searched existing PRs — this supersedes the CustomEvent-based approach in #8164 (which becomes the custom layer on top)
- [x] If a similar PR exists, explained why this is a better approach — see "Why native-first"
- [x] This PR was AI-assisted (Claude Code), authored and human-gated/verified throughout

## Additional Notes

- **Base branch:** `himanshu/agui-utils-split` (#8364) — stacked PR; GitHub retargets it to the default branch when #8364 merges. #8164 (`feat/workflow-agui-interface`) stays frozen and becomes the follow-up custom (CustomEvent) layer rebased on top.
- The +2 core lines in `workflow.py` are the only change outside `os/interfaces/agui/`; everything else is interface, tests, or cookbook.