### PR TITLE
[fix] Honor extended cache TTL for Claude tools

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -600,7 +600,10 @@ class Claude(Model):
     def _apply_cache_tools(self, request_kwargs: Dict[str, Any]) -> None:
         """Tag the last tool with cache_control when cache_tools is enabled."""
         if self.cache_tools and "tools" in request_kwargs and request_kwargs["tools"]:
-            request_kwargs["tools"][-1]["cache_control"] = {"type": "ephemeral"}
+            cache_control = {"type": "ephemeral"}
+            if self.extended_cache_time:
+                cache_control["ttl"] = "1h"
+            request_kwargs["tools"][-1]["cache_control"] = cache_control
 
     def _build_system(self, system_message: str) -> List[Dict[str, Any]]:
         """Assemble the Anthropic ``system`` array.

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -520,6 +520,29 @@ def test_cache_tools_flag():
     assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
 
 
+def test_cache_tools_honors_extended_cache_time():
+    """cache_tools=True uses the model-level extended TTL when enabled."""
+    claude = Claude(
+        cache_system_prompt=True,
+        cache_tools=True,
+        extended_cache_time=True,
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_a",
+                "description": "A",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("System.", tools=tools)
+
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
 def test_cache_tools_disabled():
     """cache_tools=False leaves tools untouched."""
     claude = Claude(cache_system_prompt=True, cache_tools=False)
@@ -666,4 +689,4 @@ def test_azure_cache_tools_and_blocks():
 
     # cache_tools marks the last tool
     assert "cache_control" not in kwargs["tools"][0]
-    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}


### PR DESCRIPTION
## Summary

Fixes #8405.

When Claude is configured with `cache_tools=True`, `cache_system_prompt=True`, and `extended_cache_time=True`, Agno currently marks the last tool with bare `cache_control={"type": "ephemeral"}`. Anthropic treats that as the default 5m TTL, then processes the 1h system block after it, so the request can fail with a mixed TTL ordering error.

This updates `_apply_cache_tools` to mirror the model-level extended cache setting: when `extended_cache_time=True`, the tool cache breakpoint is emitted with `ttl="1h"`, matching the system block. The default 5m behavior remains unchanged when `extended_cache_time` is false.

This also covers the Azure, VertexAI, and AWS Claude subclasses that use the shared helper. The previous closed PR #8234 described the same root cause, but it was closed as opened in error before issue #8405 existed; I rechecked that there is no open PR currently covering #8405.

## Validation

- Pre-fix: `PYTHONPATH=libs/agno uv run --with pytest --with anthropic --with pydantic --with pytest-asyncio --with sqlalchemy --with rich pytest libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_cache_tools_honors_extended_cache_time -q` failed because tools had `{"type": "ephemeral"}` instead of `{"type": "ephemeral", "ttl": "1h"}`.
- `PYTHONPATH=libs/agno uv run --with pytest --with anthropic --with pydantic --with pytest-asyncio --with sqlalchemy --with rich --with boto3 pytest libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_cache_tools_flag libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_cache_tools_honors_extended_cache_time libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_cache_tools_disabled libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_cache_tools_single_tool libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_cache_tools_no_tools libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_vertexai_cache_tools libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_aws_cache_tools libs/agno/tests/integration/models/anthropic/test_prompt_caching.py::test_azure_cache_tools_and_blocks -q` -> `8 passed in 1.08s`
- `PYTHONPATH=libs/agno uv run --with ruff ruff check libs/agno/agno/models/anthropic/claude.py libs/agno/tests/integration/models/anthropic/test_prompt_caching.py` -> `All checks passed!`
- `PYTHONPATH=libs/agno uv run --with ruff ruff format --check libs/agno/agno/models/anthropic/claude.py libs/agno/tests/integration/models/anthropic/test_prompt_caching.py` -> `2 files already formatted`
- `PYTHONPATH=libs/agno python3 -m py_compile libs/agno/agno/models/anthropic/claude.py libs/agno/tests/integration/models/anthropic/test_prompt_caching.py` -> passed
- `git diff --check` -> passed