### PR TITLE
fix(db): make calculate_date_metrics None-safe across DB backends

### DIFF
--- a/libs/agno/agno/db/dynamo/utils.py
+++ b/libs/agno/agno/db/dynamo/utils.py
@@ -337,15 +337,17 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
                         model_counts[f"{model_id}:{model_provider}"] = (
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
     model_metrics = []

--- a/libs/agno/agno/db/gcs_json/utils.py
+++ b/libs/agno/agno/db/gcs_json/utils.py
@@ -96,8 +96,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -105,7 +106,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/in_memory/utils.py
+++ b/libs/agno/agno/db/in_memory/utils.py
@@ -96,8 +96,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -105,7 +106,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/json/utils.py
+++ b/libs/agno/agno/db/json/utils.py
@@ -96,8 +96,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -105,7 +106,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/mysql/utils.py
+++ b/libs/agno/agno/db/mysql/utils.py
@@ -275,8 +275,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -284,7 +285,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/redis/utils.py
+++ b/libs/agno/agno/db/redis/utils.py
@@ -222,8 +222,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -231,7 +232,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/singlestore/utils.py
+++ b/libs/agno/agno/db/singlestore/utils.py
@@ -250,8 +250,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -259,7 +260,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/agno/db/surrealdb/metrics.py
+++ b/libs/agno/agno/db/surrealdb/metrics.py
@@ -255,8 +255,9 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
         for session in sessions:
             if session.get("user_id"):
                 all_user_ids.add(session["user_id"])
-            metrics[runs_count_key] += len(session.get("runs", []))
-            if runs := session.get("runs", []):
+            runs = session.get("runs", []) or []
+            metrics[runs_count_key] += len(runs)
+            if runs:
                 for run in runs:
                     if model_id := run.get("model"):
                         model_provider = run.get("model_provider", "")
@@ -264,7 +265,8 @@ def calculate_date_metrics(date_to_process: date, sessions_data: dict) -> dict:
                             model_counts.get(f"{model_id}:{model_provider}", 0) + 1
                         )
 
-            session_metrics = session.get("session_data", {}).get("session_metrics", {})
+            session_data = session.get("session_data", {}) or {}
+            session_metrics = session_data.get("session_metrics", {}) or {}
             for field in token_metrics:
                 token_metrics[field] += session_metrics.get(field, 0)
 

--- a/libs/agno/tests/unit/db/test_calculate_date_metrics_none_safe.py
+++ b/libs/agno/tests/unit/db/test_calculate_date_metrics_none_safe.py
@@ -1,0 +1,41 @@
+import datetime
+
+import pytest
+
+# calculate_date_metrics is duplicated across every DB backend. These backends
+# previously used the None-unsafe `len(session.get("runs", []))` /
+# `session.get("session_data", {}).get(...)` form (postgres/sqlite/mongo/firestore
+# already guard with `or []` / `or {}`).
+BACKEND_MODULES = [
+    "agno.db.dynamo.utils",
+    "agno.db.gcs_json.utils",
+    "agno.db.in_memory.utils",
+    "agno.db.json.utils",
+    "agno.db.mysql.utils",
+    "agno.db.redis.utils",
+    "agno.db.singlestore.utils",
+    "agno.db.surrealdb.metrics",
+]
+
+
+@pytest.mark.parametrize("module_path", BACKEND_MODULES)
+def test_calculate_date_metrics_handles_none_runs_and_session_data(module_path):
+    """A persisted session can carry runs=None / session_data=None (the defaults
+    when a session has produced no runs yet, or session_data was never set).
+    calculate_date_metrics must not crash on those, counting the session with
+    zero runs (matching the postgres backend)."""
+    module = pytest.importorskip(module_path)
+
+    sessions_data = {
+        "agent": [{"user_id": "u1", "runs": None, "session_data": None}],
+        "team": [],
+        "workflow": [],
+    }
+
+    # Before the fix this raised TypeError: object of type 'NoneType' has no len()
+    # (runs=None) or AttributeError: 'NoneType' object has no attribute 'get'
+    # (session_data=None).
+    metrics = module.calculate_date_metrics(datetime.date.today(), sessions_data)
+
+    assert metrics["agent_runs_count"] == 0
+    assert metrics["agent_sessions_count"] == 1


### PR DESCRIPTION
## Summary

A persisted session can carry `runs=None` or `session_data=None` (the defaults when a session has produced no runs yet, or `session_data` was never initialized). Eight DB backends compute metrics with `len(session.get("runs", []))` and `session.get("session_data", {}).get(...)`, which raise `TypeError: object of type 'NoneType' has no len()` / `AttributeError: 'NoneType' object has no attribute 'get'` on such sessions — crashing `calculate_date_metrics`.

Fixed `dynamo`, `gcs_json`, `in_memory`, `json`, `mysql`, `redis`, `singlestore`, `surrealdb` to guard with `or []` / `or {}`, matching the already-correct `postgres`/`sqlite`/`mongo`/`firestore` backends.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines (`ruff format --check` and `ruff check` pass on changed files)
- [x] Ran format/validation scripts (`ruff format --check` + `ruff check` clean)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: N/A — internal bug fix
- [x] Tested in clean environment (`pytest libs/agno/tests/unit/db/test_calculate_date_metrics_none_safe.py` — 7 passed, 1 skipped for the SDK-gated surrealdb backend)
- [x] Tests added/updated (parametrized `test_calculate_date_metrics_none_safe.py`; fails on all eight backends before this change, passes after)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

---

## Proof

`calculate_date_metrics` is duplicated across all DB backends; `postgres`/`sqlite`/`mongo`/`firestore` already guard `runs`/`session_data` with `or []`/`or {}`, the other eight did not. The new parametrized test feeds a session with `runs=None, session_data=None` to each backend's `calculate_date_metrics` and asserts it counts zero runs without raising — it fails on all eight before this change and passes after.