### PR TITLE
[codex] close pickle helper file handles

### DIFF
--- a/libs/agno/agno/utils/pickle.py
+++ b/libs/agno/agno/utils/pickle.py
@@ -11,7 +11,8 @@ def pickle_object_to_file(obj: Any, file_path: Path) -> Any:
     _obj_parent = file_path.parent
     if not _obj_parent.exists():
         _obj_parent.mkdir(parents=True, exist_ok=True)
-    pickle.dump(obj, file_path.open("wb"))
+    with file_path.open("wb") as f:
+        pickle.dump(obj, f)
 
 
 def unpickle_object_from_file(file_path: Path, verify_class: Optional[Any] = None) -> Any:
@@ -23,7 +24,8 @@ def unpickle_object_from_file(file_path: Path, verify_class: Optional[Any] = Non
     _obj = None
     # log_debug(f"Reading {file_path}")
     if file_path.exists() and file_path.is_file():
-        _obj = pickle.load(file_path.open("rb"))
+        with file_path.open("rb") as f:
+            _obj = pickle.load(f)
 
     if _obj and verify_class and not isinstance(_obj, verify_class):
         logger.warning(f"Object does not match {verify_class}")

--- a/libs/agno/tests/unit/utils/test_pickle.py
+++ b/libs/agno/tests/unit/utils/test_pickle.py
@@ -1,0 +1,50 @@
+import io
+import pickle
+from pathlib import Path
+
+from agno.utils.pickle import pickle_object_to_file, unpickle_object_from_file
+
+
+def test_pickle_helpers_roundtrip_object(tmp_path):
+    file_path = tmp_path / "nested" / "object.pkl"
+    obj = {"name": "agno", "values": [1, 2, 3]}
+
+    pickle_object_to_file(obj, file_path)
+
+    assert unpickle_object_from_file(file_path, verify_class=dict) == obj
+    assert unpickle_object_from_file(file_path, verify_class=list) is None
+
+
+def test_pickle_object_to_file_closes_file_handle(monkeypatch, tmp_path):
+    opened_files = []
+
+    def fake_open(self, mode="r", *args, **kwargs):
+        assert mode == "wb"
+        opened_file = io.BytesIO()
+        opened_files.append(opened_file)
+        return opened_file
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    pickle_object_to_file({"ok": True}, tmp_path / "object.pkl")
+
+    assert len(opened_files) == 1
+    assert opened_files[0].closed is True
+
+
+def test_unpickle_object_from_file_closes_file_handle(monkeypatch, tmp_path):
+    file_path = tmp_path / "object.pkl"
+    file_path.touch()
+    opened_files = []
+
+    def fake_open(self, mode="r", *args, **kwargs):
+        assert mode == "rb"
+        opened_file = io.BytesIO(pickle.dumps({"ok": True}))
+        opened_files.append(opened_file)
+        return opened_file
+
+    monkeypatch.setattr(Path, "open", fake_open)
+
+    assert unpickle_object_from_file(file_path) == {"ok": True}
+    assert len(opened_files) == 1
+    assert opened_files[0].closed is True


### PR DESCRIPTION
## Summary
- Use context managers in `agno.utils.pickle` so pickle read/write helpers close file handles promptly.
- Add regression coverage for round-trip behavior and explicit handle closure on both write and read paths.

Fixes #7405

Note: the `OpenAITools.transcribe_audio()` path mentioned in the issue already uses a `with open(...)` block on current `main`, so this PR fixes the remaining affected pickle helper paths.

## Testing
- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/utils/test_pickle.py`
- `uvx ruff==0.14.3 check libs/agno/agno/utils/pickle.py libs/agno/tests/unit/utils/test_pickle.py`
- `git diff --check`