### PR TITLE
fix: skip symlinked Antigravity agent sources

### DIFF
--- a/libs/agno/agno/agents/antigravity/agent.py
+++ b/libs/agno/agno/agents/antigravity/agent.py
@@ -5,6 +5,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 from uuid import uuid4
 
 from agno.agents.base import BaseExternalAgent
+from agno.exceptions import PathSecurityError
 from agno.models.response import ToolExecution
 from agno.run.agent import (
     RunContentEvent,
@@ -13,6 +14,7 @@ from agno.run.agent import (
     ToolCallStartedEvent,
 )
 from agno.utils.log import log_debug, log_warning
+from agno.utils.path_safety import safe_join_relative_path
 
 DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 INLINE_SOURCE_MAX_BYTES = 75 * 1024  # API limit for inline source content per file
@@ -196,7 +198,10 @@ class AntigravityAgent(BaseExternalAgent):
         if not path.is_dir():
             raise FileNotFoundError(f"agent directory not found: {directory}")
 
-        config_path = path / "agent.yaml"
+        try:
+            config_path = safe_join_relative_path(path, "agent.yaml")
+        except PathSecurityError as e:
+            raise FileNotFoundError(f"agent.yaml not found in {directory}") from e
         if not config_path.is_file():
             raise FileNotFoundError(f"agent.yaml not found in {directory}")
         config = yaml.safe_load(config_path.read_text()) or {}
@@ -208,9 +213,12 @@ class AntigravityAgent(BaseExternalAgent):
 
         # AGENTS.md takes precedence over system_instruction in the yaml
         instructions: Optional[str] = config.get("system_instruction")
-        agents_md = path / "AGENTS.md"
-        if agents_md.is_file():
-            instructions = agents_md.read_text()
+        try:
+            agents_md = safe_join_relative_path(path, "AGENTS.md")
+            if agents_md.is_file():
+                instructions = agents_md.read_text()
+        except PathSecurityError:
+            pass
 
         sources = cls._build_sources_from_directory(path)
 
@@ -263,17 +271,22 @@ class AntigravityAgent(BaseExternalAgent):
                 return
             sources.append({"type": "inline", "content": content, "target": target})
 
-        workspace = path / "workspace"
-        if workspace.is_dir():
-            for f in workspace.rglob("*"):
-                if f.is_file():
-                    add(f, "/" + f.relative_to(workspace).as_posix())
-
-        skills = path / "skills"
-        if skills.is_dir():
-            for f in skills.rglob("*"):
-                if f.is_file():
-                    add(f, "/.agents/skills/" + f.relative_to(skills).as_posix())
+        for source_name, target_prefix in (("workspace", "/"), ("skills", "/.agents/skills/")):
+            try:
+                source_dir = safe_join_relative_path(path, source_name)
+            except PathSecurityError:
+                continue
+            if not source_dir.is_dir():
+                continue
+            for f in source_dir.rglob("*"):
+                if not f.is_file():
+                    continue
+                rel = f.relative_to(source_dir).as_posix()
+                try:
+                    safe_join_relative_path(source_dir, rel)
+                except PathSecurityError:
+                    continue
+                add(f, target_prefix + rel)
 
         return sources
 

--- a/libs/agno/agno/tools/antigravity.py
+++ b/libs/agno/agno/tools/antigravity.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, List, Optional, Union
 import httpx
 
 from agno.agent import Agent
+from agno.exceptions import PathSecurityError
 from agno.team import Team
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error, log_warning
+from agno.utils.path_safety import safe_join_relative_path
 
 DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 INLINE_SOURCE_MAX_BYTES = 75 * 1024  # API limit for inline source content per file
@@ -162,7 +164,11 @@ class AntigravityTools(Toolkit):
         path = Path(directory)
         if not path.is_dir():
             raise FileNotFoundError(f"agent directory not found: {directory}")
-        config_path = path / "agent.yaml"
+
+        try:
+            config_path = safe_join_relative_path(path, "agent.yaml")
+        except PathSecurityError as e:
+            raise FileNotFoundError(f"agent.yaml not found in {directory}") from e
         if not config_path.is_file():
             raise FileNotFoundError(f"agent.yaml not found in {directory}")
         config = yaml.safe_load(config_path.read_text()) or {}
@@ -173,9 +179,12 @@ class AntigravityTools(Toolkit):
             raise ValueError("agent.yaml must contain both `id` and `base_agent`")
 
         instructions = config.get("system_instruction")
-        agents_md = path / "AGENTS.md"
-        if agents_md.is_file():
-            instructions = agents_md.read_text()
+        try:
+            agents_md = safe_join_relative_path(path, "AGENTS.md")
+            if agents_md.is_file():
+                instructions = agents_md.read_text()
+        except PathSecurityError:
+            pass
 
         sources = self._build_sources_from_directory(path)
 
@@ -236,17 +245,22 @@ class AntigravityTools(Toolkit):
                 return
             sources.append({"type": "inline", "content": content, "target": target})
 
-        workspace = path / "workspace"
-        if workspace.is_dir():
-            for f in workspace.rglob("*"):
-                if f.is_file():
-                    add(f, "/" + f.relative_to(workspace).as_posix())
-
-        skills = path / "skills"
-        if skills.is_dir():
-            for f in skills.rglob("*"):
-                if f.is_file():
-                    add(f, "/.agents/skills/" + f.relative_to(skills).as_posix())
+        for source_name, target_prefix in (("workspace", "/"), ("skills", "/.agents/skills/")):
+            try:
+                source_dir = safe_join_relative_path(path, source_name)
+            except PathSecurityError:
+                continue
+            if not source_dir.is_dir():
+                continue
+            for f in source_dir.rglob("*"):
+                if not f.is_file():
+                    continue
+                rel = f.relative_to(source_dir).as_posix()
+                try:
+                    safe_join_relative_path(source_dir, rel)
+                except PathSecurityError:
+                    continue
+                add(f, target_prefix + rel)
 
         return sources
 

--- a/libs/agno/tests/unit/agents/test_antigravity.py
+++ b/libs/agno/tests/unit/agents/test_antigravity.py
@@ -402,6 +402,95 @@ def test_from_agent_directory_builds_sources_with_correct_targets():
     assert all(s["type"] == "inline" for s in agent.sources)
 
 
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("Symlinks not supported on this system")
+
+
+def test_from_agent_directory_skips_workspace_and_skill_files_that_escape_via_symlink():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        _make_agent_dir(agent_dir)
+
+        secret = root / "outside_secret.txt"
+        secret.write_text("OUTSIDE_SECRET")
+        _symlink_or_skip(agent_dir / "workspace" / "linked.txt", secret)
+        (agent_dir / "skills" / "leaky").mkdir()
+        _symlink_or_skip(agent_dir / "skills" / "leaky" / "SKILL.md", secret)
+
+        agent = AntigravityAgent.from_agent_directory(str(agent_dir), api_key="dummy", register=False)
+
+    sources = agent.sources or []
+    targets = {s["target"] for s in sources}
+    contents = "\n".join(s["content"] for s in sources)
+    assert "/about.txt" in targets
+    assert "/linked.txt" not in targets
+    assert "/.agents/skills/leaky/SKILL.md" not in targets
+    assert "OUTSIDE_SECRET" not in contents
+
+
+def test_from_agent_directory_ignores_agents_md_that_escapes_via_symlink():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        _make_agent_dir(agent_dir, with_agents_md=False)
+
+        secret = root / "outside_secret.txt"
+        secret.write_text("OUTSIDE_SECRET")
+        _symlink_or_skip(agent_dir / "AGENTS.md", secret)
+
+        agent = AntigravityAgent.from_agent_directory(str(agent_dir), api_key="dummy", register=False)
+
+    # AGENTS.md escapes the agent dir, so it is not read; instructions fall back to the yaml value
+    assert agent.custom_agent_instructions == "yaml-instructions"
+
+
+def test_from_agent_directory_skips_source_dir_that_is_a_symlink_to_outside():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        agent_dir.joinpath("agent.yaml").write_text("id: my-bot\nbase_agent: antigravity-preview-05-2026\n")
+        (agent_dir / "skills" / "haiku").mkdir(parents=True)
+        (agent_dir / "skills" / "haiku" / "SKILL.md").write_text("# Haiku skill")
+
+        outside = root / "outside_dir"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("OUTSIDE_DIR_SECRET")
+        _symlink_or_skip(agent_dir / "workspace", outside)
+
+        agent = AntigravityAgent.from_agent_directory(str(agent_dir), api_key="dummy", register=False)
+
+    sources = agent.sources or []
+    targets = {s["target"] for s in sources}
+    contents = "\n".join(s["content"] for s in sources)
+    assert "/secret.txt" not in targets
+    assert "OUTSIDE_DIR_SECRET" not in contents
+    # the real skills/ folder is unaffected
+    assert "/.agents/skills/haiku/SKILL.md" in targets
+
+
+def test_from_agent_directory_rejects_agent_yaml_that_escapes_via_symlink():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        _make_agent_dir(agent_dir)
+
+        outside_yaml = root / "outside.yaml"
+        outside_yaml.write_text("id: evil\nbase_agent: antigravity-preview-05-2026\n")
+        (agent_dir / "agent.yaml").unlink()
+        _symlink_or_skip(agent_dir / "agent.yaml", outside_yaml)
+
+        with pytest.raises(FileNotFoundError):
+            AntigravityAgent.from_agent_directory(str(agent_dir), api_key="dummy", register=False)
+
+
 def test_from_agent_directory_requires_id_and_base_agent():
     with tempfile.TemporaryDirectory() as d:
         p = Path(d)

--- a/libs/agno/tests/unit/tools/test_antigravity.py
+++ b/libs/agno/tests/unit/tools/test_antigravity.py
@@ -389,6 +389,104 @@ def test_agent_directory_register_false_parses_without_network():
     assert "/.agents/skills/haiku/SKILL.md" in targets
 
 
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target)
+    except OSError:
+        pytest.skip("Symlinks not supported on this system")
+
+
+def test_agent_directory_skips_workspace_and_skill_files_that_escape_via_symlink():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        _make_toolkit_agent_dir(agent_dir)
+
+        secret = root / "outside_secret.txt"
+        secret.write_text("OUTSIDE_SECRET")
+        _symlink_or_skip(agent_dir / "workspace" / "linked.txt", secret)
+        (agent_dir / "skills" / "leaky").mkdir()
+        _symlink_or_skip(agent_dir / "skills" / "leaky" / "SKILL.md", secret)
+
+        tools = AntigravityTools(api_key="dummy", agent_directory=str(agent_dir), register=False)
+
+    sources = tools.default_sources or []
+    targets = {s["target"] for s in sources}
+    contents = "\n".join(s["content"] for s in sources)
+    assert "/about.txt" in targets
+    assert "/linked.txt" not in targets
+    assert "/.agents/skills/leaky/SKILL.md" not in targets
+    assert "OUTSIDE_SECRET" not in contents
+
+
+def test_agent_directory_ignores_agents_md_that_escapes_via_symlink():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append({"body": json.loads(request.content.decode())})
+        return httpx.Response(200, json={"name": "my-bot"})
+
+    with tempfile.TemporaryDirectory() as d:
+        agent_dir = Path(d) / "agent"
+        agent_dir.mkdir()
+        _make_toolkit_agent_dir(agent_dir)
+
+        secret = Path(d) / "outside_secret.txt"
+        secret.write_text("OUTSIDE_SECRET")
+        (agent_dir / "AGENTS.md").unlink()
+        _symlink_or_skip(agent_dir / "AGENTS.md", secret)
+
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            AntigravityTools(api_key="dummy", agent_directory=str(agent_dir))
+
+    # AGENTS.md escapes the agent dir, so it is not read; instructions fall back to the yaml value
+    body = captured[0]["body"]
+    assert body["instructions"] == "be brief"
+    assert "OUTSIDE_SECRET" not in body.get("instructions", "")
+
+
+def test_agent_directory_skips_source_dir_that_is_a_symlink_to_outside():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        agent_dir.joinpath("agent.yaml").write_text("id: my-bot\nbase_agent: antigravity-preview-05-2026\n")
+        (agent_dir / "skills" / "haiku").mkdir(parents=True)
+        (agent_dir / "skills" / "haiku" / "SKILL.md").write_text("# Haiku skill")
+
+        outside = root / "outside_dir"
+        outside.mkdir()
+        (outside / "secret.txt").write_text("OUTSIDE_DIR_SECRET")
+        _symlink_or_skip(agent_dir / "workspace", outside)
+
+        tools = AntigravityTools(api_key="dummy", agent_directory=str(agent_dir), register=False)
+
+    sources = tools.default_sources or []
+    targets = {s["target"] for s in sources}
+    contents = "\n".join(s["content"] for s in sources)
+    assert "/secret.txt" not in targets
+    assert "OUTSIDE_DIR_SECRET" not in contents
+    # the real skills/ folder is unaffected
+    assert "/.agents/skills/haiku/SKILL.md" in targets
+
+
+def test_agent_directory_rejects_agent_yaml_that_escapes_via_symlink():
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        agent_dir = root / "agent"
+        agent_dir.mkdir()
+        _make_toolkit_agent_dir(agent_dir)
+
+        outside_yaml = root / "outside.yaml"
+        outside_yaml.write_text("id: evil\nbase_agent: antigravity-preview-05-2026\n")
+        (agent_dir / "agent.yaml").unlink()
+        _symlink_or_skip(agent_dir / "agent.yaml", outside_yaml)
+
+        with pytest.raises(FileNotFoundError):
+            AntigravityTools(api_key="dummy", agent_directory=str(agent_dir), register=False)
+
+
 def test_agent_directory_register_true_posts_to_agents():
     captured: List[dict] = []
 


### PR DESCRIPTION
## Summary
- skip symlinked workspace and skill files when building Antigravity inline sources
- resolve workspace/skills roots and candidate files before reading content so inline sources stay within the agent directory
- add regression coverage for both AntigravityTools and AntigravityAgent agent_directory loading

Fixes #8632

## Tests
- python -m pytest libs/agno/tests/unit/tools/test_antigravity.py libs/agno/tests/unit/agents/test_antigravity.py
- python -m ruff check libs/agno/agno/tools/antigravity.py libs/agno/agno/agents/antigravity/agent.py libs/agno/tests/unit/tools/test_antigravity.py libs/agno/tests/unit/agents/test_antigravity.py
- python -m ruff format --check libs/agno/agno/tools/antigravity.py libs/agno/agno/agents/antigravity/agent.py libs/agno/tests/unit/tools/test_antigravity.py libs/agno/tests/unit/agents/test_antigravity.py