### PR TITLE
[fix] Isolate HITL user input schemas

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import json
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field
 from hashlib import md5
 from pathlib import Path
@@ -2345,7 +2346,7 @@ class Model(ABC):
 
             # The function requires user input (HITL)
             if fc.function.requires_user_input:
-                user_input_schema = fc.function.user_input_schema
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:
@@ -2542,7 +2543,7 @@ class Model(ABC):
                 )
             # If the function requires user input, we yield a message to the user
             if fc.function.requires_user_input and not skip_pause_check:
-                user_input_schema = fc.function.user_input_schema
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:

--- a/libs/agno/tests/unit/models/test_hitl_user_input_schema.py
+++ b/libs/agno/tests/unit/models/test_hitl_user_input_schema.py
@@ -1,0 +1,92 @@
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.tools.function import Function, FunctionCall, UserInputField
+
+
+class DummyModel(Model):
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield ModelResponse()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return ModelResponse()
+
+
+def _hitl_function() -> Function:
+    return Function(
+        name="submit_comment",
+        requires_user_input=True,
+        user_input_schema=[UserInputField(name="content", field_type=str, description="Comment")],
+    )
+
+
+def _schema_values(response: ModelResponse) -> dict[str, str]:
+    assert response.tool_executions is not None
+    assert len(response.tool_executions) == 1
+    schema = response.tool_executions[0].user_input_schema
+    assert schema is not None
+    return {field.name: field.value for field in schema}
+
+
+def test_parallel_user_input_tool_calls_get_isolated_schema_values():
+    function = _hitl_function()
+    function_calls = [
+        FunctionCall(function=function, arguments={"content": "first"}, call_id="call_1"),
+        FunctionCall(function=function, arguments={"content": "second"}, call_id="call_2"),
+    ]
+
+    responses = list(DummyModel(id="dummy").run_function_calls(function_calls, function_call_results=[]))
+
+    assert [response.event for response in responses] == [
+        ModelResponseEvent.tool_call_paused.value,
+        ModelResponseEvent.tool_call_paused.value,
+    ]
+    assert _schema_values(responses[0]) == {"content": "first"}
+    assert _schema_values(responses[1]) == {"content": "second"}
+
+    first_schema = responses[0].tool_executions[0].user_input_schema
+    second_schema = responses[1].tool_executions[0].user_input_schema
+    assert first_schema is not second_schema
+    assert first_schema[0] is not second_schema[0]
+    assert function.user_input_schema[0].value is None
+
+
+@pytest.mark.asyncio
+async def test_parallel_user_input_tool_calls_get_isolated_schema_values_async():
+    function = _hitl_function()
+    function_calls = [
+        FunctionCall(function=function, arguments={"content": "first"}, call_id="call_1"),
+        FunctionCall(function=function, arguments={"content": "second"}, call_id="call_2"),
+    ]
+
+    responses: list[ModelResponse] = []
+    async for response in DummyModel(id="dummy").arun_function_calls(function_calls, function_call_results=[]):
+        responses.append(response)
+
+    assert [response.event for response in responses] == [
+        ModelResponseEvent.tool_call_paused.value,
+        ModelResponseEvent.tool_call_paused.value,
+    ]
+    assert _schema_values(responses[0]) == {"content": "first"}
+    assert _schema_values(responses[1]) == {"content": "second"}
+
+    first_schema = responses[0].tool_executions[0].user_input_schema
+    second_schema = responses[1].tool_executions[0].user_input_schema
+    assert first_schema is not second_schema
+    assert first_schema[0] is not second_schema[0]
+    assert function.user_input_schema[0].value is None


### PR DESCRIPTION
## Summary

Fixes #8546.

Parallel HITL tool calls to the same registered function were sharing the function-level `user_input_schema` list. `run_function_calls()` and `arun_function_calls()` then wrote argument values into that shared list in place, so multiple paused tool executions for the same function all displayed the last call's field values.

This PR deep-copies the function's `user_input_schema` before applying per-call argument values in both sync and async paths. Each paused `ToolExecution` now owns its own schema snapshot, and the original function schema is not mutated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validated with targeted checks on the rebased branch:

```text
PYTHONPATH=. uv run --no-project --with pytest --with pytest-asyncio --with pydantic --with pydantic-settings --with rich --with typer --with packaging --with python-dotenv --with pyyaml --with httpx --with docstring-parser --with gitpython --with h11 --with python-multipart pytest tests/unit/models/test_hitl_user_input_schema.py -q
# 2 passed in 0.22s

uv run --no-project --with ruff ruff check agno/models/base.py tests/unit/models/test_hitl_user_input_schema.py
# All checks passed!

uv run --no-project --with ruff ruff format --check agno/models/base.py tests/unit/models/test_hitl_user_input_schema.py
# 2 files already formatted

git diff --check
# passed
```

I could not run the full `./scripts/format.sh` / `./scripts/validate.sh` locally because fresh project-level `uv run --with-editable . ...` resolution fails before execution on an unrelated optional-extra conflict: `agno[a2a]` requires `httpx>=0.28.1`, while `agno[brave]` pulls `brave-search` metadata requiring `httpx>=0.25.2,<0.26.0`, and the available `brave-search==0.2.0` metadata cannot be parsed by uv.
