### PR TITLE
[fix] Preserve AG-UI tool result history

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/input.py
+++ b/libs/agno/agno/os/interfaces/agui/input.py
@@ -28,9 +28,10 @@ def has_tool_state(messages: List[AGUIMessage]) -> bool:
 def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
     """Convert AG-UI messages into Agno messages while preserving tool state."""
     converted_messages: List[Message] = []
+    tool_names_by_call_id: Dict[str, str] = {}
 
     for msg in messages:
-        converted_message = _convert_agui_message_to_agno_message(msg)
+        converted_message = _convert_agui_message_to_agno_message(msg, tool_names_by_call_id)
         if converted_message is not None:
             converted_messages.append(converted_message)
 
@@ -207,7 +208,9 @@ def parse_client_tools(agui_tools: Optional[List[AGUITool]]) -> List[Function]:
     ]
 
 
-def _convert_agui_message_to_agno_message(message: AGUIMessage) -> Optional[Message]:
+def _convert_agui_message_to_agno_message(
+    message: AGUIMessage, tool_names_by_call_id: Dict[str, str]
+) -> Optional[Message]:
     role = message.role
 
     if role == "user":
@@ -224,7 +227,17 @@ def _convert_agui_message_to_agno_message(message: AGUIMessage) -> Optional[Mess
         )
 
     if role == "assistant":
-        tool_calls = [_convert_agui_tool_call(tool_call) for tool_call in getattr(message, "tool_calls", []) or []]
+        tool_calls: List[Dict[str, Any]] = []
+        for tool_call in getattr(message, "tool_calls", []) or []:
+            converted_tool_call = _convert_agui_tool_call(tool_call)
+            tool_calls.append(converted_tool_call)
+
+            tool_call_id = converted_tool_call.get("id")
+            function = converted_tool_call.get("function") or {}
+            tool_name = function.get("name")
+            if tool_call_id and tool_name:
+                tool_names_by_call_id[tool_call_id] = tool_name
+
         return Message(
             id=message.id,
             role="assistant",
@@ -240,6 +253,7 @@ def _convert_agui_message_to_agno_message(message: AGUIMessage) -> Optional[Mess
             role="tool",
             content=message.content,
             tool_call_id=message.tool_call_id,
+            tool_name=tool_names_by_call_id.get(message.tool_call_id),
             tool_call_error=bool(tool_error),
         )
 

--- a/libs/agno/agno/os/interfaces/agui/input.py
+++ b/libs/agno/agno/os/interfaces/agui/input.py
@@ -10,8 +10,31 @@ from ag_ui.core.types import ToolMessage as AGUIToolMessage
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
+from agno.models.message import Message
 from agno.tools.function import Function
 from agno.utils.log import log_warning
+
+
+def has_tool_state(messages: List[AGUIMessage]) -> bool:
+    """Return True when AG-UI history carries tool calls or tool results."""
+    for msg in messages:
+        if msg.role == "tool":
+            return True
+        if msg.role == "assistant" and getattr(msg, "tool_calls", None):
+            return True
+    return False
+
+
+def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
+    """Convert AG-UI messages into Agno messages while preserving tool state."""
+    converted_messages: List[Message] = []
+
+    for msg in messages:
+        converted_message = _convert_agui_message_to_agno_message(msg)
+        if converted_message is not None:
+            converted_messages.append(converted_message)
+
+    return converted_messages
 
 
 def extract_user_input(messages: List[AGUIMessage]) -> str:
@@ -182,3 +205,80 @@ def parse_client_tools(agui_tools: Optional[List[AGUITool]]) -> List[Function]:
         )
         for tool in agui_tools
     ]
+
+
+def _convert_agui_message_to_agno_message(message: AGUIMessage) -> Optional[Message]:
+    role = message.role
+
+    if role == "user":
+        images, audio, videos, files = extract_media([message])
+        return Message(
+            id=message.id,
+            role="user",
+            content=_extract_agui_text_content(message.content),
+            name=getattr(message, "name", None),
+            images=images or None,
+            audio=audio or None,
+            videos=videos or None,
+            files=files or None,
+        )
+
+    if role == "assistant":
+        tool_calls = [_convert_agui_tool_call(tool_call) for tool_call in getattr(message, "tool_calls", []) or []]
+        return Message(
+            id=message.id,
+            role="assistant",
+            content=message.content,
+            name=getattr(message, "name", None),
+            tool_calls=tool_calls or None,
+        )
+
+    if role == "tool":
+        tool_error = getattr(message, "error", None)
+        return Message(
+            id=message.id,
+            role="tool",
+            content=message.content,
+            tool_call_id=message.tool_call_id,
+            tool_call_error=bool(tool_error),
+        )
+
+    if role in ("system", "developer"):
+        return Message(
+            id=message.id,
+            role=role,
+            content=message.content,
+            name=getattr(message, "name", None),
+        )
+
+    return None
+
+
+def _extract_agui_text_content(content: Any) -> Optional[str]:
+    if content is None or isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        text_parts: List[str] = []
+        for part in content:
+            if hasattr(part, "type") and part.type == "text" and hasattr(part, "text"):
+                text_parts.append(part.text)
+        return "\n".join(text_parts)
+
+    return str(content)
+
+
+def _convert_agui_tool_call(tool_call: Any) -> Dict[str, Any]:
+    function = getattr(tool_call, "function", None)
+    converted: Dict[str, Any] = {
+        "id": tool_call.id,
+        "type": getattr(tool_call, "type", "function"),
+    }
+
+    if function is not None:
+        converted["function"] = {
+            "name": function.name,
+            "arguments": function.arguments,
+        }
+
+    return converted

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -22,10 +22,12 @@ from fastapi.responses import StreamingResponse
 
 from agno.agent import Agent, RemoteAgent
 from agno.os.interfaces.agui.input import (
+    convert_agui_messages_to_agno_messages,
     extract_context,
     extract_media,
     extract_tool_messages,
     extract_user_input,
+    has_tool_state,
     parse_client_tools,
     validate_state,
 )
@@ -54,12 +56,23 @@ async def run_entity(
         messages = run_input.messages or []
 
         # 1. Extract inputs from AG-UI message history
-        user_input = extract_user_input(messages)
-        images, audio, videos, files = extract_media(messages)
         tool_messages = extract_tool_messages(messages)
 
         # 2. Convert frontend tool definitions to Agno Functions
         client_tools = parse_client_tools(run_input.tools) or None
+
+        # AG-UI frontends send full conversation history every request.
+        # For plain turns, extract only the latest user message and let the
+        # entity manage history through its session DB. Non-trailing tool
+        # history must be replayed as a full transcript; trailing tool results
+        # are handled by the paused-run resume path below.
+        use_full_message_history = has_tool_state(messages) and not tool_messages
+        if use_full_message_history:
+            user_input = convert_agui_messages_to_agno_messages(messages)
+            images, audio, videos, files = [], [], [], []
+        else:
+            user_input = extract_user_input(messages)
+            images, audio, videos, files = extract_media(messages)
 
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
@@ -83,6 +96,8 @@ async def run_entity(
         run_kwargs: dict = {}
         if ui_deps:
             run_kwargs["add_dependencies_to_context"] = True
+        if use_full_message_history:
+            run_kwargs["add_history_to_context"] = False
 
         # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
         if tool_messages:

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -915,25 +915,31 @@ def _get_run_messages(
             # Extend the messages with the history
             run_messages.messages += history_copy
 
-    # 5. Add user message to run_messages (message second as per Dirk's requirement)
-    # 5.1 Build user message if message is None, str or list
-    user_message = _get_user_message(
-        team,
-        run_response=run_response,
-        run_context=run_context,
-        input_message=input_message,
-        user_id=user_id,
-        audio=audio,
-        images=images,
-        videos=videos,
-        files=files,
-        add_dependencies_to_context=add_dependencies_to_context,
-        **kwargs,
-    )
+    # 5. Add user/input messages to run_messages.
+    input_is_message_list = _is_message_list_input(input_message)
+    if input_is_message_list:
+        user_message = _add_input_messages_to_run_messages(
+            run_messages, cast(List[Union[Message, Dict[str, Any]]], input_message)
+        )
+    else:
+        user_message = _get_user_message(
+            team,
+            run_response=run_response,
+            run_context=run_context,
+            input_message=input_message,
+            user_id=user_id,
+            audio=audio,
+            images=images,
+            videos=videos,
+            files=files,
+            add_dependencies_to_context=add_dependencies_to_context,
+            **kwargs,
+        )
     # Add user message to run_messages
     if user_message is not None:
         run_messages.user_message = user_message
-        run_messages.messages.append(user_message)
+        if not input_is_message_list:
+            run_messages.messages.append(user_message)
 
     # Set messages on run_context so tool hooks can access the current message history
     run_context.messages = run_messages.messages
@@ -1049,30 +1055,76 @@ async def _aget_run_messages(
             # Extend the messages with the history
             run_messages.messages += history_copy
 
-    # 5. Add user message to run_messages (message second as per Dirk's requirement)
-    # 5.1 Build user message if message is None, str or list
-    user_message = await _aget_user_message(
-        team,
-        run_response=run_response,
-        run_context=run_context,
-        input_message=input_message,
-        user_id=user_id,
-        audio=audio,
-        images=images,
-        videos=videos,
-        files=files,
-        add_dependencies_to_context=add_dependencies_to_context,
-        **kwargs,
-    )
+    # 5. Add user/input messages to run_messages.
+    input_is_message_list = _is_message_list_input(input_message)
+    if input_is_message_list:
+        user_message = _add_input_messages_to_run_messages(
+            run_messages, cast(List[Union[Message, Dict[str, Any]]], input_message)
+        )
+    else:
+        user_message = await _aget_user_message(
+            team,
+            run_response=run_response,
+            run_context=run_context,
+            input_message=input_message,
+            user_id=user_id,
+            audio=audio,
+            images=images,
+            videos=videos,
+            files=files,
+            add_dependencies_to_context=add_dependencies_to_context,
+            **kwargs,
+        )
     # Add user message to run_messages
     if user_message is not None:
         run_messages.user_message = user_message
-        run_messages.messages.append(user_message)
+        if not input_is_message_list:
+            run_messages.messages.append(user_message)
 
     # Set messages on run_context so tool hooks can access the current message history
     run_context.messages = run_messages.messages
 
     return run_messages
+
+
+def _is_message_list_input(input_message: Any) -> bool:
+    return (
+        isinstance(input_message, list)
+        and len(input_message) > 0
+        and (
+            isinstance(input_message[0], Message) or (isinstance(input_message[0], dict) and "role" in input_message[0])
+        )
+    )
+
+
+def _add_input_messages_to_run_messages(
+    run_messages: RunMessages,
+    input_messages: List[Union[Message, Dict[str, Any]]],
+) -> Optional[Message]:
+    user_message: Optional[Message] = None
+
+    for input_message in input_messages:
+        message: Optional[Message] = None
+        if isinstance(input_message, Message):
+            message = input_message
+        elif isinstance(input_message, dict):
+            try:
+                message = Message.model_validate(input_message)
+            except Exception as e:
+                log_warning(f"Failed to validate input message: {str(e)}")
+
+        if message is None:
+            continue
+
+        run_messages.messages.append(message)
+        if run_messages.extra_messages is None:
+            run_messages.extra_messages = []
+        run_messages.extra_messages.append(message)
+
+        if message.role == "user":
+            user_message = message
+
+    return user_message
 
 
 def _get_user_message(

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -4,18 +4,28 @@ from unittest.mock import MagicMock
 import pytest
 from ag_ui.core import EventType, RunAgentInput
 from ag_ui.core.types import (
+    AssistantMessage,
     AudioInputContent,
     BinaryInputContent,
     DocumentInputContent,
+    FunctionCall,
     ImageInputContent,
     InputContentDataSource,
     InputContentUrlSource,
     TextInputContent,
+    ToolCall,
+    ToolMessage,
     UserMessage,
     VideoInputContent,
 )
 
-from agno.os.interfaces.agui.input import extract_context, extract_media, extract_user_input
+from agno.os.interfaces.agui.input import (
+    convert_agui_messages_to_agno_messages,
+    extract_context,
+    extract_media,
+    extract_user_input,
+    has_tool_state,
+)
 from agno.os.interfaces.agui.router import run_entity
 from agno.os.interfaces.agui.state import StreamState
 from agno.os.interfaces.agui.stream import async_stream_agno_response_as_agui_events
@@ -2086,6 +2096,33 @@ def _media_run_input():
     )
 
 
+def _tool_history_run_input():
+    """Build an AG-UI transcript carrying an external tool result."""
+    return RunAgentInput(
+        thread_id="thread_1",
+        run_id="run_1",
+        state={},
+        messages=[
+            UserMessage(id="u1", content="say hello to Bob"),
+            AssistantMessage(
+                id="a1",
+                content=None,
+                tool_calls=[
+                    ToolCall(
+                        id="call_1",
+                        function=FunctionCall(name="sayHello", arguments='{"name":"Bob"}'),
+                    )
+                ],
+            ),
+            ToolMessage(id="t1", content="Hello Bob", tool_call_id="call_1"),
+            UserMessage(id="u2", content="thanks"),
+        ],
+        tools=[],
+        context=[],
+        forwarded_props={},
+    )
+
+
 def _assert_media_forwarded(captured_kwargs):
     """Assert the router forwarded every media part into the run kwargs."""
     assert captured_kwargs["input"] == "please inspect"
@@ -2107,6 +2144,35 @@ async def test_run_entity_passes_agui_media():
     events = [event async for event in run_entity(fake_entity, _media_run_input())]
     assert events[0].type == EventType.RUN_STARTED
     _assert_media_forwarded(fake_entity.captured_kwargs)
+
+
+def test_convert_agui_messages_preserves_tool_state():
+    """AG-UI assistant tool calls and tool results survive conversion."""
+    messages = _tool_history_run_input().messages
+
+    assert has_tool_state(messages)
+
+    converted = convert_agui_messages_to_agno_messages(messages)
+
+    assert [message.role for message in converted] == ["user", "assistant", "tool", "user"]
+    assert converted[1].tool_calls == [
+        {"id": "call_1", "type": "function", "function": {"name": "sayHello", "arguments": '{"name":"Bob"}'}}
+    ]
+    assert converted[2].tool_call_id == "call_1"
+    assert converted[2].content == "Hello Bob"
+
+
+@pytest.mark.asyncio
+async def test_run_entity_passes_full_history_when_tool_state_present():
+    """Tool-result turns need the full AG-UI transcript, not just the last user text."""
+    fake_entity = _FakeRunner()
+    events = [event async for event in run_entity(fake_entity, _tool_history_run_input())]
+
+    assert events[0].type == EventType.RUN_STARTED
+    forwarded_input = fake_entity.captured_kwargs["input"]
+    assert [message.role for message in forwarded_input] == ["user", "assistant", "tool", "user"]
+    assert forwarded_input[2].tool_call_id == "call_1"
+    assert fake_entity.captured_kwargs["add_history_to_context"] is False
 
 
 def test_extract_context_none_returns_none():

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -2159,6 +2159,7 @@ def test_convert_agui_messages_preserves_tool_state():
         {"id": "call_1", "type": "function", "function": {"name": "sayHello", "arguments": '{"name":"Bob"}'}}
     ]
     assert converted[2].tool_call_id == "call_1"
+    assert converted[2].tool_name == "sayHello"
     assert converted[2].content == "Hello Bob"
 
 

--- a/libs/agno/tests/unit/team/test_team_run_regressions.py
+++ b/libs/agno/tests/unit/team/test_team_run_regressions.py
@@ -9,11 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from agno.agent.agent import Agent
 from agno.db.postgres import AsyncPostgresDb
+from agno.models.message import Message
 from agno.run import RunContext
 from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session import TeamSession
 from agno.team import _hooks
+from agno.team import _messages as team_messages
 from agno.team import _run as team_run
 from agno.team.team import Team
 
@@ -49,6 +51,67 @@ def test_handle_team_run_paused_forwards_run_context_to_cleanup(monkeypatch: pyt
     )
 
     assert captured["run_context"] is run_context
+
+
+def test_team_run_messages_preserve_message_list_input():
+    team = Team(name="test-team", members=[Agent(name="m1")], system_message="test system")
+    run_context = RunContext(run_id="r1", session_id="s1")
+    input_messages = [
+        Message(role="user", content="say hello to Bob"),
+        Message(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                {"id": "call_1", "type": "function", "function": {"name": "sayHello", "arguments": '{"name":"Bob"}'}}
+            ],
+        ),
+        Message(role="tool", content="Hello Bob", tool_call_id="call_1"),
+    ]
+
+    run_messages = team_messages._get_run_messages(
+        team=team,
+        run_response=TeamRunOutput(run_id="r1", session_id="s1", messages=[]),
+        run_context=run_context,
+        session=TeamSession(session_id="s1"),
+        input_message=input_messages,
+        add_history_to_context=False,
+    )
+
+    assert run_messages.messages[-3:] == input_messages
+    assert run_messages.user_message is input_messages[0]
+    assert run_messages.extra_messages == input_messages
+    assert run_context.messages[-3:] == input_messages
+
+
+@pytest.mark.asyncio
+async def test_team_arun_messages_preserve_message_list_input():
+    team = Team(name="test-team", members=[Agent(name="m1")], system_message="test system")
+    run_context = RunContext(run_id="r1", session_id="s1")
+    input_messages = [
+        Message(role="user", content="say hello to Bob"),
+        Message(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                {"id": "call_1", "type": "function", "function": {"name": "sayHello", "arguments": '{"name":"Bob"}'}}
+            ],
+        ),
+        Message(role="tool", content="Hello Bob", tool_call_id="call_1"),
+    ]
+
+    run_messages = await team_messages._aget_run_messages(
+        team=team,
+        run_response=TeamRunOutput(run_id="r1", session_id="s1", messages=[]),
+        run_context=run_context,
+        session=TeamSession(session_id="s1"),
+        input_message=input_messages,
+        add_history_to_context=False,
+    )
+
+    assert run_messages.messages[-3:] == input_messages
+    assert run_messages.user_message is input_messages[0]
+    assert run_messages.extra_messages == input_messages
+    assert run_context.messages[-3:] == input_messages
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #8229.

AG-UI clients send the full message transcript on each request. The 2.6 router always reduced that transcript to the latest user text, which dropped frontend-provided `tool` result messages and the matching assistant `tool_calls`. For `external_execution=True` / HITL flows, that means the agent never sees the browser's tool result and can re-trigger the same external tool instead of continuing.

This PR keeps the plain text/media path unchanged, but switches to a role-preserving full-message path when the AG-UI transcript contains tool state:

- convert AG-UI `user`, `assistant`, `tool`, `system`, and `developer` messages into Agno `Message` objects
- preserve assistant `tool_calls` and tool-result `tool_call_id` links
- disable session-history replay for that request to avoid duplicating the full AG-UI transcript
- keep the existing latest-user/media extraction path for normal turns
- teach Team message assembly to preserve `List[Message]` input in sync and async paths instead of flattening it into one user string

## Related PRs

PR #7819 is an older, broader AG-UI frontend-tools PR tied to #7801/#7802. This PR is intentionally narrower for #8229: it focuses on preserving the actual AG-UI transcript when tool-call/tool-result state is present, rather than treating a tool result as replacement user text.

## Validation

- `uv run --no-project --with ruff ruff check libs/agno/agno/os/interfaces/agui/input.py libs/agno/agno/os/interfaces/agui/router.py libs/agno/agno/team/_messages.py libs/agno/tests/unit/app/test_agui_app.py libs/agno/tests/unit/team/test_team_run_regressions.py`
- `PYTHONPATH=libs/agno uv run --no-project --with pytest --with pytest-asyncio --with pydantic --with pydantic-settings --with rich --with docstring-parser --with typing-extensions --with python-dotenv --with pyyaml --with typer --with httpx --with 'httpx[http2]' --with gitpython --with packaging --with python-multipart --with ag-ui-protocol --with jsonpatch --with fastapi --with opentelemetry-sdk --with openinference-instrumentation-agno --with sqlalchemy --with croniter --with pytz pytest -q libs/agno/tests/unit/app/test_agui_app.py libs/agno/tests/unit/team/test_team_run_regressions.py` -> 74 passed, 4 warnings from existing deprecated AG-UI `BinaryInputContent` test fixtures
- `git diff --check`
- `python3 -m py_compile libs/agno/agno/os/interfaces/agui/input.py libs/agno/agno/os/interfaces/agui/router.py libs/agno/agno/team/_messages.py libs/agno/tests/unit/app/test_agui_app.py libs/agno/tests/unit/team/test_team_run_regressions.py`
