### PR TITLE
fix: constrain Google Drive download filenames

### DIFF
--- a/libs/agno/agno/tools/google/drive.py
+++ b/libs/agno/agno/tools/google/drive.py
@@ -43,8 +43,10 @@ from os import getenv
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Union, cast
 
+from agno.exceptions import PathSecurityError
 from agno.tools.google.auth import google_authenticate
 from agno.tools.google.base import GoogleToolkit
+from agno.utils.path_safety import safe_join_filename
 from agno.utils.log import log_debug, log_error, log_warning
 
 try:
@@ -720,7 +722,10 @@ class GoogleDriveTools(GoogleToolkit):
             service = cast(Resource, self.service)
             metadata = self._get_file_metadata(file_id, "id,name,mimeType")
             mime_type = metadata.get("mimeType", "")
-            path = self.download_dir / metadata.get("name", file_id)
+            try:
+                path = safe_join_filename(self.download_dir, metadata.get("name", file_id))
+            except PathSecurityError as e:
+                return json.dumps({"error": f"Invalid file name from Google Drive: {e}", "file": metadata})
 
             # Resolve export target — user override > auto-detect > None for regular files
             if export_format:

--- a/libs/agno/tests/unit/tools/test_google_drive.py
+++ b/libs/agno/tests/unit/tools/test_google_drive.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -263,6 +264,24 @@ def test_download_file_success(tmp_path, drive_tools):
     assert result["status"] == "downloaded"
     assert result["fileId"] == "abc123"
     assert "file.txt" in result["path"]
+    assert Path(result["path"]).resolve().parent == tmp_path.resolve()
+
+
+@pytest.mark.parametrize("drive_name", ("../../escape.txt", r"..\..\escape.txt"))
+def test_download_file_sanitizes_path_components(tmp_path, drive_tools, drive_name):
+    drive_tools.download_dir = tmp_path
+    drive_tools.service.files.return_value.get.return_value.execute.return_value = {
+        "id": "abc123",
+        "name": drive_name,
+        "mimeType": "text/plain",
+    }
+    mock_downloader = MagicMock()
+    mock_downloader.next_chunk.side_effect = [(MagicMock(progress=lambda: 1.0), True)]
+    with patch("agno.tools.google.drive.MediaIoBaseDownload", return_value=mock_downloader):
+        result = json.loads(drive_tools.download_file("abc123"))
+    assert result["status"] == "downloaded"
+    assert "escape.txt" in result["path"]
+    assert Path(result["path"]).resolve().parent == tmp_path.resolve()
 
 
 def test_download_file_error(tmp_path, drive_tools):


### PR DESCRIPTION
## Summary
- sanitize Google Drive metadata names before saving downloaded files
- keep downloaded files within the configured download_dir
- add regression coverage for path components with both POSIX and Windows separators

Fixes #8701

## Tests
- .venv\Scripts\python.exe -m pytest libs\agno\tests\unit\tools\test_google_drive.py -q -k download_file
- .venv\Scripts\ruff.exe check libs\agno\agno\tools\google\drive.py libs\agno\tests\unit\tools\test_google_drive.py