### PR TITLE
fix: rename StudioTool to StudioTools with backward-compatible alias

### DIFF
--- a/cookbook/05_agent_os/studio_tool/README.md
+++ b/cookbook/05_agent_os/studio_tool/README.md
@@ -1,16 +1,16 @@
 # Studio Cookbook
 
-Examples for composing AgentOS agents, teams, and workflows with `StudioTool`.
+Examples for composing AgentOS agents, teams, and workflows with `StudioTools`.
 
 ## Files
-- `standalone_studio_agent.py` — Runs a local agent with `StudioTool` and SQLite persistence, without starting AgentOS.
+- `standalone_studio_agent.py` — Runs a local agent with `StudioTools` and SQLite persistence, without starting AgentOS.
 - `studio_tools_agent.py` — Starts an AgentOS app with code-defined agents, registry primitives, and a Studio agent that can create/edit/version components.
 - `studio_hitl_agent.py` — Human-in-the-loop studio on the console: the agent pauses with a structured multi-select question for tool choice (`UserFeedbackTools`), asks for free-text instructions (`UserControlFlowTools`), and `create_agent` requires explicit user confirmation before anything is persisted.
 - `studio_hitl_agent_os.py` — The same HITL studio agent served through AgentOS: pauses surface through the AgentOS API/chat UI, which collects the answers and continues the run.
 
 ## Versioning
 
-Versioning tools (`list_versions`, `get_version`, `publish_component`, `set_current_version`, `delete_version`) are opt-in: pass `versions=True` to `StudioTool`. With versioning enabled, edits are saved as drafts that need `publish_component`; without it (the default), edits are published immediately as the new current version.
+Versioning tools (`list_versions`, `get_version`, `publish_component`, `set_current_version`, `delete_version`) are opt-in: pass `versions=True` to `StudioTools`. With versioning enabled, edits are saved as drafts that need `publish_component`; without it (the default), edits are published immediately as the new current version.
 
 ## Prerequisites
 - Load environment variables with `direnv allow` (requires `.envrc`).
@@ -33,7 +33,7 @@ Useful Studio routes:
 - Teams: `/studio/teams/edit?team_id=<component_id>`
 - Workflows: `/studio/workflows/edit?workflow_id=<component_id>`
 
-## Expected StudioTool Output
+## Expected StudioTools Output
 
 When the Studio agent creates or edits a component, the user-facing response should include:
 - `component_type`

--- a/cookbook/05_agent_os/studio_tool/TEST_LOG.md
+++ b/cookbook/05_agent_os/studio_tool/TEST_LOG.md
@@ -6,7 +6,7 @@
 
 **Status:** PASS
 
-**Description:** Standalone StudioTool agent backed by local SQLite persistence with `versions=True`. The agent created the `math-tutor` agent (published v1), edited it (draft v2), listed both versions, and published the draft to current.
+**Description:** Standalone StudioTools agent backed by local SQLite persistence with `versions=True`. The agent created the `math-tutor` agent (published v1), edited it (draft v2), listed both versions, and published the draft to current.
 
 **Result:** Full create -> edit -> list_versions -> publish lifecycle completed successfully.
 
@@ -16,7 +16,7 @@
 
 **Status:** PASS (smoke test)
 
-**Description:** AgentOS Studio example with registry primitives, code-defined agents, and StudioTool component CRUD/versioning. Verified by importing the module: the FastAPI app builds (107 routes, `/agents` present), `enable_versions` is True, and `publish_component` is registered on the studio toolkit.
+**Description:** AgentOS Studio example with registry primitives, code-defined agents, and StudioTools component CRUD/versioning. Verified by importing the module: the FastAPI app builds (107 routes, `/agents` present), `enable_versions` is True, and `publish_component` is registered on the studio toolkit.
 
 **Result:** App construction and tool registration verified. Interactive Studio UI flow not exercised.
 

--- a/cookbook/05_agent_os/studio_tool/standalone_studio_agent.py
+++ b/cookbook/05_agent_os/studio_tool/standalone_studio_agent.py
@@ -1,6 +1,6 @@
-"""Standalone StudioTool agent (no AgentOS).
+"""Standalone StudioTools agent (no AgentOS).
 
-A simple Agent that uses StudioTool to build, edit, version, and run other
+A simple Agent that uses StudioTools to build, edit, version, and run other
 agents backed by a local SQLite database. No AgentOS server, no REST, just
 in-process composition.
 
@@ -17,7 +17,7 @@ from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
-from agno.tools.studio import StudioTool
+from agno.tools.studio import StudioTools
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -35,7 +35,7 @@ studio_agent = Agent(
     name="Studio",
     model=Claude(id="claude-sonnet-4-5"),
     tools=[
-        StudioTool(registry=registry, db=db, default_model_id="gpt-5.5", versions=True)
+        StudioTools(registry=registry, db=db, default_model_id="gpt-5.5", versions=True)
     ],
     instructions=[
         "You help the user compose agents, teams, and workflows from registry primitives.",

--- a/cookbook/05_agent_os/studio_tool/studio_hitl_agent.py
+++ b/cookbook/05_agent_os/studio_tool/studio_hitl_agent.py
@@ -1,4 +1,4 @@
-"""StudioTool + human-in-the-loop -- ask before building, confirm before creating.
+"""StudioTools + human-in-the-loop -- ask before building, confirm before creating.
 
 The studio agent composes new agents from registry primitives, but it never
 guesses. Three HITL mechanisms work together:
@@ -33,7 +33,7 @@ from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.function import UserInputField
 from agno.tools.hackernews import HackerNewsTools
-from agno.tools.studio import StudioTool
+from agno.tools.studio import StudioTools
 from agno.tools.user_control_flow import UserControlFlowTools
 from agno.tools.user_feedback import UserFeedbackTools
 
@@ -56,7 +56,7 @@ studio_agent = Agent(
     name="Studio HITL",
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[
-        StudioTool(
+        StudioTools(
             registry=registry,
             db=db,
             default_model_id="gpt-5.5",

--- a/cookbook/05_agent_os/studio_tool/studio_hitl_agent_os.py
+++ b/cookbook/05_agent_os/studio_tool/studio_hitl_agent_os.py
@@ -1,4 +1,4 @@
-"""StudioTool + human-in-the-loop served through AgentOS.
+"""StudioTools + human-in-the-loop served through AgentOS.
 
 Same HITL studio agent as studio_hitl_agent.py, but running behind AgentOS:
 the run pauses surface through the AgentOS API and chat UI instead of the
@@ -29,7 +29,7 @@ from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.hackernews import HackerNewsTools
-from agno.tools.studio import StudioTool
+from agno.tools.studio import StudioTools
 from agno.tools.user_control_flow import UserControlFlowTools
 from agno.tools.user_feedback import UserFeedbackTools
 
@@ -53,7 +53,7 @@ studio_agent = Agent(
     name="Studio HITL",
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[
-        StudioTool(
+        StudioTools(
             registry=registry,
             db=db,
             default_model_id="gpt-5.5",

--- a/cookbook/05_agent_os/studio_tool/studio_tools_agent.py
+++ b/cookbook/05_agent_os/studio_tool/studio_tools_agent.py
@@ -1,6 +1,6 @@
-"""Agent with StudioTool -- let the agent compose new agents, teams, and workflows.
+"""Agent with StudioTools -- let the agent compose new agents, teams, and workflows.
 
-The StudioTool uses the AgentOS Registry (tools, models, dbs) and the core
+The StudioTools uses the AgentOS Registry (tools, models, dbs) and the core
 component APIs (Agent, Team, Workflow, Step) to dynamically build new
 components described by the user in natural language.
 
@@ -29,7 +29,7 @@ from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.hackernews import HackerNewsTools
-from agno.tools.studio import StudioTool
+from agno.tools.studio import StudioTools
 
 DB_DIR = Path(__file__).parent / "tmp"
 DB_DIR.mkdir(exist_ok=True)
@@ -68,7 +68,7 @@ studio_agent = Agent(
     name="Studio Agent",
     model=OpenAIResponses(id="gpt-5.5"),
     tools=[
-        StudioTool(
+        StudioTools(
             registry=registry,
             db=db,
             agents_list=[greeter, reporter],

--- a/libs/agno/agno/tools/studio.py
+++ b/libs/agno/agno/tools/studio.py
@@ -1,15 +1,15 @@
-"""StudioTool -- give agents the ability to compose agents, teams, and workflows.
+"""StudioTools -- give agents the ability to compose agents, teams, and workflows.
 
 Uses the AgentOS Registry (tools, models, dbs, functions) and the core
 component APIs (Agent, Team, Workflow, Step) to dynamically create, edit,
 version, and execute components described in natural language.
 
 Typical use:
-    from agno.tools.studio import StudioTool
+    from agno.tools.studio import StudioTools
 
     studio_agent = Agent(
         model=Claude(id="claude-sonnet-4-5"),
-        tools=[StudioTool(registry=registry, db=db)],
+        tools=[StudioTools(registry=registry, db=db)],
     )
 
     studio_agent.print_response(
@@ -66,7 +66,7 @@ Component = Union["Agent", "Team", "Workflow"]
 TeamMember = Union["Agent", "Team"]
 
 
-class StudioTool(Toolkit):
+class StudioTools(Toolkit):
     """Toolkit that lets an agent compose agents, teams, and workflows.
 
     Args:
@@ -432,7 +432,7 @@ class StudioTool(Toolkit):
             agent.db = self.db
             return agent
         except Exception:
-            logger.warning("StudioTool: Agent.from_dict failed for %s", agent_id, exc_info=True)
+            logger.warning("StudioTools: Agent.from_dict failed for %s", agent_id, exc_info=True)
             return None
 
     def _load_team_from_db(self, team_id: str, version: Optional[int] = None) -> Optional["Team"]:
@@ -449,7 +449,7 @@ class StudioTool(Toolkit):
             team.db = self.db
             return team
         except Exception:
-            logger.warning("StudioTool: Team.from_dict failed for %s", team_id, exc_info=True)
+            logger.warning("StudioTools: Team.from_dict failed for %s", team_id, exc_info=True)
             return None
 
     def _load_workflow_from_db(self, workflow_id: str, version: Optional[int] = None) -> Optional["Workflow"]:
@@ -466,7 +466,7 @@ class StudioTool(Toolkit):
             wf.db = self.db
             return wf
         except Exception:
-            logger.warning("StudioTool: Workflow.from_dict failed for %s", workflow_id, exc_info=True)
+            logger.warning("StudioTools: Workflow.from_dict failed for %s", workflow_id, exc_info=True)
             return None
 
     def _load_config_from_db(
@@ -816,7 +816,7 @@ class StudioTool(Toolkit):
             tools = self._resolve_tools(tool_names)
             db = self._find_db(db_id)
             if db is None:
-                message = f"Db not found: {db_id}" if db_id is not None else "StudioTool has no db configured."
+                message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
                 return json.dumps({"error": message})
 
             agent_id = self._unique_component_id(name, db)
@@ -831,7 +831,7 @@ class StudioTool(Toolkit):
             )
 
             version = _persist_only(agent, db)
-            log_debug(f"StudioTool created agent id={agent_id} version={version}")
+            log_debug(f"StudioTools created agent id={agent_id} version={version}")
             return json.dumps(
                 {
                     "status": "created",
@@ -883,7 +883,7 @@ class StudioTool(Toolkit):
 
             db = self._find_db(db_id)
             if db is None:
-                message = f"Db not found: {db_id}" if db_id is not None else "StudioTool has no db configured."
+                message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
                 return json.dumps({"error": message})
             team_id = self._unique_component_id(name, db)
             team = Team(
@@ -897,7 +897,7 @@ class StudioTool(Toolkit):
             )
 
             version = _persist_only(team, db)
-            log_debug(f"StudioTool created team id={team_id} members={member_ids} version={version}")
+            log_debug(f"StudioTools created team id={team_id} members={member_ids} version={version}")
             return json.dumps(
                 {
                     "status": "created",
@@ -940,7 +940,7 @@ class StudioTool(Toolkit):
 
             db = self._find_db(db_id)
             if db is None:
-                message = f"Db not found: {db_id}" if db_id is not None else "StudioTool has no db configured."
+                message = f"Db not found: {db_id}" if db_id is not None else "StudioTools has no db configured."
                 return json.dumps({"error": message})
             workflow_id = self._unique_component_id(name, db)
             workflow = Workflow(
@@ -952,7 +952,7 @@ class StudioTool(Toolkit):
             )
 
             version = _persist_only(workflow, db)
-            log_debug(f"StudioTool created workflow id={workflow_id} steps={len(steps)} version={version}")
+            log_debug(f"StudioTools created workflow id={workflow_id} steps={len(steps)} version={version}")
             return json.dumps(
                 {
                     "status": "created",
@@ -994,7 +994,7 @@ class StudioTool(Toolkit):
             description (Optional[str]): New description. Omit to keep.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured; cannot edit components."})
+            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
         if self._is_code_defined(agent_id, self._iter_agents()):
             return json.dumps(
                 {"error": f"Cannot edit code-defined agent: {agent_id}. Only Studio-created components are editable."}
@@ -1021,7 +1021,7 @@ class StudioTool(Toolkit):
                 agent.tools = self._resolve_tools(tool_names) or None
 
             result = self._save_edit(agent)
-            log_debug(f"StudioTool edited agent id={agent_id} result={result}")
+            log_debug(f"StudioTools edited agent id={agent_id} result={result}")
             return json.dumps({"status": "edited", "id": agent_id, **result})
         except Exception as e:
             logger.exception("Failed to edit agent")
@@ -1050,7 +1050,7 @@ class StudioTool(Toolkit):
             description (Optional[str]): New description. Omit to keep.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured; cannot edit components."})
+            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
         if self._is_code_defined(team_id, self._iter_teams()):
             return json.dumps(
                 {"error": f"Cannot edit code-defined team: {team_id}. Only Studio-created components are editable."}
@@ -1082,7 +1082,7 @@ class StudioTool(Toolkit):
                 team.members = members
 
             result = self._save_edit(team)
-            log_debug(f"StudioTool edited team id={team_id} result={result}")
+            log_debug(f"StudioTools edited team id={team_id} result={result}")
             return json.dumps({"status": "edited", "id": team_id, **result})
         except Exception as e:
             logger.exception("Failed to edit team")
@@ -1108,7 +1108,7 @@ class StudioTool(Toolkit):
                 Same shape as create_workflow.step_specs.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured; cannot edit components."})
+            return json.dumps({"error": "StudioTools has no db configured; cannot edit components."})
         if self._is_code_defined(workflow_id, self._iter_workflows()):
             return json.dumps(
                 {
@@ -1133,7 +1133,7 @@ class StudioTool(Toolkit):
                 wf.steps = steps
 
             result = self._save_edit(wf)
-            log_debug(f"StudioTool edited workflow id={workflow_id} result={result}")
+            log_debug(f"StudioTools edited workflow id={workflow_id} result={result}")
             return json.dumps({"status": "edited", "id": workflow_id, **result})
         except Exception as e:
             logger.exception("Failed to edit workflow")
@@ -1150,7 +1150,7 @@ class StudioTool(Toolkit):
             component_id (str): The component id.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."})
         try:
             component = self.db.get_component(component_id) or {}
             current_version = component.get("current_version")
@@ -1178,7 +1178,7 @@ class StudioTool(Toolkit):
             version (Optional[int]): Version number, or omit for the current version.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."})
         try:
             config = self.db.get_config(component_id=component_id, version=version)
             if config is None:
@@ -1198,7 +1198,7 @@ class StudioTool(Toolkit):
                 returns status "already_published".
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."})
         try:
             configs = self.db.list_configs(component_id, include_config=False)
             target = version
@@ -1238,7 +1238,7 @@ class StudioTool(Toolkit):
             version (int): A published version to set as current.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."})
         try:
             ok = self.db.set_current_version(component_id, version=version)
             if not ok:
@@ -1256,7 +1256,7 @@ class StudioTool(Toolkit):
             version (int): The draft version to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured."})
+            return json.dumps({"error": "StudioTools has no db configured."})
         try:
             deleted = self.db.delete_config(component_id, version=version)
             if not deleted:
@@ -1277,7 +1277,7 @@ class StudioTool(Toolkit):
             agent_id (str): The id of the agent to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured; cannot delete components."})
+            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
         try:
             from agno.db.base import ComponentType
 
@@ -1299,7 +1299,7 @@ class StudioTool(Toolkit):
             team_id (str): The id of the team to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured; cannot delete components."})
+            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
         try:
             from agno.db.base import ComponentType
 
@@ -1321,7 +1321,7 @@ class StudioTool(Toolkit):
             workflow_id (str): The id of the workflow to delete.
         """
         if self.db is None:
-            return json.dumps({"error": "StudioTool has no db configured; cannot delete components."})
+            return json.dumps({"error": "StudioTools has no db configured; cannot delete components."})
         try:
             from agno.db.base import ComponentType
 
@@ -1887,3 +1887,8 @@ def _component_to_dict(component: Component) -> Dict[str, Any]:
     if isinstance(component, Workflow):
         return component.to_dict()
     raise TypeError(f"Unsupported component type: {type(component).__name__}")
+
+
+# Backward-compatible alias. The toolkit was originally released as ``StudioTool``
+# (singular); ``StudioTools`` is the canonical name. Both refer to the same class.
+StudioTool = StudioTools

--- a/libs/agno/tests/unit/tools/test_studio.py
+++ b/libs/agno/tests/unit/tools/test_studio.py
@@ -1,4 +1,4 @@
-"""Unit tests for StudioTool toolkit.
+"""Unit tests for StudioTools toolkit.
 
 Uses a real SqliteDb backed by a pytest tmp_path so the full component +
 config persistence path is exercised, not mocked.
@@ -16,7 +16,7 @@ from agno.models.openai import OpenAIResponses
 from agno.registry import Registry
 from agno.tools.calculator import CalculatorTools
 from agno.tools.duckduckgo import DuckDuckGoTools
-from agno.tools.studio import StudioTool
+from agno.tools.studio import StudioTools
 
 # ----------------------------------------------------------------------
 # Fixtures
@@ -40,16 +40,35 @@ def registry(db):
 
 @pytest.fixture
 def studio(registry, db):
-    return StudioTool(registry=registry, db=db)
+    return StudioTools(registry=registry, db=db)
 
 
 @pytest.fixture
 def studio_versioned(registry, db):
-    return StudioTool(registry=registry, db=db, versions=True)
+    return StudioTools(registry=registry, db=db, versions=True)
 
 
 def _loads(s: str) -> Dict[str, Any]:
     return json.loads(s)
+
+
+# ----------------------------------------------------------------------
+# Backward-compatible alias
+# ----------------------------------------------------------------------
+
+
+class TestStudioToolAlias:
+    def test_singular_alias_resolves_to_canonical_class(self):
+        from agno.tools.studio import StudioTool
+
+        assert StudioTool is StudioTools
+
+    def test_alias_constructs_a_working_toolkit(self, registry, db):
+        from agno.tools.studio import StudioTool
+
+        tool = StudioTool(registry=registry, db=db)
+        assert isinstance(tool, StudioTools)
+        assert "create_agent" in tool.functions
 
 
 # ----------------------------------------------------------------------
@@ -103,17 +122,17 @@ class TestInitialization:
         assert "published immediately" not in studio_versioned.instructions
 
     def test_instructions_include_component_rules_only_when_enabled(self, registry, db):
-        default = StudioTool(registry=registry, db=db)
+        default = StudioTools(registry=registry, db=db)
         assert "Team rules" not in default.instructions
         assert "Workflow rules" not in default.instructions
 
-        full = StudioTool(registry=registry, db=db, teams=True, workflows=True)
+        full = StudioTools(registry=registry, db=db, teams=True, workflows=True)
         assert "Team rules" in full.instructions
         assert "Workflow rules" in full.instructions
 
     def test_add_instructions_defaults_on_and_respects_override(self, registry, db):
-        assert StudioTool(registry=registry, db=db).add_instructions is True
-        assert StudioTool(registry=registry, db=db, add_instructions=False).add_instructions is False
+        assert StudioTools(registry=registry, db=db).add_instructions is True
+        assert StudioTools(registry=registry, db=db, add_instructions=False).add_instructions is False
 
     def test_default_does_not_register_team_or_workflow_tools(self, studio):
         names = set(studio.functions.keys())
@@ -127,17 +146,17 @@ class TestInitialization:
         assert "run_workflow" not in studio.async_functions
 
     def test_registers_all_async_run_tools_when_enabled(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, teams=True, workflows=True)
+        tool = StudioTools(registry=registry, db=db, teams=True, workflows=True)
         assert {"run_agent", "run_team", "run_workflow"}.issubset(set(tool.async_functions.keys()))
         assert set(tool.async_functions.keys()) == set(tool.functions.keys())
 
     def test_db_defaults_to_first_registry_db(self, registry):
-        tool = StudioTool(registry=registry)
+        tool = StudioTools(registry=registry)
         assert tool.db is registry.dbs[0]
 
     def test_explicit_db_overrides_registry(self, registry, db):
         other = SqliteDb(id="other", db_file=":memory:")
-        tool = StudioTool(registry=registry, db=other)
+        tool = StudioTools(registry=registry, db=other)
         assert tool.db is other
 
 
@@ -167,7 +186,7 @@ class TestDiscovery:
             return value.upper()
 
         registry.functions.append(transform_content)
-        studio = StudioTool(registry=registry, db=db)
+        studio = StudioTools(registry=registry, db=db)
 
         result = _loads(studio.list_functions())
         assert result["count"] == 1
@@ -182,7 +201,7 @@ class TestDiscovery:
 
     def test_list_agents_includes_studio_created_db_components(self, registry, db):
         code_agent = Agent(id="code-only", name="Code Only", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTool(registry=registry, db=db, agents_list=[code_agent])
+        tool = StudioTools(registry=registry, db=db, agents_list=[code_agent])
         tool.create_agent(name="math-king", instructions="i", model_id="gpt-5.4")
 
         result = _loads(tool.list_agents())
@@ -191,11 +210,11 @@ class TestDiscovery:
         assert ids.get("math-king") == "db"
 
     def test_list_agents_dedupes_when_code_shadows_db(self, registry, db):
-        tool = StudioTool(registry=registry, db=db)
+        tool = StudioTools(registry=registry, db=db)
         tool.create_agent(name="shared", instructions="i", model_id="gpt-5.4")
 
         code_agent = Agent(id="shared", name="Shared Code", model=OpenAIResponses(id="gpt-5.4"))
-        tool2 = StudioTool(registry=registry, db=db, agents_list=[code_agent])
+        tool2 = StudioTools(registry=registry, db=db, agents_list=[code_agent])
 
         result = _loads(tool2.list_agents())
         shared_entries = [a for a in result["agents"] if a["id"] == "shared"]
@@ -203,11 +222,11 @@ class TestDiscovery:
         assert shared_entries[0]["source"] == "code"
 
     def test_list_agents_dedupes_code_without_id_by_name(self, registry, db):
-        tool = StudioTool(registry=registry, db=db)
+        tool = StudioTools(registry=registry, db=db)
         tool.create_agent(name="Shared Name", instructions="i", model_id="gpt-5.4")
 
         code_agent = Agent(name="Shared Name", model=OpenAIResponses(id="gpt-5.4"))
-        tool2 = StudioTool(registry=registry, db=db, agents_list=[code_agent])
+        tool2 = StudioTools(registry=registry, db=db, agents_list=[code_agent])
 
         result = _loads(tool2.list_agents())
         shared_entries = [a for a in result["agents"] if a["name"] == "Shared Name"]
@@ -215,7 +234,7 @@ class TestDiscovery:
         assert shared_entries[0]["source"] == "code"
 
     def test_list_teams_includes_db_components(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, teams=True)
+        tool = StudioTools(registry=registry, db=db, teams=True)
         tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
         tool.create_team(name="squad", instructions="i", member_ids=["a1"], model_id="gpt-5.4")
 
@@ -224,7 +243,7 @@ class TestDiscovery:
         assert ids.get("squad") == "db"
 
     def test_list_workflows_includes_db_components(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, workflows=True)
+        tool = StudioTools(registry=registry, db=db, workflows=True)
         tool.create_agent(name="a1", instructions="i", model_id="gpt-5.4")
         tool.create_workflow(name="pipeline", description="d", step_specs=[{"name": "s1", "agent_id": "a1"}])
 
@@ -624,7 +643,7 @@ class TestDelete:
         assert "error" in out
 
     def test_delete_agent_only_deletes_db_component_when_live_agent_shadows_id(self, registry, db):
-        studio = StudioTool(registry=registry, db=db)
+        studio = StudioTools(registry=registry, db=db)
         studio.create_agent(name="temp", instructions="i", model_id="gpt-5.4")
 
         class ShadowAgent:
@@ -634,7 +653,7 @@ class TestDelete:
             def delete(self, **kwargs):
                 raise AssertionError("delete_agent should not call delete() on live agents")
 
-        tool = StudioTool(registry=registry, db=db, agents_list=[ShadowAgent()])
+        tool = StudioTools(registry=registry, db=db, agents_list=[ShadowAgent()])
 
         out = _loads(tool.delete_agent("temp"))
         assert out["status"] == "deleted"
@@ -655,13 +674,13 @@ class TestLookup:
 
     def test_find_agent_falls_back_to_live_list(self, registry, db):
         live = Agent(id="live-one", name="Live", model=OpenAIResponses(id="gpt-5.4"), db=db)
-        tool = StudioTool(registry=registry, db=db, agents_list=[live])
+        tool = StudioTools(registry=registry, db=db, agents_list=[live])
         found = tool._find_agent("live-one")
         assert found is live
 
     def test_find_agent_falls_back_to_db(self, studio, registry, db):
         studio.create_agent(name="persisted", instructions="i", model_id="gpt-5.4")
-        fresh = StudioTool(registry=registry, db=db)
+        fresh = StudioTools(registry=registry, db=db)
         found = fresh._find_agent("persisted")
         assert found is not None
         assert found.id == "persisted"
@@ -672,7 +691,7 @@ class TestLookup:
         # silently returning "edited" (review findings 9-12).
         studio.create_agent(name="shared", instructions="db", model_id="gpt-5.4")
         live = Agent(id="shared", name="Shared", model=OpenAIResponses(id="gpt-5.4"), instructions="live")
-        tool = StudioTool(registry=registry, db=db, agents_list=[live], versions=True)
+        tool = StudioTools(registry=registry, db=db, agents_list=[live], versions=True)
 
         out = _loads(tool.edit_agent(agent_id="shared", instructions="updated-live"))
 
@@ -688,7 +707,7 @@ class TestLookup:
 
 class TestTypeGuards:
     def _full(self, registry, db):
-        return StudioTool(registry=registry, db=db, teams=True, workflows=True)
+        return StudioTools(registry=registry, db=db, teams=True, workflows=True)
 
     def test_get_agent_rejects_team_id(self, registry, db):
         tool = self._full(registry, db)
@@ -753,7 +772,7 @@ class TestTypeGuards:
 
 class TestEnableFlags:
     def test_default_enables_agents_only(self, registry, db):
-        tool = StudioTool(registry=registry, db=db)
+        tool = StudioTools(registry=registry, db=db)
         assert tool.enable_agents is True
         assert tool.enable_teams is False
         assert tool.enable_workflows is False
@@ -763,7 +782,7 @@ class TestEnableFlags:
         assert "create_workflow" not in names
 
     def test_opt_in_teams(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, teams=True)
+        tool = StudioTools(registry=registry, db=db, teams=True)
         assert tool.enable_agents is True  # agents stays on by default
         assert tool.enable_teams is True
         assert tool.enable_workflows is False
@@ -771,7 +790,7 @@ class TestEnableFlags:
         assert "create_team" in names
 
     def test_agents_disabled_explicitly(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, agents=False, teams=True)
+        tool = StudioTools(registry=registry, db=db, agents=False, teams=True)
         assert tool.enable_agents is False
         assert tool.enable_teams is True
         names = set(tool.functions.keys())
@@ -779,7 +798,7 @@ class TestEnableFlags:
         assert "create_team" in names
 
     def test_workflows_only(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, agents=False, workflows=True)
+        tool = StudioTools(registry=registry, db=db, agents=False, workflows=True)
         assert tool.enable_agents is False
         assert tool.enable_teams is False
         assert tool.enable_workflows is True
@@ -788,23 +807,23 @@ class TestEnableFlags:
         assert "create_agent" not in names
 
     def test_agents_list_auto_enables_teams_and_workflows(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, agents_list=[])
+        tool = StudioTools(registry=registry, db=db, agents_list=[])
         assert tool.enable_agents is True
         assert tool.enable_teams is True
         assert tool.enable_workflows is True
 
     def test_teams_list_auto_enables_workflows(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, teams_list=[])
+        tool = StudioTools(registry=registry, db=db, teams_list=[])
         assert tool.enable_workflows is True
 
     def test_explicit_flag_overrides_auto_enable(self, registry, db):
         # User passes agents_list but explicitly disables workflows.
-        tool = StudioTool(registry=registry, db=db, agents_list=[], workflows=False)
+        tool = StudioTools(registry=registry, db=db, agents_list=[], workflows=False)
         assert tool.enable_workflows is False
 
     def test_discovery_tools_always_registered(self, registry, db):
         # Even with everything disabled, discovery tools stay registered.
-        tool = StudioTool(registry=registry, db=db, agents=False)
+        tool = StudioTools(registry=registry, db=db, agents=False)
         names = set(tool.functions.keys())
         assert {
             "list_models",
@@ -840,14 +859,14 @@ class _StubAgent:
 
 class TestRunSerialization:
     def test_run_agent_serializes_non_json_content(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, agents_list=[_StubAgent()])
+        tool = StudioTools(registry=registry, db=db, agents_list=[_StubAgent()])
         out = _loads(tool.run_agent("stub", "hi"))
         assert "error" not in out
         assert out["content"].startswith("2026-01-01")
 
     @pytest.mark.asyncio
     async def test_arun_agent_serializes_non_json_content(self, registry, db):
-        tool = StudioTool(registry=registry, db=db, agents_list=[_StubAgent()])
+        tool = StudioTools(registry=registry, db=db, agents_list=[_StubAgent()])
         out = _loads(await tool.arun_agent("stub", "hi"))
         assert "error" not in out
         assert out["content"].startswith("2026-01-01")
@@ -861,7 +880,7 @@ class TestRunSerialization:
 class TestNoCascadePersistence:
     def test_create_team_does_not_persist_code_defined_member(self, registry, db):
         greeter = Agent(id="greeter-code", name="Greeter", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTool(registry=registry, db=db, agents_list=[greeter])
+        tool = StudioTools(registry=registry, db=db, agents_list=[greeter])
 
         tool.create_agent(name="studio-agent", instructions="i", model_id="gpt-5.4")
         tool.create_team(
@@ -880,7 +899,7 @@ class TestNoCascadePersistence:
 
     def test_create_workflow_does_not_persist_code_defined_agent(self, registry, db):
         greeter = Agent(id="greeter-code", name="Greeter", model=OpenAIResponses(id="gpt-5.4"))
-        tool = StudioTool(registry=registry, db=db, agents_list=[greeter])
+        tool = StudioTools(registry=registry, db=db, agents_list=[greeter])
 
         tool.create_workflow(
             name="wf",


### PR DESCRIPTION
## Summary

The Studio toolkit shipped as `StudioTool` (singular) in v2.6.19/v2.6.20, but the Toolkit naming convention across the framework is plural (125 `*Tools` classes vs 2 `*Tool`). This renames the class to `StudioTools` (canonical) and keeps `StudioTool` as a plain alias so existing imports keep working.

No deprecation warning is emitted — both names resolve to the same class:

```python
from agno.tools.studio import StudioTools  # canonical
from agno.tools.studio import StudioTool   # still works, same class
```

Changes:
- `libs/agno/agno/tools/studio.py` — class renamed to `StudioTools`; `StudioTool = StudioTools` alias added at module end.
- `libs/agno/tests/unit/tools/test_studio.py` — switched usages to `StudioTools`; added `TestStudioToolAlias` pinning the alias (`StudioTool is StudioTools` and constructs a working toolkit).
- Cookbooks + README/TEST_LOG updated to the canonical `StudioTools`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`StudioTool` was released in v2.6.19 and v2.6.20, so the alias preserves backward compatibility for anyone already importing the singular name. All 88 studio unit tests pass, including the 2 new alias tests.