### PR TITLE
fix(knowledge): upsert missing content rows in _update_content (#7754)

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2534,11 +2534,13 @@ class Knowledge(RemoteKnowledge):
                 log_warning("Content id is required to update Knowledge content")
                 return None
 
-            # TODO: we shouldn't check for content here, we should trust the upsert method to handle conflicts
+            # Upsert semantics: if the row does not exist yet, build it from the
+            # incoming Content so the call actually inserts a row. The previous
+            # behavior returned None on a missing id, silently dropping the
+            # caller's data (issue #7754).
             content_row = self.contents_db.get_knowledge_content(content.id)
             if content_row is None:
-                log_warning(f"Content row not found for id: {content.id}, cannot update status")
-                return None
+                content_row = self._build_knowledge_row(content)
 
             # Apply safe string handling for updates as well
             if content.name is not None:
@@ -2578,14 +2580,15 @@ class Knowledge(RemoteKnowledge):
                 log_warning("Content id is required to update Knowledge content")
                 return None
 
-            # TODO: we shouldn't check for content here, we should trust the upsert method to handle conflicts
+            # Upsert semantics: if the row does not exist yet, build it from the
+            # incoming Content so the call actually inserts a row. Mirrors the
+            # fix in _update_content for the async path (issue #7754).
             if isinstance(self.contents_db, AsyncBaseDb):
                 content_row = await self.contents_db.get_knowledge_content(content.id)
             else:
                 content_row = self.contents_db.get_knowledge_content(content.id)
             if content_row is None:
-                log_warning(f"Content row not found for id: {content.id}, cannot update status")
-                return None
+                content_row = self._build_knowledge_row(content)
 
             # Apply safe string handling for updates
             if content.name is not None:

--- a/libs/agno/tests/unit/knowledge/test_knowledge_update_content.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_update_content.py
@@ -1,0 +1,135 @@
+"""Unit tests for Knowledge._update_content and Knowledge._aupdate_content.
+
+Regression tests for issue #7754: the methods used to early-return None
+when the content row was missing in the database, silently dropping the
+caller's data instead of upserting the new row.
+"""
+
+
+from agno.db.sqlite import SqliteDb
+from agno.knowledge.content import Content, ContentStatus
+from agno.knowledge.knowledge import Knowledge
+
+
+def _make_knowledge(tmp_path) -> Knowledge:
+    db = SqliteDb(db_file=str(tmp_path / "test.db"))
+    return Knowledge(contents_db=db)
+
+
+class TestUpdateContentUpsert:
+    """Sync _update_content must upsert a missing row, not bail."""
+
+    def test_missing_row_is_inserted_with_full_content(self, tmp_path):
+        knowledge = _make_knowledge(tmp_path)
+        new_content = Content(
+            id="missing-row-id",
+            name="New name",
+            description="New description",
+            status=ContentStatus.COMPLETED,
+            metadata={"source": "test"},
+        )
+
+        assert knowledge.contents_db.get_knowledge_content("missing-row-id") is None  # type: ignore[union-attr]
+
+        result = knowledge._update_content(new_content)
+
+        assert result is not None
+        assert result["id"] == "missing-row-id"
+        assert result["name"] == "New name"
+        assert result["description"] == "New description"
+        assert result["status"] == "completed"
+        assert result["metadata"] == {"source": "test"}
+
+        # Verify the row is now in the DB.
+        stored = knowledge.contents_db.get_knowledge_content("missing-row-id")  # type: ignore[union-attr]
+        assert stored is not None
+        assert stored.id == "missing-row-id"  # type: ignore[union-attr]
+        assert stored.name == "New name"  # type: ignore[union-attr]
+        assert stored.description == "New description"  # type: ignore[union-attr]
+
+    def test_existing_row_is_updated_in_place(self, tmp_path):
+        knowledge = _make_knowledge(tmp_path)
+
+        # First call inserts the row.
+        original = Content(
+            id="existing-id",
+            name="Original name",
+            description="Original description",
+            status=ContentStatus.PROCESSING,
+        )
+        knowledge._update_content(original)
+
+        # Second call updates the same row.
+        updated = Content(
+            id="existing-id",
+            name="Updated name",
+            description="Updated description",
+            status=ContentStatus.COMPLETED,
+        )
+        result = knowledge._update_content(updated)
+
+        assert result is not None
+        assert result["name"] == "Updated name"
+        assert result["description"] == "Updated description"
+        assert result["status"] == "completed"
+
+        # DB still has exactly one row, not a duplicate.
+        stored = knowledge.contents_db.get_knowledge_content("existing-id")  # type: ignore[union-attr]
+        assert stored is not None
+        assert stored.name == "Updated name"  # type: ignore[union-attr]
+        assert stored.description == "Updated description"  # type: ignore[union-attr]
+
+    def test_missing_id_returns_none(self, tmp_path):
+        """The pre-existing check for `content.id is None` must still work."""
+        knowledge = _make_knowledge(tmp_path)
+        result = knowledge._update_content(Content(name="no-id"))
+        assert result is None
+
+
+class TestAUpdateContentUpsert:
+    """Async _aupdate_content must mirror the sync behavior."""
+
+    async def test_missing_row_is_inserted_with_full_content(self, tmp_path):
+        knowledge = _make_knowledge(tmp_path)
+        new_content = Content(
+            id="async-missing-id",
+            name="Async new name",
+            description="Async new description",
+            status=ContentStatus.COMPLETED,
+        )
+
+        result = await knowledge._aupdate_content(new_content)
+
+        assert result is not None
+        assert result["id"] == "async-missing-id"
+        assert result["name"] == "Async new name"
+        assert result["description"] == "Async new description"
+
+        stored = knowledge.contents_db.get_knowledge_content("async-missing-id")  # type: ignore[union-attr]
+        assert stored is not None
+        assert stored.name == "Async new name"  # type: ignore[union-attr]
+
+    async def test_existing_row_is_updated_in_place(self, tmp_path):
+        knowledge = _make_knowledge(tmp_path)
+
+        await knowledge._aupdate_content(
+            Content(
+                id="async-existing-id",
+                name="Original async",
+                description="Original async",
+            )
+        )
+        result = await knowledge._aupdate_content(
+            Content(
+                id="async-existing-id",
+                name="Updated async",
+                description="Updated async",
+            )
+        )
+
+        assert result is not None
+        assert result["name"] == "Updated async"
+
+        stored = knowledge.contents_db.get_knowledge_content("async-existing-id")  # type: ignore[union-attr]
+        assert stored is not None
+        assert stored.name == "Updated async"  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

Fixes #7754.

`Knowledge._update_content` and `Knowledge._aupdate_content` used to early-return `None` with a `Content row not found ... cannot update status` warning when the target content id was missing from the database, silently dropping the caller's data. This contradicted the existing `# TODO: we shouldn't check for content here, we should trust the upsert method to handle conflicts` comment that has been sitting above the bail-out for a while.

The fix removes the early bail and, when the row is missing, builds a fresh `KnowledgeRow` from the incoming `Content` via the existing `_build_knowledge_row` helper. The subsequent `upsert_knowledge_content` call then inserts a new row when the id is new and merges user-controlled fields when the row already exists. The async path (`_aupdate_content`) is fixed the same way.

I also replaced the stale TODO comment with a short rationale for the new behaviour.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts — `ruff format` unchanged, `ruff check` clean, `mypy` introduces no new errors (the two pre-existing `mypy` errors in `agno/utils/message.py` and `agno/models/base.py` are unchanged)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings) — replaced the stale TODO with a rationale comment
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated — new dedicated test file `tests/unit/knowledge/test_knowledge_update_content.py` with 5 cases covering the missing-row insert, the in-place update, the missing-id guard, and the async mirror of the same paths

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — see notes below

## Notes for the maintainer

- The reproducer in #7754 was executed locally on `main` before the fix and confirmed that `_update_content` returns `None` and the row is never written. After the fix, the same script reports the row is written with the expected fields.
- `_list_files`, `_grep`, and the other knowledge methods are not affected; only `_update_content` / `_aupdate_content` changed.
- The fix is intentionally narrow: it does not change the public `patch_content` / `apatch_content` signatures, the upsert call shape, or the field-merge logic. The only behavioural change is that the bail-out is removed and replaced with a row build.

## Additional Notes

- Branch: `fix/7754-knowledge-update-content-bail`
- Diff: 2 files, +144/-6
- Tests: 5 new in `test_knowledge_update_content.py`; broader knowledge suite also green (302 pre-existing + 5 new = 307 passed)
