### PR TITLE
feat: add timeout to base Toolkit; wire HTTP timeouts across tools

### DIFF
--- a/libs/agno/agno/tools/brightdata.py
+++ b/libs/agno/agno/tools/brightdata.py
@@ -62,7 +62,6 @@ class BrightDataTools(Toolkit):
         }
         self.web_unlocker_zone = getenv("BRIGHT_DATA_WEB_UNLOCKER_ZONE", web_unlocker_zone)
         self.serp_zone = getenv("BRIGHT_DATA_SERP_ZONE", serp_zone)
-        self.timeout = timeout
 
         tools: List[Any] = []
         if all or enable_scrape_markdown:
@@ -74,7 +73,7 @@ class BrightDataTools(Toolkit):
         if all or enable_web_data_feed:
             tools.append(self.web_data_feed)
 
-        super().__init__(name="brightdata_tools", tools=tools, **kwargs)
+        super().__init__(name="brightdata_tools", tools=tools, timeout=timeout, **kwargs)
 
     def _make_request(self, payload: Dict) -> str:
         """Make a request to Bright Data API."""
@@ -82,7 +81,9 @@ class BrightDataTools(Toolkit):
             if self.verbose:
                 log_info(f"[Bright Data] Request: {payload['url']}")
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(
+                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Failed to scrape: {response.status_code} - {response.text}")
@@ -147,7 +148,9 @@ class BrightDataTools(Toolkit):
                 "data_format": "screenshot",
             }
 
-            response = requests.post(self.endpoint, headers=self.headers, data=json.dumps(payload))
+            response = requests.post(
+                self.endpoint, headers=self.headers, data=json.dumps(payload), timeout=self.timeout
+            )
 
             if response.status_code != 200:
                 raise Exception(f"Error {response.status_code}: {response.text}")
@@ -327,6 +330,7 @@ class BrightDataTools(Toolkit):
                 params={"dataset_id": dataset_id, "include_errors": "true"},
                 headers=self.headers,
                 json=[request_data],
+                timeout=self.timeout,
             )
 
             trigger_data = trigger_response.json()
@@ -346,6 +350,8 @@ class BrightDataTools(Toolkit):
                         f"https://api.brightdata.com/datasets/v3/snapshot/{snapshot_id}",
                         params={"format": "json"},
                         headers=self.headers,
+                        # Per-poll cap; self.timeout (via max_attempts) controls the total polling budget.
+                        timeout=30,
                     )
 
                     snapshot_data = snapshot_response.json()

--- a/libs/agno/agno/tools/calcom.py
+++ b/libs/agno/agno/tools/calcom.py
@@ -18,6 +18,7 @@ class CalComTools(Toolkit):
         api_key: Optional[str] = None,
         event_type_id: Optional[int] = None,
         user_timezone: Optional[str] = None,
+        timeout: int = 30,
         # Enable flags for <6 functions
         enable_get_available_slots: bool = True,
         enable_create_booking: bool = True,
@@ -33,6 +34,7 @@ class CalComTools(Toolkit):
             api_key: Cal.com API key
             event_type_id: Default event type ID for bookings
             user_timezone: User's timezone in IANA format (e.g., 'Asia/Kolkata')
+            timeout: Per-request HTTP timeout in seconds. Defaults to 30.
         """
 
         # Get credentials from environment if not provided
@@ -62,7 +64,7 @@ class CalComTools(Toolkit):
         if all or enable_cancel_booking:
             tools.append(self.cancel_booking)
 
-        super().__init__(name="calcom", tools=tools, **kwargs)
+        super().__init__(name="calcom", tools=tools, timeout=timeout, **kwargs)
 
     def _convert_to_user_timezone(self, utc_time: str) -> str:
         """Convert UTC time to user's timezone.
@@ -118,7 +120,7 @@ class CalComTools(Toolkit):
                 "eventTypeId": str(self.event_type_id),
             }
 
-            response = requests.get(url, headers=self._get_headers(), params=querystring)  # type: ignore
+            response = requests.get(url, headers=self._get_headers(), params=querystring, timeout=self.timeout)  # type: ignore
             if response.status_code == 200:
                 slots = response.json()["data"]["slots"]
                 available_slots = []
@@ -157,7 +159,7 @@ class CalComTools(Toolkit):
                 "attendee": {"name": name, "email": email, "timeZone": self.user_timezone},
             }
 
-            response = requests.post(url, json=payload, headers=self._get_headers())
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=self.timeout)
             if response.status_code == 201:
                 booking_data = response.json()["data"]
                 user_time = self._convert_to_user_timezone(booking_data["start"])
@@ -182,7 +184,7 @@ class CalComTools(Toolkit):
             if email:
                 querystring["attendeeEmail"] = email
 
-            response = requests.get(url, headers=self._get_headers(), params=querystring)
+            response = requests.get(url, headers=self._get_headers(), params=querystring, timeout=self.timeout)
             if response.status_code == 200:
                 bookings = response.json()["data"]
                 if not bookings:
@@ -222,7 +224,7 @@ class CalComTools(Toolkit):
             new_start_time = datetime.fromisoformat(new_start_time).astimezone(pytz.utc).isoformat(timespec="seconds")
             payload = {"start": new_start_time, "reschedulingReason": reason}
 
-            response = requests.post(url, json=payload, headers=self._get_headers())
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=self.timeout)
             if response.status_code == 201:
                 booking_data = response.json()["data"]
                 user_time = self._convert_to_user_timezone(booking_data["start"])
@@ -246,7 +248,7 @@ class CalComTools(Toolkit):
             url = f"https://api.cal.com/v2/bookings/{booking_uid}/cancel"
             payload = {"cancellationReason": reason}
 
-            response = requests.post(url, json=payload, headers=self._get_headers())
+            response = requests.post(url, json=payload, headers=self._get_headers(), timeout=self.timeout)
             if response.status_code == 200:
                 return "Booking cancelled successfully."
             return f"Failed to cancel booking: {response.text}"

--- a/libs/agno/agno/tools/clickup.py
+++ b/libs/agno/agno/tools/clickup.py
@@ -17,6 +17,7 @@ class ClickUpTools(Toolkit):
         self,
         api_key: Optional[str] = None,
         master_space_id: Optional[str] = None,
+        timeout: int = 30,
         **kwargs,
     ):
         self.api_key = api_key or getenv("CLICKUP_API_KEY")
@@ -39,7 +40,7 @@ class ClickUpTools(Toolkit):
             self.list_lists,
         ]
 
-        super().__init__(name="clickup", tools=tools, **kwargs)
+        super().__init__(name="clickup", tools=tools, timeout=timeout, **kwargs)
 
     def _make_request(
         self, method: str, endpoint: str, params: Optional[Dict] = None, data: Optional[Dict] = None
@@ -47,7 +48,9 @@ class ClickUpTools(Toolkit):
         """Make a request to the ClickUp API."""
         url = f"{self.base_url}/{endpoint}"
         try:
-            response = requests.request(method=method, url=url, headers=self.headers, params=params, json=data)
+            response = requests.request(
+                method=method, url=url, headers=self.headers, params=params, json=data, timeout=self.timeout
+            )
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/libs/agno/agno/tools/hackernews.py
+++ b/libs/agno/agno/tools/hackernews.py
@@ -15,10 +15,16 @@ class HackerNewsTools(Toolkit):
         enable_get_top_stories (bool): Enable getting top stories from Hacker News. Default is True.
         enable_get_user_details (bool): Enable getting user details from Hacker News. Default is True.
         all (bool): Enable all tools. Overrides individual flags when True. Default is False.
+        timeout (int): Per-request HTTP timeout in seconds. Defaults to 30.
     """
 
     def __init__(
-        self, enable_get_top_stories: bool = True, enable_get_user_details: bool = True, all: bool = False, **kwargs
+        self,
+        enable_get_top_stories: bool = True,
+        enable_get_user_details: bool = True,
+        all: bool = False,
+        timeout: int = 30,
+        **kwargs,
     ):
         tools: List[Any] = []
         if all or enable_get_top_stories:
@@ -26,7 +32,7 @@ class HackerNewsTools(Toolkit):
         if all or enable_get_user_details:
             tools.append(self.get_user_details)
 
-        super().__init__(name="hackers_news", tools=tools, **kwargs)
+        super().__init__(name="hackers_news", tools=tools, timeout=timeout, **kwargs)
 
     def get_top_hackernews_stories(self, num_stories: int = 10) -> str:
         """Use this function to get top stories from Hacker News.
@@ -41,13 +47,18 @@ class HackerNewsTools(Toolkit):
         try:
             log_debug(f"Getting top {num_stories} stories from Hacker News")
             # Fetch top story IDs
-            response = httpx.get("https://hacker-news.firebaseio.com/v0/topstories.json")
+            response = httpx.get("https://hacker-news.firebaseio.com/v0/topstories.json", timeout=self.timeout)
+            response.raise_for_status()
             story_ids = response.json()
 
             # Fetch story details
             stories = []
             for story_id in story_ids[:num_stories]:
-                story_response = httpx.get(f"https://hacker-news.firebaseio.com/v0/item/{story_id}.json")
+                story_response = httpx.get(
+                    f"https://hacker-news.firebaseio.com/v0/item/{story_id}.json",
+                    timeout=self.timeout,
+                )
+                story_response.raise_for_status()
                 story = story_response.json()
                 if story is None:
                     continue
@@ -70,7 +81,12 @@ class HackerNewsTools(Toolkit):
 
         try:
             log_debug(f"Getting details for user: {username}")
-            user = httpx.get(f"https://hacker-news.firebaseio.com/v0/user/{username}.json").json()
+            response = httpx.get(
+                f"https://hacker-news.firebaseio.com/v0/user/{username}.json",
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            user = response.json()
             user_details = {
                 "id": user.get("id"),
                 "karma": user.get("karma"),

--- a/libs/agno/agno/tools/openweather.py
+++ b/libs/agno/agno/tools/openweather.py
@@ -23,6 +23,7 @@ class OpenWeatherTools(Toolkit):
         enable_air_pollution (bool): Enable air pollution function. Default is True.
         enable_geocoding (bool): Enable geocoding function. Default is True.
         all (bool): Enable all functions. Default is False.
+        timeout (int): Per-request HTTP timeout in seconds. Default is 30.
     """
 
     def __init__(
@@ -34,6 +35,7 @@ class OpenWeatherTools(Toolkit):
         enable_air_pollution: bool = True,
         enable_geocoding: bool = True,
         all: bool = False,
+        timeout: int = 30,
         **kwargs,
     ):
         self.api_key = api_key or getenv("OPENWEATHER_API_KEY")
@@ -56,7 +58,7 @@ class OpenWeatherTools(Toolkit):
         if enable_geocoding or all:
             tools.append(self.geocode_location)
 
-        super().__init__(name="openweather_tools", tools=tools, **kwargs)
+        super().__init__(name="openweather_tools", tools=tools, timeout=timeout, **kwargs)
 
     def _make_request(self, url: str, params: Dict) -> Dict:
         """Make a request to the OpenWeatherMap API.
@@ -70,7 +72,7 @@ class OpenWeatherTools(Toolkit):
         """
         try:
             params["appid"] = self.api_key
-            response = requests.get(url, params=params)
+            response = requests.get(url, params=params, timeout=self.timeout)
             response.raise_for_status()
             return response.json()
         except requests.exceptions.RequestException as e:

--- a/libs/agno/agno/tools/searxng.py
+++ b/libs/agno/agno/tools/searxng.py
@@ -14,6 +14,7 @@ class Searxng(Toolkit):
         host: str,
         engines: Optional[List[str]] = None,
         fixed_max_results: Optional[int] = None,
+        timeout: int = 30,
         **kwargs,
     ):
         self.host = host
@@ -31,7 +32,7 @@ class Searxng(Toolkit):
             self.video_search,
         ]
 
-        super().__init__(name="searxng", tools=tools, **kwargs)
+        super().__init__(name="searxng", tools=tools, timeout=timeout, **kwargs)
 
     def search_web(self, query: str, max_results: int = 5) -> str:
         """Use this function to search the web.
@@ -140,7 +141,9 @@ class Searxng(Toolkit):
 
         log_info(f"Fetching results from searxng: {url}")
         try:
-            resp = httpx.get(url).json()
+            response = httpx.get(url, timeout=self.timeout)
+            response.raise_for_status()
+            resp = response.json()
             results = self.fixed_max_results or max_results
             resp["results"] = resp["results"][:results]
             return json.dumps(resp)

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from inspect import iscoroutinefunction
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 from agno.exceptions import PathSecurityError
 from agno.tools.function import Function
@@ -30,6 +30,7 @@ class Toolkit:
         cache_results: bool = False,
         cache_ttl: int = 3600,
         cache_dir: Optional[str] = None,
+        timeout: Optional[int] = None,
         auto_register: bool = True,
     ):
         """Initialize a new Toolkit.
@@ -49,6 +50,12 @@ class Toolkit:
             cache_results (bool): Enable in-memory caching of function results.
             cache_ttl (int): Time-to-live for cached results in seconds.
             cache_dir (Optional[str]): Directory to store cache files. Defaults to system temp dir.
+            timeout (Optional[int]): Timeout in seconds for the primary I/O operation this toolkit
+                performs (e.g. HTTP request, SDK call, sandbox execution). Subclasses that talk to
+                external systems should accept their own ``timeout`` and forward it via
+                ``super().__init__(timeout=...)`` so agents have a uniform override path. Toolkits
+                that also expose secondary timers (job-poll intervals, per-task budgets) should keep
+                their own explicit names for those.
             auto_register (bool): Whether to automatically register all methods in the class.
             stop_after_tool_call_tools (Optional[List[str]]): List of function names that should stop the agent after execution.
             show_result_tools (Optional[List[str]]): List of function names whose results should be shown.
@@ -81,6 +88,16 @@ class Toolkit:
         self.cache_results: bool = cache_results
         self.cache_ttl: int = cache_ttl
         self.cache_dir: Optional[str] = cache_dir
+
+        # Only assign timeout when the caller explicitly passed one, or when the
+        # subclass hasn't already set it before calling super().__init__(). This
+        # lets subclasses either forward timeout via super() (recommended) or set
+        # self.timeout locally without either pattern clobbering the other.
+        #
+        # Widen the value to Any at assignment: subclasses own the semantic type
+        # (int, float, or httpx.Timeout) and a base Optional[int] would break them.
+        if timeout is not None or not hasattr(self, "timeout"):
+            self.timeout = cast(Any, timeout)
 
         # Automatically register all methods if auto_register is True
         if auto_register:

--- a/libs/agno/tests/unit/tools/test_brightdata.py
+++ b/libs/agno/tests/unit/tools/test_brightdata.py
@@ -93,7 +93,10 @@ def test_make_request_success(brightdata_tools, mock_requests):
 
     assert result == "Success response"
     mock_requests.post.assert_called_once_with(
-        brightdata_tools.endpoint, headers=brightdata_tools.headers, data=json.dumps(payload)
+        brightdata_tools.endpoint,
+        headers=brightdata_tools.headers,
+        data=json.dumps(payload),
+        timeout=brightdata_tools.timeout,
     )
 
 

--- a/libs/agno/tests/unit/tools/test_hackernews.py
+++ b/libs/agno/tests/unit/tools/test_hackernews.py
@@ -93,7 +93,7 @@ class TestGetTopHackerNewsStories:
             {"id": 11111, "title": "Story 3", "by": "user3", "url": "https://example3.com"},
         ]
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -122,7 +122,7 @@ class TestGetTopHackerNewsStories:
             2: {"id": 2, "title": "Story 2", "by": "user2"},
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -142,7 +142,7 @@ class TestGetTopHackerNewsStories:
         mock_story_ids = [12345]
         mock_story = {"id": 12345, "title": "Test Story", "by": "testuser", "score": 100}
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -160,7 +160,7 @@ class TestGetTopHackerNewsStories:
     def test_get_top_stories_empty_response(self, hackernews_tools):
         """Test handling of empty story list."""
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             response.json.return_value = []
             return response
@@ -188,7 +188,7 @@ class TestGetTopHackerNewsStories:
             67890: {"id": 67890, "title": "Story 2", "by": "user2"},
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -210,7 +210,7 @@ class TestGetTopHackerNewsStories:
         mock_story_ids = [12345]
         mock_story = {"id": 12345, "title": "Job Posting", "type": "job", "url": "https://example.com"}
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -238,7 +238,7 @@ class TestGetTopHackerNewsStories:
             "type": "story",
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -385,7 +385,7 @@ class TestEdgeCases:
         """Test requesting zero stories."""
         mock_story_ids = [1, 2, 3]
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             response.json.return_value = mock_story_ids
             return response
@@ -404,7 +404,7 @@ class TestEdgeCases:
             2: {"id": 2, "title": "Story 2", "by": "user2"},
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids
@@ -447,7 +447,7 @@ class TestEdgeCases:
             "score": 5000,
         }
 
-        def mock_get(url):
+        def mock_get(url, **kwargs):
             response = MagicMock()
             if "topstories" in url:
                 response.json.return_value = mock_story_ids

--- a/libs/agno/tests/unit/tools/test_searxng.py
+++ b/libs/agno/tests/unit/tools/test_searxng.py
@@ -51,7 +51,7 @@ def test_searxng_search(searxng_instance):
         assert result_data["results"][0]["title"] == "Result 1"
         assert result_data["results"][1]["title"] == "Result 2"
 
-        mock_get.assert_called_once_with("http://localhost:53153/search?format=json&q=test%20query")
+        mock_get.assert_called_once_with("http://localhost:53153/search?format=json&q=test%20query", timeout=30)
 
 
 def test_searxng_search_with_engines(searxng_with_engines):
@@ -66,7 +66,7 @@ def test_searxng_search_with_engines(searxng_with_engines):
         searxng_with_engines.search_web("test query")
 
         expected_url = "http://localhost:53153/search?format=json&q=test%20query&engines=google,bing"
-        mock_get.assert_called_once_with(expected_url)
+        mock_get.assert_called_once_with(expected_url, timeout=30)
 
 
 def test_searxng_search_with_fixed_max_results(searxng_with_fixed_results):
@@ -101,7 +101,7 @@ def test_searxng_image_search(searxng_instance):
         result = searxng_images.image_search("test image")
 
         expected_url = "http://localhost:53153/search?format=json&q=test%20image&categories=images"
-        mock_get.assert_called_once_with(expected_url)
+        mock_get.assert_called_once_with(expected_url, timeout=30)
 
         result_data = json.loads(result)
         assert result_data["results"][0]["title"] == "Image 1"
@@ -120,7 +120,7 @@ def test_searxng_news_search():
         searxng_news.news_search("breaking news")
 
         expected_url = "http://localhost:53153/search?format=json&q=breaking%20news&categories=news"
-        mock_get.assert_called_once_with(expected_url)
+        mock_get.assert_called_once_with(expected_url, timeout=30)
 
 
 def test_searxng_search_error_handling(searxng_instance):
@@ -145,7 +145,7 @@ def test_searxng_query_encoding(searxng_instance):
         searxng_instance.search_web("test query with spaces & symbols")
 
         expected_url = "http://localhost:53153/search?format=json&q=test%20query%20with%20spaces%20%26%20symbols"
-        mock_get.assert_called_once_with(expected_url)
+        mock_get.assert_called_once_with(expected_url, timeout=30)
 
 
 def test_searxng_initialization():
@@ -208,7 +208,7 @@ def test_category_searches(category, method_name):
         result = method("test query")
 
         expected_url = f"http://localhost:53153/search?format=json&q=test%20query&categories={category}"
-        mock_get.assert_called_once_with(expected_url)
+        mock_get.assert_called_once_with(expected_url, timeout=30)
 
         result_data = json.loads(result)
         assert result_data["results"][0]["title"] == "Test"

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -157,6 +157,49 @@ def test_caching_parameters():
     assert toolkit.cache_dir == "/tmp/cache"
 
 
+def test_timeout_defaults_to_none():
+    """Timeout is opt-in — the base default is None so subclasses can decide
+    whether to expose it and what value to use."""
+    toolkit = Toolkit(name="notimeout", tools=[example_func])
+    assert toolkit.timeout is None
+
+
+def test_timeout_is_stored_on_instance():
+    """A user-supplied timeout is stored on the toolkit for subclasses to consume."""
+    toolkit = Toolkit(name="withtimeout", tools=[example_func], timeout=45)
+    assert toolkit.timeout == 45
+
+
+def test_subclass_forwards_timeout_via_super():
+    """Regression: subclasses that accept their own ``timeout`` and forward it via
+    ``super().__init__(timeout=...)`` end up with the value on ``self.timeout``.
+    This is the pattern documented in the Toolkit docstring and the calcom /
+    hackernews tools rely on it.
+    """
+
+    class _HttpToolkit(Toolkit):
+        def __init__(self, timeout: int = 30):
+            super().__init__(name="http", tools=[example_func], timeout=timeout)
+
+    assert _HttpToolkit().timeout == 30
+    assert _HttpToolkit(timeout=5).timeout == 5
+
+
+def test_subclass_setting_timeout_before_super_is_preserved():
+    """Regression: many existing toolkits assign ``self.timeout = timeout`` in
+    their own ``__init__`` before calling ``super().__init__(**kwargs)``. The
+    base class must not clobber that pre-existing value with its default None.
+    """
+
+    class _LegacyToolkit(Toolkit):
+        def __init__(self, timeout: int = 42, **kwargs):
+            self.timeout = timeout
+            super().__init__(name="legacy", tools=[example_func], **kwargs)
+
+    assert _LegacyToolkit().timeout == 42
+    assert _LegacyToolkit(timeout=7).timeout == 7
+
+
 def test_toolkit_repr(multi_func_toolkit):
     """Test the string representation of a toolkit."""
     repr_str = repr(multi_func_toolkit)


### PR DESCRIPTION
## Summary

 Fixes #8520. Fixes #8396. Fixes #8397. Fixes #8398. Fixes #8496.

follow up in- #8737

Adds an optional `timeout: Optional[int] = None` slot to the base `Toolkit` class and wires bounded per-request timeouts through six HTTP-based toolkits. Fixes a class of "agent runs hang indefinitely" bugs where tools called `requests.get/post` or `httpx.get` with no `timeout=` argument.

Base-class change is minimal: subclasses that expose their own `timeout` forward it via `super().__init__(timeout=timeout)`; subclasses that already assigned `self.timeout` before `super()` keep working unchanged (guarded assignment in `Toolkit.__init__`). No existing subclass needs to migrate — this is purely additive.

## Scope

| File | Issue / PR closed | Change |
|---|---|---|
| `libs/agno/agno/tools/toolkit.py` | — | New `timeout` param + attribute, cast to `Any` on assign so subclasses that store `float` / `httpx.Timeout` / int-as-count aren't type-narrowed |
| `libs/agno/agno/tools/calcom.py` | [#8520](https://github.com/agno-agi/agno/issues/8520) | Adds `timeout=30`, plumbed to all 5 `requests` call sites |
| `libs/agno/agno/tools/hackernews.py` | [#8397](https://github.com/agno-agi/agno/issues/8397) | Adds `timeout=30`, plumbed to all 3 `httpx.get` calls + `raise_for_status()` |
| `libs/agno/agno/tools/openweather.py` | [#8396](https://github.com/agno-agi/agno/issues/8396) | Adds `timeout=30`, plumbed to `_make_request` |
| `libs/agno/agno/tools/searxng.py` | [#8398](https://github.com/agno-agi/agno/issues/8398) | Adds `timeout=30`, plumbed to `httpx.get` + `raise_for_status()` |
| `libs/agno/agno/tools/brightdata.py` | [#8496](https://github.com/agno-agi/agno/issues/8496) (part 1) | Existing `timeout=600` now forwarded via `super()` and plumbed to 3 API calls; per-poll GET keeps a fixed 30s cap since `self.timeout` doubles as the polling attempt count |
| `libs/agno/agno/tools/clickup.py` | [#8496](https://github.com/agno-agi/agno/issues/8496) (part 2) | Adds `timeout=30`, plumbed to central `_make_request` |

## Supersedes

Closes the following open PRs, which each fix a subset of what this one covers:

- [#8521](https://github.com/agno-agi/agno/pull/8521) — calcom
- [#8490](https://github.com/agno-agi/agno/pull/8490) — brightdata + clickup
- [#8019](https://github.com/agno-agi/agno/pull/8019) — bitbucket / desi_vocal / openweather / serper / zendesk (openweather overlap; the others in that PR can be re-landed with the same base-class pattern in a follow-up)

Also renders the following previously-closed PRs unnecessary — they targeted the same bugs but were not merged:

- [#8517](https://github.com/agno-agi/agno/pull/8517), [#8532](https://github.com/agno-agi/agno/pull/8532), [#8566](https://github.com/agno-agi/agno/pull/8566) — calcom / brightdata / clickup
- [#8513](https://github.com/agno-agi/agno/pull/8513) — umbrella HTTP timeouts
- [#8439](https://github.com/agno-agi/agno/pull/8439) — openweather
- [#8440](https://github.com/agno-agi/agno/pull/8440) — hackernews
- [#8441](https://github.com/agno-agi/agno/pull/8441) — searxng

Credit to the original reporters and contributors: @luochen211 (#8396, #8397, #8398 and the fix PRs #8439–#8449), @AHMEDDEV2004 (#8520 / #8521 / #8517), @lavkeshdwivedi (#8490), @hobostay (#8019), @fengjikui (#8532), @iamadhitya1 (#8566), @its-amann (#8513).

## Design notes

- **Optional, not required.** `timeout: Optional[int] = None` — the base doesn't force a default, because "timeout" already means different things across the toolkit fleet: single HTTP request (calcom, hackernews), sandbox execution budget (e2b, daytona), long-running scrape budget (brightdata, antigravity), job-poll loop cap (parallel). Each subclass keeps its own semantic and its own default.
- **Guarded assignment.** Base sets `self.timeout` only if the caller passed a non-None value **or** the subclass hasn't already set it before calling `super().__init__()`. This preserves the ~19 existing toolkits that do `self.timeout = timeout` before `super().__init__(**kwargs)`.
- **`cast(Any, timeout)` on assignment.** Without this, mypy would infer `self.timeout: Optional[int]` for every subclass, breaking `gitlab.py` (float), `brandfetch.py` (`httpx.Timeout` object), `brightdata.py` (`int` used as attempt count where mypy would flag `int < None`), and `crawl4ai.py` (`self.timeout * 1000`). Verified: base branch has 21 mypy errors, this branch has 21 mypy errors, zero regressions.

## Type of change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Self-review completed
- [x] Documentation updated (base `Toolkit` docstring explains the convention)
- [x] Tests added/updated:
  - `libs/agno/tests/unit/tools/test_toolkit.py` — 4 new tests: default is `None`, user value stored, both forwarding patterns preserved
  - `libs/agno/tests/unit/tools/test_hackernews.py` — 10 `mock_get(url)` fixtures widened to `mock_get(url, **kwargs)`
  - `libs/agno/tests/unit/tools/test_searxng.py` — 6 `assert_called_once_with(url)` calls updated to include `timeout=30`
  - `libs/agno/tests/unit/tools/test_brightdata.py` — `test_make_request_success` updated to expect `timeout=`

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses these issues in a unified way (see "Supersedes" section)
- [x] If a similar PR exists, I have explained above why this PR is a better approach

## Test results

1780 tests pass, same 2 pre-existing matplotlib-missing failures as `main`. `ruff format` and `ruff check` clean. `mypy` reports 21 errors — identical count to `main`, no new regressions.
