### PR TITLE
[fix] Include routed member responses in team history

### DIFF
--- a/libs/agno/agno/session/summary.py
+++ b/libs/agno/agno/session/summary.py
@@ -92,6 +92,7 @@ class SessionSummaryManager:
 
     # Maximum number of messages to include in the summary conversation. None means no limit.
     conversation_limit: Optional[int] = None
+    skip_member_messages: bool = True
 
     def __post_init__(self) -> None:
         if self.id is None:
@@ -177,11 +178,19 @@ class SessionSummaryManager:
 
         response_format = self.get_response_format(self.model)
 
+        messages_kwargs: Dict[str, Any] = {
+            "last_n_runs": self.last_n_runs,
+            "limit": self.conversation_limit,
+        }
+
+        from agno.session.team import TeamSession
+        from agno.session.workflow import WorkflowSession
+
+        if isinstance(session, (TeamSession, WorkflowSession)):
+            messages_kwargs["skip_member_messages"] = self.skip_member_messages
+
         system_message = self.get_system_message(
-            conversation=session.get_messages(  # type: ignore
-                last_n_runs=self.last_n_runs,
-                limit=self.conversation_limit,
-            ),
+            conversation=session.get_messages(**messages_kwargs),  # type: ignore[arg-type]
             response_format=response_format,
         )
 

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -582,6 +582,7 @@ def _set_session_summary_manager(team: "Team") -> None:
     if team.session_summary_manager is not None:
         if team.session_summary_manager.model is None:
             team.session_summary_manager.model = team.model
+        team.session_summary_manager.skip_member_messages = not team.respond_directly
 
     if team.add_session_summary_to_context is None:
         team.add_session_summary_to_context = team.enable_session_summaries or team.session_summary_manager is not None

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -896,6 +896,7 @@ def _get_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            skip_member_messages=not team.respond_directly,
         )
 
         if len(history) > 0:
@@ -1030,6 +1031,7 @@ async def _aget_run_messages(
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
             team_id=team.id if team.parent_team_id is not None else None,
+            skip_member_messages=not team.respond_directly,
         )
 
         if len(history) > 0:

--- a/libs/agno/tests/unit/team/test_route_mode_history.py
+++ b/libs/agno/tests/unit/team/test_route_mode_history.py
@@ -1,0 +1,154 @@
+import pytest
+
+from agno.agent import Agent
+from agno.models.message import Message
+from agno.run import RunContext
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
+from agno.session.summary import SessionSummaryManager
+from agno.session.team import TeamSession
+from agno.team._messages import _aget_run_messages, _get_run_messages
+from agno.team.team import Team
+
+
+class _DummySummaryModel:
+    supports_native_structured_outputs = False
+    supports_json_schema_outputs = False
+
+
+def _build_route_like_session(team_id: str) -> TeamSession:
+    member_run = RunOutput(
+        run_id="run-member-1",
+        agent_id="member-1",
+        parent_run_id="run-team-1",
+        status=RunStatus.completed,
+        messages=[Message(role="assistant", content="Member final answer")],
+    )
+    team_run = TeamRunOutput(
+        run_id="run-team-1",
+        team_id=team_id,
+        status=RunStatus.completed,
+        messages=[Message(role="user", content="User question")],
+        member_responses=[member_run],
+    )
+    session = TeamSession(session_id="session-1", team_id=team_id, runs=[])
+    session.upsert_run(team_run)
+    session.upsert_run(member_run)
+    return session
+
+
+def test_route_mode_history_replay_includes_member_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    team = Team(name="route-team", id="team-1", members=[Agent(name="member-1")], respond_directly=True)
+    session = _build_route_like_session(team.id)
+    run_context = RunContext(run_id="run-new", session_id=session.session_id, session_state={})
+    run_response = TeamRunOutput(run_id="run-new", team_id=team.id, status=RunStatus.running)
+
+    monkeypatch.setattr(
+        team,
+        "get_system_message",
+        lambda **kwargs: Message(role="system", content="system"),
+    )
+
+    run_messages = _get_run_messages(
+        team,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        input_message="new input",
+        add_history_to_context=True,
+    )
+
+    history_assistant_contents = [
+        m.content for m in run_messages.messages if getattr(m, "from_history", False) and m.role == "assistant"
+    ]
+    assert "Member final answer" in history_assistant_contents
+
+
+@pytest.mark.asyncio
+async def test_route_mode_async_history_replay_includes_member_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    team = Team(name="route-team-async", id="team-2", members=[Agent(name="member-1")], respond_directly=True)
+    session = _build_route_like_session(team.id)
+    run_context = RunContext(run_id="run-new", session_id=session.session_id, session_state={})
+    run_response = TeamRunOutput(run_id="run-new", team_id=team.id, status=RunStatus.running)
+
+    async def _fake_async_system_message(**kwargs):
+        return Message(role="system", content="system")
+
+    monkeypatch.setattr(team, "aget_system_message", _fake_async_system_message)
+
+    run_messages = await _aget_run_messages(
+        team,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        input_message="new input",
+        add_history_to_context=True,
+    )
+
+    history_assistant_contents = [
+        m.content for m in run_messages.messages if getattr(m, "from_history", False) and m.role == "assistant"
+    ]
+    assert "Member final answer" in history_assistant_contents
+
+
+def test_coordinate_mode_history_replay_still_excludes_member_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    team = Team(name="coordinate-team", id="team-3", members=[Agent(name="member-1")], respond_directly=False)
+    session = _build_route_like_session(team.id)
+    run_context = RunContext(run_id="run-new", session_id=session.session_id, session_state={})
+    run_response = TeamRunOutput(run_id="run-new", team_id=team.id, status=RunStatus.running)
+
+    monkeypatch.setattr(
+        team,
+        "get_system_message",
+        lambda **kwargs: Message(role="system", content="system"),
+    )
+
+    run_messages = _get_run_messages(
+        team,
+        run_response=run_response,
+        run_context=run_context,
+        session=session,
+        input_message="new input",
+        add_history_to_context=True,
+    )
+
+    history_assistant_contents = [
+        m.content for m in run_messages.messages if getattr(m, "from_history", False) and m.role == "assistant"
+    ]
+    assert "Member final answer" not in history_assistant_contents
+
+
+def test_summary_manager_passes_skip_member_messages_only_for_team_like_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agno.session.summary as summary_module
+
+    monkeypatch.setattr(summary_module, "get_model", lambda _model: _DummySummaryModel())
+
+    manager = SessionSummaryManager(model="noop:model", skip_member_messages=False)
+
+    team_session = TeamSession(session_id="team-session")
+    team_kwargs = {}
+
+    def _team_get_messages(**kwargs):
+        team_kwargs.update(kwargs)
+        return [Message(role="user", content="u"), Message(role="assistant", content="a")]
+
+    monkeypatch.setattr(team_session, "get_messages", _team_get_messages)
+    prepared = manager._prepare_summary_messages(team_session)
+    assert prepared is not None
+    assert team_kwargs.get("skip_member_messages") is False
+
+    agent_session = AgentSession(session_id="agent-session")
+    agent_kwargs = {}
+
+    def _agent_get_messages(**kwargs):
+        agent_kwargs.update(kwargs)
+        return [Message(role="user", content="u"), Message(role="assistant", content="a")]
+
+    monkeypatch.setattr(agent_session, "get_messages", _agent_get_messages)
+    prepared = manager._prepare_summary_messages(agent_session)
+    assert prepared is not None
+    assert "skip_member_messages" not in agent_kwargs


### PR DESCRIPTION
## Summary

Fixes #8573.

This PR fixes route-mode team history and session summary context dropping routed member assistant responses.

In route/respond-directly teams, the delegated member response is returned as the team response, but the stored team-level run may not include that assistant message. The actual assistant answer is stored on the member run. Existing history and summary builders used the default member-message filtering behavior, so routed assistant responses were omitted from replayed history and session summaries.

Changes:
- Include routed member responses when building history for respond-directly teams
- Include routed member responses in route-mode session summary context
- Preserve coordinate-mode behavior
- Add regression coverage for sync and async route-mode history replay

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Tests

```bash
./scripts/format.sh
pytest -q libs/agno/tests/unit/team/test_get_messages_dedup.py libs/agno/tests/unit/team/test_route_mode_history.py
./scripts/validate.sh