### PR TITLE
Fix route HITL resume completion

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5878,11 +5878,53 @@ def _tool_result_requires_human_input(tool: ToolExecution) -> bool:
     return isinstance(result, str) and "requires human input" in result.lower()
 
 
+def _get_direct_member_result(member_results: List[str]) -> Optional[str]:
+    if not member_results:
+        return None
+    if len(member_results) == 1:
+        member_result = member_results[0]
+        _, separator, content = member_result.partition("]: ")
+        return content if separator else member_result
+    return "\n".join(member_results)
+
+
+def _mark_stop_after_member_hitl_complete(
+    team: "Team",
+    run_response: TeamRunOutput,
+    run_messages: RunMessages,
+    delegate_tool_call_ids: set[str],
+    direct_member_result: Optional[str],
+) -> bool:
+    if not getattr(team, "respond_directly", False) or not delegate_tool_call_ids or direct_member_result is None:
+        return False
+
+    updated_delegate_tool = False
+    for tool in run_response.tools or []:
+        if tool.tool_call_id not in delegate_tool_call_ids:
+            continue
+        if tool.tool_name not in {"delegate_task_to_member", "delegate_task_to_members"}:
+            continue
+        tool.result = direct_member_result
+        updated_delegate_tool = True
+
+    if not updated_delegate_tool:
+        return False
+
+    for msg in run_messages.messages:
+        if msg.role == "tool" and msg.tool_call_id in delegate_tool_call_ids:
+            msg.content = direct_member_result
+
+    run_response.content = direct_member_result
+    run_response.status = RunStatus.completed
+    run_response.requirements = []
+    return True
+
+
 def _prepare_member_hitl_continuation(
     run_response: TeamRunOutput,
     run_messages: RunMessages,
     member_results: List[str],
-) -> None:
+) -> Tuple[set[str], Optional[str]]:
     """Prepare run_response and run_messages for member HITL continuation.
 
     Updates the delegate_task_to_member/delegate_task_to_members tool result in both
@@ -5894,8 +5936,10 @@ def _prepare_member_hitl_continuation(
     """
 
     continuation_message = _build_continuation_message(member_results)
+    direct_member_result = _get_direct_member_result(member_results)
 
     target_tool_call_ids: set[str] = set()
+    delegate_tool_call_ids: set[str] = set()
     for tool in run_response.tools or []:
         if tool.tool_name in {
             "delegate_task_to_member",
@@ -5904,6 +5948,7 @@ def _prepare_member_hitl_continuation(
             tool.result = continuation_message
             if tool.tool_call_id is not None:
                 target_tool_call_ids.add(tool.tool_call_id)
+                delegate_tool_call_ids.add(tool.tool_call_id)
 
     if not target_tool_call_ids:
         for tool in run_response.tools or []:
@@ -5921,6 +5966,7 @@ def _prepare_member_hitl_continuation(
     # Reset run state for continuation
     run_response.status = RunStatus.running
     run_response.content = None
+    return delegate_tool_call_ids, direct_member_result
 
 
 async def _ahandle_model_response_for_continue(
@@ -6829,7 +6875,27 @@ def continue_run_dispatch(
         )
 
         # Prepare for member HITL continuation
-        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+        delegate_tool_call_ids, direct_member_result = _prepare_member_hitl_continuation(
+            run_response, run_messages, member_results
+        )
+
+        if _mark_stop_after_member_hitl_complete(
+            team, run_response, run_messages, delegate_tool_call_ids, direct_member_result
+        ):
+            return _continue_run(
+                team,
+                run_response=run_response,
+                run_messages=run_messages,
+                run_context=run_context,
+                tools=_tools,
+                session=team_session,
+                user_id=user_id,
+                response_format=response_format,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                skip_model_call=True,
+                **kwargs,
+            )
 
         log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
@@ -7030,7 +7096,30 @@ def _continue_run_dispatch_stream_with_member_events(
             run_context=run_context,
         )
 
-        _prepare_member_hitl_continuation(run_response, run_messages, member_results)
+        delegate_tool_call_ids, direct_member_result = _prepare_member_hitl_continuation(
+            run_response, run_messages, member_results
+        )
+
+        if _mark_stop_after_member_hitl_complete(
+            team, run_response, run_messages, delegate_tool_call_ids, direct_member_result
+        ):
+            yield from _continue_run_stream(
+                team,
+                run_response=run_response,
+                run_messages=run_messages,
+                run_context=run_context,
+                tools=_tools,
+                session=team_session,
+                user_id=user_id,
+                response_format=response_format,
+                stream_events=opts.stream_events,
+                yield_run_output=opts.yield_run_output,
+                debug_mode=debug_mode,
+                background_tasks=background_tasks,
+                skip_model_call=True,
+                **kwargs,
+            )
+            return
 
         log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
 
@@ -7069,6 +7158,7 @@ def _continue_run(
     response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    skip_model_call: bool = False,
     **kwargs: Any,
 ) -> TeamRunOutput:
     """Continue a paused team run (sync, non-streaming).
@@ -7110,53 +7200,54 @@ def _continue_run(
             try:
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Generate model response
-                model_response: ModelResponse = call_model_with_fallback(
-                    team.model,
-                    team.fallback_config,
-                    messages=run_messages.messages,
-                    response_format=response_format,
-                    tools=tools,
-                    tool_choice=team.tool_choice,
-                    tool_call_limit=team.tool_call_limit,
-                    run_response=run_response,
-                    send_media_to_model=team.send_media_to_model,
-                    compression_manager=team.compression_manager if team.compress_tool_results else None,
-                    after_tool_results=build_team_after_tool_results_callback(
-                        team, run_response, session, run_messages, run_context
-                    ),
-                )
-
-                raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # Parse with output/parser models if needed
-                parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
-                parse_response_with_parser_model(
-                    team, model_response, run_messages, run_context=run_context, run_response=run_response
-                )
-
-                # Update run response
-                _update_run_response(
-                    team,
-                    model_response=model_response,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    run_context=run_context,
-                )
-
-                # Check for new pauses (team-level tools or member propagation)
-                if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                    from agno.team import _hooks
-
-                    return _hooks.handle_team_run_paused(
-                        team, run_response=run_response, session=session, run_context=run_context
+                if not skip_model_call:
+                    # Generate model response
+                    model_response: ModelResponse = call_model_with_fallback(
+                        team.model,
+                        team.fallback_config,
+                        messages=run_messages.messages,
+                        response_format=response_format,
+                        tools=tools,
+                        tool_choice=team.tool_choice,
+                        tool_call_limit=team.tool_call_limit,
+                        run_response=run_response,
+                        send_media_to_model=team.send_media_to_model,
+                        compression_manager=team.compression_manager if team.compress_tool_results else None,
+                        after_tool_results=build_team_after_tool_results_callback(
+                            team, run_response, session, run_messages, run_context
+                        ),
                     )
 
-                # Convert to structured format
-                _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+                    raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Always add media to run_response for caller availability
-                store_media_util(run_response, model_response)
+                    # Parse with output/parser models if needed
+                    parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
+                    parse_response_with_parser_model(
+                        team, model_response, run_messages, run_context=run_context, run_response=run_response
+                    )
+
+                    # Update run response
+                    _update_run_response(
+                        team,
+                        model_response=model_response,
+                        run_response=run_response,
+                        run_messages=run_messages,
+                        run_context=run_context,
+                    )
+
+                    # Check for new pauses (team-level tools or member propagation)
+                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                        from agno.team import _hooks
+
+                        return _hooks.handle_team_run_paused(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+
+                    # Convert to structured format
+                    _convert_response_to_structured_format(team, run_response=run_response, run_context=run_context)
+
+                    # Always add media to run_response for caller availability
+                    store_media_util(run_response, model_response)
 
                 # Execute post-hooks
                 if team.post_hooks is not None:
@@ -7267,6 +7358,7 @@ def _continue_run_stream(
     yield_run_output: bool = False,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    skip_model_call: bool = False,
     **kwargs: Any,
 ) -> Iterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
     """Continue a paused team run (sync, streaming)."""
@@ -7297,87 +7389,88 @@ def _continue_run_stream(
 
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
-                # Handle the updated tools (execute confirmed tools, etc.) with streaming
-                yield from _handle_team_tool_call_updates_stream(
-                    team,
-                    run_response=run_response,
-                    run_messages=run_messages,
-                    tools=tools,
-                    stream_events=stream_events,
-                )
-
-                # Stream model response
-                if team.output_model is None:
-                    for event in _handle_model_response_stream(
+                if not skip_model_call:
+                    # Handle the updated tools (execute confirmed tools, etc.) with streaming
+                    yield from _handle_team_tool_call_updates_stream(
                         team,
-                        session=session,
                         run_response=run_response,
                         run_messages=run_messages,
                         tools=tools,
-                        response_format=response_format,
                         stream_events=stream_events,
-                        session_state=run_context.session_state,
-                        run_context=run_context,
-                    ):
-                        if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
-                            raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-                else:
-                    from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+                    )
 
-                    for event in _handle_model_response_stream(
-                        team,
-                        session=session,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        tools=tools,
-                        response_format=response_format,
-                        stream_events=stream_events,
-                        session_state=run_context.session_state,
-                        run_context=run_context,
-                    ):
-                        if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                    # Stream model response
+                    if team.output_model is None:
+                        for event in _handle_model_response_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            tools=tools,
+                            response_format=response_format,
+                            stream_events=stream_events,
+                            session_state=run_context.session_state,
+                            run_context=run_context,
+                        ):
+                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                raise_if_cancelled(run_response.run_id)  # type: ignore
+                            yield event
+                    else:
+                        from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+
+                        for event in _handle_model_response_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            tools=tools,
+                            response_format=response_format,
+                            stream_events=stream_events,
+                            session_state=run_context.session_state,
+                            run_context=run_context,
+                        ):
+                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                raise_if_cancelled(run_response.run_id)  # type: ignore
+                            if isinstance(event, RunContentEvent):
+                                if stream_events:
+                                    yield IntermediateRunContentEvent(
+                                        content=event.content,
+                                        content_type=event.content_type,
+                                    )
+                            else:
+                                yield event
+
+                        for event in generate_response_with_output_model_stream(
+                            team,
+                            session=session,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            stream_events=stream_events,
+                        ):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
-                        if isinstance(event, RunContentEvent):
-                            if stream_events:
-                                yield IntermediateRunContentEvent(
-                                    content=event.content,
-                                    content_type=event.content_type,
-                                )
-                        else:
                             yield event
 
-                    for event in generate_response_with_output_model_stream(
+                    raise_if_cancelled(run_response.run_id)  # type: ignore
+
+                    # Check for new pauses
+                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
+                        from agno.team import _hooks
+
+                        yield from _hooks.handle_team_run_paused_stream(
+                            team, run_response=run_response, session=session, run_context=run_context
+                        )
+                        if yield_run_output:
+                            yield run_response
+                        return
+
+                    # Parse response with parser model
+                    yield from parse_response_with_parser_model_stream(
                         team,
                         session=session,
                         run_response=run_response,
-                        run_messages=run_messages,
                         stream_events=stream_events,
-                    ):
-                        raise_if_cancelled(run_response.run_id)  # type: ignore
-                        yield event
-
-                raise_if_cancelled(run_response.run_id)  # type: ignore
-
-                # Check for new pauses
-                if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                    from agno.team import _hooks
-
-                    yield from _hooks.handle_team_run_paused_stream(
-                        team, run_response=run_response, session=session, run_context=run_context
+                        run_context=run_context,
                     )
-                    if yield_run_output:
-                        yield run_response
-                    return
-
-                # Parse response with parser model
-                yield from parse_response_with_parser_model_stream(
-                    team,
-                    session=session,
-                    run_response=run_response,
-                    stream_events=stream_events,
-                    run_context=run_context,
-                )
 
                 # Content completed event
                 if stream_events:
@@ -8164,22 +8257,27 @@ async def _acontinue_run(
                     )
 
                     # Prepare for member HITL continuation
-                    _prepare_member_hitl_continuation(run_response, run_messages, member_results)
-
-                    log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
-
-                    # Handle model response using shared helper
-                    paused_result = await _ahandle_model_response_for_continue(
-                        team,
-                        run_response=run_response,
-                        run_messages=run_messages,
-                        run_context=run_context,
-                        tools=_tools,
-                        team_session=team_session,
-                        response_format=response_format,
+                    delegate_tool_call_ids, direct_member_result = _prepare_member_hitl_continuation(
+                        run_response, run_messages, member_results
                     )
-                    if paused_result is not None:
-                        return paused_result
+
+                    if not _mark_stop_after_member_hitl_complete(
+                        team, run_response, run_messages, delegate_tool_call_ids, direct_member_result
+                    ):
+                        log_debug(f"Team Continue Run (Member HITL): {run_response.run_id}", center=True)
+
+                        # Handle model response using shared helper
+                        paused_result = await _ahandle_model_response_for_continue(
+                            team,
+                            run_response=run_response,
+                            run_messages=run_messages,
+                            run_context=run_context,
+                            tools=_tools,
+                            team_session=team_session,
+                            response_format=response_format,
+                        )
+                        if paused_result is not None:
+                            return paused_result
 
                 # Post-hooks
                 if team.post_hooks is not None:
@@ -8683,9 +8781,9 @@ async def _acontinue_run_stream(
                     )
 
                     # Prepare for member HITL continuation
-                    _prepare_member_hitl_continuation(run_response, run_messages, member_results)
-
-                    log_debug(f"Team Continue Run Stream (Member HITL): {run_response.run_id}", center=True)
+                    delegate_tool_call_ids, direct_member_result = _prepare_member_hitl_continuation(
+                        run_response, run_messages, member_results
+                    )
 
                     # Yield RunContinued event
                     if stream_events:
@@ -8696,78 +8794,85 @@ async def _acontinue_run_stream(
                             store_events=team.store_events,
                         )
 
-                    # Stream model response
-                    if team.output_model is None:
-                        async for event in _ahandle_model_response_stream(
-                            team,
-                            session=team_session,
-                            run_response=run_response,
-                            run_messages=run_messages,
-                            tools=_tools,
-                            response_format=response_format,
-                            stream_events=stream_events,
-                            session_state=run_context.session_state,
-                            run_context=run_context,
-                        ):
-                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
-                                await araise_if_cancelled(run_response.run_id)  # type: ignore
-                            yield event
-                    else:
-                        from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+                    if not _mark_stop_after_member_hitl_complete(
+                        team, run_response, run_messages, delegate_tool_call_ids, direct_member_result
+                    ):
+                        log_debug(f"Team Continue Run Stream (Member HITL): {run_response.run_id}", center=True)
 
-                        async for event in _ahandle_model_response_stream(
-                            team,
-                            session=team_session,
-                            run_response=run_response,
-                            run_messages=run_messages,
-                            tools=_tools,
-                            response_format=response_format,
-                            stream_events=stream_events,
-                            session_state=run_context.session_state,
-                            run_context=run_context,
-                        ):
-                            if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                        # Stream model response
+                        if team.output_model is None:
+                            async for event in _ahandle_model_response_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                tools=_tools,
+                                response_format=response_format,
+                                stream_events=stream_events,
+                                session_state=run_context.session_state,
+                                run_context=run_context,
+                            ):
+                                if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                    await araise_if_cancelled(run_response.run_id)  # type: ignore
+                                yield event
+                        else:
+                            from agno.run.team import IntermediateRunContentEvent, RunContentEvent
+
+                            async for event in _ahandle_model_response_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                tools=_tools,
+                                response_format=response_format,
+                                stream_events=stream_events,
+                                session_state=run_context.session_state,
+                                run_context=run_context,
+                            ):
+                                if not isinstance(event, _MEMBER_CANCEL_BYPASS_EVENT_TYPES):
+                                    await araise_if_cancelled(run_response.run_id)  # type: ignore
+                                if isinstance(event, RunContentEvent):
+                                    if stream_events:
+                                        yield IntermediateRunContentEvent(
+                                            content=event.content,
+                                            content_type=event.content_type,
+                                        )
+                                else:
+                                    yield event
+
+                            async for event in agenerate_response_with_output_model_stream(
+                                team,
+                                session=team_session,
+                                run_response=run_response,
+                                run_messages=run_messages,
+                                stream_events=stream_events,
+                            ):
                                 await araise_if_cancelled(run_response.run_id)  # type: ignore
-                            if isinstance(event, RunContentEvent):
-                                if stream_events:
-                                    yield IntermediateRunContentEvent(
-                                        content=event.content,
-                                        content_type=event.content_type,
-                                    )
-                            else:
                                 yield event
 
-                        async for event in agenerate_response_with_output_model_stream(
+                        # Check for new pauses
+                        if run_response.requirements and any(
+                            not req.is_resolved() for req in run_response.requirements
+                        ):
+                            from agno.team import _hooks
+
+                            async for item in _hooks.ahandle_team_run_paused_stream(
+                                team, run_response=run_response, session=team_session, run_context=run_context
+                            ):
+                                yield item
+                            if yield_run_output:
+                                yield run_response
+                            return
+
+                        # Parse response with parser model
+                        async for event in aparse_response_with_parser_model_stream(
                             team,
                             session=team_session,
                             run_response=run_response,
-                            run_messages=run_messages,
                             stream_events=stream_events,
+                            run_context=run_context,
                         ):
-                            await araise_if_cancelled(run_response.run_id)  # type: ignore
                             yield event
-
-                    # Check for new pauses
-                    if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
-                        from agno.team import _hooks
-
-                        async for item in _hooks.ahandle_team_run_paused_stream(
-                            team, run_response=run_response, session=team_session, run_context=run_context
-                        ):
-                            yield item
-                        if yield_run_output:
-                            yield run_response
-                        return
-
-                    # Parse response with parser model
-                    async for event in aparse_response_with_parser_model_stream(
-                        team,
-                        session=team_session,
-                        run_response=run_response,
-                        stream_events=stream_events,
-                        run_context=run_context,
-                    ):
-                        yield event
 
                 # Content completed
                 if stream_events:

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from agno.models.response import ToolExecution
 from agno.run import RunStatus
 from agno.run.requirement import RunRequirement
-from agno.run.team import TeamRunOutput
+from agno.run.team import TeamRunEvent, TeamRunOutput
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -824,6 +824,423 @@ class TestPrepareMemberHitlContinuation:
 
 
 class TestContinueRunApprovalResolution:
+    def _route_member_resume_case(self):
+        team = MagicMock()
+        team.session_id = None
+        team.add_history_to_context = False
+        team.parser_model = None
+        team.respond_directly = True
+        team.initialize_team = MagicMock()
+        team.db = MagicMock()
+        team.retries = 0
+        team.events_to_skip = []
+        team.store_events = False
+        team.model = MagicMock()
+        team.post_hooks = None
+        team.session_summary_manager = None
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="delegate-1",
+            result="Tool requires human input",
+        )
+        requirement = RunRequirement(_make_tool_execution(requires_user_input=True))
+        requirement.member_agent_id = "member-1"
+        requirement.provide_user_input({"decision": "approve"})
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            status=RunStatus.paused,
+            requirements=[requirement],
+            tools=[tool],
+        )
+
+        run_messages = MagicMock()
+        run_messages.messages = [
+            MagicMock(role="tool", tool_call_id="delegate-1", content="Tool requires human input"),
+        ]
+        team_session = MagicMock()
+        team_session.session_id = "session-1"
+        team_session.runs = [run_response]
+
+        return team, run_response, tool, run_messages, team_session
+
+    def test_route_member_hitl_resume_completes_without_team_model_call(self):
+        from agno.team._run import continue_run_dispatch
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        team.post_hooks = [MagicMock()]
+        team.session_summary_manager = MagicMock()
+        opts = SimpleNamespace(
+            stream=False,
+            stream_events=False,
+            yield_run_output=False,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=team_session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+            patch("agno.team._run._route_requirements_to_members", return_value=["[Member]: Done"]),
+            patch("agno.team._hooks._execute_post_hooks", return_value=iter(())) as mock_post_hooks,
+            patch("agno.team._telemetry.log_team_telemetry") as mock_telemetry,
+            patch("agno.team._run._cleanup_and_store") as mock_cleanup,
+            patch(
+                "agno.team._run.call_model_with_fallback", side_effect=AssertionError("team model called")
+            ) as mock_model,
+        ):
+            result = continue_run_dispatch(
+                team,
+                run_id="run-1",
+                session_id="session-1",
+                stream=False,
+            )
+
+        assert result is run_response
+        assert result.status == RunStatus.completed
+        assert result.content == "Done"
+        assert "requires human input" not in result.content.lower()
+        assert tool.result == result.content
+        assert run_messages.messages[0].content == result.content
+        mock_post_hooks.assert_called_once()
+        team_session.upsert_run.assert_called_once_with(run_response=run_response)
+        team.session_summary_manager.create_session_summary.assert_called_once()
+        mock_telemetry.assert_called_once_with(team, session_id="session-1", run_id="run-1")
+        mock_cleanup.assert_called_once()
+        mock_model.assert_not_called()
+
+    def test_route_member_hitl_resume_stream_completes_without_team_model_call(self):
+        from agno.team._run import continue_run_dispatch
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        opts = SimpleNamespace(
+            stream=True,
+            stream_events=False,
+            yield_run_output=True,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+
+        def _member_stream(*args, **kwargs):
+            kwargs["member_results"].append("[Member]: Done")
+            return iter(())
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=team_session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+            patch("agno.team._run._route_requirements_to_members_stream", side_effect=_member_stream),
+            patch("agno.team._run._cleanup_and_store") as mock_cleanup,
+            patch(
+                "agno.team._response._handle_model_response_stream", side_effect=AssertionError("team model called")
+            ) as mock_model_stream,
+        ):
+            result = continue_run_dispatch(
+                team,
+                run_id="run-1",
+                session_id="session-1",
+                stream=True,
+                yield_run_output=True,
+            )
+            events = list(result)
+
+        assert events == [run_response]
+        assert run_response.status == RunStatus.completed
+        assert run_response.content == "Done"
+        assert tool.result == run_response.content
+        assert run_messages.messages[0].content == run_response.content
+        mock_cleanup.assert_called_once()
+        mock_model_stream.assert_not_called()
+
+    def test_route_member_hitl_resume_stream_emits_lifecycle_events(self):
+        from agno.team._run import continue_run_dispatch
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        team.store_events = True
+        opts = SimpleNamespace(
+            stream=True,
+            stream_events=True,
+            yield_run_output=True,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+
+        def _member_stream(*args, **kwargs):
+            kwargs["member_results"].append("[Member]: Done")
+            return iter(())
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=team_session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+            patch("agno.team._run._route_requirements_to_members_stream", side_effect=_member_stream),
+            patch("agno.team._run._cleanup_and_store") as mock_cleanup,
+            patch(
+                "agno.team._response._handle_model_response_stream",
+                side_effect=AssertionError("team model called"),
+            ) as mock_model_stream,
+        ):
+            result = continue_run_dispatch(
+                team,
+                run_id="run-1",
+                session_id="session-1",
+                stream=True,
+                stream_events=True,
+                yield_run_output=True,
+            )
+            events = list(result)
+
+        event_names = [getattr(event, "event", None) for event in events]
+        assert event_names[:3] == [
+            TeamRunEvent.run_continued.value,
+            TeamRunEvent.run_content_completed.value,
+            TeamRunEvent.run_completed.value,
+        ]
+        assert events[-1] is run_response
+        assert [event.event for event in run_response.events] == event_names[:3]
+        assert run_response.status == RunStatus.completed
+        assert run_response.content == "Done"
+        assert tool.result == run_response.content
+        assert run_messages.messages[0].content == run_response.content
+        mock_cleanup.assert_called_once()
+        mock_model_stream.assert_not_called()
+
+    def test_route_member_hitl_resume_uses_resolved_delegate_result(self):
+        from agno.team._run import continue_run_dispatch
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        stale_tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="delegate-old",
+            result="Old result",
+        )
+        run_response.tools = [tool, stale_tool]
+        run_messages.messages.append(MagicMock(role="tool", tool_call_id="delegate-old", content="Old result"))
+        opts = SimpleNamespace(
+            stream=False,
+            stream_events=False,
+            yield_run_output=False,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=team_session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+            patch("agno.team._run._route_requirements_to_members", return_value=["[Member]: Fresh result"]),
+            patch("agno.team._run._cleanup_and_store"),
+            patch(
+                "agno.team._run.call_model_with_fallback", side_effect=AssertionError("team model called")
+            ) as mock_model,
+        ):
+            result = continue_run_dispatch(
+                team,
+                run_id="run-1",
+                session_id="session-1",
+                stream=False,
+            )
+
+        assert result.content == "Fresh result"
+        assert tool.result == "Fresh result"
+        assert run_messages.messages[0].content == "Fresh result"
+        assert stale_tool.result == "Old result"
+        assert run_messages.messages[1].content == "Old result"
+        mock_model.assert_not_called()
+
+    def test_route_member_hitl_resume_async_completes_without_team_model_call(self):
+        from agno.team._run import _acontinue_run
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        run_context = MagicMock()
+        run_context.session_state = {}
+
+        async def _exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=team_session)),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._aget_learning_tools", new=AsyncMock(return_value=[])),
+                patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+                patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+                patch("agno.team._run._aroute_requirements_to_members", new=AsyncMock(return_value=["[Member]: Done"])),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    new=AsyncMock(side_effect=RuntimeError),
+                ),
+                patch("agno.team._run._acleanup_and_store", new=AsyncMock()) as mock_cleanup,
+                patch("agno.team._run._ahandle_model_response_for_continue", new=AsyncMock()) as mock_handle,
+            ):
+                result = await _acontinue_run(
+                    team,
+                    session_id="session-1",
+                    run_context=run_context,
+                    run_id="run-1",
+                    requirements=None,
+                )
+
+            assert result is run_response
+            assert result.status == RunStatus.completed
+            assert result.content == "Done"
+            assert tool.result == result.content
+            assert run_messages.messages[0].content == result.content
+            mock_cleanup.assert_awaited_once()
+            mock_handle.assert_not_awaited()
+
+        asyncio.run(_exercise())
+
+    def test_route_member_hitl_resume_async_stream_completes_without_team_model_call(self):
+        from agno.team._run import _acontinue_run_stream
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        run_context = MagicMock()
+        run_context.session_state = {}
+
+        async def _member_stream(*args, **kwargs):
+            kwargs["member_results"].append("[Member]: Done")
+            if False:
+                yield None
+
+        async def _exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=team_session)),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._aget_learning_tools", new=AsyncMock(return_value=[])),
+                patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+                patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+                patch("agno.team._run._aroute_requirements_to_members_stream", side_effect=_member_stream),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    new=AsyncMock(side_effect=RuntimeError),
+                ),
+                patch("agno.team._run._acleanup_and_store", new=AsyncMock()) as mock_cleanup,
+                patch(
+                    "agno.team._response._ahandle_model_response_stream",
+                    side_effect=AssertionError("team model called"),
+                ) as mock_stream,
+            ):
+                events = []
+                async for event in _acontinue_run_stream(
+                    team,
+                    session_id="session-1",
+                    run_context=run_context,
+                    run_id="run-1",
+                    requirements=None,
+                    yield_run_output=True,
+                ):
+                    events.append(event)
+
+            assert events == [run_response]
+            assert run_response.status == RunStatus.completed
+            assert run_response.content == "Done"
+            assert tool.result == run_response.content
+            assert run_messages.messages[0].content == run_response.content
+            mock_cleanup.assert_awaited_once()
+            mock_stream.assert_not_called()
+
+        asyncio.run(_exercise())
+
+    def test_route_member_hitl_resume_async_stream_emits_lifecycle_events(self):
+        from agno.team._run import _acontinue_run_stream
+
+        team, run_response, tool, run_messages, team_session = self._route_member_resume_case()
+        team.store_events = True
+        run_context = MagicMock()
+        run_context.session_state = {}
+
+        async def _member_stream(*args, **kwargs):
+            kwargs["member_results"].append("[Member]: Done")
+            if False:
+                yield None
+
+        async def _exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=team_session)),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._aget_learning_tools", new=AsyncMock(return_value=[])),
+                patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+                patch("agno.team._run._get_continue_run_messages", return_value=run_messages),
+                patch("agno.team._run._aroute_requirements_to_members_stream", side_effect=_member_stream),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    new=AsyncMock(side_effect=RuntimeError),
+                ),
+                patch("agno.team._run._acleanup_and_store", new=AsyncMock()) as mock_cleanup,
+                patch(
+                    "agno.team._response._ahandle_model_response_stream",
+                    side_effect=AssertionError("team model called"),
+                ) as mock_stream,
+            ):
+                events = []
+                async for event in _acontinue_run_stream(
+                    team,
+                    session_id="session-1",
+                    run_context=run_context,
+                    run_id="run-1",
+                    requirements=None,
+                    stream_events=True,
+                    yield_run_output=True,
+                ):
+                    events.append(event)
+
+            event_names = [getattr(event, "event", None) for event in events]
+            assert event_names[:3] == [
+                TeamRunEvent.run_continued.value,
+                TeamRunEvent.run_content_completed.value,
+                TeamRunEvent.run_completed.value,
+            ]
+            assert events[-1] is run_response
+            assert [event.event for event in run_response.events] == event_names[:3]
+            assert run_response.status == RunStatus.completed
+            assert run_response.content == "Done"
+            assert tool.result == run_response.content
+            assert run_messages.messages[0].content == run_response.content
+            mock_cleanup.assert_awaited_once()
+            mock_stream.assert_not_called()
+
+        asyncio.run(_exercise())
+
     def test_continue_run_dispatch_uses_resolved_admin_approval_without_requirements(self):
         from agno.team._run import continue_run_dispatch
 


### PR DESCRIPTION
## Summary
Fixes #8528.

- Complete route-mode member HITL resume without invoking the team model again after the member result is resolved.
- Keep the continuation prompt for the normal team-model path, but use the direct member result for the `respond_directly` fast path.
- Finalize only from the delegate tool call IDs updated during this resume so stale delegate results cannot become the final response.
- Preserve sync, async, stream, and async-stream finalization, including continued/content-completed/completed lifecycle events.

## Type of change
- [x] Bug fix

## Checklist
- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] I searched existing open pull requests and did not find another linked PR for this issue

## Testing
- `python -m pytest tests/unit/team/test_continue_run_requirements.py -q`
- `python -m pytest tests/unit/team/test_continue_run_requirements.py -q -k "route_member_hitl_resume"`
- `python -m ruff check libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py`
- `python -m ruff format libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py --check`
- `git diff --check`

## Additional notes
I did not run `./scripts/format.sh` or `./scripts/validate.sh`; the focused checks above cover the touched files.
