### PR TITLE
feat: add ag setup command

### DIFF
--- a/libs/agno_infra/agno/cli/entrypoint.py
+++ b/libs/agno_infra/agno/cli/entrypoint.py
@@ -3,18 +3,22 @@
 This is the entrypoint for the `agno` cli application.
 """
 
+from typing import Optional
+
 import typer
 
 from agno.cli.infra_cli import infra_cli as infra_subcommands
+from agno.utilities.logging import set_log_level_to_debug
 
 agno_cli = typer.Typer(
     help="""\b
 Agno is a lightweight framework for building Agent Systems.
 \b
 Usage:
-1. Run `ag infra create` to create a new Agentics Infrastructure project from a template
-2. Run `ag infra up` to start the infrastructure
-3. Run `ag infra down` to stop the infrastructure
+1. Run `ag setup` to create and start a new AgentOS project in one command
+2. Run `ag infra create` to create a new Agentics Infrastructure project from a template
+3. Run `ag infra up` to start the infrastructure
+4. Run `ag infra down` to stop the infrastructure
 """,
     no_args_is_help=True,
     add_completion=False,
@@ -23,6 +27,61 @@ Usage:
     subcommand_metavar="[COMMAND] [OPTIONS]",
     pretty_exceptions_show_locals=False,
 )
+
+
+@agno_cli.command(short_help="Set up a new AgentOS: install packages, create the codebase and start it.")
+def setup(
+    name: Optional[str] = typer.Option(
+        None,
+        "-n",
+        "--name",
+        help="Name of the new AgentOS codebase directory (e.g. `my-agentos-project`).",
+        show_default=False,
+    ),
+    template: Optional[str] = typer.Option(
+        None,
+        "-t",
+        "--template",
+        help="Starter template for the Agno AgentOS codebase.",
+        show_default=False,
+    ),
+    url: Optional[str] = typer.Option(
+        None,
+        "-u",
+        "--url",
+        help="URL of the starter template.",
+        show_default=False,
+    ),
+    auto_confirm: bool = typer.Option(
+        False,
+        "-y",
+        "--yes",
+        help="Skip confirmation before deploying resources.",
+    ),
+    print_debug_log: bool = typer.Option(
+        False,
+        "-d",
+        "--debug",
+        help="Print debug logs.",
+    ),
+):
+    """\b
+    Set up a new AgentOS in a single command. This runs the following steps:
+    \b
+    1. Install missing packages (`agno`, docker support) in the current environment
+    2. Create a new AgentOS codebase from a starter template (same as `ag infra create`)
+    3. Start the AgentOS infrastructure (same as `ag infra up`)
+    \b
+    Examples:
+    > ag setup                                       -> Interactive setup in the current directory
+    > ag setup -t agentos-docker -n my-agentos -y    -> Non-interactive setup with the docker template
+    """
+    if print_debug_log:
+        set_log_level_to_debug()
+
+    from agno.infra.operator import setup_agentos
+
+    setup_agentos(name=name, template=template, url=url, auto_confirm=auto_confirm)
 
 
 agno_cli.add_typer(infra_subcommands)

--- a/libs/agno_infra/agno/infra/operator.py
+++ b/libs/agno_infra/agno/infra/operator.py
@@ -186,6 +186,66 @@ def create_infra_from_template(
     return None
 
 
+def install_setup_packages() -> None:
+    """Install the packages required to create and run an AgentOS, if missing.
+
+    Installs into the environment running this CLI (sys.executable) so the
+    packages land in the same virtual environment as agno-infra.
+    """
+    import importlib
+    import subprocess
+    import sys
+    from importlib.util import find_spec
+
+    packages_to_install: List[str] = []
+    if find_spec("agno.agent") is None:
+        packages_to_install.append("agno")
+    if find_spec("docker") is None:
+        packages_to_install.append("agno-infra[docker]")
+
+    if not packages_to_install:
+        logger.debug("All required packages are installed")
+        return
+
+    print_info("Installing required packages: {}".format(", ".join(packages_to_install)))
+    try:
+        subprocess.run([sys.executable, "-m", "pip", "install", *packages_to_install], check=True)
+    except subprocess.CalledProcessError:
+        log_warning("Could not install packages automatically. Please install them manually:")
+        log_warning("  pip install -U agno 'agno-infra[docker]'")
+        return
+    importlib.invalidate_caches()
+
+
+def setup_agentos(
+    name: Optional[str] = None,
+    template: Optional[str] = None,
+    url: Optional[str] = None,
+    auto_confirm: bool = False,
+) -> None:
+    """Set up a new AgentOS in a single command. This is called from `ag setup`.
+
+    Steps:
+    1. Install missing packages (agno, docker support) in the current environment
+    2. Create a new AgentOS codebase from a starter template (same as `ag infra create`)
+    3. Start the AgentOS infrastructure (same as `ag infra up`)
+    """
+    print_heading("Setting up your AgentOS\n")
+
+    install_setup_packages()
+
+    infra_config: Optional[InfraConfig] = create_infra_from_template(name=name, template=template, url=url)
+    if infra_config is None:
+        logger.error("AgentOS codebase creation failed, please check the logs above and try again")
+        return
+
+    start_infra(infra_config=infra_config, auto_confirm=auto_confirm)
+
+    print_info("\n--------------------------------")
+    print_info("Setup complete. Connect to your AgentOS on https://os.agno.com")
+    print_info("--------------------------------")
+
+
 def setup_infra_config_from_dir(infra_root_path: Path) -> Optional[InfraConfig]:
     from agno.cli.operator import initialize_agno_cli
     from agno.infra.helpers import get_infra_dir_path


### PR DESCRIPTION
## Summary

Adds an `ag setup` command to scaffold and start a new AgentOS in one flow.

This wires a new Typer command through `libs/agno_infra/agno/cli/entrypoint.py` and adds `setup_agentos()` in `libs/agno_infra/agno/infra/operator.py` to:

- install missing setup packages into the active CLI environment
- create an AgentOS codebase from the selected starter template
- start the generated infrastructure with the existing infra startup path

(If applicable, issue number: #____)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Validation run before opening this PR:

- `./scripts/format.sh`: passed; no files changed
- `./scripts/validate.sh`: command exited `0`, `libs/agno_infra` ruff and mypy passed, cookbook checks passed; the run printed existing mypy errors in unrelated `libs/agno` files including `tools/parallel.py`, `os/interfaces/agui/handlers.py`, `models/google/gemini*.py`, `models/aws/claude.py`, and `context/web/exa.py`
