### PR TITLE
[fix] Strip output-only citations from Claude server-tool blocks

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -19,6 +19,7 @@ from agno.utils.models.claude import (
     MCPServerConfiguration,
     _validate_cache_ttl_order,
     build_system_blocks,
+    dump_server_tool_block,
     format_messages,
     format_tools_for_model,
     supports_prefill,
@@ -1029,7 +1030,7 @@ class Claude(Model):
                     if model_response.provider_data is None:
                         model_response.provider_data = {}
                     server_blocks = model_response.provider_data.setdefault("server_tool_blocks", [])
-                    server_blocks.append(block.model_dump())
+                    server_blocks.append(dump_server_tool_block(block))
 
         # Extract tool calls from the response
         if response.stop_reason == "tool_use":
@@ -1180,7 +1181,7 @@ class Claude(Model):
                     "tool_use",
                 ):
                     # Preserve all non-text/thinking/tool_use blocks for history
-                    server_tool_blocks.append(block.model_dump())
+                    server_tool_blocks.append(dump_server_tool_block(block))
 
                 # Handle citations
                 citations = getattr(block, "citations", None)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -87,6 +87,39 @@ ROLE_MAP = {
 }
 
 
+# Output-only fields Anthropic emits on server-tool result blocks but rejects when those
+# blocks are replayed back as *input*. Persisting them into provider_data["server_tool_blocks"]
+# and echoing them on the next turn triggers a 400, e.g.:
+#   messages.N.content.M.code_execution_tool_result.citations: Extra inputs are not permitted
+# The citation data is captured separately into ModelResponse.citations, so dropping it from the
+# history-reconstruction copy loses nothing.
+_INPUT_DISALLOWED_BLOCK_FIELDS: Dict[str, Tuple[str, ...]] = {
+    "code_execution_tool_result": ("citations",),
+    "bash_code_execution_tool_result": ("citations",),
+}
+
+
+def _strip_input_disallowed_block_fields(block: Dict[str, Any]) -> Dict[str, Any]:
+    """Drop output-only fields Anthropic's input schema rejects from a server-tool block dict.
+
+    Mutates and returns ``block``. Applied both when a block is captured into history and when
+    it is replayed, so already-persisted blocks are also sanitized on the next turn.
+    """
+    for field_name in _INPUT_DISALLOWED_BLOCK_FIELDS.get(block.get("type", ""), ()):
+        block.pop(field_name, None)
+    return block
+
+
+def dump_server_tool_block(block: Any) -> Dict[str, Any]:
+    """Serialize a server-tool block for conversation history reconstruction.
+
+    Uses ``model_dump()`` then strips output-only fields (e.g. ``citations`` on
+    ``code_execution_tool_result``) that Anthropic emits but rejects on input, which would
+    otherwise cause a 400 when the block is replayed on a subsequent turn.
+    """
+    return _strip_input_disallowed_block_fields(block.model_dump())
+
+
 def _anthropic_block_identity(block: Any) -> Optional[Tuple[str, str]]:
     """Return a stable identity key for an Anthropic content block, or None if untrackable.
 
@@ -552,7 +585,9 @@ def format_messages(
                     identity = _anthropic_block_identity(block_dict)
                     if identity is not None and identity in list_block_identities:
                         continue
-                    content.append(block_dict)
+                    # Sanitize blocks persisted before dump_server_tool_block existed, so that
+                    # already-stored history (carrying output-only fields) still replays cleanly.
+                    content.append(_strip_input_disallowed_block_fields(block_dict))
 
             if structured_from_list:
                 content.extend(structured_from_list)

--- a/libs/agno/tests/unit/models/anthropic/test_server_tool_block_citations.py
+++ b/libs/agno/tests/unit/models/anthropic/test_server_tool_block_citations.py
@@ -1,0 +1,95 @@
+"""
+Tests for stripping output-only fields from Claude server-tool result blocks.
+
+Anthropic *emits* a ``citations`` field on ``code_execution_tool_result`` blocks but
+*rejects* it on input. agno preserves server-tool blocks in
+``provider_data["server_tool_blocks"]`` for conversation-history reconstruction and
+replays them verbatim on the next turn, which triggers a 400:
+
+    messages.N.content.M.code_execution_tool_result.citations: Extra inputs are not permitted
+
+The block is sanitized both when captured (``dump_server_tool_block``) and when replayed
+(``format_messages``), so new and already-persisted history both stay valid.
+"""
+
+from agno.models.message import Message
+from agno.utils.models.claude import (
+    _strip_input_disallowed_block_fields,
+    dump_server_tool_block,
+    format_messages,
+)
+
+
+class _FakeBlock:
+    """Stand-in for an Anthropic SDK content block exposing ``model_dump()``."""
+
+    def __init__(self, data: dict):
+        self._data = data
+
+    def model_dump(self) -> dict:
+        return dict(self._data)
+
+
+class TestDumpServerToolBlock:
+    def test_strips_citations_from_code_execution_result(self):
+        block = _FakeBlock(
+            {"type": "code_execution_tool_result", "tool_use_id": "srvtoolu_1", "content": {}, "citations": None}
+        )
+        dumped = dump_server_tool_block(block)
+        assert "citations" not in dumped
+        assert dumped["type"] == "code_execution_tool_result"
+
+    def test_strips_populated_citations_from_bash_code_execution_result(self):
+        block = _FakeBlock(
+            {
+                "type": "bash_code_execution_tool_result",
+                "tool_use_id": "srvtoolu_2",
+                "content": {},
+                "citations": [{"type": "char_location", "cited_text": "x"}],
+            }
+        )
+        assert "citations" not in dump_server_tool_block(block)
+
+    def test_preserves_unrelated_blocks(self):
+        block = _FakeBlock({"type": "web_search_tool_result", "tool_use_id": "srvtoolu_3", "content": []})
+        dumped = dump_server_tool_block(block)
+        assert dumped == {"type": "web_search_tool_result", "tool_use_id": "srvtoolu_3", "content": []}
+
+    def test_strip_helper_is_idempotent(self):
+        block = {"type": "code_execution_tool_result", "tool_use_id": "srvtoolu_4", "content": {}, "citations": []}
+        _strip_input_disallowed_block_fields(block)
+        _strip_input_disallowed_block_fields(block)
+        assert "citations" not in block
+
+
+class TestFormatMessagesReplayStripsCitations:
+    def _assistant_with_stored_block(self) -> Message:
+        # Simulates history persisted before the capture-time fix existed: the stored
+        # server_tool_block still carries the output-only ``citations`` field.
+        msg = Message(role="assistant", content="Here is the result.")
+        msg.provider_data = {
+            "server_tool_blocks": [
+                {
+                    "type": "code_execution_tool_result",
+                    "tool_use_id": "srvtoolu_9",
+                    "content": {"type": "code_execution_result", "stdout": "42\n"},
+                    "citations": None,
+                }
+            ]
+        }
+        return msg
+
+    def test_replayed_code_execution_block_omits_citations(self):
+        chat_messages, _ = format_messages([self._assistant_with_stored_block()])
+        result_blocks = [
+            b
+            for m in chat_messages
+            for b in (m["content"] if isinstance(m["content"], list) else [])
+            if isinstance(b, dict) and b.get("type") == "code_execution_tool_result"
+        ]
+        assert result_blocks, "code_execution_tool_result block missing from replayed payload"
+        for block in result_blocks:
+            assert "citations" not in block, (
+                "citations must be stripped when replaying server-tool blocks — "
+                "Anthropic rejects it on input with a 400"
+            )


### PR DESCRIPTION
fixes #8687

## Summary

Multi-turn conversations that use Claude's code execution tool fail on the **second turn** with:

```
400 - messages.N.content.M.code_execution_tool_result.citations:
      Extra inputs are not permitted
```

**Root cause.** Anthropic *emits* a `citations` field on `code_execution_tool_result` blocks but *rejects* it on input (output and input schemas differ). agno preserves server-tool result blocks in `provider_data["server_tool_blocks"]` via `block.model_dump()` (which keeps `citations`), then `format_messages` replays those blocks verbatim on the next turn — so the illegal field is echoed straight back and the request is rejected before it reaches the model.

**Fix.**
- Add `dump_server_tool_block()` in `utils/models/claude.py`: `model_dump()` the block, then drop the output-only fields Anthropic's input schema forbids (currently `citations` on `code_execution_tool_result` / `bash_code_execution_tool_result`). Use it at both capture sites in `Claude._parse_provider_response` and `_parse_provider_response_delta`. This is the root-cause fix — the field is never persisted.
- Also call the same strip helper at the replay point in `format_messages`. The loop over `server_tool_blocks` already exists, so this adds no extra iteration, and it ensures history **persisted before this fix** still replays cleanly after upgrading.

The citation data itself is unaffected: it is captured separately into `ModelResponse.citations`. Only the redundant history-reconstruction copy — which should never be sent back as input — is pruned.

Scope is kept to the block types Anthropic is confirmed to reject (`code_execution_tool_result` and its bash variant); the field map is trivially extensible if other output-only fields surface.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines (`ruff format --check` and `ruff check` pass on changed files)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment (new `.venv`, editable install)
- [x] Tests added/updated

New unit tests in `tests/unit/models/anthropic/test_server_tool_block_citations.py` cover the capture helper (strips `citations` from code-execution results, preserves unrelated blocks, idempotent) and the replay path (`format_messages` omits `citations` for already-persisted blocks). The new tests plus the existing `test_citation_suppression.py` all pass (17 passed).

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] This PR was drafted with AI assistance (Claude Code). The author has reviewed and understands the changes; it includes tests and passes lint/format on the touched files.

## Additional Notes

The replay-side strip is a safety net for existing stored sessions; the capture-side fix means all newly stored history is clean and never needs the replay strip.