### PR TITLE
fix: pass timeout to HTTP calls in BrightDataTools and ClickUpTools

### DIFF
--- a/libs/agno/agno/tools/brightdata.py
+++ b/libs/agno/agno/tools/brightdata.py
@@ -82,7 +82,9 @@ class BrightDataTools(Toolkit):
             if self.verbose:
                 log_info(f"[Bright Data] Request: {payload['url']}")
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(
+                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Failed to scrape: {response.status_code} - {response.text}")
@@ -147,7 +149,9 @@ class BrightDataTools(Toolkit):
                 "data_format": "screenshot",
             }
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(
+                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Error {response.status_code}: {response.text}")
@@ -327,6 +331,7 @@ class BrightDataTools(Toolkit):
                 params={"dataset_id": dataset_id, "include_errors": "true"},
                 headers=self.headers,
                 json=[request_data],
+                timeout=self.timeout,
             )
 
             trigger_data = trigger_response.json()
@@ -346,6 +351,7 @@ class BrightDataTools(Toolkit):
                         f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
                         params={"format": "json"},
                         headers=self.headers,
+                        timeout=self.timeout,
                     )
 
                     snapshot_data = snapshot_response.json()

--- a/libs/agno/agno/tools/clickup.py
+++ b/libs/agno/agno/tools/clickup.py
@@ -17,12 +17,14 @@ class ClickUpTools(Toolkit):
         self,
         api_key: Optional[str] = None,
         master_space_id: Optional[str] = None,
+        timeout: int = 30,
         **kwargs,
     ):
         self.api_key = api_key or getenv("CLICKUP_API_KEY")
         self.master_space_id = master_space_id or getenv("MASTER_SPACE_ID")
         self.base_url = "https://api.clickup.com/api/v2"
         self.headers = {"Authorization": self.api_key}
+        self.timeout = timeout
 
         if not self.api_key:
             raise ValueError("CLICKUP_API_KEY not set. Please set the CLICKUP_API_KEY environment variable.")
@@ -47,7 +49,9 @@ class ClickUpTools(Toolkit):
         """Make a request to the ClickUp API."""
         url = f"{self.base_url}/{endpoint}"
         try:
-            response = requests.request(method=method, url=url, headers=self.headers, params=params, json=data)
+            response = requests.request(
+                method=method, url=url, headers=self.headers, params=params, json=data, timeout=self.timeout
+            )
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
## Summary

- Forward `self.timeout` to all 4 HTTP call sites in `BrightDataTools` (`_make_request`, `get_screenshot`, `web_data_feed` trigger, `web_data_feed` polling)
- Add a `timeout` parameter (default 30s) to `ClickUpTools.__init__` and pass it to `requests.request` in `_make_request`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows Agno's coding patterns
- [x] I have run `ruff format` and `ruff check` with no errors
- [x] This change does not break existing functionality

## Additional context

Closes #8496

`BrightDataTools.__init__` accepts a `timeout` parameter (default 600s) but none of its HTTP calls use it — they block indefinitely. `ClickUpTools` has no timeout concept at all, so all 7 public methods can hang forever if the ClickUp API is slow or unresponsive.

This is a non-breaking change: `BrightDataTools` already stores `self.timeout`, we just wire it through. `ClickUpTools` gains a new optional kwarg with a reasonable default.