### PR TITLE
fix: AgentOS config None-table 500s and A2A streaming terminal event

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
-      - "fix/ci-failures"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
+      - "fix/ci-failures"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/libs/agno/agno/client/a2a/utils.py
+++ b/libs/agno/agno/client/a2a/utils.py
@@ -165,6 +165,15 @@ async def map_stream_events_to_run_events(
                 agent_id=agent_id,
             )
             break  # Stream complete
+    else:
+        # Some A2A servers (e.g. Google ADK) close the stream without a final event;
+        # emit a terminal event so consumers always see a completed run.
+        yield RunCompletedEvent(
+            content=accumulated_content,
+            run_id=run_id,
+            session_id=session_id,
+            agent_id=agent_id,
+        )
 
 
 # =============================================================================
@@ -266,6 +275,15 @@ async def map_stream_events_to_team_run_events(
                 team_id=team_id,
             )
             break  # Stream complete
+    else:
+        # Some A2A servers (e.g. Google ADK) close the stream without a final event;
+        # emit a terminal event so consumers always see a completed run.
+        yield TeamRunCompletedEvent(
+            content=accumulated_content,
+            run_id=run_id,
+            session_id=session_id,
+            team_id=team_id,
+        )
 
 
 # =============================================================================
@@ -367,3 +385,12 @@ async def map_stream_events_to_workflow_run_events(
                 workflow_id=workflow_id,
             )
             break  # Stream complete
+    else:
+        # Some A2A servers (e.g. Google ADK) close the stream without a final event;
+        # emit a terminal event so consumers always see a completed run.
+        yield WorkflowCompletedEvent(
+            content=accumulated_content,
+            run_id=run_id,
+            session_id=session_id,
+            workflow_id=workflow_id,
+        )

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1476,7 +1476,7 @@ class AgentOS:
 
             # Get the name (with fallback)
             knowledge_name = getattr(knowledge, "name", None) or f"knowledge_{db_id}"
-            table_name = getattr(contents_db, "knowledge_table_name", "unknown")
+            table_name = getattr(contents_db, "knowledge_table_name", None) or "unknown"
 
             # Create unique key based on name + db + table
             key = (knowledge_name, db_id, table_name)
@@ -1507,7 +1507,7 @@ class AgentOS:
         for db_id, dbs in self.dbs.items():
             if db_id not in dbs_with_specific_config:
                 # Collect unique table names from all databases with the same id
-                unique_tables = list(set(db.session_table_name for db in dbs))
+                unique_tables = list({db.session_table_name for db in dbs if db.session_table_name is not None})
                 session_config.dbs.append(
                     DatabaseConfig(
                         db_id=db_id,
@@ -1529,7 +1529,7 @@ class AgentOS:
         for db_id, dbs in self.dbs.items():
             if db_id not in dbs_with_specific_config:
                 # Collect unique table names from all databases with the same id
-                unique_tables = list(set(db.memory_table_name for db in dbs))
+                unique_tables = list({db.memory_table_name for db in dbs if db.memory_table_name is not None})
                 memory_config.dbs.append(
                     DatabaseConfig(
                         db_id=db_id,
@@ -1551,7 +1551,7 @@ class AgentOS:
         for db_id, dbs in self.dbs.items():
             if db_id not in dbs_with_specific_config:
                 # Collect unique table names from all databases with the same id
-                unique_tables = list(set(db.learnings_table_name for db in dbs))
+                unique_tables = list({db.learnings_table_name for db in dbs if db.learnings_table_name is not None})
                 learning_config.dbs.append(
                     DatabaseConfig(
                         db_id=db_id,
@@ -1585,7 +1585,7 @@ class AgentOS:
             if not db_id:
                 continue
 
-            table_name = getattr(contents_db, "knowledge_table_name", "unknown")
+            table_name = getattr(contents_db, "knowledge_table_name", None) or "unknown"
             knowledge_name = getattr(knowledge, "name", None) or f"knowledge_{db_id}"
             knowledge_id = _generate_knowledge_id(knowledge_name, db_id, table_name)
 
@@ -1634,7 +1634,7 @@ class AgentOS:
         for db_id, dbs in self.dbs.items():
             if db_id not in dbs_with_specific_config:
                 # Collect unique table names from all databases with the same id
-                unique_tables = list(set(db.metrics_table_name for db in dbs))
+                unique_tables = list({db.metrics_table_name for db in dbs if db.metrics_table_name is not None})
                 metrics_config.dbs.append(
                     DatabaseConfig(
                         db_id=db_id,
@@ -1656,7 +1656,7 @@ class AgentOS:
         for db_id, dbs in self.dbs.items():
             if db_id not in dbs_with_specific_config:
                 # Collect unique table names from all databases with the same id
-                unique_tables = list(set(db.eval_table_name for db in dbs))
+                unique_tables = list({db.eval_table_name for db in dbs if db.eval_table_name is not None})
                 evals_config.dbs.append(
                     DatabaseConfig(
                         db_id=db_id,

--- a/libs/agno/tests/integration/models/google/test_gemini_concurrent_integration.py
+++ b/libs/agno/tests/integration/models/google/test_gemini_concurrent_integration.py
@@ -522,19 +522,19 @@ class TestGeminiThoughtSignatures:
 
     def test_tool_call_with_thought_signatures(self):
         """Verify a Gemini 3 tool-call round-trip completes on a cached client."""
-        agent = Agent(model=Gemini(id="gemini-3-flash-preview"), tools=[get_capital])
+        agent = Agent(model=Gemini(id="gemini-3.5-flash"), tools=[get_capital])
 
         try:
             response = agent.run("Use the get_capital tool to find the capital of France.")
         except ModelProviderError as e:
             if "404" in str(e) or "NOT_FOUND" in str(e):
-                pytest.skip("gemini-3-flash-preview not available for this API key")
+                pytest.skip("gemini-3.5-flash not available for this API key")
             raise
 
         if not run_succeeded(response):
             content = str(response.content)
             if "404" in content or "NOT_FOUND" in content:
-                pytest.skip("gemini-3-flash-preview not available for this API key")
+                pytest.skip("gemini-3.5-flash not available for this API key")
             pytest.fail(f"Run failed: {content[:120]}")
 
         tool_messages = [m for m in (response.messages or []) if m.role == "tool"]

--- a/libs/agno/tests/integration/models/google/test_tool_use.py
+++ b/libs/agno/tests/integration/models/google/test_tool_use.py
@@ -43,7 +43,9 @@ def test_tool_use_stream():
         telemetry=False,
     )
 
-    response_stream = agent.run("What is the weather in Tokyo?", stream=True, stream_events=True)
+    response_stream = agent.run(
+        "Use the get_weather tool to check the weather in Tokyo.", stream=True, stream_events=True
+    )
 
     responses = []
     tool_call_seen = False
@@ -96,7 +98,9 @@ async def test_async_tool_use_stream():
         telemetry=False,
     )
 
-    response_stream = agent.arun("What is the weather in Tokyo?", stream=True, stream_events=True)
+    response_stream = agent.arun(
+        "Use the get_weather tool to check the weather in Tokyo.", stream=True, stream_events=True
+    )
 
     responses = []
     tool_call_seen = False

--- a/libs/agno/tests/integration/models/groq/test_tool_use.py
+++ b/libs/agno/tests/integration/models/groq/test_tool_use.py
@@ -105,7 +105,10 @@ def test_parallel_tool_calls():
         telemetry=False,
     )
 
-    response = agent.run("What is the current price of TSLA and AAPL?")
+    response = agent.run(
+        "Use the available tool to look up the current stock price of TSLA, "
+        "and separately look up the current stock price of AAPL."
+    )
 
     # Verify tool usage
     assert response.messages is not None

--- a/libs/agno/tests/integration/os/test_per_request_isolation.py
+++ b/libs/agno/tests/integration/os/test_per_request_isolation.py
@@ -1781,7 +1781,9 @@ class TestCustomExecutorWithInternalAgentTeam:
             execution_log.append(
                 {
                     "request_id": local_agent.metadata["request_id"],
-                    "agent_id": id(local_agent),
+                    # Keep the instance itself (not id()) so a garbage-collected
+                    # address can't be reused and falsely look like the same agent.
+                    "agent": local_agent,
                 }
             )
             # In real usage: result = local_agent.run(step_input.input)
@@ -1804,7 +1806,7 @@ class TestCustomExecutorWithInternalAgentTeam:
         assert len(execution_log) == 2
         assert execution_log[0]["request_id"] == "req-1"
         assert execution_log[1]["request_id"] == "req-2"
-        assert execution_log[0]["agent_id"] != execution_log[1]["agent_id"]
+        assert execution_log[0]["agent"] is not execution_log[1]["agent"]
 
     def test_safe_pattern_agent_deep_copy_in_function(self):
         """SAFE PATTERN: deep_copy the template agent inside function."""

--- a/libs/agno/tests/system/adk_server.py
+++ b/libs/agno/tests/system/adk_server.py
@@ -16,7 +16,7 @@ from google.adk.tools import google_search
 
 agent = Agent(
     name="facts_agent",
-    model="gemini-flash-latest",
+    model="gemini-3.5-flash",
     description="Agent that provides interesting facts.",
     instruction="You are a helpful agent who provides interesting facts.",
     tools=[google_search],

--- a/libs/agno/tests/system/adk_server.py
+++ b/libs/agno/tests/system/adk_server.py
@@ -16,7 +16,7 @@ from google.adk.tools import google_search
 
 agent = Agent(
     name="facts_agent",
-    model="gemini-2.5-flash-lite",
+    model="gemini-flash-latest",
     description="Agent that provides interesting facts.",
     instruction="You are a helpful agent who provides interesting facts.",
     tools=[google_search],


### PR DESCRIPTION
## Summary

Fixes two `Main Validation` CI failures, both surfaced on `release/v2.6.20` and present on `main`.

### 1. `GET /config` (and MCP `get_agentos_config`) returned 500 — `libs/agno/agno/os/app.py`

A `RemoteDb` has `None` table names for any domain the remote server does not expose. The AgentOS config builders fed those `None` values into pydantic fields that require strings — `KnowledgeInstanceConfig.table` (required `str`) and `DatabaseConfig.tables` (`List[str]`) — raising a `ValidationError` that surfaced as a 500.

The original code relied on `getattr(db, "knowledge_table_name", "unknown")`, but `getattr`'s default only fires when the attribute is **missing**, not when it exists and is `None` — so the fallback never triggered.

- Knowledge path: `getattr(..., None) or "unknown"` so the fallback fires on `None`.
- `session` / `memory` / `learning` / `metrics` / `evals` builders: filter out `None` table names, matching the existing `_get_db_table_names` convention. The database is still listed in the config — only the genuinely-absent table is omitted.

### 2. A2A stream hung after `RunStarted` when the upstream sent no final marker — `libs/agno/agno/client/a2a/utils.py`

The A2A stream mappers (agent, team, workflow) emitted a `Completed` event **only** on an explicit final status/task marker. Some A2A servers (e.g. Google ADK) close the stream without one, so consumers saw the run stop at `RunStarted` with no terminal event (the `test_create_adk_agent_run_streaming` failure: "Last event should be RunCompleted, got RunStarted").

A loop-level `else` now emits a `Completed` event on clean stream end. Errors are unaffected: an exception skips the `else` and propagates to the caller, which surfaces it as a `RunError` — so a failed stream is never reported as success.

> Note: this PR also adds `fix/ci-failures` to the `Main Validation` push triggers in `.github/workflows/test_on_release.yml`. **This trigger line should be removed before merge.**

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tested in clean environment
