### PR TITLE
fix: add Cal.com request timeout

### DIFF
--- a/libs/agno/agno/tools/calcom.py
+++ b/libs/agno/agno/tools/calcom.py
@@ -24,6 +24,7 @@ class CalComTools(Toolkit):
         enable_get_upcoming_bookings: bool = True,
         enable_reschedule_booking: bool = True,
         enable_cancel_booking: bool = True,
+        timeout: int = 30,
         all: bool = False,
         **kwargs,
     ):
@@ -33,6 +34,7 @@ class CalComTools(Toolkit):
             api_key: Cal.com API key
             event_type_id: Default event type ID for bookings
             user_timezone: User's timezone in IANA format (e.g., 'Asia/Kolkata')
+            timeout: Request timeout in seconds
         """
 
         # Get credentials from environment if not provided
@@ -49,6 +51,7 @@ class CalComTools(Toolkit):
             log_error("CALCOM_EVENT_TYPE_ID not set. Please set the CALCOM_EVENT_TYPE_ID environment variable.")
 
         self.user_timezone = user_timezone or "America/New_York"
+        self.timeout = timeout
 
         tools: List[Any] = []
         if all or enable_get_available_slots:
@@ -118,7 +121,7 @@ class CalComTools(Toolkit):
                 "eventTypeId": str(self.event_type_id),
             }
 
-            response = requests.get(url, headers=self._get_headers(), params=querystring)  # type: ignore
+            response = requests.get(url, headers=self._get_headers(), params=querystring, timeout=self.timeout)  # type: ignore
             if response.status_code == 200:
                 slots = response.json()["data"]["slots"]
                 available_slots = []
@@ -157,7 +160,7 @@ class CalComTools(Toolkit):
                 "attendee": {"name": name, "email": email, "timeZone": self.user_timezone},
             }
 
-            response = requests.post(url, json=payload, headers=self._get_headers())
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=self.timeout)
             if response.status_code == 201:
                 booking_data = response.json()["data"]
                 user_time = self._convert_to_user_timezone(booking_data["start"])
@@ -182,7 +185,7 @@ class CalComTools(Toolkit):
             if email:
                 querystring["attendeeEmail"] = email
 
-            response = requests.get(url, headers=self._get_headers(), params=querystring)
+            response = requests.get(url, headers=self._get_headers(), params=querystring, timeout=self.timeout)
             if response.status_code == 200:
                 bookings = response.json()["data"]
                 if not bookings:
@@ -222,7 +225,7 @@ class CalComTools(Toolkit):
             new_start_time = datetime.fromisoformat(new_start_time).astimezone(pytz.utc).isoformat(timespec="seconds")
             payload = {"start": new_start_time, "reschedulingReason": reason}
 
-            response = requests.post(url, json=payload, headers=self._get_headers())
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=self.timeout)
             if response.status_code == 201:
                 booking_data = response.json()["data"]
                 user_time = self._convert_to_user_timezone(booking_data["start"])
@@ -246,7 +249,7 @@ class CalComTools(Toolkit):
             url = f"https://api.cal.com/v2/bookings/{booking_uid}/cancel"
             payload = {"cancellationReason": reason}
 
-            response = requests.post(url, json=payload, headers=self._get_headers())
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=self.timeout)
             if response.status_code == 200:
                 return "Booking cancelled successfully."
             return f"Failed to cancel booking: {response.text}"

--- a/libs/agno/tests/unit/tools/test_calcom.py
+++ b/libs/agno/tests/unit/tools/test_calcom.py
@@ -1,0 +1,79 @@
+"""Unit tests for CalComTools class."""
+
+from unittest.mock import Mock, patch
+
+from agno.tools.calcom import CalComTools
+
+
+def _mock_response(status_code=200, data=None, text="OK"):
+    response = Mock()
+    response.status_code = status_code
+    response.text = text
+    response.json.return_value = data or {}
+    return response
+
+
+def test_init_uses_default_timeout():
+    tools = CalComTools(api_key="test_api_key", event_type_id=123)
+
+    assert tools.timeout == 30
+
+
+def test_get_available_slots_uses_configured_timeout():
+    tools = CalComTools(api_key="test_api_key", event_type_id=123, timeout=7)
+    response = _mock_response(data={"data": {"slots": {"2026-01-01": [{"time": "2026-01-01T15:00:00Z"}]}}})
+
+    with patch("agno.tools.calcom.requests.get", return_value=response) as mock_get:
+        result = tools.get_available_slots("2026-01-01", "2026-01-02")
+
+    assert "Available slots" in result
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["timeout"] == 7
+
+
+def test_create_booking_uses_configured_timeout():
+    tools = CalComTools(api_key="test_api_key", event_type_id=123, timeout=7)
+    response = _mock_response(status_code=201, data={"data": {"start": "2026-01-01T15:00:00Z", "uid": "abc123"}})
+
+    with patch("agno.tools.calcom.requests.post", return_value=response) as mock_post:
+        result = tools.create_booking("2026-01-01T15:00:00+00:00", "Ada", "ada@example.com")
+
+    assert "Booking created successfully" in result
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["timeout"] == 7
+
+
+def test_get_upcoming_bookings_uses_configured_timeout():
+    tools = CalComTools(api_key="test_api_key", event_type_id=123, timeout=7)
+    response = _mock_response(data={"data": []})
+
+    with patch("agno.tools.calcom.requests.get", return_value=response) as mock_get:
+        result = tools.get_upcoming_bookings("ada@example.com")
+
+    assert result == "No upcoming bookings found."
+    mock_get.assert_called_once()
+    assert mock_get.call_args.kwargs["timeout"] == 7
+
+
+def test_reschedule_booking_uses_configured_timeout():
+    tools = CalComTools(api_key="test_api_key", event_type_id=123, timeout=7)
+    response = _mock_response(status_code=201, data={"data": {"start": "2026-01-01T16:00:00Z", "uid": "def456"}})
+
+    with patch("agno.tools.calcom.requests.post", return_value=response) as mock_post:
+        result = tools.reschedule_booking("abc123", "2026-01-01T16:00:00+00:00", "Need a later slot")
+
+    assert "Booking rescheduled" in result
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["timeout"] == 7
+
+
+def test_cancel_booking_uses_configured_timeout():
+    tools = CalComTools(api_key="test_api_key", event_type_id=123, timeout=7)
+    response = _mock_response()
+
+    with patch("agno.tools.calcom.requests.post", return_value=response) as mock_post:
+        result = tools.cancel_booking("abc123", "Plans changed")
+
+    assert result == "Booking cancelled successfully."
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["timeout"] == 7


### PR DESCRIPTION
## Summary

Fixes #8520.

Adds a configurable `timeout` parameter to `CalComTools` with a default of 30 seconds, and passes it to all Cal.com `requests.get` / `requests.post` calls so agent runs do not block indefinitely on slow or unreachable Cal.com endpoints.

Also adds focused unit coverage for the default timeout and all five affected Cal.com API calls.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run:

- `PYTHONPATH=libs/agno uv run --no-project --with pytest --with requests --with pytz --with pydantic --with pydantic-settings --with docstring-parser --with rich --with typing-extensions --with python-dotenv --with packaging --with pyyaml --with gitpython --with typer --with h11 --with httpx --with python-multipart pytest libs/agno/tests/unit/tools/test_calcom.py -q`
- `uv run --no-project --with ruff ruff format --check libs/agno/agno/tools/calcom.py libs/agno/tests/unit/tools/test_calcom.py`
- `uv run --no-project --with ruff ruff check libs/agno/agno/tools/calcom.py libs/agno/tests/unit/tools/test_calcom.py`
- `PYTHONPATH=libs/agno uv run --no-project --with requests --with pytz --with pydantic --with pydantic-settings --with docstring-parser --with rich --with typing-extensions --with python-dotenv --with packaging --with pyyaml --with gitpython --with typer --with h11 --with httpx --with python-multipart python -m py_compile libs/agno/agno/tools/calcom.py libs/agno/tests/unit/tools/test_calcom.py`

I did not run the full `./scripts/validate.sh`; local `uv run --project libs/agno ...` dependency resolution currently fails before tests due an optional-extras conflict between `agno[a2a]` (`httpx>=0.28.1`) and `agno[brave]` (`httpx<0.26.0` through `brave-search`). To keep this PR focused, I used a minimal `uv --no-project` environment for the affected module tests.

I used AI assistance to prepare the patch, then manually scoped the change to the reported Cal.com calls and ran the validations above.