### PR TITLE
fix: keep PerformanceResult p95 within observed range for small samples

### DIFF
--- a/libs/agno/agno/eval/performance.py
+++ b/libs/agno/agno/eval/performance.py
@@ -57,8 +57,13 @@ class PerformanceResult:
             mx = data_sorted[-1]
             std = statistics.stdev(data_sorted) if len(data_sorted) > 1 else 0
             med = statistics.median(data_sorted)
-            # For 95th percentile, use statistics.quantiles
-            p95 = statistics.quantiles(data_sorted, n=100)[94] if len(data_sorted) > 1 else 0
+            # For 95th percentile, use statistics.quantiles with the inclusive method so the
+            # result stays within the observed range for small samples
+            p95 = (
+                statistics.quantiles(data_sorted, n=100, method="inclusive")[94]
+                if len(data_sorted) > 1
+                else data_sorted[0]
+            )
             return avg, mn, mx, std, med, p95
 
         # Populate runtime stats

--- a/libs/agno/tests/unit/eval/test_performance_eval.py
+++ b/libs/agno/tests/unit/eval/test_performance_eval.py
@@ -1,0 +1,30 @@
+"""Unit tests for PerformanceResult statistics"""
+
+from agno.eval.performance import PerformanceResult
+
+# ---------------------------------------------------------------------------
+# p95 percentile for small samples
+# ---------------------------------------------------------------------------
+
+
+def test_single_sample_p95_matches_sample():
+    result = PerformanceResult(run_times=[1.0], memory_usages=[10.0])
+    assert result.p95_run_time == 1.0
+    assert result.p95_memory_usage == 10.0
+
+
+def test_small_sample_p95_stays_within_observed_range():
+    result = PerformanceResult(run_times=[1.0, 2.0], memory_usages=[10.0, 20.0])
+    assert result.min_run_time <= result.p95_run_time <= result.max_run_time
+    assert result.min_memory_usage <= result.p95_memory_usage <= result.max_memory_usage
+
+
+def test_identical_samples_p95_equals_value():
+    result = PerformanceResult(run_times=[5.0, 5.0, 5.0])
+    assert result.p95_run_time == 5.0
+
+
+def test_empty_run_times_p95_is_zero():
+    result = PerformanceResult(run_times=[], memory_usages=[])
+    assert result.p95_run_time == 0
+    assert result.p95_memory_usage == 0


### PR DESCRIPTION
## Summary

`PerformanceResult` computes p95 with `statistics.quantiles(..., n=100)`, which uses the default `exclusive` method. For small samples this extrapolates beyond the observed data, so the reported p95 can exceed the observed `max`, and for a single run it returns `0` instead of that run's value.

```python
PerformanceResult(run_times=[1.0]).p95_run_time        # 0    -> should be 1.0
PerformanceResult(run_times=[1.0, 2.0]).p95_run_time   # 2.85 -> above max_run_time (2.0)
```

This switches the percentile to the `inclusive` method and returns the sample itself when there is a single run, so p95 always stays within `[min, max]`. The same helper feeds both run-time and memory stats. For larger samples `inclusive` and `exclusive` converge, so existing results are effectively unchanged, and the output now matches `numpy.percentile` at every sample size.

Closes #8656

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added `libs/agno/tests/unit/eval/test_performance_eval.py` covering the single-sample, small-sample-within-range, identical-values, and empty-list cases.
