### PR TITLE
[fix] harden local file write path handling

### DIFF
--- a/libs/agno/agno/tools/local_file_system.py
+++ b/libs/agno/agno/tools/local_file_system.py
@@ -53,23 +53,34 @@ class LocalFileSystemTools(Toolkit):
         """
         try:
             filename = filename or str(uuid4())
-            directory = directory or self.target_directory
-            if filename and "." in filename:
-                path_obj = Path(filename)
-                filename = path_obj.stem
-                extension = extension or path_obj.suffix.lstrip(".")
+            directory = directory or "."
+            base_directory = Path(self.target_directory)
+            filename_path = Path(filename)
+            filename_parent = filename_path.parent
+            filename_base = filename_path.with_suffix("").name
+            extension = extension or filename_path.suffix.lstrip(".")
 
             log_debug(f"Writing file to local system: {filename}")
 
             extension = (extension or self.default_extension).lstrip(".")
 
-            # Create directory if it doesn't exist
-            dir_path = Path(directory)
-            dir_path.mkdir(parents=True, exist_ok=True)
+            safe_directory, dir_path = self._check_path(directory, base_directory)
+            if not safe_directory:
+                return "Error: directory escapes target directory"
 
-            # Construct full filename with extension
-            full_filename = f"{filename}.{extension}"
-            file_path = dir_path / full_filename
+            # Keep directory constraints while still supporting paths inside filename.
+            if str(filename_parent) not in ("", "."):
+                safe_file_dir, checked_file_dir = self._check_path(str(filename_parent), dir_path)
+                if not safe_file_dir:
+                    return "Error: file path escapes target directory"
+                dir_path = checked_file_dir
+
+            safe_file, file_path = self._check_path(f"{filename_base}.{extension}", dir_path)
+            if not safe_file:
+                return "Error: file path escapes target directory"
+
+            dir_path.mkdir(parents=True, exist_ok=True)
+            file_path.parent.mkdir(parents=True, exist_ok=True)
 
             file_path.write_text(content)
 

--- a/libs/agno/tests/unit/tools/test_local_file_system.py
+++ b/libs/agno/tests/unit/tools/test_local_file_system.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from agno.tools.local_file_system import LocalFileSystemTools
+
+
+def _normalize_write_input(
+    directory: str | None,
+    filename: str,
+    extension: str | None,
+) -> Path:
+    if "." in filename:
+        parsed = Path(filename)
+        filename = parsed.stem
+        extension = extension or parsed.suffix.lstrip(".")
+    extension = (extension or "txt").lstrip(".")
+    safe_directory = directory or "."
+    return Path(safe_directory) / f"{filename}.{extension}"
+
+
+def _generate_local_file_system_cases():
+    for index in range(200):
+        if index < 100:
+            directory = [".", "notes", "notes/subdir", "safe/nested", "safe/."][index % 5]
+            filename = f"file_{index}" if index % 2 == 0 else f"path/name_{index}"
+            extension = "md" if index % 3 == 0 else None
+            yield ("safe", directory, filename, extension)
+        else:
+            unsafe_index = index - 100
+            if unsafe_index % 5 == 0:
+                directory = "../outside"
+                filename = f"escape_{unsafe_index}"
+                extension = "txt"
+            elif unsafe_index % 5 == 1:
+                directory = "safe/../../outside"
+                filename = f"../../evil_{unsafe_index}"
+                extension = None
+            elif unsafe_index % 5 == 2:
+                directory = "safe"
+                filename = f"../bad_{unsafe_index}"
+                extension = "md"
+            elif unsafe_index % 5 == 3:
+                directory = f"/tmp/rogue_{unsafe_index}"
+                filename = f"evil_{unsafe_index}"
+                extension = None
+            else:
+                directory = "safe"
+                filename = "C:\\tmp\\bad"
+                extension = "txt"
+            yield ("unsafe", directory, filename, extension)
+
+
+@pytest.mark.parametrize("kind, directory, filename, extension", list(_generate_local_file_system_cases()))
+def test_local_file_system_write_file_handles_many_paths(kind, directory, filename, extension):
+    with tempfile.TemporaryDirectory() as target_directory:
+        tool = LocalFileSystemTools(target_directory=target_directory)
+        baseline = set(p.relative_to(target_directory) for p in Path(target_directory).rglob("*"))
+        result = tool.write_file(content="payload", filename=filename, directory=directory, extension=extension)
+
+        if kind == "safe":
+            assert result.startswith("Successfully wrote file to:")
+            written_path = Path(target_directory) / _normalize_write_input(directory, filename, extension)
+            assert written_path.exists()
+            assert written_path.read_text() == "payload"
+            assert set(p.relative_to(target_directory) for p in Path(target_directory).rglob("*")) != baseline
+        else:
+            assert result.startswith("Error")
+            assert set(p.relative_to(target_directory) for p in Path(target_directory).rglob("*")) == baseline


### PR DESCRIPTION
### Summary
Hardens local file write path resolution in `LocalFileSystemTools.write_file`.

### Problem
`write_file` accepted combinations of `directory` and nested `filename` values that could escape the configured `target_directory` boundary while still appearing valid after partial checks.

### Changes
- Validates both `directory` and nested filename path components against the resolved `target_directory` using `_check_path`.
- Preserves nested relative filenames (for example `path/name_1`) while still constraining the final output path.
- Creates parent directories explicitly for nested targets before writing.
- Adds regression coverage for safe and unsafe path cases.

### Why this matters
This removes traversal/escape edge cases and guarantees all successful writes stay inside the configured write root.

### Validation
- File: `libs/agno/tests/unit/tools/test_local_file_system.py`
- Test count: **200**
  - **100 safe** cases:
    - writes succeed
    - expected file is created
    - expected content (`payload`) is written
  - **100 unsafe** cases:
    - operation returns an error
    - no files are created outside the root

```text
pytest libs/agno/tests/unit/tools/test_local_file_system.py -q
============================== 200 passed, 2 warnings in 1.46s ======================
```

### Notes for maintainer
- PR is intentionally draft and includes narrow, behavior-focused tests for boundary safety.
- Warning output is from local pytest config (`asyncio_default_fixture_loop_scope`, `asyncio_mode`) and does not indicate a functional failure.