### PR TITLE
fix: emit native reasoning deltas from model stream

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1450,6 +1450,17 @@ def handle_model_response_chunk(
             if model_response_event.citations is not None:
                 run_response.citations = model_response_event.citations
 
+            if stream_events and model_response_event.reasoning_content:
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=model_response_event.reasoning_content,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
             # Only yield if we have content to show
             if content_type != "str":
                 yield handle_event(  # type: ignore
@@ -1464,7 +1475,7 @@ def handle_model_response_chunk(
                 )
             elif (
                 model_response_event.content is not None
-                or model_response_event.reasoning_content is not None
+                or (model_response_event.reasoning_content is not None and not stream_events)
                 or model_response_event.redacted_reasoning_content is not None
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
@@ -1473,7 +1484,7 @@ def handle_model_response_chunk(
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
+                        reasoning_content=None if stream_events else model_response_event.reasoning_content,
                         redacted_reasoning_content=model_response_event.redacted_reasoning_content,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,

--- a/libs/agno/tests/unit/agent/test_native_reasoning_stream_events.py
+++ b/libs/agno/tests/unit/agent/test_native_reasoning_stream_events.py
@@ -1,0 +1,47 @@
+from agno.agent import Agent
+from agno.agent._response import handle_model_response_chunk
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.run.agent import RunEvent, RunOutput
+from agno.session import AgentSession
+
+
+def _collect_events(content=None, reasoning_content=None):
+    agent = Agent(id="agent-1", name="Agent")
+    session = AgentSession(session_id="session-1")
+    run_response = RunOutput(run_id="run-1", session_id="session-1", agent_id="agent-1", agent_name="Agent")
+    model_response = ModelResponse(content="")
+    model_response_event = ModelResponse(
+        event=ModelResponseEvent.assistant_response.value,
+        content=content,
+        reasoning_content=reasoning_content,
+    )
+
+    return list(
+        handle_model_response_chunk(
+            agent,
+            session,
+            run_response,
+            model_response,
+            model_response_event,
+            stream_events=True,
+        )
+    )
+
+
+def test_native_reasoning_delta_is_emitted_as_reasoning_event():
+    events = _collect_events(reasoning_content="thinking")
+
+    assert [event.event for event in events] == [RunEvent.reasoning_content_delta.value]
+    assert events[0].reasoning_content == "thinking"
+
+
+def test_native_reasoning_delta_does_not_replace_text_content_event():
+    events = _collect_events(content="answer", reasoning_content="thinking")
+
+    assert [event.event for event in events] == [
+        RunEvent.reasoning_content_delta.value,
+        RunEvent.run_content.value,
+    ]
+    assert events[0].reasoning_content == "thinking"
+    assert events[1].content == "answer"
+    assert events[1].reasoning_content == ""


### PR DESCRIPTION
## Summary

Fixes #8400.

When a streaming model response chunk carries native reasoning_content, the agent event pipeline now emits a ReasoningContentDelta event in stream_events=True mode instead of only surfacing that reasoning text on an ordinary RunContent event. Text content in the same chunk still emits the normal RunContent event, so answer streaming remains intact.

## Why

The AG-UI interface already maps ReasoningContentDelta events to REASONING_MESSAGE_CONTENT, but it does not treat RunContent.reasoning_content as a native reasoning-message delta. For OpenAI-compatible models such as OpenAILike backends that stream reasoning_content, this left AG-UI with reasoning start/end events but no reasoning content events.

## Validation

- PYTHONPATH=libs/agno uv run --with pytest --with pydantic --with pydantic-settings --with rich --with httpx --with packaging --with docstring-parser pytest libs/agno/tests/unit/agent/test_native_reasoning_stream_events.py -q -> 2 passed
- PYTHONPATH=libs/agno uv run --with pytest --with pytest-asyncio --with pydantic --with pydantic-settings --with rich --with httpx --with packaging --with docstring-parser --with ag-ui-protocol --with fastapi --with starlette pytest libs/agno/tests/unit/app/test_agui_app.py -q -k "reasoning_content or reasoning" -> 5 passed, 53 deselected
- uv run --with ruff ruff check libs/agno/agno/agent/_response.py libs/agno/tests/unit/agent/test_native_reasoning_stream_events.py -> All checks passed
- uv run --with ruff ruff format --check libs/agno/agno/agent/_response.py libs/agno/tests/unit/agent/test_native_reasoning_stream_events.py && git diff --check -> 2 files already formatted, whitespace clean

## AI assistance disclosure

AI assistance was used to inspect the issue, implement the focused patch, and run validation. I reviewed the diff and verified the behavior locally.