### PR TITLE
fix: use canonical conditions key when scoping trace filters for scoped users

### DIFF
--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -38,7 +38,7 @@ def _apply_user_scope_to_filter(filter_expr_dict: Optional[dict], effective_user
     """AND a ``user_id`` constraint into a filter for non-admin scoped callers.
 
     Scoped users must not be able to query across other users' traces, so their
-    ``user_id`` is ANDed into whatever filter they supplied. Admins / unscoped
+    ``user_id`` is AND-ed into whatever filter they supplied. Admins / unscoped
     callers (``effective_user_id is None``) get the raw filter unchanged.
 
     The AND/OR wrapper key is canonically ``"conditions"`` (see ``agno.filters``);

--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -34,6 +34,25 @@ from agno.utils.log import log_error
 logger = logging.getLogger(__name__)
 
 
+def _apply_user_scope_to_filter(filter_expr_dict: Optional[dict], effective_user_id: Optional[str]) -> Optional[dict]:
+    """AND a ``user_id`` constraint into a filter for non-admin scoped callers.
+
+    Scoped users must not be able to query across other users' traces, so their
+    ``user_id`` is ANDed into whatever filter they supplied. Admins / unscoped
+    callers (``effective_user_id is None``) get the raw filter unchanged.
+
+    The AND/OR wrapper key is canonically ``"conditions"`` (see ``agno.filters``);
+    using any other key makes ``from_dict`` raise and yields empty results.
+    """
+    if effective_user_id is None:
+        return filter_expr_dict
+
+    user_clause = {"op": "EQ", "key": "user_id", "value": effective_user_id}
+    if filter_expr_dict is None:
+        return user_clause
+    return {"op": "AND", "conditions": [user_clause, filter_expr_dict]}
+
+
 def get_traces_router(
     dbs: dict[str, list[Union[BaseDb, AsyncBaseDb, RemoteDb]]], settings: AgnoAPISettings = AgnoAPISettings(), **kwargs
 ) -> APIRouter:
@@ -666,12 +685,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
             # For non-admin scoped callers, AND a user_id constraint into the
             # filter so they can't query across other users' traces. Admins /
             # unscoped callers get the raw filter unchanged.
-            if effective_user_id is not None:
-                user_clause = {"op": "EQ", "key": "user_id", "value": effective_user_id}
-                if filter_expr_dict is None:
-                    filter_expr_dict = user_clause
-                else:
-                    filter_expr_dict = {"op": "AND", "exprs": [user_clause, filter_expr_dict]}
+            filter_expr_dict = _apply_user_scope_to_filter(filter_expr_dict, effective_user_id)
 
             # Branch based on group_by mode
             if body.group_by == TraceSearchGroupBy.SESSION:

--- a/libs/agno/tests/unit/test_trace_search_api.py
+++ b/libs/agno/tests/unit/test_trace_search_api.py
@@ -11,12 +11,14 @@ Tests cover:
 
 import pytest
 
+from agno.filters import from_dict
 from agno.os.routers.traces.schemas import (
     TRACE_FILTER_SCHEMA,
     FilterFieldSchema,
     FilterSchemaResponse,
     TraceSearchRequest,
 )
+from agno.os.routers.traces.traces import _apply_user_scope_to_filter
 
 
 class TestTraceSearchRequestModel:
@@ -330,3 +332,48 @@ class TestTraceFilterSchema:
         for field in TRACE_FILTER_SCHEMA.fields:
             if field.type != "enum":
                 assert field.values is None, f"Non-enum field '{field.key}' should not have values"
+
+
+class TestApplyUserScopeToFilter:
+    """Regression tests for scoped (non-admin) filtered trace search."""
+
+    def _time_filter(self) -> dict:
+        return {
+            "op": "AND",
+            "conditions": [
+                {"op": "GTE", "key": "start_time", "value": "2026-01-01T00:00:00"},
+                {"op": "LTE", "key": "end_time", "value": "2026-06-01T00:00:00"},
+            ],
+        }
+
+    def test_scoped_with_filter_wraps_with_conditions_key(self):
+        """Scoped user + supplied filter -> wrapper uses 'conditions'"""
+        wrapper = _apply_user_scope_to_filter(self._time_filter(), "scoped@user.com")
+
+        assert wrapper["op"] == "AND"
+        assert "conditions" in wrapper
+        user_clause, inner = wrapper["conditions"]
+        assert user_clause == {"op": "EQ", "key": "user_id", "value": "scoped@user.com"}
+        assert inner == self._time_filter()
+
+    def test_scoped_with_filter_survives_converter(self):
+        """The wrapped filter round-trips through from_dict"""
+        wrapper = _apply_user_scope_to_filter(self._time_filter(), "scoped@user.com")
+        from_dict(wrapper)
+
+    def test_scoped_without_filter_uses_bare_user_clause(self):
+        """Scoped user with no filter -> bare EQ user_id clause, no AND wrapper."""
+        result = _apply_user_scope_to_filter(None, "scoped@user.com")
+
+        assert result == {"op": "EQ", "key": "user_id", "value": "scoped@user.com"}
+        from_dict(result)
+
+    def test_admin_with_filter_passes_through_unchanged(self):
+        """Admin / unscoped caller (effective_user_id None) -> raw filter, no user clause."""
+        original = self._time_filter()
+
+        assert _apply_user_scope_to_filter(original, None) == original
+
+    def test_admin_without_filter_returns_none(self):
+        """Admin / unscoped caller with no filter -> still no filter."""
+        assert _apply_user_scope_to_filter(None, None) is None


### PR DESCRIPTION
## Summary

Fixes a bug in the Traces search API where scoped users got no results for any custom or time filter while the unfiltered list worked. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
