### PR TITLE
fix: block inline interpreter code in CodingTools

### DIFF
--- a/libs/agno/agno/tools/coding.py
+++ b/libs/agno/agno/tools/coding.py
@@ -247,6 +247,33 @@ class CodingTools(Toolkit):
 
     # Shell operators that enable command chaining or substitution
     _DANGEROUS_PATTERNS: List[str] = ["&&", "||", ";", "|", "$(", "`", ">", ">>", "<"]
+    _INLINE_CODE_FLAGS_BY_COMMAND = {
+        "bash": {"-c"},
+        "dash": {"-c"},
+        "ksh": {"-c"},
+        "node": {"-e", "--eval", "-p", "--print"},
+        "perl": {"-e", "-E"},
+        "php": {"-r"},
+        "python": {"-c"},
+        "python3": {"-c"},
+        "ruby": {"-e"},
+        "sh": {"-c"},
+        "zsh": {"-c"},
+    }
+
+    @classmethod
+    def _has_inline_code_flag(cls, cmd_base: str, tokens: List[str]) -> bool:
+        inline_flags = cls._INLINE_CODE_FLAGS_BY_COMMAND.get(cmd_base)
+        if inline_flags is None and cmd_base.startswith("python"):
+            inline_flags = cls._INLINE_CODE_FLAGS_BY_COMMAND["python"]
+        if inline_flags is None:
+            return False
+
+        for token in tokens[1:]:
+            flag_name = token.split("=", maxsplit=1)[0]
+            if flag_name in inline_flags:
+                return True
+        return False
 
     def _check_command(self, command: str) -> Optional[str]:
         """Check if a shell command is safe to execute.
@@ -272,11 +299,17 @@ class CodingTools(Toolkit):
             return "Error: Could not parse shell command."
 
         # Validate command against allowlist
+        cmd_base = ""
         if self.allowed_commands is not None and tokens:
             cmd = tokens[0]
             cmd_base = Path(cmd).name  # Handle /usr/bin/python -> python
             if cmd_base not in self.allowed_commands:
                 return f"Error: Command '{cmd_base}' is not in the allowed commands list."
+        elif tokens:
+            cmd_base = Path(tokens[0]).name
+
+        if cmd_base and self._has_inline_code_flag(cmd_base, tokens):
+            return f"Error: Inline code execution via '{cmd_base}' is not allowed in restricted mode."
 
         for i, token in enumerate(tokens):
             # Skip the command itself (already validated by allowlist above)

--- a/libs/agno/tests/unit/tools/test_coding_tools.py
+++ b/libs/agno/tests/unit/tools/test_coding_tools.py
@@ -597,6 +597,44 @@ def test_run_shell_allows_listed_commands():
         assert "works" in result
 
 
+def test_run_shell_blocks_inline_interpreter_code_in_restricted_mode():
+    """Test that allowlisted interpreters cannot execute opaque inline code."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir)
+
+        result = tools.run_shell("python3 -c \"print('blocked')\"")
+        assert "Error" in result
+        assert "Inline code execution" in result
+
+        (base_dir / "test_script.py").write_text("print('script still works')\n")
+        result = tools.run_shell("python3 test_script.py")
+        assert "Exit code: 0" in result
+        assert "script still works" in result
+
+
+def test_run_shell_blocks_inline_code_flags_for_custom_allowed_interpreters():
+    """Test custom-allowlisted interpreters are also blocked on inline-code flags."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir, allowed_commands=["node", "bash"])
+
+        assert "Inline code execution" in tools._check_command('node --eval="console.log(1)"')
+        assert "Inline code execution" in tools._check_command('bash -c "echo blocked"')
+
+        tools = CodingTools(base_dir=base_dir, allowed_commands=["python3.12"])
+        assert "Inline code execution" in tools._check_command("python3.12 -c \"print('blocked')\"")
+
+
+def test_run_shell_unrestricted_allows_inline_interpreter_code():
+    """Test restrict_to_base_dir=False preserves the documented escape hatch."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        tools = CodingTools(base_dir=base_dir, restrict_to_base_dir=False)
+
+        assert tools._check_command("python3 -c \"print('allowed')\"") is None
+
+
 def test_run_shell_custom_allowlist():
     """Test that a custom allowlist overrides the default."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Description

Closes #8469.

This tightens `CodingTools` restricted-mode shell checks so allowlisted interpreters cannot bypass the sandbox with inline code flags such as `python3 -c`, `node --eval`, or `bash -c`. Script files inside `base_dir` still run normally, and `restrict_to_base_dir=False` keeps the existing unrestricted behavior.

## Testing

- `uv run --isolated --with-editable libs/agno --with pytest pytest libs/agno/tests/unit/tools/test_coding_tools.py -q`
- `uv run --isolated --with ruff ruff check libs/agno/agno/tools/coding.py libs/agno/tests/unit/tools/test_coding_tools.py`
- `uv run --isolated --with ruff ruff format --check libs/agno/agno/tools/coding.py libs/agno/tests/unit/tools/test_coding_tools.py`
- `git diff --check`