### PR TITLE
fix: validate cache TTL order across tools and system blocks

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -18,6 +18,7 @@ from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.models.claude import (
     MCPServerConfiguration,
     _validate_cache_ttl_order,
+    _validate_request_cache_order,
     build_system_blocks,
     format_messages,
     format_tools_for_model,
@@ -693,6 +694,12 @@ class Claude(Model):
         output_format = self._build_output_format(response_format)
         if output_format:
             request_kwargs["output_format"] = output_format
+
+        # Validate cache TTL ordering across tools and system blocks
+        _validate_request_cache_order(
+            tools=request_kwargs.get("tools"),
+            system=request_kwargs.get("system"),
+        )
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -426,6 +426,10 @@ def _validate_cache_ttl_order(blocks: List[Dict[str, Any]]) -> None:
     Anthropic's prompt caching rejects requests where a longer-TTL cache entry
     follows a shorter-TTL one in the cached prefix. Catch this at assembly
     time with an actionable error rather than letting the API reject it.
+
+    Note: This only validates system blocks. Tools are validated separately in
+    _validate_request_cache_order because tools are processed before system blocks
+    in Anthropic's request processing order.
     """
     seen_5m = False
     for block in blocks:
@@ -446,6 +450,39 @@ def _validate_cache_ttl_order(blocks: List[Dict[str, Any]]) -> None:
                 )
         else:
             seen_5m = True
+
+
+def _validate_request_cache_order(
+    tools: Optional[List[Dict[str, Any]]] = None,
+    system: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    """Validate cache TTL ordering across tools + system blocks.
+
+    Anthropic processes cache_control in order: tools → system → messages.
+    A 1h cached system block cannot follow 5m cached tools.
+    """
+    has_cached_tools_5m = False
+    if tools:
+        for tool in tools:
+            cc = tool.get("cache_control")
+            if cc and cc.get("type") == "ephemeral" and cc.get("ttl") != "1h":
+                has_cached_tools_5m = True
+                break
+
+    if not has_cached_tools_5m or not system:
+        return
+
+    for block in system:
+        cc = block.get("cache_control")
+        if cc and cc.get("ttl") == "1h":
+            raise ValueError(
+                "Invalid Anthropic cache TTL ordering: a 1h cached system block cannot "
+                "follow 5m cached tools. Anthropic processes cache_control in order: "
+                "tools → system → messages. Fix with one of:\n"
+                "  - Set cache_tools=False to disable tool caching\n"
+                "  - Change system block ttl to '5m' or None\n"
+                "  - Set extended_cache_time=True AND cache_tools=False"
+            )
 
 
 def format_messages(

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -3,7 +3,7 @@ import base64
 import pytest
 
 from agno.media import File
-from agno.utils.models.claude import _format_file_for_message
+from agno.utils.models.claude import _format_file_for_message, _validate_request_cache_order
 
 
 class TestFormatFileForMessage:
@@ -154,3 +154,80 @@ class TestFormatFileForMessage:
 
         assert result["source"]["type"] == "url"
         assert "citations" not in result
+
+
+class TestValidateRequestCacheOrder:
+    def test_no_tools_no_error(self):
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+        _validate_request_cache_order(tools=None, system=system)
+
+    def test_no_system_no_error(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        _validate_request_cache_order(tools=tools, system=None)
+
+    def test_no_cached_tools_no_error(self):
+        tools = [{"name": "test"}]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+        _validate_request_cache_order(tools=tools, system=system)
+
+    def test_5m_tools_with_5m_system_no_error(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        _validate_request_cache_order(tools=tools, system=system)
+
+    def test_1h_tools_with_1h_system_no_error(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+        _validate_request_cache_order(tools=tools, system=system)
+
+    def test_5m_tools_with_no_cached_system_no_error(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        system = [{"text": "test"}]
+        _validate_request_cache_order(tools=tools, system=system)
+
+    def test_5m_tools_with_1h_system_raises_error(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+
+        with pytest.raises(ValueError, match="Invalid Anthropic cache TTL ordering"):
+            _validate_request_cache_order(tools=tools, system=system)
+
+    def test_error_message_includes_fix_suggestions(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+
+        with pytest.raises(ValueError) as exc_info:
+            _validate_request_cache_order(tools=tools, system=system)
+
+        error_msg = str(exc_info.value)
+        assert "cache_tools=False" in error_msg
+        assert "ttl to '5m' or None" in error_msg
+        assert "extended_cache_time=True AND cache_tools=False" in error_msg
+
+    def test_multiple_tools_last_one_cached_5m(self):
+        tools = [
+            {"name": "tool1"},
+            {"name": "tool2"},
+            {"name": "tool3", "cache_control": {"type": "ephemeral", "ttl": "5m"}},
+        ]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+
+        with pytest.raises(ValueError, match="Invalid Anthropic cache TTL ordering"):
+            _validate_request_cache_order(tools=tools, system=system)
+
+    def test_multiple_system_blocks_first_one_1h(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]
+        system = [
+            {"text": "block1", "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            {"text": "block2"},
+        ]
+
+        with pytest.raises(ValueError, match="Invalid Anthropic cache TTL ordering"):
+            _validate_request_cache_order(tools=tools, system=system)
+
+    def test_default_5m_cache_detected(self):
+        tools = [{"name": "test", "cache_control": {"type": "ephemeral"}}]
+        system = [{"text": "test", "cache_control": {"type": "ephemeral", "ttl": "1h"}}]
+
+        with pytest.raises(ValueError, match="Invalid Anthropic cache TTL ordering"):
+            _validate_request_cache_order(tools=tools, system=system)


### PR DESCRIPTION
## Summary

Fixes cache TTL ordering validation to prevent 400 errors from Anthropic API.

Fixes #8405

Previously, validation only checked system blocks for cache TTL conflicts (1h blocks after 5m blocks). However, Anthropic processes cache_control in order: **tools → system → messages**. This meant cached tools (always 5m) followed by 1h system blocks would pass validation but fail at the API with:

```
system.0.cache_control.ttl: a ttl='1h' cache_control block must not come after a ttl='5m' cache_control block
```

**Changes:**
- Added `_validate_request_cache_order()` to validate cache TTL across tools + system boundaries
- Validates before API call and raises `ValueError` with actionable fix suggestions
- Updated `_validate_cache_ttl_order()` docstring to clarify it only checks system blocks
- Added comprehensive test suite for cache TTL validation

**Error scenario:**
```python
Claude(
    cache_tools=True,  # Adds 5m cache to last tool
    system_prompt_blocks=[
        SystemPromptBlock(text="...", cache=True, ttl="1h")  # ❌ 1h after 5m
    ]
)
```

Fix suggestions provided:
- Set cache_tools=False to disable tool caching
- Change system block ttl to '5m' or None
- Set extended_cache_time=True AND cache_tools=False

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (./scripts/format.sh and ./scripts/validate.sh)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

## Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests (../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Files changed:**
- `libs/agno/agno/models/anthropic/claude.py` - Added validation call in `_prepare_request_kwargs()`
- `libs/agno/agno/utils/models/claude.py` - Added `_validate_request_cache_order()` function
- `libs/agno/tests/unit/utils/test_claude.py` - Added 11 test cases covering validation logic

**Tests added:**
- 11 unit tests covering all cache TTL ordering scenarios
- Tests validate correct pass/fail behavior
- Tests verify error messages include fix suggestions
- All tests passing

No breaking changes - This only adds validation that catches configuration errors earlier (client-side) that would have failed at the API anyway.

Testing note: Validation logic catches the error before API call, so requires setting up the specific cache configuration to trigger. The error message includes clear remediation steps.