### PR TITLE
[codex] accept singular migration table type aliases

### DIFF
--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -18,12 +18,46 @@ class MigrationManager:
         ("v2_5_6", packaging_version.parse("2.5.6")),
     ]
 
+    _table_type_to_attr = {
+        "memories": "memory_table_name",
+        "sessions": "session_table_name",
+        "metrics": "metrics_table_name",
+        "evals": "eval_table_name",
+        "knowledge": "knowledge_table_name",
+        "culture": "culture_table_name",
+        "approvals": "approvals_table_name",
+    }
+
+    _table_type_aliases = {
+        "memory": "memories",
+        "session": "sessions",
+        "eval": "evals",
+    }
+
     def __init__(self, db: Union[AsyncBaseDb, BaseDb]):
         self.db = db
 
     @property
     def latest_schema_version(self) -> Version:
         return self.available_versions[-1][1]
+
+    @classmethod
+    def _normalize_table_type(cls, table_type: str) -> str:
+        return cls._table_type_aliases.get(table_type, table_type)
+
+    @classmethod
+    def _valid_table_types(cls) -> str:
+        return ", ".join([*cls._table_type_to_attr.keys(), *cls._table_type_aliases.keys()])
+
+    def _get_tables(self, table_type: Optional[str] = None):
+        if table_type:
+            normalized_table_type = self._normalize_table_type(table_type)
+            if normalized_table_type not in self._table_type_to_attr:
+                log_warning(f"Invalid table type: {table_type}. Use one of: {self._valid_table_types()}")
+                return None
+            return [(normalized_table_type, getattr(self.db, self._table_type_to_attr[normalized_table_type]))]
+
+        return [(tt, getattr(self.db, attr)) for tt, attr in self._table_type_to_attr.items()]
 
     async def up(self, target_version: Optional[str] = None, table_type: Optional[str] = None, force: bool = False):
         """Handle executing an up migration.
@@ -42,25 +76,10 @@ class MigrationManager:
         else:
             _target_version = packaging_version.parse(target_version)
 
-        # Mapping from table_type to db attribute name
-        _table_type_to_attr = {
-            "memories": "memory_table_name",
-            "sessions": "session_table_name",
-            "metrics": "metrics_table_name",
-            "evals": "eval_table_name",
-            "knowledge": "knowledge_table_name",
-            "culture": "culture_table_name",
-            "approvals": "approvals_table_name",
-        }
-
         # Select tables to migrate
-        if table_type:
-            if table_type not in _table_type_to_attr:
-                log_warning(f"Invalid table type: {table_type}. Use one of: {', '.join(_table_type_to_attr.keys())}")
-                return
-            tables = [(table_type, getattr(self.db, _table_type_to_attr[table_type]))]
-        else:
-            tables = [(tt, getattr(self.db, attr)) for tt, attr in _table_type_to_attr.items()]
+        tables = self._get_tables(table_type)
+        if tables is None:
+            return
 
         # Handle migrations for each table separately (extend in future if needed):
         for table_type, table_name in tables:
@@ -135,25 +154,10 @@ class MigrationManager:
         """
         _target_version = packaging_version.parse(target_version)
 
-        # Mapping from table_type to db attribute name
-        _table_type_to_attr = {
-            "memories": "memory_table_name",
-            "sessions": "session_table_name",
-            "metrics": "metrics_table_name",
-            "evals": "eval_table_name",
-            "knowledge": "knowledge_table_name",
-            "culture": "culture_table_name",
-            "approvals": "approvals_table_name",
-        }
-
         # Select tables to migrate
-        if table_type:
-            if table_type not in _table_type_to_attr:
-                log_warning(f"Invalid table type: {table_type}. Use one of: {', '.join(_table_type_to_attr.keys())}")
-                return
-            tables = [(table_type, getattr(self.db, _table_type_to_attr[table_type]))]
-        else:
-            tables = [(tt, getattr(self.db, attr)) for tt, attr in _table_type_to_attr.items()]
+        tables = self._get_tables(table_type)
+        if tables is None:
+            return
 
         for table_type, table_name in tables:
             if isinstance(self.db, AsyncBaseDb):

--- a/libs/agno/tests/unit/db/test_migration_manager.py
+++ b/libs/agno/tests/unit/db/test_migration_manager.py
@@ -1,0 +1,83 @@
+import pytest
+
+from agno.db.migrations.manager import MigrationManager
+
+
+class DummyDb:
+    memory_table_name = "agno_memories"
+    session_table_name = "agno_sessions"
+    metrics_table_name = "agno_metrics"
+    eval_table_name = "agno_evals"
+    knowledge_table_name = "agno_knowledge"
+    culture_table_name = "agno_culture"
+    approvals_table_name = "agno_approvals"
+
+    def __init__(self, schema_version: str):
+        self.schema_version = schema_version
+        self.schema_version_requests = []
+        self.upserted_versions = []
+
+    def get_latest_schema_version(self, table_name: str) -> str:
+        self.schema_version_requests.append(table_name)
+        return self.schema_version
+
+    def upsert_schema_version(self, table_name: str, version: str) -> None:
+        self.upserted_versions.append((table_name, version))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("table_type", "expected_table_type", "expected_table_name"),
+    [
+        ("memory", "memories", "agno_memories"),
+        ("session", "sessions", "agno_sessions"),
+        ("eval", "evals", "agno_evals"),
+    ],
+)
+async def test_up_accepts_singular_table_type_aliases(
+    monkeypatch, table_type, expected_table_type, expected_table_name
+):
+    db = DummyDb(schema_version="2.0.0")
+    manager = MigrationManager(db)  # type: ignore[arg-type]
+    migration_calls = []
+
+    async def fake_up_migration(version: str, table_type: str, table_name: str) -> bool:
+        migration_calls.append((version, table_type, table_name))
+        return True
+
+    monkeypatch.setattr(manager, "_up_migration", fake_up_migration)
+
+    await manager.up(target_version="2.3.0", table_type=table_type)
+
+    assert migration_calls == [("v2_3_0", expected_table_type, expected_table_name)]
+    assert db.schema_version_requests == [expected_table_name]
+    assert db.upserted_versions == [(expected_table_name, "2.3.0")]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("table_type", "expected_table_type", "expected_table_name"),
+    [
+        ("memory", "memories", "agno_memories"),
+        ("session", "sessions", "agno_sessions"),
+        ("eval", "evals", "agno_evals"),
+    ],
+)
+async def test_down_accepts_singular_table_type_aliases(
+    monkeypatch, table_type, expected_table_type, expected_table_name
+):
+    db = DummyDb(schema_version="2.5.6")
+    manager = MigrationManager(db)  # type: ignore[arg-type]
+    migration_calls = []
+
+    async def fake_down_migration(version: str, table_type: str, table_name: str) -> bool:
+        migration_calls.append((version, table_type, table_name))
+        return True
+
+    monkeypatch.setattr(manager, "_down_migration", fake_down_migration)
+
+    await manager.down(target_version="2.5.0", table_type=table_type)
+
+    assert migration_calls == [("v2_5_6", expected_table_type, expected_table_name)]
+    assert db.schema_version_requests == [expected_table_name]
+    assert db.upserted_versions == [(expected_table_name, "2.5.0")]


### PR DESCRIPTION
## Summary
- Normalize documented singular migration `table_type` values (`memory`, `session`, `eval`) to the existing plural internal keys.
- Share table selection between `MigrationManager.up()` and `MigrationManager.down()` so validation stays consistent.
- Add regression tests for singular aliases in both up and down migration paths.

Fixes #8595

## Testing
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/db/test_migration_manager.py`
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/db/test_migration_v2_5_0_dispatch.py`
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/db/test_migration_manager.py libs/agno/tests/unit/db/test_migration_v2_5_0_dispatch.py`
- `uvx ruff==0.14.3 check libs/agno/agno/db/migrations/manager.py libs/agno/tests/unit/db/test_migration_manager.py`