### PR TITLE
[fix] Honor route direct response after member HITL resume

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5923,6 +5923,28 @@ def _prepare_member_hitl_continuation(
     run_response.content = None
 
 
+def _set_direct_member_hitl_continuation_content(
+    team: "Team",
+    run_response: TeamRunOutput,
+    member_results: List[str],
+) -> bool:
+    """Use resolved member HITL output directly when route/respond_directly would stop after delegation."""
+
+    if not getattr(team, "respond_directly", False):
+        return False
+
+    for tool in reversed(run_response.tools or []):
+        if tool.tool_name in {"delegate_task_to_member", "delegate_task_to_members"} and tool.result:
+            run_response.content = tool.result
+            return True
+
+    if member_results:
+        run_response.content = _build_continuation_message(member_results)
+        return True
+
+    return False
+
+
 async def _ahandle_model_response_for_continue(
     team: "Team",
     run_response: TeamRunOutput,
@@ -6824,6 +6846,7 @@ def continue_run_dispatch(
 
         # Prepare for member HITL continuation
         _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+        skip_model_response = _set_direct_member_hitl_continuation_content(team, run_response, member_results)
 
         log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
@@ -6839,6 +6862,7 @@ def continue_run_dispatch(
                 response_format=response_format,
                 stream_events=opts.stream_events,
                 yield_run_output=opts.yield_run_output,
+                skip_model_response=skip_model_response,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
                 **kwargs,
@@ -6853,6 +6877,7 @@ def continue_run_dispatch(
                 session=team_session,
                 user_id=user_id,
                 response_format=response_format,
+                skip_model_response=skip_model_response,
                 debug_mode=debug_mode,
                 background_tasks=background_tasks,
                 **kwargs,
@@ -7025,6 +7050,7 @@ def _continue_run_dispatch_stream_with_member_events(
         )
 
         _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+        skip_model_response = _set_direct_member_hitl_continuation_content(team, run_response, member_results)
 
         log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
@@ -7039,6 +7065,7 @@ def _continue_run_dispatch_stream_with_member_events(
             response_format=response_format,
             stream_events=opts.stream_events,
             yield_run_output=opts.yield_run_output,
+            skip_model_response=skip_model_response,
             debug_mode=debug_mode,
             background_tasks=background_tasks,
             **kwargs,
@@ -7061,6 +7088,7 @@ def _continue_run(
     session: TeamSession,
     user_id: Optional[str] = None,
     response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+    skip_model_response: bool = False,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
     **kwargs: Any,
@@ -7104,53 +7132,54 @@ def _continue_run(
             try:
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Generate model response
-                model_response: ModelResponse = call_model_with_fallback(
-                    team.model,
-                    team.fallback_config,
-                    messages=run_messages.messages,
-                    response_format=response_format,
-                    tools=tools,
-                    tool_choice=team.tool_choice,
-                    tool_call_limit=team.tool_call_limit,
-                    run_response=run_response,
-                    send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compression_manager if team.compress_tool_results else None,
-                    after_tool_results=build_team_after_tool_results_callback(
-                        team, run_response, session, run_messages, run_context
-                    ),
-                )
-
-                raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # Parse with output/parser models if needed
-                parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
-                parse_response_with_parser_model(
-                    team, model_response, run_messages, run_context=run_context, run_response=run_response
-                )
-
-                # Update run response
-                _update_run_response(
-                    team,
-                    model_response=model_response,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    run_context=run_context,
-                )
-
-                # Check for new pauses (team-level tools or member propagation)
-                if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                    from agno.team import _hooks
-
-                    return _hooks.handle_team_run_paused(
-                        team, run_response=run_response, session=session, run_context=run_context
+                if not skip_model_response:
+                    # Generate model response
+                    model_response: ModelResponse = call_model_with_fallback(
+                        team.model,
+                        team.fallback_config,
+                        messages=run_messages.messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=team.tool_choice,
+                        tool_call_limit=team.tool_call_limit,
+                        run_response=run_response,
+                        send_media_to_model=team.send_media_to_model,
+                        compression_manager=team.compression_manager if team.compress_tool_results else None,
+                        after_tool_results=build_team_after_tool_results_callback(
+                            team, run_response, session, run_messages, run_context
+                        ),
                     )
 
-                # Convert to structured format
-                _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                    raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Always add media to run_response for caller availability
-                store_media_util(run_response, model_response)
+                    # Parse with output/parser models if needed
+                    parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
+                    parse_response_with_parser_model(
+                        team, model_response, run_messages, run_context=run_context, run_response=run_response
+                    )
+
+                    # Update run response
+                    _update_run_response(
+                        team,
+                        model_response=model_response,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                    )
+
+                    # Check for new pauses (team-level tools or member propagation)
+                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                        from agno.team import _hooks
+
+                        return _hooks.handle_team_run_paused(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+
+                    # Convert to structured format
+                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+
+                    # Always add media to run_response for caller availability
+                    store_media_util(run_response, model_response)
 
                 # Execute post-hooks
                 if team.post_hooks is not None:
@@ -7259,6 +7288,7 @@ def _continue_run_stream(
     response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     stream_events: bool = False,
     yield_run_output: bool = False,
+    skip_model_response: bool = False,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
     **kwargs: Any,
@@ -7300,78 +7330,79 @@ def _continue_run_stream(
                     stream_events=stream_events,
                 )
 
-                # Stream model response
-                if team.output_model is None:
-                    for event in _handle_model_response_stream(
-                        team,
-                        session=session,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        tools=tools,
-                        response_format=response_format,
-                        stream_events=stream_events,
-                        session_state=run_context.session_state,
-                        run_context=run_context,
-                    ):
-                        if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
-                            raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-                else:
-                    from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+                if not skip_model_response:
+                    # Stream model response
+                    if team.output_model is None:
+                        for event in _handle_model_response_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            tools=tools,
+                            response_format=response_format,
+                            stream_events=stream_events,
+                            session_state=run_context.session_state,
+                            run_context=run_context,
+                        ):
+                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                raise_if_cancelled(run_response.run_id)  # type: ignore
+                            yield event
+                    else:
+                        from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 
-                    for event in _handle_model_response_stream(
-                        team,
-                        session=session,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        tools=tools,
-                        response_format=response_format,
-                        stream_events=stream_events,
-                        session_state=run_context.session_state,
-                        run_context=run_context,
-                    ):
-                        if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                        for event in _handle_model_response_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            tools=tools,
+                            response_format=response_format,
+                            stream_events=stream_events,
+                            session_state=run_context.session_state,
+                            run_context=run_context,
+                        ):
+                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                raise_if_cancelled(run_response.run_id)  # type: ignore
+                            if isinstance(event, RunContentEvent):
+                                if stream_events:
+                                    yield IntermediateRunContentEvent(
+                                        content=event.content,
+                                        content_type=event.content_type,
+                                    )
+                            else:
+                                yield event
+
+                        for event in generate_response_with_output_model_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            stream_events=stream_events,
+                        ):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
-                        if isinstance(event, RunContentEvent):
-                            if stream_events:
-                                yield IntermediateRunContentEvent(
-                                    content=event.content,
-                                    content_type=event.content_type,
-                                )
-                        else:
                             yield event
 
-                    for event in generate_response_with_output_model_stream(
+                    raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                    # Check for new pauses
+                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                        from agno.team import _hooks
+
+                        yield from _hooks.handle_team_run_paused_stream(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+                        if yield_run_output:
+                            yield run_response
+                        return
+
+                    # Parse response with parser model
+                    yield from parse_response_with_parser_model_stream(
                         team,
                         session=session,
                         run_response=run_response,
-                        run_messages=run_messages,
                         stream_events=stream_events,
-                    ):
-                        raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-
-                raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # Check for new pauses
-                if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                    from agno.team import _hooks
-
-                    yield from _hooks.handle_team_run_paused_stream(
-                        team, run_response=run_response, session=session, run_context=run_context
+                        run_context=run_context,
                     )
-                    if yield_run_output:
-                        yield run_response
-                    return
-
-                # Parse response with parser model
-                yield from parse_response_with_parser_model_stream(
-                    team,
-                    session=session,
-                    run_response=run_response,
-                    stream_events=stream_events,
-                    run_context=run_context,
-                )
 
                 # Content completed event
                 if stream_events:
@@ -8153,21 +8184,25 @@ async def _acontinue_run(
 
                     # Prepare for member HITL continuation
                     _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+                    skip_model_response = _set_direct_member_hitl_continuation_content(
+                        team, run_response, member_results
+                    )
 
                     log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
-                    # Handle model response using shared helper
-                    paused_result = await _ahandle_model_response_for_continue(
-                        team,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        run_context=run_context,
-                        tools=_tools,
-                        team_session=team_session,
-                        response_format=response_format,
-                    )
-                    if paused_result is not None:
-                        return paused_result
+                    if not skip_model_response:
+                        # Handle model response using shared helper
+                        paused_result = await _ahandle_model_response_for_continue(
+                            team,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            run_context=run_context,
+                            tools=_tools,
+                            team_session=team_session,
+                            response_format=response_format,
+                        )
+                        if paused_result is not None:
+                            return paused_result
 
                 # Post-hooks
                 if team.post_hooks is not None:
@@ -8666,6 +8701,9 @@ async def _acontinue_run_stream(
 
                     # Prepare for member HITL continuation
                     _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+                    skip_model_response = _set_direct_member_hitl_continuation_content(
+                        team, run_response, member_results
+                    )
 
                     log_debug(f"Team Continue Run Stream (Member HITL): {run_response.run_id}", center=True)
 
@@ -8678,78 +8716,81 @@ async def _acontinue_run_stream(
                             store_events=team.store_events,
                         )
 
-                    # Stream model response
-                    if team.output_model is None:
-                        async for event in _ahandle_model_response_stream(
-                            team,
-                            session=team_session,
-                            run_response=run_response,
-                            run_messages=run_messages,
-                            tools=_tools,
-                            response_format=response_format,
-                            stream_events=stream_events,
-                            session_state=run_context.session_state,
-                            run_context=run_context,
-                        ):
-                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
-                                await araise_if_cancelled(run_response.run_id)  # type: ignore
-                            yield event
-                    else:
-                        from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+                    if not skip_model_response:
+                        # Stream model response
+                        if team.output_model is None:
+                            async for event in _ahandle_model_response_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                tools=_tools,
+                                response_format=response_format,
+                                stream_events=stream_events,
+                                session_state=run_context.session_state,
+                                run_context=run_context,
+                            ):
+                                if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                    await araise_if_cancelled(run_response.run_id)  # type: ignore
+                                yield event
+                        else:
+                            from agno.run.team import IntermediateRunContentEvent, RunContentEvent
 
-                        async for event in _ahandle_model_response_stream(
-                            team,
-                            session=team_session,
-                            run_response=run_response,
-                            run_messages=run_messages,
-                            tools=_tools,
-                            response_format=response_format,
-                            stream_events=stream_events,
-                            session_state=run_context.session_state,
-                            run_context=run_context,
-                        ):
-                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                            async for event in _ahandle_model_response_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                tools=_tools,
+                                response_format=response_format,
+                                stream_events=stream_events,
+                                session_state=run_context.session_state,
+                                run_context=run_context,
+                            ):
+                                if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                    await araise_if_cancelled(run_response.run_id)  # type: ignore
+                                if isinstance(event, RunContentEvent):
+                                    if stream_events:
+                                        yield IntermediateRunContentEvent(
+                                            content=event.content,
+                                            content_type=event.content_type,
+                                        )
+                                else:
+                                    yield event
+
+                            async for event in agenerate_response_with_output_model_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                stream_events=stream_events,
+                            ):
                                 await araise_if_cancelled(run_response.run_id)  # type: ignore
-                            if isinstance(event, RunContentEvent):
-                                if stream_events:
-                                    yield IntermediateRunContentEvent(
-                                        content=event.content,
-                                        content_type=event.content_type,
-                                    )
-                            else:
                                 yield event
 
-                        async for event in agenerate_response_with_output_model_stream(
+                        # Check for new pauses
+                        if run_response.requirements and any(
+                            not req.is_resolved() for req in run_response.requirements
+                        ):
+                            from agno.team import _hooks
+
+                            async for item in _hooks.ahandle_team_run_paused_stream(
+                                team, run_response=run_response, session=team_session, run_context=run_context
+                            ):
+                                yield item
+                            if yield_run_output:
+                                yield run_response
+                            return
+
+                        # Parse response with parser model
+                        async for event in aparse_response_with_parser_model_stream(
                             team,
                             session=team_session,
                             run_response=run_response,
-                            run_messages=run_messages,
                             stream_events=stream_events,
+                            run_context=run_context,
                         ):
-                            await araise_if_cancelled(run_response.run_id)  # type: ignore
                             yield event
-
-                    # Check for new pauses
-                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                        from agno.team import _hooks
-
-                        async for item in _hooks.ahandle_team_run_paused_stream(
-                            team, run_response=run_response, session=team_session, run_context=run_context
-                        ):
-                            yield item
-                        if yield_run_output:
-                            yield run_response
-                        return
-
-                    # Parse response with parser model
-                    async for event in aparse_response_with_parser_model_stream(
-                        team,
-                        session=team_session,
-                        run_response=run_response,
-                        stream_events=stream_events,
-                        run_context=run_context,
-                    ):
-                        yield event
 
                 # Content completed
                 if stream_events:

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -819,7 +819,159 @@ class TestPrepareMemberHitlContinuation:
 
 
 # ===========================================================================
-# 14. Approval resolution fallback in continue_run_dispatch
+# 14. Direct response parity for member HITL resume
+# ===========================================================================
+
+
+class TestDirectMemberHITLContinuation:
+    def _make_run_messages(self, tool_call_ids):
+        msgs = []
+        for tool_call_id in tool_call_ids:
+            msg = MagicMock()
+            msg.role = "tool"
+            msg.tool_call_id = tool_call_id
+            msg.content = "requires human input"
+            msgs.append(msg)
+        run_messages = MagicMock()
+        run_messages.messages = msgs
+        return run_messages
+
+    def test_sets_content_from_resolved_delegate_result_for_respond_directly_team(self):
+        from agno.team._run import _set_direct_member_hitl_continuation_content
+
+        team = MagicMock(respond_directly=True)
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="Member results after human-in-the-loop resolution:\n[Agent]: Done",
+        )
+        run_response = TeamRunOutput(run_id="run-1", tools=[tool])
+
+        assert _set_direct_member_hitl_continuation_content(team, run_response, ["[Agent]: Done"]) is True
+        assert run_response.content == tool.result
+
+    def test_non_direct_team_keeps_model_continuation(self):
+        from agno.team._run import _set_direct_member_hitl_continuation_content
+
+        team = MagicMock(respond_directly=False)
+        run_response = TeamRunOutput(run_id="run-1", content=None)
+
+        assert _set_direct_member_hitl_continuation_content(team, run_response, ["[Agent]: Done"]) is False
+        assert run_response.content is None
+
+    def test_continue_run_skip_model_response_keeps_member_result(self):
+        from agno.run import RunContext
+        from agno.team._run import _continue_run
+
+        team = MagicMock()
+        team.retries = 0
+        team.events_to_skip = []
+        team.store_events = False
+        team.model = MagicMock()
+        team.post_hooks = None
+        team.session_summary_manager = None
+
+        session = MagicMock()
+        session.session_id = "session-1"
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            content="Member results after human-in-the-loop resolution:\n[Agent]: Done",
+            requirements=[],
+        )
+        run_messages = MagicMock(messages=[])
+        run_context = RunContext(run_id="run-1", session_id="session-1", session_state={})
+
+        with (
+            patch("agno.team._run.register_run"),
+            patch("agno.team._run.cleanup_run"),
+            patch("agno.team._run.raise_if_cancelled"),
+            patch("agno.team._run._cleanup_and_store"),
+            patch("agno.team._init._disconnect_connectable_tools"),
+            patch("agno.team._telemetry.log_team_telemetry"),
+            patch("agno.team._run.call_model_with_fallback") as mock_call_model,
+        ):
+            result = _continue_run(
+                team,
+                run_response=run_response,
+                run_messages=run_messages,
+                run_context=run_context,
+                tools=[],
+                session=session,
+                skip_model_response=True,
+            )
+
+        mock_call_model.assert_not_called()
+        assert result.status == RunStatus.completed
+        assert result.content == "Member results after human-in-the-loop resolution:\n[Agent]: Done"
+
+    def test_continue_run_dispatch_passes_skip_for_respond_directly_member_hitl(self):
+        from agno.team._run import continue_run_dispatch
+
+        team = MagicMock()
+        team.session_id = None
+        team.add_history_to_context = False
+        team.parser_model = None
+        team.respond_directly = True
+        team.initialize_team = MagicMock()
+        team.db = MagicMock()
+
+        req = _make_requirement(requires_confirmation=True)
+        req.member_agent_id = "member-1"
+        req.member_run_id = "member-run-1"
+        delegate_tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="delegate-1",
+            result="Member 'Agent' requires human input before continuing.",
+        )
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            requirements=[req],
+            tools=[delegate_tool],
+            messages=[],
+        )
+
+        opts = SimpleNamespace(
+            stream=False,
+            stream_events=False,
+            yield_run_output=False,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+        team_session = MagicMock()
+        team_session.runs = [run_response]
+        sentinel = object()
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=team_session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.run.approval.check_and_apply_approval_resolution"),
+            patch("agno.team._run._route_requirements_to_members", return_value=["[Agent]: Done"]),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=self._make_run_messages(["delegate-1"])),
+            patch("agno.team._run._continue_run", return_value=sentinel) as mock_continue,
+        ):
+            result = continue_run_dispatch(
+                team,
+                run_response=run_response,
+                requirements=[req],
+                stream=False,
+            )
+
+        assert result is sentinel
+        assert mock_continue.call_args.kwargs["skip_model_response"] is True
+        assert "Done" in run_response.content
+
+
+# ===========================================================================
+# 15. Approval resolution fallback in continue_run_dispatch
 # ===========================================================================
 
 


### PR DESCRIPTION
## Summary

Fixes #8528.

Route-mode teams set `respond_directly=True`, which makes the generated `delegate_task_to_member` tool behave like a stop-after-tool-call direct response. The initial run path already honors that behavior, but the member-HITL resume path patched the delegate result and then always called the team model one more time.

This PR keeps the existing non-direct behavior, but when a member-only HITL continuation resumes a `respond_directly` team it:

- uses the resolved delegate tool result as the team run content
- skips the extra team model response step
- preserves the existing post-hook, session-summary, storage, and completed-event tails for sync/async and stream/non-stream paths

Related open PR #8292 touches team HITL continuation too, but covers mixed team-level/member stale placeholder routing and batch grouping; it does not cover this member-only route/respond_directly skip-model path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI-assisted with Codex and manually reviewed before submission.

Validation:

- `uv run --with pytest --with pytest-asyncio --with pydantic --with rich --with docstring-parser --with httpx pytest libs/agno/tests/unit/team/test_continue_run_requirements.py -q` -> 62 passed
- `uv run --with ruff ruff check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py` -> passed
- `uv run --with ruff ruff format --check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py` -> passed
- `uv run python -m py_compile libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py` -> passed
- `git diff --check` -> clean
