### PR TITLE
fix: use per-execution run_id for eval DB logging and telemetry

### DIFF
--- a/libs/agno/agno/eval/performance.py
+++ b/libs/agno/agno/eval/performance.py
@@ -602,7 +602,7 @@ class PerformanceEval:
 
             log_eval_run(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
+                run_id=run_id,
                 run_data=self._parse_eval_run_data(),
                 eval_type=EvalType.PERFORMANCE,
                 name=self.name if self.name is not None else None,
@@ -618,9 +618,7 @@ class PerformanceEval:
             from agno.api.evals import EvalRunCreate, create_eval_run_telemetry
 
             create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
-                ),
+                eval_run=EvalRunCreate(run_id=run_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()),
             )
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")
@@ -748,7 +746,7 @@ class PerformanceEval:
 
             await async_log_eval(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
+                run_id=run_id,
                 run_data=self._parse_eval_run_data(),
                 eval_type=EvalType.PERFORMANCE,
                 name=self.name if self.name is not None else None,
@@ -764,9 +762,7 @@ class PerformanceEval:
             from agno.api.evals import EvalRunCreate, async_create_eval_run_telemetry
 
             await async_create_eval_run_telemetry(
-                eval_run=EvalRunCreate(
-                    run_id=self.eval_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()
-                ),
+                eval_run=EvalRunCreate(run_id=run_id, eval_type=EvalType.PERFORMANCE, data=self._get_telemetry_data()),
             )
 
         log_debug(f"*********** Evaluation End: {run_id} ***********")

--- a/libs/agno/agno/eval/reliability.py
+++ b/libs/agno/agno/eval/reliability.py
@@ -274,7 +274,7 @@ class ReliabilityEval:
 
             log_eval_run(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
+                run_id=run_id,
                 run_data=asdict(self.result),
                 eval_type=EvalType.RELIABILITY,
                 name=self.name if self.name is not None else None,
@@ -290,7 +290,7 @@ class ReliabilityEval:
 
             create_eval_run_telemetry(
                 eval_run=EvalRunCreate(
-                    run_id=self.eval_id,
+                    run_id=run_id,
                     eval_type=EvalType.RELIABILITY,
                     data=self._get_telemetry_data(),
                 ),
@@ -357,7 +357,7 @@ class ReliabilityEval:
 
             await async_log_eval(
                 db=self.db,
-                run_id=self.eval_id,  # type: ignore
+                run_id=run_id,
                 run_data=asdict(self.result),
                 eval_type=EvalType.RELIABILITY,
                 name=self.name if self.name is not None else None,
@@ -373,7 +373,7 @@ class ReliabilityEval:
 
             await async_create_eval_run_telemetry(
                 eval_run=EvalRunCreate(
-                    run_id=self.eval_id,
+                    run_id=run_id,
                     eval_type=EvalType.RELIABILITY,
                     data=self._get_telemetry_data(),
                 ),

--- a/libs/agno/tests/unit/eval/test_performance_eval.py
+++ b/libs/agno/tests/unit/eval/test_performance_eval.py
@@ -1,6 +1,9 @@
-"""Unit tests for PerformanceResult statistics"""
+"""Unit tests for PerformanceEval and PerformanceResult"""
 
-from agno.eval.performance import PerformanceResult
+from unittest.mock import patch
+
+from agno.db.in_memory import InMemoryDb
+from agno.eval.performance import PerformanceEval, PerformanceResult
 
 # ---------------------------------------------------------------------------
 # p95 percentile for small samples
@@ -28,3 +31,81 @@ def test_empty_run_times_p95_is_zero():
     result = PerformanceResult(run_times=[], memory_usages=[])
     assert result.p95_run_time == 0
     assert result.p95_memory_usage == 0
+
+
+# ---------------------------------------------------------------------------
+# per-execution run_id for DB logging and telemetry
+# ---------------------------------------------------------------------------
+
+
+def _perf_eval(db: InMemoryDb) -> PerformanceEval:
+    """Build a minimal PerformanceEval that logs to the given db without telemetry."""
+    return PerformanceEval(
+        func=lambda: None,
+        db=db,
+        telemetry=False,
+        warmup_runs=0,
+        num_iterations=1,
+    )
+
+
+def test_run_logs_distinct_run_id_per_execution():
+    """Running the same eval instance twice should store two distinct run_ids."""
+    db = InMemoryDb()
+    evaluation = _perf_eval(db)
+
+    evaluation.run()
+    evaluation.run()
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert runs[0].run_id != runs[1].run_id
+    # The per-execution run_id must not reuse the stable eval definition id.
+    assert runs[0].run_id != evaluation.eval_id
+    assert runs[1].run_id != evaluation.eval_id
+
+
+def test_db_and_telemetry_share_same_run_id():
+    """A single execution must log the same run_id to both the DB and telemetry."""
+    db = InMemoryDb()
+    evaluation = PerformanceEval(
+        func=lambda: None,
+        db=db,
+        telemetry=True,
+        warmup_runs=0,
+        num_iterations=1,
+    )
+
+    with patch("agno.api.evals.create_eval_run_telemetry") as mock_create:
+        evaluation.run()
+
+    telemetry_run_id = mock_create.call_args[1]["eval_run"].run_id
+    db_run_id = db.get_eval_runs()[0].run_id
+
+    assert telemetry_run_id == db_run_id
+    assert telemetry_run_id != evaluation.eval_id
+
+
+async def test_arun_logs_distinct_run_id_per_execution():
+    """Async path should also store a distinct run_id per execution."""
+
+    async def sample_func():
+        return None
+
+    db = InMemoryDb()
+    evaluation = PerformanceEval(
+        func=sample_func,
+        db=db,
+        telemetry=False,
+        warmup_runs=0,
+        num_iterations=1,
+    )
+
+    await evaluation.arun()
+    await evaluation.arun()
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert runs[0].run_id != runs[1].run_id
+    assert runs[0].run_id != evaluation.eval_id
+    assert runs[1].run_id != evaluation.eval_id

--- a/libs/agno/tests/unit/eval/test_reliability_eval.py
+++ b/libs/agno/tests/unit/eval/test_reliability_eval.py
@@ -276,3 +276,53 @@ def test_combined_subset_and_argument_check():
     assert "multiply" in result.passed_tool_calls
     assert "exponentiate" in result.additional_tool_calls
     assert "multiply" in result.passed_argument_checks
+
+
+# ---------------------------------------------------------------------------
+# run_id is per-execution, not the stable eval_id
+# ---------------------------------------------------------------------------
+
+
+def test_run_logs_distinct_run_id_per_execution():
+    """Running the same eval instance twice should store two distinct run_ids."""
+    from agno.db.in_memory import InMemoryDb
+
+    db = InMemoryDb()
+    evaluation = ReliabilityEval(
+        agent_response=_make_response(_make_tool_call("multiply")),
+        expected_tool_calls=["multiply"],
+        db=db,
+        telemetry=False,
+    )
+
+    evaluation.run(print_results=False)
+    evaluation.run(print_results=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert runs[0].run_id != runs[1].run_id
+    # The per-execution run_id must not reuse the stable eval definition id.
+    assert runs[0].run_id != evaluation.eval_id
+    assert runs[1].run_id != evaluation.eval_id
+
+
+async def test_arun_logs_distinct_run_id_per_execution():
+    """Async path should also store a distinct run_id per execution."""
+    from agno.db.in_memory import InMemoryDb
+
+    db = InMemoryDb()
+    evaluation = ReliabilityEval(
+        agent_response=_make_response(_make_tool_call("multiply")),
+        expected_tool_calls=["multiply"],
+        db=db,
+        telemetry=False,
+    )
+
+    await evaluation.arun(print_results=False)
+    await evaluation.arun(print_results=False)
+
+    runs = db.get_eval_runs()
+    assert len(runs) == 2
+    assert runs[0].run_id != runs[1].run_id
+    assert runs[0].run_id != evaluation.eval_id
+    assert runs[1].run_id != evaluation.eval_id

--- a/libs/agno/tests/unit/telemetry/test_eval_telemetry.py
+++ b/libs/agno/tests/unit/telemetry/test_eval_telemetry.py
@@ -45,7 +45,9 @@ def test_performance_evals_telemetry():
         # Verify API was called with correct parameters
         mock_create.assert_called_once()
         call_args = mock_create.call_args[1]["eval_run"]
-        assert call_args.run_id == performance_eval.eval_id
+        # run_id is a per-execution id, distinct from the stable eval_id.
+        assert call_args.run_id != performance_eval.eval_id
+        assert call_args.run_id
         assert call_args.eval_type.value == "performance"
 
 
@@ -73,7 +75,9 @@ def test_reliability_evals_telemetry():
         # Verify API was called with correct parameters
         mock_create.assert_called_once()
         call_args = mock_create.call_args[1]["eval_run"]
-        assert call_args.run_id == reliability_eval.eval_id
+        # run_id is a per-execution id, distinct from the stable eval_id.
+        assert call_args.run_id != reliability_eval.eval_id
+        assert call_args.run_id
         assert call_args.eval_type.value == "reliability"
 
 


### PR DESCRIPTION
## Summary

`PerformanceEval` and `ReliabilityEval` generate a fresh per-execution `run_id` (`run_id = str(uuid4())`), but the DB logging and telemetry calls still passed `self.eval_id`. Running the same eval instance more than once therefore recorded every run under the same id, so individual runs couldn't be told apart and — depending on the storage backend — rows could be overwritten or merged.

This passes the local `run_id` to `log_eval_run` / `async_log_eval` and the `EvalRunCreate` telemetry payload in both the sync and async paths of both evals, keeping the stable eval definition id (`eval_id`) separate from the per-run id (`run_id`). `AccuracyEval` is intentionally left alone — it's out of scope for this report.

Issue number: #8657

Closes #8657

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format` / `ruff check` / `mypy`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — n/a, behavior-only fix
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

## Additional Notes

Regression tests run each eval instance twice against `InMemoryDb` and assert two distinct stored `run_id`s (sync + async), plus a test asserting a single execution logs the *same* `run_id` to both the DB and telemetry. Existing telemetry tests were updated to assert `run_id != eval_id`.

Local verification:

```
pytest tests/unit/eval/ tests/unit/telemetry/test_eval_telemetry.py -q   # 51 passed
ruff check <changed files>   # clean
mypy agno/eval/performance.py agno/eval/reliability.py   # clean
```

This PR was AI-assisted; the diff, root cause, and tests were reviewed and are understood.

<!-- oss-radar:idempotency=auto-20260701-102639.w2.agno-agi_agno.8657 -->
