### PR TITLE
fix: redact sensitive AG-UI state deltas

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -1,9 +1,64 @@
 import copy
+import re
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from agno.utils.log import log_warning
+
+REDACTED_STATE_VALUE = "[REDACTED]"
+SENSITIVE_STATE_KEY_NAMES = {
+    "apikey",
+    "api_key",
+    "authorization",
+    "credential",
+    "db_password",
+    "password",
+    "passwd",
+    "private_key",
+    "secret",
+    "token",
+}
+SENSITIVE_STATE_KEY_SUFFIXES = (
+    "_api_key",
+    "_access_token",
+    "_auth_token",
+    "_bearer_token",
+    "_client_secret",
+    "_db_password",
+    "_id_token",
+    "_private_key",
+    "_refresh_token",
+    "_session_token",
+)
+SENSITIVE_STATE_VALUE_PATTERN = re.compile(
+    r"(Bearer\s+[A-Za-z0-9._~+/=-]{8,}|"
+    r"sk-[A-Za-z0-9_-]{8,}|"
+    r"gh[pousr]_[A-Za-z0-9_]{8,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{8,}|"
+    r"AIza[A-Za-z0-9_-]{8,})"
+)
+
+
+def _is_sensitive_agui_state_key(key: str) -> bool:
+    normalized_key = re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+    return normalized_key in SENSITIVE_STATE_KEY_NAMES or normalized_key.endswith(SENSITIVE_STATE_KEY_SUFFIXES)
+
+
+def _redact_agui_state_value(value: Any, key: Optional[str] = None) -> Any:
+    if key is not None and _is_sensitive_agui_state_key(key):
+        return REDACTED_STATE_VALUE
+
+    if isinstance(value, dict):
+        return {k: _redact_agui_state_value(v, str(k)) for k, v in value.items()}
+
+    if isinstance(value, list):
+        return [_redact_agui_state_value(item) for item in value]
+
+    if isinstance(value, str) and SENSITIVE_STATE_VALUE_PATTERN.search(value):
+        return SENSITIVE_STATE_VALUE_PATTERN.sub(REDACTED_STATE_VALUE, value)
+
+    return value
 
 
 @dataclass
@@ -98,7 +153,10 @@ class StreamState:
         try:
             import jsonpatch
 
-            patch = jsonpatch.make_patch(self._last_snapshot, current_state)
+            patch = jsonpatch.make_patch(
+                _redact_agui_state_value(self._last_snapshot),
+                _redact_agui_state_value(current_state),
+            )
             ops = patch.patch
             if not ops:
                 return None

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -1675,6 +1675,43 @@ def test_event_buffer_state_snapshot_deep_copy():
     assert delta is None
 
 
+def test_event_buffer_state_delta_redacts_sensitive_values():
+    """Test state deltas redact credentials without mutating the original state."""
+    buffer = StreamState()
+
+    state = {"status": "idle"}
+    buffer.set_state_snapshot(state)
+
+    current_state = {
+        "status": "active",
+        "token_count": 7,
+        "nested": {
+            "db_password": "super_secret_123",
+            "headers": {"Authorization": "Bearer live_token_123456789"},
+        },
+        "events": [
+            {"message": "provider returned sk-test-secret123456"},
+            {"message": "safe text"},
+        ],
+    }
+
+    delta = buffer.compute_state_delta(current_state)
+
+    assert delta is not None
+    assert any(op["path"] == "/status" and op["value"] == "active" for op in delta)
+    assert any(op["path"] == "/token_count" and op["value"] == 7 for op in delta)
+
+    serialized_delta = str(delta)
+    assert "super_secret_123" not in serialized_delta
+    assert "live_token_123456789" not in serialized_delta
+    assert "sk-test-secret123456" not in serialized_delta
+    assert "[REDACTED]" in serialized_delta
+
+    assert current_state["nested"]["db_password"] == "super_secret_123"
+    assert current_state["nested"]["headers"]["Authorization"] == "Bearer live_token_123456789"
+    assert current_state["events"][0]["message"] == "provider returned sk-test-secret123456"
+
+
 def test_event_buffer_compute_delta_no_snapshot():
     """Test compute_state_delta returns None when no snapshot has been set."""
     buffer = StreamState()


### PR DESCRIPTION
## Summary
- redact sensitive AG-UI state values before computing JSON Patch deltas
- mask credential-like keys and common token string patterns while preserving non-sensitive state deltas
- add regression coverage proving secrets are not emitted and the caller's state object is not mutated

## Context
Issue #8535 calls out that JSON Patch streams can expose raw credential dictionaries when state is diffed without a redaction pass. Agno's AG-UI state-delta path computes JSON Patch ops from session state snapshots in `EventBuffer.compute_state_delta`; this adds a defensive redaction layer immediately before diff generation so `StateDeltaEvent.delta` does not broadcast common secrets.

The redaction intentionally avoids broad token-stat false positives: fields like `token_count` continue to pass through unchanged.

## Tests
- `uv run --no-project --with pytest --with pytest-asyncio --with ag-ui-protocol --with jsonpatch --with pydantic --with rich --with typer --with typing-extensions --with fastapi --with openai --with pyyaml --with python-multipart --with sqlalchemy --with opentelemetry-sdk --with ddtrace --with httpx --with packaging --with distro --with pydantic-settings --with docstring-parser --with tomli --with gitpython --with python-dotenv --with aiofiles --with starlette --with uvicorn --with pillow --with requests --with tenacity --with httpx-sse --with anyio --with websockets --with click --with structlog --with cachetools --with python-dateutil --with pytz --with numpy --with pandas --with cryptography --with typing-inspection --with email-validator --with jsonschema --with jinja2 --with yarl --with aiosqlite --with greenlet --with fastapi pytest libs/agno/tests/unit/app/test_agui_app.py -q` -> 53 passed
- `uv run --no-project --with ruff ruff check libs/agno/agno/os/interfaces/agui/utils.py libs/agno/tests/unit/app/test_agui_app.py`
- `uv run --no-project --with ruff ruff format --check libs/agno/agno/os/interfaces/agui/utils.py libs/agno/tests/unit/app/test_agui_app.py`
- `git diff --check`
