### PR TITLE
docs: fix approvals cookbook run command

### DIFF
--- a/cookbook/02_agents/11_approvals/README.md
+++ b/cookbook/02_agents/11_approvals/README.md
@@ -53,5 +53,5 @@ Creates an approval record **after** the HITL interaction resolves. The record h
 ## Running
 
 ```bash
-.venvs/demo/bin/python cookbook/02_agents/human_in_the_loop/approvals/approval_basic.py
+.venvs/demo/bin/python cookbook/02_agents/11_approvals/approval_basic.py
 ```


### PR DESCRIPTION
﻿## Summary

Fixes the run command in the human approvals cookbook README.

The previous command pointed to an old `human_in_the_loop/approvals` path that no longer exists. The approval example is available in the current `11_approvals` cookbook directory.

## Verification

- `Test-Path cookbook\02_agents\11_approvals\approval_basic.py`
- `python -m py_compile cookbook\02_agents\11_approvals\approval_basic.py`
- `git diff --check`
