### PR TITLE
fix: prevent path traversal in LocalFileSystemTools

### DIFF
--- a/libs/agno/agno/tools/local_file_system.py
+++ b/libs/agno/agno/tools/local_file_system.py
@@ -34,6 +34,17 @@ class LocalFileSystemTools(Toolkit):
 
         super().__init__(name="write_to_local", tools=tools, **kwargs)
 
+    def _validate_path(self, file_path: Path) -> Optional[str]:
+        """Validate that the resolved path is within the target directory.
+
+        Returns None if valid, or an error message if path traversal is detected.
+        """
+        target_base = Path(self.target_directory).resolve()
+        resolved = file_path.resolve()
+        if not resolved.is_relative_to(target_base):
+            return f"Error: Path traversal detected. Cannot access paths outside of {target_base}"
+        return None
+
     def write_file(
         self,
         content: str,
@@ -71,6 +82,11 @@ class LocalFileSystemTools(Toolkit):
             full_filename = f"{filename}.{extension}"
             file_path = dir_path / full_filename
 
+            # Prevent path traversal
+            error = self._validate_path(file_path)
+            if error:
+                return error
+
             file_path.write_text(content)
 
             return f"Successfully wrote file to: {file_path}"
@@ -85,6 +101,11 @@ class LocalFileSystemTools(Toolkit):
         Read content from a local file.
         """
         file_path = Path(directory or self.target_directory) / filename
+
+        error = self._validate_path(file_path)
+        if error:
+            return error
+
         if not file_path.exists():
             return f"File not found: {file_path}"
         return file_path.read_text()


### PR DESCRIPTION
## Summary

- Add `_validate_path()` method that resolves the final file path and asserts it stays within `target_directory` using `Path.is_relative_to()`
- Apply validation to both `write_file` and `read_file` before any filesystem operation
- Returns a clear error message when path traversal is detected instead of silently writing outside the sandbox

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows Agno's coding patterns
- [x] I have run `ruff format` and `ruff check` with no errors
- [x] This change does not break existing functionality

## Additional context

Closes #8482

**Security vulnerability:** `write_file` uses `dir_path / full_filename` without resolving or validating the result. An agent can supply `../../../../tmp/malicious.py` as the filename to escape `target_directory` and write arbitrary files on the host. The same issue exists in `read_file`.

The fix resolves both paths to absolute and uses `Path.is_relative_to()` (Python 3.9+) to enforce containment. This is the standard pattern recommended for path traversal prevention.