### PR TITLE
fix: enforce OS_SECURITY_KEY when JWT env vars set but no JWT middleware installed

### DIFF
--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -1,6 +1,5 @@
 import asyncio
 import hmac
-from os import getenv
 from typing import Any, List, Optional, Set
 
 from fastapi import Depends, HTTPException, Request
@@ -51,22 +50,13 @@ def get_auth_token_from_request(request: Request) -> Optional[str]:
     return None
 
 
-def _is_jwt_configured() -> bool:
-    """Check if JWT authentication is configured via environment variables.
-
-    This covers cases where JWT middleware is set up manually (not via authorization=True).
-    """
-    return bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
-
-
 def get_authentication_dependency(settings: AgnoAPISettings):
     """
     Create an authentication dependency function for FastAPI routes.
 
     This handles security key authentication (OS_SECURITY_KEY).
-    When JWT authorization is enabled (via authorization=True, JWT environment variables,
-    or manually added JWT middleware), this dependency is skipped as JWT middleware
-    handles authentication.
+    When JWT authorization is enabled (via authorization=True or manually added JWT
+    middleware), this dependency is skipped as JWT middleware handles authentication.
 
     Args:
         settings: The API settings containing the security key and authorization flag
@@ -80,12 +70,11 @@ def get_authentication_dependency(settings: AgnoAPISettings):
         if settings and settings.authorization_enabled:
             return True
 
-        # Check if JWT middleware has already handled authentication
+        # Check if JWT middleware has already authenticated this request. We must not
+        # skip the OS_SECURITY_KEY check merely because JWT env vars are present: when
+        # authorization=False, AgentOS installs no JWT middleware, so the env vars are
+        # not proof that authentication actually happened (issue #8625).
         if getattr(request.state, "authenticated", False):
-            return True
-
-        # Also skip if JWT is configured via environment variables
-        if _is_jwt_configured():
             return True
 
         # If no security key is set, skip authentication entirely
@@ -119,8 +108,10 @@ def validate_websocket_token(token: str, settings: AgnoAPISettings) -> bool:
     """
     Validate a bearer token for WebSocket authentication (legacy os_security_key method).
 
-    When JWT authorization is enabled (via authorization=True or JWT environment variables),
-    this validation is skipped as JWT middleware handles authentication.
+    When JWT authorization is enabled (via authorization=True), this validation is
+    skipped as JWT middleware handles authentication. The WebSocket router only falls
+    back to this function when no JWT validator is configured, so the presence of JWT
+    env vars alone must not bypass the security key check (issue #8625).
 
     Args:
         token: The bearer token to validate
@@ -131,10 +122,6 @@ def validate_websocket_token(token: str, settings: AgnoAPISettings) -> bool:
     """
     # If JWT authorization is enabled, skip security key validation
     if settings and settings.authorization_enabled:
-        return True
-
-    # Also skip if JWT is configured via environment variables (manual JWT middleware setup)
-    if _is_jwt_configured():
         return True
 
     # If no security key is set, skip authentication entirely

--- a/libs/agno/tests/unit/os/test_jwt_env_os_security_key_bypass.py
+++ b/libs/agno/tests/unit/os/test_jwt_env_os_security_key_bypass.py
@@ -1,0 +1,114 @@
+"""Regression tests for the JWT-env-var vs OS_SECURITY_KEY auth bypass.
+
+When ``authorization=False`` AgentOS does not install JWT middleware, so the
+mere presence of ``JWT_VERIFICATION_KEY`` / ``JWT_JWKS_FILE`` in the process
+environment must not cause the configured ``OS_SECURITY_KEY`` check to be
+skipped — otherwise the routes become unauthenticated. See issue #8625.
+"""
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.os.app import AgentOS
+from agno.os.auth import validate_websocket_token
+from agno.os.middleware import JWTMiddleware
+from agno.os.settings import AgnoAPISettings
+
+OS_KEY = "test-os-security-key"
+JWT_SECRET = "test-secret-key-for-os-security-key-bypass"
+
+
+def _build_app(authorization: bool):
+    agent = Agent(name="Test Agent", id="test-agent", telemetry=False)
+    settings = AgnoAPISettings(os_security_key=OS_KEY)
+    return AgentOS(
+        id="os-test",
+        agents=[agent],
+        authorization=authorization,
+        settings=settings,
+        telemetry=False,
+    ).get_app()
+
+
+def test_os_security_key_enforced_without_jwt_env():
+    """Baseline: OS_SECURITY_KEY alone protects routes."""
+    client = TestClient(_build_app(authorization=False))
+
+    assert client.get("/config").status_code == 401
+    assert client.get("/config", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.get("/config", headers={"Authorization": f"Bearer {OS_KEY}"}).status_code == 200
+
+
+def test_jwt_env_does_not_bypass_os_security_key_when_authorization_disabled(monkeypatch):
+    """JWT env var present + authorization=False: OS_SECURITY_KEY must still be enforced.
+
+    No JWT middleware is installed in this configuration, so a JWT env var is not
+    proof that authentication happened.
+    """
+    monkeypatch.setenv("JWT_VERIFICATION_KEY", "not-used-when-authorization-false")
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+
+    client = TestClient(_build_app(authorization=False))
+
+    assert client.get("/config").status_code == 401
+    assert client.get("/config", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.get("/config", headers={"Authorization": f"Bearer {OS_KEY}"}).status_code == 200
+
+
+def test_jwt_jwks_file_env_does_not_bypass_os_security_key(monkeypatch):
+    """The JWT_JWKS_FILE env var must not bypass OS_SECURITY_KEY either."""
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.setenv("JWT_JWKS_FILE", "/tmp/does-not-matter.json")
+
+    client = TestClient(_build_app(authorization=False))
+
+    assert client.get("/config").status_code == 401
+    assert client.get("/config", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.get("/config", headers={"Authorization": f"Bearer {OS_KEY}"}).status_code == 200
+
+
+def test_manual_jwt_middleware_still_works_with_os_security_key():
+    """A manually installed JWTMiddleware (authorization=False) must keep working.
+
+    This locks the legitimate path the env-var bypass was meant to cover: the
+    OS_SECURITY_KEY check is skipped via request.state.authenticated (set by the
+    middleware), not via the mere presence of JWT env vars.
+    """
+    app = _build_app(authorization=False)
+    app.add_middleware(JWTMiddleware, verification_keys=[JWT_SECRET], algorithm="HS256")
+    client = TestClient(app)
+
+    valid_jwt = jwt.encode({"sub": "user-1"}, JWT_SECRET, algorithm="HS256")
+
+    # Valid JWT is authenticated by the middleware, so the route is reachable.
+    assert client.get("/config", headers={"Authorization": f"Bearer {valid_jwt}"}).status_code == 200
+    # No token / non-JWT bearer are rejected by the middleware.
+    assert client.get("/config").status_code == 401
+    assert client.get("/config", headers={"Authorization": f"Bearer {OS_KEY}"}).status_code == 401
+
+
+def test_authorization_true_still_enforces_jwt(monkeypatch):
+    """authorization=True installs JWT middleware, which keeps rejecting unauthenticated requests."""
+    monkeypatch.setenv("JWT_VERIFICATION_KEY", "secret-signing-key")
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+
+    client = TestClient(_build_app(authorization=True))
+
+    # No token and a non-JWT bearer are both rejected by the JWT middleware.
+    assert client.get("/config").status_code == 401
+    assert client.get("/config", headers={"Authorization": f"Bearer {OS_KEY}"}).status_code == 401
+
+
+@pytest.mark.parametrize("env_var", ["JWT_VERIFICATION_KEY", "JWT_JWKS_FILE"])
+def test_validate_websocket_token_not_bypassed_by_jwt_env(monkeypatch, env_var):
+    """validate_websocket_token must not accept arbitrary tokens just because a JWT env var is set."""
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+    monkeypatch.setenv(env_var, "present")
+
+    settings = AgnoAPISettings(os_security_key=OS_KEY)
+
+    assert validate_websocket_token("wrong", settings) is False
+    assert validate_websocket_token(OS_KEY, settings) is True


### PR DESCRIPTION
## Summary

Fixes the security issue in #8625: when `authorization=False`, the presence of `JWT_VERIFICATION_KEY` or `JWT_JWKS_FILE` in the environment caused `OS_SECURITY_KEY` to be skipped, even though no JWT middleware is installed in that configuration. The result is that `/config` and other routes become reachable with no token or an invalid bearer.

The bypass lived in two places in `libs/agno/agno/os/auth.py`:

- `get_authentication_dependency()` returned `True` whenever `_is_jwt_configured()` saw a JWT env var, before checking `OS_SECURITY_KEY`.
- `validate_websocket_token()` had the same env-var-only skip.

Env-var presence is not proof that authentication happened. This PR removes the `_is_jwt_configured()` bypass from both paths (and drops the now-unused helper). Legitimate setups are unaffected:

- `authorization=True` is still handled via `settings.authorization_enabled`.
- Manually installed `JWTMiddleware` is still handled via `request.state.authenticated`, which the middleware sets after validating a request. The WebSocket path already resolves its JWT validator from the installed middleware (`resolve_ws_jwt_config`), not from env vars, so the legacy `validate_websocket_token` fallback is only reached when no middleware exists.

Reproducer from the issue, after the fix:

```text
without_jwt_env_no_auth 401
without_jwt_env_bad_bearer 401
without_jwt_env_good_bearer 200
with_jwt_env_no_auth 401
with_jwt_env_bad_bearer 401
with_jwt_env_good_bearer 200
```

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines (ruff check/format, mypy clean on `auth.py`)
- [x] Self-review completed
- [x] Documentation updated (docstrings on both functions updated)
- [x] Tests added (`tests/unit/os/test_jwt_env_os_security_key_bypass.py`)

New regression tests cover: OS_SECURITY_KEY only; OS_SECURITY_KEY + `JWT_VERIFICATION_KEY`/`JWT_JWKS_FILE` with `authorization=False`; a manually installed `JWTMiddleware` (valid JWT passes, invalid/no token rejected); `authorization=True` still enforces JWT; and `validate_websocket_token` directly.

Closes #8625

<!-- oss-radar:idempotency=auto-20260630-103018.w6.agno-agi_agno.8625 -->
