### PR TITLE
[feat] Add Sofya search, extract, and research tools

### DIFF
--- a/cookbook/91_tools/sofya_tools.py
+++ b/cookbook/91_tools/sofya_tools.py
@@ -1,0 +1,58 @@
+"""
+Sofya Tools
+=============================
+
+Demonstrates Sofya tools: web search, URL extraction, and deep research.
+
+Set SOFYA_API_KEY in your environment. Get a key at https://sofya.co
+"""
+
+from agno.agent import Agent
+from agno.tools.sofya import SofyaTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Example 1: default SofyaTools (web search)
+agent = Agent(tools=[SofyaTools()])
+
+# Example 2: enable all Sofya tools (search + extract + research)
+agent_all = Agent(tools=[SofyaTools(all=True)])
+
+# Example 3: extraction only, fetch URLs as clean markdown
+extract_agent = Agent(
+    tools=[
+        SofyaTools(
+            enable_search=False,
+            enable_extract=True,
+        )
+    ]
+)
+
+# Example 4: deep research only, returns a cited report
+research_agent = Agent(
+    tools=[
+        SofyaTools(
+            enable_search=False,
+            enable_research=True,
+        )
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Search for recent developments in the Model Context Protocol", markdown=True
+    )
+
+    extract_agent.print_response(
+        "Extract the main content from https://modelcontextprotocol.io/introduction",
+        markdown=True,
+    )
+
+    research_agent.print_response(
+        "Write a short report on how AI agents use web search tools", markdown=True
+    )

--- a/cookbook/91_tools/sofya_tools.py
+++ b/cookbook/91_tools/sofya_tools.py
@@ -54,5 +54,5 @@ if __name__ == "__main__":
     )
 
     research_agent.print_response(
-        "Write a short report on how AI agents use web search tools", markdown=True
+        "Write a short report on how AI agents use web search tools", markdown=True, stream=True
     )

--- a/cookbook/91_tools/sofya_tools.py
+++ b/cookbook/91_tools/sofya_tools.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     extract_agent.print_response(
         "Extract the main content from https://modelcontextprotocol.io/introduction",
-        markdown=True,
+        markdown=True, stream=True
     )
 
     research_agent.print_response(

--- a/cookbook/91_tools/sofya_tools.py
+++ b/cookbook/91_tools/sofya_tools.py
@@ -45,7 +45,7 @@ research_agent = Agent(
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
     agent.print_response(
-        "Search for recent developments in the Model Context Protocol", markdown=True
+        "Search for recent developments in the Model Context Protocol", markdown=True, stream=True
     )
 
     extract_agent.print_response(

--- a/libs/agno/agno/tools/sofya.py
+++ b/libs/agno/agno/tools/sofya.py
@@ -1,0 +1,206 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Literal, Optional
+
+import requests
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error
+
+
+class SofyaTools(Toolkit):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        enable_search: bool = True,
+        enable_extract: bool = False,
+        enable_research: bool = False,
+        all: bool = False,
+        max_results: int = 5,
+        search_depth: Literal["snippets", "basic"] = "basic",
+        include_answer: bool = True,
+        format: Literal["json", "markdown"] = "markdown",
+        timeout: int = 180,
+        **kwargs,
+    ):
+        """Initialize SofyaTools with search, extract, and research capabilities.
+
+        Sofya (https://sofya.co) is a web tools API for AI agents. Search returns
+        extracted page content instead of snippets, extract fetches URLs as clean
+        markdown, and research returns a cited multi-source report.
+
+        Args:
+            api_key: Sofya API key. If not provided, will use SOFYA_API_KEY env var.
+            base_url: Sofya API base URL. If not provided, will use SOFYA_BASE_URL env var. Defaults to https://sofya.co.
+            enable_search: Enable web search functionality. Defaults to True.
+            enable_extract: Enable URL content extraction functionality. Defaults to False.
+            enable_research: Enable multi-source deep research functionality. Defaults to False.
+            all: Enable all available tools. Defaults to False.
+            max_results: Maximum number of search results to return (1-20). Defaults to 5.
+            search_depth: Search depth - snippets (1 credit) or basic (3 credits, full content). Defaults to "basic".
+            include_answer: Include an AI-generated answer in search results. Defaults to True.
+            format: Output format for search and research results - json or markdown. Defaults to "markdown".
+            timeout: Request timeout in seconds. Defaults to 180.
+            **kwargs: Additional arguments passed to Toolkit.
+        """
+        self.api_key: Optional[str] = api_key or getenv("SOFYA_API_KEY")
+        if not self.api_key:
+            log_error("SOFYA_API_KEY not provided")
+        self.base_url: str = (base_url or getenv("SOFYA_BASE_URL") or "https://sofya.co").rstrip("/")
+        self.max_results: int = max_results
+        self.search_depth: Literal["snippets", "basic"] = search_depth
+        self.include_answer: bool = include_answer
+        self.format: Literal["json", "markdown"] = format
+        self.timeout: int = timeout
+
+        tools: List[Any] = []
+        if enable_search or all:
+            tools.append(self.search_web)
+        if enable_extract or all:
+            tools.append(self.extract_url_content)
+        if enable_research or all:
+            tools.append(self.research)
+
+        super().__init__(name="sofya_tools", tools=tools, **kwargs)
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """POST to the Sofya API and return the parsed JSON response."""
+        url = f"{self.base_url}/v1/{path}"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "agno-sofya",
+        }
+        log_debug(f"Calling Sofya {path}")
+        response = requests.post(url, json=payload, headers=headers, timeout=self.timeout)
+        response.raise_for_status()
+        return response.json()
+
+    def search_web(self, query: str, max_results: Optional[int] = None) -> str:
+        """Search the web with Sofya and get extracted page content, not just snippets.
+
+        Args:
+            query (str): Query to search for.
+            max_results (Optional[int]): Maximum number of results to return. Defaults to the configured value.
+
+        Returns:
+            str: Search results as markdown or a JSON string.
+        """
+        if not self.api_key:
+            return json.dumps({"error": "Please provide a Sofya API key"})
+        if not query or not query.strip():
+            return json.dumps({"error": "Please provide a query to search for"})
+
+        payload = {
+            "query": query.strip(),
+            "max_results": max(1, min(max_results or self.max_results, 20)),
+            "search_depth": self.search_depth,
+            "include_answer": self.include_answer,
+        }
+
+        try:
+            data = self._post("search", payload)
+        except Exception as e:
+            log_error(f"Sofya search failed: {e}")
+            return json.dumps({"error": str(e)})
+
+        clean: Dict[str, Any] = {"query": query}
+        if data.get("answer"):
+            clean["answer"] = data["answer"]
+        clean["results"] = [
+            {
+                "title": r.get("title"),
+                "url": r.get("url"),
+                "content": r.get("content"),
+                "published_date": r.get("published_date"),
+            }
+            for r in data.get("results", [])
+        ]
+
+        if self.format == "json":
+            return json.dumps(clean)
+
+        markdown = f"# {query}\n\n"
+        if "answer" in clean:
+            markdown += f"### Summary\n{clean['answer']}\n\n"
+        for r in clean["results"]:
+            markdown += f"### [{r['title']}]({r['url']})\n{r['content']}\n\n"
+        return markdown
+
+    def extract_url_content(self, urls: str) -> str:
+        """Fetch one or more URLs as clean markdown using Sofya. Also handles PDF, DOCX, and more.
+
+        Args:
+            urls (str): Single URL or multiple comma-separated URLs to fetch.
+                Example: "https://example.com" or "https://example.com,https://another.com"
+
+        Returns:
+            str: Extracted content as markdown, with one section per URL.
+        """
+        if not self.api_key:
+            return json.dumps({"error": "Please provide a Sofya API key"})
+
+        url_list = [u.strip() for u in urls.split(",") if u.strip()]
+        if not url_list:
+            return json.dumps({"error": "No valid URLs provided"})
+
+        try:
+            data = self._post("fetch", {"urls": url_list})
+        except Exception as e:
+            log_error(f"Sofya extract failed: {e}")
+            return json.dumps({"error": str(e)})
+
+        results = data.get("results", [])
+        if not results:
+            return "No content could be extracted from the provided URL(s)."
+
+        output = []
+        for r in results:
+            url = r.get("url", "Unknown URL")
+            if not r.get("success", True):
+                output.append(f"## {url}\n\n**Extraction failed**: {r.get('error', 'unknown error')}\n\n")
+            elif r.get("content"):
+                output.append(f"## {url}\n\n{r['content']}\n\n")
+            else:
+                output.append(f"## {url}\n\n*No content available*\n\n")
+        return "".join(output)
+
+    def research(self, query: str) -> str:
+        """Run multi-source deep research with Sofya and get back a cited report.
+
+        Sofya decomposes the question into sub-queries, reads many sources in parallel,
+        and synthesizes a single report with citations. Use this for open-ended questions
+        that need several sources, not for a single lookup (use search_web for that).
+
+        Args:
+            query (str): The research question.
+
+        Returns:
+            str: The research report as markdown, or a JSON string.
+        """
+        if not self.api_key:
+            return json.dumps({"error": "Please provide a Sofya API key"})
+        if not query or not query.strip():
+            return json.dumps({"error": "Please provide a query to research"})
+
+        try:
+            data = self._post("research", {"query": query.strip()})
+        except Exception as e:
+            log_error(f"Sofya research failed: {e}")
+            return json.dumps({"error": str(e)})
+
+        if self.format == "json":
+            return json.dumps(data)
+
+        report = data.get("report", "")
+        markdown = f"# {query}\n\n{report}\n\n"
+        sources = data.get("sources", [])
+        if sources:
+            markdown += "## Sources\n"
+            for s in sources:
+                if isinstance(s, dict):
+                    markdown += f"- [{s.get('title', s.get('url'))}]({s.get('url')})\n"
+                else:
+                    markdown += f"- {s}\n"
+        return markdown

--- a/libs/agno/agno/tools/sofya.py
+++ b/libs/agno/agno/tools/sofya.py
@@ -7,6 +7,11 @@ import requests
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error
 
+# Sofya's fetch endpoint is documented as "1 credit per URL, max 10 URLs" per
+# https://sofya.co/docs — enforce it client-side to give a clean error instead
+# of an opaque 400 from the API.
+FETCH_MAX_URLS = 10
+
 
 class SofyaTools(Toolkit):
     def __init__(
@@ -65,7 +70,11 @@ class SofyaTools(Toolkit):
         super().__init__(name="sofya_tools", tools=tools, **kwargs)
 
     def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """POST to the Sofya API and return the parsed JSON response."""
+        """POST to the Sofya API and return the parsed JSON response.
+
+        On HTTP errors, re-raises with the response body appended (truncated),
+        so callers see the Sofya-side error message instead of just the status.
+        """
         url = f"{self.base_url}/v1/{path}"
         headers = {
             "Authorization": f"Bearer {self.api_key}",
@@ -74,7 +83,11 @@ class SofyaTools(Toolkit):
         }
         log_debug(f"Calling Sofya {path}")
         response = requests.post(url, json=payload, headers=headers, timeout=self.timeout)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            body = (response.text or "")[:500]
+            raise requests.HTTPError(f"{e} - body: {body}", response=response) from e
         return response.json()
 
     def search_web(self, query: str, max_results: Optional[int] = None) -> str:
@@ -125,11 +138,17 @@ class SofyaTools(Toolkit):
         if "answer" in clean:
             markdown += f"### Summary\n{clean['answer']}\n\n"
         for r in clean["results"]:
-            markdown += f"### [{r['title']}]({r['url']})\n{r['content']}\n\n"
+            url = r.get("url") or ""
+            title = r.get("title") or url or "Untitled"
+            content = r.get("content") or ""
+            markdown += f"### [{title}]({url})\n{content}\n\n"
         return markdown
 
     def extract_url_content(self, urls: str) -> str:
         """Fetch one or more URLs as clean markdown using Sofya. Also handles PDF, DOCX, and more.
+
+        Sofya's fetch endpoint accepts up to 10 URLs per call; extra URLs are dropped
+        client-side to avoid an opaque API error.
 
         Args:
             urls (str): Single URL or multiple comma-separated URLs to fetch.
@@ -144,6 +163,9 @@ class SofyaTools(Toolkit):
         url_list = [u.strip() for u in urls.split(",") if u.strip()]
         if not url_list:
             return json.dumps({"error": "No valid URLs provided"})
+        if len(url_list) > FETCH_MAX_URLS:
+            log_debug(f"Sofya fetch capped at {FETCH_MAX_URLS} URLs; dropping {len(url_list) - FETCH_MAX_URLS}")
+            url_list = url_list[:FETCH_MAX_URLS]
 
         try:
             data = self._post("fetch", {"urls": url_list})

--- a/libs/agno/tests/unit/tools/test_sofya.py
+++ b/libs/agno/tests/unit/tools/test_sofya.py
@@ -1,0 +1,173 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from agno.tools.sofya import SofyaTools
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    """Ensure SOFYA_API_KEY is unset unless explicitly needed."""
+    monkeypatch.delenv("SOFYA_API_KEY", raising=False)
+    monkeypatch.delenv("SOFYA_BASE_URL", raising=False)
+
+
+@pytest.fixture
+def api_tools():
+    """SofyaTools with a known API key and all tools enabled for testing."""
+    return SofyaTools(api_key="test_key", all=True, format="json")
+
+
+def _mock_response(payload: dict) -> Mock:
+    mock = Mock(spec=requests.Response)
+    mock.json.return_value = payload
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+# Initialization Tests
+def test_init_without_api_key_and_env(monkeypatch):
+    """If no api_key argument and no SOFYA_API_KEY in env, api_key should be None."""
+    monkeypatch.delenv("SOFYA_API_KEY", raising=False)
+    tools = SofyaTools()
+    assert tools.api_key is None
+
+
+def test_init_with_env_var(monkeypatch):
+    """If SOFYA_API_KEY is set in the environment, it is picked up."""
+    monkeypatch.setenv("SOFYA_API_KEY", "env_key")
+    tools = SofyaTools(api_key=None)
+    assert tools.api_key == "env_key"
+
+
+def test_init_base_url_default():
+    """Base URL defaults to https://sofya.co."""
+    tools = SofyaTools(api_key="test_key")
+    assert tools.base_url == "https://sofya.co"
+
+
+def test_init_base_url_override(monkeypatch):
+    """SOFYA_BASE_URL env var overrides the default and trailing slashes are stripped."""
+    monkeypatch.setenv("SOFYA_BASE_URL", "https://eu.sofya.co/")
+    tools = SofyaTools(api_key="test_key")
+    assert tools.base_url == "https://eu.sofya.co"
+
+
+def test_enabled_tools_registration():
+    """Only enabled tools are registered on the toolkit."""
+    search_only = SofyaTools(api_key="test_key")
+    names = {f.name for f in search_only.functions.values()}
+    assert "search_web" in names
+    assert "extract_url_content" not in names
+
+    all_tools = SofyaTools(api_key="test_key", all=True)
+    all_names = {f.name for f in all_tools.functions.values()}
+    assert {"search_web", "extract_url_content", "research"}.issubset(all_names)
+
+
+# Search Tests
+def test_search_no_api_key():
+    """Calling search without any API key returns an error message."""
+    tools = SofyaTools(api_key=None)
+    result = json.loads(tools.search_web("anything"))
+    assert "error" in result
+    assert "Sofya API key" in result["error"]
+
+
+def test_search_empty_query(api_tools):
+    """Calling search with an empty query returns an error message."""
+    result = json.loads(api_tools.search_web(""))
+    assert "error" in result
+    assert "query" in result["error"].lower()
+
+
+def test_search_success_json(api_tools):
+    """A successful search returns cleaned results as JSON."""
+    payload = {
+        "query": "mcp",
+        "answer": "Model Context Protocol.",
+        "results": [
+            {"title": "MCP", "url": "https://example.com", "content": "about mcp", "published_date": "2026-01-01"}
+        ],
+        "credits_used": 3,
+    }
+    with patch("agno.tools.sofya.requests.post", return_value=_mock_response(payload)) as mock_post:
+        result = json.loads(api_tools.search_web("mcp"))
+    mock_post.assert_called_once()
+    assert result["answer"] == "Model Context Protocol."
+    assert result["results"][0]["url"] == "https://example.com"
+    # internal fields are not leaked into the cleaned result
+    assert "credits_used" not in result
+
+
+def test_search_markdown_format():
+    """Markdown format renders a heading and result links."""
+    tools = SofyaTools(api_key="test_key", format="markdown")
+    payload = {
+        "query": "mcp",
+        "answer": "A protocol.",
+        "results": [{"title": "MCP", "url": "https://e.com", "content": "x"}],
+    }
+    with patch("agno.tools.sofya.requests.post", return_value=_mock_response(payload)):
+        result = tools.search_web("mcp")
+    assert "# mcp" in result
+    assert "### Summary" in result
+    assert "[MCP](https://e.com)" in result
+
+
+def test_search_request_error(api_tools):
+    """Network errors are caught and returned as an error message."""
+    with patch("agno.tools.sofya.requests.post", side_effect=requests.ConnectionError("boom")):
+        result = json.loads(api_tools.search_web("mcp"))
+    assert "error" in result
+    assert "boom" in result["error"]
+
+
+# Extract Tests
+def test_extract_no_urls(api_tools):
+    """Extract with no valid URLs returns an error."""
+    result = json.loads(api_tools.extract_url_content("   "))
+    assert "error" in result
+
+
+def test_extract_success(api_tools):
+    """Extract returns markdown sections per URL."""
+    payload = {"results": [{"url": "https://example.com", "content": "# Hello", "success": True}]}
+    with patch("agno.tools.sofya.requests.post", return_value=_mock_response(payload)):
+        result = api_tools.extract_url_content("https://example.com")
+    assert "## https://example.com" in result
+    assert "# Hello" in result
+
+
+def test_extract_failed_result(api_tools):
+    """A failed fetch result is reported clearly."""
+    payload = {"results": [{"url": "https://bad.com", "success": False, "error": "timeout"}]}
+    with patch("agno.tools.sofya.requests.post", return_value=_mock_response(payload)):
+        result = api_tools.extract_url_content("https://bad.com")
+    assert "Extraction failed" in result
+    assert "timeout" in result
+
+
+# Research Tests
+def test_research_no_api_key():
+    """Research without an API key returns an error."""
+    tools = SofyaTools(api_key=None, enable_research=True)
+    result = json.loads(tools.research("anything"))
+    assert "error" in result
+
+
+def test_research_success_markdown():
+    """Research renders the report and a sources list in markdown."""
+    tools = SofyaTools(api_key="test_key", enable_research=True, format="markdown")
+    payload = {
+        "query": "what is mcp",
+        "report": "MCP is a protocol.",
+        "sources": [{"title": "Spec", "url": "https://spec.example"}],
+    }
+    with patch("agno.tools.sofya.requests.post", return_value=_mock_response(payload)):
+        result = tools.research("what is mcp")
+    assert "MCP is a protocol." in result
+    assert "## Sources" in result
+    assert "[Spec](https://spec.example)" in result

--- a/libs/agno/tests/unit/tools/test_sofya.py
+++ b/libs/agno/tests/unit/tools/test_sofya.py
@@ -171,3 +171,51 @@ def test_research_success_markdown():
     assert "MCP is a protocol." in result
     assert "## Sources" in result
     assert "[Spec](https://spec.example)" in result
+
+
+# Tests for markdown fallbacks and API limits.
+def test_search_markdown_handles_missing_title_and_content():
+    """Sofya may omit title/content for some results; markdown must not render the literal 'None'."""
+    tools = SofyaTools(api_key="test_key", format="markdown")
+    payload = {
+        "query": "q",
+        "results": [
+            {"url": "https://e.com"},  # no title, no content
+            {"title": None, "url": "https://f.com", "content": None},
+        ],
+    }
+    with patch("agno.tools.sofya.requests.post", return_value=_mock_response(payload)):
+        result = tools.search_web("q")
+    assert "None" not in result
+    # Falls back to the URL as the link text when title is missing.
+    assert "[https://e.com](https://e.com)" in result
+    assert "[https://f.com](https://f.com)" in result
+
+
+def test_extract_url_content_caps_at_ten_urls(api_tools):
+    """Sofya's fetch endpoint caps at 10 URLs — the tool must trim client-side."""
+    urls = ",".join(f"https://e{i}.com" for i in range(15))
+    with patch(
+        "agno.tools.sofya.requests.post",
+        return_value=_mock_response({"results": []}),
+    ) as mock_post:
+        api_tools.extract_url_content(urls)
+    sent = mock_post.call_args.kwargs["json"]["urls"]
+    assert len(sent) == 10
+    assert sent[0] == "https://e0.com"
+    assert sent[-1] == "https://e9.com"
+
+
+def test_post_surfaces_http_error_body(api_tools):
+    """HTTP errors should include Sofya's response body, not just the status line."""
+    mock_resp = Mock(spec=requests.Response)
+    mock_resp.text = '{"error":"insufficient credits"}'
+    mock_resp.raise_for_status.side_effect = requests.HTTPError(
+        "402 Client Error: Payment Required for url: https://sofya.co/v1/search",
+        response=mock_resp,
+    )
+    with patch("agno.tools.sofya.requests.post", return_value=mock_resp):
+        result = json.loads(api_tools.search_web("q"))
+    assert "error" in result
+    assert "insufficient credits" in result["error"]
+    assert "402" in result["error"]


### PR DESCRIPTION
## Summary

Closes #8594.

Adds `SofyaTools`, a web tools toolkit backed by the [Sofya](https://sofya.co) API, alongside the existing Tavily, Exa, and Serper toolkits. It exposes three tools:

- `search_web`: web search that returns extracted page content, not just snippets
- `extract_url_content`: fetch one or more URLs as clean markdown (also handles PDF and DOCX)
- `research`: multi-source deep research that returns a cited report

Tools are opt-in via `enable_search`, `enable_extract`, and `enable_research` flags (or `all=True`), and results can be returned as markdown or JSON. This mirrors the existing `TavilyTools` design, so it is a drop-in alternative or complement to the current search providers. Set `SOFYA_API_KEY` to use it.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` and `ruff check` clean, `mypy` clean)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: added `cookbook/91_tools/sofya_tools.py`
- [x] Tested in clean environment
- [x] Tests added/updated (`libs/agno/tests/unit/tools/test_sofya.py`, 15 tests)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verified the toolkit end to end against the live Sofya API (search and extract return real content), and ran the new unit tests (15 passing) plus `ruff` and `mypy` from the pinned dev dependencies.