### PR TITLE
fix: add external_execution_silent support for Team paused content

### DIFF
--- a/cookbook/02_agents/11_approvals/approval_external_execution_silent.py
+++ b/cookbook/02_agents/11_approvals/approval_external_execution_silent.py
@@ -1,0 +1,108 @@
+"""
+External Execution Silent
+=========================
+
+Demonstrates external_execution_silent=True with Agents.
+
+When a tool has external_execution_silent=True, the Agent's paused
+content message is suppressed. This is useful for frontend tools that
+execute automatically without user interaction.
+
+Compare output with approval_external_execution.py to see the difference:
+- Non-silent: Shows "I have tools to execute, but it needs external execution."
+- Silent: Shows empty content (no verbose message)
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.tools import tool
+from agno.utils import pprint
+
+# ---------------------------------------------------------------------------
+# Silent external execution tool - frontend tools that run automatically
+# ---------------------------------------------------------------------------
+
+
+@tool(external_execution=True, external_execution_silent=True)
+def change_theme(theme: str) -> str:
+    """Change the UI theme. Executed by the frontend automatically."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Non-silent external execution tool - requires user action
+# ---------------------------------------------------------------------------
+
+
+@tool(external_execution=True)
+def send_notification(message: str) -> str:
+    """Send a push notification. Requires user to trigger manually."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+db = SqliteDb(db_file="tmp/silent_demo.db", session_table="sessions")
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.2"),
+    tools=[change_theme, send_notification],
+    db=db,
+    telemetry=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Demo: Compare silent vs non-silent paused content
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Demo 1: Silent tool only (change_theme)")
+    print("=" * 60)
+
+    run_response = agent.run("Change the theme to dark mode")
+
+    if run_response.is_paused:
+        print(f"Status: paused")
+        print(f"Content: '{run_response.content}'")  # Should be empty
+        print(f"Active requirements: {len(run_response.active_requirements)}")
+
+        for req in run_response.active_requirements:
+            if req.needs_external_execution:
+                print(f"  - {req.tool_execution.tool_name}")
+                print(f"    external_execution_silent: {req.external_execution_silent}")
+                # Simulate frontend executing the tool
+                req.set_external_execution_result("Theme changed to dark")
+
+        run_response = agent.continue_run(
+            run_id=run_response.run_id,
+            requirements=run_response.requirements,
+        )
+
+    pprint.pprint_run_response(run_response)
+
+    print("\n" + "=" * 60)
+    print("Demo 2: Non-silent tool only (send_notification)")
+    print("=" * 60)
+
+    run_response = agent.run("Send a notification saying hello")
+
+    if run_response.is_paused:
+        print(f"Status: paused")
+        print(f"Content: '{run_response.content}'")  # Should show the verbose message
+        print(f"Active requirements: {len(run_response.active_requirements)}")
+
+        for req in run_response.active_requirements:
+            if req.needs_external_execution:
+                print(f"  - {req.tool_execution.tool_name}")
+                print(f"    external_execution_silent: {req.external_execution_silent}")
+                req.set_external_execution_result("Notification sent")
+
+        run_response = agent.continue_run(
+            run_id=run_response.run_id,
+            requirements=run_response.requirements,
+        )
+
+    pprint.pprint_run_response(run_response)

--- a/cookbook/03_teams/20_human_in_the_loop/external_tool_execution_silent.py
+++ b/cookbook/03_teams/20_human_in_the_loop/external_tool_execution_silent.py
@@ -1,0 +1,111 @@
+"""
+External Tool Execution (Silent)
+================================
+
+Demonstrates external_execution_silent=True with Teams.
+
+When a member's tool has external_execution_silent=True, the Team's
+paused content message does NOT show that requirement. This is useful
+for frontend tools that execute automatically without user interaction.
+
+Compare output with external_tool_execution.py to see the difference:
+- Non-silent: Shows "Team run paused. The following require input: ..."
+- Silent: Shows empty content (no verbose message)
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+from agno.tools import tool
+from agno.utils import pprint
+
+# ---------------------------------------------------------------------------
+# Silent external execution tool - frontend tools that run automatically
+# ---------------------------------------------------------------------------
+
+
+@tool(external_execution=True, external_execution_silent=True)
+def change_theme(theme: str) -> str:
+    """Change the UI theme. Executed by the frontend automatically."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Non-silent external execution tool - requires user action
+# ---------------------------------------------------------------------------
+
+
+@tool(external_execution=True)
+def send_notification(message: str) -> str:
+    """Send a push notification. Requires user to trigger manually."""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Create Members
+# ---------------------------------------------------------------------------
+ui_agent = Agent(
+    name="UIAgent",
+    model=OpenAIResponses(id="gpt-5.2"),
+    tools=[change_theme, send_notification],
+    telemetry=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Create Team
+# ---------------------------------------------------------------------------
+team = Team(
+    name="UITeam",
+    model=OpenAIResponses(id="gpt-5.2"),
+    members=[ui_agent],
+    telemetry=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Demo: Compare silent vs non-silent paused content
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Demo 1: Silent tool only (change_theme)")
+    print("=" * 60)
+
+    run_response = team.run("Change the theme to dark mode")
+
+    if run_response.is_paused:
+        print(f"Status: paused")
+        print(f"Content: '{run_response.content}'")  # Should be empty
+        print(f"Active requirements: {len(run_response.active_requirements)}")
+
+        for req in run_response.active_requirements:
+            print(f"  - {req.member_agent_name}: {req.tool_execution.tool_name}")
+            print(f"    external_execution_silent: {req.external_execution_silent}")
+
+            # Simulate frontend executing the tool
+            req.set_external_execution_result("Theme changed to dark")
+
+        run_response = team.continue_run(run_response)
+
+    pprint.pprint_run_response(run_response)
+
+    print("\n" + "=" * 60)
+    print("Demo 2: Non-silent tool only (send_notification)")
+    print("=" * 60)
+
+    run_response = team.run("Send a notification saying hello")
+
+    if run_response.is_paused:
+        print(f"Status: paused")
+        print(f"Content: '{run_response.content}'")  # Should show the requirement
+        print(f"Active requirements: {len(run_response.active_requirements)}")
+
+        for req in run_response.active_requirements:
+            print(f"  - {req.member_agent_name}: {req.tool_execution.tool_name}")
+            print(f"    external_execution_silent: {req.external_execution_silent}")
+
+            req.set_external_execution_result("Notification sent")
+
+        run_response = team.continue_run(run_response)
+
+    pprint.pprint_run_response(run_response)

--- a/libs/agno/agno/run/requirement.py
+++ b/libs/agno/agno/run/requirement.py
@@ -99,6 +99,13 @@ class RunRequirement:
 
         return self.tool_execution.external_execution_required or False
 
+    @property
+    def external_execution_silent(self) -> bool:
+        """Return True if this is a silent external execution (no verbose messages)."""
+        return bool(
+            self.needs_external_execution and self.tool_execution and self.tool_execution.external_execution_silent
+        )
+
     def confirm(self):
         if not self.needs_confirmation:
             raise ValueError("This requirement does not require confirmation")

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -328,6 +328,10 @@ class RunPausedEvent(BaseTeamRunEvent):
             return []
         return [req for req in self.requirements if not req.is_resolved()]
 
+    @property
+    def tools_awaiting_external_execution(self):
+        return [t for t in self.tools if t.external_execution_required] if self.tools else []
+
 
 @dataclass
 class RunContinuedEvent(BaseTeamRunEvent):

--- a/libs/agno/agno/team/_hooks.py
+++ b/libs/agno/agno/team/_hooks.py
@@ -63,6 +63,9 @@ def _get_team_paused_content(run_response: TeamRunOutput) -> str:
         return "Team run paused."
     parts: list[str] = []
     for req in active:
+        # Skip silent external execution requirements — mirrors agent-side filter
+        if req.external_execution_silent:
+            continue
         member = req.member_agent_name or "team"
         tool_name = req.tool_execution.tool_name if req.tool_execution else "unknown"
         if req.needs_confirmation:
@@ -71,6 +74,8 @@ def _get_team_paused_content(run_response: TeamRunOutput) -> str:
             parts.append(f"- {member}: {tool_name} requires user input")
         elif req.needs_external_execution:
             parts.append(f"- {member}: {tool_name} requires external execution")
+    if not parts:
+        return ""
     return "Team run paused. The following require input:\n" + "\n".join(parts)
 
 

--- a/libs/agno/tests/unit/team/test_team_paused_content.py
+++ b/libs/agno/tests/unit/team/test_team_paused_content.py
@@ -1,0 +1,211 @@
+"""Tests for _get_team_paused_content and external_execution_silent behavior."""
+
+import pytest
+
+from agno.models.response import ToolExecution
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.team._hooks import _get_team_paused_content
+
+
+def _make_requirement(
+    tool_name: str,
+    external_execution: bool = False,
+    external_execution_silent: bool = False,
+    requires_confirmation: bool = False,
+    requires_user_input: bool = False,
+    member_agent_name: str | None = None,
+) -> RunRequirement:
+    """Helper to create a RunRequirement with specific flags."""
+    tool_execution = ToolExecution(
+        tool_call_id="test_call_id",
+        tool_name=tool_name,
+        tool_args={},
+        external_execution_required=external_execution,
+        external_execution_silent=external_execution_silent if external_execution else None,
+        requires_confirmation=requires_confirmation,
+        requires_user_input=requires_user_input,
+    )
+    req = RunRequirement(tool_execution=tool_execution)
+    req.member_agent_name = member_agent_name
+    return req
+
+
+def _make_team_run_output(requirements: list[RunRequirement]) -> TeamRunOutput:
+    """Helper to create TeamRunOutput with requirements."""
+    return TeamRunOutput(requirements=requirements)
+
+
+class TestGetTeamPausedContent:
+    """Tests for _get_team_paused_content function."""
+
+    def test_no_requirements_returns_default(self):
+        run_response = _make_team_run_output([])
+        assert _get_team_paused_content(run_response) == "Team run paused."
+
+    def test_all_resolved_returns_default(self):
+        req = _make_requirement("my_tool", external_execution=True)
+        req.set_external_execution_result("done")  # Resolve it
+        run_response = _make_team_run_output([req])
+        assert _get_team_paused_content(run_response) == "Team run paused."
+
+    def test_external_execution_shown(self):
+        req = _make_requirement(
+            "send_email",
+            external_execution=True,
+            member_agent_name="EmailAgent",
+        )
+        run_response = _make_team_run_output([req])
+        content = _get_team_paused_content(run_response)
+        assert "EmailAgent: send_email requires external execution" in content
+
+    def test_confirmation_shown(self):
+        req = _make_requirement(
+            "delete_file",
+            requires_confirmation=True,
+            member_agent_name="FileAgent",
+        )
+        run_response = _make_team_run_output([req])
+        content = _get_team_paused_content(run_response)
+        assert "FileAgent: delete_file requires confirmation" in content
+
+    def test_user_input_shown(self):
+        req = _make_requirement(
+            "get_credentials",
+            requires_user_input=True,
+            member_agent_name="AuthAgent",
+        )
+        run_response = _make_team_run_output([req])
+        content = _get_team_paused_content(run_response)
+        assert "AuthAgent: get_credentials requires user input" in content
+
+
+class TestExternalExecutionSilent:
+    """Tests for external_execution_silent filtering in Team paused content."""
+
+    def test_silent_requirement_skipped(self):
+        """Silent external execution should not appear in paused content."""
+        req = _make_requirement(
+            "change_theme",
+            external_execution=True,
+            external_execution_silent=True,
+            member_agent_name="UIAgent",
+        )
+        run_response = _make_team_run_output([req])
+        content = _get_team_paused_content(run_response)
+        # Silent requirement: should return empty string
+        assert content == ""
+
+    def test_non_silent_requirement_shown(self):
+        """Non-silent external execution should appear in paused content."""
+        req = _make_requirement(
+            "send_email",
+            external_execution=True,
+            external_execution_silent=False,
+            member_agent_name="EmailAgent",
+        )
+        run_response = _make_team_run_output([req])
+        content = _get_team_paused_content(run_response)
+        assert "EmailAgent: send_email requires external execution" in content
+
+    def test_mixed_silent_and_non_silent(self):
+        """Mixed requirements: only non-silent should appear."""
+        silent_req = _make_requirement(
+            "change_theme",
+            external_execution=True,
+            external_execution_silent=True,
+            member_agent_name="UIAgent",
+        )
+        non_silent_req = _make_requirement(
+            "send_email",
+            external_execution=True,
+            external_execution_silent=False,
+            member_agent_name="EmailAgent",
+        )
+        run_response = _make_team_run_output([silent_req, non_silent_req])
+        content = _get_team_paused_content(run_response)
+        # Non-silent should be shown
+        assert "EmailAgent: send_email requires external execution" in content
+        # Silent should NOT be shown
+        assert "UIAgent" not in content
+        assert "change_theme" not in content
+
+    def test_all_silent_returns_empty(self):
+        """When all requirements are silent, return empty string."""
+        req1 = _make_requirement(
+            "change_theme",
+            external_execution=True,
+            external_execution_silent=True,
+            member_agent_name="UIAgent",
+        )
+        req2 = _make_requirement(
+            "update_ui",
+            external_execution=True,
+            external_execution_silent=True,
+            member_agent_name="UIAgent",
+        )
+        run_response = _make_team_run_output([req1, req2])
+        content = _get_team_paused_content(run_response)
+        assert content == ""
+
+    def test_silent_with_confirmation_mixed(self):
+        """Silent external + non-silent confirmation: only confirmation shown."""
+        silent_req = _make_requirement(
+            "change_theme",
+            external_execution=True,
+            external_execution_silent=True,
+            member_agent_name="UIAgent",
+        )
+        confirm_req = _make_requirement(
+            "delete_file",
+            requires_confirmation=True,
+            member_agent_name="FileAgent",
+        )
+        run_response = _make_team_run_output([silent_req, confirm_req])
+        content = _get_team_paused_content(run_response)
+        # Confirmation should be shown
+        assert "FileAgent: delete_file requires confirmation" in content
+        # Silent external should NOT be shown
+        assert "UIAgent" not in content
+
+
+class TestRunRequirementExternalExecutionSilentProperty:
+    """Tests for RunRequirement.external_execution_silent property."""
+
+    def test_silent_property_true(self):
+        req = _make_requirement(
+            "my_tool",
+            external_execution=True,
+            external_execution_silent=True,
+        )
+        assert req.external_execution_silent is True
+
+    def test_silent_property_false_when_not_external(self):
+        """Silent property requires needs_external_execution to be True."""
+        req = _make_requirement(
+            "my_tool",
+            external_execution=False,
+            external_execution_silent=True,  # Flag set but not external execution
+        )
+        # Should be False because needs_external_execution is False
+        assert req.external_execution_silent is False
+
+    def test_silent_property_false_when_not_silent(self):
+        req = _make_requirement(
+            "my_tool",
+            external_execution=True,
+            external_execution_silent=False,
+        )
+        assert req.external_execution_silent is False
+
+    def test_silent_property_false_when_resolved(self):
+        """Once resolved, external_execution_silent should be False."""
+        req = _make_requirement(
+            "my_tool",
+            external_execution=True,
+            external_execution_silent=True,
+        )
+        assert req.external_execution_silent is True
+        req.set_external_execution_result("done")
+        # After resolution, needs_external_execution is False
+        assert req.external_execution_silent is False


### PR DESCRIPTION
## Summary

When a Team member's tool has `external_execution_silent=True`, the Team's paused content message should suppress that requirement, matching Agent's behavior in `get_paused_content()`.

**Root cause:** PR #5842 (Jan 2026) added `external_execution_silent` to Agent, but Team HITL was added 11 days later in a separate PR without the corresponding filter.

## Changes

- Add `external_execution_silent` property to `RunRequirement` that encapsulates the check for silent external execution requirements
- Use the new property in `_get_team_paused_content()` to filter out silent requirements  
- Return empty string when all requirements are silent (no verbose "Team run paused" header with empty body)

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed

## Test plan

- [ ] Verify Team with member having `@tool(external_execution=True, external_execution_silent=True)` produces empty content
- [ ] Verify mixed silent/non-silent requirements only show non-silent
- [ ] Run existing Team external_execution integration tests