### PR TITLE
test: cover nested team continuation stream outputs

### DIFF
--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -1212,6 +1212,48 @@ class TestRoutingForwardsRunContextToMembers:
         assert kwargs["metadata"] == {"trace": "id"}
         assert kwargs["knowledge_filters"] == {"tag": "v"}
 
+    def test_async_streaming_routing_accepts_nested_team_run_output(self):
+        from agno.team._run import _aroute_requirements_to_members_stream
+
+        run_response, session, _ = self._make_run_response_with_member_req()
+
+        member_response = TeamRunOutput(
+            team_id="nested-team-id",
+            run_id="nested-team-run-1",
+            content="nested team completed",
+        )
+
+        async def _member_stream(*args, **kwargs):
+            yield member_response
+
+        member = MagicMock()
+        member.name = "Nested Team"
+        member.acontinue_run = MagicMock(side_effect=lambda *a, **kw: _member_stream())
+
+        team = MagicMock()
+        team.stream_member_events = False
+        team.events_to_skip = []
+        team.store_events = False
+
+        async def _exercise():
+            with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+                member_results = []
+                async for _ in _aroute_requirements_to_members_stream(
+                    team,
+                    run_response=run_response,
+                    session=session,
+                    member_results=member_results,
+                    stream_events=False,
+                ):
+                    pass
+
+            return member_results
+
+        member_results = asyncio.run(_exercise())
+
+        session.upsert_run.assert_called_once_with(member_response)
+        assert member_results == ["[Nested Team]: nested team completed"]
+
     def test_sync_streaming_routing_forwards_dependencies(self):
         from agno.team._run import _route_requirements_to_members_stream
 
@@ -1250,6 +1292,44 @@ class TestRoutingForwardsRunContextToMembers:
         assert kwargs["dependencies"] == {"user_token": "Bearer abc"}
         assert kwargs["metadata"] == {"trace": "id"}
         assert kwargs["knowledge_filters"] == {"tag": "v"}
+
+    def test_sync_streaming_routing_accepts_nested_team_run_output(self):
+        from agno.team._run import _route_requirements_to_members_stream
+
+        run_response, session, _ = self._make_run_response_with_member_req()
+
+        member_response = TeamRunOutput(
+            team_id="nested-team-id",
+            run_id="nested-team-run-1",
+            content="nested team completed",
+        )
+
+        def _member_stream(*args, **kwargs):
+            yield member_response
+
+        member = MagicMock()
+        member.name = "Nested Team"
+        member.continue_run = MagicMock(side_effect=lambda *a, **kw: _member_stream())
+
+        team = MagicMock()
+        team.stream_member_events = False
+        team.events_to_skip = []
+        team.store_events = False
+
+        with patch("agno.team._tools._find_member_route_by_id", return_value=(0, member)):
+            member_results = []
+            list(
+                _route_requirements_to_members_stream(
+                    team,
+                    run_response=run_response,
+                    session=session,
+                    member_results=member_results,
+                    stream_events=False,
+                )
+            )
+
+        session.upsert_run.assert_called_once_with(member_response)
+        assert member_results == ["[Nested Team]: nested team completed"]
 
     def test_routing_with_none_run_context_does_not_inject_kwargs(self):
         """When the team has no run_context (defensive), no forwarding kwargs are added."""


### PR DESCRIPTION
## Summary

- Adds regression coverage for nested Team members returning a `TeamRunOutput` from continuation streaming.
- Covers both sync and async member routing so `TeamRunOutput` finals are persisted and summarized instead of being treated as missing final output.

(If applicable, issue number: #8467)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: tests

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Duplicate check: `gh search prs --repo agno-agi/agno '8467 OR TeamRunOutput agent_id OR "TeamRunOutput" "agent_id" OR "streaming" "TeamRunOutput"' --state open --json number,title,state,url,author,createdAt,updatedAt --limit 20` returned no open PRs.
- Validation: `uv run --isolated --with-editable libs/agno --with pytest pytest libs/agno/tests/unit/team/test_continue_run_requirements.py::TestRoutingForwardsRunContextToMembers -q` passed: 8 passed, 2 pytest config warnings.
- Format check: `uv run --isolated --with ruff ruff format --check libs/agno/tests/unit/team/test_continue_run_requirements.py` passed: 1 file already formatted.
