### PR TITLE
[fix] Write MoviePy outputs atomically

### DIFF
--- a/libs/agno/agno/tools/moviepy_video.py
+++ b/libs/agno/agno/tools/moviepy_video.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
 from agno.tools import Toolkit
@@ -7,6 +10,22 @@ try:
     from moviepy import ColorClip, CompositeVideoClip, TextClip, VideoFileClip  # type: ignore
 except ImportError:
     raise ImportError("`moviepy` not installed. Please install using `pip install moviepy ffmpeg`")
+
+
+def _make_temp_output_path(output_path: str) -> str:
+    output_dir = os.path.dirname(os.path.abspath(output_path))
+    filename = os.path.basename(output_path)
+    stem, suffix = os.path.splitext(filename)
+    fd, temp_path = tempfile.mkstemp(prefix=f".{stem}.", suffix=f".tmp{suffix}", dir=output_dir)
+    os.close(fd)
+    os.unlink(temp_path)
+    return temp_path
+
+
+def _remove_file_if_exists(path: Optional[str]) -> None:
+    if path:
+        with suppress(FileNotFoundError):
+            os.remove(path)
 
 
 class MoviePyVideoTools(Toolkit):
@@ -247,14 +266,19 @@ class MoviePyVideoTools(Toolkit):
         Returns:
             str: Path to the created SRT file, or error message if failed
         """
+        temp_output_path: Optional[str] = None
         try:
             log_debug(f"Creating SRT file at {output_path}")
             # Since we're getting SRT format from Whisper API now,
             # we can just write it directly to file
-            with open(output_path, "w", encoding="utf-8") as f:
+            temp_output_path = _make_temp_output_path(output_path)
+            with open(temp_output_path, "w", encoding="utf-8") as f:
                 f.write(transcription)
+            os.replace(temp_output_path, output_path)
+            temp_output_path = None
             return output_path
         except Exception as e:
+            _remove_file_if_exists(temp_output_path)
             logger.exception("Failed to create SRT file")
             return f"Failed to create SRT file: {str(e)}"
 
@@ -280,6 +304,10 @@ class MoviePyVideoTools(Toolkit):
         Returns:
             str: Path to the captioned video file, or error message if failed
         """
+        video = None
+        final_video = None
+        all_caption_clips = []
+        temp_output_path: Optional[str] = None
         try:
             # If no output path provided, create one based on input video
             if output_path is None:
@@ -297,8 +325,6 @@ class MoviePyVideoTools(Toolkit):
 
             # Split into lines
             subtitle_lines = self.split_text_into_lines(words)
-
-            all_caption_clips = []
 
             # Create caption clips for each line
             for line in subtitle_lines:
@@ -326,8 +352,9 @@ class MoviePyVideoTools(Toolkit):
             final_video = CompositeVideoClip([video] + all_caption_clips, size=video.size)
 
             # Write output with optimized settings
+            temp_output_path = _make_temp_output_path(output_path)
             final_video.write_videofile(
-                output_path,
+                temp_output_path,
                 codec="libx264",
                 audio_codec="aac",
                 fps=video.fps,
@@ -335,15 +362,22 @@ class MoviePyVideoTools(Toolkit):
                 threads=4,
                 # Disable default progress bar
             )
-
-            # Cleanup
-            video.close()
-            final_video.close()
-            for clip in all_caption_clips:
-                clip.close()
+            os.replace(temp_output_path, output_path)
+            temp_output_path = None
 
             return output_path
 
         except Exception as e:
+            _remove_file_if_exists(temp_output_path)
             logger.exception("Failed to embed captions")
             return f"Failed to embed captions: {str(e)}"
+        finally:
+            for clip in all_caption_clips:
+                with suppress(Exception):
+                    clip.close()
+            if final_video is not None:
+                with suppress(Exception):
+                    final_video.close()
+            if video is not None:
+                with suppress(Exception):
+                    video.close()

--- a/libs/agno/tests/unit/tools/test_moviepy_video.py
+++ b/libs/agno/tests/unit/tools/test_moviepy_video.py
@@ -1,0 +1,96 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture()
+def moviepy_video_module(monkeypatch):
+    fake_moviepy = types.ModuleType("moviepy")
+
+    class FakeClip:
+        pass
+
+    fake_moviepy.ColorClip = FakeClip
+    fake_moviepy.CompositeVideoClip = FakeClip
+    fake_moviepy.TextClip = FakeClip
+    fake_moviepy.VideoFileClip = FakeClip
+
+    monkeypatch.setitem(sys.modules, "moviepy", fake_moviepy)
+    sys.modules.pop("agno.tools.moviepy_video", None)
+    module = importlib.import_module("agno.tools.moviepy_video")
+    yield module
+    sys.modules.pop("agno.tools.moviepy_video", None)
+
+
+def test_create_srt_cleans_temp_file_when_replace_fails(moviepy_video_module, monkeypatch, tmp_path):
+    output_path = tmp_path / "captions.srt"
+    output_path.write_text("existing", encoding="utf-8")
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise RuntimeError("replace failed")
+
+    monkeypatch.setattr(moviepy_video_module.os, "replace", fail_replace)
+
+    tools = moviepy_video_module.MoviePyVideoTools(enable_process_video=False, enable_embed_captions=False)
+    result = tools.create_srt("new subtitles", str(output_path))
+
+    assert result == "Failed to create SRT file: replace failed"
+    assert output_path.read_text(encoding="utf-8") == "existing"
+    assert list(tmp_path.glob(".*.tmp.srt")) == []
+
+
+def test_create_srt_replaces_output_after_successful_temp_write(moviepy_video_module, tmp_path):
+    output_path = tmp_path / "captions.srt"
+
+    tools = moviepy_video_module.MoviePyVideoTools(enable_process_video=False, enable_embed_captions=False)
+    result = tools.create_srt("new subtitles", str(output_path))
+
+    assert result == str(output_path)
+    assert output_path.read_text(encoding="utf-8") == "new subtitles"
+    assert list(tmp_path.glob(".*.tmp.srt")) == []
+
+
+def test_embed_captions_cleans_temp_video_when_render_fails(moviepy_video_module, monkeypatch, tmp_path):
+    video_path = tmp_path / "input.mp4"
+    srt_path = tmp_path / "captions.srt"
+    output_path = tmp_path / "output.mp4"
+    video_path.write_text("input video", encoding="utf-8")
+    srt_path.write_text("", encoding="utf-8")
+    output_path.write_text("existing video", encoding="utf-8")
+
+    closed = []
+
+    class FakeVideo:
+        h = 100
+        w = 200
+        fps = 30
+        size = (200, 100)
+
+        def close(self):
+            closed.append("video")
+
+    class FailingFinalVideo:
+        def __init__(self, clips, size):
+            self.clips = clips
+            self.size = size
+
+        def write_videofile(self, path: str, **kwargs):
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("partial video")
+            raise RuntimeError("render failed")
+
+        def close(self):
+            closed.append("final")
+
+    monkeypatch.setattr(moviepy_video_module, "VideoFileClip", lambda path: FakeVideo())
+    monkeypatch.setattr(moviepy_video_module, "CompositeVideoClip", FailingFinalVideo)
+
+    tools = moviepy_video_module.MoviePyVideoTools(enable_process_video=False, enable_generate_captions=False)
+    result = tools.embed_captions(str(video_path), str(srt_path), str(output_path))
+
+    assert result == "Failed to embed captions: render failed"
+    assert output_path.read_text(encoding="utf-8") == "existing video"
+    assert list(tmp_path.glob(".*.tmp.mp4")) == []
+    assert closed == ["final", "video"]


### PR DESCRIPTION
## Summary

Fixes #8534.

`MoviePyVideoTools.create_srt()` and `embed_captions()` wrote directly to their final output paths. If a write failed after creating partial content, downstream workflows that only check `os.path.exists()` could observe a corrupted target file.

This changes both paths to write into a same-directory temporary file and only publish the result with `os.replace()` after a successful write. On exceptions, the temporary file is removed and any previous target file is left untouched. `embed_captions()` also closes video resources from a `finally` block so render errors still release clips.

## Validation

- `PYTHONPATH=/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/agno-moviepy-atomic-output/libs/agno /Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/agno/libs/agno/.venv/bin/pytest libs/agno/tests/unit/tools/test_moviepy_video.py -q`
  - `3 passed`
- `/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/agno/libs/agno/.venv/bin/ruff check libs/agno/agno/tools/moviepy_video.py libs/agno/tests/unit/tools/test_moviepy_video.py`
  - `All checks passed!`
- `/Users/fengjikui/Documents/dev-coding/codex_build/oss_contrib/agno/libs/agno/.venv/bin/ruff format --check libs/agno/agno/tools/moviepy_video.py libs/agno/tests/unit/tools/test_moviepy_video.py`
  - `2 files already formatted`
- `git diff --check`

Note: running `uv run --directory libs/agno ...` currently fails during dependency resolution because the project extras include incompatible `agno[a2a]` and `agno[brave]` constraints for the supported Python split. I used the existing local agno test environment and explicitly pointed `PYTHONPATH` at this worktree for the focused validation above.
