### PR TITLE
fix: stamp ModelResponse.created_at per instance instead of at import time

### DIFF
--- a/cookbook/11_memory/integrations/dakera_integration.py
+++ b/cookbook/11_memory/integrations/dakera_integration.py
@@ -23,6 +23,7 @@ Usage:
 import os
 from dataclasses import dataclass, field
 from typing import Optional
+
 import httpx
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
@@ -40,6 +41,7 @@ except ImportError:
 # Dakera memory store — thin REST client
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class DakeraMemoryStore:
     """Persistent memory store backed by a self-hosted Dakera server.
@@ -52,7 +54,9 @@ class DakeraMemoryStore:
         POST /v1/memories/search   — semantic recall (decay-weighted)
     """
 
-    base_url: str = field(default_factory=lambda: os.getenv("DAKERA_URL", "http://localhost:3300"))
+    base_url: str = field(
+        default_factory=lambda: os.getenv("DAKERA_URL", "http://localhost:3300")
+    )
     api_key: str = field(default_factory=lambda: os.getenv("DAKERA_API_KEY", ""))
     namespace: str = "agno-agent"
 
@@ -62,7 +66,9 @@ class DakeraMemoryStore:
             "Content-Type": "application/json",
         }
 
-    def store(self, content: str, user_id: str = "default", session_id: str = "default") -> None:
+    def store(
+        self, content: str, user_id: str = "default", session_id: str = "default"
+    ) -> None:
         """Persist a memory entry to Dakera."""
         httpx.post(
             f"{self.base_url}/v1/memories",
@@ -76,7 +82,9 @@ class DakeraMemoryStore:
             timeout=10.0,
         ).raise_for_status()
 
-    def recall(self, query: str, user_id: Optional[str] = None, top_k: int = 5) -> list[str]:
+    def recall(
+        self, query: str, user_id: Optional[str] = None, top_k: int = 5
+    ) -> list[str]:
         """Recall memories semantically relevant to the query.
 
         Dakera uses decay-weighted scoring: memories that are recent and
@@ -119,6 +127,7 @@ print(f"Stored {len(initial_facts)} memories.\n")
 # ---------------------------------------------------------------------------
 # Build agent with recalled context
 # ---------------------------------------------------------------------------
+
 
 def build_agent_with_memory(task: str) -> Agent:
     """Build an Agno agent with prior memories injected into the system prompt."""

--- a/libs/agno/agno/models/response.py
+++ b/libs/agno/agno/models/response.py
@@ -143,7 +143,7 @@ class ModelResponse:
 
     response_usage: Optional[MessageMetrics] = None
 
-    created_at: int = int(time())
+    created_at: int = field(default_factory=lambda: int(time()))
 
     extra: Optional[Dict[str, Any]] = None
 

--- a/libs/agno/agno/tools/google/drive.py
+++ b/libs/agno/agno/tools/google/drive.py
@@ -46,8 +46,8 @@ from typing import Any, List, Optional, Tuple, Union, cast
 from agno.exceptions import PathSecurityError
 from agno.tools.google.auth import google_authenticate
 from agno.tools.google.base import GoogleToolkit
-from agno.utils.path_safety import safe_join_filename
 from agno.utils.log import log_debug, log_error, log_warning
+from agno.utils.path_safety import safe_join_filename
 
 try:
     from google.oauth2.credentials import Credentials

--- a/libs/agno/tests/unit/knowledge/chunking/test_reader_chunk_flag.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_reader_chunk_flag.py
@@ -91,8 +91,8 @@ def test_s3_reader_propagates_chunk_flag_to_inner_reader():
     """S3Reader must forward chunk/chunk_size/chunking_strategy to its inner reader."""
     pytest.importorskip("agno.knowledge.reader.s3_reader", exc_type=ImportError)
 
-    from agno.knowledge.reader.s3_reader import S3Reader
     from agno.knowledge.chunking.fixed import FixedSizeChunking
+    from agno.knowledge.reader.s3_reader import S3Reader
     from agno.knowledge.reader.text_reader import TextReader
 
     strategy = FixedSizeChunking(chunk_size=123)

--- a/libs/agno/tests/unit/models/test_response.py
+++ b/libs/agno/tests/unit/models/test_response.py
@@ -1,0 +1,98 @@
+"""Tests for ModelResponse and ToolExecution dataclass defaults.
+
+Regression coverage for the boot-time ``created_at`` bug: ``created_at`` used
+to be defined as ``int = int(time())`` (a class-level expression evaluated
+once at import), so every instance in a process shared the same timestamp.
+The fix is to use ``field(default_factory=lambda: int(time()))`` so each
+instance is stamped at construction time.
+"""
+
+from dataclasses import fields
+from time import sleep, time
+from unittest.mock import patch
+
+from agno.models.response import ModelResponse, ToolExecution
+
+
+class TestModelResponseCreatedAt:
+    def test_created_at_is_near_construction_time(self):
+        before = int(time())
+        response = ModelResponse()
+        after = int(time())
+        assert before <= response.created_at <= after
+
+    def test_two_instances_get_distinct_timestamps(self):
+        """Regression: pre-fix, both instances shared the module-import timestamp."""
+        first = ModelResponse()
+        sleep(1.1)
+        second = ModelResponse()
+        assert second.created_at > first.created_at
+        assert second.created_at - first.created_at >= 1
+
+    def test_uses_default_factory_not_class_level_default(self):
+        """Guard against a regression to ``int = int(time())``.
+
+        A class-level int default would be captured on the dataclass field's
+        ``default`` attribute; the correct pattern leaves ``default`` as
+        MISSING and sets ``default_factory`` instead.
+        """
+        from dataclasses import MISSING
+
+        created_at_field = next(f for f in fields(ModelResponse) if f.name == "created_at")
+        assert created_at_field.default is MISSING, (
+            "created_at must not have a class-level default; use default_factory "
+            "or every instance will share the module-import timestamp"
+        )
+        assert created_at_field.default_factory is not MISSING
+        # The factory should be callable and return an int at call time.
+        assert isinstance(created_at_field.default_factory(), int)
+
+    def test_factory_invoked_per_instance(self):
+        """Patch ``time`` in the module and confirm each construction re-reads it."""
+        with patch("agno.models.response.time") as mock_time:
+            mock_time.side_effect = [1000.0, 2000.0, 3000.0]
+            a = ModelResponse()
+            b = ModelResponse()
+            c = ModelResponse()
+        assert a.created_at == 1000
+        assert b.created_at == 2000
+        assert c.created_at == 3000
+
+    def test_explicit_created_at_is_respected(self):
+        response = ModelResponse(created_at=42)
+        assert response.created_at == 42
+
+    def test_created_at_survives_to_dict_roundtrip(self):
+        response = ModelResponse(created_at=1234567890)
+        data = response.to_dict()
+        assert data["created_at"] == 1234567890
+
+
+class TestToolExecutionCreatedAt:
+    """ToolExecution already uses default_factory; these guard against regressions."""
+
+    def test_two_instances_get_distinct_timestamps(self):
+        first = ToolExecution()
+        sleep(1.1)
+        second = ToolExecution()
+        assert second.created_at - first.created_at >= 1
+
+    def test_factory_invoked_per_instance(self):
+        with patch("agno.models.response.time") as mock_time:
+            mock_time.side_effect = [5000.0, 6000.0]
+            a = ToolExecution()
+            b = ToolExecution()
+        assert a.created_at == 5000
+        assert b.created_at == 6000
+
+    def test_from_dict_preserves_explicit_created_at(self):
+        original = ToolExecution(tool_name="foo", created_at=111)
+        restored = ToolExecution.from_dict(original.to_dict())
+        assert restored.created_at == 111
+
+    def test_from_dict_without_created_at_uses_factory(self):
+        """When the payload omits created_at, from_dict falls back to the factory."""
+        before = int(time())
+        restored = ToolExecution.from_dict({"tool_name": "foo"})
+        after = int(time())
+        assert before <= restored.created_at <= after


### PR DESCRIPTION
## Summary

`ModelResponse.created_at` was defined as `int = int(time())` — a class-level
expression evaluated **once at module import**. Every `ModelResponse`
instance in a Python process therefore shared the same timestamp: the moment
`agno.models.response` was first imported. In long-lived processes (API
servers, workers), all responses ended up stamped with process boot time
instead of their actual creation time, breaking ordering, TTLs, "recent
runs" queries, and any downstream analytics keyed on `created_at`.

The same file already has the correct pattern three classes above — 
`ToolExecution.created_at` uses `field(default_factory=lambda: int(time()))`.
This PR makes `ModelResponse` consistent with its sibling.

**The fix** (one line, `libs/agno/agno/models/response.py`):

```python
# before
created_at: int = int(time())
# after
created_at: int = field(default_factory=lambda: int(time()))
```

Downstream sites in agno/agent/_response.py that propagate
model_response.created_at onto run_response.created_at become correct
automatically once the source value is correct — no changes needed there.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
