### PR TITLE
fix: restore eval model override when an eval run fails

### DIFF
--- a/libs/agno/agno/os/routers/evals/evals.py
+++ b/libs/agno/agno/os/routers/evals/evals.py
@@ -469,42 +469,47 @@ def attach_routes(
         else:
             raise HTTPException(status_code=400, detail="One of agent_id or team_id must be provided")
 
-        # Run the evaluation
-        if eval_run_input.eval_type == EvalType.ACCURACY:
-            if isinstance(agent, RemoteAgent) or isinstance(team, RemoteTeam):
-                # TODO: Handle remote evaluation
-                log_warning("Evaluation against remote agents are not supported yet")
-                return None
-            return await run_accuracy_eval(
-                eval_run_input=eval_run_input, db=db, agent=agent, team=team, default_model=default_model
-            )
+        # Run the evaluation. The model override applied above is temporary, so it
+        # must be restored on the shared in-memory agent/team regardless of whether
+        # the eval succeeds, raises during validation, or fails while running.
+        try:
+            if eval_run_input.eval_type == EvalType.ACCURACY:
+                if isinstance(agent, RemoteAgent) or isinstance(team, RemoteTeam):
+                    # TODO: Handle remote evaluation
+                    log_warning("Evaluation against remote agents are not supported yet")
+                    return None
+                return await run_accuracy_eval(
+                    eval_run_input=eval_run_input, db=db, agent=agent, team=team, default_model=default_model
+                )
 
-        elif eval_run_input.eval_type == EvalType.AGENT_AS_JUDGE:
-            return await run_agent_as_judge_eval(
-                eval_run_input=eval_run_input,
-                db=db,
-                agent=agent,
-                team=team,
-                default_model=default_model,  # type: ignore
-            )
+            elif eval_run_input.eval_type == EvalType.AGENT_AS_JUDGE:
+                return await run_agent_as_judge_eval(
+                    eval_run_input=eval_run_input,
+                    db=db,
+                    agent=agent,
+                    team=team,
+                    default_model=default_model,  # type: ignore
+                )
 
-        elif eval_run_input.eval_type == EvalType.PERFORMANCE:
-            if isinstance(agent, RemoteAgent) or isinstance(team, RemoteTeam):
-                # TODO: Handle remote evaluation
-                log_warning("Evaluation against remote agents are not supported yet")
-                return None
-            return await run_performance_eval(
-                eval_run_input=eval_run_input, db=db, agent=agent, team=team, default_model=default_model
-            )
+            elif eval_run_input.eval_type == EvalType.PERFORMANCE:
+                if isinstance(agent, RemoteAgent) or isinstance(team, RemoteTeam):
+                    # TODO: Handle remote evaluation
+                    log_warning("Evaluation against remote agents are not supported yet")
+                    return None
+                return await run_performance_eval(eval_run_input=eval_run_input, db=db, agent=agent, team=team)
 
-        else:
-            if isinstance(agent, RemoteAgent) or isinstance(team, RemoteTeam):
-                # TODO: Handle remote evaluation
-                log_warning("Evaluation against remote agents are not supported yet")
-                return None
-            return await run_reliability_eval(
-                eval_run_input=eval_run_input, db=db, agent=agent, team=team, default_model=default_model
-            )
+            else:
+                if isinstance(agent, RemoteAgent) or isinstance(team, RemoteTeam):
+                    # TODO: Handle remote evaluation
+                    log_warning("Evaluation against remote agents are not supported yet")
+                    return None
+                return await run_reliability_eval(eval_run_input=eval_run_input, db=db, agent=agent, team=team)
+        finally:
+            if default_model is not None:
+                if isinstance(agent, Agent):
+                    agent.model = default_model
+                elif isinstance(team, Team):
+                    team.model = default_model
 
     return router
 

--- a/libs/agno/agno/os/routers/evals/utils.py
+++ b/libs/agno/agno/os/routers/evals/utils.py
@@ -43,13 +43,6 @@ async def run_accuracy_eval(
 
     eval_run = EvalSchema.from_accuracy_eval(accuracy_eval=accuracy_eval, result=result)
 
-    # Restore original model after eval
-    if default_model is not None:
-        if agent is not None:
-            agent.model = default_model
-        elif team is not None:
-            team.model = default_model
-
     return eval_run
 
 
@@ -107,13 +100,6 @@ async def run_agent_as_judge_eval(
         model_provider=eval_model_provider,
     )
 
-    # Restore original model after eval
-    if default_model is not None:
-        if agent is not None and isinstance(agent, Agent):
-            agent.model = default_model
-        elif team is not None and isinstance(team, Team):
-            team.model = default_model
-
     return eval_run
 
 
@@ -122,7 +108,6 @@ async def run_performance_eval(
     db: Union[BaseDb, AsyncBaseDb],
     agent: Optional[Agent] = None,
     team: Optional[Team] = None,
-    default_model: Optional[Model] = None,
 ) -> EvalSchema:
     """Run a performance evaluation for the given agent or team"""
     if agent:
@@ -166,13 +151,6 @@ async def run_performance_eval(
         model_provider=model_provider,
     )
 
-    # Restore original model after eval
-    if default_model is not None:
-        if agent is not None:
-            agent.model = default_model
-        elif team is not None:
-            team.model = default_model
-
     return eval_run
 
 
@@ -181,7 +159,6 @@ async def run_reliability_eval(
     db: Union[BaseDb, AsyncBaseDb],
     agent: Optional[Agent] = None,
     team: Optional[Team] = None,
-    default_model: Optional[Model] = None,
 ) -> EvalSchema:
     """Run a reliability evaluation for the given agent or team"""
     if eval_run_input.expected_tool_calls is None:
@@ -225,12 +202,5 @@ async def run_reliability_eval(
         model_id=model_id,
         model_provider=model_provider,
     )
-
-    # Restore original model after eval
-    if default_model is not None:
-        if agent is not None:
-            agent.model = default_model
-        elif team is not None:
-            team.model = default_model
 
     return eval_run

--- a/libs/agno/tests/unit/os/routers/test_evals_router.py
+++ b/libs/agno/tests/unit/os/routers/test_evals_router.py
@@ -1,0 +1,104 @@
+"""Regression tests for the eval router's temporary model override handling.
+
+Covers #8655: POST /eval-runs temporarily swaps the target agent/team model when
+``model_id`` is supplied. The original model must be restored on the shared
+in-memory agent/team even when the eval run fails, otherwise a single failed
+request silently changes the model for every later run in the same process.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.base import AsyncBaseDb
+from agno.db.schemas.evals import EvalType
+from agno.os.routers.evals import get_eval_router
+from agno.os.routers.evals.schemas import EvalSchema
+from agno.os.settings import AgnoAPISettings
+
+
+def _make_async_db() -> MagicMock:
+    db = MagicMock(spec=AsyncBaseDb)
+    db.id = "test-db"
+    return db
+
+
+def _build_client(agent: Agent) -> TestClient:
+    app = FastAPI()
+    router = get_eval_router(dbs={"test-db": [_make_async_db()]}, agents=[agent], settings=AgnoAPISettings())
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _agent_with_model(model_id: str = "model-a", provider: str = "openai") -> Agent:
+    agent = Agent(name="test-agent", id="test-agent-id")
+    agent.model = SimpleNamespace(id=model_id, provider=provider)  # type: ignore[assignment]
+    return agent
+
+
+def test_model_override_restored_when_eval_fails():
+    """A failed eval run must not leave the temporary override model on the agent."""
+    agent = _agent_with_model()
+    client = _build_client(agent)
+
+    override_model = SimpleNamespace(id="model-b", provider="openai")
+    with patch("agno.os.routers.evals.evals.get_model", return_value=override_model):
+        # expected_output is intentionally omitted, so accuracy eval raises 400
+        # after the temporary model has already been applied.
+        response = client.post(
+            "/eval-runs?db_id=test-db",
+            json={
+                "agent_id": "test-agent-id",
+                "eval_type": "accuracy",
+                "input": "What is 2 + 2?",
+                "model_id": "model-b",
+                "model_provider": "openai",
+            },
+        )
+
+    assert response.status_code == 400
+    assert agent.model.id == "model-a"
+    assert agent.model.provider == "openai"
+
+
+def test_model_override_restored_on_success():
+    """The override is also restored on the happy path (guards the shared restore)."""
+    agent = _agent_with_model()
+    client = _build_client(agent)
+
+    override_model = SimpleNamespace(id="model-b", provider="openai")
+
+    # agent is a shared mutable object, so capture the model in effect *during*
+    # the eval rather than reading it back after the restore has run.
+    model_id_during_eval = {}
+
+    eval_result = EvalSchema(id="eval-1", eval_type=EvalType.ACCURACY, eval_data={})
+
+    async def _capture_model(*args, **kwargs):
+        model_id_during_eval["value"] = kwargs["agent"].model.id
+        return eval_result
+
+    with (
+        patch("agno.os.routers.evals.evals.get_model", return_value=override_model),
+        patch("agno.os.routers.evals.evals.run_accuracy_eval", new=AsyncMock(side_effect=_capture_model)),
+    ):
+        response = client.post(
+            "/eval-runs?db_id=test-db",
+            json={
+                "agent_id": "test-agent-id",
+                "eval_type": "accuracy",
+                "input": "What is 2 + 2?",
+                "expected_output": "4",
+                "model_id": "model-b",
+                "model_provider": "openai",
+            },
+        )
+
+    assert response.status_code == 200
+    # The eval saw the overridden model while running...
+    assert model_id_during_eval["value"] == "model-b"
+    # ...and the agent is back to its original model afterwards.
+    assert agent.model.id == "model-a"


### PR DESCRIPTION
## Summary

`POST /eval-runs` temporarily swaps the target agent/team model when `model_id` is supplied, but the original model was only restored on the happy path. If validation or the eval run raised (e.g. an accuracy eval with a missing `expected_output`), the shared in-memory agent/team kept the temporary model, so a single failed request silently changed the model for every later run in the same process.

The override is applied in `run_eval`, while restoration lived at the tail of each `run_*_eval` helper — so any exception before that tail leaked the override. This centralizes restoration in a `finally` block around the eval dispatch in `run_eval`, and drops the now-redundant per-helper restore blocks (and the unused `default_model` params on the performance/reliability helpers).

closes #8655

## Type of change

- [x] Bug fix

## Repro (before this change)

1. Register an agent with model A.
2. `POST /eval-runs` for that agent with `model_id` pointing to model B and an invalid accuracy payload (missing `expected_output`).
3. The request returns 400, but the agent is left with model B.

## Tests

Added `libs/agno/tests/unit/os/routers/test_evals_router.py`:
- `test_model_override_restored_when_eval_fails` — a failed eval returns an error and leaves the agent on its original model (fails without this change).
- `test_model_override_restored_on_success` — the override is live during the run and restored afterwards.

```
python -m pytest tests/unit/os/routers/test_evals_router.py tests/unit/eval -q   # 64 passed
ruff check / ruff format --check / mypy   # clean
```

## Note / out of scope

This keeps the existing design of mutating the shared in-memory agent/team model for the duration of the eval. That means concurrent `/eval-runs` against the *same* agent/team can still interleave overrides — a pre-existing limitation independent of this fix, which only concerns the restore-on-failure path requested in the issue. Fully isolating concurrent runs would need per-request cloning or locking and is best handled separately.

<!-- oss-radar:idempotency=auto-20260701-102639.w3.agno-agi_agno.8655 -->
