### PR TITLE
fix: apply timeouts to HTTP toolkits

### DIFF
--- a/libs/agno/agno/tools/brightdata.py
+++ b/libs/agno/agno/tools/brightdata.py
@@ -82,7 +82,9 @@ class BrightDataTools(Toolkit):
             if self.verbose:
                 log_info(f"[Bright Data] Request: {payload['url']}")
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(
+                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Failed to scrape: {response.status_code} - {response.text}")
@@ -147,7 +149,9 @@ class BrightDataTools(Toolkit):
                 "data_format": "screenshot",
             }
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(
+                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Error {response.status_code}: {response.text}")
@@ -327,6 +331,7 @@ class BrightDataTools(Toolkit):
                 params={"dataset_id": dataset_id, "include_errors": "true"},
                 headers=self.headers,
                 json=[request_data],
+                timeout=self.timeout,
             )
 
             trigger_data = trigger_response.json()
@@ -346,6 +351,7 @@ class BrightDataTools(Toolkit):
                         f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
                         params={"format": "json"},
                         headers=self.headers,
+                        timeout=self.timeout,
                     )
 
                     snapshot_data = snapshot_response.json()

--- a/libs/agno/agno/tools/clickup.py
+++ b/libs/agno/agno/tools/clickup.py
@@ -17,12 +17,14 @@ class ClickUpTools(Toolkit):
         self,
         api_key: Optional[str] = None,
         master_space_id: Optional[str] = None,
+        timeout: int = 30,
         **kwargs,
     ):
         self.api_key = api_key or getenv("CLICKUP_API_KEY")
         self.master_space_id = master_space_id or getenv("MASTER_SPACE_ID")
         self.base_url = "https://api.clickup.com/api/v2"
         self.headers = {"Authorization": self.api_key}
+        self.timeout = timeout
 
         if not self.api_key:
             raise ValueError("CLICKUP_API_KEY not set. Please set the CLICKUP_API_KEY environment variable.")
@@ -47,7 +49,14 @@ class ClickUpTools(Toolkit):
         """Make a request to the ClickUp API."""
         url = f"{self.base_url}/{endpoint}"
         try:
-            response = requests.request(method=method, url=url, headers=self.headers, params=params, json=data)
+            response = requests.request(
+                method=method,
+                url=url,
+                headers=self.headers,
+                params=params,
+                json=data,
+                timeout=self.timeout,
+            )
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/libs/agno/tests/unit/tools/test_brightdata.py
+++ b/libs/agno/tests/unit/tools/test_brightdata.py
@@ -93,7 +93,29 @@ def test_make_request_success(brightdata_tools, mock_requests):
 
     assert result == "Success response"
     mock_requests.post.assert_called_once_with(
-        brightdata_tools.endpoint, headers=brightdata_tools.headers, data=json.dumps(payload)
+        brightdata_tools.endpoint,
+        headers=brightdata_tools.headers,
+        data=json.dumps(payload),
+        timeout=brightdata_tools.timeout,
+    )
+
+
+def test_make_request_uses_configured_timeout(mock_requests):
+    """Test _make_request passes the configured timeout to requests."""
+    tools = BrightDataTools(api_key="test_key", timeout=42)
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.text = "Success response"
+    mock_requests.post.return_value = mock_response
+
+    payload = {"url": "https://example.com", "zone": "test_zone"}
+    tools._make_request(payload)
+
+    mock_requests.post.assert_called_once_with(
+        tools.endpoint,
+        headers=tools.headers,
+        data=json.dumps(payload),
+        timeout=42,
     )
 
 
@@ -201,6 +223,19 @@ def test_get_screenshot_success(brightdata_tools, mock_requests, mock_agent):
     # Verify base64 encoding
     expected_base64 = base64.b64encode(mock_image_bytes).decode("utf-8")
     assert image_artifact.content == expected_base64.encode("utf-8")
+
+
+def test_get_screenshot_uses_configured_timeout(mock_requests, mock_agent):
+    """Test get_screenshot passes the configured timeout to requests."""
+    tools = BrightDataTools(api_key="test_key", timeout=21)
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = b"fake_png_data"
+    mock_requests.post.return_value = mock_response
+
+    tools.get_screenshot(mock_agent, "https://example.com")
+
+    assert mock_requests.post.call_args.kwargs["timeout"] == 21
 
 
 def test_get_screenshot_no_api_key(mock_agent):
@@ -398,6 +433,22 @@ def test_web_data_feed_with_reviews_param(brightdata_tools, mock_requests):
     # Verify the request included num_of_reviews
     trigger_args = mock_requests.post.call_args
     assert trigger_args[1]["json"] == [{"url": "https://facebook.com/company", "num_of_reviews": "50"}]
+
+
+def test_web_data_feed_uses_configured_timeout(mock_requests):
+    """Test web_data_feed passes the configured timeout to trigger and snapshot requests."""
+    tools = BrightDataTools(api_key="test_key", timeout=13)
+    mock_trigger_response = Mock()
+    mock_trigger_response.json.return_value = {"snapshot_id": "test_snapshot_123"}
+    mock_snapshot_response = Mock()
+    mock_snapshot_response.json.return_value = {"product_title": "Test Product"}
+    mock_requests.post.return_value = mock_trigger_response
+    mock_requests.get.return_value = mock_snapshot_response
+
+    tools.web_data_feed("amazon_product", "https://amazon.com/dp/B123")
+
+    assert mock_requests.post.call_args.kwargs["timeout"] == 13
+    assert mock_requests.get.call_args.kwargs["timeout"] == 13
 
 
 def test_web_data_feed_exception(brightdata_tools, mock_requests):

--- a/libs/agno/tests/unit/tools/test_clickup.py
+++ b/libs/agno/tests/unit/tools/test_clickup.py
@@ -1,0 +1,26 @@
+"""Unit tests for ClickUpTools class."""
+
+from unittest.mock import Mock, patch
+
+from agno.tools.clickup import ClickUpTools
+
+
+def test_make_request_uses_configured_timeout():
+    """Test _make_request passes the configured timeout to requests."""
+    tools = ClickUpTools(api_key="test_key", master_space_id="space_id", timeout=17)
+    mock_response = Mock()
+    mock_response.json.return_value = {"ok": True}
+
+    with patch("agno.tools.clickup.requests.request", return_value=mock_response) as mock_request:
+        result = tools._make_request("GET", "task/task_id", params={"include_subtasks": "true"})
+
+    assert result == {"ok": True}
+    mock_response.raise_for_status.assert_called_once_with()
+    mock_request.assert_called_once_with(
+        method="GET",
+        url="https://api.clickup.com/api/v2/task/task_id",
+        headers=tools.headers,
+        params={"include_subtasks": "true"},
+        json=None,
+        timeout=17,
+    )


### PR DESCRIPTION
## Summary

Fixes #8496.

`BrightDataTools` already accepted a timeout, but the value was not passed into its HTTP requests. This now applies the configured timeout to the shared request helper, screenshot requests, dataset trigger requests, and dataset snapshot polling.

`ClickUpTools` now accepts a `timeout` option and passes it through its shared request helper, so every ClickUp API call has the same timeout behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Tests

Added coverage for:

- `BrightDataTools._make_request` passing the configured timeout into `requests.post`
- `BrightDataTools.get_screenshot` passing the configured timeout into its direct request
- `BrightDataTools.web_data_feed` passing the configured timeout into both trigger and snapshot polling requests
- `ClickUpTools._make_request` accepting a timeout option and passing it into `requests.request`

Validation run:

- `.\.venv\Scripts\python.exe -m pytest tests\unit\tools\test_brightdata.py tests\unit\tools\test_clickup.py -q` - 32 passed
- `.\.venv\Scripts\python.exe -m ruff check agno\tools\brightdata.py agno\tools\clickup.py tests\unit\tools\test_brightdata.py tests\unit\tools\test_clickup.py` - passed
- `.\.venv\Scripts\python.exe -m ruff format --check agno\tools\brightdata.py agno\tools\clickup.py tests\unit\tools\test_brightdata.py tests\unit\tools\test_clickup.py` - already formatted

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and PR Check

- [x] I searched existing open pull requests and did not find another PR already addressing #8496
- [x] I kept the diff scoped to the timeout behavior described in the issue

## Additional Notes

I ran the focused checks listed above. I did not run the full shell validation scripts locally in this Windows checkout.