### PR TITLE
fix: prevent path traversal in AirflowTools save_dag_file and read_dag_file

### DIFF
--- a/libs/agno/agno/tools/airflow.py
+++ b/libs/agno/agno/tools/airflow.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 from typing import Any, List, Optional, Union
 
+from agno.exceptions import PathSecurityError
 from agno.tools import Toolkit
-from agno.utils.log import log_debug, log_info, logger
+from agno.utils.log import log_debug, log_info, log_warning, logger
+from agno.utils.path_safety import safe_join_relative_path
 
 
 class AirflowTools(Toolkit):
@@ -18,13 +20,7 @@ class AirflowTools(Toolkit):
         quick start to work with airflow : https://airflow.apache.org/docs/apache-airflow/stable/start.html
         """
 
-        _dags_dir: Optional[Path] = None
-        if dags_dir is not None:
-            if isinstance(dags_dir, str):
-                _dags_dir = Path.cwd().joinpath(dags_dir)
-            else:
-                _dags_dir = dags_dir
-        self.dags_dir: Path = _dags_dir or Path.cwd()
+        self.dags_dir = Path(dags_dir).resolve() if dags_dir is not None else Path.cwd().resolve()
 
         tools: List[Any] = []
         if all or enable_save_dag_file:
@@ -42,13 +38,16 @@ class AirflowTools(Toolkit):
         :return: The file path if successful, otherwise returns an error message.
         """
         try:
-            file_path = self.dags_dir.joinpath(dag_file)
+            file_path = safe_join_relative_path(self.dags_dir, dag_file)
             log_debug(f"Saving contents to {file_path}")
             if not file_path.parent.exists():
                 file_path.parent.mkdir(parents=True, exist_ok=True)
             file_path.write_text(contents)
             log_info(f"Saved: {file_path}")
             return str(file_path)
+        except PathSecurityError as e:
+            log_warning(f"Error saving to file: {str(e)}")
+            return f"Error saving to file: {e}"
         except Exception as e:
             logger.exception("Error saving to file")
             return f"Error saving to file: {e}"
@@ -61,9 +60,12 @@ class AirflowTools(Toolkit):
         """
         try:
             log_info(f"Reading file: {dag_file}")
-            file_path = self.dags_dir.joinpath(dag_file)
+            file_path = safe_join_relative_path(self.dags_dir, dag_file)
             contents = file_path.read_text()
             return str(contents)
+        except PathSecurityError as e:
+            log_warning(f"Error reading file: {str(e)}")
+            return f"Error reading file: {e}"
         except Exception as e:
             logger.exception("Error reading file")
             return f"Error reading file: {e}"

--- a/libs/agno/tests/unit/tools/test_airflow_tools.py
+++ b/libs/agno/tests/unit/tools/test_airflow_tools.py
@@ -1,0 +1,82 @@
+import tempfile
+from pathlib import Path
+
+from agno.tools.airflow import AirflowTools
+
+
+def test_save_and_read_dag_file_basic():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dags_dir = Path(tmp_dir)
+        airflow_tools = AirflowTools(dags_dir=dags_dir)
+
+        contents = "from airflow import DAG\n"
+        result = airflow_tools.save_dag_file(contents=contents, dag_file="nested/example.py")
+
+        expected_path = dags_dir / "nested" / "example.py"
+        assert result == str(expected_path.resolve())
+        assert expected_path.read_text() == contents
+        assert airflow_tools.read_dag_file("nested/example.py") == contents
+
+
+def test_save_dag_file_rejects_absolute_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        dags_dir = base_dir / "dags"
+        outside_file = base_dir / "outside.py"
+        airflow_tools = AirflowTools(dags_dir=dags_dir)
+
+        result = airflow_tools.save_dag_file(contents="malicious", dag_file=str(outside_file))
+
+        assert result.startswith("Error saving to file:")
+        assert not outside_file.exists()
+
+
+def test_save_dag_file_rejects_traversal():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        dags_dir = base_dir / "dags"
+        outside_file = base_dir / "outside.py"
+        airflow_tools = AirflowTools(dags_dir=dags_dir)
+
+        result = airflow_tools.save_dag_file(contents="malicious", dag_file="../outside.py")
+
+        assert result.startswith("Error saving to file:")
+        assert not outside_file.exists()
+
+
+def test_read_dag_file_rejects_absolute_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        dags_dir = base_dir / "dags"
+        outside_file = base_dir / "outside.py"
+        outside_file.write_text("secret")
+        airflow_tools = AirflowTools(dags_dir=dags_dir)
+
+        result = airflow_tools.read_dag_file(str(outside_file))
+
+        assert result.startswith("Error reading file:")
+        assert "secret" not in result
+
+
+def test_read_dag_file_rejects_traversal():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        dags_dir = base_dir / "dags"
+        outside_file = base_dir / "outside.py"
+        outside_file.write_text("secret")
+        airflow_tools = AirflowTools(dags_dir=dags_dir)
+
+        result = airflow_tools.read_dag_file("../outside.py")
+
+        assert result.startswith("Error reading file:")
+        assert "secret" not in result
+
+
+def test_dags_dir_resolved():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dags_dir = Path(tmp_dir) / "dags" / ".." / "dags"
+
+        airflow_tools = AirflowTools(dags_dir=dags_dir)
+
+        assert airflow_tools.dags_dir == dags_dir.resolve()
+        assert airflow_tools.dags_dir.is_absolute()


### PR DESCRIPTION
## Summary

Replace `dags_dir.joinpath(dag_file)` with `safe_join_relative_path` in both `save_dag_file` and `read_dag_file` to prevent path traversal attacks. Absolute paths and `../` traversal are now rejected with an error message instead of reading or writing files outside `dags_dir`.

This follows the same pattern already used in `slack.py` and `toolkit.py`, which use `safe_join_relative_path` from `agno.utils.path_safety`.

Additionally, `dags_dir` is now resolved to an absolute path at init time via `Path(dags_dir).resolve()`.

## Type of change

- [x] Bug fix (security)

## Changes

- `libs/agno/agno/tools/airflow.py`: use `safe_join_relative_path` in `save_dag_file` and `read_dag_file`, resolve `dags_dir` at init, add `PathSecurityError` handling
- `libs/agno/tests/unit/tools/test_airflow_tools.py`: new regression tests

## Test plan

- [x] `test_save_and_read_dag_file_basic` - normal relative path works
- [x] `test_save_dag_file_rejects_absolute_path` - absolute path rejected, no file created
- [x] `test_save_dag_file_rejects_traversal` - `../` traversal rejected, no file created
- [x] `test_read_dag_file_rejects_absolute_path` - reading via absolute path rejected
- [x] `test_read_dag_file_rejects_traversal` - reading via `../` rejected
- [x] `test_dags_dir_resolved` - `dags_dir` stored as absolute resolved path

All tests pass: `PYTHONPATH=libs/agno pytest libs/agno/tests/unit/tools/test_airflow_tools.py -v` (6 passed)

Addresses #8623
