### PR TITLE
feat: support custom HTTP clients for MCP streamable HTTP

### DIFF
--- a/cookbook/91_tools/mcp/streamable_http_transport/client.py
+++ b/cookbook/91_tools/mcp/streamable_http_transport/client.py
@@ -6,6 +6,8 @@ Check the README.md file for instructions on how to run these examples.
 
 import asyncio
 
+import httpx
+
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.tools.mcp import MCPTools, MultiMCPTools
@@ -33,6 +35,25 @@ async def run_agent(message: str) -> None:
     )
     await agent.aprint_response(input=message, stream=True, markdown=True)
     await mcp_tools.close()
+
+
+async def run_agent_with_custom_http_client(message: str) -> None:
+    # Swap verify=False for verify="/path/to/ca.pem" when you need a custom CA bundle.
+    async with httpx.AsyncClient(verify=False) as http_client:
+        mcp_tools = MCPTools(
+            transport="streamable-http",
+            url=server_url,
+            http_client=http_client,
+            refresh_connection=True,
+        )
+        await mcp_tools.connect()
+        agent = Agent(
+            model=OpenAIChat(id="gpt-4o"),
+            tools=[mcp_tools],
+            markdown=True,
+        )
+        await agent.aprint_response(input=message, stream=True, markdown=True)
+        await mcp_tools.close()
 
 
 # Using MultiMCPTools, we can connect to multiple MCP servers at once, even if they use different transports.

--- a/cookbook/91_tools/mcp/streamable_http_transport/client.py
+++ b/cookbook/91_tools/mcp/streamable_http_transport/client.py
@@ -7,7 +7,6 @@ Check the README.md file for instructions on how to run these examples.
 import asyncio
 
 import httpx
-
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.tools.mcp import MCPTools, MultiMCPTools
@@ -44,7 +43,9 @@ async def run_agent_with_custom_http_client(message: str) -> None:
         timeout: httpx.Timeout | None = None,
         auth: httpx.Auth | None = None,
     ) -> httpx.AsyncClient:
-        return httpx.AsyncClient(headers=headers, timeout=timeout, auth=auth, verify=False)
+        return httpx.AsyncClient(
+            headers=headers, timeout=timeout, auth=auth, verify=False
+        )
 
     async with MCPTools(
         transport="streamable-http",

--- a/cookbook/91_tools/mcp/streamable_http_transport/client.py
+++ b/cookbook/91_tools/mcp/streamable_http_transport/client.py
@@ -39,21 +39,25 @@ async def run_agent(message: str) -> None:
 
 async def run_agent_with_custom_http_client(message: str) -> None:
     # Swap verify=False for verify="/path/to/ca.pem" when you need a custom CA bundle.
-    async with httpx.AsyncClient(verify=False) as http_client:
-        mcp_tools = MCPTools(
-            transport="streamable-http",
-            url=server_url,
-            http_client=http_client,
-            refresh_connection=True,
-        )
-        await mcp_tools.connect()
+    def httpx_client_factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(headers=headers, timeout=timeout, auth=auth, verify=False)
+
+    async with MCPTools(
+        transport="streamable-http",
+        url=server_url,
+        httpx_client_factory=httpx_client_factory,
+        refresh_connection=True,
+    ) as mcp_tools:
         agent = Agent(
             model=OpenAIChat(id="gpt-4o"),
             tools=[mcp_tools],
             markdown=True,
         )
         await agent.aprint_response(input=message, stream=True, markdown=True)
-        await mcp_tools.close()
 
 
 # Using MultiMCPTools, we can connect to multiple MCP servers at once, even if they use different transports.

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -49,7 +49,7 @@ class MCPTools(Toolkit):
         session: Optional[ClientSession] = None,
         timeout_seconds: int = 10,
         client=None,
-        http_client=None,
+        httpx_client_factory=None,
         include_tools: Optional[list[str]] = None,
         exclude_tools: Optional[list[str]] = None,
         refresh_connection: bool = False,
@@ -67,7 +67,7 @@ class MCPTools(Toolkit):
             url: The URL endpoint for SSE or Streamable HTTP connection when transport is "sse" or "streamable-http".
             env: The environment variables to pass to the server. Should be used in conjunction with command.
             client: The underlying MCP client (optional, used to prevent garbage collection)
-            http_client: The underlying HTTP client for streamable-http transport.
+            httpx_client_factory: Factory for a customized streamable-http transport client.
             timeout_seconds: Read timeout in seconds for the MCP client
             include_tools: Optional list of tool names to include (if None, includes all)
             exclude_tools: Optional list of tool names to exclude (if None, excludes none)
@@ -158,7 +158,7 @@ class MCPTools(Toolkit):
             server_params
         )
         self.url = url
-        self._http_client = http_client
+        self._httpx_client_factory = httpx_client_factory
 
         # Merge provided env with system env
         if env is not None:
@@ -330,7 +330,7 @@ class MCPTools(Toolkit):
             streamable_http_params = streamable_http_client_kwargs(
                 self.server_params if isinstance(self.server_params, StreamableHTTPClientParams) else None,
                 url=self.url,
-                http_client=self._http_client,
+                httpx_client_factory=self._httpx_client_factory,
             )
             existing_headers = streamable_http_params.get("headers") or {}
             streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
@@ -441,7 +441,7 @@ class MCPTools(Toolkit):
                 streamable_http_params = streamable_http_client_kwargs(
                     self.server_params if isinstance(self.server_params, StreamableHTTPClientParams) else None,
                     url=self.url,
-                    http_client=self._http_client,
+                    httpx_client_factory=self._httpx_client_factory,
                 )
                 existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
@@ -612,7 +612,7 @@ class MCPTools(Toolkit):
             streamable_http_params = streamable_http_client_kwargs(
                 self.server_params if isinstance(self.server_params, StreamableHTTPClientParams) else None,
                 url=self.url,
-                http_client=self._http_client,
+                httpx_client_factory=self._httpx_client_factory,
             )
             if init_headers:
                 existing_headers = streamable_http_params.get("headers") or {}

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Callable, Literal, Optiona
 
 from agno.tools import Toolkit
 from agno.tools.function import Function
-from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams, streamable_http_client_kwargs
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.mcp import get_entrypoint_for_tool, prepare_command
 
@@ -49,6 +49,7 @@ class MCPTools(Toolkit):
         session: Optional[ClientSession] = None,
         timeout_seconds: int = 10,
         client=None,
+        http_client=None,
         include_tools: Optional[list[str]] = None,
         exclude_tools: Optional[list[str]] = None,
         refresh_connection: bool = False,
@@ -66,6 +67,7 @@ class MCPTools(Toolkit):
             url: The URL endpoint for SSE or Streamable HTTP connection when transport is "sse" or "streamable-http".
             env: The environment variables to pass to the server. Should be used in conjunction with command.
             client: The underlying MCP client (optional, used to prevent garbage collection)
+            http_client: The underlying HTTP client for streamable-http transport.
             timeout_seconds: Read timeout in seconds for the MCP client
             include_tools: Optional list of tool names to include (if None, includes all)
             exclude_tools: Optional list of tool names to exclude (if None, excludes none)
@@ -156,6 +158,7 @@ class MCPTools(Toolkit):
             server_params
         )
         self.url = url
+        self._http_client = http_client
 
         # Merge provided env with system env
         if env is not None:
@@ -324,9 +327,11 @@ class MCPTools(Toolkit):
             context = sse_client(**sse_params)  # type: ignore
             client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
         elif self.transport == "streamable-http":
-            streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-            if "url" not in streamable_http_params:
-                streamable_http_params["url"] = self.url
+            streamable_http_params = streamable_http_client_kwargs(
+                self.server_params if isinstance(self.server_params, StreamableHTTPClientParams) else None,
+                url=self.url,
+                http_client=self._http_client,
+            )
             existing_headers = streamable_http_params.get("headers") or {}
             streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
             context = streamablehttp_client(**streamable_http_params)  # type: ignore
@@ -433,11 +438,11 @@ class MCPTools(Toolkit):
                 client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
 
             elif self.transport == "streamable-http":
-                streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-                if "url" not in streamable_http_params:
-                    streamable_http_params["url"] = self.url
-
-                # Merge dynamic headers into existing headers
+                streamable_http_params = streamable_http_client_kwargs(
+                    self.server_params if isinstance(self.server_params, StreamableHTTPClientParams) else None,
+                    url=self.url,
+                    http_client=self._http_client,
+                )
                 existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
 
@@ -604,9 +609,11 @@ class MCPTools(Toolkit):
 
         # Create a new streamable HTTP session
         elif self.transport == "streamable-http":
-            streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-            if "url" not in streamable_http_params:
-                streamable_http_params["url"] = self.url
+            streamable_http_params = streamable_http_client_kwargs(
+                self.server_params if isinstance(self.server_params, StreamableHTTPClientParams) else None,
+                url=self.url,
+                http_client=self._http_client,
+            )
             if init_headers:
                 existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **init_headers}

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -52,7 +52,7 @@ class MultiMCPTools(Toolkit):
         ] = None,
         timeout_seconds: int = 10,
         client=None,
-        http_client=None,
+        httpx_client_factory=None,
         include_tools: Optional[list[str]] = None,
         exclude_tools: Optional[list[str]] = None,
         refresh_connection: bool = False,
@@ -70,7 +70,7 @@ class MultiMCPTools(Toolkit):
             server_params_list: List of StdioServerParameters or SSEClientParams or StreamableHTTPClientParams for creating new sessions.
             env: The environment variables to pass to the servers. Should be used in conjunction with commands.
             client: The underlying MCP client (optional, used to prevent garbage collection).
-            http_client: The underlying HTTP client for streamable-http transport.
+            httpx_client_factory: Factory for a customized streamable-http transport client.
             timeout_seconds: Timeout in seconds for managing timeouts for Client Session if Agent or Tool doesn't respond.
             include_tools: Optional list of tool names to include (if None, includes all).
             exclude_tools: Optional list of tool names to exclude (if None, excludes none).
@@ -106,7 +106,7 @@ class MultiMCPTools(Toolkit):
         self.refresh_connection = refresh_connection
 
         self.header_provider = header_provider
-        self._http_client = http_client
+        self._httpx_client_factory = httpx_client_factory
 
         # Validate header_provider signature
         if header_provider:
@@ -349,7 +349,9 @@ class MultiMCPTools(Toolkit):
                 client_timeout = min(self.timeout_seconds, params_dict.get("timeout", self.timeout_seconds))
 
             elif isinstance(server_params, StreamableHTTPClientParams):
-                params_dict = streamable_http_client_kwargs(server_params, http_client=self._http_client)
+                params_dict = streamable_http_client_kwargs(
+                    server_params, httpx_client_factory=self._httpx_client_factory
+                )
                 existing_headers = params_dict.get("headers") or {}
                 params_dict["headers"] = {**existing_headers, **dynamic_headers}
 
@@ -552,7 +554,9 @@ class MultiMCPTools(Toolkit):
 
                 # Handle Streamable HTTP connections
                 elif isinstance(server_params, StreamableHTTPClientParams):
-                    streamable_http_params = streamable_http_client_kwargs(server_params, http_client=self._http_client)
+                    streamable_http_params = streamable_http_client_kwargs(
+                        server_params, httpx_client_factory=self._httpx_client_factory
+                    )
                     if init_headers:
                         existing_headers = streamable_http_params.get("headers") or {}
                         streamable_http_params["headers"] = {**existing_headers, **init_headers}

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, 
 
 from agno.tools import Toolkit
 from agno.tools.function import Function
-from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams, streamable_http_client_kwargs
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.mcp import get_entrypoint_for_tool, prepare_command
 
@@ -52,6 +52,7 @@ class MultiMCPTools(Toolkit):
         ] = None,
         timeout_seconds: int = 10,
         client=None,
+        http_client=None,
         include_tools: Optional[list[str]] = None,
         exclude_tools: Optional[list[str]] = None,
         refresh_connection: bool = False,
@@ -69,6 +70,7 @@ class MultiMCPTools(Toolkit):
             server_params_list: List of StdioServerParameters or SSEClientParams or StreamableHTTPClientParams for creating new sessions.
             env: The environment variables to pass to the servers. Should be used in conjunction with commands.
             client: The underlying MCP client (optional, used to prevent garbage collection).
+            http_client: The underlying HTTP client for streamable-http transport.
             timeout_seconds: Timeout in seconds for managing timeouts for Client Session if Agent or Tool doesn't respond.
             include_tools: Optional list of tool names to include (if None, includes all).
             exclude_tools: Optional list of tool names to exclude (if None, excludes none).
@@ -104,6 +106,7 @@ class MultiMCPTools(Toolkit):
         self.refresh_connection = refresh_connection
 
         self.header_provider = header_provider
+        self._http_client = http_client
 
         # Validate header_provider signature
         if header_provider:
@@ -346,7 +349,7 @@ class MultiMCPTools(Toolkit):
                 client_timeout = min(self.timeout_seconds, params_dict.get("timeout", self.timeout_seconds))
 
             elif isinstance(server_params, StreamableHTTPClientParams):
-                params_dict = asdict(server_params)
+                params_dict = streamable_http_client_kwargs(server_params, http_client=self._http_client)
                 existing_headers = params_dict.get("headers") or {}
                 params_dict["headers"] = {**existing_headers, **dynamic_headers}
 
@@ -549,7 +552,7 @@ class MultiMCPTools(Toolkit):
 
                 # Handle Streamable HTTP connections
                 elif isinstance(server_params, StreamableHTTPClientParams):
-                    streamable_http_params = asdict(server_params)
+                    streamable_http_params = streamable_http_client_kwargs(server_params, http_client=self._http_client)
                     if init_headers:
                         existing_headers = streamable_http_params.get("headers") or {}
                         streamable_http_params["headers"] = {**existing_headers, **init_headers}

--- a/libs/agno/agno/tools/mcp/params.py
+++ b/libs/agno/agno/tools/mcp/params.py
@@ -22,14 +22,14 @@ class StreamableHTTPClientParams:
     timeout: Optional[timedelta] = timedelta(seconds=30)
     sse_read_timeout: Optional[timedelta] = timedelta(seconds=60 * 5)
     terminate_on_close: Optional[bool] = None
-    http_client: Optional[Any] = None
+    httpx_client_factory: Optional[Any] = None
 
 
 def streamable_http_client_kwargs(
     server_params: Optional[StreamableHTTPClientParams] = None,
     *,
     url: Optional[str] = None,
-    http_client: Any = None,
+    httpx_client_factory: Any = None,
 ) -> dict[str, Any]:
     """Build kwargs for ``streamablehttp_client`` without copying values."""
     kwargs: dict[str, Any] = {}
@@ -37,13 +37,13 @@ def streamable_http_client_kwargs(
     if server_params is not None:
         for field in fields(StreamableHTTPClientParams):
             value = getattr(server_params, field.name)
-            if field.name == "http_client" and value is None:
+            if field.name == "httpx_client_factory" and value is None:
                 continue
             kwargs[field.name] = value
     elif url is not None:
         kwargs["url"] = url
 
-    if http_client is not None and "http_client" not in kwargs:
-        kwargs["http_client"] = http_client
+    if httpx_client_factory is not None and "httpx_client_factory" not in kwargs:
+        kwargs["httpx_client_factory"] = httpx_client_factory
 
     return kwargs

--- a/libs/agno/agno/tools/mcp/params.py
+++ b/libs/agno/agno/tools/mcp/params.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from datetime import timedelta
 from typing import Any, Dict, Optional
 
@@ -22,3 +22,28 @@ class StreamableHTTPClientParams:
     timeout: Optional[timedelta] = timedelta(seconds=30)
     sse_read_timeout: Optional[timedelta] = timedelta(seconds=60 * 5)
     terminate_on_close: Optional[bool] = None
+    http_client: Optional[Any] = None
+
+
+def streamable_http_client_kwargs(
+    server_params: Optional[StreamableHTTPClientParams] = None,
+    *,
+    url: Optional[str] = None,
+    http_client: Any = None,
+) -> dict[str, Any]:
+    """Build kwargs for ``streamablehttp_client`` without copying values."""
+    kwargs: dict[str, Any] = {}
+
+    if server_params is not None:
+        for field in fields(StreamableHTTPClientParams):
+            value = getattr(server_params, field.name)
+            if field.name == "http_client" and value is None:
+                continue
+            kwargs[field.name] = value
+    elif url is not None:
+        kwargs["url"] = url
+
+    if http_client is not None and "http_client" not in kwargs:
+        kwargs["http_client"] = http_client
+
+    return kwargs

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -909,19 +909,19 @@ def test_mcp_kwargs_escape_hatch_forwards_to_mcptools():
     assert tools.tool_name_prefix == "srv_"
 
 
-def test_mcp_kwargs_http_client_passes_through_unchanged():
-    client = MagicMock()
+def test_mcp_kwargs_httpx_client_factory_passes_through_unchanged():
+    client_factory = MagicMock()
     p = MCPContextProvider(
         "srv",
         transport="streamable-http",
         url="https://example.com/mcp",
-        mcp_kwargs={"http_client": client},
+        mcp_kwargs={"httpx_client_factory": client_factory},
     )
 
     with patch("agno.context.mcp.provider.MCPTools") as mock_mcptools:
         p._build_tools_instance()
 
-    assert mock_mcptools.call_args.kwargs["http_client"] is client
+    assert mock_mcptools.call_args.kwargs["httpx_client_factory"] is client_factory
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine
@@ -906,6 +907,21 @@ def test_mcp_kwargs_escape_hatch_forwards_to_mcptools():
     # User-provided keys win over provider-computed ones (timeout 99 > 5).
     assert tools.timeout_seconds == 99
     assert tools.tool_name_prefix == "srv_"
+
+
+def test_mcp_kwargs_http_client_passes_through_unchanged():
+    client = MagicMock()
+    p = MCPContextProvider(
+        "srv",
+        transport="streamable-http",
+        url="https://example.com/mcp",
+        mcp_kwargs={"http_client": client},
+    )
+
+    with patch("agno.context.mcp.provider.MCPTools") as mock_mcptools:
+        p._build_tools_instance()
+
+    assert mock_mcptools.call_args.kwargs["http_client"] is client
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -202,8 +202,8 @@ def test_call_header_provider_with_team():
 
 
 def test_streamable_http_client_kwargs_preserves_identity_and_fallback_order():
-    params_client = object()
-    fallback_client = object()
+    params_factory = object()
+    fallback_factory = object()
     headers = {"X-Test": "value"}
     timeout = timedelta(seconds=37)
     sse_read_timeout = timedelta(seconds=91)
@@ -213,17 +213,17 @@ def test_streamable_http_client_kwargs_preserves_identity_and_fallback_order():
         timeout=timeout,
         sse_read_timeout=sse_read_timeout,
         terminate_on_close=True,
-        http_client=params_client,
+        httpx_client_factory=params_factory,
     )
 
-    kwargs = streamable_http_client_kwargs(params, http_client=fallback_client)
+    kwargs = streamable_http_client_kwargs(params, httpx_client_factory=fallback_factory)
 
     assert kwargs["url"] == "http://localhost:8080/mcp"
     assert kwargs["headers"] is headers
     assert kwargs["timeout"] is timeout
     assert kwargs["sse_read_timeout"] is sse_read_timeout
     assert kwargs["terminate_on_close"] is True
-    assert kwargs["http_client"] is params_client
+    assert kwargs["httpx_client_factory"] is params_factory
 
     fallback_params = StreamableHTTPClientParams(
         url="http://localhost:8080/mcp",
@@ -231,11 +231,11 @@ def test_streamable_http_client_kwargs_preserves_identity_and_fallback_order():
         timeout=timeout,
         sse_read_timeout=sse_read_timeout,
     )
-    fallback_kwargs = streamable_http_client_kwargs(fallback_params, http_client=fallback_client)
-    assert fallback_kwargs["http_client"] is fallback_client
+    fallback_kwargs = streamable_http_client_kwargs(fallback_params, httpx_client_factory=fallback_factory)
+    assert fallback_kwargs["httpx_client_factory"] is fallback_factory
 
 
-def test_streamable_http_client_kwargs_default_shape_omits_http_client():
+def test_streamable_http_client_kwargs_default_shape_omits_httpx_client_factory():
     headers = {"X-Test": "value"}
     timeout = timedelta(seconds=30)
     sse_read_timeout = timedelta(seconds=300)
@@ -252,7 +252,7 @@ def test_streamable_http_client_kwargs_default_shape_omits_http_client():
     assert kwargs["headers"] is headers
     assert kwargs["timeout"] is timeout
     assert kwargs["sse_read_timeout"] is sse_read_timeout
-    assert "http_client" not in kwargs
+    assert "httpx_client_factory" not in kwargs
 
 
 @pytest.mark.asyncio
@@ -433,13 +433,15 @@ async def test_get_session_for_run_merges_headers_when_streamable_http_headers_d
 
 
 @pytest.mark.asyncio
-async def test_connect_forwards_params_level_http_client_before_constructor_fallback():
-    params_client = object()
-    fallback_client = object()
+async def test_connect_forwards_params_level_httpx_client_factory_before_constructor_fallback():
+    params_factory = object()
+    fallback_factory = object()
     tools = MCPTools(
-        server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp", http_client=params_client),
+        server_params=StreamableHTTPClientParams(
+            url="http://localhost:8080/mcp", httpx_client_factory=params_factory
+        ),
         transport="streamable-http",
-        http_client=fallback_client,
+        httpx_client_factory=fallback_factory,
     )
 
     with (
@@ -450,17 +452,17 @@ async def test_connect_forwards_params_level_http_client_before_constructor_fall
     ):
         await tools._connect()
 
-    assert streamable_mock.call_args.kwargs["http_client"] is params_client
-    assert "http_client" in streamable_mock.call_args.kwargs
+    assert streamable_mock.call_args.kwargs["httpx_client_factory"] is params_factory
+    assert "httpx_client_factory" in streamable_mock.call_args.kwargs
 
 
 @pytest.mark.asyncio
-async def test_connect_forwards_constructor_http_client_when_params_client_missing():
-    constructor_client = object()
+async def test_connect_forwards_constructor_httpx_client_factory_when_params_factory_missing():
+    constructor_factory = object()
     tools = MCPTools(
         url="http://localhost:8080/mcp",
         transport="streamable-http",
-        http_client=constructor_client,
+        httpx_client_factory=constructor_factory,
     )
 
     with (
@@ -471,18 +473,18 @@ async def test_connect_forwards_constructor_http_client_when_params_client_missi
     ):
         await tools._connect()
 
-    assert streamable_mock.call_args.kwargs["http_client"] is constructor_client
+    assert streamable_mock.call_args.kwargs["httpx_client_factory"] is constructor_factory
     assert streamable_mock.call_args.kwargs["url"] == "http://localhost:8080/mcp"
 
 
 @pytest.mark.asyncio
-async def test_multimcp_forwards_per_server_http_client():
-    first_client = object()
-    second_client = object()
+async def test_multimcp_forwards_per_server_httpx_client_factory():
+    first_factory = object()
+    second_factory = object()
     tools = MultiMCPTools(
         server_params_list=[
-            StreamableHTTPClientParams(url="http://localhost:8080/mcp", http_client=first_client),
-            StreamableHTTPClientParams(url="http://localhost:8081/mcp", http_client=second_client),
+            StreamableHTTPClientParams(url="http://localhost:8080/mcp", httpx_client_factory=first_factory),
+            StreamableHTTPClientParams(url="http://localhost:8081/mcp", httpx_client_factory=second_factory),
         ],
     )
     tools._async_exit_stack = _AsyncExitStackStub()
@@ -498,8 +500,8 @@ async def test_multimcp_forwards_per_server_http_client():
     ):
         await tools._connect()
 
-    assert streamable_mock.call_args_list[0].kwargs["http_client"] is first_client
-    assert streamable_mock.call_args_list[1].kwargs["http_client"] is second_client
+    assert streamable_mock.call_args_list[0].kwargs["httpx_client_factory"] is first_factory
+    assert streamable_mock.call_args_list[1].kwargs["httpx_client_factory"] is second_factory
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -403,10 +403,12 @@ async def test_get_session_for_run_merges_headers_when_sse_headers_default_to_no
 
 @pytest.mark.asyncio
 async def test_get_session_for_run_merges_headers_when_streamable_http_headers_default_to_none():
+    constructor_factory = object()
     tools = MCPTools(
         server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp"),
         transport="streamable-http",
         header_provider=lambda run_context: {"Authorization": "Bearer token"},
+        httpx_client_factory=constructor_factory,
     )
     tools.session = MagicMock()
 
@@ -429,6 +431,39 @@ async def test_get_session_for_run_merges_headers_when_streamable_http_headers_d
         session = await tools.get_session_for_run(run_context=run_context)
 
     assert streamable_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+    assert streamable_mock.call_args.kwargs["httpx_client_factory"] is constructor_factory
+    assert session is mock_session
+
+
+@pytest.mark.asyncio
+async def test_multimcp_get_session_for_run_forwards_per_server_httpx_client_factory():
+    factory = object()
+    tools = MultiMCPTools(
+        server_params_list=[StreamableHTTPClientParams(url="http://localhost:8080/mcp")],
+        header_provider=lambda run_context: {"Authorization": "Bearer token"},
+        httpx_client_factory=factory,
+    )
+
+    run_context = MagicMock()
+    run_context.run_id = "multi-run-http-factory"
+
+    with (
+        patch(
+            "agno.tools.mcp.multi_mcp.streamablehttp_client",
+            return_value=_AsyncContextManager(("read", "write")),
+        ) as streamable_mock,
+        patch("agno.tools.mcp.multi_mcp.ClientSession") as mock_session_cls,
+    ):
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session_context = AsyncMock()
+        mock_session_context.__aenter__.return_value = mock_session
+        mock_session_cls.return_value = mock_session_context
+
+        session = await tools.get_session_for_run(run_context=run_context, server_idx=0)
+
+    assert streamable_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+    assert streamable_mock.call_args.kwargs["httpx_client_factory"] is factory
     assert session is mock_session
 
 
@@ -1005,10 +1040,12 @@ async def test_connect_failure_cleans_up_both_contexts_when_session_aenter_fails
 async def test_refresh_connection_tool_call_closes_dynamic_session_without_caching():
     """A refresh_connection call should open and close its HTTP session inside
     the same tool-call task instead of leaving it for later cleanup."""
+    constructor_factory = object()
     tools = MCPTools(
         server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp"),
         transport="streamable-http",
         header_provider=lambda run_context: {"Authorization": f"Bearer {run_context.token}"},
+        httpx_client_factory=constructor_factory,
         refresh_connection=True,
     )
     fallback_session = _make_session_returning("fallback")
@@ -1032,6 +1069,7 @@ async def test_refresh_connection_tool_call_closes_dynamic_session_without_cachi
     dynamic_session.call_tool.assert_awaited_once_with("search_docs", {"query": "anyio"})
     fallback_session.call_tool.assert_not_awaited()
     assert streamable_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer run-token"}
+    assert streamable_mock.call_args.kwargs["httpx_client_factory"] is constructor_factory
     assert session_context.aexit_called
     assert transport_context.aexit_called
     assert tools._run_sessions == {}

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1,5 +1,5 @@
-from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from mcp.types import CallToolResult, TextContent
@@ -270,11 +270,17 @@ async def test_streamable_http_call_sites_route_through_shared_helper():
 
     with (
         patch("agno.tools.mcp.mcp.streamable_http_client_kwargs", return_value=helper_return) as mcp_helper_mock,
-        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))) as mcp_client_mock,
+        patch(
+            "agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))
+        ) as mcp_client_mock,
         patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
         patch.object(MCPTools, "initialize", new=AsyncMock()),
-        patch("agno.tools.mcp.multi_mcp.streamable_http_client_kwargs", return_value=helper_return) as multi_helper_mock,
-        patch("agno.tools.mcp.multi_mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))) as multi_client_mock,
+        patch(
+            "agno.tools.mcp.multi_mcp.streamable_http_client_kwargs", return_value=helper_return
+        ) as multi_helper_mock,
+        patch(
+            "agno.tools.mcp.multi_mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))
+        ) as multi_client_mock,
         patch("agno.tools.mcp.multi_mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
         patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
         patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),
@@ -472,16 +478,15 @@ async def test_connect_forwards_params_level_httpx_client_factory_before_constru
     params_factory = object()
     fallback_factory = object()
     tools = MCPTools(
-        server_params=StreamableHTTPClientParams(
-            url="http://localhost:8080/mcp", httpx_client_factory=params_factory
-        ),
+        server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp", httpx_client_factory=params_factory),
         transport="streamable-http",
         httpx_client_factory=fallback_factory,
     )
 
     with (
-        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write")))
-        as streamable_mock,
+        patch(
+            "agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))
+        ) as streamable_mock,
         patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
         patch.object(MCPTools, "initialize", new=AsyncMock()),
     ):
@@ -501,8 +506,9 @@ async def test_connect_forwards_constructor_httpx_client_factory_when_params_fac
     )
 
     with (
-        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write")))
-        as streamable_mock,
+        patch(
+            "agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))
+        ) as streamable_mock,
         patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
         patch.object(MCPTools, "initialize", new=AsyncMock()),
     ):
@@ -529,7 +535,10 @@ async def test_multimcp_forwards_per_server_httpx_client_factory():
             "agno.tools.mcp.multi_mcp.streamablehttp_client",
             side_effect=lambda **kwargs: _AsyncContextManager(("read", "write")),
         ) as streamable_mock,
-        patch("agno.tools.mcp.multi_mcp.ClientSession", side_effect=lambda *args, **kwargs: _AsyncContextManager(MagicMock())),
+        patch(
+            "agno.tools.mcp.multi_mcp.ClientSession",
+            side_effect=lambda *args, **kwargs: _AsyncContextManager(MagicMock()),
+        ),
         patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
         patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),
     ):

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1,11 +1,12 @@
 from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import timedelta
 
 import pytest
 from mcp.types import CallToolResult, TextContent
 
 from agno.tools.function import Function, FunctionCall, ToolResult
 from agno.tools.mcp import MCPTools, MultiMCPTools
-from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams, streamable_http_client_kwargs
 from agno.utils.mcp import get_entrypoint_for_tool
 
 
@@ -200,6 +201,95 @@ def test_call_header_provider_with_team():
     assert result == {"X-Agent": "member-agent", "X-Team": "test-team"}
 
 
+def test_streamable_http_client_kwargs_preserves_identity_and_fallback_order():
+    params_client = object()
+    fallback_client = object()
+    headers = {"X-Test": "value"}
+    timeout = timedelta(seconds=37)
+    sse_read_timeout = timedelta(seconds=91)
+    params = StreamableHTTPClientParams(
+        url="http://localhost:8080/mcp",
+        headers=headers,
+        timeout=timeout,
+        sse_read_timeout=sse_read_timeout,
+        terminate_on_close=True,
+        http_client=params_client,
+    )
+
+    kwargs = streamable_http_client_kwargs(params, http_client=fallback_client)
+
+    assert kwargs["url"] == "http://localhost:8080/mcp"
+    assert kwargs["headers"] is headers
+    assert kwargs["timeout"] is timeout
+    assert kwargs["sse_read_timeout"] is sse_read_timeout
+    assert kwargs["terminate_on_close"] is True
+    assert kwargs["http_client"] is params_client
+
+    fallback_params = StreamableHTTPClientParams(
+        url="http://localhost:8080/mcp",
+        headers=headers,
+        timeout=timeout,
+        sse_read_timeout=sse_read_timeout,
+    )
+    fallback_kwargs = streamable_http_client_kwargs(fallback_params, http_client=fallback_client)
+    assert fallback_kwargs["http_client"] is fallback_client
+
+
+def test_streamable_http_client_kwargs_default_shape_omits_http_client():
+    headers = {"X-Test": "value"}
+    timeout = timedelta(seconds=30)
+    sse_read_timeout = timedelta(seconds=300)
+    params = StreamableHTTPClientParams(
+        url="http://localhost:8080/mcp",
+        headers=headers,
+        timeout=timeout,
+        sse_read_timeout=sse_read_timeout,
+    )
+
+    kwargs = streamable_http_client_kwargs(params)
+
+    assert set(kwargs) == {"url", "headers", "timeout", "sse_read_timeout", "terminate_on_close"}
+    assert kwargs["headers"] is headers
+    assert kwargs["timeout"] is timeout
+    assert kwargs["sse_read_timeout"] is sse_read_timeout
+    assert "http_client" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_streamable_http_call_sites_route_through_shared_helper():
+    helper_return = {"url": "http://localhost:8080/mcp", "headers": {}}
+
+    mcp_tools = MCPTools(
+        server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp"),
+        transport="streamable-http",
+    )
+    multimcp_tools = MultiMCPTools(
+        server_params_list=[StreamableHTTPClientParams(url="http://localhost:8081/mcp")],
+    )
+    multimcp_tools._async_exit_stack = _AsyncExitStackStub()
+
+    with (
+        patch("agno.tools.mcp.mcp.streamable_http_client_kwargs", return_value=helper_return) as mcp_helper_mock,
+        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))) as mcp_client_mock,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MCPTools, "initialize", new=AsyncMock()),
+        patch("agno.tools.mcp.multi_mcp.streamable_http_client_kwargs", return_value=helper_return) as multi_helper_mock,
+        patch("agno.tools.mcp.multi_mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write"))) as multi_client_mock,
+        patch("agno.tools.mcp.multi_mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
+        patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),
+    ):
+        await mcp_tools._connect()
+        await multimcp_tools._connect()
+
+    assert mcp_helper_mock.called
+    assert multi_helper_mock.called
+    assert mcp_client_mock.call_args.args == ()
+    assert mcp_client_mock.call_args.kwargs == helper_return
+    assert multi_client_mock.call_args.args == ()
+    assert multi_client_mock.call_args.kwargs == helper_return
+
+
 @pytest.mark.asyncio
 async def test_connect_merges_init_headers_when_streamable_http_headers_default_to_none():
     tools = MCPTools(
@@ -340,6 +430,76 @@ async def test_get_session_for_run_merges_headers_when_streamable_http_headers_d
 
     assert streamable_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
     assert session is mock_session
+
+
+@pytest.mark.asyncio
+async def test_connect_forwards_params_level_http_client_before_constructor_fallback():
+    params_client = object()
+    fallback_client = object()
+    tools = MCPTools(
+        server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp", http_client=params_client),
+        transport="streamable-http",
+        http_client=fallback_client,
+    )
+
+    with (
+        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write")))
+        as streamable_mock,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MCPTools, "initialize", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert streamable_mock.call_args.kwargs["http_client"] is params_client
+    assert "http_client" in streamable_mock.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_connect_forwards_constructor_http_client_when_params_client_missing():
+    constructor_client = object()
+    tools = MCPTools(
+        url="http://localhost:8080/mcp",
+        transport="streamable-http",
+        http_client=constructor_client,
+    )
+
+    with (
+        patch("agno.tools.mcp.mcp.streamablehttp_client", return_value=_AsyncContextManager(("read", "write")))
+        as streamable_mock,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MCPTools, "initialize", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert streamable_mock.call_args.kwargs["http_client"] is constructor_client
+    assert streamable_mock.call_args.kwargs["url"] == "http://localhost:8080/mcp"
+
+
+@pytest.mark.asyncio
+async def test_multimcp_forwards_per_server_http_client():
+    first_client = object()
+    second_client = object()
+    tools = MultiMCPTools(
+        server_params_list=[
+            StreamableHTTPClientParams(url="http://localhost:8080/mcp", http_client=first_client),
+            StreamableHTTPClientParams(url="http://localhost:8081/mcp", http_client=second_client),
+        ],
+    )
+    tools._async_exit_stack = _AsyncExitStackStub()
+
+    with (
+        patch(
+            "agno.tools.mcp.multi_mcp.streamablehttp_client",
+            side_effect=lambda **kwargs: _AsyncContextManager(("read", "write")),
+        ) as streamable_mock,
+        patch("agno.tools.mcp.multi_mcp.ClientSession", side_effect=lambda *args, **kwargs: _AsyncContextManager(MagicMock())),
+        patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
+        patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert streamable_mock.call_args_list[0].kwargs["http_client"] is first_client
+    assert streamable_mock.call_args_list[1].kwargs["http_client"] is second_client
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

MCP streamable HTTP connections currently stop at Agno's transport wrapper, so callers cannot pass a preconfigured `httpx.AsyncClient` into the official MCP SDK client helper. That blocks the two concrete workflows raised in the issue: disabling TLS verification for local development and supplying a custom CA bundle path for enterprise MCP servers.

Add explicit `httpx_client_factory` support to `StreamableHTTPClientParams`, `MCPTools`, and `MultiMCPTools`, then route that factory through the stable SDK's `streamablehttp_client(..., httpx_client_factory=...)` seam. Scope stays inside streamable HTTP transport configuration; SSE, stdio, and unrelated web backends are unchanged.

Closes #7741

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Prior art: [issue #5812](https://github.com/agno-agi/agno/issues/5812) and [PR #5815](https://github.com/agno-agi/agno/pull/5815) identified the same need for custom HTTP client support on MCP tools, but the PR closed before merge.

This implementation follows the current MCP Python SDK contract by forwarding `httpx_client_factory` through Agno's streamable HTTP transport helpers instead of adding Agno-only TLS fields. Users who need certificate control can pass a preconfigured `httpx.AsyncClient`, including `httpx.AsyncClient(verify=False)` for local development or `httpx.AsyncClient(verify="/path/to/ca.pem")` for custom CA bundles.

`MultiMCPTools` accepts the same constructor-level `httpx_client_factory` fallback for URL-generated streamable HTTP entries, while `server_params_list` remains the per-server override surface when different MCP endpoints need different factories.

Verification on this branch:

- `pytest libs/agno/tests/unit/tools/test_mcp.py libs/agno/tests/unit/context/test_providers.py -q` — 150 passed
- `./scripts/format.sh` — passed, reformatted `cookbook/91_tools/mcp/streamable_http_transport/client.py` and `libs/agno/tests/unit/tools/test_mcp.py`
- `./scripts/validate.sh` — ruff passed for all packages, mypy passed for libs/agno_infra; libs/agno mypy has 6 pre-existing upstream errors unrelated to this patch
