### PR TITLE
[fix] Respect reader chunk settings for URL knowledge inserts

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1311,25 +1311,6 @@ class Knowledge(RemoteKnowledge):
             document.meta_data["linked_to"] = self.name or ""
         return documents
 
-    def _chunk_documents_sync(self, reader: Reader, documents: List[Document]) -> List[Document]:
-        """
-        Chunk documents synchronously.
-
-        Args:
-            reader: Reader with chunking strategy
-            documents: Documents to chunk
-
-        Returns:
-            List of chunked documents
-        """
-        if not reader or reader.chunk:
-            return documents
-
-        chunked_documents = []
-        for doc in documents:
-            chunked_documents.extend(reader.chunk_document(doc))
-        return chunked_documents
-
     async def _aload_from_path(
         self,
         content: Content,
@@ -1605,11 +1586,7 @@ class Knowledge(RemoteKnowledge):
             await self._aupdate_content(content)
             return
 
-        # 6. Chunk documents if needed
-        if reader and not reader.chunk:
-            read_documents = await reader.chunk_documents_async(read_documents)
-
-        # 7. Group documents by source URL for multi-page readers (like WebsiteReader)
+        # 6. Group documents by source URL for multi-page readers (like WebsiteReader)
         docs_by_source: Dict[str, List[Document]] = {}
         for doc in read_documents:
             source_url = doc.meta_data.get("url", content.url) if doc.meta_data else content.url
@@ -1618,7 +1595,7 @@ class Knowledge(RemoteKnowledge):
                 docs_by_source[source_url] = []
             docs_by_source[source_url].append(doc)
 
-        # 8. Process each source separately if multiple sources exist
+        # 7. Process each source separately if multiple sources exist
         if len(docs_by_source) > 1:
             for source_url, source_docs in docs_by_source.items():
                 # Compute per-document hash based on actual source URL
@@ -1650,7 +1627,7 @@ class Knowledge(RemoteKnowledge):
             await self._aupdate_content(content)
             return
 
-        # 9. Single source - use existing logic with original content hash
+        # 8. Single source - use existing logic with original content hash
         if not content.id:
             content.id = generate_id(content.content_hash or "")
         self._prepare_documents_for_insert(read_documents, content.id, calculate_sizes=True)
@@ -1764,11 +1741,7 @@ class Knowledge(RemoteKnowledge):
             self._update_content(content)
             return
 
-        # 6. Chunk documents if needed (sync version)
-        if reader:
-            read_documents = self._chunk_documents_sync(reader, read_documents)
-
-        # 7. Group documents by source URL for multi-page readers (like WebsiteReader)
+        # 6. Group documents by source URL for multi-page readers (like WebsiteReader)
         docs_by_source: Dict[str, List[Document]] = {}
         for doc in read_documents:
             source_url = doc.meta_data.get("url", content.url) if doc.meta_data else content.url
@@ -1777,7 +1750,7 @@ class Knowledge(RemoteKnowledge):
                 docs_by_source[source_url] = []
             docs_by_source[source_url].append(doc)
 
-        # 8. Process each source separately if multiple sources exist
+        # 7. Process each source separately if multiple sources exist
         if len(docs_by_source) > 1:
             for source_url, source_docs in docs_by_source.items():
                 # Compute per-document hash based on actual source URL
@@ -1809,7 +1782,7 @@ class Knowledge(RemoteKnowledge):
             self._update_content(content)
             return
 
-        # 9. Single source - use existing logic with original content hash
+        # 8. Single source - use existing logic with original content hash
         if not content.id:
             content.id = generate_id(content.content_hash or "")
         self._prepare_documents_for_insert(read_documents, content.id, calculate_sizes=True)

--- a/libs/agno/tests/unit/knowledge/test_knowledge_url_reader_chunking.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_url_reader_chunking.py
@@ -1,0 +1,152 @@
+import pytest
+
+from agno.knowledge.document.base import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.base import Reader
+from agno.knowledge.types import ContentType
+from agno.vectordb.base import VectorDb
+
+
+class RecordingVectorDb(VectorDb):
+    def __init__(self):
+        self.inserted = []
+
+    def create(self) -> None:
+        pass
+
+    async def async_create(self) -> None:
+        pass
+
+    def name_exists(self, name: str) -> bool:
+        return False
+
+    def async_name_exists(self, name: str) -> bool:
+        return False
+
+    def id_exists(self, id: str) -> bool:
+        return False
+
+    def content_hash_exists(self, content_hash: str) -> bool:
+        return False
+
+    def upsert_available(self) -> bool:
+        return False
+
+    def insert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted.append((content_hash, documents, filters))
+
+    async def async_insert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted.append((content_hash, documents, filters))
+
+    def upsert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted.append((content_hash, documents, filters))
+
+    async def async_upsert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted.append((content_hash, documents, filters))
+
+    def search(self, query: str, limit: int = 5, filters=None):
+        return []
+
+    async def async_search(self, query: str, limit: int = 5, filters=None):
+        return []
+
+    def drop(self) -> None:
+        pass
+
+    async def async_drop(self) -> None:
+        pass
+
+    def exists(self) -> bool:
+        return True
+
+    async def async_exists(self) -> bool:
+        return True
+
+    def delete(self) -> bool:
+        return True
+
+    def delete_by_id(self, id: str) -> bool:
+        return True
+
+    def delete_by_name(self, name: str) -> bool:
+        return True
+
+    def delete_by_metadata(self, metadata) -> bool:
+        return True
+
+    def update_metadata(self, content_id: str, metadata) -> None:
+        pass
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        return True
+
+    def get_supported_search_types(self):
+        return ["vector"]
+
+
+class NoChunkUrlReader(Reader):
+    def __init__(self):
+        super().__init__(chunk=False)
+        self.chunk_calls = 0
+        self.async_chunk_calls = 0
+
+    @classmethod
+    def get_supported_chunking_strategies(cls):
+        return []
+
+    @classmethod
+    def get_supported_content_types(cls):
+        return [ContentType.URL]
+
+    def read(self, obj, name=None, password=None):
+        return [Document(content="full document", meta_data={"url": obj})]
+
+    async def async_read(self, obj, name=None, password=None):
+        return [Document(content="full document", meta_data={"url": obj})]
+
+    def chunk_document(self, document):
+        self.chunk_calls += 1
+        return [
+            Document(content="chunk 1", meta_data=document.meta_data),
+            Document(content="chunk 2", meta_data=document.meta_data),
+        ]
+
+    async def chunk_documents_async(self, documents):
+        self.async_chunk_calls += 1
+        return [
+            Document(content="chunk 1", meta_data=documents[0].meta_data),
+            Document(content="chunk 2", meta_data=documents[0].meta_data),
+        ]
+
+
+def test_insert_url_respects_reader_chunk_false():
+    vector_db = RecordingVectorDb()
+    reader = NoChunkUrlReader()
+    knowledge = Knowledge(vector_db=vector_db)
+
+    knowledge.insert(
+        url="https://example.com/knowledge",
+        reader=reader,
+        upsert=False,
+    )
+
+    assert reader.chunk_calls == 0
+    assert len(vector_db.inserted) == 1
+    assert [doc.content for doc in vector_db.inserted[0][1]] == ["full document"]
+
+
+@pytest.mark.asyncio
+async def test_ainsert_url_respects_reader_chunk_false():
+    vector_db = RecordingVectorDb()
+    reader = NoChunkUrlReader()
+    knowledge = Knowledge(vector_db=vector_db)
+
+    await knowledge.ainsert(
+        url="https://example.com/knowledge",
+        reader=reader,
+        upsert=False,
+    )
+
+    assert reader.async_chunk_calls == 0
+    assert len(vector_db.inserted) == 1
+    assert [doc.content for doc in vector_db.inserted[0][1]] == ["full document"]


### PR DESCRIPTION
## Summary

Fixes #8667.

`Knowledge.insert(url=..., reader=Reader(chunk=False))` should preserve the documents returned by the reader. The URL loading path was chunking documents again after reading, so readers configured with `chunk=False` could still produce chunks.

This removes the URL-specific post-read chunking step and adds sync/async regression tests to verify URL inserts respect the reader's chunk setting.

## Type of change

- [x] Bug fix

## Checklist

- [x] Self-review completed
- [x] Tests added/updated
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Tested in clean environment

## Additional Notes

Local validation performed: Python bytecode compilation for the modified source and test files.
