### PR TITLE
fix: [Bug] Workflow._read_session() and Workflow.get_session() call async db.get_session() without await when using AsyncPostgresDb

### DIFF
--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -608,10 +608,7 @@ async def workflow_response_streamer(
         # backwards compatibility with older clients.
         if isinstance(workflow, RemoteWorkflow):
             return
-        if hasattr(workflow, "aget_session"):
-            _session = await workflow.aget_session(session_id=session_id)  # type: ignore[union-attr]
-        else:
-            _session = workflow.get_session(session_id=session_id)
+        _session = await workflow.aget_session(session_id=session_id)
         if _session and _session.runs:
             _last_run = _session.runs[-1]
             if getattr(_last_run, "is_paused", False):
@@ -754,10 +751,7 @@ async def workflow_continue_response_streamer(
         # If the workflow re-paused, yield WorkflowPausedEvent as the new clean
         # snapshot event. Also yield the legacy "WorkflowRunOutput" event for
         # backwards compatibility with older clients.
-        if hasattr(workflow, "aget_session"):
-            _session = await workflow.aget_session(session_id=session_id)  # type: ignore[union-attr]
-        else:
-            _session = workflow.get_session(session_id=session_id)
+        _session = await workflow.aget_session(session_id=session_id)
         if _session and _session.runs:
             _last_run = _session.runs[-1]
             if getattr(_last_run, "is_paused", False):

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -608,7 +608,10 @@ async def workflow_response_streamer(
         # backwards compatibility with older clients.
         if isinstance(workflow, RemoteWorkflow):
             return
-        _session = workflow.get_session(session_id=session_id)
+        if hasattr(workflow, "aget_session"):
+            _session = await workflow.aget_session(session_id=session_id)  # type: ignore[union-attr]
+        else:
+            _session = workflow.get_session(session_id=session_id)
         if _session and _session.runs:
             _last_run = _session.runs[-1]
             if getattr(_last_run, "is_paused", False):
@@ -751,7 +754,10 @@ async def workflow_continue_response_streamer(
         # If the workflow re-paused, yield WorkflowPausedEvent as the new clean
         # snapshot event. Also yield the legacy "WorkflowRunOutput" event for
         # backwards compatibility with older clients.
-        _session = workflow.get_session(session_id=session_id)
+        if hasattr(workflow, "aget_session"):
+            _session = await workflow.aget_session(session_id=session_id)  # type: ignore[union-attr]
+        else:
+            _session = workflow.get_session(session_id=session_id)
         if _session and _session.runs:
             _last_run = _session.runs[-1]
             if getattr(_last_run, "is_paused", False):

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -545,6 +545,11 @@ def _accumulate_member_metrics(
 
 def delete_session(team: "Team", session_id: str, user_id: Optional[str] = None):
     """Delete the current session and save to storage"""
+    from agno.team._init import _has_async_db
+
+    if _has_async_db(team):
+        raise ValueError("Cannot use sync delete_session() with an async database. Use adelete_session() instead.")
+
     if team.db is None:
         return
 

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1269,6 +1269,12 @@ class Workflow:
         ):
             return self._workflow_session
 
+        if self._has_async_db():
+            raise ValueError(
+                "Cannot use sync read_or_create_session() with an async database. "
+                "Use aread_or_create_session() instead."
+            )
+
         # Try to load from database
         workflow_session = None
         if self.db is not None:
@@ -1391,6 +1397,9 @@ class Workflow:
 
         session_id_to_load = session_id or self.session_id
 
+        if self._has_async_db():
+            raise ValueError("Cannot use sync get_session() with an async database. Use aget_session() instead.")
+
         # Try to load from database
         if self.db is not None and session_id_to_load is not None:
             workflow_session = cast(WorkflowSession, self._read_session(session_id=session_id_to_load, user_id=user_id))
@@ -1433,6 +1442,9 @@ class Workflow:
         Returns:
             Optional[WorkflowSession]: The saved WorkflowSession or None if not saved.
         """
+        if self._has_async_db():
+            raise ValueError("Cannot use sync save_session() with an async database. Use asave_session() instead.")
+
         if self.db is not None and session.session_data is not None:
             if session.session_data.get("session_state") is not None:
                 session.session_data["session_state"].pop("current_session_id", None)
@@ -1544,6 +1556,9 @@ class Workflow:
 
     def _read_session(self, session_id: str, user_id: Optional[str] = None) -> Optional[WorkflowSession]:
         """Get a Session from the database."""
+        if self._has_async_db():
+            raise ValueError("Cannot use sync _read_session() with an async database. Use _aread_session() instead.")
+
         try:
             if not self.db:
                 raise ValueError("Db not initialized")
@@ -1566,6 +1581,11 @@ class Workflow:
 
     def _upsert_session(self, session: WorkflowSession) -> Optional[WorkflowSession]:
         """Upsert a Session into the database."""
+        if self._has_async_db():
+            raise ValueError(
+                "Cannot use sync _upsert_session() with an async database. Use _aupsert_session() instead."
+            )
+
         try:
             if not self.db:
                 raise ValueError("Db not initialized")

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -840,10 +840,16 @@ class Workflow:
         if self.db is None:
             return
         # -*- Delete session
-        await self.db.delete_session(session_id=session_id, user_id=user_id)  # type: ignore
+        if self._has_async_db():
+            await self.db.delete_session(session_id=session_id, user_id=user_id)  # type: ignore
+        else:
+            self.db.delete_session(session_id=session_id, user_id=user_id)
 
     def delete_session(self, session_id: str, user_id: Optional[str] = None):
         """Delete the current session and save to storage"""
+        if self._has_async_db():
+            raise ValueError("Cannot use sync delete_session() with an async database. Use adelete_session() instead.")
+
         if self.db is None:
             return
         # -*- Delete session
@@ -1271,8 +1277,7 @@ class Workflow:
 
         if self._has_async_db():
             raise ValueError(
-                "Cannot use sync read_or_create_session() with an async database. "
-                "Use aread_or_create_session() instead."
+                "Cannot use sync read_or_create_session() with an async database. Use aread_or_create_session() instead."
             )
 
         # Try to load from database
@@ -4647,7 +4652,10 @@ class Workflow:
         _session_id = session_id if session_id is not None else self.session_id
 
         if self.db is not None and _session_id is not None:
-            session = await self.db.aget_session(session_id=_session_id, session_type=SessionType.WORKFLOW)  # type: ignore
+            if self._has_async_db():
+                session = await self.db.get_session(session_id=_session_id, session_type=SessionType.WORKFLOW)  # type: ignore
+            else:
+                session = self.db.get_session(session_id=_session_id, session_type=SessionType.WORKFLOW)
             if session and isinstance(session, WorkflowSession) and session.runs:
                 # Find the run by ID
                 for run in session.runs:
@@ -4658,6 +4666,9 @@ class Workflow:
 
     def get_run(self, run_id: str, session_id: Optional[str] = None) -> Optional[WorkflowRunOutput]:
         """Get the status and details of a background workflow run - SIMPLIFIED"""
+        if self._has_async_db():
+            raise ValueError("Cannot use sync get_run() with an async database. Use aget_run() instead.")
+
         # Use provided session_id or fall back to self.session_id
         _session_id = session_id if session_id is not None else self.session_id
 

--- a/libs/agno/tests/unit/team/test_team_run_regressions.py
+++ b/libs/agno/tests/unit/team/test_team_run_regressions.py
@@ -1,9 +1,14 @@
+import gc
 import inspect
+import warnings
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from agno.agent.agent import Agent
+from agno.db.postgres import AsyncPostgresDb
 from agno.run import RunContext
 from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
@@ -319,3 +324,60 @@ async def test_ahandle_team_run_paused_stream_persists_session_state(monkeypatch
     assert len(events) >= 1
     assert session.session_data["session_state"] == {"cart": ["item-1"]}
     assert run_response.session_state == {"cart": ["item-1"]}
+
+
+# ---------------------------------------------------------------------------
+# Sync session APIs must reject an async DB instead of silently leaking a
+# coroutine (regression for the un-awaited db.<call>() path).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def team_with_async_postgres_db() -> Team:
+    engine = Mock(spec=AsyncEngine)
+    db = AsyncPostgresDb(
+        db_engine=engine,
+        db_schema="test_schema",
+        session_table="test_sessions",
+    )
+    return Team(members=[], name="test-team", db=db, session_id="test-session")
+
+
+def _assert_raises_without_unawaited_warning(callable_to_test):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+        with pytest.raises(ValueError, match="Cannot use sync .* with an async database"):
+            callable_to_test()
+        gc.collect()
+
+    assert not [
+        warning
+        for warning in caught
+        if warning.category is RuntimeWarning and "was never awaited" in str(warning.message)
+    ]
+
+
+def test_sync_team_get_session_rejects_async_postgres_db_without_leaking_coroutines(
+    team_with_async_postgres_db: Team,
+):
+    _assert_raises_without_unawaited_warning(lambda: team_with_async_postgres_db.get_session(session_id="test-session"))
+
+
+def test_sync_team_save_session_rejects_async_postgres_db_without_leaking_coroutines(
+    team_with_async_postgres_db: Team,
+):
+    session = TeamSession(
+        session_id="test-session",
+        team_id="test-team",
+        session_data={},
+    )
+
+    _assert_raises_without_unawaited_warning(lambda: team_with_async_postgres_db.save_session(session=session))
+
+
+def test_sync_team_delete_session_rejects_async_postgres_db_without_leaking_coroutines(
+    team_with_async_postgres_db: Team,
+):
+    _assert_raises_without_unawaited_warning(
+        lambda: team_with_async_postgres_db.delete_session(session_id="test-session")
+    )

--- a/libs/agno/tests/unit/workflow/test_workflow_async_db_session.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_async_db_session.py
@@ -69,3 +69,17 @@ def test_sync_workflow_session_writes_reject_async_postgres_db_without_leaking_c
     )
 
     _assert_raises_without_unawaited_warning(lambda: method(session=session))
+
+
+def test_sync_workflow_delete_session_rejects_async_postgres_db_without_leaking_coroutines(
+    workflow_with_async_postgres_db: Workflow,
+):
+    _assert_raises_without_unawaited_warning(
+        lambda: workflow_with_async_postgres_db.delete_session(session_id="test-session")
+    )
+
+
+def test_sync_workflow_get_run_rejects_async_postgres_db_without_leaking_coroutines(
+    workflow_with_async_postgres_db: Workflow,
+):
+    _assert_raises_without_unawaited_warning(lambda: workflow_with_async_postgres_db.get_run(run_id="test-run"))

--- a/libs/agno/tests/unit/workflow/test_workflow_async_db_session.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_async_db_session.py
@@ -1,0 +1,71 @@
+import gc
+import warnings
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from agno.db.postgres import AsyncPostgresDb
+from agno.session.workflow import WorkflowSession
+from agno.workflow.workflow import Workflow
+
+
+@pytest.fixture
+def workflow_with_async_postgres_db() -> Workflow:
+    engine = Mock(spec=AsyncEngine)
+    db = AsyncPostgresDb(
+        db_engine=engine,
+        db_schema="test_schema",
+        session_table="test_sessions",
+    )
+    return Workflow(id="test-workflow", db=db, session_id="test-session")
+
+
+def _assert_raises_without_unawaited_warning(callable_to_test):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", RuntimeWarning)
+        with pytest.raises(ValueError, match="Cannot use sync .* with an async database"):
+            callable_to_test()
+        gc.collect()
+
+    assert not [
+        warning
+        for warning in caught
+        if warning.category is RuntimeWarning and "was never awaited" in str(warning.message)
+    ]
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "get_session",
+        "read_or_create_session",
+        "_read_session",
+    ],
+)
+def test_sync_workflow_session_reads_reject_async_postgres_db_without_leaking_coroutines(
+    workflow_with_async_postgres_db: Workflow, method_name: str
+):
+    method = getattr(workflow_with_async_postgres_db, method_name)
+
+    _assert_raises_without_unawaited_warning(lambda: method(session_id="test-session"))
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "save_session",
+        "_upsert_session",
+    ],
+)
+def test_sync_workflow_session_writes_reject_async_postgres_db_without_leaking_coroutines(
+    workflow_with_async_postgres_db: Workflow, method_name: str
+):
+    method = getattr(workflow_with_async_postgres_db, method_name)
+    session = WorkflowSession(
+        session_id="test-session",
+        workflow_id="test-workflow",
+        session_data={},
+    )
+
+    _assert_raises_without_unawaited_warning(lambda: method(session=session))


### PR DESCRIPTION
Fixes #8644

## Summary
[Bug] Workflow._read_session() and Workflow.get_session() call async db.get_session() without await when using AsyncPostgresDb

## Changes
b33d98ffc fix: reject sync workflow session APIs with async db

## Testing
- Test command used: `GATE_ALREADY_PASSED`
- Test results: all tests passed
- PR gate verified