### PR TITLE
fix: get_last_run_output returns None for Agent and Team subclasses

### DIFF
--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -690,6 +690,9 @@ def get_last_run_output_util(
     Returns:
         RunOutput: The last run response from the database.
     """
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
     _ensure_entity_id(entity)
 
     if session_id is not None:
@@ -699,11 +702,11 @@ def get_last_run_output_util(
         session = entity.get_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:
             for run_output in reversed(session.runs):
-                if entity.__class__.__name__ == "Agent":
-                    if hasattr(run_output, "agent_id") and run_output.agent_id == entity.id:
+                if isinstance(entity, Agent):
+                    if getattr(run_output, "agent_id", None) == entity.id:
                         return run_output  # type: ignore
-                elif entity.__class__.__name__ == "Team":
-                    if hasattr(run_output, "team_id") and run_output.team_id == entity.id:
+                elif isinstance(entity, Team):
+                    if getattr(run_output, "team_id", None) == entity.id:
                         return run_output  # type: ignore
         else:
             log_warning(f"No run responses found in Session {session_id}")
@@ -714,11 +717,11 @@ def get_last_run_output_util(
         and len(entity.cached_session.runs) > 0
     ):
         for run_output in reversed(entity.cached_session.runs):
-            if entity.__class__.__name__ == "Agent":
-                if hasattr(run_output, "agent_id") and run_output.agent_id == entity.id:
+            if isinstance(entity, Agent):
+                if getattr(run_output, "agent_id", None) == entity.id:
                     return run_output  # type: ignore
-            elif entity.__class__.__name__ == "Team":
-                if hasattr(run_output, "team_id") and run_output.team_id == entity.id:
+            elif isinstance(entity, Team):
+                if getattr(run_output, "team_id", None) == entity.id:
                     return run_output  # type: ignore
     return None
 
@@ -735,17 +738,20 @@ async def aget_last_run_output_util(
     Returns:
         RunOutput: The last run response from the database.
     """
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
     _ensure_entity_id(entity)
 
     if session_id is not None:
         session = await entity.aget_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:
             for run_output in reversed(session.runs):
-                if entity.__class__.__name__ == "Agent":
-                    if hasattr(run_output, "agent_id") and run_output.agent_id == entity.id:
+                if isinstance(entity, Agent):
+                    if getattr(run_output, "agent_id", None) == entity.id:
                         return run_output  # type: ignore
-                elif entity.__class__.__name__ == "Team":
-                    if hasattr(run_output, "team_id") and run_output.team_id == entity.id:
+                elif isinstance(entity, Team):
+                    if getattr(run_output, "team_id", None) == entity.id:
                         return run_output  # type: ignore
         else:
             log_warning(f"No run responses found in Session {session_id}")
@@ -756,11 +762,11 @@ async def aget_last_run_output_util(
         and len(entity.cached_session.runs) > 0
     ):
         for run_output in reversed(entity.cached_session.runs):
-            if entity.__class__.__name__ == "Agent":
-                if hasattr(run_output, "agent_id") and run_output.agent_id == entity.id:
+            if isinstance(entity, Agent):
+                if getattr(run_output, "agent_id", None) == entity.id:
                     return run_output  # type: ignore
-            elif entity.__class__.__name__ == "Team":
-                if hasattr(run_output, "team_id") and run_output.team_id == entity.id:
+            elif isinstance(entity, Team):
+                if getattr(run_output, "team_id", None) == entity.id:
                     return run_output  # type: ignore
     return None
 

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -702,11 +702,11 @@ def get_last_run_output_util(
         session = entity.get_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:
             for run_output in reversed(session.runs):
-                if isinstance(entity, Agent):
-                    if getattr(run_output, "agent_id", None) == entity.id:
-                        return run_output  # type: ignore
-                elif isinstance(entity, Team):
+                if isinstance(entity, Team):
                     if getattr(run_output, "team_id", None) == entity.id:
+                        return run_output  # type: ignore
+                elif isinstance(entity, Agent):
+                    if getattr(run_output, "agent_id", None) == entity.id:
                         return run_output  # type: ignore
         else:
             log_warning(f"No run responses found in Session {session_id}")
@@ -717,11 +717,11 @@ def get_last_run_output_util(
         and len(entity.cached_session.runs) > 0
     ):
         for run_output in reversed(entity.cached_session.runs):
-            if isinstance(entity, Agent):
-                if getattr(run_output, "agent_id", None) == entity.id:
-                    return run_output  # type: ignore
-            elif isinstance(entity, Team):
+            if isinstance(entity, Team):
                 if getattr(run_output, "team_id", None) == entity.id:
+                    return run_output  # type: ignore
+            elif isinstance(entity, Agent):
+                if getattr(run_output, "agent_id", None) == entity.id:
                     return run_output  # type: ignore
     return None
 
@@ -747,11 +747,11 @@ async def aget_last_run_output_util(
         session = await entity.aget_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:
             for run_output in reversed(session.runs):
-                if isinstance(entity, Agent):
-                    if getattr(run_output, "agent_id", None) == entity.id:
-                        return run_output  # type: ignore
-                elif isinstance(entity, Team):
+                if isinstance(entity, Team):
                     if getattr(run_output, "team_id", None) == entity.id:
+                        return run_output  # type: ignore
+                elif isinstance(entity, Agent):
+                    if getattr(run_output, "agent_id", None) == entity.id:
                         return run_output  # type: ignore
         else:
             log_warning(f"No run responses found in Session {session_id}")
@@ -762,11 +762,11 @@ async def aget_last_run_output_util(
         and len(entity.cached_session.runs) > 0
     ):
         for run_output in reversed(entity.cached_session.runs):
-            if isinstance(entity, Agent):
-                if getattr(run_output, "agent_id", None) == entity.id:
-                    return run_output  # type: ignore
-            elif isinstance(entity, Team):
+            if isinstance(entity, Team):
                 if getattr(run_output, "team_id", None) == entity.id:
+                    return run_output  # type: ignore
+            elif isinstance(entity, Agent):
+                if getattr(run_output, "agent_id", None) == entity.id:
                     return run_output  # type: ignore
     return None
 

--- a/libs/agno/tests/integration/agent/test_agent_convenience_functions.py
+++ b/libs/agno/tests/integration/agent/test_agent_convenience_functions.py
@@ -405,6 +405,47 @@ async def test_aget_last_run_output_with_fresh_agent_instance(async_shared_db):
     assert agent2.id == agent1.id
 
 
+def test_get_last_run_output_supports_agent_subclasses(shared_db):
+    """A user-defined Agent subclass with the same id must find its persisted
+    runs. The retrieval loop previously compared ``__class__.__name__`` to
+    ``"Agent"``, which silently returned None for subclasses.
+    """
+
+    class CustomAgent(Agent):
+        pass
+
+    session_id = str(uuid.uuid4())
+
+    writer = CustomAgent(id="custom-agent", model=OpenAIChat(id="gpt-4o-mini"), db=shared_db)
+    response = writer.run("Hello", session_id=session_id)
+
+    # Fresh subclass instance sharing the id — mirrors real usage.
+    reader = CustomAgent(id="custom-agent", model=OpenAIChat(id="gpt-4o-mini"), db=shared_db)
+    last_output = reader.get_last_run_output(session_id=session_id)
+
+    assert last_output is not None
+    assert last_output.run_id == response.run_id
+
+
+@pytest.mark.asyncio
+async def test_aget_last_run_output_supports_agent_subclasses(async_shared_db):
+    """Async variant of the subclass regression."""
+
+    class CustomAgent(Agent):
+        pass
+
+    session_id = str(uuid.uuid4())
+
+    writer = CustomAgent(id="custom-agent-async", model=OpenAIChat(id="gpt-4o-mini"), db=async_shared_db)
+    response = await writer.arun("Hello", session_id=session_id)
+
+    reader = CustomAgent(id="custom-agent-async", model=OpenAIChat(id="gpt-4o-mini"), db=async_shared_db)
+    last_output = await reader.aget_last_run_output(session_id=session_id)
+
+    assert last_output is not None
+    assert last_output.run_id == response.run_id
+
+
 # Tests for delete_session() and adelete_session()
 def test_delete_session(test_agent):
     """Test delete_session removes a session."""

--- a/libs/agno/tests/integration/teams/test_team_convenience_functions.py
+++ b/libs/agno/tests/integration/teams/test_team_convenience_functions.py
@@ -365,6 +365,66 @@ async def test_aget_last_run_output(async_test_team):
     assert last_output.run_id == response2.run_id
 
 
+def test_get_last_run_output_supports_team_subclasses(shared_db, simple_agent):
+    """A user-defined Team subclass with the same id must find its persisted
+    runs. The retrieval loop previously compared ``__class__.__name__`` to
+    ``"Team"``, which silently returned None for subclasses.
+    """
+
+    class CustomTeam(Team):
+        pass
+
+    session_id = str(uuid.uuid4())
+
+    writer = CustomTeam(
+        id="custom-team",
+        members=[simple_agent],
+        model=OpenAIChat(id="gpt-4o-mini"),
+        db=shared_db,
+    )
+    response = writer.run("Hello", session_id=session_id)
+
+    reader = CustomTeam(
+        id="custom-team",
+        members=[simple_agent],
+        model=OpenAIChat(id="gpt-4o-mini"),
+        db=shared_db,
+    )
+    last_output = reader.get_last_run_output(session_id=session_id)
+
+    assert last_output is not None
+    assert last_output.run_id == response.run_id
+
+
+@pytest.mark.asyncio
+async def test_aget_last_run_output_supports_team_subclasses(async_shared_db, simple_agent):
+    """Async variant of the subclass regression."""
+
+    class CustomTeam(Team):
+        pass
+
+    session_id = str(uuid.uuid4())
+
+    writer = CustomTeam(
+        id="custom-team-async",
+        members=[simple_agent],
+        model=OpenAIChat(id="gpt-4o-mini"),
+        db=async_shared_db,
+    )
+    response = await writer.arun("Hello", session_id=session_id)
+
+    reader = CustomTeam(
+        id="custom-team-async",
+        members=[simple_agent],
+        model=OpenAIChat(id="gpt-4o-mini"),
+        db=async_shared_db,
+    )
+    last_output = await reader.aget_last_run_output(session_id=session_id)
+
+    assert last_output is not None
+    assert last_output.run_id == response.run_id
+
+
 # Tests for delete_session()
 def test_delete_session(test_team):
     """Test delete_session removes a session."""

--- a/libs/agno/tests/unit/agent/test_get_last_run_output_subclasses.py
+++ b/libs/agno/tests/unit/agent/test_get_last_run_output_subclasses.py
@@ -1,0 +1,145 @@
+"""Regression tests for get_last_run_output / aget_last_run_output on Agent
+and Team subclasses.
+
+Bug: the retrieval loop in ``agno.utils.agent`` checked
+``entity.__class__.__name__ == "Agent" / "Team"`` which fails for user
+subclasses like ``class CustomAgent(Agent): pass``. The fix uses
+``isinstance()`` instead. These tests exercise the utility directly (no
+LLM calls) using InMemoryDb + direct session inserts.
+"""
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+from agno.team.team import Team
+
+
+class CustomAgent(Agent):
+    pass
+
+
+class CustomTeam(Team):
+    pass
+
+
+def _seed_agent_session(db: InMemoryDb, agent_id: str, session_id: str, run_id: str) -> None:
+    db.upsert_session(
+        AgentSession(
+            session_id=session_id,
+            agent_id=agent_id,
+            runs=[
+                RunOutput(
+                    run_id=run_id,
+                    agent_id=agent_id,
+                    content="ok",
+                    status=RunStatus.completed,
+                )
+            ],
+            created_at=1,
+            updated_at=1,
+        )
+    )
+
+
+def _seed_team_session(db: InMemoryDb, team_id: str, session_id: str, run_id: str) -> None:
+    db.upsert_session(
+        TeamSession(
+            session_id=session_id,
+            team_id=team_id,
+            runs=[
+                TeamRunOutput(
+                    run_id=run_id,
+                    team_id=team_id,
+                    content="ok",
+                    status=RunStatus.completed,
+                )
+            ],
+            created_at=1,
+            updated_at=1,
+        )
+    )
+
+
+def test_get_last_run_output_supports_agent_subclasses():
+    db = InMemoryDb()
+    _seed_agent_session(db, agent_id="custom-agent", session_id="s1", run_id="r1")
+
+    agent = CustomAgent(id="custom-agent", db=db)
+    last_output = agent.get_last_run_output(session_id="s1")
+
+    assert last_output is not None
+    assert last_output.run_id == "r1"
+
+
+@pytest.mark.asyncio
+async def test_aget_last_run_output_supports_agent_subclasses():
+    db = InMemoryDb()
+    _seed_agent_session(db, agent_id="custom-agent", session_id="s1", run_id="r1")
+
+    agent = CustomAgent(id="custom-agent", db=db)
+    last_output = await agent.aget_last_run_output(session_id="s1")
+
+    assert last_output is not None
+    assert last_output.run_id == "r1"
+
+
+def test_get_last_run_output_supports_team_subclasses():
+    db = InMemoryDb()
+    _seed_team_session(db, team_id="custom-team", session_id="ts1", run_id="tr1")
+
+    team = CustomTeam(id="custom-team", db=db, members=[])
+    last_output = team.get_last_run_output(session_id="ts1")
+
+    assert last_output is not None
+    assert last_output.run_id == "tr1"
+
+
+@pytest.mark.asyncio
+async def test_aget_last_run_output_supports_team_subclasses():
+    db = InMemoryDb()
+    _seed_team_session(db, team_id="custom-team", session_id="ts1", run_id="tr1")
+
+    team = CustomTeam(id="custom-team", db=db, members=[])
+    last_output = await team.aget_last_run_output(session_id="ts1")
+
+    assert last_output is not None
+    assert last_output.run_id == "tr1"
+
+
+def test_get_last_run_output_base_agent_still_works():
+    """Baseline: the fix must not regress the base Agent case."""
+    db = InMemoryDb()
+    _seed_agent_session(db, agent_id="base-agent", session_id="s1", run_id="r1")
+
+    agent = Agent(id="base-agent", db=db)
+    last_output = agent.get_last_run_output(session_id="s1")
+
+    assert last_output is not None
+    assert last_output.run_id == "r1"
+
+
+def test_get_last_run_output_util_cached_session_branch_subclasses():
+    """The ``cached_session`` branch of the util must also handle subclasses.
+
+    The public ``get_last_run_output()`` requires a ``session_id`` and never
+    falls into that branch, so exercise the util directly.
+    """
+    from agno.utils.agent import get_last_run_output_util
+
+    db = InMemoryDb()
+    _seed_agent_session(db, agent_id="custom-agent", session_id="s1", run_id="r1")
+
+    agent = CustomAgent(id="custom-agent", db=db)
+    agent._cached_session = agent.get_session(session_id="s1")
+
+    # No session_id -> forces the cached_session branch inside the util.
+    last_output = get_last_run_output_util(agent, session_id=None)
+
+    assert last_output is not None
+    assert last_output.run_id == "r1"


### PR DESCRIPTION
## Summary

`Agent.get_last_run_output()` / `Agent.aget_last_run_output()` and the matching
`Team` methods returned `None` for user-defined subclasses, even when the stored
run had the correct `agent_id` / `team_id`. The same session worked fine on the
base `Agent` / `Team` classes.

Root cause: the retrieval loop in `libs/agno/agno/utils/agent.py` gated its
per-entity branches on an exact class-name match:

```python
if entity.__class__.__name__ == "Agent":
    ...
elif entity.__class__.__name__ == "Team":
    ...
```

That branch is skipped for any subclass (CustomAgent(Agent) → "CustomAgent").
The nearby _ensure_entity_id() helper in the same file already handles this
correctly with isinstance(); the retrieval loop is now consistent with it.

Fixes #8680.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
