### PR TITLE
[fix] Serialize PostgresDb table materialization

### DIFF
--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from datetime import date, datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast
@@ -159,6 +160,8 @@ class PostgresDb(BaseDb):
 
         self.db_schema: str = db_schema if db_schema is not None else "ai"
         self.metadata: MetaData = MetaData(schema=self.db_schema)
+        self._table_lock = threading.RLock()
+        self.memory_table: Optional[Table] = None
         self.create_schema: bool = create_schema
 
         # Initialize database session
@@ -449,137 +452,154 @@ class PostgresDb(BaseDb):
         }
         return table_map.get(logical_name, logical_name)
 
+    def _get_table_with_lock(
+        self,
+        table_attr: str,
+        table_name: str,
+        table_type: str,
+        create_table_if_not_found: Optional[bool] = False,
+    ) -> Optional[Table]:
+        with self._table_lock:
+            table = self._get_or_create_table(
+                table_name=table_name,
+                table_type=table_type,
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            setattr(self, table_attr, table)
+            return table
+
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
         if table_type == "sessions":
-            self.session_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="session_table",
                 table_name=self.session_table_name,
                 table_type="sessions",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.session_table
 
         if table_type == "memories":
-            self.memory_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="memory_table",
                 table_name=self.memory_table_name,
                 table_type="memories",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.memory_table
 
         if table_type == "metrics":
-            self.metrics_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="metrics_table",
                 table_name=self.metrics_table_name,
                 table_type="metrics",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.metrics_table
 
         if table_type == "evals":
-            self.eval_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="eval_table",
                 table_name=self.eval_table_name,
                 table_type="evals",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.eval_table
 
         if table_type == "knowledge":
-            self.knowledge_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="knowledge_table",
                 table_name=self.knowledge_table_name,
                 table_type="knowledge",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.knowledge_table
 
         if table_type == "culture":
-            self.culture_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="culture_table",
                 table_name=self.culture_table_name,
                 table_type="culture",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.culture_table
 
         if table_type == "versions":
-            self.versions_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="versions_table",
                 table_name=self.versions_table_name,
                 table_type="versions",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.versions_table
 
         if table_type == "traces":
-            self.traces_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="traces_table",
                 table_name=self.trace_table_name,
                 table_type="traces",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.traces_table
 
         if table_type == "spans":
             # Ensure traces table exists first (spans has FK to traces)
             if create_table_if_not_found:
                 self._get_table(table_type="traces", create_table_if_not_found=True)
 
-            self.spans_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="spans_table",
                 table_name=self.span_table_name,
                 table_type="spans",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.spans_table
 
         if table_type == "components":
-            self.component_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="component_table",
                 table_name=self.components_table_name,
                 table_type="components",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.component_table
 
         if table_type == "component_configs":
-            self.component_configs_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="component_configs_table",
                 table_name=self.component_configs_table_name,
                 table_type="component_configs",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.component_configs_table
 
         if table_type == "component_links":
-            self.component_links_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="component_links_table",
                 table_name=self.component_links_table_name,
                 table_type="component_links",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.component_links_table
+
         if table_type == "learnings":
-            self.learnings_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="learnings_table",
                 table_name=self.learnings_table_name,
                 table_type="learnings",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.learnings_table
 
         if table_type == "schedules":
-            self.schedules_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="schedules_table",
                 table_name=self.schedules_table_name,
                 table_type="schedules",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.schedules_table
 
         if table_type == "schedule_runs":
-            self.schedule_runs_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="schedule_runs_table",
                 table_name=self.schedule_runs_table_name,
                 table_type="schedule_runs",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.schedule_runs_table
 
         if table_type == "approvals":
-            self.approvals_table = self._get_or_create_table(
+            return self._get_table_with_lock(
+                table_attr="approvals_table",
                 table_name=self.approvals_table_name,
                 table_type="approvals",
                 create_table_if_not_found=create_table_if_not_found,
             )
-            return self.approvals_table
 
         raise ValueError(f"Unknown table type: {table_type}")
 

--- a/libs/agno/tests/unit/db/test_postgres.py
+++ b/libs/agno/tests/unit/db/test_postgres.py
@@ -1,3 +1,6 @@
+from concurrent.futures import ThreadPoolExecutor
+import threading
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -289,6 +292,46 @@ def test_get_table_evals(postgres_db):
 
     assert table == mock_table
     assert hasattr(postgres_db, "eval_table")
+
+
+def test_get_table_materialization_is_serialized_when_called_concurrently(postgres_db):
+    """Concurrent table access should not mutate shared metadata at the same time."""
+    mock_table = Mock(spec=Table)
+    active_calls = 0
+    max_active_calls = 0
+    call_lock = threading.Lock()
+    start_event = threading.Event()
+
+    def slow_get_or_create_table(*args, **kwargs):
+        nonlocal active_calls, max_active_calls
+        with call_lock:
+            active_calls += 1
+            max_active_calls = max(max_active_calls, active_calls)
+
+        time.sleep(0.05)
+
+        with call_lock:
+            active_calls -= 1
+        return mock_table
+
+    def get_table():
+        start_event.wait()
+        return postgres_db._get_table("evals", create_table_if_not_found=True)
+
+    with patch.object(postgres_db, "_get_or_create_table", side_effect=slow_get_or_create_table) as mock_get_or_create:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(get_table) for _ in range(2)]
+            start_event.set()
+            tables = [future.result() for future in futures]
+
+    assert tables == [mock_table, mock_table]
+    assert mock_get_or_create.call_count == 2
+    mock_get_or_create.assert_called_with(
+        table_name=postgres_db.eval_table_name,
+        table_type="evals",
+        create_table_if_not_found=True,
+    )
+    assert max_active_calls == 1
 
 
 def test_get_table_knowledge(postgres_db):


### PR DESCRIPTION
## Summary

Fixes #8196.

`PostgresDb._get_table()` now serializes the table materialization path with an instance-level `RLock`, so concurrent first callers sharing one `PostgresDb` instance cannot mutate the shared SQLAlchemy `MetaData` at the same time. The helper preserves the existing behavior of calling `_get_or_create_table()` on each `_get_table()` call; it only prevents overlapping materialization/validation work.

Added a unit regression test that starts two threads through the `evals` table path and asserts `_get_or_create_table()` is never active concurrently.

Previous duplicate PRs #8199 and #8293 are both closed; I also rechecked current open PRs and did not find an active PR addressing #8196.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation performed locally:

- `PYTHONPATH=$PWD/libs/agno uv run --no-project --with pytest --with sqlalchemy --with psycopg-binary --with pydantic --with pydantic-settings --with python-dotenv --with rich --with typer --with typing-extensions --with packaging --with pyyaml --with gitpython --with httpx --with docstring-parser --with python-multipart python -m pytest libs/agno/tests/unit/db/test_postgres.py::test_get_table_materialization_is_serialized_when_called_concurrently -q` -> passed
- `PYTHONPATH=$PWD/libs/agno uv run --no-project --with pytest --with sqlalchemy --with psycopg-binary --with pydantic --with pydantic-settings --with python-dotenv --with rich --with typer --with typing-extensions --with packaging --with pyyaml --with gitpython --with httpx --with docstring-parser --with python-multipart python -m pytest libs/agno/tests/unit/db/test_postgres.py -q` -> 28 passed
- `PYTHONPATH=$PWD/libs/agno uv run --no-project --with ruff ruff check libs/agno/agno/db/postgres/postgres.py libs/agno/tests/unit/db/test_postgres.py` -> passed
- `PYTHONPATH=$PWD/libs/agno uv run --no-project --with ruff ruff format --check libs/agno/agno/db/postgres/postgres.py libs/agno/tests/unit/db/test_postgres.py` -> passed
- `git diff --check` -> passed

I did not run the full `./scripts/format.sh` / `./scripts/validate.sh` suite. `uv run --extra dev --extra postgres pytest ...` currently fails before test execution while resolving optional extras because `agno[a2a]` requires `httpx>=0.28.1` and `agno[brave]` pulls `brave-search` metadata constrained to `httpx<0.26.0`. I used a minimal `uv --no-project --with ...` environment for the targeted unit checks above.

This PR was AI-assisted and self-reviewed against #8196, the old duplicate #8199, and the existing `PostgresDb` table-loading behavior.
