### PR TITLE
fix: persist fallback model response in session history

### DIFF
--- a/libs/agno/agno/models/fallback.py
+++ b/libs/agno/agno/models/fallback.py
@@ -7,6 +7,7 @@ from typing import Any, AsyncIterator, Callable, Iterator, List, Optional, Union
 
 from agno.exceptions import ContextWindowExceededError, ModelProviderError, ModelRateLimitError
 from agno.models.base import Model
+from agno.models.message import Message
 from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.run.agent import RunOutputEvent
 from agno.run.team import TeamRunOutputEvent
@@ -128,6 +129,32 @@ def _clean_kwargs_for_fallback(kwargs: dict) -> dict:
     return cleaned
 
 
+def _copy_kwargs_with_fresh_messages(kwargs: dict) -> dict:
+    """Copy kwargs, duplicating the messages list so each attempt gets its own.
+
+    Each fallback attempt runs on its own copy so a failed attempt cannot pollute
+    the messages the next attempt (or the caller's list) sees.
+    """
+    attempt = dict(kwargs)
+    if "messages" in attempt:
+        attempt["messages"] = list(attempt["messages"])
+    return attempt
+
+
+def _sync_appended_messages(
+    original_messages: Optional[List[Message]], attempt_messages: Optional[List[Message]], seed_len: int
+) -> None:
+    """Append the messages the fallback model added back onto the caller's list.
+
+    The fallback runs on a copy of the (temporary-stripped) seed, so anything past
+    seed_len is what it appended this turn — the assistant message and any tool
+    messages. Extending keeps them in the caller's run_messages.messages so they
+    are persisted in session history.
+    """
+    if original_messages is not None and attempt_messages is not None:
+        original_messages.extend(attempt_messages[seed_len:])
+
+
 def call_model_with_fallback(
     model: Model,
     fallback_config: Optional[FallbackConfig],
@@ -145,7 +172,13 @@ def call_model_with_fallback(
             raise
         log_warning(f"Primary model '{model.id}' failed. Trying fallback models...: {primary_error}")
         return _try_fallback_models(
-            fallbacks, primary_error, "response", _clean_kwargs_for_fallback(kwargs), model.id, fallback_config
+            fallbacks,
+            primary_error,
+            "response",
+            _clean_kwargs_for_fallback(kwargs),
+            model.id,
+            fallback_config,
+            original_messages=kwargs.get("messages"),
         )
 
 
@@ -163,7 +196,13 @@ async def acall_model_with_fallback(
             raise
         log_warning(f"Primary model '{model.id}' failed. Trying fallback models...: {primary_error}")
         return await _atry_fallback_models(
-            fallbacks, primary_error, "aresponse", _clean_kwargs_for_fallback(kwargs), model.id, fallback_config
+            fallbacks,
+            primary_error,
+            "aresponse",
+            _clean_kwargs_for_fallback(kwargs),
+            model.id,
+            fallback_config,
+            original_messages=kwargs.get("messages"),
         )
 
 
@@ -187,7 +226,12 @@ def call_model_stream_with_fallback(
         log_warning(f"Primary model '{model.id}' failed. Trying fallback models...: {primary_error}")
         yield ModelResponse(event=ModelResponseEvent.fallback_model_activated.value)
         yield from _try_fallback_models_stream(
-            fallbacks, primary_error, _clean_kwargs_for_fallback(kwargs), model.id, fallback_config
+            fallbacks,
+            primary_error,
+            _clean_kwargs_for_fallback(kwargs),
+            model.id,
+            fallback_config,
+            original_messages=kwargs.get("messages"),
         )
 
 
@@ -207,7 +251,12 @@ async def acall_model_stream_with_fallback(
         log_warning(f"Primary model '{model.id}' failed. Trying fallback models...: {primary_error}")
         yield ModelResponse(event=ModelResponseEvent.fallback_model_activated.value)
         async for event in _atry_fallback_models_stream(
-            fallbacks, primary_error, _clean_kwargs_for_fallback(kwargs), model.id, fallback_config
+            fallbacks,
+            primary_error,
+            _clean_kwargs_for_fallback(kwargs),
+            model.id,
+            fallback_config,
+            original_messages=kwargs.get("messages"),
         ):
             yield event
 
@@ -238,12 +287,20 @@ def _try_fallback_models(
     kwargs: dict,
     primary_model_id: str = "",
     fallback_config: Optional[FallbackConfig] = None,
+    original_messages: Optional[List[Message]] = None,
 ) -> ModelResponse:
-    """Try each fallback model in order. Raises the primary error if all fail."""
+    """Try each fallback model in order. Raises the primary error if all fail.
+
+    Messages the successful fallback appends are synced back into original_messages
+    so the fallback's response is persisted in session history.
+    """
+    seed_len = len(kwargs["messages"]) if "messages" in kwargs else 0
     for i, fallback in enumerate(fallback_models):
         try:
             log_warning(f"Trying fallback model {i + 1}/{len(fallback_models)}: {fallback.id}")
-            result = getattr(fallback, method_name)(**kwargs)
+            attempt_kwargs = _copy_kwargs_with_fresh_messages(kwargs)
+            result = getattr(fallback, method_name)(**attempt_kwargs)
+            _sync_appended_messages(original_messages, attempt_kwargs.get("messages"), seed_len)
             _notify_fallback(fallback_config, primary_model_id, fallback.id, primary_error)
             return result
         except ModelProviderError as e:
@@ -259,12 +316,20 @@ async def _atry_fallback_models(
     kwargs: dict,
     primary_model_id: str = "",
     fallback_config: Optional[FallbackConfig] = None,
+    original_messages: Optional[List[Message]] = None,
 ) -> ModelResponse:
-    """Async: try each fallback model in order. Raises the primary error if all fail."""
+    """Async: try each fallback model in order. Raises the primary error if all fail.
+
+    Messages the successful fallback appends are synced back into original_messages
+    so the fallback's response is persisted in session history.
+    """
+    seed_len = len(kwargs["messages"]) if "messages" in kwargs else 0
     for i, fallback in enumerate(fallback_models):
         try:
             log_warning(f"Trying fallback model {i + 1}/{len(fallback_models)}: {fallback.id}")
-            result = await getattr(fallback, method_name)(**kwargs)
+            attempt_kwargs = _copy_kwargs_with_fresh_messages(kwargs)
+            result = await getattr(fallback, method_name)(**attempt_kwargs)
+            _sync_appended_messages(original_messages, attempt_kwargs.get("messages"), seed_len)
             _notify_fallback(fallback_config, primary_model_id, fallback.id, primary_error)
             return result
         except ModelProviderError as e:
@@ -279,12 +344,20 @@ def _try_fallback_models_stream(
     kwargs: dict,
     primary_model_id: str = "",
     fallback_config: Optional[FallbackConfig] = None,
+    original_messages: Optional[List[Message]] = None,
 ) -> Iterator[StreamEvent]:
-    """Try each fallback model stream in order. Raises the primary error if all fail."""
+    """Try each fallback model stream in order. Raises the primary error if all fail.
+
+    Messages the successful fallback appends are synced back into original_messages
+    so the fallback's response is persisted in session history.
+    """
+    seed_len = len(kwargs["messages"]) if "messages" in kwargs else 0
     for i, fallback in enumerate(fallback_models):
         try:
             log_warning(f"Trying fallback model {i + 1}/{len(fallback_models)}: {fallback.id}")
-            yield from fallback.response_stream(**kwargs)
+            attempt_kwargs = _copy_kwargs_with_fresh_messages(kwargs)
+            yield from fallback.response_stream(**attempt_kwargs)
+            _sync_appended_messages(original_messages, attempt_kwargs.get("messages"), seed_len)
             _notify_fallback(fallback_config, primary_model_id, fallback.id, primary_error)
             return
         except ModelProviderError as e:
@@ -299,13 +372,21 @@ async def _atry_fallback_models_stream(
     kwargs: dict,
     primary_model_id: str = "",
     fallback_config: Optional[FallbackConfig] = None,
+    original_messages: Optional[List[Message]] = None,
 ) -> AsyncIterator[StreamEvent]:
-    """Async: try each fallback model stream in order. Raises the primary error if all fail."""
+    """Async: try each fallback model stream in order. Raises the primary error if all fail.
+
+    Messages the successful fallback appends are synced back into original_messages
+    so the fallback's response is persisted in session history.
+    """
+    seed_len = len(kwargs["messages"]) if "messages" in kwargs else 0
     for i, fallback in enumerate(fallback_models):
         try:
             log_warning(f"Trying fallback model {i + 1}/{len(fallback_models)}: {fallback.id}")
-            async for event in fallback.aresponse_stream(**kwargs):
+            attempt_kwargs = _copy_kwargs_with_fresh_messages(kwargs)
+            async for event in fallback.aresponse_stream(**attempt_kwargs):
                 yield event
+            _sync_appended_messages(original_messages, attempt_kwargs.get("messages"), seed_len)
             _notify_fallback(fallback_config, primary_model_id, fallback.id, primary_error)
             return
         except ModelProviderError as e:

--- a/libs/agno/tests/unit/test_fallback.py
+++ b/libs/agno/tests/unit/test_fallback.py
@@ -19,6 +19,7 @@ from agno.models.fallback import (
     call_model_with_fallback,
     get_fallback_models,
 )
+from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
 from agno.models.response import ModelResponse, ModelResponseEvent
 
@@ -234,6 +235,46 @@ class TestCallModelWithFallback:
                     result = call_model_with_fallback(primary, config, messages=[])
                     assert result.content == "second-ok"
 
+    def test_fallback_response_synced_to_messages(self):
+        """The assistant message the fallback appends lands in the caller's messages list."""
+        primary = _make_model("primary")
+        fallback = _make_model("fallback")
+        config = FallbackConfig(on_error=[fallback])
+        messages = [Message(role="user", content="hi")]
+
+        def _fallback_response(messages, **kwargs):
+            messages.append(Message(role="assistant", content="fallback-reply"))
+            return ModelResponse(content="fallback-reply")
+
+        with patch.object(primary, "response", side_effect=ModelProviderError("fail", status_code=500)):
+            with patch.object(fallback, "response", side_effect=_fallback_response):
+                call_model_with_fallback(primary, config, messages=messages)
+
+        assert [m.content for m in messages if m.role == "assistant"] == ["fallback-reply"]
+
+    def test_fallback_strips_temporary_and_does_not_duplicate(self):
+        """Fallback does not see temporary messages, and its reply syncs back exactly once."""
+        primary = _make_model("primary")
+        fallback = _make_model("fallback")
+        config = FallbackConfig(on_error=[fallback])
+        temporary = Message(role="user", content="guidance")
+        temporary.temporary = True
+        messages = [Message(role="user", content="hi"), temporary]
+        seen_by_fallback = {}
+
+        def _fallback_response(messages, **kwargs):
+            seen_by_fallback["count"] = len(messages)
+            messages.append(Message(role="assistant", content="fallback-reply"))
+            return ModelResponse(content="fallback-reply")
+
+        with patch.object(primary, "response", side_effect=ModelProviderError("fail", status_code=500)):
+            with patch.object(fallback, "response", side_effect=_fallback_response):
+                call_model_with_fallback(primary, config, messages=messages)
+
+        assert seen_by_fallback["count"] == 1  # temporary message stripped from what the fallback sees
+        assert sum(1 for m in messages if m.content == "fallback-reply") == 1
+        assert any(getattr(m, "temporary", False) for m in messages)  # temporary preserved in caller's list
+
     def test_fallback_receives_same_kwargs(self):
         """Verify fallback model gets the same messages/tools/etc as the primary."""
         primary = _make_model("primary")
@@ -301,6 +342,26 @@ class TestAsyncCallModelWithFallback:
                 with pytest.raises(ModelProviderError, match="primary fail"):
                     await acall_model_with_fallback(primary, config, messages=[])
 
+    @pytest.mark.asyncio
+    async def test_async_fallback_response_synced_to_messages(self):
+        """Async: the assistant message the fallback appends lands in the caller's messages list."""
+        primary = _make_model("primary")
+        fallback = _make_model("fallback")
+        config = FallbackConfig(on_error=[fallback])
+        messages = [Message(role="user", content="hi")]
+
+        async def _fallback_aresponse(messages, **kwargs):
+            messages.append(Message(role="assistant", content="fallback-reply"))
+            return ModelResponse(content="fallback-reply")
+
+        with patch.object(
+            primary, "aresponse", new_callable=AsyncMock, side_effect=ModelProviderError("fail", status_code=500)
+        ):
+            with patch.object(fallback, "aresponse", side_effect=_fallback_aresponse):
+                await acall_model_with_fallback(primary, config, messages=messages)
+
+        assert [m.content for m in messages if m.role == "assistant"] == ["fallback-reply"]
+
 
 # =============================================================================
 # Group 5: call_model_stream_with_fallback() (sync streaming)
@@ -334,6 +395,23 @@ class TestCallModelStreamWithFallback:
                 assert len(result) == 2
                 assert result[0].event == ModelResponseEvent.fallback_model_activated.value
                 assert result[1].content == "fb-chunk"
+
+    def test_stream_fallback_response_synced_to_messages(self):
+        """Streaming: the assistant message the fallback appends lands in the caller's messages list."""
+        primary = _make_model("primary")
+        fallback = _make_model("fallback")
+        config = FallbackConfig(on_error=[fallback])
+        messages = [Message(role="user", content="hi")]
+
+        def _fallback_stream(messages, **kwargs):
+            yield ModelResponse(content="fb-chunk")
+            messages.append(Message(role="assistant", content="fallback-reply"))
+
+        with patch.object(primary, "response_stream", side_effect=ModelProviderError("fail", status_code=500)):
+            with patch.object(fallback, "response_stream", side_effect=_fallback_stream):
+                list(call_model_stream_with_fallback(primary, config, messages=messages))
+
+        assert [m.content for m in messages if m.role == "assistant"] == ["fallback-reply"]
 
 
 # =============================================================================
@@ -383,6 +461,29 @@ class TestAsyncCallModelStreamWithFallback:
                 assert len(result) == 2
                 assert result[0].event == ModelResponseEvent.fallback_model_activated.value
                 assert result[1].content == "fb-chunk"
+
+    @pytest.mark.asyncio
+    async def test_async_stream_fallback_response_synced_to_messages(self):
+        """Async streaming: the assistant message the fallback appends lands in the caller's messages list."""
+        primary = _make_model("primary")
+        fallback = _make_model("fallback")
+        config = FallbackConfig(on_error=[fallback])
+        messages = [Message(role="user", content="hi")]
+
+        async def mock_primary_stream(**kwargs):
+            raise ModelProviderError("fail", status_code=500)
+            yield  # make it an async generator
+
+        async def mock_fallback_stream(messages, **kwargs):
+            yield ModelResponse(content="fb-chunk")
+            messages.append(Message(role="assistant", content="fallback-reply"))
+
+        with patch.object(primary, "aresponse_stream", side_effect=mock_primary_stream):
+            with patch.object(fallback, "aresponse_stream", side_effect=mock_fallback_stream):
+                async for _ in acall_model_stream_with_fallback(primary, config, messages=messages):
+                    pass
+
+        assert [m.content for m in messages if m.role == "assistant"] == ["fallback-reply"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

When the primary model fails and a fallback model answers, the fallback's assistant message was returned to the user but **not persisted in session history**. On the next turn the agent had a gap in its conversation history (the fallback turn was missing), which also affected multi-turn recall and summaries.

**Cause:** before calling a fallback, `_clean_kwargs_for_fallback` builds a *new* messages list to strip `temporary` retry-guidance messages. The fallback model appends its reply to that detached copy, which is then discarded — so `run_messages.messages` (the list that gets persisted) never receives it.

**Fix:** run each fallback attempt on its own copy of the (temporary-stripped) messages, and after a fallback succeeds, sync the messages it appended back onto the caller's list:

```python
seed_len = len(kwargs["messages"]) if "messages" in kwargs else 0
attempt_kwargs = _copy_kwargs_with_fresh_messages(kwargs)
result = getattr(fallback, method_name)(**attempt_kwargs)
_sync_appended_messages(original_messages, attempt_kwargs.get("messages"), seed_len)
```

`attempt_messages[seed_len:]` is exactly what the fallback appended this turn — the assistant message plus any tool messages — so the caller's list is extended with those and nothing is duplicated. Temporary messages are still hidden from the fallback, and message-level metrics ride along on the copied message object.

The change lives entirely in the shared `models/fallback.py`, so it applies uniformly to agents, teams and workflows, across sync/async and streaming/non-streaming, and is database-agnostic.

Also fixes a latent issue: because each attempt now runs on its own copy, a fallback that partially appends and then fails no longer pollutes the messages the next attempt (or the caller) sees.

fixes #8727

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added unit tests in `test_fallback.py` asserting the fallback's appended assistant message is synced back into the caller's list for sync, async, sync-streaming and async-streaming paths, plus a case verifying temporary messages are stripped from what the fallback sees and the reply is not duplicated. Verified end-to-end with a live primary→fallback setup (failing primary, real fallback) across agent/team/workflow × sync/async × streaming/non-streaming, on SQLite and Postgres, including a multi-turn recall scenario and tool-calling turns.
