### PR TITLE
[fix] Confine LocalFileSystemTools writes to target directory

### DIFF
--- a/libs/agno/agno/tools/local_file_system.py
+++ b/libs/agno/agno/tools/local_file_system.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional
 from uuid import uuid4
 
@@ -53,7 +53,9 @@ class LocalFileSystemTools(Toolkit):
         """
         try:
             filename = filename or str(uuid4())
-            directory = directory or self.target_directory
+            if self._filename_has_path_components(filename):
+                return f"Error: Path '{filename}' is outside the allowed target directory"
+
             if filename and "." in filename:
                 path_obj = Path(filename)
                 filename = path_obj.stem
@@ -63,14 +65,18 @@ class LocalFileSystemTools(Toolkit):
 
             extension = (extension or self.default_extension).lstrip(".")
 
-            # Create directory if it doesn't exist
-            dir_path = Path(directory)
-            dir_path.mkdir(parents=True, exist_ok=True)
+            target_path = Path(self.target_directory).resolve()
+            dir_path = self._resolve_write_directory(directory, target_path)
+            if dir_path is None:
+                return f"Error: Directory '{directory}' is outside the allowed target directory"
 
             # Construct full filename with extension
             full_filename = f"{filename}.{extension}"
-            file_path = dir_path / full_filename
+            file_path = (dir_path / full_filename).resolve()
+            if not self._is_path_within_base(file_path, target_path):
+                return f"Error: Path '{full_filename}' is outside the allowed target directory"
 
+            file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text(content)
 
             return f"Successfully wrote file to: {file_path}"
@@ -79,6 +85,45 @@ class LocalFileSystemTools(Toolkit):
             error_msg = f"Failed to write file: {str(e)}"
             log_error(error_msg)
             return f"Error: {error_msg}"
+
+    def _resolve_write_directory(self, directory: Optional[str], target_path: Path) -> Optional[Path]:
+        if not directory:
+            return target_path
+
+        requested_directory = Path(directory)
+        if requested_directory.is_absolute():
+            resolved_directory = requested_directory.resolve()
+        else:
+            safe, resolved_directory = self._check_path(directory, target_path)
+            if not safe:
+                return None
+
+        if not self._is_path_within_base(resolved_directory, target_path):
+            return None
+
+        return resolved_directory
+
+    @staticmethod
+    def _filename_has_path_components(filename: str) -> bool:
+        if filename in (".", ".."):
+            return True
+
+        native_path = Path(filename)
+        windows_path = PureWindowsPath(filename)
+        return (
+            native_path.is_absolute()
+            or windows_path.is_absolute()
+            or len(native_path.parts) > 1
+            or len(windows_path.parts) > 1
+        )
+
+    @staticmethod
+    def _is_path_within_base(path: Path, base: Path) -> bool:
+        try:
+            path.relative_to(base)
+        except ValueError:
+            return False
+        return True
 
     def read_file(self, filename: str, directory: Optional[str] = None) -> str:
         """

--- a/libs/agno/tests/unit/tools/test_local_file_system.py
+++ b/libs/agno/tests/unit/tools/test_local_file_system.py
@@ -1,0 +1,50 @@
+import tempfile
+from pathlib import Path
+
+from agno.tools.local_file_system import LocalFileSystemTools
+
+
+def test_write_file_writes_inside_target_directory():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = LocalFileSystemTools(target_directory=tmp_dir)
+
+        result = tools.write_file("hello", filename="report")
+
+        assert "Successfully wrote file" in result
+        assert (Path(tmp_dir) / "report.txt").read_text() == "hello"
+
+
+def test_write_file_allows_relative_directory_inside_target_directory():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tools = LocalFileSystemTools(target_directory=tmp_dir)
+
+        result = tools.write_file("hello", filename="report", directory="nested")
+
+        assert "Successfully wrote file" in result
+        assert (Path(tmp_dir) / "nested" / "report.txt").read_text() == "hello"
+
+
+def test_write_file_blocks_filename_path_escape():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        target_dir = Path(tmp_dir) / "target"
+        target_dir.mkdir()
+        tools = LocalFileSystemTools(target_directory=str(target_dir))
+
+        result = tools.write_file("boom", filename="../escaped", extension="txt")
+
+        assert "Error" in result
+        assert "outside" in result
+        assert not (Path(tmp_dir) / "escaped.txt").exists()
+
+
+def test_write_file_blocks_directory_path_escape():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        target_dir = Path(tmp_dir) / "target"
+        target_dir.mkdir()
+        tools = LocalFileSystemTools(target_directory=str(target_dir))
+
+        result = tools.write_file("boom", filename="report", directory="../outside")
+
+        assert "Error" in result
+        assert "outside" in result
+        assert not (Path(tmp_dir) / "outside").exists()


### PR DESCRIPTION
## Summary

Fixes #8482.

`LocalFileSystemTools.write_file()` now validates both the requested output directory and the final resolved file path against `target_directory` before creating directories or writing content. It also rejects `filename` values that include path components, keeping nested writes on the existing `directory` parameter where the directory can be validated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- `python -m pytest libs\agno\tests\unit\tools\test_local_file_system.py -q` (`4 passed`)
- `python -m ruff check libs\agno\agno\tools\local_file_system.py libs\agno\tests\unit\tools\test_local_file_system.py`
- `python -m ruff format --check libs\agno\agno\tools\local_file_system.py libs\agno\tests\unit\tools\test_local_file_system.py`

I also ran `python -m pytest libs\agno\tests\unit\tools\test_coding_tools.py libs\agno\tests\unit\tools\test_workspace.py -q` on Windows. The path-boundary tests in those suites passed, but the run reported 15 unrelated failures because POSIX commands such as `sleep`, `seq`, `grep`, `ls`, `pwd`, and `printf` are not available in this shell environment.

## Additional Notes

I did not run the full repository format/validation scripts locally; I ran targeted tests and Ruff checks for the touched files.