### PR TITLE
[fix] PandasTools: restrict create_pandas_dataframe to safe constructors (block read_pickle RCE)

### DIFF
--- a/libs/agno/agno/tools/pandas.py
+++ b/libs/agno/agno/tools/pandas.py
@@ -70,9 +70,6 @@ class PandasTools(Toolkit):
             if dataframe_name in self.dataframes:
                 return f"Dataframe already exists: {dataframe_name}"
 
-            # Only allow a fixed set of safe constructors. This blocks reaching
-            # pd.read_pickle (untrusted deserialization -> RCE) and any other
-            # non-constructor callable via model-controlled input.
             if create_using_function not in _ALLOWED_CREATE_FUNCS:
                 return f"Error creating dataframe: unsupported function '{create_using_function}'"
             create_fn = getattr(pd, create_using_function, None)
@@ -117,7 +114,6 @@ class PandasTools(Toolkit):
             if dataframe is None:
                 return f"Error running operation: dataframe not found: {dataframe_name}"
 
-            # Reject private/dunder attributes and code-executing / arbitrary-write methods.
             if operation.startswith("_") or operation in _BLOCKED_DF_OPERATIONS:
                 return f"Error running operation: unsupported operation '{operation}'"
             operation_fn = getattr(dataframe, operation, None)

--- a/libs/agno/agno/tools/pandas.py
+++ b/libs/agno/agno/tools/pandas.py
@@ -9,6 +9,26 @@ except ImportError:
     raise ImportError("`pandas` not installed. Please install using `pip install pandas`.")
 
 
+# Only these top-level pandas constructors may be invoked from model-controlled input.
+# read_pickle / read_hdf are intentionally excluded: they deserialize untrusted data
+# (pickle) and can lead to remote code execution.
+_ALLOWED_CREATE_FUNCS = {
+    "DataFrame",
+    "read_csv",
+    "read_json",
+    "read_excel",
+    "read_parquet",
+    "read_table",
+    "read_html",
+    "read_feather",
+    "read_orc",
+    "read_xml",
+}
+
+# DataFrame methods that execute code or (de)serialize to arbitrary locations.
+_BLOCKED_DF_OPERATIONS = {"query", "eval", "to_pickle", "to_hdf"}
+
+
 class PandasTools(Toolkit):
     def __init__(
         self,
@@ -50,8 +70,17 @@ class PandasTools(Toolkit):
             if dataframe_name in self.dataframes:
                 return f"Dataframe already exists: {dataframe_name}"
 
+            # Only allow a fixed set of safe constructors. This blocks reaching
+            # pd.read_pickle (untrusted deserialization -> RCE) and any other
+            # non-constructor callable via model-controlled input.
+            if create_using_function not in _ALLOWED_CREATE_FUNCS:
+                return f"Error creating dataframe: unsupported function '{create_using_function}'"
+            create_fn = getattr(pd, create_using_function, None)
+            if not callable(create_fn):
+                return f"Error creating dataframe: unsupported function '{create_using_function}'"
+
             # Create the dataframe
-            dataframe = getattr(pd, create_using_function)(**function_parameters)
+            dataframe = create_fn(**function_parameters)
             if dataframe is None:
                 return f"Error creating dataframe: {dataframe_name}"
             if not isinstance(dataframe, pd.DataFrame):
@@ -85,9 +114,18 @@ class PandasTools(Toolkit):
 
             # Get the dataframe
             dataframe = self.dataframes.get(dataframe_name)
+            if dataframe is None:
+                return f"Error running operation: dataframe not found: {dataframe_name}"
+
+            # Reject private/dunder attributes and code-executing / arbitrary-write methods.
+            if operation.startswith("_") or operation in _BLOCKED_DF_OPERATIONS:
+                return f"Error running operation: unsupported operation '{operation}'"
+            operation_fn = getattr(dataframe, operation, None)
+            if not callable(operation_fn):
+                return f"Error running operation: unsupported operation '{operation}'"
 
             # Run the operation
-            result = getattr(dataframe, operation)(**operation_parameters)
+            result = operation_fn(**operation_parameters)
 
             log_debug(f"Ran operation: {operation}")
             try:

--- a/libs/agno/tests/unit/tools/test_pandas.py
+++ b/libs/agno/tests/unit/tools/test_pandas.py
@@ -83,3 +83,48 @@ def test_run_dataframe_operation(pandas_tools):
         dataframe_name="nonexistent_df", operation="head", operation_parameters={"n": 2}
     )
     assert "Error running operation:" in result
+
+
+def test_create_pandas_dataframe_rejects_read_pickle(pandas_tools, tmp_path):
+    """Security regression: read_pickle (untrusted deserialization) must be rejected, never executed."""
+    import os
+    import pickle
+
+    marker = tmp_path / "pwned"
+
+    class _Evil:
+        def __reduce__(self):
+            return (os.system, (f"echo pwned > {marker}",))
+
+    payload = tmp_path / "evil.pkl"
+    payload.write_bytes(pickle.dumps(_Evil()))
+
+    result = pandas_tools.create_pandas_dataframe(
+        dataframe_name="x",
+        create_using_function="read_pickle",
+        function_parameters={"filepath_or_buffer": str(payload)},
+    )
+    assert "unsupported function" in result
+    assert not marker.exists()  # deserialization payload must not run
+
+
+def test_create_pandas_dataframe_allows_safe_reader(pandas_tools, tmp_path):
+    csv = tmp_path / "data.csv"
+    csv.write_text("a,b\n1,2\n")
+    result = pandas_tools.create_pandas_dataframe(
+        dataframe_name="csv_df",
+        create_using_function="read_csv",
+        function_parameters={"filepath_or_buffer": str(csv)},
+    )
+    assert result == "csv_df"
+
+
+def test_run_dataframe_operation_blocks_dangerous_ops(pandas_tools):
+    pandas_tools.create_pandas_dataframe(
+        dataframe_name="df", create_using_function="DataFrame", function_parameters={"data": {"a": [1, 2]}}
+    )
+    for op in ("query", "eval", "to_pickle", "__class__"):
+        result = pandas_tools.run_dataframe_operation(
+            dataframe_name="df", operation=op, operation_parameters={}
+        )
+        assert "unsupported operation" in result


### PR DESCRIPTION
## Summary

Fixes #8699.

`PandasTools.create_pandas_dataframe` picked the pandas callable from a model-controlled string and invoked it with model-controlled kwargs: `getattr(pd, create_using_function)(**function_parameters)`. A prompt-injection-controlled model could choose `read_pickle` and pass an attacker path/URL, so `pandas.read_pickle` would deserialize untrusted data and run a `__reduce__` payload (remote code execution). The same `getattr` pattern in `run_dataframe_operation` also exposed code-executing / arbitrary-write methods (`query`, `eval`, `to_pickle`).

## Fix

- Restrict `create_using_function` to an allowlist of safe constructors (`DataFrame`, `read_csv`, `read_json`, `read_excel`, `read_parquet`, `read_table`, `read_html`, `read_feather`, `read_orc`, `read_xml`). `read_pickle` and `read_hdf` are intentionally excluded.
- In `run_dataframe_operation`, reject private/dunder attributes and code-executing / serialize methods (`query`, `eval`, `to_pickle`, `to_hdf`), and require the resolved attribute to be callable.
- Error messages stay backward compatible (`Error creating dataframe: ...` / `Error running operation: ...`), so existing behaviour and tests are preserved.

## Tests

Added to `libs/agno/tests/unit/tools/test_pandas.py`:
- `read_pickle` is rejected and the pickle `__reduce__` payload never runs (the marker file is not created).
- A safe reader (`read_csv`) still works.
- `run_dataframe_operation` blocks `query` / `eval` / `to_pickle` / dunder ops.

Existing tests are unchanged and still pass. Verified locally: `pytest libs/agno/tests/unit/tools/test_pandas.py` (6 passed), plus `ruff check` and `ruff format --check` clean.

## AI disclosure

Prepared with my own AI-assisted security-research tooling (a setup I build and fine-tune on my own datasets and tests). I manually reviewed and verified this change, and the tests above pass locally.