### PR TITLE
feat: add CoinGeckoTools toolkit for cryptocurrency market data

### DIFF
--- a/libs/agno/agno/tools/coingecko.py
+++ b/libs/agno/agno/tools/coingecko.py
@@ -1,0 +1,193 @@
+import json
+from typing import Any, Dict, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+try:
+    import requests
+except ImportError:
+    raise ImportError("`requests` not installed. Please install using `pip install requests`")
+
+
+class CoinGeckoTools(Toolkit):
+    """CoinGecko toolkit for cryptocurrency market data.
+
+    Uses the free CoinGecko public API (no API key required for basic endpoints).
+
+    Args:
+        enable_price: Enable coin price lookup. Default is True.
+        enable_search: Enable coin search. Default is True.
+        enable_trending: Enable trending coins. Default is True.
+        enable_market_data: Enable detailed market data. Default is False.
+        all: Enable all tools. Default is False.
+        timeout: Timeout in seconds for HTTP requests. Default is 30.
+        currency: Default fiat currency for prices. Default is 'usd'.
+    """
+
+    def __init__(
+        self,
+        enable_price: bool = True,
+        enable_search: bool = True,
+        enable_trending: bool = True,
+        enable_market_data: bool = False,
+        all: bool = False,
+        timeout: int = 30,
+        currency: str = "usd",
+        **kwargs,
+    ):
+        self.base_url = "https://api.coingecko.com/api/v3"
+        self.timeout = timeout
+        self.currency = currency
+
+        tools: List[Any] = []
+        if all or enable_price:
+            tools.append(self.get_coin_price)
+        if all or enable_search:
+            tools.append(self.search_coins)
+        if all or enable_trending:
+            tools.append(self.get_trending)
+        if all or enable_market_data:
+            tools.append(self.get_coin_market_data)
+
+        super().__init__(name="coingecko_tools", tools=tools, **kwargs)
+
+    def _request(self, endpoint: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Make a GET request to the CoinGecko API."""
+        url = f"{self.base_url}{endpoint}"
+        response = requests.get(url, params=params, timeout=self.timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def get_coin_price(self, coin_ids: str, currency: Optional[str] = None) -> str:
+        """Get current price for one or more cryptocurrencies.
+
+        Args:
+            coin_ids (str): Comma-separated CoinGecko coin IDs (e.g., 'bitcoin,ethereum,solana').
+            currency (Optional[str]): Fiat currency for prices (e.g., 'usd', 'eur'). Defaults to toolkit currency.
+
+        Returns:
+            str: JSON with current prices, 24h change, and market cap.
+        """
+        try:
+            vs_currency = currency or self.currency
+            data = self._request(
+                "/simple/price",
+                params={
+                    "ids": coin_ids,
+                    "vs_currencies": vs_currency,
+                    "include_24hr_change": "true",
+                    "include_market_cap": "true",
+                },
+            )
+
+            results = []
+            for coin_id, info in data.items():
+                results.append(
+                    {
+                        "coin": coin_id,
+                        "price": info.get(vs_currency),
+                        "market_cap": info.get(f"{vs_currency}_market_cap"),
+                        "24h_change_pct": info.get(f"{vs_currency}_24h_change"),
+                    }
+                )
+            return json.dumps({"prices": results}, indent=2)
+        except Exception as e:
+            logger.exception(f"Error fetching price for: {coin_ids}")
+            return f"Error fetching coin price: {e}"
+
+    def search_coins(self, query: str) -> str:
+        """Search for cryptocurrencies by name or symbol.
+
+        Args:
+            query (str): Search query (coin name or symbol, e.g., 'bitcoin' or 'btc').
+
+        Returns:
+            str: JSON with matching coins (id, name, symbol, market cap rank).
+        """
+        try:
+            data = self._request("/search", params={"query": query})
+
+            coins = data.get("coins", [])[:10]
+            results = []
+            for coin in coins:
+                results.append(
+                    {
+                        "id": coin.get("id"),
+                        "name": coin.get("name"),
+                        "symbol": coin.get("symbol"),
+                        "market_cap_rank": coin.get("market_cap_rank"),
+                    }
+                )
+            return json.dumps({"coins": results}, indent=2)
+        except Exception as e:
+            logger.exception(f"Error searching for: {query}")
+            return f"Error searching coins: {e}"
+
+    def get_trending(self) -> str:
+        """Get trending cryptocurrencies in the last 24 hours.
+
+        Returns:
+            str: JSON with trending coins (name, symbol, market cap rank, price info).
+        """
+        try:
+            data = self._request("/search/trending")
+
+            coins = data.get("coins", [])
+            results = []
+            for item in coins[:10]:
+                coin = item.get("item", {})
+                results.append(
+                    {
+                        "id": coin.get("id"),
+                        "name": coin.get("name"),
+                        "symbol": coin.get("symbol"),
+                        "market_cap_rank": coin.get("market_cap_rank"),
+                        "price_btc": coin.get("price_btc"),
+                    }
+                )
+            return json.dumps({"trending": results}, indent=2)
+        except Exception as e:
+            logger.exception("Error fetching trending coins")
+            return f"Error fetching trending coins: {e}"
+
+    def get_coin_market_data(self, coin_id: str, currency: Optional[str] = None) -> str:
+        """Get detailed market data for a cryptocurrency.
+
+        Args:
+            coin_id (str): CoinGecko coin ID (e.g., 'bitcoin', 'ethereum').
+            currency (Optional[str]): Fiat currency for prices. Defaults to toolkit currency.
+
+        Returns:
+            str: JSON with detailed market data including price, volume, supply, and ATH.
+        """
+        try:
+            vs_currency = currency or self.currency
+            data = self._request(
+                f"/coins/{coin_id}",
+                params={"localization": "false", "tickers": "false", "community_data": "false"},
+            )
+
+            market = data.get("market_data", {})
+            result = {
+                "id": data.get("id"),
+                "name": data.get("name"),
+                "symbol": data.get("symbol"),
+                "current_price": market.get("current_price", {}).get(vs_currency),
+                "market_cap": market.get("market_cap", {}).get(vs_currency),
+                "market_cap_rank": market.get("market_cap_rank"),
+                "total_volume": market.get("total_volume", {}).get(vs_currency),
+                "high_24h": market.get("high_24h", {}).get(vs_currency),
+                "low_24h": market.get("low_24h", {}).get(vs_currency),
+                "price_change_24h_pct": market.get("price_change_percentage_24h"),
+                "price_change_7d_pct": market.get("price_change_percentage_7d"),
+                "price_change_30d_pct": market.get("price_change_percentage_30d"),
+                "circulating_supply": market.get("circulating_supply"),
+                "total_supply": market.get("total_supply"),
+                "ath": market.get("ath", {}).get(vs_currency),
+                "ath_change_pct": market.get("ath_change_percentage", {}).get(vs_currency),
+            }
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            logger.exception(f"Error fetching market data for: {coin_id}")
+            return f"Error fetching market data: {e}"

--- a/libs/agno/tests/unit/tools/test_coingecko.py
+++ b/libs/agno/tests/unit/tools/test_coingecko.py
@@ -1,0 +1,308 @@
+"""Unit tests for CoinGeckoTools class."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agno.tools.coingecko import CoinGeckoTools
+
+
+@pytest.fixture
+def mock_requests():
+    """Mock the requests module."""
+    with patch("agno.tools.coingecko.requests") as mock_req:
+        yield mock_req
+
+
+@pytest.fixture
+def coingecko_tools():
+    """Create a CoinGeckoTools instance."""
+    return CoinGeckoTools()
+
+
+# ============================================================================
+# INITIALIZATION TESTS
+# ============================================================================
+
+
+def test_init_defaults():
+    """Test default initialization."""
+    tools = CoinGeckoTools()
+    assert tools.timeout == 30
+    assert tools.currency == "usd"
+    assert tools.base_url == "https://api.coingecko.com/api/v3"
+
+
+def test_init_custom_params():
+    """Test initialization with custom parameters."""
+    tools = CoinGeckoTools(timeout=60, currency="eur")
+    assert tools.timeout == 60
+    assert tools.currency == "eur"
+
+
+def test_init_default_tools():
+    """Test default tool registration."""
+    tools = CoinGeckoTools()
+    tool_names = [t.__name__ for t in tools.tools]
+    assert "get_coin_price" in tool_names
+    assert "search_coins" in tool_names
+    assert "get_trending" in tool_names
+    assert "get_coin_market_data" not in tool_names
+
+
+def test_init_all_flag():
+    """Test all=True enables all tools."""
+    tools = CoinGeckoTools(all=True)
+    tool_names = [t.__name__ for t in tools.tools]
+    assert "get_coin_price" in tool_names
+    assert "search_coins" in tool_names
+    assert "get_trending" in tool_names
+    assert "get_coin_market_data" in tool_names
+
+
+def test_init_selective_tools():
+    """Test selective tool flags."""
+    tools = CoinGeckoTools(enable_price=False, enable_search=False, enable_trending=True)
+    tool_names = [t.__name__ for t in tools.tools]
+    assert "get_coin_price" not in tool_names
+    assert "search_coins" not in tool_names
+    assert "get_trending" in tool_names
+
+
+# ============================================================================
+# GET COIN PRICE TESTS
+# ============================================================================
+
+
+def test_get_coin_price(coingecko_tools, mock_requests):
+    """Test get_coin_price returns formatted data."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "bitcoin": {"usd": 67000, "usd_market_cap": 1300000000000, "usd_24h_change": 2.5},
+        "ethereum": {"usd": 3500, "usd_market_cap": 420000000000, "usd_24h_change": -1.2},
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = coingecko_tools.get_coin_price("bitcoin,ethereum")
+
+    assert "bitcoin" in result
+    assert "67000" in result
+    assert "ethereum" in result
+    mock_requests.get.assert_called_once()
+    call_kwargs = mock_requests.get.call_args[1]
+    assert call_kwargs["timeout"] == 30
+
+
+def test_get_coin_price_custom_currency(coingecko_tools, mock_requests):
+    """Test get_coin_price with custom currency."""
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "bitcoin": {"eur": 62000, "eur_market_cap": 1200000000000, "eur_24h_change": 1.0}
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = coingecko_tools.get_coin_price("bitcoin", currency="eur")
+
+    assert "62000" in result
+    call_params = mock_requests.get.call_args[1]["params"]
+    assert call_params["vs_currencies"] == "eur"
+
+
+def test_get_coin_price_error(coingecko_tools, mock_requests):
+    """Test get_coin_price handles errors."""
+    mock_requests.get.side_effect = Exception("Connection timeout")
+
+    result = coingecko_tools.get_coin_price("bitcoin")
+
+    assert "Error" in result
+    assert "Connection timeout" in result
+
+
+# ============================================================================
+# SEARCH COINS TESTS
+# ============================================================================
+
+
+def test_search_coins(coingecko_tools, mock_requests):
+    """Test search_coins returns matching results."""
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "coins": [
+            {"id": "bitcoin", "name": "Bitcoin", "symbol": "btc", "market_cap_rank": 1},
+            {"id": "bitcoin-cash", "name": "Bitcoin Cash", "symbol": "bch", "market_cap_rank": 20},
+        ]
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = coingecko_tools.search_coins("bitcoin")
+
+    assert "bitcoin" in result
+    assert "Bitcoin" in result
+    assert "btc" in result
+    mock_requests.get.assert_called_once()
+
+
+def test_search_coins_limits_results(coingecko_tools, mock_requests):
+    """Test search_coins limits to 10 results."""
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "coins": [{"id": f"coin-{i}", "name": f"Coin {i}", "symbol": f"c{i}", "market_cap_rank": i} for i in range(20)]
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = coingecko_tools.search_coins("coin")
+
+    assert "coin-9" in result
+    assert "coin-10" not in result
+
+
+def test_search_coins_error(coingecko_tools, mock_requests):
+    """Test search_coins handles errors."""
+    mock_requests.get.side_effect = Exception("Rate limited")
+
+    result = coingecko_tools.search_coins("btc")
+
+    assert "Error" in result
+
+
+# ============================================================================
+# GET TRENDING TESTS
+# ============================================================================
+
+
+def test_get_trending(coingecko_tools, mock_requests):
+    """Test get_trending returns trending coins."""
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "coins": [
+            {"item": {"id": "pepe", "name": "Pepe", "symbol": "pepe", "market_cap_rank": 30, "price_btc": 0.0000001}},
+            {"item": {"id": "bonk", "name": "Bonk", "symbol": "bonk", "market_cap_rank": 60, "price_btc": 0.0000002}},
+        ]
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = coingecko_tools.get_trending()
+
+    assert "pepe" in result
+    assert "Pepe" in result
+    assert "bonk" in result
+    mock_requests.get.assert_called_once()
+
+
+def test_get_trending_error(coingecko_tools, mock_requests):
+    """Test get_trending handles errors."""
+    mock_requests.get.side_effect = Exception("Server error")
+
+    result = coingecko_tools.get_trending()
+
+    assert "Error" in result
+
+
+# ============================================================================
+# GET COIN MARKET DATA TESTS
+# ============================================================================
+
+
+def test_get_coin_market_data(mock_requests):
+    """Test get_coin_market_data returns detailed info."""
+    tools = CoinGeckoTools(all=True)
+
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "id": "bitcoin",
+        "name": "Bitcoin",
+        "symbol": "btc",
+        "market_data": {
+            "current_price": {"usd": 67000},
+            "market_cap": {"usd": 1300000000000},
+            "market_cap_rank": 1,
+            "total_volume": {"usd": 30000000000},
+            "high_24h": {"usd": 68000},
+            "low_24h": {"usd": 66000},
+            "price_change_percentage_24h": 2.5,
+            "price_change_percentage_7d": 5.0,
+            "price_change_percentage_30d": 10.0,
+            "circulating_supply": 19500000,
+            "total_supply": 21000000,
+            "ath": {"usd": 73000},
+            "ath_change_percentage": {"usd": -8.2},
+        },
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = tools.get_coin_market_data("bitcoin")
+
+    assert "Bitcoin" in result
+    assert "67000" in result
+    assert "21000000" in result
+
+
+def test_get_coin_market_data_custom_currency(mock_requests):
+    """Test get_coin_market_data with custom currency."""
+    tools = CoinGeckoTools(all=True, currency="eur")
+
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "id": "ethereum",
+        "name": "Ethereum",
+        "symbol": "eth",
+        "market_data": {
+            "current_price": {"eur": 3200},
+            "market_cap": {"eur": 380000000000},
+            "market_cap_rank": 2,
+            "total_volume": {"eur": 15000000000},
+            "high_24h": {"eur": 3300},
+            "low_24h": {"eur": 3100},
+            "price_change_percentage_24h": -1.5,
+            "price_change_percentage_7d": 3.0,
+            "price_change_percentage_30d": 8.0,
+            "circulating_supply": 120000000,
+            "total_supply": None,
+            "ath": {"eur": 4500},
+            "ath_change_percentage": {"eur": -28.9},
+        },
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    result = tools.get_coin_market_data("ethereum")
+
+    assert "Ethereum" in result
+    assert "3200" in result
+
+
+def test_get_coin_market_data_error(mock_requests):
+    """Test get_coin_market_data handles errors."""
+    tools = CoinGeckoTools(all=True)
+    mock_requests.get.side_effect = Exception("Not found")
+
+    result = tools.get_coin_market_data("invalid-coin")
+
+    assert "Error" in result
+
+
+# ============================================================================
+# TIMEOUT TESTS
+# ============================================================================
+
+
+def test_timeout_passed_to_requests(mock_requests):
+    """Test that timeout is passed to all requests."""
+    tools = CoinGeckoTools(timeout=60)
+
+    mock_response = Mock()
+    mock_response.json.return_value = {"bitcoin": {"usd": 67000, "usd_market_cap": 0, "usd_24h_change": 0}}
+    mock_response.raise_for_status = Mock()
+    mock_requests.get.return_value = mock_response
+
+    tools.get_coin_price("bitcoin")
+
+    call_kwargs = mock_requests.get.call_args[1]
+    assert call_kwargs["timeout"] == 60


### PR DESCRIPTION
## Summary

- Add `CoinGeckoTools` toolkit wrapping the free [CoinGecko API](https://docs.coingecko.com/reference/introduction)
- No API key required — uses free public endpoints
- 4 tools: `get_coin_price`, `search_coins`, `get_trending`, `get_coin_market_data`
- Follows existing patterns: `enable_*` flags, `all=True`, configurable `timeout` (default 30s)
- 17 unit tests covering all methods, init, error handling, and timeout propagation

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How has this been tested?

```bash
python -m pytest libs/agno/tests/unit/tools/test_coingecko.py -v
# 17 passed
```

## Checklist

- [x] My code follows Agno's coding patterns
- [x] I have run `ruff format` and `ruff check` with no errors
- [x] I have added tests that prove my fix/feature works
- [x] This change does not break existing functionality

## Additional context

Closes #8522

Agno has `YFinanceTools` for stock data but no crypto-specific toolkit. CoinGecko's free tier requires no API key and covers all major crypto data needs for agent interactions.

Usage:
```python
from agno.agent import Agent
from agno.tools.coingecko import CoinGeckoTools

agent = Agent(tools=[CoinGeckoTools()])
agent.print_response("What's the current price of Bitcoin and Ethereum?")
```