### PR TITLE
Handle wrapped text parts in A2A task stream events

### DIFF
--- a/libs/agno/agno/client/a2a/client.py
+++ b/libs/agno/agno/client/a2a/client.py
@@ -258,8 +258,9 @@ class A2AClient:
             for msg in result.get("history", []):
                 if msg.get("role") == "agent":
                     for part in msg.get("parts", []):
-                        if part.get("kind") == "text" or "text" in part:
-                            content = part.get("text", "")
+                        part_data = part.get("root", part)
+                        if part_data.get("kind") == "text" or "text" in part_data:
+                            content = part_data.get("text", "")
                             break
 
         elif kind == "status-update":

--- a/libs/agno/tests/unit/a2a/test_client.py
+++ b/libs/agno/tests/unit/a2a/test_client.py
@@ -231,6 +231,29 @@ class TestParseStreamEvent:
         assert event.event_type == "completed"
         assert event.is_final
 
+    def test_parse_task_event_with_wrapped_text_part(self):
+        """Test parsing final task events with wrapped text parts."""
+        client = A2AClient("http://localhost:7777")
+        data = {
+            "result": {
+                "kind": "task",
+                "id": "task-123",
+                "contextId": "ctx-456",
+                "history": [
+                    {
+                        "role": "agent",
+                        "parts": [{"root": {"kind": "text", "text": "Wrapped final content"}}],
+                    }
+                ],
+            },
+        }
+
+        event = client._parse_stream_event(data)
+
+        assert event.event_type == "task"
+        assert event.content == "Wrapped final content"
+        assert event.is_final
+
 
 class TestSendMessage:
     """Test send_message method."""


### PR DESCRIPTION
## What changed

This updates A2A stream task-event parsing to unwrap text parts shaped as `{"root": {"kind": "text", "text": ...}}` before extracting final task content.

## Why

`_parse_task_result()` and fallback stream parsing already handle wrapped parts, but the standard `kind="task"` stream branch did not. As a result, final task stream events with wrapped text parts produced `content=None` even though the text was present.

## Validation

- `PYTHONPATH=libs/agno python -m pytest libs/agno/tests/unit/a2a/test_client.py::TestParseStreamEvent -q`
- `python -m ruff check libs/agno/agno/client/a2a/client.py libs/agno/tests/unit/a2a/test_client.py`
- `git diff --check`

Fixes #8590
