### PR TITLE
fix: add sleep after transient poll failures in scheduler executor

### DIFF
--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -416,10 +416,12 @@ class ScheduleExecutor:
                     params={"session_id": session_id},
                 )
             except Exception as exc:
-                log_warning(f"Poll request failed for run {run_id}: {exc}: {exc}")
+                log_warning(f"Poll request failed for run {run_id}: {exc}")
+                await asyncio.sleep(self.poll_interval)
                 continue
 
             if resp.status_code == 404:
+                await asyncio.sleep(self.poll_interval)
                 continue
 
             if resp.status_code >= 400:
@@ -437,7 +439,8 @@ class ScheduleExecutor:
             try:
                 data = resp.json()
             except (json.JSONDecodeError, ValueError) as e:
-                log_warning(f"Invalid JSON in poll response for run {run_id}: {str(e)}")
+                log_warning(f"Invalid JSON in poll response for run {run_id}: {e}")
+                await asyncio.sleep(self.poll_interval)
                 continue
 
             run_status = data.get("status")


### PR DESCRIPTION
## Summary

- Add `await asyncio.sleep(self.poll_interval)` after transient exceptions in `ScheduleExecutor._poll_run()` to prevent busy-loop on network failures
- Apply the same sleep to the 404 and invalid JSON response paths which also immediately `continue` without sleeping
- Fix duplicated exception text in warning log (`{exc}: {exc}` → `{exc}`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows Agno's coding patterns
- [x] I have run `ruff format` and `ruff check` with no errors
- [x] This change does not break existing functionality

## Additional context

Closes #8498

When a transient network error occurs during run-status polling (e.g., reverse-proxy blip, DNS failure, or AgentOS restart), the exception handler logs and immediately continues the `while True` loop. This creates a tight CPU/log hot loop for up to `timeout_seconds` (default 3600s).

The fix ensures all non-terminal error paths in `_poll_run()` sleep for `self.poll_interval` before retrying, matching the behavior of the successful non-terminal response path.