### PR TITLE
feat: surface a normalized finish_reason across model providers

### DIFF
--- a/cookbook/02_agents/02_input_output/README.md
+++ b/cookbook/02_agents/02_input_output/README.md
@@ -9,6 +9,7 @@ Examples for input formats, validation schemas, streaming, and structured output
 - `output_model.py` - Return structured data using output_model with a Pydantic model.
 - `output_schema.py` - Demonstrates output schema.
 - `parser_model.py` - Demonstrates parser model for structured extraction.
+- `finish_reason.py` - Read why the model stopped (normalized finish_reason, including truncation).
 - `response_as_variable.py` - Capture agent response as a variable.
 - `save_to_file.py` - Save agent responses to a file automatically.
 - `streaming.py` - Stream agent responses token by token.

--- a/cookbook/02_agents/02_input_output/TEST_LOG.md
+++ b/cookbook/02_agents/02_input_output/TEST_LOG.md
@@ -85,3 +85,12 @@
 **Result:** Completed successfully in 9s.
 
 ---
+
+### finish_reason.py
+
+**Status:** NOT RUN
+**Tier:** untagged
+**Description:** Reads RunOutput.finish_reason for a normal completion (stop) and a token-capped run (length), plus the raw native_finish_reason. Not executed end-to-end here: no demo venv and no OPENAI_API_KEY in this environment.
+**Result:** py_compile passes; imports and model construction verified with .venv. Underlying mapping/propagation covered by unit tests (test_finish_reason_mapping.py, openai/test_finish_reason_openai.py, agent/test_finish_reason.py). Run with `.venvs/demo/bin/python cookbook/02_agents/02_input_output/finish_reason.py` once OPENAI_API_KEY is set.
+
+---

--- a/cookbook/02_agents/02_input_output/finish_reason.py
+++ b/cookbook/02_agents/02_input_output/finish_reason.py
@@ -1,0 +1,44 @@
+"""
+Finish Reason
+=============================
+
+Read why the model stopped generating from RunOutput.finish_reason.
+
+The normalized FinishReason is consistent across providers (stop, length, tool_call,
+content_filter, pause, refusal, error, unknown). The raw provider value is preserved under
+model_provider_data["native_finish_reason"].
+
+A truncated answer (the model hit the output token cap) reports FinishReason.LENGTH instead of
+looking exactly like a clean completion.
+"""
+
+from agno.agent import Agent, RunOutput
+from agno.models.finish_reason import FinishReason
+from agno.models.openai import OpenAIResponses
+
+# A normal completion stops on its own -> FinishReason.STOP
+agent = Agent(model=OpenAIResponses(id="gpt-5.5"))
+
+# A tiny output cap forces truncation -> FinishReason.LENGTH (a warning is logged)
+truncating_agent = Agent(model=OpenAIResponses(id="gpt-5.5", max_output_tokens=16))
+
+if __name__ == "__main__":
+    run_output: RunOutput = agent.run(
+        "Give me one short sentence about the printing press."
+    )
+    print("Normal run")
+    print("  content:", run_output.content)
+    print("  finish_reason:", run_output.finish_reason)
+
+    truncated: RunOutput = truncating_agent.run(
+        "Write a 500-word essay on the history of the printing press."
+    )
+    print("Truncated run")
+    print("  content:", truncated.content)
+    print("  finish_reason:", truncated.finish_reason)
+    print("  is truncated:", truncated.finish_reason == FinishReason.LENGTH)
+    if truncated.model_provider_data:
+        print(
+            "  native_finish_reason:",
+            truncated.model_provider_data.get("native_finish_reason"),
+        )

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -27,6 +27,7 @@ from agno.exceptions import RunCancelledException
 from agno.media import Audio
 from agno.models.base import Model
 from agno.models.fallback import acall_model_stream_with_fallback, call_model_stream_with_fallback
+from agno.models.finish_reason import warn_if_truncated
 from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
@@ -998,6 +999,9 @@ def update_run_response(
         run_response.citations = model_response.citations
     if model_response.provider_data is not None:
         run_response.model_provider_data = model_response.provider_data
+    if model_response.finish_reason is not None:
+        run_response.finish_reason = model_response.finish_reason
+        warn_if_truncated(run_response, run_response.finish_reason)
 
     # Update the run_response tools with the model response tool_executions.
     # Dedupe by tool_call_id: with checkpoint="tool-batch" the per-batch callback
@@ -1445,6 +1449,13 @@ def handle_model_response_chunk(
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data
+
+            # Handle finish reason (one chunk). Copied onto run_response only; the completion
+            # event is built from run_response.finish_reason, so this must NOT join the
+            # content-event guard below (that would emit a spurious content event).
+            if model_response_event.finish_reason is not None:
+                run_response.finish_reason = model_response_event.finish_reason
+                warn_if_truncated(run_response, run_response.finish_reason)
 
             # Handle citations (one chunk)
             if model_response_event.citations is not None:

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ValidationError
 
 from agno.exceptions import ModelProviderError, ModelRateLimitError
 from agno.models.base import Model
+from agno.models.finish_reason import map_anthropic_finish_reason
 from agno.models.message import Citations, DocumentCitation, Message, UrlCitation
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -1056,6 +1057,14 @@ class Claude(Model):
         if response.usage is not None:
             model_response.response_usage = self._get_metrics(response.usage)
 
+        # Normalize the stop reason and preserve the raw provider value
+        if isinstance(response.stop_reason, str):
+            finish_reason, native_finish_reason = map_anthropic_finish_reason(response.stop_reason)
+            model_response.finish_reason = finish_reason
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
+
         # Capture context management information if present
         if self.context_management is not None and hasattr(response, "context_management"):
             if response.context_management is not None:  # type: ignore
@@ -1264,6 +1273,16 @@ class Claude(Model):
             and response.message.usage is not None  # type: ignore
         ):
             model_response.response_usage = self._get_metrics(response.message.usage)  # type: ignore
+
+        # Normalize the stop reason from the terminal MessageStop event and preserve the raw value
+        if isinstance(response, (MessageStopEvent, ParsedBetaMessageStopEvent)) and hasattr(response, "message"):
+            stop_reason = getattr(response.message, "stop_reason", None)  # type: ignore
+            if isinstance(stop_reason, str):
+                finish_reason, native_finish_reason = map_anthropic_finish_reason(stop_reason)
+                model_response.finish_reason = finish_reason
+                if model_response.provider_data is None:
+                    model_response.provider_data = {}
+                model_response.provider_data["native_finish_reason"] = native_finish_reason
 
         # Capture the Beta response
         try:

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1161,6 +1161,11 @@ class Model(ABC):
             model_response.provider_data = provider_response.provider_data
         if provider_response.response_usage is not None:
             model_response.response_usage = provider_response.response_usage
+        # Copy the normalized finish reason. Guarded so a later None (the aggregate
+        # model_response is reused across a multi-step tool loop) cannot wipe the
+        # terminal reason; last non-null writer wins.
+        if provider_response.finish_reason is not None:
+            model_response.finish_reason = provider_response.finish_reason
         # Providers (e.g. GeminiInteractions on the agent path) can produce
         # already-executed ToolExecution records server-side; carry them
         # through so run_response.tools / AgentOS UI sees the audit.
@@ -1231,6 +1236,11 @@ class Model(ABC):
             model_response.provider_data = provider_response.provider_data
         if provider_response.response_usage is not None:
             model_response.response_usage = provider_response.response_usage
+        # Copy the normalized finish reason. Guarded so a later None (the aggregate
+        # model_response is reused across a multi-step tool loop) cannot wipe the
+        # terminal reason; last non-null writer wins.
+        if provider_response.finish_reason is not None:
+            model_response.finish_reason = provider_response.finish_reason
         # Providers (e.g. GeminiInteractions on the agent path) can produce
         # already-executed ToolExecution records server-side; carry them
         # through so run_response.tools / AgentOS UI sees the audit.

--- a/libs/agno/agno/models/cerebras/cerebras.py
+++ b/libs/agno/agno/models/cerebras/cerebras.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic import BaseModel
 
 from agno.models.base import Model
+from agno.models.finish_reason import map_cerebras_finish_reason
 from agno.models.message import Message
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -487,6 +488,15 @@ class Cerebras(Model):
         if response.usage:
             model_response.response_usage = self._get_metrics(response.usage)
 
+        # Normalize the finish reason and preserve the raw provider value
+        raw_finish_reason = getattr(choice, "finish_reason", None)
+        if raw_finish_reason is not None:
+            finish_reason, native_finish_reason = map_cerebras_finish_reason(raw_finish_reason)
+            model_response.finish_reason = finish_reason
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
+
         return model_response
 
     def _parse_provider_response_delta(
@@ -527,6 +537,15 @@ class Cerebras(Model):
                         }
                         for idx, tool_call in enumerate(choice_delta.tool_calls)
                     ]
+
+            # Normalize the finish reason from the final chunk and preserve the raw provider value
+            raw_finish_reason = getattr(choice, "finish_reason", None)
+            if raw_finish_reason is not None:
+                finish_reason, native_finish_reason = map_cerebras_finish_reason(raw_finish_reason)
+                model_response.finish_reason = finish_reason
+                if model_response.provider_data is None:
+                    model_response.provider_data = {}
+                model_response.provider_data["native_finish_reason"] = native_finish_reason
 
         # Add usage metrics
         if response.usage:

--- a/libs/agno/agno/models/finish_reason.py
+++ b/libs/agno/agno/models/finish_reason.py
@@ -1,0 +1,186 @@
+"""Normalized, cross-provider finish reasons.
+
+Every provider reports why a generation stopped, but each uses a different name and value
+set (Anthropic ``stop_reason``, OpenAI ``finish_reason``, Gemini ``finishReason``). Agno
+previously inspected that value only to detect tool calls and discarded every other case,
+so a truncated answer looked exactly like a clean one. This module normalizes the raw
+provider value into a single :class:`FinishReason` enum while preserving the verbatim
+provider string, so callers can reason about truncation, content filtering, tool calls,
+etc. consistently across providers.
+
+Design rules:
+
+- Normalize to a str-backed enum AND keep the raw provider string (returned alongside).
+- Never crash on an unseen value: every lookup falls back to ``FinishReason.UNKNOWN``.
+- Unknown maps to ``UNKNOWN``, never to ``STOP`` (avoid silently reporting a clean
+  completion for a generation that was actually truncated, filtered, or errored).
+
+This module must stay import-clean: it imports nothing from agno except ``agno.utils.log``,
+so it creates no import cycle with ``models/response.py``, ``run/agent.py``, or the providers.
+"""
+
+from enum import Enum
+from typing import Any, Optional, Tuple
+
+from agno.utils.log import log_warning
+
+
+class FinishReason(str, Enum):
+    """Normalized reason a model stopped generating.
+
+    str-backed so it serializes for free and compares equal to its string value
+    (``FinishReason.LENGTH == "length"``), keeping the field backward compatible.
+    """
+
+    STOP = "stop"
+    LENGTH = "length"
+    TOOL_CALL = "tool_call"
+    CONTENT_FILTER = "content_filter"
+    PAUSE = "pause"
+    REFUSAL = "refusal"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+
+def _key(value: Any) -> str:
+    """Derive a stable string lookup key from a raw provider value.
+
+    Provider values may be plain strings or SDK enum members. ``str(member)`` can render
+    e.g. ``"FinishReason.MAX_TOKENS"`` for a str-backed SDK enum, so key off ``.name`` first
+    and fall back to ``str()``. This is what keeps the live ``google.genai`` enum members
+    (which are enum instances, not plain strings) from silently missing every map entry.
+    """
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(value)
+
+
+# Anthropic Messages API stop reasons (direct + AWS Bedrock via AnthropicBedrock + Vertex + Azure).
+_ANTHROPIC_MAP = {
+    "end_turn": FinishReason.STOP,
+    "stop_sequence": FinishReason.STOP,
+    "max_tokens": FinishReason.LENGTH,
+    "model_context_window_exceeded": FinishReason.LENGTH,
+    "compaction": FinishReason.LENGTH,
+    "tool_use": FinishReason.TOOL_CALL,
+    "pause_turn": FinishReason.PAUSE,
+    "refusal": FinishReason.REFUSAL,
+}
+
+# OpenAI Chat Completions finish reasons (covers the OpenAILike family + Groq + Cerebras).
+_OPENAI_MAP = {
+    "stop": FinishReason.STOP,
+    "length": FinishReason.LENGTH,
+    "tool_calls": FinishReason.TOOL_CALL,
+    "function_call": FinishReason.TOOL_CALL,
+    "content_filter": FinishReason.CONTENT_FILTER,
+}
+
+# OpenAI Responses API: incomplete_details.reason values when status == "incomplete".
+_OPENAI_RESPONSES_INCOMPLETE_MAP = {
+    "max_output_tokens": FinishReason.LENGTH,
+    "content_filter": FinishReason.CONTENT_FILTER,
+}
+
+# Gemini (google.genai) finish reasons. Keyed by the enum member name (see _key).
+_GEMINI_MAP = {
+    "STOP": FinishReason.STOP,
+    "MAX_TOKENS": FinishReason.LENGTH,
+    "SAFETY": FinishReason.CONTENT_FILTER,
+    "RECITATION": FinishReason.CONTENT_FILTER,
+    "BLOCKLIST": FinishReason.CONTENT_FILTER,
+    "PROHIBITED_CONTENT": FinishReason.CONTENT_FILTER,
+    "SPII": FinishReason.CONTENT_FILTER,
+    "LANGUAGE": FinishReason.CONTENT_FILTER,
+    "IMAGE_SAFETY": FinishReason.CONTENT_FILTER,
+    "MALFORMED_FUNCTION_CALL": FinishReason.ERROR,
+    # OTHER, FINISH_REASON_UNSPECIFIED -> UNKNOWN via fallback.
+}
+
+# Bedrock Converse API stop reasons. Kept here for a future aws/bedrock.py (class AwsBedrock)
+# wiring; the Anthropic Claude path (aws/claude.py) returns Anthropic-style stop_reason strings
+# handled by _ANTHROPIC_MAP, not these Converse strings.
+_BEDROCK_MAP = {
+    "end_turn": FinishReason.STOP,
+    "stop_sequence": FinishReason.STOP,
+    "max_tokens": FinishReason.LENGTH,
+    "tool_use": FinishReason.TOOL_CALL,
+    "guardrail_intervened": FinishReason.CONTENT_FILTER,
+    "content_filtered": FinishReason.CONTENT_FILTER,
+}
+
+
+def map_anthropic_finish_reason(value: Any) -> Tuple[FinishReason, str]:
+    """Map an Anthropic ``stop_reason`` to a normalized reason and its raw key."""
+    key = _key(value)
+    return _ANTHROPIC_MAP.get(key, FinishReason.UNKNOWN), key
+
+
+def map_openai_finish_reason(value: Any) -> Tuple[FinishReason, str]:
+    """Map an OpenAI Chat Completions ``finish_reason`` to a normalized reason and its raw key."""
+    key = _key(value)
+    return _OPENAI_MAP.get(key, FinishReason.UNKNOWN), key
+
+
+def map_openai_responses_finish_reason(status: Any, incomplete_reason: Any = None) -> Tuple[FinishReason, str]:
+    """Map an OpenAI Responses API ``status`` (+ ``incomplete_details.reason``) to a normalized reason.
+
+    ``status == "incomplete"`` carries the real reason in ``incomplete_details.reason``
+    (``max_output_tokens`` -> LENGTH, ``content_filter`` -> CONTENT_FILTER). A ``completed``
+    status is a normal stop. ``failed`` / ``cancelled`` are raised upstream as errors before
+    parsing, so they are not mapped here.
+    """
+    status_key = _key(status)
+    if status_key == "incomplete":
+        reason_key = _key(incomplete_reason) if incomplete_reason is not None else "incomplete"
+        return _OPENAI_RESPONSES_INCOMPLETE_MAP.get(reason_key, FinishReason.UNKNOWN), reason_key
+    if status_key == "completed":
+        return FinishReason.STOP, status_key
+    return FinishReason.UNKNOWN, status_key
+
+
+def map_gemini_finish_reason(value: Any) -> Tuple[FinishReason, str]:
+    """Map a Gemini ``finish_reason`` (string or ``google.genai`` enum member) to a normalized reason."""
+    key = _key(value)
+    return _GEMINI_MAP.get(key, FinishReason.UNKNOWN), key
+
+
+def map_bedrock_finish_reason(value: Any) -> Tuple[FinishReason, str]:
+    """Map a Bedrock Converse API ``stopReason`` to a normalized reason and its raw key."""
+    key = _key(value)
+    return _BEDROCK_MAP.get(key, FinishReason.UNKNOWN), key
+
+
+# Groq and native Cerebras both expose an OpenAI-shaped ``finish_reason``, so they reuse the map.
+map_groq_finish_reason = map_openai_finish_reason
+map_cerebras_finish_reason = map_openai_finish_reason
+
+
+# Transient attribute used to deduplicate the truncation warning within a single run. It is set
+# on the RunOutput/TeamRunOutput instance and is intentionally not a dataclass field, so it never
+# appears in to_dict()/asdict() output or serialization.
+_TRUNCATION_WARNED_ATTR = "_finish_reason_length_warned"
+
+
+def warn_if_truncated(run_response: Any, finish_reason: Optional[FinishReason]) -> None:
+    """Emit one de-duplicated warning per run when output was cut off by the token cap.
+
+    ``run_response`` is an Agno ``RunOutput`` / ``TeamRunOutput``. It is kept untyped to avoid
+    importing the run package (which would create an import cycle). A multi-step tool loop can
+    reach ``LENGTH`` on more than one step, so the warning is guarded by a transient flag on the
+    run so it fires at most once.
+    """
+    if finish_reason != FinishReason.LENGTH:
+        return
+    if run_response is None or getattr(run_response, _TRUNCATION_WARNED_ATTR, False):
+        return
+    try:
+        setattr(run_response, _TRUNCATION_WARNED_ATTR, True)
+    except Exception:
+        # If the run object rejects the attribute, fall back to warning each time rather than crashing.
+        pass
+    log_warning(
+        "The model stopped because it reached the maximum output token limit (finish_reason=length). "
+        "The response is likely truncated; increase max_tokens for a complete response."
+    )

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from agno.exceptions import ModelProviderError
 from agno.media import Audio, File, Image, Video
 from agno.models.base import Model, RetryableModelProviderError
+from agno.models.finish_reason import map_gemini_finish_reason
 from agno.models.google.utils import MALFORMED_FUNCTION_CALL_GUIDANCE, GeminiFinishReason, get_mime_type
 from agno.models.message import Citations, Message, UrlCitation
 from agno.models.metrics import MessageMetrics
@@ -1147,6 +1148,13 @@ class Gemini(Model):
                             original_error=f"Generation ended with finish reason: {candidate.finish_reason}",
                         )
 
+                # Normalize the finish reason (key off the enum member name) and preserve the raw value
+                finish_reason, native_finish_reason = map_gemini_finish_reason(candidate.finish_reason)
+                model_response.finish_reason = finish_reason
+                if model_response.provider_data is None:
+                    model_response.provider_data = {}
+                model_response.provider_data["native_finish_reason"] = native_finish_reason
+
             if candidate.content:
                 response_message = candidate.content
 
@@ -1310,6 +1318,13 @@ class Gemini(Model):
                             retry_guidance_message=MALFORMED_FUNCTION_CALL_GUIDANCE,
                             original_error=f"Generation ended with finish reason: {candidate.finish_reason}",
                         )
+
+                # Normalize the finish reason (key off the enum member name) and preserve the raw value
+                finish_reason, native_finish_reason = map_gemini_finish_reason(candidate.finish_reason)
+                model_response.finish_reason = finish_reason
+                if model_response.provider_data is None:
+                    model_response.provider_data = {}
+                model_response.provider_data["native_finish_reason"] = native_finish_reason
 
             response_message: Content = Content(role="model", parts=[])
             if candidate_content is not None:

--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from agno.exceptions import ModelAuthenticationError, ModelProviderError
 from agno.models.base import Model
+from agno.models.finish_reason import map_groq_finish_reason
 from agno.models.message import Message
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -517,6 +518,14 @@ class Groq(Model):
         if response.usage is not None:
             model_response.response_usage = self._get_metrics(response.usage)
 
+        # Normalize the finish reason and preserve the raw provider value
+        if response.choices and response.choices[0].finish_reason is not None:
+            finish_reason, native_finish_reason = map_groq_finish_reason(response.choices[0].finish_reason)
+            model_response.finish_reason = finish_reason
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
+
         return model_response
 
     def _parse_provider_response_delta(self, response: ChatCompletionChunk) -> ModelResponse:
@@ -542,6 +551,14 @@ class Groq(Model):
                 # Add tool calls
                 if choice_delta.tool_calls is not None:
                     model_response.tool_calls = choice_delta.tool_calls  # type: ignore
+
+        # Normalize the finish reason from the final chunk and preserve the raw provider value
+        if len(response.choices) > 0 and response.choices[0].finish_reason is not None:
+            finish_reason, native_finish_reason = map_groq_finish_reason(response.choices[0].finish_reason)
+            model_response.finish_reason = finish_reason
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
 
         # Add usage metrics if present
         if response.x_groq is not None and response.x_groq.usage is not None:

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 from agno.exceptions import ContextWindowExceededError, ModelAuthenticationError, ModelProviderError
 from agno.media import Audio
 from agno.models.base import Model
+from agno.models.finish_reason import map_openai_finish_reason
 from agno.models.message import Citations, Message, UrlCitation
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -899,6 +900,13 @@ class OpenAIChat(Model):
         if response.model_extra:
             model_response.provider_data["model_extra"] = response.model_extra
 
+        # Normalize the finish reason and preserve the raw provider value
+        raw_finish_reason = getattr(response.choices[0], "finish_reason", None) if response.choices else None
+        if raw_finish_reason is not None:
+            finish_reason, native_finish_reason = map_openai_finish_reason(raw_finish_reason)
+            model_response.finish_reason = finish_reason
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
+
         return model_response
 
     def _parse_provider_response_delta(self, response_delta: ChatCompletionChunk) -> ModelResponse:
@@ -997,6 +1005,17 @@ class OpenAIChat(Model):
                             )
                     except Exception as e:
                         log_warning(f"Error processing audio: {str(e)}")
+
+        # Normalize the finish reason from the final chunk and preserve the raw provider value
+        raw_finish_reason = (
+            getattr(response_delta.choices[0], "finish_reason", None) if response_delta.choices else None
+        )
+        if raw_finish_reason is not None:
+            finish_reason, native_finish_reason = map_openai_finish_reason(raw_finish_reason)
+            model_response.finish_reason = finish_reason
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
 
         # Add usage metrics if present
         if self._should_collect_metrics(response_delta) and response_delta.usage is not None:

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -10,6 +10,7 @@ from typing_extensions import Literal
 from agno.exceptions import ContextWindowExceededError, ModelAuthenticationError, ModelProviderError
 from agno.media import File
 from agno.models.base import Model
+from agno.models.finish_reason import map_openai_responses_finish_reason
 from agno.models.message import Citations, Message, UrlCitation
 from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
@@ -1253,6 +1254,16 @@ class OpenAIResponses(Model):
         if response.usage is not None:
             model_response.response_usage = self._get_metrics(response.usage)
 
+        # Normalize the finish reason from status / incomplete_details and preserve the raw value
+        status = getattr(response, "status", None)
+        if status is not None:
+            incomplete_reason = getattr(getattr(response, "incomplete_details", None), "reason", None)
+            finish_reason, native_finish_reason = map_openai_responses_finish_reason(status, incomplete_reason)
+            model_response.finish_reason = finish_reason
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["native_finish_reason"] = native_finish_reason
+
         return model_response
 
     def _parse_provider_response_delta(
@@ -1360,7 +1371,32 @@ class OpenAIResponses(Model):
             if stream_event.response.usage is not None:
                 model_response.response_usage = self._get_metrics(stream_event.response.usage)
 
+            # Normalize the finish reason and preserve the raw value
+            self._apply_responses_finish_reason(model_response, stream_event.response)
+
+        # 6. Truncated or content-filtered completion
+        elif stream_event.type == "response.incomplete":
+            model_response = ModelResponse()
+
+            incomplete_usage = getattr(stream_event.response, "usage", None)
+            if incomplete_usage is not None:
+                model_response.response_usage = self._get_metrics(incomplete_usage)
+
+            self._apply_responses_finish_reason(model_response, stream_event.response)
+
         return model_response, tool_use
+
+    def _apply_responses_finish_reason(self, model_response: ModelResponse, response: Any) -> None:
+        """Set the normalized finish reason (and raw value) on the model response from a Responses object."""
+        status = getattr(response, "status", None)
+        if status is None:
+            return
+        incomplete_reason = getattr(getattr(response, "incomplete_details", None), "reason", None)
+        finish_reason, native_finish_reason = map_openai_responses_finish_reason(status, incomplete_reason)
+        model_response.finish_reason = finish_reason
+        if model_response.provider_data is None:
+            model_response.provider_data = {}
+        model_response.provider_data["native_finish_reason"] = native_finish_reason
 
     def _get_metrics(self, response_usage: ResponseUsage) -> MessageMetrics:
         """

--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from agno.media import Audio, File, Image, Video
 from agno.metrics import ToolCallMetrics
+from agno.models.finish_reason import FinishReason
 from agno.models.message import Citations
 from agno.models.metrics import MessageMetrics
 from agno.tools.function import UserFeedbackQuestion, UserInputField
@@ -143,6 +144,10 @@ class ModelResponse:
 
     response_usage: Optional[MessageMetrics] = None
 
+    # Normalized reason the model stopped generating (raw provider value is kept in
+    # provider_data["native_finish_reason"]).
+    finish_reason: Optional[FinishReason] = None
+
     created_at: int = field(default_factory=lambda: int(time()))
 
     extra: Optional[Dict[str, Any]] = None
@@ -196,6 +201,12 @@ class ModelResponse:
             except ImportError:
                 _dict["response_usage"] = response_usage
 
+        # Serialize finish_reason as its plain string value
+        if self.finish_reason is not None:
+            _dict["finish_reason"] = (
+                self.finish_reason.value if isinstance(self.finish_reason, FinishReason) else self.finish_reason
+            )
+
         return _dict
 
     @classmethod
@@ -227,6 +238,13 @@ class ModelResponse:
             from agno.models.metrics import MessageMetrics as _MessageMetrics
 
             data["response_usage"] = _MessageMetrics.from_dict(data["response_usage"])
+
+        # Normalize finish_reason back into the enum (rehydrated as a plain str after JSON)
+        if data.get("finish_reason") is not None and not isinstance(data["finish_reason"], FinishReason):
+            try:
+                data["finish_reason"] = FinishReason(data["finish_reason"])
+            except ValueError:
+                data["finish_reason"] = FinishReason.UNKNOWN
 
         return cls(**data)
 

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 from pydantic import BaseModel, Field
 
 from agno.media import Audio, File, Image, Video
+from agno.models.finish_reason import FinishReason
 from agno.models.message import Citations, Message
 from agno.models.metrics import RunMetrics
 from agno.models.response import ToolExecution
@@ -291,6 +292,7 @@ class RunCompletedEvent(BaseAgentRunEvent):
     metadata: Optional[Dict[str, Any]] = None
     metrics: Optional[RunMetrics] = None
     session_state: Optional[Dict[str, Any]] = None
+    finish_reason: Optional[FinishReason] = None
 
 
 @dataclass
@@ -660,6 +662,9 @@ class RunOutput:
 
     status: RunStatus = RunStatus.running
 
+    # Normalized reason the model stopped generating (raw value in model_provider_data["native_finish_reason"])
+    finish_reason: Optional[FinishReason] = None
+
     # User control flow (HITL) requirements to continue a run when paused, in order of arrival
     requirements: Optional[list[RunRequirement]] = None
 
@@ -747,6 +752,11 @@ class RunOutput:
 
         if self.status is not None:
             _dict["status"] = self.status.value if isinstance(self.status, RunStatus) else self.status
+
+        if self.finish_reason is not None:
+            _dict["finish_reason"] = (
+                self.finish_reason.value if isinstance(self.finish_reason, FinishReason) else self.finish_reason
+            )
 
         if self.messages is not None:
             _dict["messages"] = [m.to_dict() for m in self.messages]
@@ -916,6 +926,14 @@ class RunOutput:
         references = data.pop("references", None)
         if references is not None:
             references = [MessageReferences.model_validate(reference) for reference in references]
+
+        # Normalize finish_reason back into the enum (rehydrated as a plain str after JSON)
+        finish_reason = data.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, FinishReason):
+            try:
+                data["finish_reason"] = FinishReason(finish_reason)
+            except ValueError:
+                data["finish_reason"] = FinishReason.UNKNOWN
 
         # Filter data to only include fields that are actually defined in the RunOutput dataclass
         from dataclasses import fields

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 from pydantic import BaseModel
 
 from agno.media import Audio, File, Image, Video
+from agno.models.finish_reason import FinishReason
 from agno.models.message import Citations, Message
 from agno.models.metrics import RunMetrics
 from agno.models.response import ToolExecution
@@ -287,6 +288,7 @@ class RunCompletedEvent(BaseTeamRunEvent):
     metadata: Optional[Dict[str, Any]] = None
     metrics: Optional[RunMetrics] = None
     session_state: Optional[Dict[str, Any]] = None
+    finish_reason: Optional[FinishReason] = None
 
 
 @dataclass
@@ -775,6 +777,9 @@ class TeamRunOutput:
 
     status: RunStatus = RunStatus.running
 
+    # Normalized reason the model stopped generating (raw value in model_provider_data["native_finish_reason"])
+    finish_reason: Optional[FinishReason] = None
+
     # User control flow (HITL) requirements to continue a run when paused, in order of arrival
     requirements: Optional[list[RunRequirement]] = None
 
@@ -849,6 +854,11 @@ class TeamRunOutput:
 
         if self.status is not None:
             _dict["status"] = self.status.value if isinstance(self.status, RunStatus) else self.status
+
+        if self.finish_reason is not None:
+            _dict["finish_reason"] = (
+                self.finish_reason.value if isinstance(self.finish_reason, FinishReason) else self.finish_reason
+            )
 
         if self.messages is not None:
             _dict["messages"] = [m.to_dict() for m in self.messages]
@@ -997,6 +1007,14 @@ class TeamRunOutput:
 
         citations = data.pop("citations", None)
         citations = Citations.model_validate(citations) if citations else None
+
+        # Normalize finish_reason back into the enum (rehydrated as a plain str after JSON)
+        finish_reason = data.get("finish_reason")
+        if finish_reason is not None and not isinstance(finish_reason, FinishReason):
+            try:
+                data["finish_reason"] = FinishReason(finish_reason)
+            except ValueError:
+                data["finish_reason"] = FinishReason.UNKNOWN
 
         # Filter data to only include fields that are actually defined in the TeamRunOutput dataclass
         from dataclasses import fields

--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -24,6 +24,7 @@ from agno.exceptions import RunCancelledException
 from agno.media import Audio
 from agno.models.base import Model
 from agno.models.fallback import acall_model_stream_with_fallback, call_model_stream_with_fallback
+from agno.models.finish_reason import warn_if_truncated
 from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import NextAction, ReasoningStep, ReasoningSteps
@@ -951,6 +952,10 @@ def _update_run_response(
     # Update provider data
     if model_response.provider_data is not None:
         run_response.model_provider_data = model_response.provider_data
+    # Update finish reason
+    if model_response.finish_reason is not None:
+        run_response.finish_reason = model_response.finish_reason
+        warn_if_truncated(run_response, run_response.finish_reason)
     # Update citations
     if model_response.citations is not None:
         run_response.citations = model_response.citations
@@ -1138,6 +1143,9 @@ def _handle_model_response_stream(
         run_response.citations = full_model_response.citations
     if full_model_response.provider_data is not None:
         run_response.model_provider_data = full_model_response.provider_data
+    if full_model_response.finish_reason is not None:
+        run_response.finish_reason = full_model_response.finish_reason
+        warn_if_truncated(run_response, run_response.finish_reason)
 
     # Build a list of messages that should be added to the RunOutput
     messages_for_run_response = [m for m in run_messages.messages if m.add_to_agent_memory]
@@ -1300,6 +1308,9 @@ async def _ahandle_model_response_stream(
         run_response.citations = full_model_response.citations
     if full_model_response.provider_data is not None:
         run_response.model_provider_data = full_model_response.provider_data
+    if full_model_response.finish_reason is not None:
+        run_response.finish_reason = full_model_response.finish_reason
+        warn_if_truncated(run_response, run_response.finish_reason)
 
     # Build a list of messages that should be added to the RunOutput
     messages_for_run_response = [m for m in run_messages.messages if m.add_to_agent_memory]
@@ -1438,6 +1449,11 @@ def _handle_model_response_chunk(
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
                 run_response.model_provider_data = model_response_event.provider_data
+
+            # Handle finish reason (one chunk)
+            if model_response_event.finish_reason is not None:
+                run_response.finish_reason = model_response_event.finish_reason
+                warn_if_truncated(run_response, run_response.finish_reason)
 
             # Handle citations (one chunk)
             if model_response_event.citations is not None:

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -133,6 +133,7 @@ def create_team_run_completed_event(from_run_response: TeamRunOutput) -> TeamRun
         metadata=from_run_response.metadata,  # type: ignore
         metrics=from_run_response.metrics,  # type: ignore
         session_state=from_run_response.session_state,  # type: ignore
+        finish_reason=from_run_response.finish_reason,  # type: ignore
     )
 
 
@@ -159,6 +160,7 @@ def create_run_completed_event(from_run_response: RunOutput) -> RunCompletedEven
         metadata=from_run_response.metadata,  # type: ignore
         metrics=from_run_response.metrics,  # type: ignore
         session_state=from_run_response.session_state,  # type: ignore
+        finish_reason=from_run_response.finish_reason,  # type: ignore
     )
 
 

--- a/libs/agno/tests/unit/agent/test_finish_reason.py
+++ b/libs/agno/tests/unit/agent/test_finish_reason.py
@@ -1,0 +1,151 @@
+"""Propagation tests: finish_reason flows from ModelResponse to RunOutput / RunCompletedEvent.
+
+Covers sync, async, streaming, team, the multi-step guard (an intermediate None must not wipe
+the terminal reason), and the serialization round trip. No network: a mock model sets
+finish_reason on its ModelResponse.
+"""
+
+import json
+from typing import Any, AsyncIterator, Iterator, List, Optional
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.finish_reason import FinishReason
+from agno.models.message import Message, MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run.agent import RunCompletedEvent, RunOutput
+from agno.team.team import Team
+
+
+class MockModel(Model):
+    """Model that returns a single ModelResponse carrying a configurable finish_reason."""
+
+    def __init__(self, finish_reason: Optional[FinishReason] = FinishReason.STOP):
+        super().__init__(id="test-model", name="test-model", provider="test")
+        self.instructions = None
+        self._mock_response = ModelResponse(
+            content="Hello there",
+            role="assistant",
+            finish_reason=finish_reason,
+            response_usage=MessageMetrics(),
+        )
+        self.response = Mock(return_value=self._mock_response)
+        self.aresponse = AsyncMock(return_value=self._mock_response)
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self._mock_response
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self._mock_response
+        return
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return self._mock_response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return self._mock_response
+
+
+def test_finish_reason_propagates_to_run_output_sync():
+    agent = Agent(model=MockModel(finish_reason=FinishReason.LENGTH))
+    result = agent.run("hi")
+    assert result.finish_reason == FinishReason.LENGTH
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_propagates_to_run_output_async():
+    agent = Agent(model=MockModel(finish_reason=FinishReason.LENGTH))
+    result = await agent.arun("hi")
+    assert result.finish_reason == FinishReason.LENGTH
+
+
+def test_finish_reason_propagates_to_completed_event_stream():
+    agent = Agent(model=MockModel(finish_reason=FinishReason.LENGTH))
+    completed = [e for e in agent.run("hi", stream=True, stream_events=True) if isinstance(e, RunCompletedEvent)]
+    assert len(completed) == 1
+    assert completed[0].finish_reason == FinishReason.LENGTH
+
+
+@pytest.mark.asyncio
+async def test_finish_reason_propagates_to_completed_event_async_stream():
+    agent = Agent(model=MockModel(finish_reason=FinishReason.LENGTH))
+    completed = []
+    async for e in agent.arun("hi", stream=True, stream_events=True):
+        if isinstance(e, RunCompletedEvent):
+            completed.append(e)
+    assert len(completed) == 1
+    assert completed[0].finish_reason == FinishReason.LENGTH
+
+
+def test_finish_reason_propagates_to_team_run_output():
+    member = Agent(name="member", model=MockModel(finish_reason=FinishReason.STOP))
+    team = Team(members=[member], model=MockModel(finish_reason=FinishReason.LENGTH))
+    result = team.run("hi")
+    assert result.finish_reason == FinishReason.LENGTH
+
+
+class MultiStepModel(MockModel):
+    """Drives _process_model_response directly with a queue of provider responses."""
+
+    def __init__(self, provider_responses: List[ModelResponse]):
+        super().__init__()
+        self._queue = list(provider_responses)
+
+    def _invoke_with_retry(self, *args, **kwargs) -> ModelResponse:
+        return self._queue.pop(0)
+
+    def _populate_assistant_message(self, assistant_message: Message, provider_response: ModelResponse) -> Message:
+        return assistant_message
+
+
+def test_multi_step_terminal_reason_not_wiped_by_intermediate_step():
+    """The aggregate model_response is reused across the tool loop; a later None must not wipe it."""
+    model = MultiStepModel(
+        provider_responses=[
+            ModelResponse(content="a", finish_reason=FinishReason.TOOL_CALL),
+            ModelResponse(content="b", finish_reason=None),  # intermediate step, no terminal reason
+            ModelResponse(content="c", finish_reason=FinishReason.STOP),
+        ]
+    )
+    aggregate = ModelResponse()
+    assistant = Message(role="assistant")
+
+    model._process_model_response(messages=[], assistant_message=assistant, model_response=aggregate)
+    assert aggregate.finish_reason == FinishReason.TOOL_CALL
+
+    model._process_model_response(messages=[], assistant_message=assistant, model_response=aggregate)
+    assert aggregate.finish_reason == FinishReason.TOOL_CALL  # not wiped by the None step
+
+    model._process_model_response(messages=[], assistant_message=assistant, model_response=aggregate)
+    assert aggregate.finish_reason == FinishReason.STOP  # terminal reason wins
+
+
+def test_run_output_finish_reason_serialization_round_trip():
+    original = RunOutput(finish_reason=FinishReason.LENGTH)
+    restored = RunOutput.from_dict(json.loads(json.dumps(original.to_dict())))
+    assert restored.finish_reason == FinishReason.LENGTH
+    assert isinstance(restored.finish_reason, FinishReason)

--- a/libs/agno/tests/unit/models/anthropic/test_finish_reason_claude.py
+++ b/libs/agno/tests/unit/models/anthropic/test_finish_reason_claude.py
@@ -1,0 +1,77 @@
+"""Regression tests: Claude parsers surface a normalized finish_reason.
+
+Covers the bug where a truncated generation (stop_reason="max_tokens") was indistinguishable
+from a clean one because the stop reason was only ever read to detect tool calls.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from anthropic.types import MessageStopEvent
+
+from agno.models.anthropic.claude import Claude
+from agno.models.finish_reason import FinishReason
+
+
+def test_non_stream_max_tokens_maps_to_length():
+    claude = Claude(id="claude-sonnet-4-5-20250929")
+    response = SimpleNamespace(role="assistant", content=[], stop_reason="max_tokens", usage=None)
+
+    result = claude._parse_provider_response(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data is not None
+    assert result.provider_data["native_finish_reason"] == "max_tokens"
+
+
+def test_non_stream_end_turn_maps_to_stop():
+    claude = Claude(id="claude-sonnet-4-5-20250929")
+    response = SimpleNamespace(role="assistant", content=[], stop_reason="end_turn", usage=None)
+
+    result = claude._parse_provider_response(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.STOP
+    assert result.provider_data["native_finish_reason"] == "end_turn"
+
+
+def test_non_stream_unknown_stop_reason_degrades_to_unknown():
+    claude = Claude(id="claude-sonnet-4-5-20250929")
+    response = SimpleNamespace(role="assistant", content=[], stop_reason="some_new_anthropic_reason", usage=None)
+
+    result = claude._parse_provider_response(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.UNKNOWN
+    assert result.provider_data["native_finish_reason"] == "some_new_anthropic_reason"
+
+
+def test_stream_message_stop_max_tokens_maps_to_length():
+    claude = Claude(id="claude-sonnet-4-5-20250929")
+    event = MagicMock(spec=MessageStopEvent)
+    event.message = SimpleNamespace(content=[], usage=None, stop_reason="max_tokens", container=None)
+
+    result = claude._parse_provider_response_delta(event)
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data is not None
+    assert result.provider_data["native_finish_reason"] == "max_tokens"
+
+
+def test_aws_claude_inherits_anthropic_mapping():
+    """AWS Bedrock Claude subclasses AnthropicClaude and does not override the parser.
+
+    Proves the inherited mapping fires on Anthropic-style stop_reason strings (not Converse
+    guardrail strings, which travel through the separate aws/bedrock.py parser).
+    """
+    try:
+        from agno.models.aws.claude import Claude as AwsClaude
+    except ImportError:
+        pytest.skip("aws extras (boto3 / anthropic[bedrock]) not installed")
+
+    model = AwsClaude(id="anthropic.claude-sonnet-4-5-20250929-v1:0")
+    response = SimpleNamespace(role="assistant", content=[], stop_reason="max_tokens", usage=None)
+
+    result = model._parse_provider_response(response)
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "max_tokens"

--- a/libs/agno/tests/unit/models/cerebras/test_finish_reason_cerebras.py
+++ b/libs/agno/tests/unit/models/cerebras/test_finish_reason_cerebras.py
@@ -1,0 +1,30 @@
+"""Regression test: the native Cerebras parser surfaces a normalized finish_reason (OpenAI-shaped)."""
+
+from types import SimpleNamespace
+
+from agno.models.cerebras.cerebras import Cerebras
+from agno.models.finish_reason import FinishReason
+
+
+def test_non_stream_length():
+    model = Cerebras(id="llama-3.3-70b")
+    message = SimpleNamespace(role="assistant", content="partial", tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="length")
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = model._parse_provider_response(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "length"
+
+
+def test_stream_length():
+    model = Cerebras(id="llama-3.3-70b")
+    choice_delta = SimpleNamespace(content=None, tool_calls=None)
+    choice = SimpleNamespace(delta=choice_delta, finish_reason="length")
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = model._parse_provider_response_delta(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "length"

--- a/libs/agno/tests/unit/models/google/test_finish_reason_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_finish_reason_gemini.py
@@ -1,0 +1,46 @@
+"""Regression tests: the Gemini parser surfaces a normalized finish_reason.
+
+Feeds the parser both a raw string and a real google.genai FinishReason enum member, because
+``str(member)`` renders ``"FinishReason.MAX_TOKENS"`` and would silently miss the map if the
+mapper keyed off ``str()`` instead of ``.name``.
+"""
+
+from types import SimpleNamespace
+
+from google.genai.types import FinishReason as GeminiSDKFinishReason
+
+from agno.models.finish_reason import FinishReason
+from agno.models.google.gemini import Gemini
+
+
+def _response(finish_reason):
+    candidate = SimpleNamespace(finish_reason=finish_reason, content=None)
+    return SimpleNamespace(candidates=[candidate], usage_metadata=None)
+
+
+def test_non_stream_max_tokens_from_real_enum_member():
+    model = Gemini(id="gemini-2.0-flash")
+    result = model._parse_provider_response(_response(GeminiSDKFinishReason.MAX_TOKENS))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "MAX_TOKENS"
+
+
+def test_non_stream_safety_from_string():
+    model = Gemini(id="gemini-2.0-flash")
+    result = model._parse_provider_response(_response("SAFETY"))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.CONTENT_FILTER
+    assert result.provider_data["native_finish_reason"] == "SAFETY"
+
+
+def test_stream_max_tokens_from_real_enum_member():
+    model = Gemini(id="gemini-2.0-flash")
+    result = model._parse_provider_response_delta(_response(GeminiSDKFinishReason.MAX_TOKENS))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "MAX_TOKENS"
+
+
+def test_non_stream_unknown_reason_degrades_to_unknown():
+    model = Gemini(id="gemini-2.0-flash")
+    result = model._parse_provider_response(_response("FINISH_REASON_UNSPECIFIED"))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.UNKNOWN
+    assert result.provider_data["native_finish_reason"] == "FINISH_REASON_UNSPECIFIED"

--- a/libs/agno/tests/unit/models/groq/test_finish_reason_groq.py
+++ b/libs/agno/tests/unit/models/groq/test_finish_reason_groq.py
@@ -1,0 +1,30 @@
+"""Regression test: the Groq parser surfaces a normalized finish_reason (OpenAI-shaped)."""
+
+from types import SimpleNamespace
+
+from agno.models.finish_reason import FinishReason
+from agno.models.groq.groq import Groq
+
+
+def test_non_stream_length():
+    model = Groq(id="llama-3.3-70b-versatile")
+    message = SimpleNamespace(role="assistant", content="partial", tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="length")
+    response = SimpleNamespace(choices=[choice], usage=None)
+
+    result = model._parse_provider_response(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "length"
+
+
+def test_stream_length():
+    model = Groq(id="llama-3.3-70b-versatile")
+    choice_delta = SimpleNamespace(content=None, tool_calls=None)
+    choice = SimpleNamespace(delta=choice_delta, finish_reason="length")
+    response = SimpleNamespace(choices=[choice], x_groq=None)
+
+    result = model._parse_provider_response_delta(response)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "length"

--- a/libs/agno/tests/unit/models/openai/test_finish_reason_openai.py
+++ b/libs/agno/tests/unit/models/openai/test_finish_reason_openai.py
@@ -1,0 +1,90 @@
+"""Regression tests: OpenAI Chat + Responses parsers surface a normalized finish_reason."""
+
+from types import SimpleNamespace
+
+from agno.models.finish_reason import FinishReason
+from agno.models.openai.chat import OpenAIChat
+from agno.models.openai.responses import OpenAIResponses
+
+
+def _chat_response(finish_reason: str):
+    message = SimpleNamespace(role="assistant", content="partial answer", tool_calls=None, audio=None)
+    choice = SimpleNamespace(message=message, finish_reason=finish_reason)
+    return SimpleNamespace(choices=[choice], usage=None, id=None, system_fingerprint=None, model_extra=None)
+
+
+def test_chat_non_stream_length():
+    model = OpenAIChat(id="gpt-4o")
+    result = model._parse_provider_response(_chat_response("length"))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "length"
+
+
+def test_chat_non_stream_content_filter():
+    model = OpenAIChat(id="gpt-4o")
+    result = model._parse_provider_response(_chat_response("content_filter"))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.CONTENT_FILTER
+    assert result.provider_data["native_finish_reason"] == "content_filter"
+
+
+def test_chat_non_stream_tool_calls():
+    model = OpenAIChat(id="gpt-4o")
+    result = model._parse_provider_response(_chat_response("tool_calls"))  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.TOOL_CALL
+
+
+def test_chat_stream_length():
+    model = OpenAIChat(id="gpt-4o")
+    choice_delta = SimpleNamespace(content=None, tool_calls=None)
+    choice = SimpleNamespace(delta=choice_delta, finish_reason="length")
+    chunk = SimpleNamespace(choices=[choice], usage=None)
+
+    result = model._parse_provider_response_delta(chunk)  # type: ignore[arg-type]
+
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "length"
+
+
+def test_responses_non_stream_incomplete_max_output_tokens():
+    model = OpenAIResponses(id="gpt-5")
+    response = SimpleNamespace(
+        error=None,
+        id=None,
+        output=[],
+        usage=None,
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+    )
+    result = model._parse_provider_response(response)  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.LENGTH
+    assert result.provider_data["native_finish_reason"] == "max_output_tokens"
+
+
+def test_responses_non_stream_incomplete_content_filter():
+    model = OpenAIResponses(id="gpt-5")
+    response = SimpleNamespace(
+        error=None,
+        id=None,
+        output=[],
+        usage=None,
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="content_filter"),
+    )
+    result = model._parse_provider_response(response)  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.CONTENT_FILTER
+    assert result.provider_data["native_finish_reason"] == "content_filter"
+
+
+def test_responses_non_stream_completed_maps_to_stop():
+    model = OpenAIResponses(id="gpt-5")
+    response = SimpleNamespace(
+        error=None,
+        id=None,
+        output=[],
+        usage=None,
+        status="completed",
+        incomplete_details=None,
+    )
+    result = model._parse_provider_response(response)  # type: ignore[arg-type]
+    assert result.finish_reason == FinishReason.STOP
+    assert result.provider_data["native_finish_reason"] == "completed"

--- a/libs/agno/tests/unit/models/test_finish_reason_mapping.py
+++ b/libs/agno/tests/unit/models/test_finish_reason_mapping.py
@@ -1,0 +1,192 @@
+"""Unit tests for the normalized cross-provider finish_reason mappers.
+
+Each mapper is fed (a) the raw provider string, (b) a real SDK enum member where one exists,
+and (c) an unmapped value. The real-enum case is what proves the ``str(enum)`` trap is handled:
+``str(google.genai.types.FinishReason.MAX_TOKENS)`` renders ``"FinishReason.MAX_TOKENS"``, so the
+mapper must key off the member ``.name`` instead.
+"""
+
+import pytest
+
+from agno.models.finish_reason import (
+    FinishReason,
+    map_anthropic_finish_reason,
+    map_bedrock_finish_reason,
+    map_cerebras_finish_reason,
+    map_gemini_finish_reason,
+    map_groq_finish_reason,
+    map_openai_finish_reason,
+    map_openai_responses_finish_reason,
+    warn_if_truncated,
+)
+
+
+def test_finish_reason_is_str_backed():
+    """The enum compares equal to its string value, keeping the field backward compatible."""
+    assert FinishReason.LENGTH == "length"
+    assert FinishReason.STOP == "stop"
+    assert isinstance(FinishReason.LENGTH, str)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("end_turn", FinishReason.STOP),
+        ("stop_sequence", FinishReason.STOP),
+        ("max_tokens", FinishReason.LENGTH),
+        ("model_context_window_exceeded", FinishReason.LENGTH),
+        ("compaction", FinishReason.LENGTH),
+        ("tool_use", FinishReason.TOOL_CALL),
+        ("pause_turn", FinishReason.PAUSE),
+        ("refusal", FinishReason.REFUSAL),
+    ],
+)
+def test_anthropic_mapping(raw, expected):
+    finish_reason, native = map_anthropic_finish_reason(raw)
+    assert finish_reason == expected
+    assert native == raw
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("stop", FinishReason.STOP),
+        ("length", FinishReason.LENGTH),
+        ("tool_calls", FinishReason.TOOL_CALL),
+        ("function_call", FinishReason.TOOL_CALL),
+        ("content_filter", FinishReason.CONTENT_FILTER),
+    ],
+)
+def test_openai_mapping(raw, expected):
+    finish_reason, native = map_openai_finish_reason(raw)
+    assert finish_reason == expected
+    assert native == raw
+
+
+def test_groq_and_cerebras_reuse_openai_mapping():
+    assert map_groq_finish_reason("length") == (FinishReason.LENGTH, "length")
+    assert map_cerebras_finish_reason("length") == (FinishReason.LENGTH, "length")
+    assert map_groq_finish_reason("tool_calls")[0] == FinishReason.TOOL_CALL
+
+
+@pytest.mark.parametrize(
+    "status,incomplete_reason,expected,expected_native",
+    [
+        ("completed", None, FinishReason.STOP, "completed"),
+        ("incomplete", "max_output_tokens", FinishReason.LENGTH, "max_output_tokens"),
+        ("incomplete", "content_filter", FinishReason.CONTENT_FILTER, "content_filter"),
+        ("incomplete", None, FinishReason.UNKNOWN, "incomplete"),
+        ("incomplete", "something_new", FinishReason.UNKNOWN, "something_new"),
+    ],
+)
+def test_openai_responses_mapping(status, incomplete_reason, expected, expected_native):
+    finish_reason, native = map_openai_responses_finish_reason(status, incomplete_reason)
+    assert finish_reason == expected
+    assert native == expected_native
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("STOP", FinishReason.STOP),
+        ("MAX_TOKENS", FinishReason.LENGTH),
+        ("SAFETY", FinishReason.CONTENT_FILTER),
+        ("RECITATION", FinishReason.CONTENT_FILTER),
+        ("BLOCKLIST", FinishReason.CONTENT_FILTER),
+        ("PROHIBITED_CONTENT", FinishReason.CONTENT_FILTER),
+        ("SPII", FinishReason.CONTENT_FILTER),
+        ("LANGUAGE", FinishReason.CONTENT_FILTER),
+        ("IMAGE_SAFETY", FinishReason.CONTENT_FILTER),
+        ("MALFORMED_FUNCTION_CALL", FinishReason.ERROR),
+    ],
+)
+def test_gemini_mapping_from_string(raw, expected):
+    finish_reason, native = map_gemini_finish_reason(raw)
+    assert finish_reason == expected
+    assert native == raw
+
+
+def test_gemini_mapping_from_real_enum_member():
+    """A real google.genai FinishReason member must map by .name, not str(member)."""
+    from google.genai.types import FinishReason as GeminiSDKFinishReason
+
+    # str(member) renders "FinishReason.MAX_TOKENS", which would never match the table.
+    assert str(GeminiSDKFinishReason.MAX_TOKENS) != "MAX_TOKENS"
+
+    finish_reason, native = map_gemini_finish_reason(GeminiSDKFinishReason.MAX_TOKENS)
+    assert finish_reason == FinishReason.LENGTH
+    assert native == "MAX_TOKENS"
+
+    finish_reason, native = map_gemini_finish_reason(GeminiSDKFinishReason.SAFETY)
+    assert finish_reason == FinishReason.CONTENT_FILTER
+    assert native == "SAFETY"
+
+
+def test_bedrock_mapping():
+    assert map_bedrock_finish_reason("guardrail_intervened")[0] == FinishReason.CONTENT_FILTER
+    assert map_bedrock_finish_reason("content_filtered")[0] == FinishReason.CONTENT_FILTER
+    assert map_bedrock_finish_reason("max_tokens")[0] == FinishReason.LENGTH
+
+
+@pytest.mark.parametrize(
+    "mapper,raw",
+    [
+        (map_anthropic_finish_reason, "some_unknown_reason"),
+        (map_openai_finish_reason, "some_unknown_reason"),
+        (map_gemini_finish_reason, "FINISH_REASON_UNSPECIFIED"),
+        (map_gemini_finish_reason, "OTHER"),
+        (map_bedrock_finish_reason, "some_unknown_reason"),
+    ],
+)
+def test_unknown_value_maps_to_unknown_and_preserves_raw(mapper, raw):
+    """The anti-crash guarantee: an unmapped value degrades to UNKNOWN, raw preserved, no raise."""
+    finish_reason, native = mapper(raw)
+    assert finish_reason == FinishReason.UNKNOWN
+    assert native == raw
+
+
+def test_unknown_never_maps_to_stop():
+    """We never copy the LiteLLM default-to-stop footgun."""
+    finish_reason, _ = map_openai_finish_reason("brand_new_reason")
+    assert finish_reason != FinishReason.STOP
+    assert finish_reason == FinishReason.UNKNOWN
+
+
+class _FakeRun:
+    """Minimal stand-in for a RunOutput; warn_if_truncated only needs attribute get/set."""
+
+
+def test_warn_if_truncated_dedupes_per_run():
+    run = _FakeRun()
+    warning_calls = []
+
+    import agno.models.finish_reason as module
+
+    original = module.log_warning
+    module.log_warning = lambda msg: warning_calls.append(msg)
+    try:
+        warn_if_truncated(run, FinishReason.LENGTH)
+        warn_if_truncated(run, FinishReason.LENGTH)  # second call must be deduped
+        warn_if_truncated(run, FinishReason.STOP)  # non-LENGTH must never warn
+    finally:
+        module.log_warning = original
+
+    assert len(warning_calls) == 1
+
+
+def test_warn_if_truncated_silent_on_non_length():
+    run = _FakeRun()
+    warning_calls = []
+
+    import agno.models.finish_reason as module
+
+    original = module.log_warning
+    module.log_warning = lambda msg: warning_calls.append(msg)
+    try:
+        warn_if_truncated(run, FinishReason.STOP)
+        warn_if_truncated(run, FinishReason.TOOL_CALL)
+        warn_if_truncated(run, None)
+    finally:
+        module.log_warning = original
+
+    assert warning_calls == []


### PR DESCRIPTION
## Summary

right now when a model stops generating, agno doesn't tell you why. the provider always sends back a stop/finish reason (anthropic `stop_reason`, openai `finish_reason`, gemini `finishReason`), but agno only ever reads it to catch tool calls and drops the rest. so a truncated answer that ran out of output tokens comes back looking exactly like a clean one.. no field, no warning, no exception. it's worst for structured output, where you get half a json that won't parse and no way to tell truncation from a bad response.

this adds a normalized `finish_reason` to the response contract and fills it in per provider. i followed the pattern the bigger multi-provider libs settled on (litellm, vercel ai sdk, pydantic ai, semantic kernel): normalize to a typed enum AND keep the raw provider string so nothing is lost.

what's in here:

- new `FinishReason(str, Enum)`: `STOP`, `LENGTH`, `TOOL_CALL`, `CONTENT_FILTER`, `PAUSE`, `REFUSAL`, `ERROR`, `UNKNOWN`. the raw value stays under `provider_data["native_finish_reason"]`.
- the mappers key off the value's `.name`, so a real sdk enum member maps correctly (that's the `str(enum)` trap that caused a real crash in langchain-google), and anything unmapped falls back to `UNKNOWN`, never `STOP`. so a new or undocumented provider value can't silently report a clean stop.
- `finish_reason` added to `ModelResponse`, `RunOutput`, `RunCompletedEvent`, `TeamRunOutput` and the team `RunCompletedEvent`, threaded through sync, async and streaming. on `LENGTH` it logs one warning per run.
- providers: anthropic (covers aws/vertex/azure claude by inheritance), openai chat (covers the openai-like family), openai responses, gemini, groq, cerebras.

all new fields are optional with defaults and the str-enum compares equal to its string value, so it's additive.. existing callers and serialization aren't affected, and there's no behavior change if you ignore the field.

(issue number: #6179)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: cookbook example added (`cookbook/02_agents/02_input_output/finish_reason.py`)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

there's a cluster of related open PRs in this area, so here's the lay of the land and why this one is broader:

- #8143 surfaces a raw passthrough `stop_reason` for claude only. this normalizes across all the major providers and still keeps the raw value, so callers don't each have to switch on a pile of provider strings.
- #6626 and #6188 handle max_tokens for claude / openai specifically. this covers the same thing as a single normalized `LENGTH` reason across providers, with one warn-once-per-run.
- #6911 detects truncated openai responses and raises. i deliberately left the raise out here to keep this additive, but the field this adds is what you'd build that on, and it's not openai-only.
- #7999 propagates litellm streaming `finish_reason`. same idea scoped to litellm streaming.. this is the cross-provider version.

none of them close #6179 across providers, which is what this is going for. happy to coordinate or fold things together if maintainers would rather build on one of the existing ones.

other notes:

- the opt-in `ModelResponseTruncatedError` for structured output (raise instead of handing back broken json) is intentionally left out to keep this additive and break nobody. can send it as a follow-up.
- on testing: the unit tests all pass.. mappers including real sdk enum members and unknown values, the per-provider parsers, and propagation across sync/async/stream/team plus a multi-step guard and a serialization round trip. i didn't run the cookbook end to end since i didn't have an api key handy, but it compiles and the behavior it shows is covered by the tests.