### PR TITLE
fix: serialize the singular image field in BaseRunOutputEvent.to_dict()

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -236,6 +236,10 @@ class BaseRunOutputEvent:
         if response_audio:
             data["response_audio"] = Audio.model_validate(response_audio)
 
+        image = data.pop("image", None)
+        if image:
+            data["image"] = Image.model_validate(image)
+
         additional_input = data.pop("additional_input", None)
         if additional_input is not None:
             data["additional_input"] = [Message.model_validate(message) for message in additional_input]

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -131,6 +131,12 @@ class BaseRunOutputEvent:
             else:
                 _dict["response_audio"] = self.response_audio
 
+        if hasattr(self, "image") and self.image is not None:
+            if isinstance(self.image, Image):
+                _dict["image"] = self.image.to_dict()
+            else:
+                _dict["image"] = self.image
+
         if hasattr(self, "citations") and self.citations is not None:
             if isinstance(self.citations, Citations):
                 _dict["citations"] = self.citations.model_dump(exclude_none=True)

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -166,6 +166,11 @@ def test_run_content_event_includes_image():
     assert event_dict["image"]["id"] == "img-1"
     assert event_dict["image"]["url"] == "https://example.com/a.png"
 
+    reconstructed = type(event).from_dict(event_dict)
+    assert isinstance(reconstructed.image, Image)
+    assert reconstructed.image.id == "img-1"
+    assert reconstructed.image.url == "https://example.com/a.png"
+
 
 def test_agent_session_state_in_completed_event():
     """Test that RunCompletedEvent includes session_state field."""

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -144,6 +144,29 @@ def test_run_completed_event_includes_files():
     assert reconstructed.files[0].filename == "report.pdf"
 
 
+def test_run_content_event_includes_image():
+    """RunContentEvent must serialize its singular `image` field in to_dict().
+
+    `image` is excluded from the asdict() call but, unlike its sibling media
+    fields (images/videos/audio/response_audio), was never re-added, so it was
+    silently dropped from to_dict()/to_json() (e.g. in AgentOS SSE streaming).
+    """
+    from agno.media import Image
+    from agno.run.agent import RunContentEvent
+
+    event = RunContentEvent(
+        content="hello",
+        image=Image(id="img-1", url="https://example.com/a.png"),
+    )
+
+    assert event.image is not None
+
+    event_dict = event.to_dict()
+    assert "image" in event_dict
+    assert event_dict["image"]["id"] == "img-1"
+    assert event_dict["image"]["url"] == "https://example.com/a.png"
+
+
 def test_agent_session_state_in_completed_event():
     """Test that RunCompletedEvent includes session_state field."""
     from agno.run.agent import RunOutput


### PR DESCRIPTION
## Summary

`BaseRunOutputEvent.to_dict()` drops the singular `image` field. `image` is listed in the `asdict()` exclusion set, but — unlike its sibling media fields `images` / `videos` / `audio` / `response_audio`, which are all re-added later in the method — it is never re-serialized. So `RunContentEvent` and `TeamRunContentEvent` (both of which define `image: Optional[Image]`) silently drop `image` from `to_dict()` / `to_json()`, e.g. in AgentOS SSE streaming.

Fix: re-serialize `image` mirroring the existing `response_audio` block (`Image` is already imported).

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines (`ruff format --check` and `ruff check` pass on changed files)
- [x] Ran format/validation scripts (`ruff format --check` + `ruff check` clean)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: N/A — internal serialization fix
- [x] Tested in clean environment (`pytest libs/agno/tests/unit/run/test_run_events.py` — 14 passed)
- [x] Tests added/updated (`test_run_content_event_includes_image`; fails before this change, passes after)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

---

## Proof

`test_run_content_event_includes_image` builds a `RunContentEvent(content="hello", image=Image(id="img-1", url="https://example.com/a.png"))` and asserts `to_dict()["image"]` is present with the expected id/url. It fails on `main` (`image` absent) and passes with this change.