### PR TITLE
[fix] Respect scheduler poll interval after request failures

### DIFF
--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -416,7 +416,8 @@ class ScheduleExecutor:
                     params={"session_id": session_id},
                 )
             except Exception as exc:
-                log_warning(f"Poll request failed for run {run_id}: {exc}: {exc}")
+                log_warning(f"Poll request failed for run {run_id}: {exc}")
+                await asyncio.sleep(self.poll_interval)
                 continue
 
             if resp.status_code == 404:

--- a/libs/agno/tests/unit/scheduler/test_executor.py
+++ b/libs/agno/tests/unit/scheduler/test_executor.py
@@ -182,6 +182,23 @@ class TestExecutorPollRun:
         assert result["session_id"] == "sess-1"
 
     @pytest.mark.asyncio
+    @patch("agno.scheduler.executor.asyncio.sleep", new_callable=AsyncMock)
+    async def test_poll_request_exception_waits_before_retry(self, mock_sleep):
+        executor = ScheduleExecutor(base_url="http://localhost:8000", internal_service_token="tok", poll_interval=5)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json = MagicMock(return_value={"status": "COMPLETED"})
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=[RuntimeError("temporary outage"), mock_resp])
+
+        result = await executor._poll_run(mock_client, {}, "agents", "a1", "run-1", "sess-1", 60)
+
+        assert result["status"] == "success"
+        assert mock_client.request.await_count == 2
+        mock_sleep.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
     async def test_poll_error(self, executor):
         mock_resp = MagicMock()
         mock_resp.status_code = 200


### PR DESCRIPTION
## Summary

Fixes #8498.

`ScheduleExecutor._poll_run()` now waits for the configured `poll_interval` after a transient poll request exception before retrying. This prevents a failed run-status request from turning into a tight retry/log loop. The warning message also no longer repeats the same exception text twice.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- `python -m pytest libs\agno\tests\unit\scheduler\test_executor.py -q` (`24 passed`)
- `python -m ruff check libs\agno\agno\scheduler\executor.py libs\agno\tests\unit\scheduler\test_executor.py`
- `python -m ruff format --check libs\agno\agno\scheduler\executor.py libs\agno\tests\unit\scheduler\test_executor.py`

## Additional Notes

I did not run the full repository format/validation scripts locally; I ran targeted tests and Ruff checks for the touched scheduler files.