### PR TITLE
[fix] Propagate trusted JWT context for WebSocket workflow factory runs

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -435,7 +435,7 @@ def get_websocket_router(
                             message.setdefault("user_id", jwt_user_id)
                         else:
                             message["user_id"] = jwt_user_id
-                    await handle_workflow_via_websocket(websocket, message, os)
+                    await handle_workflow_via_websocket(websocket, message, os, ws_user_context=websocket_user_context)
 
                 elif action == "reconnect":
                     # Force user_id from JWT for non-admins so reconnecting

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -1,16 +1,15 @@
 """Integration tests for running Workflows in AgentOS."""
 
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
-import jwt
 import httpx
+import jwt
 import pytest
-import tempfile
 from fastapi.testclient import TestClient
 from httpx import ASGITransport
 from pydantic import BaseModel
-from datetime import UTC, datetime, timedelta
 
 from agno.db.base import ComponentType
 from agno.db.sqlite import SqliteDb
@@ -196,21 +195,30 @@ def test_factory_workflow_get_run_and_list_runs(factory_workflow_client):
 
 @pytest.fixture
 def websocket_factory_client(temp_storage_db_file):
-    """Create a WebSocket TestClient with an authorized workflow factory."""
+    """Create a WebSocket TestClient with an authorized workflow factory.
+
+    The fixture records what the factory sees in ``factory_calls`` so tests can
+    assert on the trusted JWT context *after* the run without swallowing
+    assertions inside the factory callback (which would surface as opaque
+    "Factory error: ..." frames).
+    """
 
     secret = "x" * 40
     os_id = "ws-factory-os"
 
     db = SqliteDb(db_file=temp_storage_db_file)
+    factory_calls: list[dict] = []
 
     def websocket_workflow_step(_: StepInput) -> StepOutput:
         return StepOutput(content="ok")
 
     def build_workflow(ctx):
-        assert ctx.trusted.claims
-        assert ctx.trusted.claims["sub"] == "alice"
-        assert "workflows:run" in ctx.trusted.scopes
-
+        factory_calls.append(
+            {
+                "claims": dict(ctx.trusted.claims) if ctx.trusted.claims else {},
+                "scopes": set(ctx.trusted.scopes) if ctx.trusted.scopes else set(),
+            }
+        )
         return Workflow(
             id="ws-factory",
             name="ws-factory",
@@ -240,23 +248,16 @@ def websocket_factory_client(temp_storage_db_file):
             "client": client,
             "secret": secret,
             "os_id": os_id,
+            "factory_calls": factory_calls,
         }
 
 
-def test_websocket_workflow_factory_receives_trusted_jwt_context(
-    websocket_factory_client,
-):
-    """Test that workflow factories receive trusted JWT context over WebSocket."""
-
-    client = websocket_factory_client["client"]
-    secret = websocket_factory_client["secret"]
-    os_id = websocket_factory_client["os_id"]
-
-    token = jwt.encode(
+def _issue_token(secret: str, os_id: str, sub: str, scopes: list[str]) -> str:
+    return jwt.encode(
         {
-            "sub": "alice",
+            "sub": sub,
             "aud": os_id,
-            "scopes": ["workflows:run"],
+            "scopes": scopes,
             "exp": datetime.now(UTC) + timedelta(minutes=5),
             "iat": datetime.now(UTC),
         },
@@ -264,31 +265,48 @@ def test_websocket_workflow_factory_receives_trusted_jwt_context(
         algorithm="HS256",
     )
 
+
+def _authenticate_ws(ws, token: str, expected_user_id: str) -> None:
+    connection_event = json.loads(ws.receive_text())
+    assert connection_event["event"] == "connected"
+
+    ws.send_text(json.dumps({"action": "authenticate", "token": token}))
+
+    for _ in range(5):
+        frame = json.loads(ws.receive_text())
+        if frame.get("event") == "authenticated" and frame.get("user_id") == expected_user_id:
+            return
+    raise AssertionError(f"Did not receive authenticated event for user_id={expected_user_id}")
+
+
+def _drain_until(ws, predicate, max_frames: int = 20) -> str:
+    """Read text frames until ``predicate(frame_text)`` is truthy or the limit is hit."""
+    for _ in range(max_frames):
+        frame = ws.receive_text()
+        if predicate(frame):
+            return frame
+    raise AssertionError(f"No frame matched predicate within {max_frames} frames")
+
+
+def test_websocket_workflow_factory_receives_trusted_jwt_context(
+    websocket_factory_client,
+):
+    """Regression for #8684: WS start-workflow must forward JWT context to factory.
+
+    Assertions live in the test body (not the factory callback) so a regression
+    shows up as a clear diff on captured claims/scopes rather than an opaque
+    ``Factory error: ...`` frame.
+    """
+
+    client = websocket_factory_client["client"]
+    secret = websocket_factory_client["secret"]
+    os_id = websocket_factory_client["os_id"]
+    factory_calls = websocket_factory_client["factory_calls"]
+
+    token = _issue_token(secret, os_id, sub="alice", scopes=["workflows:run"])
+
     with client.websocket_connect("/workflows/ws") as ws:
-        connection_event = json.loads(ws.receive_text())
-        assert connection_event["event"] == "connected"
-
-        ws.send_text(
-            json.dumps(
-                {
-                    "action": "authenticate",
-                    "token": token,
-                }
-            )
-        )
-
-        authenticated = False
-
-        for _ in range(5):
-            frame = json.loads(ws.receive_text())
-            if (
-                frame.get("event") == "authenticated"
-                and frame.get("user_id") == "alice"
-            ):
-                authenticated = True
-                break
-
-        assert authenticated, "Did not receive authenticated event with user_id"
+        _authenticate_ws(ws, token, expected_user_id="alice")
 
         ws.send_text(
             json.dumps(
@@ -300,10 +318,53 @@ def test_websocket_workflow_factory_receives_trusted_jwt_context(
             )
         )
 
-        response = ws.receive_text()
+        started = _drain_until(ws, lambda f: "WorkflowStarted" in f)
+        assert '"workflow_id": "ws-factory"' in started
 
-        assert "event: WorkflowStarted" in response
-        assert '"workflow_id": "ws-factory"' in response 
+    assert len(factory_calls) == 1, "Factory should be built exactly once"
+    call = factory_calls[0]
+    assert call["claims"].get("sub") == "alice", (
+        f"Factory did not see trusted JWT sub. Saw claims={call['claims']}. "
+        "This means websocket_user_context was not forwarded to "
+        "handle_workflow_via_websocket — see agno/os/router.py."
+    )
+    assert "workflows:run" in call["scopes"], f"Factory did not see trusted JWT scopes. Saw scopes={call['scopes']}."
+
+
+def test_websocket_workflow_factory_rejects_missing_scope(
+    websocket_factory_client,
+):
+    """A token without ``workflows:run`` must be blocked at the dispatcher RBAC gate.
+
+    The factory must not even be invoked in this case — the reject happens
+    before ``handle_workflow_via_websocket`` is called.
+    """
+
+    client = websocket_factory_client["client"]
+    secret = websocket_factory_client["secret"]
+    os_id = websocket_factory_client["os_id"]
+    factory_calls = websocket_factory_client["factory_calls"]
+
+    token = _issue_token(secret, os_id, sub="alice", scopes=[])
+
+    with client.websocket_connect("/workflows/ws") as ws:
+        _authenticate_ws(ws, token, expected_user_id="alice")
+
+        ws.send_text(
+            json.dumps(
+                {
+                    "action": "start-workflow",
+                    "workflow_id": "ws-factory",
+                    "message": "go",
+                }
+            )
+        )
+
+        error_frame = json.loads(_drain_until(ws, lambda f: '"event": "error"' in f))
+        assert error_frame["event"] == "error"
+        assert "permission" in error_frame["error"].lower()
+
+    assert factory_calls == [], "Factory must not be invoked when RBAC rejects the call"
 
 
 # =============================================================================

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -3,15 +3,19 @@
 import json
 from unittest.mock import AsyncMock, patch
 
+import jwt
 import httpx
 import pytest
+import tempfile
 from fastapi.testclient import TestClient
 from httpx import ASGITransport
 from pydantic import BaseModel
+from datetime import UTC, datetime, timedelta
 
 from agno.db.base import ComponentType
 from agno.db.sqlite import SqliteDb
 from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
 from agno.workflow.factory import WorkflowFactory
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
@@ -188,6 +192,118 @@ def test_factory_workflow_get_run_and_list_runs(factory_workflow_client):
     assert list_response.status_code == 200
     runs = list_response.json()
     assert any(run["run_id"] == run_id for run in runs)
+
+
+@pytest.fixture
+def websocket_factory_client(temp_storage_db_file):
+    """Create a WebSocket TestClient with an authorized workflow factory."""
+
+    secret = "x" * 40
+    os_id = "ws-factory-os"
+
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    def websocket_workflow_step(_: StepInput) -> StepOutput:
+        return StepOutput(content="ok")
+
+    def build_workflow(ctx):
+        assert ctx.trusted.claims
+        assert ctx.trusted.claims["sub"] == "alice"
+        assert "workflows:run" in ctx.trusted.scopes
+
+        return Workflow(
+            id="ws-factory",
+            name="ws-factory",
+            steps=[Step(name="s", executor=websocket_workflow_step)],
+            db=db,
+        )
+
+    app = AgentOS(
+        id=os_id,
+        workflows=[
+            WorkflowFactory(
+                id="ws-factory",
+                db=db,
+                factory=build_workflow,
+            )
+        ],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[secret],
+            algorithm="HS256",
+        ),
+        telemetry=False,
+    ).get_app()
+
+    with TestClient(app) as client:
+        yield {
+            "client": client,
+            "secret": secret,
+            "os_id": os_id,
+        }
+
+
+def test_websocket_workflow_factory_receives_trusted_jwt_context(
+    websocket_factory_client,
+):
+    """Test that workflow factories receive trusted JWT context over WebSocket."""
+
+    client = websocket_factory_client["client"]
+    secret = websocket_factory_client["secret"]
+    os_id = websocket_factory_client["os_id"]
+
+    token = jwt.encode(
+        {
+            "sub": "alice",
+            "aud": os_id,
+            "scopes": ["workflows:run"],
+            "exp": datetime.now(UTC) + timedelta(minutes=5),
+            "iat": datetime.now(UTC),
+        },
+        secret,
+        algorithm="HS256",
+    )
+
+    with client.websocket_connect("/workflows/ws") as ws:
+        connection_event = json.loads(ws.receive_text())
+        assert connection_event["event"] == "connected"
+
+        ws.send_text(
+            json.dumps(
+                {
+                    "action": "authenticate",
+                    "token": token,
+                }
+            )
+        )
+
+        authenticated = False
+
+        for _ in range(5):
+            frame = json.loads(ws.receive_text())
+            if (
+                frame.get("event") == "authenticated"
+                and frame.get("user_id") == "alice"
+            ):
+                authenticated = True
+                break
+
+        assert authenticated, "Did not receive authenticated event with user_id"
+
+        ws.send_text(
+            json.dumps(
+                {
+                    "action": "start-workflow",
+                    "workflow_id": "ws-factory",
+                    "message": "go",
+                }
+            )
+        )
+
+        response = ws.receive_text()
+
+        assert "event: WorkflowStarted" in response
+        assert '"workflow_id": "ws-factory"' in response 
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

This PR fixes the missing trusted JWT context propagation for WebSocket workflow factory runs.

Previously, authenticated WebSocket workflow runs did not pass the verified `websocket_user_context` to `handle_workflow_via_websocket()`. As a result, `WorkflowFactory` instances received an empty `ctx.trusted`, unlike the HTTP workflow execution path.

### Changes
- Pass `websocket_user_context` to `handle_workflow_via_websocket()`.
- Add an integration regression test verifying that authenticated WebSocket workflow factory runs receive trusted JWT claims and scopes.
- Verify that the workflow starts successfully after WebSocket authentication.

Fixes #8684

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added an integration regression test covering the WebSocket workflow factory path to prevent future regressions in trusted JWT context propagation.
