### PR TITLE
perf(in_memory_db): index sessions by session_id to avoid O(n) scans

### DIFF
--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -32,11 +32,25 @@ class InMemoryDb(BaseDb):
 
         # Initialize in-memory storage dictionaries
         self._sessions: List[Dict[str, Any]] = []
+        # session_id -> positions in ``_sessions``. A list of positions (rather
+        # than a single one) because a session_id is not guaranteed unique across
+        # components in the worst case. Keeps get/upsert/rename O(matches) instead
+        # of O(total sessions).
+        self._session_index: Dict[str, List[int]] = {}
         self._memories: List[Dict[str, Any]] = []
         self._metrics: List[Dict[str, Any]] = []
         self._eval_runs: List[Dict[str, Any]] = []
         self._knowledge: List[Dict[str, Any]] = []
         self._cultural_knowledge: List[Dict[str, Any]] = []
+
+    def _rebuild_session_index(self) -> None:
+        """Rebuild the session_id -> positions index from ``_sessions``."""
+        index: Dict[str, List[int]] = {}
+        for position, session_data in enumerate(self._sessions):
+            session_id = session_data.get("session_id")
+            if session_id is not None:
+                index.setdefault(session_id, []).append(position)
+        self._session_index = index
 
     def table_exists(self, table_name: str) -> bool:
         """In-memory implementation, always returns True."""
@@ -71,6 +85,7 @@ class InMemoryDb(BaseDb):
                 for s in self._sessions
                 if not (s.get("session_id") == session_id and (user_id is None or s.get("user_id") == user_id))
             ]
+            self._rebuild_session_index()
 
             if len(self._sessions) < original_count:
                 log_debug(f"Successfully deleted session with session_id: {session_id}")
@@ -99,6 +114,7 @@ class InMemoryDb(BaseDb):
                 for s in self._sessions
                 if not (s.get("session_id") in session_ids and (user_id is None or s.get("user_id") == user_id))
             ]
+            self._rebuild_session_index()
             log_debug(f"Successfully deleted sessions with ids: {session_ids}")
 
         except Exception as e:
@@ -129,17 +145,17 @@ class InMemoryDb(BaseDb):
             Exception: If an error occurs while reading the session.
         """
         try:
-            for session_data in self._sessions:
-                if session_data.get("session_id") == session_id:
-                    if user_id is not None and session_data.get("user_id") != user_id:
-                        continue
+            for position in self._session_index.get(session_id, []):
+                session_data = self._sessions[position]
+                if user_id is not None and session_data.get("user_id") != user_id:
+                    continue
 
-                    session_data_copy = deepcopy(session_data)
+                session_data_copy = deepcopy(session_data)
 
-                    if not deserialize:
-                        return session_data_copy
+                if not deserialize:
+                    return session_data_copy
 
-                    return deserialize_session(session_type, session_data_copy)
+                return deserialize_session(session_type, session_data_copy)
 
             return None
 
@@ -252,9 +268,8 @@ class InMemoryDb(BaseDb):
         deserialize: Optional[bool] = True,
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         try:
-            for i, session in enumerate(self._sessions):
-                if session.get("session_id") != session_id:
-                    continue
+            for i in self._session_index.get(session_id, []):
+                session = self._sessions[i]
                 if session_type is not None and session.get("session_type") != session_type.value:
                     continue
                 if user_id is not None and session.get("user_id") != user_id:
@@ -294,17 +309,18 @@ class InMemoryDb(BaseDb):
             elif isinstance(session, WorkflowSession):
                 session_dict["session_type"] = SessionType.WORKFLOW.value
 
-            # Find existing session to update
+            # Find existing session to update (only scan rows sharing this
+            # session_id via the index, instead of the whole table).
+            session_id = session_dict.get("session_id")
             session_updated = False
-            for i, existing_session in enumerate(self._sessions):
-                if existing_session.get("session_id") == session_dict.get("session_id") and self._matches_session_key(
-                    existing_session, session
-                ):
+            for i in self._session_index.get(session_id, []):
+                existing_session = self._sessions[i]
+                if self._matches_session_key(existing_session, session):
                     existing_uid = existing_session.get("user_id")
                     if existing_uid is not None and existing_uid != session_dict.get("user_id"):
                         return None
                     session_dict["updated_at"] = int(time.time())
-                    self._sessions[i] = deepcopy(session_dict)
+                    self._sessions[i] = deepcopy(session_dict)  # session_id unchanged -> index stays valid
                     session_updated = True
                     break
 
@@ -312,6 +328,8 @@ class InMemoryDb(BaseDb):
                 session_dict["created_at"] = session_dict.get("created_at", int(time.time()))
                 session_dict["updated_at"] = session_dict.get("created_at")
                 self._sessions.append(deepcopy(session_dict))
+                if session_id is not None:
+                    self._session_index.setdefault(session_id, []).append(len(self._sessions) - 1)
 
             session_dict_copy = deepcopy(session_dict)
             if not deserialize:

--- a/libs/agno/tests/unit/db/test_in_memory_session_index.py
+++ b/libs/agno/tests/unit/db/test_in_memory_session_index.py
@@ -1,0 +1,93 @@
+"""Tests for InMemoryDb's session_id index.
+
+The index makes get/upsert/rename O(matches) instead of O(total sessions). These
+tests pin its correctness: an index-consistency invariant is asserted after every
+mutation, and a randomized op sequence is compared against a brute-force scan.
+"""
+
+import random
+from copy import deepcopy
+
+from agno.db.in_memory import InMemoryDb
+from agno.session.agent import AgentSession
+
+
+def _sess(session_id: str, agent_id: str = "a1", user_id=None) -> AgentSession:
+    return AgentSession(session_id=session_id, agent_id=agent_id, user_id=user_id, runs=[])
+
+
+def _assert_index_consistent(db: InMemoryDb) -> None:
+    """The index must always equal a freshly-built session_id -> positions map."""
+    expected: dict[str, list[int]] = {}
+    for pos, sd in enumerate(db._sessions):
+        sid = sd.get("session_id")
+        if sid is not None:
+            expected.setdefault(sid, []).append(pos)
+    assert db._session_index == expected
+
+
+def test_get_upsert_delete_rename_with_index():
+    db = InMemoryDb()
+    db.upsert_session(_sess("s1", user_id="u1"))
+    db.upsert_session(_sess("s2", user_id="u2"))
+    _assert_index_consistent(db)
+
+    got = db.get_session("s1", user_id="u1")
+    assert got is not None and got.session_id == "s1"
+    assert db.get_session("s1", user_id="other") is None  # user_id filter
+    assert db.get_session("missing") is None
+
+    # Update (same session_id + agent) must not duplicate, index unchanged.
+    db.upsert_session(_sess("s1", user_id="u1"))
+    assert len(db._sessions) == 2
+    assert db._session_index["s1"] == [0]
+    _assert_index_consistent(db)
+
+    # Rename keeps the position/id; index stays valid.
+    renamed = db.rename_session("s2", None, "renamed", user_id="u2")
+    assert renamed is not None
+    _assert_index_consistent(db)
+
+    # Delete rebuilds positions -> index rebuilt.
+    assert db.delete_session("s1") is True
+    assert db.get_session("s1") is None
+    assert db.get_session("s2", user_id="u2") is not None
+    _assert_index_consistent(db)
+
+
+def test_delete_sessions_keeps_index_consistent():
+    db = InMemoryDb()
+    for i in range(5):
+        db.upsert_session(_sess(f"s{i}"))
+    db.delete_sessions(["s1", "s3"])
+    assert {sd["session_id"] for sd in db._sessions} == {"s0", "s2", "s4"}
+    _assert_index_consistent(db)
+    assert db.get_session("s1") is None
+    assert db.get_session("s2") is not None
+
+
+def test_parity_with_full_scan_under_random_ops():
+    db = InMemoryDb()
+    rng = random.Random(20260624)
+    ids = [f"s{i}" for i in range(6)]
+
+    for _ in range(300):
+        op = rng.choice(["upsert", "delete", "delete_many", "get", "rename"])
+        sid = rng.choice(ids)
+        if op == "upsert":
+            db.upsert_session(_sess(sid, user_id=rng.choice([None, "u1", "u2"])))
+        elif op == "delete":
+            db.delete_session(sid, user_id=rng.choice([None, "u1"]))
+        elif op == "delete_many":
+            db.delete_sessions(rng.sample(ids, 2))
+        elif op == "rename":
+            db.rename_session(sid, None, f"name-{rng.randint(0, 9)}")
+        else:  # get -> must match a brute-force scan of _sessions (original semantics)
+            uid = rng.choice([None, "u1", "u2"])
+            got = db.get_session(sid, user_id=uid, deserialize=False)
+            ref = next(
+                (deepcopy(s) for s in db._sessions if s.get("session_id") == sid and (uid is None or s.get("user_id") == uid)),
+                None,
+            )
+            assert got == ref, (sid, uid)
+        _assert_index_consistent(db)


### PR DESCRIPTION
## Summary

`InMemoryDb` keeps sessions in a list (`self._sessions`) and locates a session by **linearly scanning the whole list** on every `get_session`, `upsert_session` (find-existing), and `rename_session`:

```python
for session_data in self._sessions:
    if session_data.get("session_id") == session_id:
        ...
```

That's **O(total sessions)** per call — on the session store that is read *and* written on every agent turn (get the session, run, upsert it back). With many sessions accumulating in a long-running process, each turn's get/upsert grows linearly.

This adds a `session_id -> positions` index (`self._session_index`), so those lookups become **O(matches)** (≈ O(1) in practice):

- maintained on `upsert_session` (append a new position; in-place updates keep the position and id, so no index change);
- rebuilt on `delete_session` / `delete_sessions`, which already rebuild `self._sessions` in O(n), so no extra asymptotic cost;
- `rename_session` mutates in place (position/id unchanged), so the index stays valid.

It maps each id to a **list** of positions so it remains correct even in the worst case where a `session_id` is not unique across components (the prior `upsert` matched on `session_id` **and** the component key). `get_sessions` (full filtered/paginated scan) is unchanged — it's inherently O(n).

**Behavior is unchanged** — same sessions returned, same ordering, same `user_id` / component / `_matches_session_key` semantics.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement (performance; no behavior change)
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines (`ruff check` clean)
- [ ] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments/docstrings on the new index + helper)
- [ ] Examples and guides (N/A)
- [x] Tested in clean environment

New `tests/unit/db/test_in_memory_session_index.py` (3 tests): get/upsert/delete/rename correctness; `delete_sessions` consistency; and a **300-op randomized fuzz** that compares `get_session` against a brute-force scan of `_sessions` and asserts an **index-consistency invariant after every mutation** (the index always equals a freshly rebuilt `session_id -> positions` map). Existing session/memory unit tests (`test_sessions`, `test_datetime_serialization`, `test_in_memory_memory`) stay green — 26 passed.
