### PR TITLE
fix: prevent silent MCP tool loss in Registry + StudioTool persistence

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -64,6 +64,7 @@ from agno.os.settings import AgnoAPISettings
 from agno.os.utils import (
     _generate_knowledge_id,
     collect_components_from_os,
+    collect_mcp_tools_from_registry,
     collect_mcp_tools_from_team,
     collect_mcp_tools_from_workflow,
     find_conflicting_routes,
@@ -381,6 +382,11 @@ class AgentOS:
         # Collect models, tools, dbs and vector dbs from the agent/team/workflow tree
         self._populate_registry_components()
 
+        # Track MCP tools declared on the registry so they connect in the same
+        # lifespan as agent/team/workflow MCP tools (e.g. for components created
+        # from registry tools via StudioTool)
+        collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
+
         # Check for duplicate IDs
         self._raise_if_duplicate_ids()
 
@@ -438,6 +444,9 @@ class AgentOS:
 
         # Collect models, tools, dbs and vector dbs from the agent/team/workflow tree
         self._populate_registry_components()
+
+        # Track MCP tools declared on the registry
+        collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
 
         if self.enable_mcp_server:
             from agno.os.mcp import get_mcp_server
@@ -882,6 +891,10 @@ class AgentOS:
         setup_tracing_for_os(db=db)
 
     def get_app(self) -> FastAPI:
+        # Pick up MCP tools added to the registry after construction, before the
+        # lifespan that connects them is assembled below
+        collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
+
         if self.base_app:
             fastapi_app = self.base_app
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1391,6 +1391,26 @@ def collect_mcp_tools_from_team(team: Team, mcp_tools: List[Any]) -> None:
                 collect_mcp_tools_from_team(member, mcp_tools)
 
 
+def collect_mcp_tools_from_registry(registry: Optional[Registry], mcp_tools: List[Any]) -> None:
+    """Collect MCP tools declared directly on the registry.
+
+    Registry tools are not attached to any agent, team or workflow, so the
+    other collectors never see them. They still must be connected in the
+    AgentOS lifespan: components created from registry tools (e.g. via
+    StudioTool) serialize a toolkit's functions at persist time, and an
+    unconnected MCP toolkit has none -- its tools would be silently dropped.
+    """
+    if registry is None or not registry.tools:
+        return
+    for tool in registry.tools:
+        # Alternate method of using isinstance(tool, (MCPTools, MultiMCPTools)) to avoid imports
+        if hasattr(type(tool), "__mro__") and any(
+            c.__name__ in ["MCPTools", "MultiMCPTools"] for c in type(tool).__mro__
+        ):
+            if tool not in mcp_tools:
+                mcp_tools.append(tool)
+
+
 def collect_mcp_tools_from_workflow(workflow: Workflow, mcp_tools: List[Any]) -> None:
     """Recursively collect MCP tools from a workflow and its steps."""
     from agno.workflow.steps import Steps

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -61,31 +61,36 @@ class Registry:
     _emit_dedup_logs: bool = field(default=True, repr=False, compare=False)
 
     @cached_property
-    def _entrypoint_lookup(self) -> Dict[str, Callable]:
-        lookup: Dict[str, Callable] = {}
+    def _entrypoint_lookup(self) -> Dict[str, Any]:
+        # Maps function name -> source: the Function that owns the entrypoint
+        # (for Toolkit and Function tools) or the plain callable itself.
+        lookup: Dict[str, Any] = {}
 
-        def register(name: str, entrypoint: Callable) -> None:
+        def _entrypoint(source: Any) -> Optional[Callable]:
+            return source.entrypoint if isinstance(source, Function) else source
+
+        def register(name: str, source: Any) -> None:
             # This lookup is keyed by name only, so two genuinely different tools
             # that share a name collapse to one slot (last wins). We can't resolve
             # that from a serialized function name alone, but we can surface it so
             # the user can give the tools distinct names.
             existing = lookup.get(name)
-            if existing is not None and existing is not entrypoint:
+            if existing is not None and existing is not source and _entrypoint(existing) is not _entrypoint(source):
                 log_warning(
                     f"Registry: multiple distinct tools share the name '{name}'. "
                     "rehydrate_function() can only resolve one of them; give the tools "
                     "or toolkits distinct names to disambiguate."
                 )
-            lookup[name] = entrypoint
+            lookup[name] = source
 
         for tool in self.tools:
             if isinstance(tool, Toolkit):
                 for func in tool.functions.values():
                     if func.entrypoint is not None:
-                        register(func.name, func.entrypoint)
+                        register(func.name, func)
             elif isinstance(tool, Function):
                 if tool.entrypoint is not None:
-                    register(tool.name, tool.entrypoint)
+                    register(tool.name, tool)
             elif callable(tool):
                 register(tool.__name__, tool)
         return lookup
@@ -93,7 +98,27 @@ class Registry:
     def rehydrate_function(self, func_dict: Dict[str, Any]) -> Function:
         """Reconstruct a Function from dict, reattaching its entrypoint."""
         func = Function.from_dict(func_dict)
-        func.entrypoint = self._entrypoint_lookup.get(func.name)
+        source = self._entrypoint_lookup.get(func.name)
+        if source is None:
+            # Toolkits can gain functions after the lookup is first built -- MCP
+            # toolkits only register their functions once connected -- so a miss
+            # may just mean the cache is stale. Rebuild once and retry.
+            self.__dict__.pop("_entrypoint_lookup", None)
+            source = self._entrypoint_lookup.get(func.name)
+        if isinstance(source, Function):
+            func.entrypoint = source.entrypoint
+            # Entrypoints built for a fixed schema (e.g. MCP call proxies) must
+            # not be re-introspected at run time: processing would rebuild the
+            # schema's `required` list from the proxy's signature.
+            func.skip_entrypoint_processing = source.skip_entrypoint_processing
+        else:
+            func.entrypoint = source
+        if func.entrypoint is None:
+            log_warning(
+                f"Registry: no tool named '{func.name}' found while rehydrating; "
+                "the function will have no entrypoint and cannot be executed. "
+                "Make sure the tool is in the registry and, for MCP toolkits, connected."
+            )
         return func
 
     def add_model(self, model: Any) -> None:

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -11,7 +11,7 @@ from agno.tools import Toolkit
 from agno.tools.function import Function
 from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
 from agno.utils.log import log_debug, log_error, log_info, log_warning
-from agno.utils.mcp import get_entrypoint_for_tool, prepare_command
+from agno.utils.mcp import get_default_toolkit_name, get_entrypoint_for_tool, prepare_command
 
 if TYPE_CHECKING:
     from agno.agent import Agent
@@ -42,6 +42,7 @@ class MCPTools(Toolkit):
         self,
         command: Optional[str] = None,
         *,
+        name: Optional[str] = None,
         url: Optional[str] = None,
         env: Optional[dict[str, str]] = None,
         transport: Optional[Literal["stdio", "sse", "streamable-http"]] = None,
@@ -60,6 +61,10 @@ class MCPTools(Toolkit):
         Initialize the MCP toolkit.
 
         Args:
+            name: The toolkit name. Defaults to a stable name derived from the connection
+                parameters (URL or command), so multiple MCP toolkits in one registry stay
+                distinguishable and selectable by name. Falls back to "MCPTools" when only
+                a session is provided.
             session: An initialized MCP ClientSession connected to an MCP server
             server_params: Parameters for creating a new session
             command: The command to run to start the server. Should be used in conjunction with env.
@@ -83,7 +88,10 @@ class MCPTools(Toolkit):
         stop_after_tool_call_tools = kwargs.pop("stop_after_tool_call_tools", None)
         show_result_tools = kwargs.pop("show_result_tools", None)
 
-        super().__init__(name="MCPTools", **kwargs)
+        super().__init__(
+            name=name or get_default_toolkit_name(url=url, command=command, server_params=server_params),
+            **kwargs,
+        )
 
         if url is not None:
             if transport is None:

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -46,6 +46,7 @@ class MultiMCPTools(Toolkit):
         urls: Optional[List[str]] = None,
         urls_transports: Optional[List[Literal["sse", "streamable-http"]]] = None,
         *,
+        name: Optional[str] = None,
         env: Optional[dict[str, str]] = None,
         server_params_list: Optional[
             list[Union[SSEClientParams, StdioServerParameters, StreamableHTTPClientParams]]
@@ -63,6 +64,8 @@ class MultiMCPTools(Toolkit):
         Initialize the MCP toolkit.
 
         Args:
+            name: The toolkit name. Defaults to "MultiMCPTools". Pass a distinct name when
+                registering multiple MultiMCPTools instances in one registry.
             commands: List of commands to run to start the servers. Should be used in conjunction with env.
             urls: List of URLs for SSE and/or Streamable HTTP endpoints.
             urls_transports: List of transports to use for the given URLs.
@@ -82,7 +85,7 @@ class MultiMCPTools(Toolkit):
             stacklevel=2,
         )
 
-        super().__init__(name="MultiMCPTools", **kwargs)
+        super().__init__(name=name or "MultiMCPTools", **kwargs)
 
         if urls_transports is not None:
             if "sse" in urls_transports:

--- a/libs/agno/agno/tools/mcp_toolbox.py
+++ b/libs/agno/agno/tools/mcp_toolbox.py
@@ -54,7 +54,9 @@ class MCPToolbox(MCPTools, metaclass=MCPToolsMeta):
 
         super().__init__(url=url, transport=transport, **kwargs)
 
-        self.name = "toolbox_client"
+        # Keep the historical default name, but let an explicit name= win.
+        if kwargs.get("name") is None:
+            self.name = "toolbox_client"
         self.toolbox_url = url
         self.toolsets = toolsets
         self.tool_name = tool_name

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -283,17 +283,37 @@ class StudioTool(Toolkit):
         return self.registry.get_db(db_id)
 
     def _find_tool(self, name: str) -> Optional[Any]:
-        """Match by Toolkit.name, Function.name, callable __name__, or toolkit function key."""
+        """Match by Toolkit.name, Function.name, callable __name__, or toolkit function key.
+
+        Top-level name matches take precedence over functions found inside a
+        toolkit. When a name matches more than one distinct registry entry
+        (e.g. two toolkits sharing a name), a ValueError is raised instead of
+        silently returning the first match -- resolving to whichever entry was
+        registered first would wire the agent to the wrong tool.
+        """
+        matches: List[Any] = []
+        function_matches: List[Any] = []
         for tool in self.registry.tools:
-            if isinstance(tool, Toolkit) and tool.name == name:
-                return tool
-            if isinstance(tool, Function) and tool.name == name:
-                return tool
-            if callable(tool) and getattr(tool, "__name__", None) == name:
-                return tool
-            if isinstance(tool, Toolkit) and name in tool.functions:
-                return tool.functions[name]
-        return None
+            if isinstance(tool, Toolkit):
+                if tool.name == name:
+                    matches.append(tool)
+                elif name in tool.functions:
+                    function_matches.append(tool.functions[name])
+            elif isinstance(tool, Function):
+                if tool.name == name:
+                    matches.append(tool)
+            elif callable(tool) and getattr(tool, "__name__", None) == name:
+                matches.append(tool)
+
+        candidates = matches or function_matches
+        if not candidates:
+            return None
+        if len(candidates) > 1:
+            raise ValueError(
+                f"Tool name '{name}' is ambiguous: it matches {len(candidates)} registry entries. "
+                "Give each tool a distinct name (e.g. MCPTools(name=...)) so it can be selected unambiguously."
+            )
+        return candidates[0]
 
     def _resolve_tools(self, names: Optional[List[str]]) -> List[Any]:
         if not names:
@@ -308,6 +328,17 @@ class StudioTool(Toolkit):
                 resolved.append(found)
         if missing:
             raise ValueError(f"Tools not found in registry: {missing}")
+        # Persisting a component serializes each toolkit's functions; a toolkit
+        # with none (e.g. an MCP toolkit that never connected) would be silently
+        # dropped from the config, permanently. Refuse instead.
+        empty_toolkits = [t.name for t in resolved if isinstance(t, Toolkit) and not t.functions]
+        if empty_toolkits:
+            raise ValueError(
+                f"Toolkits have no functions and cannot be persisted: {empty_toolkits}. "
+                "An MCP toolkit has no functions until it is connected. Connect it before "
+                "creating or editing components with it (AgentOS connects MCP tools found in "
+                "the registry and on agents/teams/workflows at startup)."
+            )
         return resolved
 
     def _normalize_tool_names(self, names: List[str]) -> List[str]:

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -24,6 +24,66 @@ if TYPE_CHECKING:
     from agno.tools.mcp.multi_mcp import MultiMCPTools
 
 
+def get_default_toolkit_name(
+    url: Optional[str] = None,
+    command: Optional[str] = None,
+    server_params: Optional[Any] = None,
+    fallback: str = "MCPTools",
+) -> str:
+    """Derive a stable toolkit name from MCP connection parameters.
+
+    Distinct servers produce distinct names so that multiple MCP toolkits can
+    coexist in one Registry: they stay distinguishable in listings, selectable
+    by name, and are not collapsed by structural deduplication. The name is
+    derived at construction time (no connection needed): from the URL for HTTP
+    transports, from the command for stdio, or from the equivalent fields of
+    ``server_params``. Query strings and fragments are dropped from URLs so
+    credentials passed as query parameters never end up in the toolkit name.
+
+    Returns ``fallback`` when no connection parameters are available (e.g. the
+    toolkit wraps an existing session).
+    """
+    target: Optional[str] = None
+    if url:
+        target = _strip_url_for_name(url)
+    elif command:
+        target = command
+    elif server_params is not None:
+        params_url = getattr(server_params, "url", None)
+        params_command = getattr(server_params, "command", None)
+        if params_url:
+            target = _strip_url_for_name(params_url)
+        elif params_command:
+            args = getattr(server_params, "args", None) or []
+            target = " ".join([str(params_command), *(str(arg) for arg in args)])
+
+    if not target:
+        return fallback
+
+    slug = "".join(char if char.isalnum() else "_" for char in target.lower())
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    slug = slug.strip("_")
+    if not slug:
+        return fallback
+    return f"mcp_{slug}"[:64]
+
+
+def _strip_url_for_name(url: str) -> str:
+    """Reduce a URL to scheme-less host + path, dropping userinfo, query and fragment.
+
+    Everything that can carry credentials (``user:pass@`` userinfo, query
+    parameters, fragments) is removed so it can never leak into the toolkit
+    name, which surfaces in registry listings and persisted configs.
+    """
+    remainder = url.split("://", 1)[-1]
+    remainder = remainder.split("?", 1)[0].split("#", 1)[0]
+    authority, slash, path = remainder.partition("/")
+    if "@" in authority:
+        authority = authority.rsplit("@", 1)[-1]
+    return authority + slash + path
+
+
 def get_entrypoint_for_tool(
     tool: MCPTool,
     session: ClientSession,

--- a/libs/agno/tests/unit/os/test_registry_mcp_tools.py
+++ b/libs/agno/tests/unit/os/test_registry_mcp_tools.py
@@ -1,0 +1,123 @@
+"""
+Unit tests for AgentOS collection and startup connection of MCP tools
+declared on the registry.
+
+MCP toolkits in ``registry.tools`` are not attached to any agent, team or
+workflow, so they are not covered by the per-component collectors. AgentOS
+must still connect them in its lifespan: components created from registry
+tools (e.g. via StudioTool) serialize a toolkit's functions at persist time,
+and an unconnected MCP toolkit has none -- its tools would be silently and
+permanently dropped from the persisted config.
+
+Detection is by class name in the MRO (``MCPTools`` / ``MultiMCPTools``), so
+the stubs below carry those names and the ``mcp`` package is not required.
+"""
+
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.os import AgentOS
+from agno.registry import Registry
+from agno.tools.function import Function
+from agno.tools.toolkit import Toolkit
+
+
+class MCPTools(Toolkit):
+    """Stub with the MCPTools interface AgentOS relies on: name-based
+    detection, async connect()/close(), and functions that only exist after
+    connect."""
+
+    def __init__(self, name: str = "stub_mcp"):
+        super().__init__(name=name)
+        self.connected = False
+        self.closed = False
+
+    async def connect(self, force: bool = False):
+        self.connected = True
+        self.functions["search_docs"] = Function(
+            name="search_docs",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            skip_entrypoint_processing=True,
+        )
+
+    async def close(self):
+        self.closed = True
+
+
+class MultiMCPTools(Toolkit):
+    def __init__(self, name: str = "stub_multi_mcp"):
+        super().__init__(name=name)
+        self.connected = False
+
+    async def connect(self, force: bool = False):
+        self.connected = True
+
+    async def close(self):
+        pass
+
+
+def _agent() -> Agent:
+    return Agent(name="Plain Agent", id="plain-agent", telemetry=False)
+
+
+class TestRegistryMCPToolCollection:
+    def test_registry_only_mcp_tools_are_collected(self):
+        mcp_tool = MCPTools()
+        registry = Registry(tools=[mcp_tool])
+
+        os = AgentOS(agents=[_agent()], registry=registry, telemetry=False)
+
+        assert mcp_tool in os.mcp_tools
+
+    def test_multi_mcp_tools_are_collected(self):
+        multi = MultiMCPTools()
+        registry = Registry(tools=[multi])
+
+        os = AgentOS(agents=[_agent()], registry=registry, telemetry=False)
+
+        assert multi in os.mcp_tools
+
+    def test_non_mcp_registry_tools_are_not_collected(self):
+        plain = Toolkit(name="plain_toolkit")
+        registry = Registry(tools=[plain])
+
+        os = AgentOS(agents=[_agent()], registry=registry, telemetry=False)
+
+        assert plain not in os.mcp_tools
+
+    def test_tool_shared_between_agent_and_registry_is_collected_once(self):
+        mcp_tool = MCPTools()
+        agent = Agent(name="MCP Agent", id="mcp-agent", tools=[mcp_tool], telemetry=False)
+        registry = Registry(tools=[mcp_tool])
+
+        os = AgentOS(agents=[agent], registry=registry, telemetry=False)
+
+        assert os.mcp_tools.count(mcp_tool) == 1
+
+    def test_mcp_tool_added_to_registry_after_init_is_collected_by_get_app(self):
+        registry = Registry()
+        os = AgentOS(agents=[_agent()], registry=registry, telemetry=False)
+        late = MCPTools(name="late_mcp")
+        registry.tools.append(late)
+
+        os.get_app()
+
+        assert late in os.mcp_tools
+
+
+class TestRegistryMCPToolStartup:
+    def test_registry_mcp_tools_connect_at_startup(self):
+        """The app lifespan must connect registry MCP tools, so that their
+        functions exist before any Studio operation persists a component."""
+        mcp_tool = MCPTools()
+        registry = Registry(tools=[mcp_tool])
+        os = AgentOS(agents=[_agent()], registry=registry, telemetry=False)
+
+        app = os.get_app()
+        assert not mcp_tool.connected
+
+        with TestClient(app):
+            assert mcp_tool.connected
+            assert mcp_tool.functions  # populated by connect()
+
+        assert mcp_tool.closed

--- a/libs/agno/tests/unit/os/test_registry_population.py
+++ b/libs/agno/tests/unit/os/test_registry_population.py
@@ -466,7 +466,8 @@ class TestPopulateRegistryComponentsToolDedup:
 
         kept = [t for t in os.registry.tools if isinstance(t, DuckDuckGoTools)]
         assert len(kept) == 1 and kept[0] is first
-        assert os.registry._entrypoint_lookup["web_search"].__self__ is first
+        # The lookup stores the source Function; its entrypoint is bound to the kept instance
+        assert os.registry._entrypoint_lookup["web_search"].entrypoint.__self__ is first
 
     def test_toolkits_sharing_name_with_different_functions_both_kept(self):
         # Same name but different function sets are genuinely different tools and

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -261,8 +261,11 @@ class TestEntrypointLookup:
         reg = Registry(tools=[function_tool])
         lookup = reg._entrypoint_lookup
 
+        # Function tools are stored as the source Function itself, so
+        # rehydration can also recover flags like skip_entrypoint_processing.
         assert "sample_function" in lookup
-        assert lookup["sample_function"] == function_tool.entrypoint
+        assert lookup["sample_function"] is function_tool
+        assert lookup["sample_function"].entrypoint == function_tool.entrypoint
 
     def test_entrypoint_lookup_with_callable(self):
         """Test entrypoint lookup with raw callable."""
@@ -392,6 +395,57 @@ class TestRehydrateFunction:
         for func in funcs:
             rehydrated = reg.rehydrate_function(func.to_dict())
             assert rehydrated.entrypoint is not None
+
+    def test_rehydrate_function_after_toolkit_gains_functions(self):
+        """A stale cached lookup is rebuilt when a name misses.
+
+        MCP toolkits only register their functions once connected, which may
+        happen after the lookup was first built (e.g. it was primed during
+        startup, before the connect lifespan ran).
+        """
+        toolkit = Toolkit(name="mcp_stub")
+        reg = Registry(tools=[toolkit])
+
+        # Prime the cache while the toolkit is still "unconnected"
+        assert reg._entrypoint_lookup == {}
+
+        # Simulate connect(): the toolkit registers a function with a fixed schema
+        async def search_docs(query: str) -> str:
+            return query
+
+        func = Function(
+            name="search_docs",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            entrypoint=search_docs,
+            skip_entrypoint_processing=True,
+        )
+        toolkit.functions[func.name] = func
+
+        rehydrated = reg.rehydrate_function(func.to_dict())
+
+        assert rehydrated.entrypoint is search_docs
+
+    def test_rehydrate_function_preserves_skip_entrypoint_processing(self):
+        """Fixed-schema entrypoints (e.g. MCP call proxies) must not be
+        re-introspected at run time, so the source flag is carried over."""
+
+        async def call_proxy(**kwargs) -> str:
+            return "ok"
+
+        func = Function(
+            name="mcp_func",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            entrypoint=call_proxy,
+            skip_entrypoint_processing=True,
+        )
+        toolkit = Toolkit(name="mcp_stub")
+        toolkit.functions[func.name] = func
+        reg = Registry(tools=[toolkit])
+
+        rehydrated = reg.rehydrate_function(func.to_dict())
+
+        assert rehydrated.entrypoint is call_proxy
+        assert rehydrated.skip_entrypoint_processing is True
 
 
 # =============================================================================
@@ -1237,6 +1291,32 @@ class TestAddTool:
         reg.add_tool(tk1)
         reg.add_tool(tk2)
         assert tk1 in reg.tools and tk2 in reg.tools
+
+    def test_keeps_mcp_toolkits_for_distinct_servers(self):
+        # Two unconnected MCP toolkits have identical (empty) function sets, so
+        # they are only distinguishable by name. The derived default name keeps
+        # them from collapsing into one entry.
+        pytest.importorskip("mcp")
+        from agno.tools.mcp import MCPTools
+
+        reg = Registry()
+        docs = MCPTools(url="https://docs.example.com/mcp")
+        search = MCPTools(url="https://search.example.com/mcp")
+        reg.add_tool(docs)
+        reg.add_tool(search)
+        assert docs in reg.tools and search in reg.tools
+
+    def test_dedupes_mcp_toolkits_for_same_server(self):
+        # Same server re-instantiated in two places is still a duplicate.
+        pytest.importorskip("mcp")
+        from agno.tools.mcp import MCPTools
+
+        reg = Registry()
+        first = MCPTools(url="https://docs.example.com/mcp")
+        second = MCPTools(url="https://docs.example.com/mcp")
+        reg.add_tool(first)
+        reg.add_tool(second)
+        assert reg.tools == [first]
 
     def test_keeps_distinct_toolkit_subclasses_sharing_a_name(self):
         class ToolkitA(Toolkit):

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp import StdioServerParameters
 from mcp.types import CallToolResult, TextContent
 
 from agno.tools.function import Function, FunctionCall, ToolResult
@@ -90,6 +91,67 @@ def test_multimcp_urls_default_to_streamable_http():
     tools = MultiMCPTools(urls=["http://localhost:8080/mcp", "http://localhost:8081/mcp"])
     assert len(tools.server_params_list) == 2
     assert all(isinstance(params, StreamableHTTPClientParams) for params in tools.server_params_list)
+
+
+def test_default_name_derived_from_url_is_distinct_and_stable():
+    """Two servers get distinct default names; the same server always gets the same name."""
+    docs = MCPTools(url="https://docs.example.com/mcp")
+    search = MCPTools(url="https://search.example.com/mcp")
+    assert docs.name != search.name
+    assert docs.name != "MCPTools"
+    assert docs.name == MCPTools(url="https://docs.example.com/mcp").name
+
+
+def test_default_name_drops_url_query_and_fragment():
+    """Credentials passed as query params must never leak into the toolkit name."""
+    tools = MCPTools(url="https://server.example.com/mcp?api_key=supersecret123#fragment")
+    assert "supersecret123" not in tools.name
+    assert "fragment" not in tools.name
+    assert tools.name == MCPTools(url="https://server.example.com/mcp").name
+
+
+def test_default_name_drops_url_userinfo():
+    """Credentials passed as URL userinfo must never leak into the toolkit name."""
+    tools = MCPTools(url="https://alice:hunter2pass@server.example.com/mcp")
+    assert "hunter2pass" not in tools.name
+    assert "alice" not in tools.name
+    assert tools.name == MCPTools(url="https://server.example.com/mcp").name
+
+
+def test_default_name_derived_from_command():
+    server_a = MCPTools(command="npx -y @acme/server-a")
+    server_b = MCPTools(command="npx -y @acme/server-b")
+    assert server_a.name != server_b.name
+    assert server_a.name != "MCPTools"
+
+
+def test_default_name_derived_from_server_params():
+    http_tools = MCPTools(
+        server_params=StreamableHTTPClientParams(url="https://a.example.com/mcp"), transport="streamable-http"
+    )
+    stdio_tools = MCPTools(
+        server_params=StdioServerParameters(command="npx", args=["-y", "@acme/server-b"]), transport="stdio"
+    )
+    assert http_tools.name != "MCPTools"
+    assert stdio_tools.name != "MCPTools"
+    assert http_tools.name != stdio_tools.name
+
+
+def test_session_only_init_falls_back_to_default_name():
+    tools = MCPTools(session=AsyncMock())
+    assert tools.name == "MCPTools"
+
+
+def test_explicit_name_overrides_derived_default():
+    tools = MCPTools(url="https://docs.example.com/mcp", name="agno_docs")
+    assert tools.name == "agno_docs"
+
+
+def test_multimcp_accepts_explicit_name():
+    default_named = MultiMCPTools(urls=["http://localhost:8080/mcp"])
+    named = MultiMCPTools(urls=["http://localhost:8080/mcp"], name="my_servers")
+    assert default_named.name == "MultiMCPTools"
+    assert named.name == "my_servers"
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -16,7 +16,9 @@ from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
+from agno.tools.function import Function
 from agno.tools.studio import StudioTool
+from agno.tools.toolkit import Toolkit
 
 # ----------------------------------------------------------------------
 # Fixtures
@@ -307,6 +309,180 @@ class TestCreateAgent:
         out = _loads(await studio.acreate_agent(name="async-agent", instructions="i", model_id="gpt-5.4"))
         assert out["status"] == "created"
         assert db.get_component("async-agent") is not None
+
+
+class TestToolNameResolution:
+    """Multiple MCP servers in one registry must stay independently addressable."""
+
+    @pytest.fixture
+    def mcp_registry(self, db):
+        pytest.importorskip("mcp")
+        from agno.tools.mcp import MCPTools
+
+        docs = MCPTools(url="https://docs.example.com/mcp")
+        search = MCPTools(url="https://search.example.com/mcp")
+        registry = Registry(
+            name="MCP Registry",
+            tools=[docs, search],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+        return registry, docs, search
+
+    def test_two_mcp_toolkits_are_independently_listable(self, mcp_registry, db):
+        registry, docs, search = mcp_registry
+        studio = StudioTool(registry=registry, db=db)
+
+        result = _loads(studio.list_tools())
+        names = [t["name"] for t in result["tools"]]
+        assert len(names) == len(set(names))
+        assert docs.name in names and search.name in names
+
+    def test_two_mcp_toolkits_survive_add_tool_dedup(self, mcp_registry):
+        registry, docs, search = mcp_registry
+        fresh = Registry()
+        fresh.add_tool(docs)
+        fresh.add_tool(search)
+        assert docs in fresh.tools and search in fresh.tools
+
+    def test_create_agent_selects_the_right_mcp_toolkit_by_name(self, mcp_registry, db):
+        registry, docs, search = mcp_registry
+        studio = StudioTool(registry=registry, db=db)
+
+        assert studio._find_tool(docs.name) is docs
+        assert studio._find_tool(search.name) is search
+
+        # Simulate a connected toolkit: create_agent refuses toolkits with no
+        # functions, since they would persist as an empty tool set.
+        search.functions["web_search"] = Function(
+            name="web_search",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            skip_entrypoint_processing=True,
+        )
+
+        out = _loads(
+            studio.create_agent(name="web-search-agent", instructions="Search the web.", tool_names=[search.name])
+        )
+        assert out["status"] == "created"
+        assert out["tools"] == [search.name]
+
+    def test_ambiguous_tool_name_errors_instead_of_first_matching(self, db):
+        def alpha():
+            pass
+
+        def beta():
+            pass
+
+        registry = Registry(
+            name="Ambiguous Registry",
+            tools=[Toolkit(name="dup", tools=[alpha]), Toolkit(name="dup", tools=[beta])],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+        studio = StudioTool(registry=registry, db=db)
+
+        with pytest.raises(ValueError, match="ambiguous"):
+            studio._find_tool("dup")
+
+        out = _loads(studio.create_agent(name="x", instructions="i", tool_names=["dup"]))
+        assert "error" in out
+        assert "ambiguous" in out["error"]
+
+
+class TestMCPToolkitPersistence:
+    """Registry MCP toolkits must persist their functions and survive rehydration.
+
+    Uses stub toolkits with the connected-MCP shape: functions registered on
+    the toolkit at connect time, with a fixed schema and
+    skip_entrypoint_processing=True.
+    """
+
+    @staticmethod
+    def _connect(toolkit: Toolkit) -> Function:
+        """Simulate MCPTools.connect(): register a fixed-schema function."""
+
+        async def call_proxy(**kwargs) -> str:
+            return "docs result"
+
+        func = Function(
+            name="search_docs",
+            description="Search the docs.",
+            parameters={"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+            entrypoint=call_proxy,
+            skip_entrypoint_processing=True,
+        )
+        toolkit.functions[func.name] = func
+        return func
+
+    def _registry(self, db, toolkit: Toolkit) -> Registry:
+        return Registry(
+            name="MCP Persistence Registry",
+            tools=[toolkit],
+            models=[OpenAIResponses(id="gpt-5.5")],
+            dbs=[db],
+        )
+
+    def test_create_agent_refuses_unconnected_toolkit(self, db):
+        toolkit = Toolkit(name="agno_docs")  # no functions: never connected
+        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
+
+        out = _loads(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+
+        assert "error" in out
+        assert "agno_docs" in out["error"]
+        assert db.get_component("docs-agent") is None
+
+    def test_edit_agent_refuses_unconnected_toolkit(self, db):
+        toolkit = Toolkit(name="agno_docs")
+        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
+        studio.create_agent(name="docs-agent", instructions="i")
+
+        out = _loads(studio.edit_agent(agent_id="docs-agent", tool_names=["agno_docs"]))
+
+        assert "error" in out
+        assert "agno_docs" in out["error"]
+
+    def test_create_agent_persists_connected_toolkit_functions(self, db):
+        toolkit = Toolkit(name="agno_docs")
+        self._connect(toolkit)
+        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
+
+        out = _loads(studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"]))
+        assert out["status"] == "created"
+
+        config = db.get_config("docs-agent")["config"]
+        persisted_tools = config.get("tools")
+        assert persisted_tools, "connected toolkit functions must be persisted"
+        assert [t["name"] for t in persisted_tools] == ["search_docs"]
+        assert persisted_tools[0]["parameters"]["required"] == ["query"]
+
+    def test_rehydrated_agent_resolves_mcp_tools_after_late_connect(self, db):
+        """Simulate a restart: persist with a connected toolkit, then rehydrate
+        against a fresh registry whose toolkit connects only after the
+        entrypoint lookup cache was first built."""
+        toolkit = Toolkit(name="agno_docs")
+        self._connect(toolkit)
+        studio = StudioTool(registry=self._registry(db, toolkit), db=db)
+        studio.create_agent(name="docs-agent", instructions="i", tool_names=["agno_docs"])
+
+        # Fresh process: new registry, toolkit not yet connected
+        fresh_toolkit = Toolkit(name="agno_docs")
+        fresh_registry = self._registry(db, fresh_toolkit)
+
+        # Prime the lookup cache before "connect", as startup code paths may
+        assert fresh_registry._entrypoint_lookup == {}
+
+        # The AgentOS lifespan connects the toolkit
+        func = self._connect(fresh_toolkit)
+
+        config = db.get_config("docs-agent")["config"]
+        agent = Agent.from_dict(config, registry=fresh_registry)
+
+        assert agent.tools, "rehydrated agent must keep its MCP tools"
+        rehydrated = {t.name: t for t in agent.tools if isinstance(t, Function)}
+        assert "search_docs" in rehydrated
+        assert rehydrated["search_docs"].entrypoint is func.entrypoint
+        assert rehydrated["search_docs"].skip_entrypoint_processing is True
 
 
 class TestCreateTeam:

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -17,8 +17,8 @@ from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.function import Function
+from agno.tools.studio import StudioTool, StudioTools
 from agno.tools.toolkit import Toolkit
-from agno.tools.studio import StudioTools
 
 # ----------------------------------------------------------------------
 # Fixtures
@@ -61,13 +61,9 @@ def _loads(s: str) -> Dict[str, Any]:
 
 class TestStudioToolAlias:
     def test_singular_alias_resolves_to_canonical_class(self):
-        from agno.tools.studio import StudioTool
-
         assert StudioTool is StudioTools
 
     def test_alias_constructs_a_working_toolkit(self, registry, db):
-        from agno.tools.studio import StudioTool
-
         tool = StudioTool(registry=registry, db=db)
         assert isinstance(tool, StudioTools)
         assert "create_agent" in tool.functions


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in the Studio/Registry + MCPTools integration (repro on agno 2.6.20): MCP toolkits declared in `registry.tools` were never connected by AgentOS, so any component created through `StudioTool` that selected them was persisted with **zero functions** — no warning, no error, and the loss was permanent because runs rehydrate from the persisted config.

Found while reviewing `agno-agi/agent-platform-railway` (feat/agent-builder), where the Agent Builder demo produced agents with no web/docs tools: `GET /registry` showed the MCP entries with `functions: []`, and the persisted Studio config dropped them.

### Root cause chain

1. AgentOS collected MCP tools for its startup connect lifespan only from agents, teams, and workflows — `registry.tools` never entered `self.mcp_tools`, so registry MCP toolkits stayed unconnected with an empty `functions` dict.
2. `StudioTool.create_agent` persists via `agent_to_dict` → `parse_tools` → `tool.get_functions()` — empty for an unconnected `MCPTools` — so the toolkit was persisted with zero functions.
3. `run_agent` rehydrates with `Agent.from_dict(config, registry=...)` on every run; there is no live-object cache, so the tools never came back.
4. `Registry._entrypoint_lookup` is a `cached_property` built from `self.tools` — if toolkits connect after the cache is built, rehydrated entrypoints still didn't resolve.
5. All `MCPTools` instances shared the default name `"MCPTools"` with identical (empty) function sets, so distinct MCP servers in one registry were collapsed by structural dedup, and name-based selection couldn't distinguish them.

### Fixes

**Connection & persistence**
- New `collect_mcp_tools_from_registry()` wired into AgentOS `__init__`, `resync()`, and `get_app()`: registry MCP toolkits now connect in the same startup lifespan as agent/team/workflow MCP tools, before any Studio operation can persist a component.
- `StudioTool._resolve_tools` now **refuses** (clear error back to the calling agent) when a selected toolkit has an empty function set, instead of silently persisting a component that drops it. Covers both `create_agent` and `edit_agent`.
- `Registry.rehydrate_function` rebuilds the cached entrypoint lookup once on a name miss, so a cache primed before MCP connect self-heals after. It also carries `skip_entrypoint_processing` over from the source `Function` (fixed schemas like MCP `inputSchema` are no longer re-introspected and clobbered at run time), and logs a warning when an entrypoint cannot be resolved at all.

**Naming & selection**
- `MCPTools` accepts `name=` and derives a stable default name from its URL or command (e.g. `mcp_docs_agno_com_mcp`), so multiple MCP toolkits in one registry stay distinguishable, selectable by name, and are not collapsed by dedup. Userinfo, query strings, and fragments are stripped from URLs so credentials can never leak into the toolkit name.
- `MultiMCPTools` accepts `name=` (deprecated class, minimal treatment); `MCPToolbox` keeps its historical `toolbox_client` default unless an explicit `name=` is passed.
- `StudioTool._find_tool` raises on ambiguous tool names instead of silently returning the first match.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests** (23 new/updated, all unit-level, no network):
- `tests/unit/os/test_registry_mcp_tools.py` (new): registry-only MCP tools are collected and connected by the app lifespan (TestClient startup/shutdown), MultiMCP collection, dedup with agent-attached instances, post-`__init__` registry additions picked up by `get_app()`.
- `tests/unit/tools/test_studio.py`: create/edit refuse unconnected toolkits (and persist nothing); connected toolkit functions round-trip into the persisted config; fresh-registry restart simulation where the entrypoint cache is primed *before* connect and rehydration still resolves entrypoints with `skip_entrypoint_processing` intact; multi-MCP name resolution and ambiguity errors.
- `tests/unit/registry/test_registry.py`: stale-cache rebuild on miss, `skip_entrypoint_processing` propagation, MCP toolkit dedup by derived name.
- `tests/unit/tools/test_mcp.py`: derived-name stability/distinctness, credential stripping (query, fragment, userinfo), explicit `name=` override.

**Behavior changes to be aware of:**
- The default `MCPTools` toolkit name changes from `"MCPTools"` to a URL/command-derived slug (session-only construction still falls back to `"MCPTools"`). Anything matching on the literal default name will see the new derived name.
- `StudioTool` now returns an error instead of succeeding when asked to build a component with a functionless toolkit — intentional, since the previous "success" silently dropped the tools.
- `validate.sh` reports 6 pre-existing mypy errors in unrelated files (`jina.py`, `zoom.py`, `clickup.py`, `calcom.py`, `desi_vocal.py`, `azure_openai.py`) that exist on `main`; all files touched by this PR pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
