### PR TITLE
fix: [Bug] Vertex AI Search grounding chunks (retrieved_context) are dropped from citations

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -1121,6 +1121,18 @@ class Gemini(Model):
         if len(function_call_results) > 0:
             messages.extend(function_call_results)
 
+    @staticmethod
+    def _get_url_citation_from_grounding_chunk(chunk: Any) -> Optional[UrlCitation]:
+        source = getattr(chunk, "web", None) or getattr(chunk, "retrieved_context", None)
+        if not source:
+            return None
+
+        uri = source.uri
+        title = source.title
+        if uri:
+            return UrlCitation(url=uri, title=title)
+        return None
+
     def _parse_provider_response(self, response: GenerateContentResponse, **kwargs) -> ModelResponse:
         """
         Parse the Gemini response into a ModelResponse.
@@ -1246,13 +1258,9 @@ class Gemini(Model):
                 for chunk in chunks:
                     if not chunk:
                         continue
-                    web = chunk.web
-                    if not web:
-                        continue
-                    uri = web.uri
-                    title = web.title
-                    if uri:
-                        citations_urls.append(UrlCitation(url=uri, title=title))
+                    citation = self._get_url_citation_from_grounding_chunk(chunk)
+                    if citation:
+                        citations_urls.append(citation)
 
             # Handle URLs from URL context tool
             if (
@@ -1399,13 +1407,9 @@ class Gemini(Model):
                 for chunk in chunks:
                     if not chunk:
                         continue
-                    web = chunk.web
-                    if not web:
-                        continue
-                    uri = web.uri
-                    title = web.title
-                    if uri:
-                        citations.urls.append(UrlCitation(url=uri, title=title))
+                    citation = self._get_url_citation_from_grounding_chunk(chunk)
+                    if citation:
+                        citations.urls.append(citation)
 
             # Handle URLs from URL context tool
             if (

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -7,6 +7,8 @@ import pytest
 
 pytest.importorskip("google.genai")
 
+from google.genai import types
+
 from agno.exceptions import ModelProviderError
 from agno.media import File
 from agno.models.google.gemini import Gemini
@@ -89,6 +91,62 @@ def test_gemini_invoke_wraps_generic_errors_with_exception_type():
     ):
         with pytest.raises(ModelProviderError, match="TimeoutError"):
             model.invoke(messages=[Message(role="user", content="Hello")], assistant_message=assistant_message)
+
+
+def test_gemini_parse_provider_response_includes_retrieved_context_citations():
+    response = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(role="model", parts=[types.Part(text="Grounded answer")]),
+                grounding_metadata=types.GroundingMetadata(
+                    grounding_chunks=[
+                        types.GroundingChunk(
+                            retrieved_context=types.GroundingChunkRetrievedContext(
+                                uri="https://vertex.example/doc1",
+                                title="Vertex document",
+                            )
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+
+    model_response = Gemini(api_key="test-key")._parse_provider_response(response)
+
+    assert model_response.citations is not None
+    assert model_response.citations.urls is not None
+    assert len(model_response.citations.urls) == 1
+    assert model_response.citations.urls[0].url == "https://vertex.example/doc1"
+    assert model_response.citations.urls[0].title == "Vertex document"
+
+
+def test_gemini_parse_provider_response_delta_includes_retrieved_context_citations():
+    response_delta = types.GenerateContentResponse(
+        candidates=[
+            types.Candidate(
+                content=types.Content(role="model", parts=[types.Part(text="Grounded answer")]),
+                grounding_metadata=types.GroundingMetadata(
+                    grounding_chunks=[
+                        types.GroundingChunk(
+                            retrieved_context=types.GroundingChunkRetrievedContext(
+                                uri="https://vertex.example/doc1",
+                                title="Vertex document",
+                            )
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+
+    model_response = Gemini(api_key="test-key")._parse_provider_response_delta(response_delta)
+
+    assert model_response.citations is not None
+    assert model_response.citations.urls is not None
+    assert len(model_response.citations.urls) == 1
+    assert model_response.citations.urls[0].url == "https://vertex.example/doc1"
+    assert model_response.citations.urls[0].title == "Vertex document"
 
 
 class TestFormatFileForMessage:


### PR DESCRIPTION
Fixes #8604

## Summary
[Bug] Vertex AI Search grounding chunks (retrieved_context) are dropped from citations

## Changes
d1024acc2 fix: include vertex search grounding citations

## Testing
- Test command used: `GATE_ALREADY_PASSED`
- Test results: all tests passed
- PR gate verified