### PR TITLE
[fix] Prevent CustomApiTools auth header leakage

### DIFF
--- a/libs/agno/agno/tools/api.py
+++ b/libs/agno/agno/tools/api.py
@@ -45,10 +45,14 @@ class CustomApiTools(Toolkit):
             return HTTPBasicAuth(self.username, self.password)
         return None
 
-    def _get_headers(self, additional_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    def _get_headers(
+        self,
+        additional_headers: Optional[Dict[str, str]] = None,
+        include_api_key: bool = True,
+    ) -> Dict[str, str]:
         """Combine default headers with additional headers."""
         headers = self.default_headers.copy()
-        if self.api_key:
+        if self.api_key and include_api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
         if additional_headers:
             headers.update(additional_headers)
@@ -89,7 +93,7 @@ class CustomApiTools(Toolkit):
                 params=params,
                 data=data,
                 json=json_data,
-                headers=self._get_headers(headers),
+                headers=self._get_headers(headers, include_api_key=bool(self.base_url)),
                 auth=self._get_auth(),
                 verify=self.verify_ssl,
                 timeout=self.timeout,

--- a/libs/agno/tests/unit/tools/test_custom_api.py
+++ b/libs/agno/tests/unit/tools/test_custom_api.py
@@ -320,3 +320,51 @@ def test_make_request_all_http_methods(api_tools, mock_dog_image_response):
                 verify=True,
                 timeout=10,
             )
+
+
+def test_make_request_with_base_url_and_api_key(mock_dog_image_response):
+    tools = CustomApiTools(base_url="https://dog.ceo/api", api_key="test_key")
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(endpoint="/breeds/image/random", method="GET")
+        mock_request.assert_called_once()
+        called_headers = mock_request.call_args[1]["headers"]
+        assert called_headers.get("Authorization") == "Bearer test_key"
+
+
+def test_make_request_without_base_url_and_api_key(mock_dog_image_response):
+    tools = CustomApiTools(api_key="test_key")
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(endpoint="https://dog.ceo/api/breeds/image/random", method="GET")
+        mock_request.assert_called_once()
+        called_headers = mock_request.call_args[1]["headers"]
+        assert "Authorization" not in called_headers
+
+
+def test_make_request_without_base_url_api_key_and_explicit_auth(mock_dog_image_response):
+    tools = CustomApiTools(api_key="test_key")
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(
+            endpoint="https://dog.ceo/api/breeds/image/random",
+            method="GET",
+            headers={"Authorization": "Bearer explicit"},
+        )
+        mock_request.assert_called_once()
+        called_headers = mock_request.call_args[1]["headers"]
+        assert called_headers.get("Authorization") == "Bearer explicit"
+
+
+def test_make_request_explicit_headers_override_defaults(mock_dog_image_response):
+    tools = CustomApiTools(
+        base_url="https://dog.ceo/api", headers={"X-Custom-Header": "default_val", "X-Other-Header": "keep_val"}
+    )
+    with patch("requests.request", return_value=mock_dog_image_response) as mock_request:
+        tools.make_request(
+            endpoint="/breeds/image/random",
+            method="GET",
+            headers={"X-Custom-Header": "override_val", "X-New-Header": "new_val"},
+        )
+        mock_request.assert_called_once()
+        called_headers = mock_request.call_args[1]["headers"]
+        assert called_headers.get("X-Custom-Header") == "override_val"
+        assert called_headers.get("X-Other-Header") == "keep_val"
+        assert called_headers.get("X-New-Header") == "new_val"


### PR DESCRIPTION
## Summary

Fixes #8578.

This PR prevents `CustomApiTools` from automatically attaching the configured API key authorization header when `base_url` is not set and the request endpoint is used as the full URL.

Changes:
- Keep automatic `Authorization: Bearer <api_key>` behavior when `base_url` is configured
- Do not automatically attach the API key authorization header when `base_url` is unset
- Preserve explicit caller-provided `Authorization` headers passed through `make_request(headers=...)`
- Add regression tests for base URL and non-base URL header behavior

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach

---

## Tests

```bash
ruff check libs/agno/agno/tools/api.py libs/agno/tests/unit/tools/test_custom_api.py
mypy libs/agno/agno/tools/api.py libs/agno/tests/unit/tools/test_custom_api.py --config-file libs/agno/pyproject.toml
pytest -q libs/agno/tests/unit/tools/test_custom_api.py
git diff --check
```

`./scripts/format.sh` was run successfully.

`./scripts/validate.sh` was run, but full repository validation currently fails on unrelated pre-existing mypy errors outside this PR's modified files. The modified files pass ruff, mypy, focused unit tests, and `git diff --check`.

## Additional Notes

Documentation and cookbook updates are not applicable because this is a focused internal bug fix for request header handling in `CustomApiTools`.