### PR TITLE
fix: render numeric enums as numeric literal unions in token type formatting

### DIFF
--- a/libs/agno/agno/utils/tokens.py
+++ b/libs/agno/agno/utils/tokens.py
@@ -211,6 +211,9 @@ def _format_type(props: Dict[str, Any], indent: int) -> str:
         return "boolean"
     elif type_name == "null":
         return "null"
+    elif "enum" in props:
+        # Untyped enums (e.g. mixed-type Literals) still map to a literal union; quote strings, leave numbers bare
+        return " | ".join([f'"{item}"' if isinstance(item, str) else str(item) for item in props["enum"]])
     else:
         # Default to "any" for unknown types
         return "any"

--- a/libs/agno/agno/utils/tokens.py
+++ b/libs/agno/agno/utils/tokens.py
@@ -204,7 +204,8 @@ def _format_type(props: Dict[str, Any], indent: int) -> str:
         return f"{{\n{_format_object_parameters(props, indent + 2)}\n}}"
     elif type_name in ["integer", "number"]:
         if "enum" in props:
-            return " | ".join([f'"{item}"' for item in props["enum"]])
+            # Numeric enums map to TypeScript numeric literal unions (e.g. 1 | 2 | 3), not quoted strings
+            return " | ".join([str(item) for item in props["enum"]])
         return "number"
     elif type_name == "boolean":
         return "boolean"

--- a/libs/agno/tests/unit/utils/test_tokens.py
+++ b/libs/agno/tests/unit/utils/test_tokens.py
@@ -3,6 +3,7 @@ import pytest
 from agno.media import Audio, File, Image, Video
 from agno.models.message import Message
 from agno.utils.tokens import (
+    _format_type,
     count_audio_tokens,
     count_file_tokens,
     count_image_tokens,
@@ -404,6 +405,14 @@ def test_model_count_tokens_with_schema():
 
     # Schema should add tokens
     assert tokens_with_schema > tokens_no_schema
+
+
+def test_format_type_numeric_enum_unquoted():
+    """Numeric enums must become numeric literal unions, not quoted strings."""
+    assert _format_type({"type": "integer", "enum": [1, 2, 3]}, 0) == "1 | 2 | 3"
+    assert _format_type({"type": "number", "enum": [1.5, 2.5]}, 0) == "1.5 | 2.5"
+    # String enums are unchanged (still quoted literals).
+    assert _format_type({"type": "string", "enum": ["low", "high"]}, 0) == '"low" | "high"'
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/utils/test_tokens.py
+++ b/libs/agno/tests/unit/utils/test_tokens.py
@@ -415,6 +415,14 @@ def test_format_type_numeric_enum_unquoted():
     assert _format_type({"type": "string", "enum": ["low", "high"]}, 0) == '"low" | "high"'
 
 
+def test_format_type_untyped_enum_renders_union():
+    """Untyped enums (e.g. mixed-type Literals) must become a literal union, not 'any'."""
+    assert _format_type({"enum": [1, "auto"]}, 0) == '1 | "auto"'
+    assert _format_type({"enum": [1, 2]}, 0) == "1 | 2"
+    # An unknown type with no enum still falls back to "any".
+    assert _format_type({"type": "weird"}, 0) == "any"
+
+
 @pytest.mark.asyncio
 async def test_model_acount_tokens_with_schema():
     """Test model.acount_tokens includes schema tokens."""


### PR DESCRIPTION
Fixes #8555

## Problem

`_format_type` (used by `count_schema_tokens` to build a TypeScript-style type string for token estimation) formatted `integer`/`number` enums with quoted string literals:

```python
elif type_name in ["integer", "number"]:
    if "enum" in props:
        return " | ".join([f'"{item}"' for item in props["enum"]])
```

So a numeric enum produced a string-literal union:

| schema | before | expected |
|---|---|---|
| `{"type": "integer", "enum": [1, 2, 3]}` | `"1" \| "2" \| "3"` | `1 \| 2 \| 3` |
| `{"type": "number", "enum": [1.5, 2.5]}` | `"1.5" \| "2.5"` | `1.5 \| 2.5` |

That is the wrong TypeScript type (string literals, not numeric literals) and inflates the token count, since the added quote characters cost extra tokens.

## Fix

Join numeric enum members without quotes. String enums are untouched (they remain quoted literals, matching the docstring example).

## Test

Adds `test_format_type_numeric_enum_unquoted` covering integer, number, and string enums. Full `tests/unit/utils/test_tokens.py` passes (38 tests).