### PR TITLE
refactor: consolidate MCP ToolResult metadata into a single field

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1353,7 +1353,7 @@ class ToolResult(BaseModel):
     """Result from a tool that can include media artifacts."""
 
     content: str
-    # Holds extra MCP tool data, stored as "meta" and "structured_content".
+    # Holds extra MCP tool data, stored as "meta" and "structured_content". Can be used for any other provider's extra data.
     metadata: Optional[Dict[str, Any]] = None
     images: Optional[List[Image]] = None
     videos: Optional[List[Video]] = None

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1353,9 +1353,9 @@ class ToolResult(BaseModel):
     """Result from a tool that can include media artifacts."""
 
     content: str
+    # Holds extra MCP tool data, stored as "meta" and "structured_content".
     metadata: Optional[Dict[str, Any]] = None
     images: Optional[List[Image]] = None
     videos: Optional[List[Video]] = None
     audios: Optional[List[Audio]] = None
     files: Optional[List[File]] = None
-    structured_content: Optional[Dict[str, Any]] = None

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -1,6 +1,6 @@
 import json
 from functools import partial
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from uuid import uuid4
 
 from agno.utils.log import log_debug, log_exception
@@ -67,8 +67,7 @@ def get_entrypoint_for_tool(
             if result.isError:
                 return ToolResult(
                     content=f"Error from MCP tool '{tool_name}': {result.content}",
-                    metadata=result.meta,
-                    structured_content=getattr(result, "structuredContent", None),
+                    metadata=_build_mcp_metadata(result),
                 )
 
             # Process the result content
@@ -149,9 +148,8 @@ def get_entrypoint_for_tool(
 
             return ToolResult(
                 content=response_str.strip(),
-                metadata=result.meta,
+                metadata=_build_mcp_metadata(result),
                 images=images if images else None,
-                structured_content=getattr(result, "structuredContent", None),
             )
 
         # Execute the MCP tool call
@@ -196,6 +194,24 @@ def get_entrypoint_for_tool(
             return ToolResult(content=f"Error: {e}")
 
     return partial(call_tool, tool_name=tool.name)
+
+
+def _build_mcp_metadata(result: "CallToolResult") -> Optional[Dict[str, Any]]:
+    """Collect a tool result's extra MCP data into a single ToolResult.metadata dict.
+
+    Protocol `_meta` and the tool's `structuredContent` are stored as the reserved keys
+    `meta` and `structured_content` rather than as separate ToolResult fields, so future MCP
+    additions become new keys here instead of new attributes. `getattr` guards both: older MCP
+    servers (mcp < 1.10.0) expose no `structuredContent`, so the key is simply omitted. Returns
+    None when there is nothing to preserve.
+    """
+    metadata: Dict[str, Any] = {}
+    if getattr(result, "meta", None) is not None:
+        metadata["meta"] = result.meta
+    structured_content = getattr(result, "structuredContent", None)
+    if structured_content is not None:
+        metadata["structured_content"] = structured_content
+    return metadata or None
 
 
 def prepare_command(command: str) -> list[str]:

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1053,7 +1053,7 @@ async def test_mcp_tool_result_preserves_structured_content():
     entrypoint = get_entrypoint_for_tool(mock_tool, session)
     result = await entrypoint()
 
-    assert result.structured_content == {"id": "u1", "name": "Ada"}
+    assert result.metadata["structured_content"] == {"id": "u1", "name": "Ada"}
 
 
 @pytest.mark.asyncio
@@ -1075,7 +1075,7 @@ async def test_mcp_tool_error_result_preserves_structured_content():
     result = await entrypoint()
 
     assert "Error from MCP tool 'get_data'" in result.content
-    assert result.structured_content == {"error_details": {"code": 42}}
+    assert result.metadata["structured_content"] == {"error_details": {"code": 42}}
 
 
 @pytest.mark.asyncio
@@ -1099,14 +1099,15 @@ async def test_mcp_tool_result_handles_missing_structured_content_attr():
     result = await entrypoint()
 
     assert result.content == "hello"
-    assert result.structured_content is None
+    # No _meta and no structuredContent -> the envelope collapses to None.
+    assert result.metadata is None
 
 
 def test_tool_result_model_dump_roundtrip_preserves_structured_content():
-    tool_result = ToolResult(content="hello", structured_content={"key": "value", "list": [1, 2, 3]})
+    tool_result = ToolResult(content="hello", metadata={"structured_content": {"key": "value", "list": [1, 2, 3]}})
     payload = tool_result.model_dump()
     restored = ToolResult.model_validate(payload)
-    assert restored.structured_content == {"key": "value", "list": [1, 2, 3]}
+    assert restored.metadata["structured_content"] == {"key": "value", "list": [1, 2, 3]}
 
 
 @pytest.mark.asyncio
@@ -1128,7 +1129,7 @@ async def test_mcp_tool_result_preserves_meta():
     result = await entrypoint()
 
     assert result.content == "hello"
-    assert result.metadata == {"trace_id": "abc-123"}
+    assert result.metadata == {"meta": {"trace_id": "abc-123"}}
 
 
 @pytest.mark.asyncio
@@ -1150,7 +1151,30 @@ async def test_mcp_tool_error_result_preserves_meta():
     result = await entrypoint()
 
     assert "Error from MCP tool 'get_data'" in result.content
-    assert result.metadata == {"trace_id": "err-456"}
+    assert result.metadata == {"meta": {"trace_id": "err-456"}}
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_result_preserves_meta_and_structured_content():
+    mock_tool = MagicMock()
+    mock_tool.name = "get_data"
+
+    session = AsyncMock()
+    session.send_ping = AsyncMock()
+    session.call_tool = AsyncMock(
+        return_value=CallToolResult(
+            content=[TextContent(type="text", text="hello")],
+            isError=False,
+            _meta={"trace_id": "abc-123"},
+            structuredContent={"id": "u1", "name": "Ada"},
+        )
+    )
+
+    entrypoint = get_entrypoint_for_tool(mock_tool, session)
+    result = await entrypoint()
+
+    # Both sidecar values coexist under reserved keys in the single metadata envelope.
+    assert result.metadata == {"meta": {"trace_id": "abc-123"}, "structured_content": {"id": "u1", "name": "Ada"}}
 
 
 def test_tool_result_model_dump_roundtrip_preserves_metadata():


### PR DESCRIPTION
## Summary

`ToolResult` recently gained two separate optional dict fields in quick succession:
`metadata` (MCP `_meta`, #7659) and `structured_content` (MCP `structuredContent`, #7715).
Rather than keep adding a new field for each piece of MCP data, this consolidates them
into the single `metadata` dict, with `_meta` and `structuredContent` stored under the
reserved keys `meta` and `structured_content`.

Future MCP additions become new keys in `metadata` instead of new attributes on `ToolResult`.

**Behaviour**
- `metadata = {"meta": {...}, "structured_content": {...}}` when both are present.
- A key appears only when its value is present; it is never stored as `None`.
- When neither is present, `metadata` is `None`.
- `getattr` guards both, so older MCP servers (`mcp < 1.10.0`) that expose no
  `structuredContent` simply omit that key — no `AttributeError`.
- Keys are namespaced, so a tool whose own `structuredContent` contains a `meta` key
  cannot collide with the protocol `_meta`.

The conversion lives at a single boundary (`_build_mcp_metadata` in `utils/mcp.py`) used by
both `MCPTools` and `MultiMCPTools`; these fields are not propagated into the run/stream/message
pipeline, so the change is independent of run mode.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this

---

## Additional Notes
