### PR TITLE
[fix] Expose LiteLLM finish reason

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1901,6 +1901,7 @@ class Model(ABC):
                     existing.extend(value)
                 else:
                     stream_data.response_provider_data[key] = value
+            should_yield = True
 
         # Update stream_data tool calls
         if model_response_delta.tool_calls is not None:

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -346,6 +346,8 @@ class LiteLLM(Model):
         """Parse the provider response."""
         model_response = ModelResponse()
 
+        self._add_finish_reason(model_response, response)
+
         response_message = response.choices[0].message
 
         if response_message.content is not None:
@@ -373,6 +375,8 @@ class LiteLLM(Model):
     def _parse_provider_response_delta(self, response_delta: Any) -> ModelResponse:
         """Parse the provider response delta for streaming responses."""
         model_response = ModelResponse()
+
+        self._add_finish_reason(model_response, response_delta)
 
         if hasattr(response_delta, "choices") and len(response_delta.choices) > 0:
             choice_delta = response_delta.choices[0].delta
@@ -415,6 +419,19 @@ class LiteLLM(Model):
             model_response.response_usage = self._get_metrics(response_delta.usage)
 
         return model_response
+
+    @staticmethod
+    def _add_finish_reason(model_response: ModelResponse, response: Any) -> None:
+        if not hasattr(response, "choices") or len(response.choices) == 0:
+            return
+
+        finish_reason = getattr(response.choices[0], "finish_reason", None)
+        if finish_reason is None:
+            return
+
+        if model_response.provider_data is None:
+            model_response.provider_data = {}
+        model_response.provider_data["finish_reason"] = finish_reason
 
     @staticmethod
     def parse_tool_calls(tool_calls_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/libs/agno/tests/unit/models/litellm/test_finish_reason.py
+++ b/libs/agno/tests/unit/models/litellm/test_finish_reason.py
@@ -1,0 +1,72 @@
+from agno.models.base import MessageData
+from agno.models.litellm import LiteLLM
+from agno.models.response import ModelResponse
+
+
+class MockChoice:
+    def __init__(self, *, message=None, delta=None, finish_reason=None):
+        self.message = message
+        self.delta = delta
+        self.finish_reason = finish_reason
+
+
+class MockMessage:
+    content = "final"
+    reasoning_content = None
+    tool_calls = None
+
+
+class MockDelta:
+    content = "chunk"
+    reasoning_content = None
+    tool_calls = None
+
+
+class MockResponse:
+    def __init__(self, *, finish_reason=None):
+        self.choices = [MockChoice(message=MockMessage(), finish_reason=finish_reason)]
+        self.usage = None
+
+
+class MockChunk:
+    def __init__(self, *, finish_reason=None):
+        self.choices = [MockChoice(delta=MockDelta(), finish_reason=finish_reason)]
+        self.usage = None
+
+
+def test_litellm_non_stream_response_exposes_finish_reason_in_provider_data():
+    model = LiteLLM(id="gpt-4o", api_key="test-key")
+
+    response = model._parse_provider_response(MockResponse(finish_reason="length"))
+
+    assert response.content == "final"
+    assert response.provider_data == {"finish_reason": "length"}
+
+
+def test_litellm_stream_delta_exposes_finish_reason_in_provider_data():
+    model = LiteLLM(id="gpt-4o", api_key="test-key")
+
+    response = model._parse_provider_response_delta(MockChunk(finish_reason="stop"))
+
+    assert response.content == "chunk"
+    assert response.provider_data == {"finish_reason": "stop"}
+
+
+def test_provider_data_only_stream_delta_is_yielded():
+    model = LiteLLM(id="gpt-4o", api_key="test-key")
+    stream_data = MessageData()
+    delta = ModelResponse(provider_data={"finish_reason": "length"})
+
+    yielded = list(model._populate_stream_data(stream_data, delta))
+
+    assert yielded == [delta]
+    assert stream_data.response_provider_data == {"finish_reason": "length"}
+
+
+def test_litellm_stream_delta_omits_empty_finish_reason_provider_data():
+    model = LiteLLM(id="gpt-4o", api_key="test-key")
+
+    response = model._parse_provider_response_delta(MockChunk(finish_reason=None))
+
+    assert response.content == "chunk"
+    assert response.provider_data is None


### PR DESCRIPTION
## Summary

Fixes #7985.

LiteLLM streaming chunks can carry `choices[0].finish_reason` on the final chunk, but Agno previously dropped it while parsing LiteLLM responses. This PR preserves that value in `ModelResponse.provider_data["finish_reason"]` for both non-stream and stream responses.

It also lets provider-data-only stream deltas yield through the shared stream aggregator, so a final chunk that only contains `finish_reason` can still reach the run event path and final `RunOutput.model_provider_data`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

AI-assisted by Codex; I reviewed the diff and validation results.

Duplicate screen: checked open PRs for `finish_reason` / LiteLLM-related fixes and found no open PR covering #7985.

Targeted validation run locally:

```text
PYTHONPATH=libs/agno uv run --with pytest --with pydantic --with litellm --with docstring-parser pytest libs/agno/tests/unit/models/litellm/test_finish_reason.py -q
# 4 passed

uv run --with ruff ruff check libs/agno/agno/models/litellm/chat.py libs/agno/agno/models/base.py libs/agno/tests/unit/models/litellm/test_finish_reason.py
# All checks passed

uv run --with ruff ruff format --check libs/agno/agno/models/litellm/chat.py libs/agno/agno/models/base.py libs/agno/tests/unit/models/litellm/test_finish_reason.py
# 3 files already formatted

PYTHONPATH=libs/agno uv run python -m py_compile libs/agno/agno/models/base.py libs/agno/agno/models/litellm/chat.py libs/agno/tests/unit/models/litellm/test_finish_reason.py
# passed

git diff --check
# clean
```

I did not run the full repository format/validation scripts because this is a narrow LiteLLM parser + stream aggregation fix; the targeted checks above cover the changed files.