### PR TITLE
fix: make memory optimization apply replace memories atomically

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -307,6 +307,8 @@ class BaseDb(ABC):
         replacement_ids = {memory.memory_id for memory in memories if memory.memory_id is not None}
 
         replaced_memories = self.upsert_memories(memories=memories, deserialize=deserialize)
+        if len(replaced_memories) != len(memories):
+            return replaced_memories
 
         stale_ids = list(existing_ids - replacement_ids)
         if stale_ids:
@@ -1489,6 +1491,8 @@ class AsyncBaseDb(ABC):
                     replaced_memories.append(replaced_memory)
         else:
             replaced_memories = await self.upsert_memories(memories=memories, deserialize=deserialize)
+        if len(replaced_memories) != len(memories):
+            return replaced_memories
 
         stale_ids = list(existing_ids - replacement_ids)
         if stale_ids:

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -287,6 +287,9 @@ class BaseDb(ABC):
         deserialize: Optional[bool] = True,
     ) -> List[Union[UserMemory, Dict[str, Any]]]:
         """Replace one user's memory set without deleting before replacement is staged."""
+        if not memories:
+            return []
+
         existing_memories_result = self.get_user_memories(user_id=user_id)
         existing_memory_rows = (
             existing_memories_result[0] if isinstance(existing_memories_result, tuple) else existing_memories_result
@@ -1459,6 +1462,9 @@ class AsyncBaseDb(ABC):
         deserialize: Optional[bool] = True,
     ) -> List[Union[UserMemory, Dict[str, Any]]]:
         """Replace one user's memory set without deleting before replacement is staged."""
+        if not memories:
+            return []
+
         existing_memories_result = await self.get_user_memories(user_id=user_id)
         existing_memory_rows = (
             existing_memories_result[0] if isinstance(existing_memories_result, tuple) else existing_memories_result

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1475,7 +1475,14 @@ class AsyncBaseDb(ABC):
         }
         replacement_ids = {memory.memory_id for memory in memories if memory.memory_id is not None}
 
-        replaced_memories = await self.upsert_memories(memories=memories, deserialize=deserialize)
+        if getattr(type(self), "upsert_memories", None) is AsyncBaseDb.upsert_memories:
+            replaced_memories = []
+            for memory in memories:
+                replaced_memory = await self.upsert_user_memory(memory=memory, deserialize=deserialize)
+                if replaced_memory is not None:
+                    replaced_memories.append(replaced_memory)
+        else:
+            replaced_memories = await self.upsert_memories(memories=memories, deserialize=deserialize)
 
         stale_ids = list(existing_ids - replacement_ids)
         if stale_ids:

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -280,6 +280,30 @@ class BaseDb(ABC):
         """Bulk upsert multiple memories for improved performance on large datasets."""
         raise NotImplementedError
 
+    def replace_user_memories(
+        self,
+        user_id: str,
+        memories: List[UserMemory],
+        deserialize: Optional[bool] = True,
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """Replace one user's memory set without deleting before replacement is staged."""
+        existing_memories = self.get_user_memories(user_id=user_id)
+        if isinstance(existing_memories, tuple):
+            existing_memories = existing_memories[0]
+
+        existing_ids = {
+            memory.memory_id for memory in existing_memories if isinstance(memory, UserMemory) and memory.memory_id is not None
+        }
+        replacement_ids = {memory.memory_id for memory in memories if memory.memory_id is not None}
+
+        replaced_memories = self.upsert_memories(memories=memories, deserialize=deserialize)
+
+        stale_ids = list(existing_ids - replacement_ids)
+        if stale_ids:
+            self.delete_user_memories(memory_ids=stale_ids, user_id=user_id)
+
+        return replaced_memories
+
     # --- Metrics ---
     @abstractmethod
     def get_metrics(
@@ -1411,6 +1435,39 @@ class AsyncBaseDb(ABC):
         self, memory: UserMemory, deserialize: Optional[bool] = True
     ) -> Optional[Union[UserMemory, Dict[str, Any]]]:
         raise NotImplementedError
+
+    async def upsert_memories(
+        self,
+        memories: List[UserMemory],
+        deserialize: Optional[bool] = True,
+        preserve_updated_at: bool = False,
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """Bulk upsert multiple memories for improved performance on large datasets."""
+        raise NotImplementedError
+
+    async def replace_user_memories(
+        self,
+        user_id: str,
+        memories: List[UserMemory],
+        deserialize: Optional[bool] = True,
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        """Replace one user's memory set without deleting before replacement is staged."""
+        existing_memories = await self.get_user_memories(user_id=user_id)
+        if isinstance(existing_memories, tuple):
+            existing_memories = existing_memories[0]
+
+        existing_ids = {
+            memory.memory_id for memory in existing_memories if isinstance(memory, UserMemory) and memory.memory_id is not None
+        }
+        replacement_ids = {memory.memory_id for memory in memories if memory.memory_id is not None}
+
+        replaced_memories = await self.upsert_memories(memories=memories, deserialize=deserialize)
+
+        stale_ids = list(existing_ids - replacement_ids)
+        if stale_ids:
+            await self.delete_user_memories(memory_ids=stale_ids, user_id=user_id)
+
+        return replaced_memories
 
     # --- Metrics ---
     @abstractmethod

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -287,12 +287,19 @@ class BaseDb(ABC):
         deserialize: Optional[bool] = True,
     ) -> List[Union[UserMemory, Dict[str, Any]]]:
         """Replace one user's memory set without deleting before replacement is staged."""
-        existing_memories = self.get_user_memories(user_id=user_id)
-        if isinstance(existing_memories, tuple):
-            existing_memories = existing_memories[0]
+        existing_memories_result = self.get_user_memories(user_id=user_id)
+        existing_memory_rows = (
+            existing_memories_result[0] if isinstance(existing_memories_result, tuple) else existing_memories_result
+        )
+        existing_memories = [
+            memory if isinstance(memory, UserMemory) else UserMemory.from_dict(memory)
+            for memory in existing_memory_rows
+        ]
 
         existing_ids = {
-            memory.memory_id for memory in existing_memories if isinstance(memory, UserMemory) and memory.memory_id is not None
+            memory.memory_id
+            for memory in existing_memories
+            if isinstance(memory, UserMemory) and memory.memory_id is not None
         }
         replacement_ids = {memory.memory_id for memory in memories if memory.memory_id is not None}
 
@@ -1452,12 +1459,19 @@ class AsyncBaseDb(ABC):
         deserialize: Optional[bool] = True,
     ) -> List[Union[UserMemory, Dict[str, Any]]]:
         """Replace one user's memory set without deleting before replacement is staged."""
-        existing_memories = await self.get_user_memories(user_id=user_id)
-        if isinstance(existing_memories, tuple):
-            existing_memories = existing_memories[0]
+        existing_memories_result = await self.get_user_memories(user_id=user_id)
+        existing_memory_rows = (
+            existing_memories_result[0] if isinstance(existing_memories_result, tuple) else existing_memories_result
+        )
+        existing_memories = [
+            memory if isinstance(memory, UserMemory) else UserMemory.from_dict(memory)
+            for memory in existing_memory_rows
+        ]
 
         existing_ids = {
-            memory.memory_id for memory in existing_memories if isinstance(memory, UserMemory) and memory.memory_id is not None
+            memory.memory_id
+            for memory in existing_memories
+            if isinstance(memory, UserMemory) and memory.memory_id is not None
         }
         replacement_ids = {memory.memory_id for memory in memories if memory.memory_id is not None}
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -1645,10 +1645,12 @@ class AsyncSqliteDb(AsyncBaseDb):
                     }
                 )
 
+            replacement_id_set = set(memory_ids)
             async with self.async_session_factory() as sess, sess.begin():
-                await sess.execute(table.delete().where(table.c.user_id == user_id))
-                if not bulk_data:
-                    return []
+                existing_ids = set(
+                    (await sess.execute(select(table.c.memory_id).where(table.c.user_id == user_id))).scalars().all()
+                )
+                stale_ids = list(existing_ids - replacement_id_set)
 
                 stmt = sqlite.insert(table)
                 stmt = stmt.on_conflict_do_update(
@@ -1665,6 +1667,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                     ),
                 )
                 await sess.execute(stmt, bulk_data)
+
+                if stale_ids:
+                    await sess.execute(
+                        table.delete().where(
+                            table.c.user_id == user_id,
+                            table.c.memory_id.in_(stale_ids),
+                        )
+                    )
 
                 result = await sess.execute(select(table).where(table.c.memory_id.in_(memory_ids)))
                 rows = result.fetchall()

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -1607,6 +1607,77 @@ class AsyncSqliteDb(AsyncBaseDb):
                 if result is not None
             ]
 
+    async def replace_user_memories(
+        self,
+        user_id: str,
+        memories: List[UserMemory],
+        deserialize: Optional[bool] = True,
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        try:
+            table = await self._get_table(table_type="memories", create_table_if_not_found=True)
+            if table is None:
+                return []
+
+            current_time = int(time.time())
+            memory_ids: List[str] = []
+            bulk_data: List[Dict[str, Any]] = []
+
+            for memory in memories:
+                if memory.memory_id is None:
+                    memory.memory_id = str(uuid4())
+                memory.user_id = user_id
+                memory_ids.append(memory.memory_id)
+                bulk_data.append(
+                    {
+                        "user_id": memory.user_id,
+                        "agent_id": memory.agent_id,
+                        "team_id": memory.team_id,
+                        "memory_id": memory.memory_id,
+                        "memory": memory.memory,
+                        "topics": memory.topics,
+                        "input": memory.input,
+                        "feedback": memory.feedback,
+                        "created_at": memory.created_at,
+                        "updated_at": memory.created_at,
+                    }
+                )
+
+            async with self.async_session_factory() as sess, sess.begin():
+                await sess.execute(table.delete().where(table.c.user_id == user_id))
+                if not bulk_data:
+                    return []
+
+                stmt = sqlite.insert(table)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["memory_id"],
+                    set_=dict(
+                        memory=stmt.excluded.memory,
+                        topics=stmt.excluded.topics,
+                        input=stmt.excluded.input,
+                        agent_id=stmt.excluded.agent_id,
+                        team_id=stmt.excluded.team_id,
+                        feedback=stmt.excluded.feedback,
+                        updated_at=current_time,
+                        created_at=table.c.created_at,
+                    ),
+                )
+                await sess.execute(stmt, bulk_data)
+
+                result = await sess.execute(select(table).where(table.c.memory_id.in_(memory_ids)))
+                rows = result.fetchall()
+
+            memory_rows: Dict[str, Dict[str, Any]] = {row.memory_id: dict(row._mapping) for row in rows}
+            replaced_memories: List[Dict[str, Any]] = [
+                memory_rows[memory_id] for memory_id in memory_ids if memory_id in memory_rows
+            ]
+            if not deserialize:
+                return cast(List[Union[UserMemory, Dict[str, Any]]], replaced_memories)
+            return [UserMemory.from_dict(memory_row) for memory_row in replaced_memories]
+
+        except Exception as e:
+            log_error(f"Error replacing user memories: {str(e)}")
+            raise e
+
     async def clear_memories(self) -> None:
         """Delete all memories from the database.
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -1614,6 +1614,9 @@ class AsyncSqliteDb(AsyncBaseDb):
         deserialize: Optional[bool] = True,
     ) -> List[Union[UserMemory, Dict[str, Any]]]:
         try:
+            if not memories:
+                return []
+
             table = await self._get_table(table_type="memories", create_table_if_not_found=True)
             if table is None:
                 return []

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1780,6 +1780,9 @@ class SqliteDb(BaseDb):
         deserialize: Optional[bool] = True,
     ) -> List[Union[UserMemory, Dict[str, Any]]]:
         try:
+            if not memories:
+                return []
+
             table = self._get_table(table_type="memories", create_table_if_not_found=True)
             if table is None:
                 return []

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1773,6 +1773,76 @@ class SqliteDb(BaseDb):
                 if result is not None
             ]
 
+    def replace_user_memories(
+        self,
+        user_id: str,
+        memories: List[UserMemory],
+        deserialize: Optional[bool] = True,
+    ) -> List[Union[UserMemory, Dict[str, Any]]]:
+        try:
+            table = self._get_table(table_type="memories", create_table_if_not_found=True)
+            if table is None:
+                return []
+
+            current_time = int(time.time())
+            memory_ids: List[str] = []
+            bulk_data: List[Dict[str, Any]] = []
+
+            for memory in memories:
+                if memory.memory_id is None:
+                    memory.memory_id = str(uuid4())
+                memory.user_id = user_id
+                memory_ids.append(memory.memory_id)
+                bulk_data.append(
+                    {
+                        "user_id": memory.user_id,
+                        "agent_id": memory.agent_id,
+                        "team_id": memory.team_id,
+                        "memory_id": memory.memory_id,
+                        "memory": memory.memory,
+                        "topics": memory.topics,
+                        "input": memory.input,
+                        "feedback": memory.feedback,
+                        "created_at": memory.created_at,
+                        "updated_at": memory.created_at,
+                    }
+                )
+
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.delete().where(table.c.user_id == user_id))
+                if not bulk_data:
+                    return []
+
+                stmt = sqlite.insert(table)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["memory_id"],
+                    set_=dict(
+                        memory=stmt.excluded.memory,
+                        topics=stmt.excluded.topics,
+                        input=stmt.excluded.input,
+                        agent_id=stmt.excluded.agent_id,
+                        team_id=stmt.excluded.team_id,
+                        feedback=stmt.excluded.feedback,
+                        updated_at=current_time,
+                        created_at=table.c.created_at,
+                    ),
+                )
+                sess.execute(stmt, bulk_data)
+
+                result = sess.execute(select(table).where(table.c.memory_id.in_(memory_ids))).fetchall()
+
+            memory_rows: Dict[str, Dict[str, Any]] = {row.memory_id: dict(row._mapping) for row in result}
+            replaced_memories: List[Dict[str, Any]] = [
+                memory_rows[memory_id] for memory_id in memory_ids if memory_id in memory_rows
+            ]
+            if not deserialize:
+                return cast(List[Union[UserMemory, Dict[str, Any]]], replaced_memories)
+            return [UserMemory.from_dict(memory_row) for memory_row in replaced_memories]
+
+        except Exception as e:
+            log_error(f"Error replacing user memories: {str(e)}")
+            raise e
+
     def clear_memories(self) -> None:
         """Delete all memories from the database.
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1811,10 +1811,12 @@ class SqliteDb(BaseDb):
                     }
                 )
 
+            replacement_id_set = set(memory_ids)
             with self.Session() as sess, sess.begin():
-                sess.execute(table.delete().where(table.c.user_id == user_id))
-                if not bulk_data:
-                    return []
+                existing_ids = set(
+                    sess.execute(select(table.c.memory_id).where(table.c.user_id == user_id)).scalars().all()
+                )
+                stale_ids = list(existing_ids - replacement_id_set)
 
                 stmt = sqlite.insert(table)
                 stmt = stmt.on_conflict_do_update(
@@ -1831,6 +1833,14 @@ class SqliteDb(BaseDb):
                     ),
                 )
                 sess.execute(stmt, bulk_data)
+
+                if stale_ids:
+                    sess.execute(
+                        table.delete().where(
+                            table.c.user_id == user_id,
+                            table.c.memory_id.in_(stale_ids),
+                        )
+                    )
 
                 result = sess.execute(select(table).where(table.c.memory_id.in_(memory_ids))).fetchall()
 

--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -593,6 +593,15 @@ class MemoryManager:
             log_warning(f"Error deleting memory in db: {str(e)}")
             return "Error deleting memory"
 
+    def _prepare_optimized_memories_for_user(self, memories: List[UserMemory], user_id: str) -> List[UserMemory]:
+        for memory in memories:
+            if not memory.memory_id:
+                from uuid import uuid4
+
+                memory.memory_id = str(uuid4())
+            memory.user_id = user_id
+        return memories
+
     # -*- Utility Functions
     def search_user_memories(
         self,
@@ -852,18 +861,10 @@ class MemoryManager:
                 log_warning("Memory DB not provided. Cannot apply optimized memories.")
                 return optimized_memories
 
-            # Clear all existing memories for the user
-            self.clear_user_memories(user_id=user_id)
-
-            # Add all optimized memories
-            for opt_mem in optimized_memories:
-                # Ensure memory has an ID (generate if needed for new memories)
-                if not opt_mem.memory_id:
-                    from uuid import uuid4
-
-                    opt_mem.memory_id = str(uuid4())
-
-                self.db.upsert_user_memory(memory=opt_mem)
+            self.db.replace_user_memories(
+                user_id=user_id,
+                memories=self._prepare_optimized_memories_for_user(optimized_memories, user_id),
+            )
 
         optimized_tokens = strategy_instance.count_tokens(optimized_memories)
         log_debug(f"Optimization complete. New token count: {optimized_tokens}")
@@ -922,21 +923,11 @@ class MemoryManager:
                 log_warning("Memory DB not provided. Cannot apply optimized memories.")
                 return optimized_memories
 
-            # Clear all existing memories for the user
-            await self.aclear_user_memories(user_id=user_id)
-
-            # Add all optimized memories
-            for opt_mem in optimized_memories:
-                # Ensure memory has an ID (generate if needed for new memories)
-                if not opt_mem.memory_id:
-                    from uuid import uuid4
-
-                    opt_mem.memory_id = str(uuid4())
-
-                if isinstance(self.db, AsyncBaseDb):
-                    await self.db.upsert_user_memory(memory=opt_mem)
-                elif isinstance(self.db, BaseDb):
-                    self.db.upsert_user_memory(memory=opt_mem)
+            replacement_memories = self._prepare_optimized_memories_for_user(optimized_memories, user_id)
+            if isinstance(self.db, AsyncBaseDb):
+                await self.db.replace_user_memories(user_id=user_id, memories=replacement_memories)
+            elif isinstance(self.db, BaseDb):
+                self.db.replace_user_memories(user_id=user_id, memories=replacement_memories)
 
         optimized_tokens = strategy_instance.count_tokens(optimized_memories)
         log_debug(f"Memory optimization complete. New token count: {optimized_tokens}")

--- a/libs/agno/tests/integration/managers/test_memory_manager.py
+++ b/libs/agno/tests/integration/managers/test_memory_manager.py
@@ -1,14 +1,37 @@
 import os
 import tempfile
+from copy import deepcopy
 from datetime import datetime
 
 import pytest
 
-from agno.db.sqlite import SqliteDb
+from agno.db.sqlite import AsyncSqliteDb, SqliteDb
 from agno.memory import MemoryManager, UserMemory
-from agno.memory.strategies.types import MemoryOptimizationStrategyType
+from agno.memory.strategies import MemoryOptimizationStrategy
 from agno.models.message import Message
 from agno.models.openai import OpenAIChat
+
+
+class DeterministicOptimizationStrategy(MemoryOptimizationStrategy):
+    def __init__(self, optimized_memories):
+        self.optimized_memories = optimized_memories
+
+    def optimize(self, memories, model):
+        return deepcopy(self.optimized_memories)
+
+    async def aoptimize(self, memories, model):
+        return deepcopy(self.optimized_memories)
+
+
+class FailingReplaceSqliteDb(SqliteDb):
+    def replace_user_memories(self, user_id, memories, deserialize=True):
+        table = self._get_table(table_type="memories", create_table_if_not_found=True)
+        if table is None:
+            return []
+
+        with self.Session() as sess, sess.begin():
+            sess.execute(table.delete().where(table.c.user_id == user_id))
+            raise RuntimeError("injected replacement failure")
 
 
 @pytest.fixture
@@ -28,7 +51,8 @@ def temp_db_file():
 def memory_db(temp_db_file):
     """Create a SQLite memory database for testing."""
     db = SqliteDb(db_file=temp_db_file)
-    return db
+    yield db
+    db.close()
 
 
 @pytest.fixture
@@ -388,136 +412,216 @@ async def test_aupdate_memory_task_with_db(memory_with_db):
 
 
 def test_optimize_memories_with_db(memory_with_db):
-    """Test optimizing memories with database persistence."""
-    # Add multiple memories with different content
-    memory1 = UserMemory(
-        memory="The user's name is John Doe", topics=["name", "user"], user_id="test_user", updated_at=datetime.now()
-    )
-    memory2 = UserMemory(
-        memory="The user likes to play basketball",
-        topics=["sports", "hobbies"],
+    """Test optimizing memories replaces stale rows and persists."""
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="The user's name is John Doe",
+            topics=["name", "user"],
+            memory_id="stale-1",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
         user_id="test_user",
-        updated_at=datetime.now(),
     )
-    memory3 = UserMemory(
-        memory="The user's favorite color is blue",
-        topics=["preferences", "colors"],
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="The user likes to play basketball",
+            topics=["sports", "hobbies"],
+            memory_id="stale-2",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
         user_id="test_user",
-        updated_at=datetime.now(),
+    )
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="The user's favorite color is blue",
+            topics=["preferences", "colors"],
+            memory_id="stale-3",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
+        user_id="test_user",
     )
 
-    # Add the memories
-    memory_with_db.add_user_memory(memory=memory1, user_id="test_user")
-    memory_with_db.add_user_memory(memory=memory2, user_id="test_user")
-    memory_with_db.add_user_memory(memory=memory3, user_id="test_user")
+    strategy = DeterministicOptimizationStrategy(
+        [
+            UserMemory(
+                memory="John Doe likes basketball and prefers blue.",
+                topics=["summary"],
+                memory_id="optimized-1",
+            )
+        ]
+    )
 
-    # Get original count
-    original_memories = memory_with_db.get_user_memories(user_id="test_user")
-    original_count = len(original_memories)
-
-    # Optimize memories with default SUMMARIZE strategy
     optimized = memory_with_db.optimize_memories(
         user_id="test_user",
-        strategy=MemoryOptimizationStrategyType.SUMMARIZE,
+        strategy=strategy,
         apply=True,
     )
 
-    # Verify optimization returned results
-    assert len(optimized) > 0
-    assert all(isinstance(mem, UserMemory) for mem in optimized)
+    assert [memory.memory_id for memory in optimized] == ["optimized-1"]
 
-    # Verify memories were replaced in database
     final_memories = memory_with_db.get_user_memories(user_id="test_user")
-    assert len(final_memories) == len(optimized)
-    assert len(final_memories) < original_count  # Should be fewer after summarization
+    assert [memory.memory_id for memory in final_memories] == ["optimized-1"]
+    assert final_memories[0].memory == "John Doe likes basketball and prefers blue."
 
-    # Verify optimized memory contains information from original memories
-    optimized_content = " ".join([mem.memory.lower() for mem in optimized])
-    assert "john doe" in optimized_content or "basketball" in optimized_content or "blue" in optimized_content
+    persisted_manager = MemoryManager(model=memory_with_db.model, db=memory_with_db.db)
+    persisted_memories = persisted_manager.get_user_memories(user_id="test_user")
+    assert [memory.memory_id for memory in persisted_memories] == ["optimized-1"]
 
 
 def test_optimize_memories_with_db_apply_false(memory_with_db):
     """Test optimizing memories without applying to database."""
-    # Add multiple memories with different content
-    memory1 = UserMemory(
-        memory="The user's name is John Doe", topics=["name", "user"], user_id="test_user", updated_at=datetime.now()
-    )
-    memory2 = UserMemory(
-        memory="The user likes to play basketball",
-        topics=["sports", "hobbies"],
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="The user's name is John Doe",
+            topics=["name", "user"],
+            memory_id="original-1",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
         user_id="test_user",
-        updated_at=datetime.now(),
+    )
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="The user likes to play basketball",
+            topics=["sports", "hobbies"],
+            memory_id="original-2",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
+        user_id="test_user",
     )
 
-    # Add the memories
-    memory_with_db.add_user_memory(memory=memory1, user_id="test_user")
-    memory_with_db.add_user_memory(memory=memory2, user_id="test_user")
-
-    # Get original memories
     original_memories = memory_with_db.get_user_memories(user_id="test_user")
-    original_count = len(original_memories)
+    strategy = DeterministicOptimizationStrategy(
+        [UserMemory(memory="Optimized memory", topics=["summary"], memory_id="optimized-1")]
+    )
 
-    # Optimize memories with apply=False
     optimized = memory_with_db.optimize_memories(
         user_id="test_user",
-        strategy=MemoryOptimizationStrategyType.SUMMARIZE,
+        strategy=strategy,
         apply=False,
     )
 
-    # Verify optimization returned results
-    assert len(optimized) > 0
-
-    # Verify original memories are still in database (not replaced)
     final_memories = memory_with_db.get_user_memories(user_id="test_user")
-    assert len(final_memories) == original_count
+    assert [memory.memory_id for memory in optimized] == ["optimized-1"]
     assert final_memories == original_memories
 
 
 def test_optimize_memories_with_db_empty(memory_with_db):
     """Test optimizing memories when no memories exist."""
-    # Optimize memories for user with no memories
     optimized = memory_with_db.optimize_memories(user_id="test_user", apply=False)
 
-    # Should return empty list
     assert optimized == []
 
 
 def test_optimize_memories_with_db_default_user_id(memory_with_db):
     """Test optimizing memories with default user_id."""
-    # Add memories with default user_id
-    memory1 = UserMemory(memory="Default user memory", topics=["test"], user_id="default", updated_at=datetime.now())
-    memory_with_db.add_user_memory(memory=memory1, user_id="default")
+    memory_with_db.add_user_memory(
+        memory=UserMemory(memory="Default user memory", topics=["test"], user_id="default", updated_at=datetime.now()),
+        user_id="default",
+    )
 
-    # Optimize without specifying user_id (should default to "default")
-    optimized = memory_with_db.optimize_memories(strategy=MemoryOptimizationStrategyType.SUMMARIZE, apply=False)
+    strategy = DeterministicOptimizationStrategy(
+        [UserMemory(memory="Default user summary", topics=["summary"], memory_id="default-optimized-1")]
+    )
+    optimized = memory_with_db.optimize_memories(strategy=strategy, apply=False)
 
-    # Verify optimization worked
-    assert len(optimized) > 0
+    assert [memory.memory_id for memory in optimized] == ["default-optimized-1"]
 
 
 def test_optimize_memories_persistence_across_instances(model, memory_db):
     """Test that optimized memories persist across different Memory instances."""
-    # Create the first Memory instance
     memory1 = MemoryManager(model=model, db=memory_db)
-
-    # Add multiple memories
-    memory1_obj = UserMemory(
-        memory="The user's name is John Doe", topics=["name"], user_id="test_user", updated_at=datetime.now()
+    memory1.add_user_memory(
+        memory=UserMemory(
+            memory="The user's name is John Doe",
+            topics=["name"],
+            memory_id="persist-stale-1",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
+        user_id="test_user",
     )
-    memory2_obj = UserMemory(
-        memory="The user likes basketball", topics=["sports"], user_id="test_user", updated_at=datetime.now()
+    memory1.add_user_memory(
+        memory=UserMemory(
+            memory="The user likes basketball",
+            topics=["sports"],
+            memory_id="persist-stale-2",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
+        user_id="test_user",
     )
 
-    memory1.add_user_memory(memory=memory1_obj, user_id="test_user")
-    memory1.add_user_memory(memory=memory2_obj, user_id="test_user")
+    strategy = DeterministicOptimizationStrategy(
+        [UserMemory(memory="Persisted optimized memory", topics=["summary"], memory_id="persist-optimized-1")]
+    )
+    optimized = memory1.optimize_memories(user_id="test_user", strategy=strategy, apply=True)
 
-    # Optimize memories
-    optimized = memory1.optimize_memories(user_id="test_user", apply=True)
-
-    # Create a second Memory instance with the same database
     memory2 = MemoryManager(model=model, db=memory_db)
-
-    # Verify optimized memories are accessible from the second instance
     final_memories = memory2.get_user_memories(user_id="test_user")
     assert len(final_memories) == len(optimized)
     assert final_memories[0].memory_id == optimized[0].memory_id
+
+
+def test_optimize_memories_replace_failure_preserves_existing_rows(temp_db_file, model):
+    """Test replacement rollback preserves existing memories on failure."""
+    db = FailingReplaceSqliteDb(db_file=temp_db_file)
+    try:
+        manager = MemoryManager(model=model, db=db)
+        manager.add_user_memory(
+            memory=UserMemory(memory="Keep me", topics=["test"], memory_id="keep-1", user_id="test_user"),
+            user_id="test_user",
+        )
+        manager.add_user_memory(
+            memory=UserMemory(memory="Keep me too", topics=["test"], memory_id="keep-2", user_id="test_user"),
+            user_id="test_user",
+        )
+
+        strategy = DeterministicOptimizationStrategy(
+            [UserMemory(memory="Should not persist", topics=["summary"], memory_id="optimized-1")]
+        )
+
+        before = [(memory.memory_id, memory.memory) for memory in manager.get_user_memories(user_id="test_user")]
+
+        with pytest.raises(RuntimeError, match="injected replacement failure"):
+            manager.optimize_memories(user_id="test_user", strategy=strategy, apply=True)
+
+        after = [(memory.memory_id, memory.memory) for memory in manager.get_user_memories(user_id="test_user")]
+        assert after == before
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_aoptimize_memories_with_async_sqlite_persists_replacement(temp_db_file, model):
+    """Test async optimization uses async SQLite replacement."""
+    db = AsyncSqliteDb(db_file=temp_db_file)
+    try:
+        await db._get_table(table_type="memories", create_table_if_not_found=True)
+        await db.upsert_user_memory(
+            UserMemory(memory="Stale memory one", topics=["test"], memory_id="async-stale-1", user_id="test_user")
+        )
+        await db.upsert_user_memory(
+            UserMemory(memory="Stale memory two", topics=["test"], memory_id="async-stale-2", user_id="test_user")
+        )
+
+        manager = MemoryManager(model=model, db=db)
+        strategy = DeterministicOptimizationStrategy(
+            [UserMemory(memory="Async optimized memory", topics=["summary"], memory_id="async-optimized-1")]
+        )
+
+        optimized = await manager.aoptimize_memories(user_id="test_user", strategy=strategy, apply=True)
+
+        final_memories = await db.get_user_memories(user_id="test_user")
+        assert [memory.memory_id for memory in optimized] == ["async-optimized-1"]
+        assert [memory.memory_id for memory in final_memories] == ["async-optimized-1"]
+
+        persisted_manager = MemoryManager(model=model, db=db)
+        persisted_memories = await persisted_manager.aget_user_memories(user_id="test_user")
+        assert [memory.memory_id for memory in persisted_memories] == ["async-optimized-1"]
+    finally:
+        await db.close()

--- a/libs/agno/tests/integration/managers/test_memory_manager.py
+++ b/libs/agno/tests/integration/managers/test_memory_manager.py
@@ -23,15 +23,64 @@ class DeterministicOptimizationStrategy(MemoryOptimizationStrategy):
         return deepcopy(self.optimized_memories)
 
 
-class FailingReplaceSqliteDb(SqliteDb):
-    def replace_user_memories(self, user_id, memories, deserialize=True):
-        table = self._get_table(table_type="memories", create_table_if_not_found=True)
-        if table is None:
-            return []
+class _FailingSyncSession:
+    def __init__(self, session_factory):
+        self._session = session_factory()
+        self._failed = False
 
-        with self.Session() as sess, sess.begin():
-            sess.execute(table.delete().where(table.c.user_id == user_id))
+    def __enter__(self):
+        self._session.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return self._session.__exit__(exc_type, exc, tb)
+
+    def begin(self):
+        return self._session.begin()
+
+    def execute(self, stmt, *args, **kwargs):
+        if not self._failed and getattr(stmt, "is_insert", False):
+            self._failed = True
             raise RuntimeError("injected replacement failure")
+        return self._session.execute(stmt, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
+
+
+class _FailingAsyncSession:
+    def __init__(self, session_factory):
+        self._session = session_factory()
+        self._failed = False
+
+    async def __aenter__(self):
+        await self._session.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return await self._session.__aexit__(exc_type, exc, tb)
+
+    def begin(self):
+        return self._session.begin()
+
+    async def execute(self, stmt, *args, **kwargs):
+        if not self._failed and getattr(stmt, "is_insert", False):
+            self._failed = True
+            raise RuntimeError("injected replacement failure")
+        return await self._session.execute(stmt, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
+
+
+def _inject_sync_replace_failure(db: SqliteDb) -> None:
+    original_session_factory = db.Session
+    db.Session = lambda: _FailingSyncSession(original_session_factory)
+
+
+def _inject_async_replace_failure(db: AsyncSqliteDb) -> None:
+    original_session_factory = db.async_session_factory
+    db.async_session_factory = lambda: _FailingAsyncSession(original_session_factory)
 
 
 @pytest.fixture
@@ -636,7 +685,7 @@ def test_optimize_memories_persistence_across_instances(model, memory_db):
 
 def test_optimize_memories_replace_failure_preserves_existing_rows(temp_db_file, model):
     """Test replacement rollback preserves existing memories on failure."""
-    db = FailingReplaceSqliteDb(db_file=temp_db_file)
+    db = SqliteDb(db_file=temp_db_file)
     try:
         manager = MemoryManager(model=model, db=db)
         manager.add_user_memory(
@@ -653,6 +702,7 @@ def test_optimize_memories_replace_failure_preserves_existing_rows(temp_db_file,
         )
 
         before = [(memory.memory_id, memory.memory) for memory in manager.get_user_memories(user_id="test_user")]
+        _inject_sync_replace_failure(db)
 
         with pytest.raises(RuntimeError, match="injected replacement failure"):
             manager.optimize_memories(user_id="test_user", strategy=strategy, apply=True)
@@ -690,6 +740,38 @@ async def test_aoptimize_memories_with_async_sqlite_persists_replacement(temp_db
         persisted_manager = MemoryManager(model=model, db=db)
         persisted_memories = await persisted_manager.aget_user_memories(user_id="test_user")
         assert [memory.memory_id for memory in persisted_memories] == ["async-optimized-1"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_aoptimize_memories_with_async_sqlite_replace_failure_preserves_existing_rows(temp_db_file, model):
+    """Test async replacement rollback preserves existing memories on failure."""
+    db = AsyncSqliteDb(db_file=temp_db_file)
+    try:
+        await db._get_table(table_type="memories", create_table_if_not_found=True)
+        await db.upsert_user_memory(
+            UserMemory(memory="Keep me", topics=["test"], memory_id="async-keep-1", user_id="test_user")
+        )
+        await db.upsert_user_memory(
+            UserMemory(memory="Keep me too", topics=["test"], memory_id="async-keep-2", user_id="test_user")
+        )
+
+        manager = MemoryManager(model=model, db=db)
+        before = [(memory.memory_id, memory.memory) for memory in await db.get_user_memories(user_id="test_user")]
+        _inject_async_replace_failure(db)
+
+        with pytest.raises(RuntimeError, match="injected replacement failure"):
+            await manager.aoptimize_memories(
+                user_id="test_user",
+                strategy=DeterministicOptimizationStrategy(
+                    [UserMemory(memory="Should not persist", topics=["summary"], memory_id="async-optimized-1")]
+                ),
+                apply=True,
+            )
+
+        after = [(memory.memory_id, memory.memory) for memory in await db.get_user_memories(user_id="test_user")]
+        assert after == before
     finally:
         await db.close()
 

--- a/libs/agno/tests/integration/managers/test_memory_manager.py
+++ b/libs/agno/tests/integration/managers/test_memory_manager.py
@@ -553,6 +553,37 @@ def test_optimize_memories_with_db_empty_optimized_output_preserves_existing_row
     assert after == before
 
 
+def test_optimize_memories_with_db_same_id_preserves_created_at_and_refreshes_updated_at(memory_with_db):
+    """Test same-ID replacements keep created_at and advance updated_at."""
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="Original",
+            topics=["test"],
+            memory_id="same-1",
+            user_id="test_user",
+            created_at=1000,
+            updated_at=1000,
+        ),
+        user_id="test_user",
+    )
+
+    optimized = memory_with_db.optimize_memories(
+        user_id="test_user",
+        strategy=DeterministicOptimizationStrategy(
+            [UserMemory(memory="Optimized", topics=["summary"], memory_id="same-1")]
+        ),
+        apply=True,
+    )
+
+    final_memories = memory_with_db.get_user_memories(user_id="test_user")
+    assert [memory.memory_id for memory in optimized] == ["same-1"]
+    assert [memory.memory_id for memory in final_memories] == ["same-1"]
+    assert final_memories[0].memory == "Optimized"
+    assert final_memories[0].created_at == 1000
+    assert final_memories[0].updated_at is not None
+    assert final_memories[0].updated_at > 1000
+
+
 def test_optimize_memories_with_db_default_user_id(memory_with_db):
     """Test optimizing memories with default user_id."""
     memory_with_db.add_user_memory(
@@ -688,5 +719,44 @@ async def test_aoptimize_memories_with_async_sqlite_empty_optimized_output_prese
         after = [(memory.memory_id, memory.memory) for memory in await db.get_user_memories(user_id="test_user")]
         assert optimized == []
         assert after == before
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_aoptimize_memories_with_async_sqlite_same_id_preserves_created_at_and_refreshes_updated_at(
+    temp_db_file, model
+):
+    """Test async same-ID replacements keep created_at and advance updated_at."""
+    db = AsyncSqliteDb(db_file=temp_db_file)
+    try:
+        await db._get_table(table_type="memories", create_table_if_not_found=True)
+        await db.upsert_user_memory(
+            UserMemory(
+                memory="Original",
+                topics=["test"],
+                memory_id="async-same-1",
+                user_id="test_user",
+                created_at=1000,
+                updated_at=1000,
+            )
+        )
+
+        manager = MemoryManager(model=model, db=db)
+        optimized = await manager.aoptimize_memories(
+            user_id="test_user",
+            strategy=DeterministicOptimizationStrategy(
+                [UserMemory(memory="Optimized", topics=["summary"], memory_id="async-same-1")]
+            ),
+            apply=True,
+        )
+
+        final_memories = await db.get_user_memories(user_id="test_user")
+        assert [memory.memory_id for memory in optimized] == ["async-same-1"]
+        assert [memory.memory_id for memory in final_memories] == ["async-same-1"]
+        assert final_memories[0].memory == "Optimized"
+        assert final_memories[0].created_at == 1000
+        assert final_memories[0].updated_at is not None
+        assert final_memories[0].updated_at > 1000
     finally:
         await db.close()

--- a/libs/agno/tests/integration/managers/test_memory_manager.py
+++ b/libs/agno/tests/integration/managers/test_memory_manager.py
@@ -517,6 +517,42 @@ def test_optimize_memories_with_db_empty(memory_with_db):
     assert optimized == []
 
 
+def test_optimize_memories_with_db_empty_optimized_output_preserves_existing_rows(memory_with_db):
+    """Test empty optimized output leaves existing rows intact."""
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="Keep me",
+            topics=["test"],
+            memory_id="keep-1",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
+        user_id="test_user",
+    )
+    memory_with_db.add_user_memory(
+        memory=UserMemory(
+            memory="Keep me too",
+            topics=["test"],
+            memory_id="keep-2",
+            user_id="test_user",
+            updated_at=datetime.now(),
+        ),
+        user_id="test_user",
+    )
+
+    before = [(memory.memory_id, memory.memory) for memory in memory_with_db.get_user_memories(user_id="test_user")]
+
+    optimized = memory_with_db.optimize_memories(
+        user_id="test_user",
+        strategy=DeterministicOptimizationStrategy([]),
+        apply=True,
+    )
+
+    after = [(memory.memory_id, memory.memory) for memory in memory_with_db.get_user_memories(user_id="test_user")]
+    assert optimized == []
+    assert after == before
+
+
 def test_optimize_memories_with_db_default_user_id(memory_with_db):
     """Test optimizing memories with default user_id."""
     memory_with_db.add_user_memory(
@@ -623,5 +659,34 @@ async def test_aoptimize_memories_with_async_sqlite_persists_replacement(temp_db
         persisted_manager = MemoryManager(model=model, db=db)
         persisted_memories = await persisted_manager.aget_user_memories(user_id="test_user")
         assert [memory.memory_id for memory in persisted_memories] == ["async-optimized-1"]
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_aoptimize_memories_with_async_sqlite_empty_optimized_output_preserves_rows(temp_db_file, model):
+    """Test async empty optimized output leaves existing rows intact."""
+    db = AsyncSqliteDb(db_file=temp_db_file)
+    try:
+        await db._get_table(table_type="memories", create_table_if_not_found=True)
+        await db.upsert_user_memory(
+            UserMemory(memory="Keep me", topics=["test"], memory_id="async-keep-1", user_id="test_user")
+        )
+        await db.upsert_user_memory(
+            UserMemory(memory="Keep me too", topics=["test"], memory_id="async-keep-2", user_id="test_user")
+        )
+
+        manager = MemoryManager(model=model, db=db)
+        before = [(memory.memory_id, memory.memory) for memory in await db.get_user_memories(user_id="test_user")]
+
+        optimized = await manager.aoptimize_memories(
+            user_id="test_user",
+            strategy=DeterministicOptimizationStrategy([]),
+            apply=True,
+        )
+
+        after = [(memory.memory_id, memory.memory) for memory in await db.get_user_memories(user_id="test_user")]
+        assert optimized == []
+        assert after == before
     finally:
         await db.close()

--- a/libs/agno/tests/unit/memory/test_memory_optimization.py
+++ b/libs/agno/tests/unit/memory/test_memory_optimization.py
@@ -186,6 +186,17 @@ def test_base_db_replace_user_memories_stages_upserts_before_stale_deletes():
     ]
 
 
+def test_base_db_replace_user_memories_empty_replacement_is_noop():
+    db = MagicMock(spec=BaseDb)
+
+    result = BaseDb.replace_user_memories(db, user_id="user-1", memories=[])
+
+    assert result == []
+    db.get_user_memories.assert_not_called()
+    db.upsert_memories.assert_not_called()
+    db.delete_user_memories.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_async_base_db_replace_user_memories_stages_upserts_before_stale_deletes():
     db = AsyncMock(spec=AsyncBaseDb)
@@ -211,6 +222,19 @@ async def test_async_base_db_replace_user_memories_stages_upserts_before_stale_d
         call.upsert_memories(memories=replacement_memories, deserialize=True),
         call.delete_user_memories(memory_ids=["stale-1"], user_id="user-1"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_async_base_db_replace_user_memories_empty_replacement_is_noop():
+    db = AsyncMock(spec=AsyncBaseDb)
+
+    result = await AsyncBaseDb.replace_user_memories(db, user_id="user-1", memories=[])
+
+    assert result == []
+    db.get_user_memories.assert_not_called()
+    db.upsert_memories.assert_not_called()
+    db.upsert_user_memory.assert_not_called()
+    db.delete_user_memories.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/memory/test_memory_optimization.py
+++ b/libs/agno/tests/unit/memory/test_memory_optimization.py
@@ -126,9 +126,38 @@ def test_optimize_memories_async_db_error(mock_async_db, mock_model):
         manager.optimize_memories(user_id="user-1")
 
 
-def test_async_db_contract_exposes_replacement_and_bulk_upsert(mock_async_db):
-    assert hasattr(mock_async_db, "replace_user_memories")
-    assert hasattr(mock_async_db, "upsert_memories")
+@pytest.mark.asyncio
+async def test_async_db_contract_exposes_replacement_and_bulk_upsert():
+    class AsyncSingleUpsertFallbackDb:
+        upsert_memories = AsyncBaseDb.upsert_memories
+
+        def __init__(self):
+            self.get_user_memories = AsyncMock(
+                return_value=[UserMemory(memory="stale", user_id="user-1", memory_id="stale-1")]
+            )
+            self.upsert_user_memory = AsyncMock(
+                side_effect=[
+                    UserMemory(memory="kept", user_id="user-1", memory_id="keep-1"),
+                    UserMemory(memory="new", user_id="user-1", memory_id="new-1"),
+                ]
+            )
+            self.delete_user_memories = AsyncMock()
+
+    db = AsyncSingleUpsertFallbackDb()
+    replacement_memories = [
+        UserMemory(memory="kept", user_id="user-1", memory_id="keep-1"),
+        UserMemory(memory="new", user_id="user-1", memory_id="new-1"),
+    ]
+
+    result = await AsyncBaseDb.replace_user_memories(db, user_id="user-1", memories=replacement_memories)
+
+    assert result == replacement_memories
+    db.get_user_memories.assert_awaited_once_with(user_id="user-1")
+    assert db.upsert_user_memory.await_args_list == [
+        call(memory=replacement_memories[0], deserialize=True),
+        call(memory=replacement_memories[1], deserialize=True),
+    ]
+    db.delete_user_memories.assert_awaited_once_with(memory_ids=["stale-1"], user_id="user-1")
 
 
 def test_base_db_replace_user_memories_stages_upserts_before_stale_deletes():

--- a/libs/agno/tests/unit/memory/test_memory_optimization.py
+++ b/libs/agno/tests/unit/memory/test_memory_optimization.py
@@ -1,33 +1,28 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.memory.manager import MemoryManager, UserMemory
-from agno.memory.strategies import (
-    MemoryOptimizationStrategy,
-    MemoryOptimizationStrategyType,
-)
+from agno.memory.strategies import MemoryOptimizationStrategy, MemoryOptimizationStrategyType
 
 
 @pytest.fixture
 def mock_db():
     db = MagicMock(spec=BaseDb)
-    # Setup default behaviors
     db.upsert_user_memory.return_value = None
+    db.replace_user_memories.return_value = None
     return db
 
 
 @pytest.fixture
 def mock_async_db():
-    db = AsyncMock(spec=AsyncBaseDb)
-    return db
+    return AsyncMock(spec=AsyncBaseDb)
 
 
 @pytest.fixture
 def mock_model():
     model = MagicMock()
-    # Patch get_model to return our mock model instead of validating it
     with patch("agno.memory.manager.get_model", return_value=model):
         yield model
 
@@ -53,39 +48,31 @@ def optimized_memories():
 
 
 def test_optimize_memories_success(mock_db, mock_model, mock_strategy, sample_memories, optimized_memories):
-    """Test successful synchronous memory optimization."""
-    # Setup
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=sample_memories)
     manager.clear_user_memories = MagicMock()
 
-    # Mock factory to return our mock strategy
     with patch(
-        "agno.memory.strategies.MemoryOptimizationStrategyFactory.create_strategy", return_value=mock_strategy
+        "agno.memory.strategies.MemoryOptimizationStrategyFactory.create_strategy",
+        return_value=mock_strategy,
     ) as mock_factory:
-        # Mock strategy optimize method
         mock_strategy.optimize.return_value = optimized_memories
 
-        # Execute
         result = manager.optimize_memories(
-            user_id="user-1", strategy=MemoryOptimizationStrategyType.SUMMARIZE, apply=True
+            user_id="user-1",
+            strategy=MemoryOptimizationStrategyType.SUMMARIZE,
+            apply=True,
         )
 
-        # Verify Factory usage
-        mock_factory.assert_called_once_with(MemoryOptimizationStrategyType.SUMMARIZE)
-
-        # Verify Optimization call
-        mock_strategy.optimize.assert_called_once_with(memories=sample_memories, model=mock_model)
-
-        # Verify DB operations (apply=True)
-        manager.clear_user_memories.assert_called_once_with(user_id="user-1")
-        mock_db.upsert_user_memory.assert_called()
-        assert mock_db.upsert_user_memory.call_count == len(optimized_memories)
-        assert result == optimized_memories
+    mock_factory.assert_called_once_with(MemoryOptimizationStrategyType.SUMMARIZE)
+    mock_strategy.optimize.assert_called_once_with(memories=sample_memories, model=mock_model)
+    manager.clear_user_memories.assert_not_called()
+    mock_db.upsert_user_memory.assert_not_called()
+    mock_db.replace_user_memories.assert_called_once_with(user_id="user-1", memories=optimized_memories)
+    assert result == optimized_memories
 
 
 def test_optimize_memories_apply_false(mock_db, mock_model, mock_strategy, sample_memories, optimized_memories):
-    """Test optimization without applying changes to DB."""
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=sample_memories)
     manager.clear_user_memories = MagicMock()
@@ -95,54 +82,116 @@ def test_optimize_memories_apply_false(mock_db, mock_model, mock_strategy, sampl
 
         result = manager.optimize_memories(user_id="user-1", apply=False)
 
-        # Verify DB was NOT touched
-        manager.clear_user_memories.assert_not_called()
-        mock_db.upsert_user_memory.assert_not_called()
-        assert result == optimized_memories
+    manager.clear_user_memories.assert_not_called()
+    mock_db.upsert_user_memory.assert_not_called()
+    mock_db.replace_user_memories.assert_not_called()
+    assert result == optimized_memories
 
 
 def test_optimize_memories_empty(mock_db, mock_model):
-    """Test optimization with no existing memories."""
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=[])
 
     result = manager.optimize_memories(user_id="user-1")
 
     assert result == []
-    # Should return early before creating strategy
     mock_model.assert_not_called()
+    mock_db.replace_user_memories.assert_not_called()
 
 
 def test_optimize_memories_custom_strategy_instance(
-    mock_db, mock_model, mock_strategy, sample_memories, optimized_memories
+    mock_db,
+    mock_model,
+    mock_strategy,
+    sample_memories,
+    optimized_memories,
 ):
-    """Test optimization passing a strategy instance directly."""
     manager = MemoryManager(db=mock_db, model=mock_model)
     manager.get_user_memories = MagicMock(return_value=sample_memories)
     manager.clear_user_memories = MagicMock()
-
     mock_strategy.optimize.return_value = optimized_memories
 
-    # Pass instance directly
     manager.optimize_memories(user_id="user-1", strategy=mock_strategy, apply=True)
 
-    # Verify method called on passed instance
     mock_strategy.optimize.assert_called_once()
+    manager.clear_user_memories.assert_not_called()
+    mock_db.upsert_user_memory.assert_not_called()
+    mock_db.replace_user_memories.assert_called_once_with(user_id="user-1", memories=optimized_memories)
 
 
 def test_optimize_memories_async_db_error(mock_async_db, mock_model):
-    """Test that calling sync optimize with async DB raises ValueError."""
     manager = MemoryManager(db=mock_async_db, model=mock_model)
 
     with pytest.raises(ValueError, match="not supported with an async DB"):
         manager.optimize_memories(user_id="user-1")
 
 
+def test_async_db_contract_exposes_replacement_and_bulk_upsert(mock_async_db):
+    assert hasattr(mock_async_db, "replace_user_memories")
+    assert hasattr(mock_async_db, "upsert_memories")
+
+
+def test_base_db_replace_user_memories_stages_upserts_before_stale_deletes():
+    db = MagicMock(spec=BaseDb)
+    existing_memories = [
+        UserMemory(memory="stale", user_id="user-1", memory_id="stale-1"),
+        UserMemory(memory="shared", user_id="user-1", memory_id="shared-1"),
+    ]
+    replacement_memories = [
+        UserMemory(memory="shared updated", user_id="user-1", memory_id="shared-1"),
+        UserMemory(memory="new", user_id="user-1", memory_id="new-1"),
+    ]
+    db.get_user_memories.return_value = existing_memories
+    db.upsert_memories.return_value = replacement_memories
+
+    result = BaseDb.replace_user_memories(db, user_id="user-1", memories=replacement_memories)
+
+    assert result == replacement_memories
+    db.get_user_memories.assert_called_once_with(user_id="user-1")
+    db.upsert_memories.assert_called_once_with(memories=replacement_memories, deserialize=True)
+    db.delete_user_memories.assert_called_once_with(memory_ids=["stale-1"], user_id="user-1")
+    assert db.mock_calls == [
+        call.get_user_memories(user_id="user-1"),
+        call.upsert_memories(memories=replacement_memories, deserialize=True),
+        call.delete_user_memories(memory_ids=["stale-1"], user_id="user-1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_base_db_replace_user_memories_stages_upserts_before_stale_deletes():
+    db = AsyncMock(spec=AsyncBaseDb)
+    existing_memories = [
+        UserMemory(memory="stale", user_id="user-1", memory_id="stale-1"),
+        UserMemory(memory="shared", user_id="user-1", memory_id="shared-1"),
+    ]
+    replacement_memories = [
+        UserMemory(memory="shared updated", user_id="user-1", memory_id="shared-1"),
+        UserMemory(memory="new", user_id="user-1", memory_id="new-1"),
+    ]
+    db.get_user_memories.return_value = existing_memories
+    db.upsert_memories.return_value = replacement_memories
+
+    result = await AsyncBaseDb.replace_user_memories(db, user_id="user-1", memories=replacement_memories)
+
+    assert result == replacement_memories
+    db.get_user_memories.assert_awaited_once_with(user_id="user-1")
+    db.upsert_memories.assert_awaited_once_with(memories=replacement_memories, deserialize=True)
+    db.delete_user_memories.assert_awaited_once_with(memory_ids=["stale-1"], user_id="user-1")
+    assert db.mock_calls == [
+        call.get_user_memories(user_id="user-1"),
+        call.upsert_memories(memories=replacement_memories, deserialize=True),
+        call.delete_user_memories(memory_ids=["stale-1"], user_id="user-1"),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_aoptimize_memories_success(
-    mock_async_db, mock_model, mock_strategy, sample_memories, optimized_memories
+    mock_async_db,
+    mock_model,
+    mock_strategy,
+    sample_memories,
+    optimized_memories,
 ):
-    """Test successful async memory optimization."""
     manager = MemoryManager(db=mock_async_db, model=mock_model)
     manager.aget_user_memories = AsyncMock(return_value=sample_memories)
     manager.aclear_user_memories = AsyncMock()
@@ -151,21 +200,29 @@ async def test_aoptimize_memories_success(
         mock_strategy.aoptimize = AsyncMock(return_value=optimized_memories)
 
         result = await manager.aoptimize_memories(
-            user_id="user-1", strategy=MemoryOptimizationStrategyType.SUMMARIZE, apply=True
+            user_id="user-1",
+            strategy=MemoryOptimizationStrategyType.SUMMARIZE,
+            apply=True,
         )
 
-        # Verify async calls
-        mock_strategy.aoptimize.assert_called_once_with(memories=sample_memories, model=mock_model)
-        manager.aclear_user_memories.assert_called_once_with(user_id="user-1")
-        assert mock_async_db.upsert_user_memory.await_count == len(optimized_memories)
-        assert result == optimized_memories
+    mock_strategy.aoptimize.assert_called_once_with(memories=sample_memories, model=mock_model)
+    manager.aclear_user_memories.assert_not_called()
+    mock_async_db.upsert_user_memory.assert_not_called()
+    mock_async_db.replace_user_memories.assert_awaited_once_with(
+        user_id="user-1",
+        memories=optimized_memories,
+    )
+    assert result == optimized_memories
 
 
 @pytest.mark.asyncio
 async def test_aoptimize_memories_apply_false(
-    mock_async_db, mock_model, mock_strategy, sample_memories, optimized_memories
+    mock_async_db,
+    mock_model,
+    mock_strategy,
+    sample_memories,
+    optimized_memories,
 ):
-    """Test async optimization without applying to DB."""
     manager = MemoryManager(db=mock_async_db, model=mock_model)
     manager.aget_user_memories = AsyncMock(return_value=sample_memories)
     manager.aclear_user_memories = AsyncMock()
@@ -175,43 +232,42 @@ async def test_aoptimize_memories_apply_false(
 
         result = await manager.aoptimize_memories(user_id="user-1", apply=False)
 
-        manager.aclear_user_memories.assert_not_called()
-        mock_async_db.upsert_user_memory.assert_not_called()
-        assert result == optimized_memories
+    manager.aclear_user_memories.assert_not_called()
+    mock_async_db.upsert_user_memory.assert_not_called()
+    mock_async_db.replace_user_memories.assert_not_called()
+    assert result == optimized_memories
 
 
 @pytest.mark.asyncio
 async def test_aoptimize_memories_empty(mock_async_db, mock_model):
-    """Test async optimization with empty memories."""
     manager = MemoryManager(db=mock_async_db, model=mock_model)
     manager.aget_user_memories = AsyncMock(return_value=[])
 
     result = await manager.aoptimize_memories(user_id="user-1")
 
     assert result == []
+    mock_async_db.replace_user_memories.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_aoptimize_memories_sync_db_compatibility(
-    mock_db, mock_model, mock_strategy, sample_memories, optimized_memories
+    mock_db,
+    mock_model,
+    mock_strategy,
+    sample_memories,
+    optimized_memories,
 ):
-    """Test that async optimize works even with a sync DB (hybrid usage)."""
     manager = MemoryManager(db=mock_db, model=mock_model)
-    # Note: With sync DB, it calls get_user_memories (sync) not aget
     manager.get_user_memories = MagicMock(return_value=sample_memories)
     manager.clear_user_memories = MagicMock()
-    # But upsert/clear might be handled differently depending on implementation
-    # The code handles `isinstance(self.db, AsyncBaseDb)` checks.
-
-    # Since we mocked db as BaseDb, manager treats it as sync
 
     with patch("agno.memory.strategies.MemoryOptimizationStrategyFactory.create_strategy", return_value=mock_strategy):
         mock_strategy.aoptimize = AsyncMock(return_value=optimized_memories)
 
-        # It should use the async strategy method, but sync DB methods
         result = await manager.aoptimize_memories(user_id="user-1", apply=True)
 
-        mock_strategy.aoptimize.assert_called_once()
-        # Should use sync upsert since DB is sync
-        mock_db.upsert_user_memory.assert_called()
-        assert result == optimized_memories
+    mock_strategy.aoptimize.assert_called_once()
+    manager.clear_user_memories.assert_not_called()
+    mock_db.upsert_user_memory.assert_not_called()
+    mock_db.replace_user_memories.assert_called_once_with(user_id="user-1", memories=optimized_memories)
+    assert result == optimized_memories

--- a/libs/agno/tests/unit/memory/test_memory_optimization.py
+++ b/libs/agno/tests/unit/memory/test_memory_optimization.py
@@ -197,6 +197,25 @@ def test_base_db_replace_user_memories_empty_replacement_is_noop():
     db.delete_user_memories.assert_not_called()
 
 
+def test_base_db_replace_user_memories_skips_stale_delete_when_staging_is_incomplete():
+    db = MagicMock(spec=BaseDb)
+    replacement_memories = [
+        UserMemory(memory="first", user_id="user-1", memory_id="first-1"),
+        UserMemory(memory="second", user_id="user-1", memory_id="second-1"),
+    ]
+    db.get_user_memories.return_value = [
+        UserMemory(memory="stale", user_id="user-1", memory_id="stale-1"),
+    ]
+    db.upsert_memories.return_value = replacement_memories[:1]
+
+    result = BaseDb.replace_user_memories(db, user_id="user-1", memories=replacement_memories)
+
+    assert result == replacement_memories[:1]
+    db.get_user_memories.assert_called_once_with(user_id="user-1")
+    db.upsert_memories.assert_called_once_with(memories=replacement_memories, deserialize=True)
+    db.delete_user_memories.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_async_base_db_replace_user_memories_stages_upserts_before_stale_deletes():
     db = AsyncMock(spec=AsyncBaseDb)
@@ -235,6 +254,27 @@ async def test_async_base_db_replace_user_memories_empty_replacement_is_noop():
     db.upsert_memories.assert_not_called()
     db.upsert_user_memory.assert_not_called()
     db.delete_user_memories.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_base_db_replace_user_memories_skips_stale_delete_when_staging_is_incomplete():
+    db = AsyncMock(spec=AsyncBaseDb)
+    replacement_memories = [
+        UserMemory(memory="first", user_id="user-1", memory_id="first-1"),
+        UserMemory(memory="second", user_id="user-1", memory_id="second-1"),
+    ]
+    db.get_user_memories.return_value = [
+        UserMemory(memory="stale", user_id="user-1", memory_id="stale-1"),
+    ]
+    db.upsert_memories.return_value = replacement_memories[:1]
+
+    result = await AsyncBaseDb.replace_user_memories(db, user_id="user-1", memories=replacement_memories)
+
+    assert result == replacement_memories[:1]
+    db.get_user_memories.assert_awaited_once_with(user_id="user-1")
+    db.upsert_memories.assert_awaited_once_with(memories=replacement_memories, deserialize=True)
+    db.delete_user_memories.assert_not_called()
+    db.upsert_user_memory.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`MemoryManager.optimize_memories(..., apply=True)` and `MemoryManager.aoptimize_memories(..., apply=True)` currently clear a user's stored memories before writing the optimized replacement set. If a DB failure lands between those steps, the old memories are already gone.

This routes optimization apply through DB-owned `replace_user_memories(...)` contracts for sync and async backends instead of manager-level delete-then-upsert sequencing. Transaction-capable backends can perform stale-row deletion and replacement upsert inside one backend transaction, same-ID replacements keep SQLite recency semantics intact, empty optimized outputs preserve the existing rows, and the fallback path only prunes stale rows after replacement staging completes.

Closes #7051.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Scope is limited to user-memory replacement during optimization apply. Single-memory add, update, delete, search, and `apply=False` optimization behavior are outside this change.

ashpreetbedi's 2026-04-03 issue comment confirmed the current data-loss risk and kept this scoped as a high-priority bug.

Similar open PR `#7312` (https://github.com/agno-agi/agno/pull/7312) still exists, but current `origin/main` evidence shows it is stale and structurally weaker for this bug. It keeps replacement sequencing in `memory/manager.py` by reordering inserts and deletes; this implementation moves replacement semantics into a DB-owned contract, gives sync and async optimize paths the same seam, preserves same-ID timestamp semantics in SQLite, and avoids stale-row pruning when fallback staging is incomplete.

Validation from this branch state:

```cmd
python -m pytest libs/agno/tests/unit/memory/test_memory_optimization.py -q
# 16 passed

python -m pytest libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_with_db libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_with_db_apply_false libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_with_db_empty libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_with_db_empty_optimized_output_preserves_existing_rows libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_with_db_same_id_preserves_created_at_and_refreshes_updated_at libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_with_db_default_user_id libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_persistence_across_instances libs/agno/tests/integration/managers/test_memory_manager.py::test_optimize_memories_replace_failure_preserves_existing_rows libs/agno/tests/integration/managers/test_memory_manager.py::test_aoptimize_memories_with_async_sqlite_persists_replacement libs/agno/tests/integration/managers/test_memory_manager.py::test_aoptimize_memories_with_async_sqlite_replace_failure_preserves_existing_rows libs/agno/tests/integration/managers/test_memory_manager.py::test_aoptimize_memories_with_async_sqlite_empty_optimized_output_preserves_rows libs/agno/tests/integration/managers/test_memory_manager.py::test_aoptimize_memories_with_async_sqlite_same_id_preserves_created_at_and_refreshes_updated_at -q
# 12 passed, 1 warning

scripts\format.bat

bash -lc 'source .venv/Scripts/activate && python3(){ python "$@"; } && export -f python3 && ./scripts/validate.sh'
```
