### PR TITLE
[fix] Stream model reasoning deltas as reasoning events

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1442,6 +1442,20 @@ def handle_model_response_chunk(
                     model_response.reasoning_content += model_response_event.redacted_reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
 
+            reasoning_content_delta = (model_response_event.reasoning_content or "") + (
+                model_response_event.redacted_reasoning_content or ""
+            )
+            if stream_events and reasoning_content_delta:
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_content_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data
@@ -1464,8 +1478,7 @@ def handle_model_response_chunk(
                 )
             elif (
                 model_response_event.content is not None
-                or model_response_event.reasoning_content is not None
-                or model_response_event.redacted_reasoning_content is not None
+                or (not stream_events and reasoning_content_delta)
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
             ):
@@ -1473,8 +1486,10 @@ def handle_model_response_chunk(
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
-                        redacted_reasoning_content=model_response_event.redacted_reasoning_content,
+                        reasoning_content=model_response_event.reasoning_content if not stream_events else None,
+                        redacted_reasoning_content=model_response_event.redacted_reasoning_content
+                        if not stream_events
+                        else None,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,
                     ),

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from agno.models.message import Message
+from agno.models.response import ModelResponse
 from agno.reasoning.step import ReasoningStep, ReasoningSteps
 from agno.run.agent import RunEvent
 
@@ -298,3 +299,60 @@ def test_message_reasoning_content_optional():
     msg = Message(role="assistant", content="Just content")
     # Should not raise, reasoning_content should be None or not set
     assert msg.content == "Just content"
+
+
+def test_model_stream_reasoning_chunk_emits_reasoning_delta_event():
+    from agno.agent import Agent
+    from agno.agent._response import handle_model_response_chunk
+    from agno.run.agent import RunOutput
+    from agno.session import AgentSession
+
+    agent = Agent(id="agent-1", name="Agent 1")
+    session = AgentSession(session_id="session-1")
+    run_response = RunOutput(run_id="run-1", agent_id=agent.id, agent_name=agent.name, session_id=session.session_id)
+    model_response = ModelResponse()
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=ModelResponse(reasoning_content="thinking"),
+            stream_events=True,
+        )
+    )
+
+    assert [event.event for event in events] == [RunEvent.reasoning_content_delta]
+    assert events[0].reasoning_content == "thinking"  # type: ignore[attr-defined]
+    assert run_response.reasoning_content == "thinking"
+
+
+def test_model_stream_mixed_reasoning_and_content_emits_both_events():
+    from agno.agent import Agent
+    from agno.agent._response import handle_model_response_chunk
+    from agno.run.agent import RunOutput
+    from agno.session import AgentSession
+
+    agent = Agent(id="agent-1", name="Agent 1")
+    session = AgentSession(session_id="session-1")
+    run_response = RunOutput(run_id="run-1", agent_id=agent.id, agent_name=agent.name, session_id=session.session_id)
+    model_response = ModelResponse()
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=ModelResponse(content="answer", reasoning_content="thinking"),
+            stream_events=True,
+        )
+    )
+
+    assert [event.event for event in events] == [RunEvent.reasoning_content_delta, RunEvent.run_content]
+    assert events[0].reasoning_content == "thinking"  # type: ignore[attr-defined]
+    assert events[1].content == "answer"  # type: ignore[attr-defined]
+    assert events[1].reasoning_content == ""  # type: ignore[attr-defined]
+    assert run_response.content == "answer"
+    assert run_response.reasoning_content == "thinking"


### PR DESCRIPTION
## Summary
- emit `ReasoningContentDelta` events when model stream chunks carry `reasoning_content` or redacted reasoning content
- keep non-streaming behavior unchanged by preserving reasoning text on `RunContent` events
- add regression coverage for reasoning-only and mixed reasoning/content chunks

Fixes #8400

## Tests
- `uv run --with pytest --with pytest-asyncio --with pydantic --with pydantic-settings --with python-dotenv --with rich --with typer --with typing-extensions --with packaging --with gitpython --with 'httpx[http2]' --with pyyaml --with python-multipart --with h11 --with-editable libs/agno pytest libs/agno/tests/unit/reasoning/test_reasoning_streaming.py -q`\n- `uv run --with ruff ruff check libs/agno/agno/agent/_response.py libs/agno/tests/unit/reasoning/test_reasoning_streaming.py`\n- `uv run --with pytest --with pytest-asyncio --with pydantic --with pydantic-settings --with python-dotenv --with rich --with typer --with typing-extensions --with packaging --with gitpython --with 'httpx[http2]' --with pyyaml --with python-multipart --with h11 --with ag-ui-protocol --with jsonpatch --with fastapi --with-editable libs/agno pytest libs/agno/tests/unit/app/test_agui_app.py::test_reasoning_content_delta_streaming libs/agno/tests/unit/app/test_agui_reasoning_tools.py -q`\n- `uv run --with ruff ruff format --check libs/agno/agno/agent/_response.py libs/agno/tests/unit/reasoning/test_reasoning_streaming.py`\n- `git diff --check`