### PR TITLE
fix: preserve knowledge filters without contents db

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -778,7 +778,7 @@ class Knowledge(RemoteKnowledge):
 
     def get_valid_filters(self) -> Set[str]:
         if self.contents_db is None:
-            log_info("Advanced filtering is not supported without a contents db. All filter keys considered valid.")
+            log_info("No contents db configured; returning an empty filter validation key set.")
             return set()
         contents, _ = self.get_content()
         valid_filters: Set[str] = set()
@@ -790,7 +790,7 @@ class Knowledge(RemoteKnowledge):
 
     async def aget_valid_filters(self) -> Set[str]:
         if self.contents_db is None:
-            log_info("Advanced filtering is not supported without a contents db. All filter keys considered valid.")
+            log_info("No contents db configured; returning an empty filter validation key set.")
             return set()
         contents, _ = await self.aget_content()
         valid_filters: Set[str] = set()
@@ -804,7 +804,7 @@ class Knowledge(RemoteKnowledge):
         self, filters: Union[Dict[str, Any], List[FilterExpr]]
     ) -> Tuple[Union[Dict[str, Any], List[FilterExpr]], List[str]]:
         if self.contents_db is None:
-            log_info("Advanced filtering is not supported without a contents db. Filter keys will not be validated.")
+            log_info("No contents db configured; skipping filter key validation and preserving filters.")
             return filters, []
 
         valid_filters_from_db = self.get_valid_filters()
@@ -818,7 +818,7 @@ class Knowledge(RemoteKnowledge):
     ) -> Tuple[Union[Dict[str, Any], List[FilterExpr]], List[str]]:
         """Return a tuple containing a dict with all valid filters and a list of invalid filter keys"""
         if self.contents_db is None:
-            log_info("Advanced filtering is not supported without a contents db. Filter keys will not be validated.")
+            log_info("No contents db configured; skipping filter key validation and preserving filters.")
             return filters, []
 
         valid_filters_from_db = await self.aget_valid_filters()

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -803,6 +803,10 @@ class Knowledge(RemoteKnowledge):
     def validate_filters(
         self, filters: Union[Dict[str, Any], List[FilterExpr]]
     ) -> Tuple[Union[Dict[str, Any], List[FilterExpr]], List[str]]:
+        if self.contents_db is None:
+            log_info("Advanced filtering is not supported without a contents db. Filter keys will not be validated.")
+            return filters, []
+
         valid_filters_from_db = self.get_valid_filters()
 
         valid_filters, invalid_keys = self._validate_filters(filters, valid_filters_from_db)
@@ -813,6 +817,10 @@ class Knowledge(RemoteKnowledge):
         self, filters: Union[Dict[str, Any], List[FilterExpr]]
     ) -> Tuple[Union[Dict[str, Any], List[FilterExpr]], List[str]]:
         """Return a tuple containing a dict with all valid filters and a list of invalid filter keys"""
+        if self.contents_db is None:
+            log_info("Advanced filtering is not supported without a contents db. Filter keys will not be validated.")
+            return filters, []
+
         valid_filters_from_db = await self.aget_valid_filters()
 
         valid_filters, invalid_keys = self._validate_filters(filters, valid_filters_from_db)

--- a/libs/agno/tests/unit/knowledge/test_knowledge_filter_validation.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_filter_validation.py
@@ -176,6 +176,24 @@ def test_validate_filters_mixed_valid_invalid_list(knowledge):
     assert "invalid2" in invalid
 
 
+def test_validate_filters_without_contents_db_keeps_dict_filters(knowledge):
+    filters = {"region": "us"}
+
+    valid, invalid = knowledge.validate_filters(filters)
+
+    assert valid == filters
+    assert invalid == []
+
+
+async def test_avalidate_filters_without_contents_db_keeps_dict_filters(knowledge):
+    filters = {"region": "us"}
+
+    valid, invalid = await knowledge.avalidate_filters(filters)
+
+    assert valid == filters
+    assert invalid == []
+
+
 def test_filter_merge_raises_on_type_mismatch():
     from agno.utils.knowledge import get_agentic_or_user_search_filters
 

--- a/libs/agno/tests/unit/knowledge/test_knowledge_filter_validation.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_filter_validation.py
@@ -177,6 +177,7 @@ def test_validate_filters_mixed_valid_invalid_list(knowledge):
 
 
 def test_validate_filters_without_contents_db_keeps_dict_filters(knowledge):
+    knowledge.contents_db = None
     filters = {"region": "us"}
 
     valid, invalid = knowledge.validate_filters(filters)
@@ -185,8 +186,29 @@ def test_validate_filters_without_contents_db_keeps_dict_filters(knowledge):
     assert invalid == []
 
 
+def test_validate_filters_without_contents_db_keeps_list_filters(knowledge):
+    knowledge.contents_db = None
+    filters = [EQ("region", "us"), GT("year", 2024)]
+
+    valid, invalid = knowledge.validate_filters(filters)
+
+    assert valid == filters
+    assert invalid == []
+
+
 async def test_avalidate_filters_without_contents_db_keeps_dict_filters(knowledge):
+    knowledge.contents_db = None
     filters = {"region": "us"}
+
+    valid, invalid = await knowledge.avalidate_filters(filters)
+
+    assert valid == filters
+    assert invalid == []
+
+
+async def test_avalidate_filters_without_contents_db_keeps_list_filters(knowledge):
+    knowledge.contents_db = None
+    filters = [EQ("region", "us"), GT("year", 2024)]
 
     valid, invalid = await knowledge.avalidate_filters(filters)
 


### PR DESCRIPTION
## Summary
- keep user-provided knowledge filters unchanged when no contents DB is configured
- apply the same pass-through behavior to sync and async filter validation
- rephrase validation logs so they describe skipped key validation instead of unsupported filtering
- add regression coverage for dict and list filters without a contents DB

Closes #8660

## Tests
- `uv run --no-sync python -m pytest tests\unit\knowledge\test_knowledge_filter_validation.py -q`
- `uvx ruff@0.14.3 check agno\knowledge\knowledge.py tests\unit\knowledge\test_knowledge_filter_validation.py`
- `uvx ruff@0.14.3 format --check agno\knowledge\knowledge.py tests\unit\knowledge\test_knowledge_filter_validation.py`
- `git diff --check`