### PR TITLE
[codex] restore RunStatus in run output deserialization

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -10,7 +10,7 @@ from agno.models.message import Citations, Message
 from agno.models.metrics import RunMetrics
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
-from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus
+from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus, deserialize_run_status
 from agno.run.requirement import RunRequirement
 from agno.utils.log import log_error
 from agno.utils.media import (
@@ -922,6 +922,8 @@ class RunOutput:
 
         supported_fields = {f.name for f in fields(cls)}
         filtered_data = {k: v for k, v in data.items() if k in supported_fields}
+        if "status" in filtered_data:
+            filtered_data["status"] = deserialize_run_status(filtered_data["status"])
 
         return cls(
             messages=messages,

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -335,3 +335,16 @@ class RunStatus(str, Enum):
     # history-builders can skip it when rebuilding context. Pass replace_original=false
     # to keep the original COMPLETED and visible instead.
     regenerated = "REGENERATED"
+
+
+def deserialize_run_status(status: Any) -> Any:
+    if status is None or isinstance(status, RunStatus):
+        return status
+
+    if isinstance(status, str):
+        try:
+            return RunStatus(status)
+        except ValueError:
+            return status
+
+    return status

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -11,7 +11,7 @@ from agno.models.metrics import RunMetrics
 from agno.models.response import ToolExecution
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import RunEvent, RunOutput, RunOutputEvent, run_output_event_from_dict
-from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus
+from agno.run.base import BaseRunOutputEvent, MessageReferences, RunStatus, deserialize_run_status
 from agno.run.requirement import RunRequirement
 from agno.utils.log import log_error
 from agno.utils.media import (
@@ -1003,6 +1003,8 @@ class TeamRunOutput:
 
         supported_fields = {f.name for f in fields(cls)}
         filtered_data = {k: v for k, v in data.items() if k in supported_fields}
+        if "status" in filtered_data:
+            filtered_data["status"] = deserialize_run_status(filtered_data["status"])
 
         return cls(
             messages=messages,

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
 from agno.run.agent import RunEvent, RunOutput, run_output_event_from_dict
-from agno.run.base import BaseRunOutputEvent, RunStatus
+from agno.run.base import BaseRunOutputEvent, RunStatus, deserialize_run_status
 from agno.run.team import TeamRunEvent, TeamRunOutput, team_run_output_event_from_dict
 from agno.utils.log import log_warning
 from agno.utils.media import (
@@ -1032,6 +1032,8 @@ class WorkflowRunOutput:
 
         supported_fields = {f.name for f in fields(cls)}
         filtered_data = {k: v for k, v in data.items() if k in supported_fields}
+        if "status" in filtered_data:
+            filtered_data["status"] = deserialize_run_status(filtered_data["status"])
 
         result = cls(
             step_results=parsed_step_results,

--- a/libs/agno/tests/unit/run/test_run_output_status.py
+++ b/libs/agno/tests/unit/run/test_run_output_status.py
@@ -1,0 +1,37 @@
+import pytest
+
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+
+
+@pytest.mark.parametrize(
+    ("output_cls", "kwargs"),
+    [
+        (RunOutput, {"run_id": "agent-run-1"}),
+        (TeamRunOutput, {"run_id": "team-run-1", "team_id": "team-1"}),
+        (WorkflowRunOutput, {"run_id": "workflow-run-1", "workflow_id": "workflow-1"}),
+    ],
+)
+def test_run_output_from_dict_restores_run_status_enum(output_cls, kwargs):
+    run_output = output_cls(status=RunStatus.completed, **kwargs)
+
+    restored = output_cls.from_dict(run_output.to_dict())
+
+    assert restored.status is RunStatus.completed
+    assert restored.status.value == "COMPLETED"
+
+
+@pytest.mark.parametrize(
+    ("output_cls", "kwargs"),
+    [
+        (RunOutput, {"run_id": "agent-run-1"}),
+        (TeamRunOutput, {"run_id": "team-run-1", "team_id": "team-1"}),
+        (WorkflowRunOutput, {"run_id": "workflow-run-1", "workflow_id": "workflow-1"}),
+    ],
+)
+def test_run_output_from_dict_preserves_unknown_status_string(output_cls, kwargs):
+    restored = output_cls.from_dict({"status": "LEGACY_STATUS", **kwargs})
+
+    assert restored.status == "LEGACY_STATUS"


### PR DESCRIPTION
## Summary
- Restore serialized run status strings back to `RunStatus` in agent, team, and workflow `from_dict()` paths.
- Preserve unknown/legacy status strings unchanged instead of coercing them to a default.
- Add regression coverage for all three run output classes.

Fixes #8454

## Testing
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/run/test_run_output_status.py`
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/run/test_run_events.py`
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/run`
- `uvx ruff==0.14.3 check libs/agno/agno/run/base.py libs/agno/agno/run/agent.py libs/agno/agno/run/team.py libs/agno/agno/run/workflow.py libs/agno/tests/unit/run/test_run_output_status.py`