### PR TITLE
[fix] Stream OpenAILike reasoning deltas as native events

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1442,6 +1442,20 @@ def handle_model_response_chunk(
                     model_response.reasoning_content += model_response_event.redacted_reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
 
+            reasoning_content_delta = (model_response_event.reasoning_content or "") + (
+                model_response_event.redacted_reasoning_content or ""
+            )
+            if stream_events and reasoning_content_delta:
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_content_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data
@@ -1464,8 +1478,7 @@ def handle_model_response_chunk(
                 )
             elif (
                 model_response_event.content is not None
-                or model_response_event.reasoning_content is not None
-                or model_response_event.redacted_reasoning_content is not None
+                or (not stream_events and reasoning_content_delta)
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
             ):
@@ -1473,8 +1486,10 @@ def handle_model_response_chunk(
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
-                        redacted_reasoning_content=model_response_event.redacted_reasoning_content,
+                        reasoning_content=model_response_event.reasoning_content if not stream_events else None,
+                        redacted_reasoning_content=model_response_event.redacted_reasoning_content
+                        if not stream_events
+                        else None,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,
                     ),

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from agno.models.message import Message
+from agno.models.response import ModelResponse
 from agno.reasoning.step import ReasoningStep, ReasoningSteps
 from agno.run.agent import RunEvent
 
@@ -298,3 +299,60 @@ def test_message_reasoning_content_optional():
     msg = Message(role="assistant", content="Just content")
     # Should not raise, reasoning_content should be None or not set
     assert msg.content == "Just content"
+
+
+def test_model_stream_reasoning_chunk_emits_reasoning_delta_event():
+    from agno.agent import Agent
+    from agno.agent._response import handle_model_response_chunk
+    from agno.run.agent import RunOutput
+    from agno.session import AgentSession
+
+    agent = Agent(id="agent-1", name="Agent 1")
+    session = AgentSession(session_id="session-1")
+    run_response = RunOutput(run_id="run-1", agent_id=agent.id, agent_name=agent.name, session_id=session.session_id)
+    model_response = ModelResponse()
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=ModelResponse(reasoning_content="thinking"),
+            stream_events=True,
+        )
+    )
+
+    assert [event.event for event in events] == [RunEvent.reasoning_content_delta]
+    assert events[0].reasoning_content == "thinking"  # type: ignore[attr-defined]
+    assert run_response.reasoning_content == "thinking"
+
+
+def test_model_stream_mixed_reasoning_and_content_emits_both_events():
+    from agno.agent import Agent
+    from agno.agent._response import handle_model_response_chunk
+    from agno.run.agent import RunOutput
+    from agno.session import AgentSession
+
+    agent = Agent(id="agent-1", name="Agent 1")
+    session = AgentSession(session_id="session-1")
+    run_response = RunOutput(run_id="run-1", agent_id=agent.id, agent_name=agent.name, session_id=session.session_id)
+    model_response = ModelResponse()
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=ModelResponse(content="answer", reasoning_content="thinking"),
+            stream_events=True,
+        )
+    )
+
+    assert [event.event for event in events] == [RunEvent.reasoning_content_delta, RunEvent.run_content]
+    assert events[0].reasoning_content == "thinking"  # type: ignore[attr-defined]
+    assert events[1].content == "answer"  # type: ignore[attr-defined]
+    assert events[1].reasoning_content == ""  # type: ignore[attr-defined]
+    assert run_response.content == "answer"
+    assert run_response.reasoning_content == "thinking"


### PR DESCRIPTION
## Summary

Fixes #8400 by routing streaming model chunks that contain `reasoning_content` or `redacted_reasoning_content` through Agno's native reasoning event pipeline when `stream_events=True`.

On current `main`, a model stream chunk with only `reasoning_content` updates `run_response.reasoning_content`, but it is emitted as a generic `RunContent` event. That means `/runs` and downstream `/agui` consumers do not receive `ReasoningContentDelta` / `REASONING_MESSAGE_CONTENT` events for OpenAI-compatible models that expose reasoning text in streaming chunks.

This PR emits `ReasoningContentDelta` for reasoning deltas during event streaming, while preserving the existing non-event-streaming behavior where reasoning content remains attached to the run content event.

## Root cause

`handle_model_response_chunk()` already accumulates `model_response_event.reasoning_content` onto the run response, but the event emission branch treated reasoning-only chunks as ordinary run content. Native reasoning delta events were only emitted by provider-specific stream helpers, so `OpenAILike` chunks with `reasoning_content` did not enter the common reasoning event path.

## Validation

Reproduced on current `origin/main` before the fix:

```text
['RunContent']
run reasoning: thinking
```

Validation after rebasing onto current `origin/main`:

```text
uv run --with-editable ./libs/agno --with pytest pytest libs/agno/tests/unit/reasoning/test_reasoning_streaming.py::test_model_stream_reasoning_chunk_emits_reasoning_delta_event libs/agno/tests/unit/reasoning/test_reasoning_streaming.py::test_model_stream_mixed_reasoning_and_content_emits_both_events -q
uv run --with-editable ./libs/agno --with pytest --with pytest-asyncio pytest libs/agno/tests/unit/reasoning/test_reasoning_streaming.py -q
uv run --with ruff ruff check libs/agno/agno/agent/_response.py libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
uv run --with ruff ruff format --check libs/agno/agno/agent/_response.py libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
git diff --check
```

AI assistance was used to prepare this patch; I reviewed the diff and validation evidence before opening the PR.
