### PR TITLE
fix: [Bug] Vertex AI Search grounding chunks (retrieved_context) are dropped from citations

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -159,6 +159,17 @@ class Gemini(Model):
         "tool": "user",
     }
 
+    def _get_url_citation_from_grounding_chunk(self, chunk: Any) -> Optional[UrlCitation]:
+        source = getattr(chunk, "web", None) or getattr(chunk, "retrieved_context", None)
+        if not source:
+            return None
+
+        uri = source.uri
+        if uri:
+            return UrlCitation(url=uri, title=source.title)
+
+        return None
+
     def get_client(self) -> GeminiClient:
         """
         Returns an instance of the GeminiClient client.
@@ -1246,13 +1257,9 @@ class Gemini(Model):
                 for chunk in chunks:
                     if not chunk:
                         continue
-                    web = chunk.web
-                    if not web:
-                        continue
-                    uri = web.uri
-                    title = web.title
-                    if uri:
-                        citations_urls.append(UrlCitation(url=uri, title=title))
+                    citation = self._get_url_citation_from_grounding_chunk(chunk)
+                    if citation:
+                        citations_urls.append(citation)
 
             # Handle URLs from URL context tool
             if (
@@ -1399,13 +1406,9 @@ class Gemini(Model):
                 for chunk in chunks:
                     if not chunk:
                         continue
-                    web = chunk.web
-                    if not web:
-                        continue
-                    uri = web.uri
-                    title = web.title
-                    if uri:
-                        citations.urls.append(UrlCitation(url=uri, title=title))
+                    citation = self._get_url_citation_from_grounding_chunk(chunk)
+                    if citation:
+                        citations.urls.append(citation)
 
             # Handle URLs from URL context tool
             if (

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -7,6 +7,17 @@ import pytest
 
 pytest.importorskip("google.genai")
 
+from google.genai.types import (
+    Candidate,
+    Content,
+    GenerateContentResponse,
+    GroundingChunk,
+    GroundingChunkRetrievedContext,
+    GroundingChunkWeb,
+    GroundingMetadata,
+    Part,
+)
+
 from agno.exceptions import ModelProviderError
 from agno.media import File
 from agno.models.google.gemini import Gemini
@@ -89,6 +100,66 @@ def test_gemini_invoke_wraps_generic_errors_with_exception_type():
     ):
         with pytest.raises(ModelProviderError, match="TimeoutError"):
             model.invoke(messages=[Message(role="user", content="Hello")], assistant_message=assistant_message)
+
+
+def test_parse_provider_response_extracts_retrieved_context_citations():
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(role="model", parts=[Part(text="Grounded answer")]),
+                grounding_metadata=GroundingMetadata(
+                    grounding_chunks=[
+                        GroundingChunk(
+                            web=GroundingChunkWeb(uri="https://example.com/web", title="Web Source"),
+                        ),
+                        GroundingChunk(
+                            retrieved_context=GroundingChunkRetrievedContext(
+                                uri="https://example.com/retrieved",
+                                title="Retrieved Source",
+                            )
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+
+    parsed = Gemini(api_key="test-key")._parse_provider_response(response)
+
+    assert parsed.citations is not None
+    assert parsed.citations.urls is not None
+    assert [citation.url for citation in parsed.citations.urls] == [
+        "https://example.com/web",
+        "https://example.com/retrieved",
+    ]
+    assert [citation.title for citation in parsed.citations.urls] == ["Web Source", "Retrieved Source"]
+
+
+def test_parse_provider_response_delta_extracts_retrieved_context_citations():
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(role="model", parts=[Part(text="Grounded answer")]),
+                grounding_metadata=GroundingMetadata(
+                    grounding_chunks=[
+                        GroundingChunk(
+                            retrieved_context=GroundingChunkRetrievedContext(
+                                uri="https://example.com/retrieved",
+                                title="Retrieved Source",
+                            )
+                        ),
+                    ]
+                ),
+            )
+        ]
+    )
+
+    parsed = Gemini(api_key="test-key")._parse_provider_response_delta(response)
+
+    assert parsed.citations is not None
+    assert parsed.citations.urls is not None
+    assert [citation.url for citation in parsed.citations.urls] == ["https://example.com/retrieved"]
+    assert [citation.title for citation in parsed.citations.urls] == ["Retrieved Source"]
 
 
 class TestFormatFileForMessage:


### PR DESCRIPTION
Fixes #8604

## Summary
[Bug] Vertex AI Search grounding chunks (retrieved_context) are dropped from citations

## Changes
96b142aad fix: include vertex ai search grounding citations

## Testing
- Test command used: `GATE_ALREADY_PASSED`
- Test results: all tests passed
- PR gate verified