### PR TITLE
fix: keep chunk hash ids in sync with content when overlap is applied

### DIFF
--- a/libs/agno/agno/knowledge/chunking/document.py
+++ b/libs/agno/agno/knowledge/chunking/document.py
@@ -111,16 +111,18 @@ class DocumentChunking(ChunkingStrategy):
                     meta_data = chunk_meta_data.copy()
                     # Use the chunk's existing metadata and ID instead of stale chunk_number
                     meta_data["chunk"] = chunks[i].meta_data["chunk"]
-                    chunk_id = chunks[i].id
-                    meta_data["chunk_size"] = len(prev_text + chunks[i].content)
 
                     if prev_text:
+                        # Build the final content first, then generate the id from it.
+                        new_content = prev_text + chunks[i].content
+                        chunk_id = self._generate_chunk_id(document, meta_data["chunk"], new_content)
+                        meta_data["chunk_size"] = len(new_content)
                         overlapped_chunks.append(
                             Document(
                                 id=chunk_id,
                                 name=document.name,
                                 meta_data=meta_data,
-                                content=prev_text + chunks[i].content,
+                                content=new_content,
                             )
                         )
                     else:

--- a/libs/agno/agno/knowledge/chunking/markdown.py
+++ b/libs/agno/agno/knowledge/chunking/markdown.py
@@ -307,16 +307,18 @@ class MarkdownChunking(ChunkingStrategy):
                     prev_text = chunks[i - 1].content[-self.overlap :]
                     meta_data = chunk_meta_data.copy()
                     meta_data["chunk"] = chunks[i].meta_data["chunk"]
-                    chunk_id = chunks[i].id
-                    meta_data["chunk_size"] = len(prev_text + chunks[i].content)
 
                     if prev_text:
+                        # Build the final content first, then generate the id from it.
+                        new_content = prev_text + chunks[i].content
+                        chunk_id = self._generate_chunk_id(document, meta_data["chunk"], new_content)
+                        meta_data["chunk_size"] = len(new_content)
                         overlapped_chunks.append(
                             Document(
                                 id=chunk_id,
                                 name=document.name,
                                 meta_data=meta_data,
-                                content=prev_text + chunks[i].content,
+                                content=new_content,
                             )
                         )
                     else:

--- a/libs/agno/tests/unit/knowledge/chunking/test_chunk_id_generation.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_chunk_id_generation.py
@@ -1,7 +1,15 @@
+import hashlib
+
 from agno.knowledge.chunking.document import DocumentChunking
 from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.chunking.row import RowChunking
 from agno.knowledge.document.base import Document
+
+
+def _expected_hash_id(content: str, chunk_number: int) -> str:
+    content_hash = hashlib.md5(content.encode("utf-8")).hexdigest()[:12]
+    return f"chunk_{content_hash}_{chunk_number}"
+
 
 # --- Fallback chain tests ---
 
@@ -136,3 +144,18 @@ def test_document_chunking_uses_fallback():
     for chunk in chunks:
         assert chunk.id is not None
         assert chunk.id.startswith("chunk_")
+
+
+# --- Overlap keeps hash-based ids in sync with content ---
+
+
+def test_document_chunking_overlap_hash_matches_final_content():
+    """With overlap, the hash-based id must match the final content."""
+    doc = Document(content="First paragraph is long.\n\nSecond paragraph is long.\n\nThird paragraph is long.")
+    chunks = DocumentChunking(chunk_size=30, overlap=8).chunk(doc)
+
+    # More than one chunk so overlap is actually applied
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        assert chunk.id == _expected_hash_id(chunk.content, chunk.meta_data["chunk"])
+        assert chunk.meta_data["chunk_size"] == len(chunk.content)

--- a/libs/agno/tests/unit/knowledge/chunking/test_markdown_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_markdown_chunking.py
@@ -1,5 +1,7 @@
 """Tests for MarkdownChunking with split_on_headings parameter."""
 
+import hashlib
+
 import pytest
 
 pytest.importorskip("unstructured")
@@ -568,3 +570,24 @@ def test_split_on_headings_overlap_between_sub_chunks():
         # The end of previous chunk should appear at start of current chunk
         prev_ending = chunks[i - 1].content[-20:]
         assert chunks[i].content.startswith(prev_ending), f"Chunk {i + 1} should start with overlap from chunk {i}"
+
+
+def test_overlap_hash_id_matches_final_content():
+    """With overlap and no id/name, the hash-based id must match the final content."""
+    content = (
+        "First section is fairly long.\n\n"
+        "Second section is fairly long.\n\n"
+        "Third section is fairly long.\n\n"
+        "Fourth section is fairly long."
+    )
+    # No id and no name -> chunk ids fall back to a hash of the content
+    doc = Document(content=content)
+    chunks = MarkdownChunking(chunk_size=40, overlap=8).chunk(doc)
+
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        assert chunk.id is not None and chunk.id.startswith("chunk_")
+        content_hash = hashlib.md5(chunk.content.encode("utf-8")).hexdigest()[:12]
+        expected_id = f"chunk_{content_hash}_{chunk.meta_data['chunk']}"
+        assert chunk.id == expected_id
+        assert chunk.meta_data["chunk_size"] == len(chunk.content)


### PR DESCRIPTION
## Summary

When a document has no `id` and no `name`, chunk ids fall back to a hash of the chunk content. Because the id is computed from the pre-overlap content but the stored content now includes the overlap, the hash embedded in the id no longer matches the content it labels. This leads to two different final chunks ending up carrying ids derived from stale hashes.
                                                                                                                                                                                                         
The fix builds the final content first, then generates the id and `chunk_size` from that content.

Closes #8659

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
