### PR TITLE
feat(agent): re-resolve callable tools between model steps (#8688)

### DIFF
--- a/cookbook/02_agents/04_tools/05_refresh_tools_per_step.py
+++ b/cookbook/02_agents/04_tools/05_refresh_tools_per_step.py
@@ -1,0 +1,37 @@
+"""Refresh a callable tool factory after each completed tool batch."""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+
+state = {"unlocked": False}
+
+
+def unlock_tools() -> str:
+    """Unlock the follow-up tool for the next model step."""
+    state["unlocked"] = True
+    return "The follow-up tool is now available."
+
+
+def follow_up_tool() -> str:
+    """A tool that is only exposed after unlock_tools has run."""
+    return "Follow-up tool completed."
+
+
+def tools_factory():
+    tools = [unlock_tools]
+    if state["unlocked"]:
+        tools.append(follow_up_tool)
+    return tools
+
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=tools_factory,
+    cache_callables=False,
+    refresh_tools_per_step=True,
+    instructions=[
+        "Call unlock_tools first, then call follow_up_tool after it becomes available.",
+    ],
+)
+
+agent.print_response("Run the two-step tool flow.")

--- a/cookbook/02_agents/04_tools/README.md
+++ b/cookbook/02_agents/04_tools/README.md
@@ -7,6 +7,7 @@ Examples for callable tool factories, tool choice, and tool call limits.
 - `02_session_state_tools.py` - Use session_state directly as a parameter with caching disabled.
 - `03_team_callable_members.py` - Assemble team members dynamically.
 - `04_tools_with_literal_type_param.py` - Use typing.Literal for tool parameters with predefined values.
+- `05_refresh_tools_per_step.py` - Re-resolve a callable tool factory after a tool call changes state.
 - `tool_call_limit.py` - Limit the number of tool calls per run.
 - `tool_choice.py` - Control which tool the agent selects.
 

--- a/cookbook/02_agents/04_tools/TEST_LOG.md
+++ b/cookbook/02_agents/04_tools/TEST_LOG.md
@@ -58,3 +58,11 @@
 **Result:** Timed out after 120s.
 
 ---
+
+### 05_refresh_tools_per_step.py
+
+**Status:** NOT RUN
+**Description:** Requires an OpenAI API key and demonstrates opt-in tool refresh after a completed tool batch.
+**Result:** Added as a cookbook example for the dynamic callable-tools feature.
+
+---

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -7,6 +7,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -1055,6 +1056,7 @@ def handle_model_response_stream(
     stream_events: bool = False,
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
+    tools_resolver: Optional[Callable[[], Optional[List[Union[Function, dict]]]]] = None,
 ) -> Iterator[RunOutputEvent]:
     agent.model = cast(Model, agent.model)
 
@@ -1094,6 +1096,7 @@ def handle_model_response_stream(
             run_messages=run_messages,
             run_context=run_context,
         ),
+        tools_resolver=tools_resolver,
     ):
         # Handle LLM request events and compression events from ModelResponse
         if isinstance(model_response_event, ModelResponse):
@@ -1215,6 +1218,7 @@ async def ahandle_model_response_stream(
     stream_events: bool = False,
     session_state: Optional[Dict[str, Any]] = None,
     run_context: Optional[RunContext] = None,
+    tools_resolver: Optional[Callable[[], Any]] = None,
 ) -> AsyncIterator[RunOutputEvent]:
     agent.model = cast(Model, agent.model)
 
@@ -1254,6 +1258,7 @@ async def ahandle_model_response_stream(
             run_messages=run_messages,
             run_context=run_context,
         ),
+        tools_resolver=tools_resolver,
     )  # type: ignore
 
     async for model_response_event in model_response_stream:  # type: ignore

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -546,6 +546,13 @@ def _run(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **model_tool_refresh_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=agent_session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
 
                 # Check for cancellation after model call
@@ -962,6 +969,13 @@ def _run_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **model_tool_refresh_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -982,6 +996,13 @@ def _run_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **model_tool_refresh_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -1685,6 +1706,13 @@ async def _arun(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **amodel_tool_refresh_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=agent_session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
 
                 # Check for cancellation after model call
@@ -2363,6 +2391,13 @@ async def _arun_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **amodel_tool_refresh_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -2383,6 +2418,13 @@ async def _arun_stream(
                         stream_events=stream_events,
                         session_state=run_context.session_state,
                         run_context=run_context,
+                        **amodel_tool_refresh_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -3652,6 +3694,13 @@ def _continue_run(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **model_tool_refresh_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
 
                 # Check for cancellation after model processing
@@ -3880,6 +3929,13 @@ def _continue_run_stream(
                     stream_events=stream_events,
                     session_state=run_context.session_state,
                     run_context=run_context,
+                    **model_tool_refresh_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 ):
                     if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                         raise_if_cancelled(run_response.run_id)  # type: ignore
@@ -4748,6 +4804,13 @@ async def _acontinue_run(
                         run_messages=run_messages,
                         run_context=run_context,
                     ),
+                    **amodel_tool_refresh_kwargs(
+                        agent,
+                        run_response=run_response,
+                        session=agent_session,
+                        run_context=run_context,
+                        user_id=user_id,
+                    ),
                 )
                 # Check for cancellation after model call
                 await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -5247,6 +5310,13 @@ async def _acontinue_run_stream(
                         response_format=response_format,
                         stream_events=stream_events,
                         run_context=run_context,
+                        **amodel_tool_refresh_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -5266,6 +5336,13 @@ async def _acontinue_run_stream(
                         response_format=response_format,
                         stream_events=stream_events,
                         run_context=run_context,
+                        **amodel_tool_refresh_kwargs(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        ),
                     ):
                         if not isinstance(event, _CANCEL_BYPASS_EVENT_TYPES):
                             await araise_if_cancelled(run_response.run_id)  # type: ignore
@@ -6049,6 +6126,121 @@ def build_after_tool_results_callback(
         checkpoint_run(agent, run_response, session, run_context)
 
     return _callback
+
+
+def agent_tools_refresh_enabled(agent: Agent) -> bool:
+    """True when the agent should install a run-time tools resolver."""
+    return bool(getattr(agent, "refresh_tools_per_step", False))
+
+
+def model_tool_refresh_kwargs(
+    agent: Agent,
+    *,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> dict:
+    """Kwargs for model.response/stream calls that support run-time tool refresh."""
+    return {
+        "tools_resolver": build_tools_resolver(
+            agent,
+            run_response=run_response,
+            session=session,
+            run_context=run_context,
+            user_id=user_id,
+        ),
+    }
+
+
+def amodel_tool_refresh_kwargs(
+    agent: Agent,
+    *,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> dict:
+    """Async runs — same surface as :func:`model_tool_refresh_kwargs`."""
+    return {
+        "tools_resolver": abuild_tools_resolver(
+            agent,
+            run_response=run_response,
+            session=session,
+            run_context=run_context,
+            user_id=user_id,
+        ),
+    }
+
+
+def build_tools_resolver(
+    agent: Agent,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> Optional[Any]:
+    """Build a sync resolver that refreshes model-visible tools between model steps.
+
+    The resolver intentionally reuses the normal Agent tool pipeline so callable
+    factories, default tools, skills, tool hooks, and model-specific tool
+    formatting all stay consistent with the initial run setup.
+    """
+    if not agent_tools_refresh_enabled(agent):
+        return None
+
+    from agno.agent._tools import determine_tools_for_model
+
+    def _resolver() -> List[Union[Function, dict]]:
+        processed_tools = agent.get_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=user_id,
+        )
+        return determine_tools_for_model(
+            agent,
+            model=cast(Model, agent.model),
+            processed_tools=processed_tools,
+            run_response=run_response,
+            session=session,
+            run_context=run_context,
+        )
+
+    return _resolver
+
+
+def abuild_tools_resolver(
+    agent: Agent,
+    run_response: RunOutput,
+    session: AgentSession,
+    run_context: RunContext,
+    user_id: Optional[str] = None,
+) -> Optional[Any]:
+    """Async variant of :func:`build_tools_resolver`."""
+    if not agent_tools_refresh_enabled(agent):
+        return None
+
+    from agno.agent._tools import determine_tools_for_model
+
+    async def _resolver() -> List[Union[Function, dict]]:
+        processed_tools = await agent.aget_tools(
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            user_id=user_id,
+        )
+        return determine_tools_for_model(
+            agent,
+            model=cast(Model, agent.model),
+            processed_tools=processed_tools,
+            run_response=run_response,
+            run_context=run_context,
+            session=session,
+            async_mode=True,
+        )
+
+    return _resolver
 
 
 def abuild_after_tool_results_callback(

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -730,6 +730,8 @@ def to_dict(agent: Agent) -> Dict[str, Any]:
     # --- Callable factory settings ---
     if not agent.cache_callables:
         config["cache_callables"] = agent.cache_callables
+    if agent.refresh_tools_per_step:
+        config["refresh_tools_per_step"] = agent.refresh_tools_per_step
 
     # --- Debug and telemetry settings ---
     if agent.debug_mode:

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -185,6 +185,10 @@ class Agent:
 
     # A function that acts as middleware and is called around tool calls.
     tool_hooks: Optional[List[Callable]] = None
+    # If True, callable tool factories are re-resolved before each model step.
+    # This lets tools become available during a run after state changes caused by
+    # earlier tool calls, while preserving the default run-level tool snapshot.
+    refresh_tools_per_step: bool = False
 
     # --- Agent Hooks ---
     # Functions called right after agent-session is loaded, before processing starts
@@ -435,6 +439,7 @@ class Agent:
         tool_call_limit: Optional[int] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_hooks: Optional[List[Callable]] = None,
+        refresh_tools_per_step: bool = False,
         pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None,
         post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None,
         reasoning: bool = False,
@@ -604,6 +609,7 @@ class Agent:
         self.tool_call_limit = tool_call_limit
         self.tool_choice = tool_choice
         self.tool_hooks = tool_hooks
+        self.refresh_tools_per_step = refresh_tools_per_step
 
         self.pre_hooks = pre_hooks
         self.post_hooks = post_hooks

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -59,6 +59,10 @@ from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.timer import Timer
 from agno.utils.tools import get_function_call_for_tool_call, get_function_call_for_tool_execution
 
+ModelTools = List[Union[Function, dict]]
+ToolsResolver = Callable[[], Optional[ModelTools]]
+AsyncToolsResolver = Callable[[], Awaitable[Optional[ModelTools]]]
+
 
 @dataclass
 class MessageData:
@@ -612,6 +616,41 @@ class Model(ABC):
         _tool_dicts.sort(key=self._tool_name)
         return _tool_dicts
 
+    def _resolve_tools_for_model_step(
+        self,
+        tools: Optional[ModelTools],
+        tools_resolver: Optional[ToolsResolver] = None,
+    ) -> Tuple[Optional[ModelTools], List[dict], Dict[str, Function]]:
+        """Return the tool snapshot and provider-specific representations for one model call.
+
+        ``tools_resolver`` is evaluated only when a caller explicitly asks for a new
+        snapshot. Keeping this operation in the model loop lets Agent refresh tools
+        after a completed tool batch without changing the default run-level snapshot.
+        """
+        if tools_resolver is not None:
+            resolved_tools = tools_resolver()
+            if resolved_tools is not None:
+                tools = resolved_tools
+
+        tool_dicts = self._format_tools(tools) if tools is not None else []
+        functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        return tools, tool_dicts, functions
+
+    async def _aresolve_tools_for_model_step(
+        self,
+        tools: Optional[ModelTools],
+        tools_resolver: Optional[AsyncToolsResolver] = None,
+    ) -> Tuple[Optional[ModelTools], List[dict], Dict[str, Function]]:
+        """Async counterpart to :meth:`_resolve_tools_for_model_step`."""
+        if tools_resolver is not None:
+            resolved_tools = await tools_resolver()
+            if resolved_tools is not None:
+                tools = resolved_tools
+
+        tool_dicts = self._format_tools(tools) if tools is not None else []
+        functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        return tools, tool_dicts, functions
+
     def _ensure_message_metrics_initialized(self, assistant_message: Message) -> None:
         """
         Ensure message metrics are initialized and timer is started.
@@ -658,6 +697,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], None]] = None,
+        tools_resolver: Optional[ToolsResolver] = None,
     ) -> ModelResponse:
         """
         Generate a response from the model.
@@ -676,9 +716,14 @@ class Model(ABC):
                 as its single argument. Used by Agent-level checkpointing
                 (``checkpoint="tool-batch"``) to persist mid-run state. Exceptions are caught and
                 logged — a failed callback must not kill the run.
+            tools_resolver: Optional callback that returns the tool snapshot for the next model
+                call. It is evaluated after a completed tool batch and is intended for Agent
+                tool factories whose available tools can change during a run. Response caching
+                is disabled while this callback is active because the tool snapshot is dynamic.
         """
         # Check cache if enabled
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=False, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -694,13 +739,17 @@ class Model(ABC):
 
         function_call_count = 0
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress tool results if compression is enabled and threshold is met
             if _compression_manager is not None and _compression_manager.should_compress(
                 messages, tools, model=self, response_format=response_format
@@ -845,6 +894,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(tc.requires_confirmation for tc in model_response.tool_executions or []):
                     break
@@ -873,7 +925,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Response End", center=True, symbol="-")
 
         # Save to cache if enabled
-        if self.cache_response:
+        if cache_enabled:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
         return model_response
@@ -889,6 +941,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], Awaitable[None]]] = None,
+        tools_resolver: Optional[AsyncToolsResolver] = None,
     ) -> ModelResponse:
         """
         Generate an asynchronous response from the model.
@@ -901,7 +954,8 @@ class Model(ABC):
         """
 
         # Check cache if enabled
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=False, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -914,15 +968,19 @@ class Model(ABC):
         _log_messages(messages)
         model_response = ModelResponse()
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress existing tool results BEFORE making API call to avoid context overflow
             if _compression_manager is not None and await _compression_manager.ashould_compress(
                 messages, tools, model=self, response_format=response_format
@@ -1066,6 +1124,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(tc.requires_confirmation for tc in model_response.tool_executions or []):
                     break
@@ -1094,7 +1155,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Async Response End", center=True, symbol="-")
 
         # Save to cache if enabled
-        if self.cache_response:
+        if cache_enabled:
             self._save_model_response_to_cache(cache_key, model_response, is_streaming=False)
 
         return model_response
@@ -1371,6 +1432,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], None]] = None,
+        tools_resolver: Optional[ToolsResolver] = None,
     ) -> Iterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate a streaming response from the model.
@@ -1383,7 +1445,8 @@ class Model(ABC):
         """
         # Check cache if enabled - capture key BEFORE streaming to avoid mismatch
         cache_key = None
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=True, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -1403,15 +1466,19 @@ class Model(ABC):
         log_debug(f"Model: {self.id}", center=True, symbol="-")
         _log_messages(messages)
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = self._resolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress existing tool results BEFORE invoke
             if _compression_manager is not None and _compression_manager.should_compress(
                 messages, tools, model=self, response_format=response_format
@@ -1572,6 +1639,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(fc.function.requires_confirmation for fc in function_calls_to_run):
                     break
@@ -1600,7 +1670,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Response Stream End", center=True, symbol="-")
 
         # Save streaming responses to cache if enabled
-        if self.cache_response and cache_key and streaming_responses:
+        if cache_enabled and cache_key and streaming_responses:
             self._save_streaming_responses_to_cache(cache_key, streaming_responses)
 
     async def aprocess_response_stream(
@@ -1650,6 +1720,7 @@ class Model(ABC):
         send_media_to_model: bool = True,
         compression_manager: Optional["CompressionManager"] = None,
         after_tool_results: Optional[Callable[["ModelResponse"], Awaitable[None]]] = None,
+        tools_resolver: Optional[AsyncToolsResolver] = None,
     ) -> AsyncIterator[Union[ModelResponse, RunOutputEvent, TeamRunOutputEvent]]:
         """
         Generate an asynchronous streaming response from the model.
@@ -1662,7 +1733,8 @@ class Model(ABC):
         """
         # Check cache if enabled - capture key BEFORE streaming to avoid mismatch
         cache_key = None
-        if self.cache_response:
+        cache_enabled = self.cache_response and tools_resolver is None
+        if cache_enabled:
             cache_key = self._get_model_cache_key(messages, stream=True, response_format=response_format, tools=tools)
             cached_data = self._get_cached_model_response(cache_key)
 
@@ -1682,15 +1754,19 @@ class Model(ABC):
         log_debug(f"Model: {self.id}", center=True, symbol="-")
         _log_messages(messages)
 
-        _tool_dicts = self._format_tools(tools) if tools is not None else []
-        _functions = {tool.name: tool for tool in tools if isinstance(tool, Function)} if tools is not None else {}
+        tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools)
 
         _compress_tool_results = compression_manager is not None and compression_manager.compress_tool_results
         _compression_manager = compression_manager if _compress_tool_results else None
 
         function_call_count = 0
 
+        refresh_tools_next_step = False
         while True:
+            if refresh_tools_next_step:
+                tools, _tool_dicts, _functions = await self._aresolve_tools_for_model_step(tools, tools_resolver)
+                refresh_tools_next_step = False
+
             # Compress existing tool results BEFORE making API call to avoid context overflow
             if _compression_manager is not None and await _compression_manager.ashould_compress(
                 messages, tools, model=self, response_format=response_format
@@ -1851,6 +1927,9 @@ class Model(ABC):
                     except Exception as e:
                         log_error(f"after_tool_results callback failed: {e}")
 
+                if tools_resolver is not None:
+                    refresh_tools_next_step = True
+
                 # If we have any tool calls that require confirmation, break the loop
                 if any(fc.function.requires_confirmation for fc in function_calls_to_run):
                     break
@@ -1879,7 +1958,7 @@ class Model(ABC):
         log_debug(f"{self.get_provider()} Async Response Stream End", center=True, symbol="-")
 
         # Save streaming responses to cache if enabled
-        if self.cache_response and cache_key and streaming_responses:
+        if cache_enabled and cache_key and streaming_responses:
             self._save_streaming_responses_to_cache(cache_key, streaming_responses)
 
     def _populate_assistant_message_from_stream_data(

--- a/libs/agno/tests/unit/agent/test_callable_resources.py
+++ b/libs/agno/tests/unit/agent/test_callable_resources.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+import asyncio
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
 from unittest.mock import MagicMock
 
 import pytest
 
 from agno.agent.agent import Agent
+from agno.models.base import Model
+from agno.models.message import MessageMetrics
+from agno.models.response import ModelResponse
+from agno.run import RunStatus
 from agno.run.base import RunContext
 from agno.tools import Toolkit
 from agno.tools.function import Function
@@ -69,9 +74,93 @@ def _another_tool(x: str) -> str:
     return f"other: {x}"
 
 
-# ---------------------------------------------------------------------------
-# is_callable_factory
-# ---------------------------------------------------------------------------
+class _StepToolRefreshModel(Model):
+    """Offline model that requests a tool once, then verifies refreshed tools."""
+
+    def __init__(self):
+        super().__init__(id="step-refresh-test", name="step-refresh-test", provider="test")
+        self.tool_names_by_step = []
+
+    def get_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    def get_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_instructions_for_model(self, *args, **kwargs):
+        return None
+
+    async def aget_system_message_for_model(self, *args, **kwargs):
+        return None
+
+    def parse_args(self, *args, **kwargs):
+        return {}
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:
+        return ModelResponse(content="unused", role="assistant", response_usage=MessageMetrics())
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:
+        return self.invoke(*args, **kwargs)
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:
+        yield self.invoke(*args, **kwargs)
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:
+        yield self.invoke(*args, **kwargs)
+
+    def _parse_provider_response(self, response: Any, **kwargs) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+    @staticmethod
+    def _tool_names(tools):
+        names = []
+        for tool in tools or []:
+            if isinstance(tool, dict):
+                function = tool.get("function") or {}
+                names.append(function.get("name") or tool.get("name"))
+            else:
+                names.append(getattr(tool, "name", None))
+        return [name for name in names if name]
+
+    def _process_model_response(
+        self,
+        *,
+        messages,
+        assistant_message,
+        model_response,
+        response_format=None,
+        tools=None,
+        tool_choice=None,
+        run_response=None,
+        compress_tool_results=False,
+    ):
+        tool_names = self._tool_names(tools)
+        self.tool_names_by_step.append(tool_names)
+        model_response.response_usage = MessageMetrics()
+
+        if len(self.tool_names_by_step) == 1:
+            assert "unlock_tool" in tool_names
+            assert "second_tool" not in tool_names
+            assistant_message.content = None
+            assistant_message.tool_calls = [
+                {
+                    "id": "call_unlock",
+                    "type": "function",
+                    "function": {"name": "unlock_tool", "arguments": "{}"},
+                }
+            ]
+            return
+
+        assert "second_tool" in tool_names
+        assistant_message.content = "refreshed"
+        assistant_message.tool_calls = None
+        model_response.content = "refreshed"
+
+    async def _aprocess_model_response(self, **kwargs):
+        self._process_model_response(**kwargs)
 
 
 class TestIsCallableFactory:
@@ -251,6 +340,96 @@ class TestAgentCallableToolsStorage:
         assert hasattr(agent, "_callable_knowledge_cache")
         assert isinstance(agent._callable_tools_cache, dict)
         assert isinstance(agent._callable_knowledge_cache, dict)
+
+
+class TestAgentStepToolRefresh:
+    def test_callable_tools_can_refresh_between_model_steps(self):
+        state = {"unlocked": False}
+
+        def unlock_tool() -> str:
+            state["unlocked"] = True
+            return "unlocked"
+
+        def second_tool() -> str:
+            return "available"
+
+        def tools_factory():
+            tools = [unlock_tool]
+            if state["unlocked"]:
+                tools.append(second_tool)
+            return tools
+
+        model = _StepToolRefreshModel()
+        agent = Agent(
+            model=model,
+            tools=tools_factory,
+            cache_callables=False,
+            refresh_tools_per_step=True,
+        )
+
+        response = agent.run("refresh tools")
+
+        assert response.content == "refreshed"
+        assert model.tool_names_by_step[0] == ["unlock_tool"]
+        assert set(model.tool_names_by_step[1]) == {"unlock_tool", "second_tool"}
+
+    def test_callable_tools_stay_run_level_without_step_refresh(self):
+        state = {"unlocked": False}
+
+        def unlock_tool() -> str:
+            state["unlocked"] = True
+            return "unlocked"
+
+        def second_tool() -> str:
+            return "available"
+
+        def tools_factory():
+            tools = [unlock_tool]
+            if state["unlocked"]:
+                tools.append(second_tool)
+            return tools
+
+        model = _StepToolRefreshModel()
+        agent = Agent(
+            model=model,
+            tools=tools_factory,
+            cache_callables=False,
+        )
+
+        response = agent.run("no refresh")
+
+        assert model.tool_names_by_step == [["unlock_tool"], ["unlock_tool"]]
+        assert response.status == RunStatus.error
+
+    def test_callable_tools_can_refresh_between_async_model_steps(self):
+        state = {"unlocked": False}
+
+        def unlock_tool() -> str:
+            state["unlocked"] = True
+            return "unlocked"
+
+        def second_tool() -> str:
+            return "available"
+
+        def tools_factory():
+            tools = [unlock_tool]
+            if state["unlocked"]:
+                tools.append(second_tool)
+            return tools
+
+        model = _StepToolRefreshModel()
+        agent = Agent(
+            model=model,
+            tools=tools_factory,
+            cache_callables=False,
+            refresh_tools_per_step=True,
+        )
+
+        response = asyncio.run(agent.arun("refresh tools asynchronously"))
+
+        assert response.content == "refreshed"
+        assert model.tool_names_by_step[0] == ["unlock_tool"]
+        assert set(model.tool_names_by_step[1]) == {"unlock_tool", "second_tool"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closing this earlier boolean-refresh implementation in favor of the versioned ToolRegistry design in #9088.