### PR TITLE
fix: quote DuckDB table name in CsvTools.query_csv_file

### DIFF
--- a/libs/agno/agno/tools/csv_toolkit.py
+++ b/libs/agno/agno/tools/csv_toolkit.py
@@ -151,9 +151,11 @@ class CsvTools(Toolkit):
 
             # Create a table from the csv file
             # Quote the table name so stems with hyphens or special characters are valid identifiers
+            # Bind the file path as a parameter so it can't break out of the SQL statement
             table_name = csv_name.replace('"', '""')
             con.execute(
-                f"CREATE TABLE \"{table_name}\" AS SELECT * FROM read_csv('{file_path}', ignore_errors=false, auto_detect=true)"
+                f'CREATE TABLE "{table_name}" AS SELECT * FROM read_csv(?, ignore_errors=false, auto_detect=true)',
+                [str(file_path)],
             )
 
             # -*- Format the SQL Query

--- a/libs/agno/agno/tools/csv_toolkit.py
+++ b/libs/agno/agno/tools/csv_toolkit.py
@@ -150,8 +150,10 @@ class CsvTools(Toolkit):
                 return "Error connecting to DuckDB, please check the connection."
 
             # Create a table from the csv file
+            # Quote the table name so stems with hyphens or special characters are valid identifiers
+            table_name = csv_name.replace('"', '""')
             con.execute(
-                f"CREATE TABLE {csv_name} AS SELECT * FROM read_csv('{file_path}', ignore_errors=false, auto_detect=true)"
+                f"CREATE TABLE \"{table_name}\" AS SELECT * FROM read_csv('{file_path}', ignore_errors=false, auto_detect=true)"
             )
 
             # -*- Format the SQL Query

--- a/libs/agno/tests/unit/tools/test_csv_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_csv_toolkit.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from agno.tools.csv_toolkit import CsvTools
 
 
@@ -26,3 +28,25 @@ def test_read_csv_file_handles_utf8_bom_header(tmp_path):
 
     assert rows == [{"name": "José", "city": "São Paulo"}]
     assert columns == ["name", "city"]
+
+
+def test_query_csv_file_quotes_hyphenated_table_name(tmp_path):
+    pytest.importorskip("duckdb")
+    csv_path = tmp_path / "sales-data.csv"
+    csv_path.write_text("region,total\nEU,10\nUS,20\n", encoding="utf-8")
+    tools = CsvTools(csvs=[csv_path])
+
+    result = tools.query_csv_file("sales-data", 'SELECT SUM(total) FROM "sales-data"')
+
+    assert "30" in result
+
+
+def test_query_csv_file_quotes_table_name_with_special_chars(tmp_path):
+    pytest.importorskip("duckdb")
+    csv_path = tmp_path / "2024 report#1.csv"
+    csv_path.write_text("region,total\nEU,10\nUS,20\n", encoding="utf-8")
+    tools = CsvTools(csvs=[csv_path])
+
+    result = tools.query_csv_file("2024 report#1", 'SELECT SUM(total) FROM "2024 report#1"')
+
+    assert "30" in result

--- a/libs/agno/tests/unit/tools/test_csv_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_csv_toolkit.py
@@ -50,3 +50,19 @@ def test_query_csv_file_quotes_table_name_with_special_chars(tmp_path):
     result = tools.query_csv_file("2024 report#1", 'SELECT SUM(total) FROM "2024 report#1"')
 
     assert "30" in result
+
+
+def test_query_csv_file_path_injection_is_neutralized(tmp_path):
+    duckdb = pytest.importorskip("duckdb")
+    connection = duckdb.connect()
+    connection.execute("CREATE TABLE inventory AS SELECT 1")
+
+    crafted_name = "orders'; DROP TABLE inventory; --"
+    csv_path = tmp_path / f"{crafted_name}.csv"
+    csv_path.write_text("a\n1\n", encoding="utf-8")
+    tools = CsvTools(csvs=[csv_path], duckdb_connection=connection)
+
+    tools.query_csv_file(crafted_name, f'SELECT COUNT(*) FROM "{crafted_name}"')
+
+    # The path is bound as a parameter, so the injected statement never runs
+    assert connection.execute("SELECT COUNT(*) FROM inventory").fetchone()[0] == 1


### PR DESCRIPTION
## Summary

`CsvTools.query_csv_file` loads a CSV into a temporary DuckDB table named after the file stem, but it interpolated that name into the internal `CREATE TABLE` statement unquoted. For valid filenames that are not bare SQL identifiers (hyphens, spaces, `#`, dots, leading digits) DuckDB fails before the user query runs, even though `list_csv_files` and `read_csv_file` accept the same stem.

```python
tools.query_csv_file("sales-data", 'SELECT SUM(total) FROM "sales-data"')
# Parser Error: syntax error at or near "-"
# LINE 1: CREATE TABLE sales-data AS SELECT * FROM read_csv(...)
```

This quotes the table identifier in the internal `CREATE TABLE`, doubling any embedded quote so stems with special characters resolve to a single valid identifier. The user-supplied SQL is unchanged, and a malicious filename can no longer break out of the quoted identifier.

Closes #8675

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added regression tests in `libs/agno/tests/unit/tools/test_csv_toolkit.py` for a hyphenated table name and a name with spaces/`#`, guarded with `pytest.importorskip("duckdb")`.
