### PR TITLE
fix: include retrieved_context chunks in Gemini grounding citations

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -1247,12 +1247,15 @@ class Gemini(Model):
                     if not chunk:
                         continue
                     web = chunk.web
-                    if not web:
+                    if web and web.uri:
+                        citations_urls.append(UrlCitation(url=web.uri, title=web.title))
                         continue
-                    uri = web.uri
-                    title = web.title
-                    if uri:
-                        citations_urls.append(UrlCitation(url=uri, title=title))
+                    # Vertex AI Search / RAG datastore sources arrive under retrieved_context, not web
+                    retrieved = chunk.retrieved_context
+                    if retrieved and retrieved.uri:
+                        existing_urls = [citation.url for citation in citations_urls]
+                        if retrieved.uri not in existing_urls:
+                            citations_urls.append(UrlCitation(url=retrieved.uri, title=retrieved.title))
 
             # Handle URLs from URL context tool
             if (
@@ -1400,12 +1403,15 @@ class Gemini(Model):
                     if not chunk:
                         continue
                     web = chunk.web
-                    if not web:
+                    if web and web.uri:
+                        citations.urls.append(UrlCitation(url=web.uri, title=web.title))
                         continue
-                    uri = web.uri
-                    title = web.title
-                    if uri:
-                        citations.urls.append(UrlCitation(url=uri, title=title))
+                    # Vertex AI Search / RAG datastore sources arrive under retrieved_context, not web
+                    retrieved = chunk.retrieved_context
+                    if retrieved and retrieved.uri:
+                        existing_urls = [citation.url for citation in citations.urls]
+                        if retrieved.uri not in existing_urls:
+                            citations.urls.append(UrlCitation(url=retrieved.uri, title=retrieved.title))
 
             # Handle URLs from URL context tool
             if (

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -7,6 +7,17 @@ import pytest
 
 pytest.importorskip("google.genai")
 
+from google.genai.types import (
+    Candidate,
+    Content,
+    GenerateContentResponse,
+    GroundingChunk,
+    GroundingChunkRetrievedContext,
+    GroundingChunkWeb,
+    GroundingMetadata,
+    Part,
+)
+
 from agno.exceptions import ModelProviderError
 from agno.media import File
 from agno.models.google.gemini import Gemini
@@ -778,3 +789,107 @@ class TestFileSearchToolWiring:
             return  # No tools at all, which is the expected case
         file_search_tools = [t for t in config.tools if getattr(t, "file_search", None) is not None]
         assert len(file_search_tools) == 0
+
+
+def _grounding_response(chunks):
+    """Build a minimal grounded GenerateContentResponse with the given grounding chunks."""
+    return GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(role="model", parts=[Part(text="answer")]),
+                grounding_metadata=GroundingMetadata(grounding_chunks=chunks),
+            )
+        ]
+    )
+
+
+def test_parse_provider_response_extracts_retrieved_context_citations():
+    """Vertex AI Search sources arrive under retrieved_context and should populate citations."""
+    model = Gemini(api_key="test-key")
+    response = _grounding_response(
+        [GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/doc1", title="Doc 1"))]
+    )
+
+    model_response = model._parse_provider_response(response)
+
+    assert model_response.citations is not None
+    assert [(c.url, c.title) for c in model_response.citations.urls] == [("gs://ds/doc1", "Doc 1")]
+
+
+def test_parse_provider_response_extracts_web_and_retrieved_context_citations():
+    """A mixed response should yield both web and retrieved_context citations."""
+    model = Gemini(api_key="test-key")
+    response = _grounding_response(
+        [
+            GroundingChunk(web=GroundingChunkWeb(uri="https://example.com", title="Example")),
+            GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/doc2", title="Doc 2")),
+        ]
+    )
+
+    model_response = model._parse_provider_response(response)
+
+    assert [(c.url, c.title) for c in model_response.citations.urls] == [
+        ("https://example.com", "Example"),
+        ("gs://ds/doc2", "Doc 2"),
+    ]
+
+
+def test_parse_provider_response_deduplicates_retrieved_context_citations():
+    """Repeated retrieved_context URIs should be appended only once."""
+    model = Gemini(api_key="test-key")
+    response = _grounding_response(
+        [
+            GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/dup", title="Dup")),
+            GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/dup", title="Dup")),
+        ]
+    )
+
+    model_response = model._parse_provider_response(response)
+
+    assert [c.url for c in model_response.citations.urls] == ["gs://ds/dup"]
+
+
+def test_parse_provider_response_delta_extracts_retrieved_context_citations():
+    """Streaming responses should also extract retrieved_context citations."""
+    model = Gemini(api_key="test-key")
+    response = _grounding_response(
+        [GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/doc1", title="Doc 1"))]
+    )
+
+    model_response = model._parse_provider_response_delta(response)
+
+    assert model_response.citations is not None
+    assert [(c.url, c.title) for c in model_response.citations.urls] == [("gs://ds/doc1", "Doc 1")]
+
+
+def test_parse_provider_response_delta_extracts_web_and_retrieved_context_citations():
+    """A mixed streaming response should yield both web and retrieved_context citations."""
+    model = Gemini(api_key="test-key")
+    response = _grounding_response(
+        [
+            GroundingChunk(web=GroundingChunkWeb(uri="https://example.com", title="Example")),
+            GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/doc2", title="Doc 2")),
+        ]
+    )
+
+    model_response = model._parse_provider_response_delta(response)
+
+    assert [(c.url, c.title) for c in model_response.citations.urls] == [
+        ("https://example.com", "Example"),
+        ("gs://ds/doc2", "Doc 2"),
+    ]
+
+
+def test_parse_provider_response_delta_deduplicates_retrieved_context_citations():
+    """Repeated retrieved_context URIs should be appended only once when streaming."""
+    model = Gemini(api_key="test-key")
+    response = _grounding_response(
+        [
+            GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/dup", title="Dup")),
+            GroundingChunk(retrieved_context=GroundingChunkRetrievedContext(uri="gs://ds/dup", title="Dup")),
+        ]
+    )
+
+    model_response = model._parse_provider_response_delta(response)
+
+    assert [c.url for c in model_response.citations.urls] == ["gs://ds/dup"]


### PR DESCRIPTION
## Summary

Closes #8604.

I'm using Gemini with Vertex AI Search grounding (`Retrieval(vertex_ai_search=...)`). Grounded responses came back with an empty `citations.urls`, even though the model was clearly grounding against the datastore.

The grounding loop in both `_parse_provider_response` and `_parse_provider_response_delta` only read `chunk.web` and skipped anything else:

```python
web = chunk.web
if not web:
    continue
