### PR TITLE
fix(anthropic): extract tool_use blocks regardless of stop_reason

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -1031,26 +1031,29 @@ class Claude(Model):
                     server_blocks = model_response.provider_data.setdefault("server_tool_blocks", [])
                     server_blocks.append(block.model_dump())
 
-        # Extract tool calls from the response
-        if response.stop_reason == "tool_use":
-            for block in response.content:
-                if block.type == "tool_use":
-                    tool_name = block.name
-                    tool_input = block.input
+        # Extract tool calls from the response. A complete tool_use block can be
+        # returned with a stop_reason other than "tool_use" (e.g. "max_tokens" or
+        # "pause_turn"); gating extraction on stop_reason silently dropped those
+        # tool calls so the requested tool never ran. Extract purely on block
+        # type, mirroring the streaming path (_parse_provider_response_delta).
+        for block in response.content:
+            if block.type == "tool_use":
+                tool_name = block.name
+                tool_input = block.input
 
-                    function_def = {"name": tool_name}
-                    if tool_input:
-                        function_def["arguments"] = json.dumps(tool_input)
+                function_def = {"name": tool_name}
+                if tool_input:
+                    function_def["arguments"] = json.dumps(tool_input)
 
-                    model_response.extra = model_response.extra or {}
+                model_response.extra = model_response.extra or {}
 
-                    model_response.tool_calls.append(
-                        {
-                            "id": block.id,
-                            "type": "function",
-                            "function": function_def,
-                        }
-                    )
+                model_response.tool_calls.append(
+                    {
+                        "id": block.id,
+                        "type": "function",
+                        "function": function_def,
+                    }
+                )
 
         # Add usage metrics
         if response.usage is not None:

--- a/libs/agno/tests/unit/models/anthropic/test_tool_use_stop_reason.py
+++ b/libs/agno/tests/unit/models/anthropic/test_tool_use_stop_reason.py
@@ -1,0 +1,38 @@
+"""Claude must extract tool_use blocks regardless of stop_reason.
+
+A complete tool_use block can be returned with a stop_reason other than
+"tool_use" (e.g. "pause_turn" for long-running server-tool turns, or "max_tokens"
+after a complete tool_use block). The non-streaming parser previously gated tool
+extraction on ``stop_reason == "tool_use"``, so those tool calls were silently
+dropped and the requested tool never ran — unlike the streaming path and every
+OpenAI-compatible model, which extract tool calls independent of the stop reason.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agno.models.anthropic.claude import Claude
+
+
+def _response(stop_reason: str) -> SimpleNamespace:
+    tool_block = SimpleNamespace(type="tool_use", id="toolu_1", name="get_weather", input={"city": "SF"})
+    usage = SimpleNamespace(
+        input_tokens=10,
+        output_tokens=5,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        server_tool_use=None,
+    )
+    return SimpleNamespace(role="assistant", content=[tool_block], stop_reason=stop_reason, usage=usage)
+
+
+@pytest.mark.parametrize("stop_reason", ["tool_use", "max_tokens", "pause_turn"])
+def test_tool_use_extracted_regardless_of_stop_reason(stop_reason):
+    model = Claude(id="claude-sonnet-4-5")
+
+    result = model._parse_provider_response(_response(stop_reason))
+
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0]["id"] == "toolu_1"
+    assert result.tool_calls[0]["function"]["name"] == "get_weather"


### PR DESCRIPTION
## Summary

The non-streaming Claude parser (`_parse_provider_response`) gated tool-call extraction on `stop_reason == "tool_use"`. A complete `tool_use` block can be returned with a different `stop_reason` — `"pause_turn"` (long-running server-tool turns) or `"max_tokens"` (truncated after a complete `tool_use` block) — and the gate then skipped extraction, leaving `model_response.tool_calls` empty so the requested tool silently never ran.

The streaming path (`_parse_provider_response_delta`) and every OpenAI-compatible model extract tool calls independent of the finish/stop reason. This makes the non-streaming Anthropic path consistent by extracting purely on block type. It also fixes the inherited AWS Bedrock `Claude` (which reuses this method).

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines (`ruff format --check` and `ruff check` pass)
- [x] Ran format/validation scripts (`ruff format` + `ruff check` clean)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: N/A — internal bug fix
- [x] Tested in clean environment (`pytest libs/agno/tests/unit/models/anthropic/test_tool_use_stop_reason.py` — 3 passed)
- [x] Tests added/updated (parametrized over `tool_use`/`max_tokens`/`pause_turn`; the two non-`tool_use` cases fail before this change, pass after)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

---

## Proof

New test feeds a response containing a complete `tool_use` block with each `stop_reason`. On `main`, `stop_reason="max_tokens"` and `"pause_turn"` yield zero `tool_calls` (tool dropped); with this change all three extract the call. The fix mirrors the existing streaming extraction, which already ignores `stop_reason`.