### PR TITLE
fix: enforce target scopes for AgentOS schedules

### DIFF
--- a/libs/agno/agno/os/routers/schedules/router.py
+++ b/libs/agno/agno/os/routers/schedules/router.py
@@ -1,12 +1,16 @@
 """Schedule API router -- CRUD + trigger for cron schedules."""
 
 import asyncio
+import fnmatch
+import re
 import time
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
+from urllib.parse import unquote, urlsplit
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
+from agno.os.auth import build_insufficient_permissions_detail
 from agno.os.routers.schedules.schema import (
     ScheduleCreate,
     ScheduleResponse,
@@ -15,6 +19,7 @@ from agno.os.routers.schedules.schema import (
     ScheduleUpdate,
 )
 from agno.os.schema import PaginatedResponse, PaginationInfo
+from agno.os.scopes import get_default_scope_mappings, has_required_scopes
 from agno.utils.log import log_info
 
 # Valid DB method names that _db_call can invoke
@@ -28,6 +33,63 @@ _SchedulerDbMethod = Literal[
     "get_schedule_run",
     "get_schedule_runs",
 ]
+
+_TARGET_SCOPE_MAPPINGS = get_default_scope_mappings()
+
+
+def _get_required_scopes_for_target(method: str, endpoint: str) -> List[str]:
+    """Resolve the AgentOS scopes required by a scheduled target endpoint."""
+    target_path = unquote(urlsplit(endpoint).path).rstrip("/") or "/"
+    route_key = f"{method.upper()} {target_path}"
+
+    if route_key in _TARGET_SCOPE_MAPPINGS:
+        return _TARGET_SCOPE_MAPPINGS[route_key]
+
+    for pattern, scopes in _TARGET_SCOPE_MAPPINGS.items():
+        pattern_method, pattern_path = pattern.split(" ", 1)
+        if pattern_method != method.upper():
+            continue
+
+        normalized_pattern = re.sub(r"\{[^}]+\}", "*", pattern_path)
+        if fnmatch.fnmatch(target_path, normalized_pattern):
+            return scopes
+
+    return []
+
+
+def _extract_target_resource_context(endpoint: str) -> tuple[Optional[str], Optional[str]]:
+    """Return the resource type/id used for per-resource scope checks."""
+    target_path = unquote(urlsplit(endpoint).path)
+    match = re.match(r"^/(agents|teams|workflows)/([^/]+)(?:/|$)", target_path)
+    if match is None:
+        return None, None
+    return match.group(1), match.group(2)
+
+
+def _require_target_endpoint_scopes(request: Request, method: str, endpoint: str) -> None:
+    """Ensure the caller can access the endpoint a schedule will execute."""
+    if not getattr(request.state, "authorization_enabled", False):
+        return
+
+    required_scopes = _get_required_scopes_for_target(method, endpoint)
+    if not required_scopes:
+        return
+
+    resource_type, resource_id = _extract_target_resource_context(endpoint)
+    user_scopes = getattr(request.state, "scopes", [])
+    admin_scope_raw = getattr(request.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+
+    if has_required_scopes(
+        user_scopes,
+        required_scopes,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        admin_scope=admin_scope,
+    ):
+        return
+
+    raise HTTPException(status_code=403, detail=build_insufficient_permissions_detail(required_scopes))
 
 
 def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
@@ -96,6 +158,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
     @router.post("/schedules", response_model=ScheduleResponse, status_code=201)
     async def create_schedule(
         body: ScheduleCreate,
+        request: Request,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
         _check_scheduler_deps()
@@ -105,6 +168,8 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
             raise HTTPException(status_code=422, detail=f"Invalid cron expression: {body.cron_expr}")
         if not validate_timezone(body.timezone):
             raise HTTPException(status_code=422, detail=f"Invalid timezone: {body.timezone}")
+
+        _require_target_endpoint_scopes(request, body.method, body.endpoint)
 
         # Check name uniqueness
         existing = await _db_call("get_schedule_by_name", body.name)
@@ -153,6 +218,7 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
     async def update_schedule(
         schedule_id: str,
         body: ScheduleUpdate,
+        request: Request,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
         existing = await _db_call("get_schedule", schedule_id)
@@ -162,6 +228,10 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
         updates = body.model_dump(exclude_unset=True)
         if not updates:
             return existing
+
+        target_method = updates.get("method", existing["method"])
+        target_endpoint = updates.get("endpoint", existing["endpoint"])
+        _require_target_endpoint_scopes(request, target_method, target_endpoint)
 
         # Validate cron/timezone if changing
         cron_changed = "cron_expr" in updates or "timezone" in updates
@@ -204,11 +274,14 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
     @router.post("/schedules/{schedule_id}/enable", response_model=ScheduleStateResponse)
     async def enable_schedule(
         schedule_id: str,
+        request: Request,
         _: bool = Depends(auth_dependency),
     ) -> Dict[str, Any]:
         existing = await _db_call("get_schedule", schedule_id)
         if existing is None:
             raise HTTPException(status_code=404, detail="Schedule not found")
+
+        _require_target_endpoint_scopes(request, existing.get("method", "POST"), existing["endpoint"])
 
         _check_scheduler_deps()
         from agno.scheduler.cron import compute_next_run
@@ -247,6 +320,8 @@ def get_schedule_router(os_db: Any, settings: Any) -> APIRouter:
 
         if not existing.get("enabled", True):
             raise HTTPException(status_code=409, detail="Schedule is disabled")
+
+        _require_target_endpoint_scopes(request, existing.get("method", "POST"), existing["endpoint"])
 
         executor = getattr(request.app.state, "scheduler_executor", None)
         if executor is not None:

--- a/libs/agno/tests/unit/os/routers/test_schedules_router.py
+++ b/libs/agno/tests/unit/os/routers/test_schedules_router.py
@@ -3,10 +3,12 @@
 import time
 from unittest.mock import MagicMock, patch
 
+import jwt
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from agno.os.middleware.jwt import JWTMiddleware
 from agno.os.routers.schedules import get_schedule_router
 from agno.os.settings import AgnoAPISettings
 
@@ -68,6 +70,18 @@ def client(mock_db, settings):
     router = get_schedule_router(os_db=mock_db, settings=settings)
     app.include_router(router)
     return TestClient(app)
+
+
+def _make_auth_client(mock_db):
+    app = FastAPI()
+    app.include_router(get_schedule_router(os_db=mock_db, settings=AgnoAPISettings(authorization_enabled=True)))
+    app.add_middleware(JWTMiddleware, validate=False, authorization=True)
+    return TestClient(app)
+
+
+def _auth_headers(scopes):
+    token = jwt.encode({"sub": "schedule-writer", "scopes": scopes}, key=None, algorithm="none")
+    return {"Authorization": f"Bearer {token}"}
 
 
 # =============================================================================
@@ -161,6 +175,80 @@ class TestCreateSchedule:
         assert resp.status_code == 409
         assert "already exists" in resp.json()["detail"]
 
+    @patch("agno.scheduler.cron._require_pytz")
+    @patch("agno.scheduler.cron._require_croniter")
+    @patch("agno.scheduler.cron.validate_cron_expr", return_value=True)
+    @patch("agno.scheduler.cron.validate_timezone", return_value=True)
+    @patch("agno.scheduler.cron.compute_next_run", return_value=int(time.time()) + 60)
+    def test_create_rejects_target_endpoint_without_required_scope(
+        self, mock_compute, mock_tz, mock_cron, mock_req_cron, mock_req_pytz, mock_db
+    ):
+        client = _make_auth_client(mock_db)
+
+        resp = client.post(
+            "/schedules",
+            json={
+                "name": "agent-hop",
+                "cron_expr": "0 9 * * *",
+                "endpoint": "/agents/secret-agent/runs",
+            },
+            headers=_auth_headers(["schedules:write"]),
+        )
+
+        assert resp.status_code == 403
+        assert "agents:run" in resp.json()["detail"]
+        mock_db.create_schedule.assert_not_called()
+
+    @patch("agno.scheduler.cron._require_pytz")
+    @patch("agno.scheduler.cron._require_croniter")
+    @patch("agno.scheduler.cron.validate_cron_expr", return_value=True)
+    @patch("agno.scheduler.cron.validate_timezone", return_value=True)
+    @patch("agno.scheduler.cron.compute_next_run", return_value=int(time.time()) + 60)
+    def test_create_rejects_url_encoded_target_endpoint_without_required_scope(
+        self, mock_compute, mock_tz, mock_cron, mock_req_cron, mock_req_pytz, mock_db
+    ):
+        client = _make_auth_client(mock_db)
+
+        resp = client.post(
+            "/schedules",
+            json={
+                "name": "agent-hop-encoded",
+                "cron_expr": "0 9 * * *",
+                "endpoint": "/agents/secret-agent/%72uns",
+            },
+            headers=_auth_headers(["schedules:write"]),
+        )
+
+        assert resp.status_code == 403
+        assert "agents:run" in resp.json()["detail"]
+        mock_db.create_schedule.assert_not_called()
+
+    @patch("agno.scheduler.cron._require_pytz")
+    @patch("agno.scheduler.cron._require_croniter")
+    @patch("agno.scheduler.cron.validate_cron_expr", return_value=True)
+    @patch("agno.scheduler.cron.validate_timezone", return_value=True)
+    @patch("agno.scheduler.cron.compute_next_run", return_value=int(time.time()) + 60)
+    def test_create_allows_target_endpoint_with_required_scope(
+        self, mock_compute, mock_tz, mock_cron, mock_req_cron, mock_req_pytz, mock_db
+    ):
+        client = _make_auth_client(mock_db)
+        created = _make_schedule_dict(name="agent-hop", endpoint="/agents/secret-agent/runs")
+        mock_db.create_schedule = MagicMock(return_value=created)
+
+        resp = client.post(
+            "/schedules",
+            json={
+                "name": "agent-hop",
+                "cron_expr": "0 9 * * *",
+                "endpoint": "/agents/secret-agent/runs",
+            },
+            headers=_auth_headers(["schedules:write", "agents:secret-agent:run"]),
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["endpoint"] == "/agents/secret-agent/runs"
+        mock_db.create_schedule.assert_called_once()
+
 
 # =============================================================================
 # Tests: GET /schedules/{schedule_id}
@@ -253,6 +341,23 @@ class TestEnableSchedule:
         resp = client.post("/schedules/missing/enable")
         assert resp.status_code == 404
 
+    @patch("agno.scheduler.cron._require_pytz")
+    @patch("agno.scheduler.cron._require_croniter")
+    @patch("agno.scheduler.cron.compute_next_run", return_value=int(time.time()) + 60)
+    def test_enable_rejects_target_endpoint_without_required_scope(
+        self, mock_compute, mock_req_cron, mock_req_pytz, mock_db
+    ):
+        client = _make_auth_client(mock_db)
+        mock_db.get_schedule = MagicMock(
+            return_value=_make_schedule_dict(enabled=False, endpoint="/agents/secret-agent/runs")
+        )
+
+        resp = client.post("/schedules/sched-1/enable", headers=_auth_headers(["schedules:write"]))
+
+        assert resp.status_code == 403
+        assert "agents:run" in resp.json()["detail"]
+        mock_db.update_schedule.assert_not_called()
+
 
 # =============================================================================
 # Tests: POST /schedules/{schedule_id}/disable
@@ -293,6 +398,15 @@ class TestTriggerSchedule:
         resp = client.post("/schedules/sched-1/trigger")
         assert resp.status_code == 409
         assert "disabled" in resp.json()["detail"].lower()
+
+    def test_trigger_rejects_target_endpoint_without_required_scope(self, mock_db):
+        client = _make_auth_client(mock_db)
+        mock_db.get_schedule = MagicMock(return_value=_make_schedule_dict(endpoint="/agents/secret-agent/runs"))
+
+        resp = client.post("/schedules/sched-1/trigger", headers=_auth_headers(["schedules:write"]))
+
+        assert resp.status_code == 403
+        assert "agents:run" in resp.json()["detail"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #8640.

AgentOS schedule create/update/enable/trigger now checks the scopes required by the stored target endpoint before the scheduler can execute it with the internal scheduler token. A caller with only `schedules:write` can no longer create or manually arm a schedule that runs `/agents/{id}/runs`, `/teams/{id}/runs`, `/workflows/{id}/runs`, or `DELETE /schedules/{id}` unless their token also has the target endpoint's required scope.

The target-scope check reuses the existing AgentOS scope map and `has_required_scopes` behavior, including per-resource scopes such as `agents:secret-agent:run`. The matcher normalizes query strings, trailing slashes, and one percent-decode pass before checking the target path so encoded route segments like `%72uns` are not missed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

No cookbook update: this is a focused AgentOS RBAC security fix, not a new user-facing scheduling pattern.

Duplicate/overlap check:

- Open PR search for `8640`: no PRs.
- Open PR search for `ScheduleExecutor`: only #8499, which fixes scheduler polling backoff for #8498 and does not address target endpoint authorization.
- Open PR search for `schedules:write`: no PRs.
- Supersedes target / old-attempt gap:

- #8499 fixes scheduler polling backoff for transient executor errors. It does not enforce target endpoint scopes before a schedule is created, enabled, or triggered, so it would still leave #8640's privilege-escalation path open. This PR is narrower for #8640: it leaves polling behavior untouched and only gates scheduled target endpoints against the existing AgentOS scope map.

Related PR #8245 targets `feat/v3.0` and broad user isolation for schedules/metrics. It does not add main-branch target endpoint scope checks for schedule create/update/enable/trigger. This PR is a narrow main-branch RBAC fix for #8640.

Validation:

```bash
# RED before implementation
uv run --with pytest --with fastapi --with PyJWT --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with httpx --with starlette --with croniter --with pytz -- python -m pytest libs/agno/tests/unit/os/routers/test_schedules_router.py::TestCreateSchedule::test_create_rejects_target_endpoint_without_required_scope libs/agno/tests/unit/os/routers/test_schedules_router.py::TestTriggerSchedule::test_trigger_rejects_target_endpoint_without_required_scope -q
# Result before fix: 2 failed

# RED for second-agent enable-path finding
uv run --no-project --with pytest --with pytest-asyncio --with-editable libs/agno --with fastapi --with PyJWT --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with httpx --with starlette --with croniter --with pytz -- python -m pytest libs/agno/tests/unit/os/routers/test_schedules_router.py::TestEnableSchedule::test_enable_rejects_target_endpoint_without_required_scope -q
# Result before enable fix: 1 failed

# RED for encoded target path hardening
uv run --no-project --with pytest --with pytest-asyncio --with-editable libs/agno --with fastapi --with PyJWT --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with httpx --with starlette --with croniter --with pytz -- python -m pytest libs/agno/tests/unit/os/routers/test_schedules_router.py::TestCreateSchedule::test_create_rejects_url_encoded_target_endpoint_without_required_scope -q
# Result before encoded-path fix: 1 failed

# Focused unit suite after fix
uv run --no-project --with pytest --with pytest-asyncio --with-editable libs/agno --with fastapi --with PyJWT --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with httpx --with starlette --with croniter --with pytz -- python -m pytest libs/agno/tests/unit/os/routers/test_schedules_router.py -q
# Result: 33 passed, 34 warnings

# Formatting and lint
uv run --with ruff==0.14.3 -- ruff format --check --config libs/agno/pyproject.toml libs/agno/agno/os/routers/schedules/router.py libs/agno/tests/unit/os/routers/test_schedules_router.py
uv run --with ruff==0.14.3 -- ruff check --config libs/agno/pyproject.toml libs/agno/agno/os/routers/schedules/router.py libs/agno/tests/unit/os/routers/test_schedules_router.py
# Result: formatted, all checks passed

# Focused type check
uv run --no-project --with mypy --with-editable libs/agno --with fastapi --with PyJWT --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with httpx --with starlette --with croniter --with pytz -- python -m mypy libs/agno/agno/os/routers/schedules/router.py --config-file libs/agno/pyproject.toml --follow-imports=silent
# Result: Success, no issues found in 1 source file

# Whitespace/static diff check
git diff --check
# Result: passed
```

API QA:

```bash
uv run --no-project --with-editable libs/agno --with fastapi --with PyJWT --with pydantic --with pydantic-settings --with python-dotenv --with pyyaml --with rich --with typer --with typing-extensions --with docstring-parser --with gitpython --with python-multipart --with packaging --with h11 --with httpx --with starlette --with croniter --with pytz -- python /tmp/agno_scheduler_scope_qa.py
```

Result:

```text
blocked_agent_create 403 Insufficient permissions. Required scope(s): agents:run
allowed_agent_create 201 /agents/secret-agent/runs
blocked_delete_create 403 Insufficient permissions. Required scope(s): schedules:delete
allowed_delete_create 201 /schedules/a7d9123f-be89-47f0-acc0-f652bc7d452d
blocked_agent_enable 403 Insufficient permissions. Required scope(s): agents:run
blocked_agent_trigger 403 Insufficient permissions. Required scope(s): agents:run
```

Notes on repository-wide scripts:

- I did not run full `./scripts/format.sh` / `./scripts/validate.sh` because this daily lane used focused gates for the two touched files. Focused pytest, ruff, mypy, API QA, and `git diff --check` passed.

Second-agent review:

- Reviewer used: `claude -p` on `/tmp/oss-pr-second-agent-review.diff`.
- First pass: CLEAN with a high-priority non-blocking note that enabling an existing disabled privileged schedule should also re-check the target scope.
- Fix applied: `POST /schedules/{id}/enable` now re-checks the target endpoint before arming the schedule, with a regression test.
- Second pass: CLEAN with a non-blocking note to harden encoded route matching.
- Fix applied: target matching now percent-decodes the scheduled path once before resolving required scopes, with a regression test for `/agents/secret-agent/%72uns`.
- Final pass: `CLEAN — no blocking findings`.

AI assistance disclosure: this PR was prepared with Hermes Agent and reviewed with a fresh-context Claude reviewer.
