### PR TITLE
fix: configure team history skips and bound media lookups

### DIFF
--- a/libs/agno/agno/session/summary.py
+++ b/libs/agno/agno/session/summary.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from agno.models.base import Model
 from agno.models.utils import get_model
+from agno.run import RunStatus
 from agno.run.agent import Message
 from agno.utils.log import log_debug, log_warning
 
@@ -92,6 +93,9 @@ class SessionSummaryManager:
 
     # Maximum number of messages to include in the summary conversation. None means no limit.
     conversation_limit: Optional[int] = None
+
+    # Statuses to skip when building the conversation used for summaries.
+    skip_statuses: Optional[List[RunStatus]] = None
 
     def __post_init__(self) -> None:
         if self.id is None:
@@ -181,6 +185,7 @@ class SessionSummaryManager:
             conversation=session.get_messages(  # type: ignore
                 last_n_runs=self.last_n_runs,
                 limit=self.conversation_limit,
+                skip_statuses=self.skip_statuses,
             ),
             response_format=response_format,
         )

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -38,6 +38,7 @@ from agno.models.base import Model
 from agno.models.fallback import FallbackConfig
 from agno.models.message import Message
 from agno.models.utils import get_model
+from agno.run import RunStatus
 from agno.run.agent import RunEvent
 from agno.run.team import (
     TeamRunEvent,
@@ -128,6 +129,7 @@ def __init__(
     num_history_runs: Optional[int] = None,
     num_history_messages: Optional[int] = None,
     max_tool_calls_from_history: Optional[int] = None,
+    history_skip_statuses: Optional[List[RunStatus]] = None,
     skills: Optional[Skills] = None,
     tools: Optional[Union[List[Union[Toolkit, Callable, Function, Dict]], Callable[..., List]]] = None,
     tool_call_limit: Optional[int] = None,
@@ -249,6 +251,7 @@ def __init__(
         team.num_history_runs = 3
 
     team.max_tool_calls_from_history = max_tool_calls_from_history
+    team.history_skip_statuses = history_skip_statuses
 
     team.add_team_history_to_members = add_team_history_to_members
     team.num_team_history_runs = num_team_history_runs
@@ -577,11 +580,13 @@ def _set_memory_manager(team: "Team") -> None:
 
 def _set_session_summary_manager(team: "Team") -> None:
     if team.enable_session_summaries and team.session_summary_manager is None:
-        team.session_summary_manager = SessionSummaryManager(model=team.model)
+        team.session_summary_manager = SessionSummaryManager(model=team.model, skip_statuses=team.history_skip_statuses)
 
     if team.session_summary_manager is not None:
         if team.session_summary_manager.model is None:
             team.session_summary_manager.model = team.model
+        if team.session_summary_manager.skip_statuses is None and team.history_skip_statuses is not None:
+            team.session_summary_manager.skip_statuses = team.history_skip_statuses
 
     if team.add_session_summary_to_context is None:
         team.add_session_summary_to_context = team.enable_session_summaries or team.session_summary_manager is not None

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -895,6 +895,7 @@ def _get_run_messages(
             last_n_runs=team.num_history_runs,
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
+            skip_statuses=team.history_skip_statuses,
             team_id=team.id if team.parent_team_id is not None else None,
         )
 
@@ -1029,6 +1030,7 @@ async def _aget_run_messages(
             last_n_runs=team.num_history_runs,
             limit=team.num_history_messages,
             skip_roles=[skip_role] if skip_role else None,
+            skip_statuses=team.history_skip_statuses,
             team_id=team.id if team.parent_team_id is not None else None,
         )
 

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -27,6 +27,7 @@ from agno.models.base import Model
 from agno.models.message import Message
 from agno.models.utils import resolve_model
 from agno.registry.registry import Registry
+from agno.run import RunStatus
 from agno.run.agent import RunOutput
 from agno.run.team import (
     TeamRunOutput,
@@ -639,6 +640,10 @@ def to_dict(team: "Team") -> Dict[str, Any]:
         config["num_history_messages"] = team.num_history_messages
     if team.max_tool_calls_from_history is not None:
         config["max_tool_calls_from_history"] = team.max_tool_calls_from_history
+    if team.history_skip_statuses is not None:
+        config["history_skip_statuses"] = [
+            status.value if isinstance(status, RunStatus) else str(status) for status in team.history_skip_statuses
+        ]
 
     # --- Media/storage settings ---
     if not team.send_media_to_model:  # default is True
@@ -726,6 +731,12 @@ def _parse_team_mode(value: Optional[str]) -> Optional["TeamMode"]:
     from agno.team.mode import TeamMode
 
     return TeamMode(value)
+
+
+def _parse_run_statuses(value: Optional[List[Union[RunStatus, str]]]) -> Optional[List[RunStatus]]:
+    if value is None:
+        return None
+    return [status if isinstance(status, RunStatus) else RunStatus(status) for status in value]
 
 
 def from_dict(
@@ -968,6 +979,7 @@ def from_dict(
             num_history_runs=config.get("num_history_runs"),
             num_history_messages=config.get("num_history_messages"),
             max_tool_calls_from_history=config.get("max_tool_calls_from_history"),
+            history_skip_statuses=_parse_run_statuses(config.get("history_skip_statuses")),
             # --- Compression settings ---
             compress_tool_results=config.get("compress_tool_results", False),
             # compression_manager=config.get("compression_manager"),  # TODO

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -338,6 +338,9 @@ class Team:
     num_history_messages: Optional[int] = None
     # Maximum number of tool calls to include from history (None = no limit)
     max_tool_calls_from_history: Optional[int] = None
+    # Run statuses to skip when building model history and team session summaries.
+    # None preserves TeamSession.get_messages() defaults.
+    history_skip_statuses: Optional[List[RunStatus]] = None
 
     # --- Team Storage ---
     # Metadata stored with this team
@@ -502,6 +505,7 @@ class Team:
         num_history_runs: Optional[int] = None,
         num_history_messages: Optional[int] = None,
         max_tool_calls_from_history: Optional[int] = None,
+        history_skip_statuses: Optional[List[RunStatus]] = None,
         skills: Optional[Skills] = None,
         tools: Optional[Union[List[Union[Toolkit, Callable, Function, Dict]], Callable[..., List]]] = None,
         tool_call_limit: Optional[int] = None,
@@ -625,6 +629,7 @@ class Team:
             num_history_runs=num_history_runs,
             num_history_messages=num_history_messages,
             max_tool_calls_from_history=max_tool_calls_from_history,
+            history_skip_statuses=history_skip_statuses,
             skills=skills,
             tools=tools,
             tool_call_limit=tool_call_limit,

--- a/libs/agno/agno/tools/unsplash.py
+++ b/libs/agno/agno/tools/unsplash.py
@@ -48,6 +48,7 @@ class UnsplashTools(Toolkit):
         enable_get_random_photo: bool = True,
         enable_download_photo: bool = False,
         all: bool = False,
+        timeout: float = 10,
         **kwargs: Any,
     ):
         """Initialize the Unsplash toolkit.
@@ -60,6 +61,7 @@ class UnsplashTools(Toolkit):
             enable_get_random_photo: Enable the get_random_photo tool. Default: True.
             enable_download_photo: Enable the download_photo tool. Default: False.
             all: Enable all tools. Default: False.
+            timeout: Request timeout in seconds. Default: 10.
             **kwargs: Additional arguments passed to the Toolkit base class.
         """
         self.access_key = access_key or getenv("UNSPLASH_ACCESS_KEY")
@@ -67,6 +69,7 @@ class UnsplashTools(Toolkit):
             logger.warning("No Unsplash API key provided. Set UNSPLASH_ACCESS_KEY environment variable.")
 
         self.base_url = "https://api.unsplash.com"
+        self.timeout = timeout
 
         tools: List[Any] = []
         if all or enable_search_photos:
@@ -103,7 +106,7 @@ class UnsplashTools(Toolkit):
         }
 
         request = Request(url, headers=headers)
-        with urlopen(request) as response:
+        with urlopen(request, timeout=self.timeout) as response:
             return json.loads(response.read().decode())
 
     def _format_photo(self, photo: Dict[str, Any]) -> Dict[str, Any]:

--- a/libs/agno/agno/tools/youtube.py
+++ b/libs/agno/agno/tools/youtube.py
@@ -23,10 +23,12 @@ class YouTubeTools(Toolkit):
         all: bool = False,
         languages: Optional[List[str]] = None,
         proxies: Optional[Dict[str, Any]] = None,
+        timeout: float = 10,
         **kwargs,
     ):
         self.languages: Optional[List[str]] = languages
         self.proxies: Optional[Dict[str, Any]] = proxies
+        self.timeout = timeout
 
         tools: List[Any] = []
         if all or enable_get_video_captions:
@@ -88,7 +90,7 @@ class YouTubeTools(Toolkit):
             query_string = urlencode(params)
             url = url + "?" + query_string
 
-            with urlopen(url) as response:
+            with urlopen(url, timeout=self.timeout) as response:
                 response_text = response.read()
                 video_data = json.loads(response_text.decode())
                 clean_data = {

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -19,6 +19,7 @@ import pytest
 from agno.agent.agent import Agent
 from agno.db.base import BaseDb, ComponentType
 from agno.registry import Registry
+from agno.run import RunStatus
 from agno.session import TeamSession
 from agno.team.team import Team, get_team_by_id, get_teams
 
@@ -201,6 +202,18 @@ class TestTeamToDict:
 
         assert team.store_history_messages is False
         assert "store_history_messages" not in team.to_dict()
+
+    def test_history_skip_statuses_are_serialized(self):
+        """Test custom history skip statuses are serialized as enum values."""
+        team = Team(id="history-skip-team", members=[], history_skip_statuses=[RunStatus.paused, RunStatus.error])
+
+        assert team.to_dict()["history_skip_statuses"] == ["PAUSED", "ERROR"]
+
+    def test_history_skip_statuses_round_trip_from_dict(self):
+        """Test custom history skip statuses are restored from config."""
+        team = Team.from_dict({"id": "history-skip-team", "members": [], "history_skip_statuses": ["PAUSED"]})
+
+        assert team.history_skip_statuses == [RunStatus.paused]
 
     def test_add_search_knowledge_instructions_default_omitted(self):
         """Test add_search_knowledge_instructions default is omitted from config."""

--- a/libs/agno/tests/unit/team/test_team_run_regressions.py
+++ b/libs/agno/tests/unit/team/test_team_run_regressions.py
@@ -8,7 +8,8 @@ from agno.run import RunContext
 from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session import TeamSession
-from agno.team import _hooks
+from agno.session.summary import SessionSummaryManager
+from agno.team import _hooks, _init, _messages
 from agno.team import _run as team_run
 from agno.team.team import Team
 
@@ -114,6 +115,64 @@ def test_handle_team_run_paused_without_run_context_does_not_set_state(monkeypat
 
     assert result.status == RunStatus.paused
     assert "session_state" not in session.session_data
+
+
+def test_team_history_skip_statuses_are_passed_to_context_history(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, Any] = {}
+    team = Team(name="test-team", members=[], add_history_to_context=True, history_skip_statuses=[])
+    session = TeamSession(session_id="s1")
+
+    monkeypatch.setattr(team, "get_system_message", lambda **kwargs: None)
+
+    def spy_get_messages(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(session, "get_messages", spy_get_messages)
+
+    _messages._get_run_messages(
+        team=team,
+        run_response=TeamRunOutput(run_id="r1", session_id="s1", messages=[]),
+        run_context=RunContext(run_id="r1", session_id="s1"),
+        session=session,
+        add_history_to_context=True,
+        input_message="hello",
+    )
+
+    assert captured["skip_statuses"] == []
+
+
+def test_team_summary_manager_inherits_history_skip_statuses():
+    team = Team(name="test-team", members=[], history_skip_statuses=[])
+    team.session_summary_manager = SessionSummaryManager()
+    team.add_session_summary_to_context = None
+
+    _init._set_session_summary_manager(team)
+
+    assert team.session_summary_manager.skip_statuses == []
+
+
+def test_session_summary_manager_uses_configured_skip_statuses(monkeypatch: pytest.MonkeyPatch):
+    captured: dict[str, Any] = {}
+    summary_manager = SessionSummaryManager(model=object(), skip_statuses=[])
+    session = TeamSession(session_id="s1")
+
+    class DummyModel:
+        supports_native_structured_outputs = False
+        supports_json_schema_outputs = False
+
+    monkeypatch.setattr("agno.session.summary.get_model", lambda model: DummyModel())
+
+    def spy_get_messages(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(session, "get_messages", spy_get_messages)
+
+    messages = summary_manager._prepare_summary_messages(session)
+
+    assert messages is not None
+    assert captured["skip_statuses"] == []
 
 
 def test_handle_team_run_paused_persists_state_when_session_data_is_none(monkeypatch: pytest.MonkeyPatch):

--- a/libs/agno/tests/unit/tools/test_unsplash.py
+++ b/libs/agno/tests/unit/tools/test_unsplash.py
@@ -96,6 +96,11 @@ class TestUnsplashToolsInit:
         tools = UnsplashTools(access_key="provided_key")
         assert tools.access_key == "provided_key"
 
+    def test_init_with_custom_timeout(self):
+        """Test initialization with a custom timeout."""
+        tools = UnsplashTools(access_key="provided_key", timeout=15)
+        assert tools.timeout == 15
+
     def test_init_without_api_key_logs_warning(self):
         """Test initialization without API key logs a warning."""
         with patch.dict("os.environ", {}, clear=True):
@@ -493,3 +498,12 @@ class TestMakeRequest:
         call_args = mock_urlopen.call_args[0][0]
         assert call_args.headers["Authorization"] == "Client-ID test_key"
         assert call_args.headers["Accept-version"] == "v1"
+
+    def test_make_request_passes_timeout(self, unsplash_tools, mock_urlopen):
+        """Test request passes the configured timeout to urlopen."""
+        mock_urlopen.return_value = create_mock_response({"test": "data"})
+        unsplash_tools.timeout = 15
+
+        unsplash_tools._make_request("/test")
+
+        assert mock_urlopen.call_args.kwargs["timeout"] == 15

--- a/libs/agno/tests/unit/tools/test_youtube_tools.py
+++ b/libs/agno/tests/unit/tools/test_youtube_tools.py
@@ -1,0 +1,53 @@
+"""Unit tests for YouTubeTools."""
+
+import importlib
+import json
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, Mock, patch
+
+youtube_transcript_api = ModuleType("youtube_transcript_api")
+youtube_transcript_api.YouTubeTranscriptApi = Mock
+sys.modules.setdefault("youtube_transcript_api", youtube_transcript_api)
+
+
+def create_mock_response(data):
+    """Create a mock HTTP response."""
+    mock_response = MagicMock()
+    mock_response.read.return_value = json.dumps(data).encode()
+    mock_response.__enter__ = Mock(return_value=mock_response)
+    mock_response.__exit__ = Mock(return_value=False)
+    return mock_response
+
+
+def _get_youtube_tools_cls():
+    return importlib.import_module("agno.tools.youtube").YouTubeTools
+
+
+def test_init_with_custom_timeout():
+    """Test initialization with a custom timeout."""
+    YouTubeTools = _get_youtube_tools_cls()
+    tools = YouTubeTools(timeout=15)
+    assert tools.timeout == 15
+
+
+def test_get_youtube_video_data_passes_timeout():
+    """Test get_youtube_video_data passes the configured timeout to urlopen."""
+    YouTubeTools = _get_youtube_tools_cls()
+    tools = YouTubeTools(
+        enable_get_video_captions=False,
+        enable_get_video_timestamps=False,
+        timeout=15,
+    )
+    mock_response_data = {
+        "title": "Test Video",
+        "author_name": "Test Author",
+        "provider_name": "YouTube",
+    }
+
+    with patch("agno.tools.youtube.urlopen", return_value=create_mock_response(mock_response_data)) as mock_urlopen:
+        result = tools.get_youtube_video_data("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+    result_data = json.loads(result)
+    assert result_data["title"] == "Test Video"
+    assert mock_urlopen.call_args.kwargs["timeout"] == 15


### PR DESCRIPTION
## Summary

- Fixes #8574 by adding configurable `Team.history_skip_statuses` support for team context history and session summary generation.
- Fixes #8438 by adding a configurable `YouTubeTools` oEmbed timeout and passing it to `urlopen`.
- Fixes #8437 by adding a configurable `UnsplashTools` request timeout and passing it to shared `urlopen` calls.
- Adds regression coverage for timeout propagation, team config serialization/round-trip, and history/summary skip-status propagation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Duplicate check: searched open PRs for exact `#8574`, `#8438`, and `#8437` references before opening this PR; no open PRs were found for these issues.
- Validation:
  - `./scripts/format.sh`
  - `python -m pytest libs/agno/tests/unit/tools/test_unsplash.py::TestUnsplashToolsInit::test_init_with_custom_timeout libs/agno/tests/unit/tools/test_unsplash.py::TestMakeRequest::test_make_request_passes_timeout libs/agno/tests/unit/tools/test_youtube_tools.py libs/agno/tests/unit/team/test_team_config.py::TestTeamToDict::test_history_skip_statuses_are_serialized libs/agno/tests/unit/team/test_team_config.py::TestTeamToDict::test_history_skip_statuses_round_trip_from_dict libs/agno/tests/unit/team/test_team_run_regressions.py::test_team_history_skip_statuses_are_passed_to_context_history libs/agno/tests/unit/team/test_team_run_regressions.py::test_team_summary_manager_inherits_history_skip_statuses libs/agno/tests/unit/team/test_team_run_regressions.py::test_session_summary_manager_uses_configured_skip_statuses`
  - `./scripts/validate.sh`
