### PR TITLE
fix: WorkflowMetrics.from_dict raises KeyError on older/partial metrics payload

### DIFF
--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -681,9 +681,9 @@ class StepMetrics:
                 metrics = metrics_data
 
         return cls(
-            step_name=data["step_name"],
-            executor_type=data["executor_type"],
-            executor_name=data["executor_name"],
+            step_name=data.get("step_name", ""),
+            executor_type=data.get("executor_type", ""),
+            executor_name=data.get("executor_name", ""),
             metrics=metrics,
         )
 
@@ -709,7 +709,7 @@ class WorkflowMetrics:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "WorkflowMetrics":
         """Create WorkflowMetrics from dictionary"""
-        steps = {name: StepMetrics.from_dict(step_data) for name, step_data in data["steps"].items()}
+        steps = {name: StepMetrics.from_dict(step_data) for name, step_data in data.get("steps", {}).items()}
 
         return cls(
             steps=steps,

--- a/libs/agno/tests/unit/workflow/test_metrics_serialization.py
+++ b/libs/agno/tests/unit/workflow/test_metrics_serialization.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for WorkflowMetrics and StepMetrics serialization/deserialization."""
+
+from agno.workflow.types import StepMetrics, WorkflowMetrics
+
+# =============================================================================
+# WorkflowMetrics.from_dict backward compatibility
+# =============================================================================
+
+
+def test_workflow_metrics_from_dict_missing_steps():
+    """Older payloads may not include a "steps" key at all.
+
+    This used to raise KeyError: 'steps'.
+    """
+    metrics = WorkflowMetrics.from_dict({"duration": 1.23})
+
+    assert metrics.steps == {}
+    assert metrics.duration == 1.23
+
+
+def test_workflow_metrics_from_dict_empty():
+    """A completely empty payload should not crash."""
+    metrics = WorkflowMetrics.from_dict({})
+
+    assert metrics.steps == {}
+    assert metrics.duration is None
+
+
+def test_workflow_metrics_from_dict_roundtrip():
+    """A normally-serialized payload should deserialize with steps intact."""
+    payload = {
+        "steps": {
+            "step_1": {
+                "step_name": "step_1",
+                "executor_type": "agent",
+                "executor_name": "my_agent",
+                "metrics": None,
+            }
+        },
+        "duration": 2.5,
+    }
+
+    metrics = WorkflowMetrics.from_dict(payload)
+
+    assert set(metrics.steps.keys()) == {"step_1"}
+    assert metrics.steps["step_1"].step_name == "step_1"
+    assert metrics.steps["step_1"].executor_type == "agent"
+    assert metrics.steps["step_1"].executor_name == "my_agent"
+    assert metrics.duration == 2.5
+
+
+# =============================================================================
+# StepMetrics.from_dict backward compatibility
+# =============================================================================
+
+
+def test_step_metrics_from_dict_missing_required_fields():
+    """Older/partial step payloads may omit required fields.
+
+    This used to raise KeyError on step_name/executor_type/executor_name.
+    """
+    step = StepMetrics.from_dict({})
+
+    assert step.step_name == ""
+    assert step.executor_type == ""
+    assert step.executor_name == ""
+    assert step.metrics is None
+
+
+def test_step_metrics_from_dict_partial_fields():
+    """A payload with only some fields present should fill the rest with defaults."""
+    step = StepMetrics.from_dict({"step_name": "step_1"})
+
+    assert step.step_name == "step_1"
+    assert step.executor_type == ""
+    assert step.executor_name == ""


### PR DESCRIPTION
## Summary

`WorkflowMetrics.from_dict()` accessed `data["steps"]` via direct subscript, so deserializing any persisted metrics dict that lacks a `"steps"` key raised KeyError: 'steps'`.  

We get errors in demo-os due to this:

```
File ".../agno/workflow/types.py", line 712, in from_dict
    steps = {name: StepMetrics.from_dict(step_data) for name, step_data in data["steps"].items()}
KeyError: 'steps'
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
