### PR TITLE
fix: URL knowledge ingestion ignores `Reader(chunk=False)` and chunks docs

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1613,11 +1613,7 @@ class Knowledge(RemoteKnowledge):
             await self._aupdate_content(content)
             return
 
-        # 6. Chunk documents if needed
-        if reader and not reader.chunk:
-            read_documents = await reader.chunk_documents_async(read_documents)
-
-        # 7. Group documents by source URL for multi-page readers (like WebsiteReader)
+        # 6. Group documents by source URL for multi-page readers (like WebsiteReader)
         docs_by_source: Dict[str, List[Document]] = {}
         for doc in read_documents:
             source_url = doc.meta_data.get("url", content.url) if doc.meta_data else content.url
@@ -1772,11 +1768,7 @@ class Knowledge(RemoteKnowledge):
             self._update_content(content)
             return
 
-        # 6. Chunk documents if needed (sync version)
-        if reader:
-            read_documents = self._chunk_documents_sync(reader, read_documents)
-
-        # 7. Group documents by source URL for multi-page readers (like WebsiteReader)
+        # 6. Group documents by source URL for multi-page readers (like WebsiteReader)
         docs_by_source: Dict[str, List[Document]] = {}
         for doc in read_documents:
             source_url = doc.meta_data.get("url", content.url) if doc.meta_data else content.url

--- a/libs/agno/agno/knowledge/reader/arxiv_reader.py
+++ b/libs/agno/agno/knowledge/reader/arxiv_reader.py
@@ -69,14 +69,16 @@ class ArxivReader(Reader):
         for result in self.get_client().results(search):
             links = ", ".join([x.href for x in result.links])
 
-            documents.append(
-                Document(
-                    name=result.title,
-                    id=result.title,
-                    meta_data={"pdf_url": str(result.pdf_url), "article_links": links},
-                    content=result.summary,
-                )
+            document = Document(
+                name=result.title,
+                id=result.title,
+                meta_data={"pdf_url": str(result.pdf_url), "article_links": links},
+                content=result.summary,
             )
+            if self.chunk:
+                documents.extend(self.chunk_document(document))
+            else:
+                documents.append(document)
 
         return documents
 

--- a/libs/agno/agno/knowledge/reader/base.py
+++ b/libs/agno/agno/knowledge/reader/base.py
@@ -57,9 +57,18 @@ class Reader:
             raise ValueError(f"Failed to set chunking strategy: {e}")
 
     def read(self, obj: Any, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+        """Read ``obj`` and return the resulting documents.
+
+        Subclasses must honor ``self.chunk``. When ``self.chunk``
+        is True, apply ``self.chunk_document`` to each document before returning;
+        when False, return whole documents unchanged. Ingestion does not chunk on
+        the reader's behalf, so a reader that ignores ``self.chunk`` will silently
+        drop the caller's chunking preference.
+        """
         raise NotImplementedError
 
     async def async_read(self, obj: Any, name: Optional[str] = None, password: Optional[str] = None) -> List[Document]:
+        """Async variant of :meth:`read`. Subclasses must honor ``self.chunk`` (see :meth:`read`)."""
         raise NotImplementedError
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/s3_reader.py
+++ b/libs/agno/agno/knowledge/reader/s3_reader.py
@@ -53,6 +53,14 @@ class S3Reader(Reader):
     def get_supported_content_types(cls) -> List[ContentType]:
         return [ContentType.FILE, ContentType.URL, ContentType.TEXT]
 
+    def _inner_reader(self, reader_cls):
+        """Build the inner reader, propagating this reader's chunking configuration"""
+        return reader_cls(
+            chunk=self.chunk,
+            chunk_size=self.chunk_size,
+            chunking_strategy=self.chunking_strategy,
+        )
+
     def read(self, name: Optional[str], s3_object: S3Object) -> List[Document]:
         try:
             log_debug(f"Reading S3 file: {s3_object.uri}")
@@ -63,14 +71,14 @@ class S3Reader(Reader):
             if s3_object.uri.endswith(".pdf"):
                 object_resource = s3_object.get_resource()
                 object_body = object_resource.get()["Body"]
-                return PDFReader().read(pdf=BytesIO(object_body.read()), name=doc_name)
+                return self._inner_reader(PDFReader).read(pdf=BytesIO(object_body.read()), name=doc_name)
 
             # Read text files
             else:
                 obj_name = s3_object.name.split("/")[-1]
                 temporary_file = Path("storage").joinpath(obj_name)
                 s3_object.download(temporary_file)
-                documents = TextReader().read(file=temporary_file, name=doc_name)
+                documents = self._inner_reader(TextReader).read(file=temporary_file, name=doc_name)
                 temporary_file.unlink()
                 return documents
 

--- a/libs/agno/agno/knowledge/reader/wikipedia_reader.py
+++ b/libs/agno/agno/knowledge/reader/wikipedia_reader.py
@@ -52,13 +52,14 @@ class WikipediaReader(Reader):
 
         # Only create Document if we successfully got a summary
         if summary:
-            return [
-                Document(
-                    name=topic,
-                    meta_data={"topic": topic},
-                    content=summary,
-                )
-            ]
+            document = Document(
+                name=topic,
+                meta_data={"topic": topic},
+                content=summary,
+            )
+            if self.chunk:
+                return self.chunk_document(document)
+            return [document]
         return []
 
     async def async_read(self, topic: str) -> List[Document]:
@@ -83,11 +84,12 @@ class WikipediaReader(Reader):
 
         # Only create Document if we successfully got a summary
         if summary:
-            return [
-                Document(
-                    name=topic,
-                    meta_data={"topic": topic},
-                    content=summary,
-                )
-            ]
+            document = Document(
+                name=topic,
+                meta_data={"topic": topic},
+                content=summary,
+            )
+            if self.chunk:
+                return self.chunk_document(document)
+            return [document]
         return []

--- a/libs/agno/tests/unit/knowledge/chunking/test_reader_chunk_flag.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_reader_chunk_flag.py
@@ -1,0 +1,104 @@
+"""Tests that URL/topic readers honor their own ``self.chunk`` flag"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+# Content long enough that fixed-size chunking splits it into several chunks.
+LONG_TEXT = "word " * 2000
+
+
+def test_arxiv_reader_chunks_when_chunk_true():
+    """chunk=True -> ArxivReader chunks each summary into multiple documents."""
+    pytest.importorskip("arxiv")
+    from agno.knowledge.reader.arxiv_reader import ArxivReader
+
+    result = SimpleNamespace(
+        title="A Paper",
+        summary=LONG_TEXT,
+        pdf_url="https://arxiv.org/pdf/1234.5678",
+        links=[SimpleNamespace(href="https://arxiv.org/abs/1234.5678")],
+    )
+    reader = ArxivReader(chunk=True)
+    with patch.object(reader, "get_client") as get_client:
+        get_client.return_value.results.return_value = [result]
+        docs = reader.read("quantum")
+
+    assert len(docs) > 1
+
+
+def test_arxiv_reader_keeps_whole_document_when_chunk_false():
+    """chunk=False -> ArxivReader returns each summary as a single whole document."""
+    pytest.importorskip("arxiv")
+    from agno.knowledge.reader.arxiv_reader import ArxivReader
+
+    result = SimpleNamespace(
+        title="A Paper",
+        summary=LONG_TEXT,
+        pdf_url="https://arxiv.org/pdf/1234.5678",
+        links=[SimpleNamespace(href="https://arxiv.org/abs/1234.5678")],
+    )
+    reader = ArxivReader(chunk=False)
+    with patch.object(reader, "get_client") as get_client:
+        get_client.return_value.results.return_value = [result]
+        docs = reader.read("quantum")
+
+    assert len(docs) == 1
+
+
+def test_wikipedia_reader_chunks_when_chunk_true():
+    """chunk=True -> WikipediaReader chunks the summary into multiple documents."""
+    pytest.importorskip("wikipedia")
+    from agno.knowledge.reader.wikipedia_reader import WikipediaReader
+
+    reader = WikipediaReader(chunk=True)
+    with patch("agno.knowledge.reader.wikipedia_reader.wikipedia") as wiki:
+        wiki.summary.return_value = LONG_TEXT
+        docs = reader.read("Python")
+
+    assert len(docs) > 1
+
+
+def test_wikipedia_reader_keeps_whole_document_when_chunk_false():
+    """chunk=False -> WikipediaReader returns the summary as a single whole document."""
+    pytest.importorskip("wikipedia")
+    from agno.knowledge.reader.wikipedia_reader import WikipediaReader
+
+    reader = WikipediaReader(chunk=False)
+    with patch("agno.knowledge.reader.wikipedia_reader.wikipedia") as wiki:
+        wiki.summary.return_value = LONG_TEXT
+        docs = reader.read("Python")
+
+    assert len(docs) == 1
+
+
+@pytest.mark.asyncio
+async def test_wikipedia_reader_async_respects_chunk_false():
+    """Async path: chunk=False -> WikipediaReader returns a single whole document."""
+    pytest.importorskip("wikipedia")
+    from agno.knowledge.reader.wikipedia_reader import WikipediaReader
+
+    reader = WikipediaReader(chunk=False)
+    with patch("agno.knowledge.reader.wikipedia_reader.wikipedia") as wiki:
+        wiki.summary.return_value = LONG_TEXT
+        docs = await reader.async_read("Python")
+
+    assert len(docs) == 1
+
+
+def test_s3_reader_propagates_chunk_flag_to_inner_reader():
+    """S3Reader must forward chunk/chunk_size/chunking_strategy to its inner reader."""
+    s3_module = pytest.importorskip("agno.knowledge.reader.s3_reader", exc_type=ImportError)
+    from agno.knowledge.chunking.fixed import FixedSizeChunking
+    from agno.knowledge.reader.text_reader import TextReader
+
+    strategy = FixedSizeChunking(chunk_size=123)
+    reader = s3_module.S3Reader(chunk=False, chunk_size=123, chunking_strategy=strategy)
+
+    # The inner reader must inherit the S3Reader's chunking configuration; without
+    # this it would default to chunk=True and ignore S3Reader(chunk=False).
+    text_reader = reader._inner_reader(TextReader)
+    assert text_reader.chunk is False
+    assert text_reader.chunk_size == 123
+    assert text_reader.chunking_strategy is strategy

--- a/libs/agno/tests/unit/knowledge/chunking/test_reader_chunk_flag.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_reader_chunk_flag.py
@@ -89,12 +89,14 @@ async def test_wikipedia_reader_async_respects_chunk_false():
 
 def test_s3_reader_propagates_chunk_flag_to_inner_reader():
     """S3Reader must forward chunk/chunk_size/chunking_strategy to its inner reader."""
-    s3_module = pytest.importorskip("agno.knowledge.reader.s3_reader", exc_type=ImportError)
+    pytest.importorskip("agno.knowledge.reader.s3_reader", exc_type=ImportError)
+
+    from agno.knowledge.reader.s3_reader import S3Reader
     from agno.knowledge.chunking.fixed import FixedSizeChunking
     from agno.knowledge.reader.text_reader import TextReader
 
     strategy = FixedSizeChunking(chunk_size=123)
-    reader = s3_module.S3Reader(chunk=False, chunk_size=123, chunking_strategy=strategy)
+    reader = S3Reader(chunk=False, chunk_size=123, chunking_strategy=strategy)
 
     # The inner reader must inherit the S3Reader's chunking configuration; without
     # this it would default to chunk=True and ignore S3Reader(chunk=False).

--- a/libs/agno/tests/unit/knowledge/chunking/test_url_ingestion_chunk_flag.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_url_ingestion_chunk_flag.py
@@ -1,0 +1,178 @@
+"""Tests URL ingestion which must respect Reader(chunk=...)"""
+
+from typing import List, Optional
+
+import pytest
+
+from agno.knowledge.content import Content
+from agno.knowledge.document.base import Document
+from agno.knowledge.knowledge import Knowledge
+from agno.knowledge.reader.base import Reader
+from agno.knowledge.types import ContentType
+from agno.vectordb.base import VectorDb
+
+
+class CapturingVectorDb(VectorDb):
+    """VectorDb stub that records the documents handed to insert/upsert."""
+
+    def __init__(self):
+        self.inserted_documents: List[Document] = []
+
+    def create(self) -> None:
+        pass
+
+    async def async_create(self) -> None:
+        pass
+
+    def name_exists(self, name: str) -> bool:
+        return False
+
+    def async_name_exists(self, name: str) -> bool:
+        return False
+
+    def id_exists(self, id: str) -> bool:
+        return False
+
+    def content_hash_exists(self, content_hash: str) -> bool:
+        return False
+
+    def insert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    async def async_insert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    def upsert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    async def async_upsert(self, content_hash: str, documents, filters=None) -> None:
+        self.inserted_documents.extend(documents)
+
+    def upsert_available(self) -> bool:
+        return False
+
+    def search(self, query: str, limit: int = 5, filters=None):
+        return []
+
+    async def async_search(self, query: str, limit: int = 5, filters=None):
+        return []
+
+    def drop(self) -> None:
+        pass
+
+    async def async_drop(self) -> None:
+        pass
+
+    def exists(self) -> bool:
+        return True
+
+    async def async_exists(self) -> bool:
+        return True
+
+    def delete(self) -> bool:
+        return True
+
+    def delete_by_id(self, id: str) -> bool:
+        return True
+
+    def delete_by_name(self, name: str) -> bool:
+        return True
+
+    def delete_by_metadata(self, metadata) -> bool:
+        return True
+
+    def delete_by_content_id(self, content_id: str) -> bool:
+        return True
+
+    def update_metadata(self, content_id: str, metadata) -> None:
+        pass
+
+    def get_supported_search_types(self):
+        return ["vector"]
+
+
+class FakeUrlReader(Reader):
+    """URL reader that returns a single whole document and honours self.chunk.
+
+    Advertises ContentType.URL so the ingestion path skips network download and
+    calls the reader with the URL directly."""
+
+    @classmethod
+    def get_supported_chunking_strategies(cls):
+        from agno.knowledge.chunking.strategy import ChunkingStrategyType
+
+        return [ChunkingStrategyType.FIXED_SIZE_CHUNKER]
+
+    @classmethod
+    def get_supported_content_types(cls):
+        return [ContentType.URL]
+
+    def _build_documents(self, name: Optional[str]) -> List[Document]:
+        # Long enough that fixed-size chunking would split it into many pieces.
+        content = "word " * 2000
+        document = Document(name=name or "doc", id="doc-1", content=content)
+        if self.chunk:
+            return self.chunk_document(document)
+        return [document]
+
+    def read(self, obj, name=None, password=None) -> List[Document]:
+        return self._build_documents(name)
+
+    async def async_read(self, obj, name=None, password=None) -> List[Document]:
+        return self._build_documents(name)
+
+
+def _make_content(reader: Reader) -> Content:
+    return Content(url="https://example.com/page", reader=reader)
+
+
+def test_sync_url_ingestion_respects_chunk_false():
+    """chunk=False -> the single whole document is inserted unchanged."""
+    vector_db = CapturingVectorDb()
+    knowledge = Knowledge(vector_db=vector_db)
+    reader = FakeUrlReader(chunk=False)
+
+    knowledge._load_from_url(_make_content(reader), upsert=False, skip_if_exists=False)
+
+    assert len(vector_db.inserted_documents) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_url_ingestion_respects_chunk_false():
+    """Async path: chunk=False -> exactly one document inserted."""
+    vector_db = CapturingVectorDb()
+    knowledge = Knowledge(vector_db=vector_db)
+    reader = FakeUrlReader(chunk=False)
+
+    await knowledge._aload_from_url(_make_content(reader), upsert=False, skip_if_exists=False)
+
+    assert len(vector_db.inserted_documents) == 1
+
+
+def test_sync_url_ingestion_does_not_double_chunk_when_chunk_true():
+    """chunk=True -> reader chunks once; URL path must not re-chunk on top of that."""
+    vector_db = CapturingVectorDb()
+    knowledge = Knowledge(vector_db=vector_db)
+
+    reader = FakeUrlReader(chunk=True)
+    expected = len(reader.read("https://example.com/page", name="doc"))
+
+    knowledge._load_from_url(_make_content(reader), upsert=False, skip_if_exists=False)
+
+    assert expected > 1  # sanity: the content really is chunkable
+    assert len(vector_db.inserted_documents) == expected
+
+
+@pytest.mark.asyncio
+async def test_async_url_ingestion_does_not_double_chunk_when_chunk_true():
+    """Async path: chunk=True -> reader chunks once; no extra chunking on top."""
+    vector_db = CapturingVectorDb()
+    knowledge = Knowledge(vector_db=vector_db)
+
+    reader = FakeUrlReader(chunk=True)
+    expected = len(await reader.async_read("https://example.com/page", name="doc"))
+
+    await knowledge._aload_from_url(_make_content(reader), upsert=False, skip_if_exists=False)
+
+    assert expected > 1
+    assert len(vector_db.inserted_documents) == expected


### PR DESCRIPTION
## Summary

URL knowledge ingestion applied its own post-read chunking step ignoring the reader's `chunk` flag.                                                                                                                                                          
                                                                                                                                                                                                                     
Readers already chunk internally inside `read()`/`async_read()` when `chunk=True`, so any post-read chunking in the URL path is both redundant and wrongly conditioned.                                                                                                                

The path-based and text-content ingestion paths already do the right thing and rely on the reader; this PR changes makes URL ingestion consistent with them.  

Closes #8667.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
