### PR TITLE
fix: preserve async-generator identity when wrapping tools with validate_call

### DIFF
--- a/cookbook/91_tools/async_generator_tool_with_pydantic_args.py
+++ b/cookbook/91_tools/async_generator_tool_with_pydantic_args.py
@@ -1,0 +1,175 @@
+"""
+Async generator tools with Pydantic BaseModel arguments
+=======================================================
+
+Demonstrates that async generator tools (`async def` + `yield`) correctly
+receive Pydantic BaseModel instances when the LLM passes a JSON object for a
+model-typed parameter. Previously (pre-fix for #8711), the parameter arrived
+as a raw dict on the async path only, producing
+`AttributeError: 'dict' object has no attribute '...'` on the first attribute
+access. Sync generator tools already worked.
+
+This cookbook shows three tools on the same `Toolkit`:
+
+  1. `sync_search`  - `def` + `yield` (sync generator)
+  2. `async_search` - `async def` + `yield` (async generator, the fixed path)
+  3. `async_search_no_yield` - `async def` returning a value (coroutine)
+
+All three declare a Pydantic model as their `params` argument. The agent is
+prompted to invoke each; every tool observes `params` as a real `SearchParams`
+instance and can access `.query`, `.time_range`, and `.num_results`
+attribute-style. Custom events yielded from the generator tools stream out.
+"""
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.run.agent import CustomEvent
+from agno.tools import Toolkit
+from pydantic import BaseModel, Field
+
+
+class SearchParams(BaseModel):
+    """Parameters for the search tools. Deserialization of this model from a
+    JSON object supplied by the LLM is what #8711 was about."""
+
+    query: str
+    time_range: Literal["OneDay", "OneWeek", "OneMonth", "OneYear", "NoLimit"] = (
+        "NoLimit"
+    )
+    num_results: int = Field(default=10, ge=1, le=50)
+
+
+@dataclass
+class SearchProgressEvent(CustomEvent):
+    """CustomEvent emitted by the streaming tools as they make progress."""
+
+    tool_name: Optional[str] = None
+    query: Optional[str] = None
+    stage: Optional[str] = None
+
+
+class SearchToolkit(Toolkit):
+    """Toolkit demonstrating sync-gen, async-gen, and async-coroutine tools
+    that all take a Pydantic BaseModel as an argument."""
+
+    def __init__(self):
+        super().__init__(
+            name="search_toolkit",
+            tools=[self.sync_search, self.async_search, self.async_search_no_yield],
+        )
+
+    def sync_search(self, params: SearchParams):
+        """Sync generator: yields progress events, then a final result payload.
+
+        Args:
+            params: Search parameters (query, time range, num results).
+        """
+        # Attribute access proves `params` is a SearchParams, not a dict.
+        yield SearchProgressEvent(
+            tool_name="sync_search", query=params.query, stage="starting"
+        )
+        yield SearchProgressEvent(
+            tool_name="sync_search", query=params.query, stage="completed"
+        )
+        yield {
+            "tool": "sync_search",
+            "query": params.query,
+            "time_range": params.time_range,
+            "num_results": params.num_results,
+            "results": [f"sync-result-{i}" for i in range(params.num_results)],
+        }
+
+    async def async_search(self, params: SearchParams):
+        """Async generator: previously broken by #8711 - `params` used to
+        arrive as a raw dict on this path. After the fix, it is a real
+        SearchParams instance, matching the sync generator path.
+
+        Args:
+            params: Search parameters (query, time range, num results).
+        """
+        yield SearchProgressEvent(
+            tool_name="async_search", query=params.query, stage="starting"
+        )
+        # A real await between yields, to make sure this is exercised as a
+        # true async generator rather than a sync path in disguise.
+        await asyncio.sleep(0)
+        yield SearchProgressEvent(
+            tool_name="async_search", query=params.query, stage="completed"
+        )
+        yield {
+            "tool": "async_search",
+            "query": params.query,
+            "time_range": params.time_range,
+            "num_results": params.num_results,
+            "results": [f"async-result-{i}" for i in range(params.num_results)],
+        }
+
+    async def async_search_no_yield(self, params: SearchParams) -> dict:
+        """Async coroutine (no yield) with a Pydantic argument. This path
+        already worked pre-fix; included as a control.
+
+        Args:
+            params: Search parameters (query, time range, num results).
+        """
+        await asyncio.sleep(0)
+        return {
+            "tool": "async_search_no_yield",
+            "query": params.query,
+            "time_range": params.time_range,
+            "num_results": params.num_results,
+        }
+
+
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[SearchToolkit()],
+    instructions=[
+        "You have three search tools: sync_search, async_search, and async_search_no_yield.",
+        "When the user asks you to run the demonstration, call all three tools in order.",
+        "Use query='machine learning', time_range='OneWeek', num_results=3 for every call.",
+        "After all three calls complete, summarise which tools returned progress events.",
+    ],
+    markdown=True,
+)
+
+
+async def main():
+    print("Running async generator tool demonstration")
+    print("=" * 70)
+
+    seen_progress_events = []
+
+    async for event in agent.arun(
+        "Run the demonstration: call all three search tools with the parameters "
+        "from your instructions, then summarise the results.",
+        stream=True,
+    ):
+        if isinstance(event, SearchProgressEvent):
+            seen_progress_events.append(event)
+            print(
+                "  progress:",
+                event.tool_name,
+                "-",
+                event.query,
+                "-",
+                event.stage,
+            )
+
+    print()
+    print("Progress events observed:", len(seen_progress_events))
+    tools_that_streamed = {e.tool_name for e in seen_progress_events}
+    print("Tools that streamed progress:", sorted(tools_that_streamed))
+    assert "sync_search" in tools_that_streamed, "sync_search should stream progress"
+    assert "async_search" in tools_that_streamed, (
+        "async_search should stream progress. If missing, #8711 has regressed "
+        "and the async generator tool is not being dispatched correctly."
+    )
+    print("OK: sync_search and async_search both streamed progress events.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from functools import partial
+from functools import partial, wraps
 from importlib.metadata import version
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Type, TypeVar, get_type_hints
 
@@ -565,9 +565,28 @@ class Function(BaseModel):
 
         pydantic_version = Version(version("pydantic"))
 
-        # Don't wrap async generators validate_call
+        # Async generators need special handling: validate_call turns an `async def ... yield`
+        # into a plain function that returns an async_generator, which makes
+        # inspect.isasyncgenfunction return False. Downstream dispatch (models/base.py,
+        # FunctionCall.aexecute) uses that predicate to route the call, so we wrap the
+        # validated callable in an outer `async def ... yield` shim that preserves the
+        # async-generator identity while still coercing arguments through Pydantic.
         if isasyncgenfunction(func):
-            return func
+            if getattr(func, "_wrapped_for_validation", False):
+                return func
+            validated = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
+
+            @wraps(func)
+            async def async_gen_wrapper(*args, **kwargs):
+                inner = validated(*args, **kwargs)
+                try:
+                    async for item in inner:
+                        yield item
+                finally:
+                    await inner.aclose()
+
+            async_gen_wrapper._wrapped_for_validation = True  # type: ignore[attr-defined]
+            return async_gen_wrapper
 
         # Don't wrap coroutines with validate_call if pydantic version is less than 2.10.0
         if iscoroutinefunction(func) and pydantic_version < Version("2.10.0"):

--- a/libs/agno/tests/unit/tools/test_async_generator_deserialize.py
+++ b/libs/agno/tests/unit/tools/test_async_generator_deserialize.py
@@ -1,0 +1,175 @@
+"""Regression tests for async generator tools with Pydantic argument coercion (#8711).
+
+The bug: async generator tools received a raw ``dict`` where the signature
+declared a Pydantic ``BaseModel``, producing ``AttributeError: 'dict' object
+has no attribute '...'`` on the first attribute access. Sync generator tools
+already worked because ``pydantic.validate_call`` wrapped them.
+
+The naive fix (remove the ``isasyncgenfunction`` guard in ``_wrap_callable``)
+made deserialization work but broke dispatch: ``validate_call`` around an async
+generator turns it into a plain function that returns an ``async_generator``,
+so ``inspect.isasyncgenfunction(wrapped)`` returns False. Multiple call sites
+(``models/base.py:arun_function_call``, ``function.py:_build_..._chain_async``,
+``function.py: aexecute`` result handling, cache gating) rely on that predicate
+to route the call correctly.
+
+These tests pin both properties: (a) the wrapped entrypoint still reports as an
+async generator function, and (b) argument coercion works end-to-end through
+``FunctionCall.aexecute`` — the real dispatch path used by ``arun_function_call``.
+"""
+
+from inspect import isasyncgen, isasyncgenfunction, iscoroutinefunction, isgeneratorfunction
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from agno.tools.function import Function, FunctionCall
+
+
+class SearchParams(BaseModel):
+    query: str
+    time_range: Literal["OneDay", "OneWeek"] = "OneWeek"
+
+
+async def async_gen_tool(params: SearchParams):
+    yield {"query": params.query, "time_range": params.time_range}
+
+
+def test_async_gen_wrapped_still_reports_as_async_gen_function():
+    """The wrapped entrypoint must still be detectable as an async generator function.
+
+    Regression guard: without the outer ``async def ... yield`` shim,
+    ``pydantic.validate_call`` flips ``isasyncgenfunction`` to False and Agno's
+    dispatcher would take the sync ``asyncio.to_thread(execute)`` path.
+    """
+    func = Function(name="async_gen_tool", entrypoint=async_gen_tool)
+    func.process_entrypoint()
+
+    assert isasyncgenfunction(func.entrypoint)
+    assert not iscoroutinefunction(func.entrypoint)
+    assert not isgeneratorfunction(func.entrypoint)
+    assert getattr(func.entrypoint, "_wrapped_for_validation", False)
+
+
+def test_wrap_callable_is_idempotent_for_async_gen():
+    """Wrapping an already-wrapped async generator must return the same object.
+
+    Prevents unbounded shim nesting if ``_wrap_callable`` is invoked more than once.
+    """
+    once = Function._wrap_callable(async_gen_tool)
+    twice = Function._wrap_callable(once)
+    assert twice is once
+
+
+@pytest.mark.asyncio
+async def test_async_gen_deserializes_pydantic_model_direct_call():
+    """Calling the wrapped entrypoint with a dict must coerce it into the BaseModel.
+
+    Before the fix, this raised ``AttributeError: 'dict' object has no attribute 'query'``
+    on the first attribute access inside the generator body.
+    """
+    func = Function(name="async_gen_tool", entrypoint=async_gen_tool)
+    func.process_entrypoint()
+
+    result = func.entrypoint(params={"query": "hello", "time_range": "OneDay"})
+    assert isasyncgen(result)
+
+    items = [item async for item in result]
+    assert items == [{"query": "hello", "time_range": "OneDay"}]
+
+
+@pytest.mark.asyncio
+async def test_async_gen_full_dispatch_through_function_call_aexecute():
+    """End-to-end: ``FunctionCall.aexecute`` must route to the async-gen branch.
+
+    This is the path taken by ``Model.arun_function_call`` when the model
+    invokes an async generator tool with args from the LLM. It exercises the
+    same dispatch predicates the naive fix would break — so removing the shim
+    would make this test fail.
+    """
+    func = Function(name="async_gen_tool", entrypoint=async_gen_tool)
+    func.process_entrypoint()
+
+    call = FunctionCall(
+        function=func,
+        arguments={"params": {"query": "hello", "time_range": "OneWeek"}},
+    )
+
+    exec_result = await call.aexecute()
+
+    assert exec_result.status == "success", f"error: {exec_result.error}"
+    assert isasyncgen(call.result), (
+        "aexecute must store the async_generator on self.result — if this is "
+        "not an async_generator, the dispatcher hit the wrong branch and treated "
+        "the tool as a plain sync function."
+    )
+
+    items = [item async for item in call.result]
+    assert items == [{"query": "hello", "time_range": "OneWeek"}]
+
+
+@pytest.mark.asyncio
+async def test_async_gen_shim_propagates_aclose_to_inner_generator():
+    """``aclose()`` on the outer shim must run the inner generator's ``finally``.
+
+    The shim's ``try/finally: await inner.aclose()`` block exists so that when a
+    caller (or Python's GC) closes the outer generator, resource-holding
+    ``finally`` blocks inside the underlying tool still execute — open files,
+    HTTP sessions, DB cursors get their cleanup.
+
+    This test defines a tool whose ``finally`` block flips a flag, iterates one
+    item from the outer generator, then explicitly ``aclose()``s the outer one
+    and asserts the inner's ``finally`` fired.
+    """
+    cleanup_ran = False
+
+    class Params(BaseModel):
+        n: int
+
+    async def resource_holding_tool(params: Params):
+        nonlocal cleanup_ran
+        try:
+            for i in range(params.n):
+                yield i
+        finally:
+            cleanup_ran = True
+
+    func = Function(name="resource_holding_tool", entrypoint=resource_holding_tool)
+    func.process_entrypoint()
+
+    outer = func.entrypoint(params={"n": 10})
+    first = await outer.__anext__()
+    assert first == 0
+    assert not cleanup_ran
+
+    await outer.aclose()
+
+    assert cleanup_ran, (
+        "outer.aclose() did not propagate to inner generator's finally block — "
+        "the shim's try/finally is not correctly proxying aclose()."
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_gen_validation_error_surfaces_on_iteration():
+    """Invalid arguments must produce a Pydantic ``ValidationError`` when iterated.
+
+    Async generators are lazy — the wrapped call returns an ``async_generator``
+    object immediately, so validation only fires on the first ``__anext__``.
+    That means ``FunctionCall.aexecute`` sees ``success`` (it only stores the
+    generator on ``self.result``), and the caller catches the error on iteration.
+    This confirms the wrapping is actually doing validation, not just passing
+    dicts straight through.
+    """
+    from pydantic import ValidationError
+
+    func = Function(name="async_gen_tool", entrypoint=async_gen_tool)
+    func.process_entrypoint()
+
+    result = func.entrypoint(params={"query": "hello", "time_range": "InvalidValue"})
+    assert isasyncgen(result)
+
+    with pytest.raises(ValidationError, match="time_range"):
+        async for _ in result:
+            pass


### PR DESCRIPTION
## Summary

Async generator tools received `dict` where their signature declared a Pydantic `BaseModel`, producing `AttributeError: 'dict' object has no attribute '...'` on the first attribute access. Sync generator tools already worked correctly.

Fixes #8711.

## Why the previous PR (#8712) is insufficient

An earlier PR removed the `isasyncgenfunction` guard in `Function._wrap_callable` to let async gens flow through `pydantic.validate_call`. That fixes the immediate `AttributeError` but introduces a second, subtler bug: `validate_call(async_def_yield_func)` returns a **regular function** that returns an `async_generator` when called, so `inspect.isasyncgenfunction(wrapped)` flips from `True` to `False`.

That flip breaks dispatch. Agno uses `isasyncgenfunction(entrypoint)` at several critical call sites — *before* the tool is invoked — to decide how to route it:

- [`models/base.py:2475-2491`](libs/agno/agno/models/base.py#L2475-L2491) — routes async gens to `aexecute()`. After the naive fix, wrapped async gens fall through to `asyncio.to_thread(execute)` (the sync-in-thread path).
- [`function.py:1292-1299`](libs/agno/agno/tools/function.py#L1292-L1299) — decides whether to `await result`, store as an async gen, store as a sync gen, or treat as a completed sync value.
- [`function.py:1199`](libs/agno/agno/tools/function.py#L1199) — hook-chain path decides whether to `await`.
- [`function.py:1266`](libs/agno/agno/tools/function.py#L1266) — cache gating (generators skip the cache).
- [`tools/decorator.py:211`](libs/agno/agno/tools/decorator.py#L211) — tool registration.

## The fix

Instead of returning `validate_call(func)` directly, wrap the validated callable in an outer `async def ... yield` shim. This preserves the async-generator identity that Agno's dispatch predicates rely on, while still coercing arguments through Pydantic:

```python
if isasyncgenfunction(func):
    if getattr(func, "_wrapped_for_validation", False):
        return func
    validated = validate_call(func, config=dict(arbitrary_types_allowed=True))

    @wraps(func)
    async def async_gen_wrapper(*args, **kwargs):
        inner = validated(*args, **kwargs)
        try:
            async for item in inner:
                yield item
        finally:
            await inner.aclose()

    async_gen_wrapper._wrapped_for_validation = True
    return async_gen_wrapper
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
