### PR TITLE
feat: service accounts (PAT auth) + MCP interface v2

### DIFF
--- a/cookbook/05_agent_os/mcp_demo/README.md
+++ b/cookbook/05_agent_os/mcp_demo/README.md
@@ -8,12 +8,28 @@ Examples for `mcp_demo` in AgentOS.
 - `mcp_tools_advanced_example.py` — Example AgentOS app where the agent has MCPTools.
 - `mcp_tools_example.py` — Example AgentOS app where the agent has MCPTools.
 - `mcp_tools_existing_lifespan.py` — Example AgentOS app where the agent has MCPTools.
-- `test_client.py` — First run the AgentOS with enable_mcp=True.
+- `test_client.py` — First run the AgentOS with `enable_mcp_server=True` (`enable_mcp_example.py`), then run this client against it.
+
+## The MCP tool surface
+
+`enable_mcp_server=True` serves 8 built-in tools at `/mcp` — an operator surface for LLM
+frontends (Claude, ChatGPT, Claude Code, Cursor), not a database console:
+
+| Tool | Tag | What it does |
+|------|-----|--------------|
+| `get_agentos_config` | `core` | Discover agents/teams/workflows (ids + descriptions) and database ids. Call first. |
+| `run_agent` / `run_team` / `run_workflow` | `core` | Run a component. Results are trimmed for the consuming model: answer text + media blocks + `run_id`/`session_id`/`status` (set `MCPServerConfig(result_mode="full")` for the complete run object). Long runs report MCP progress. |
+| `continue_run` | `core` | Resume a PAUSED (human-in-the-loop) run by passing back its resolved requirements. |
+| `cancel_run` | `core` | Request cancellation of a run by `run_id`. |
+| `get_sessions` | `session` | List past conversations (read-only). |
+| `get_session_runs` | `session` | Read a conversation's history (read-only, auto-detects session type). |
+
+Session writes and memory CRUD live on the REST surface; anything else can be exposed as a
+custom tool.
 
 ## Customizing the MCP server
 
-By default `enable_mcp_server=True` registers ~19 built-in tools (config, run_agent/team/workflow,
-session CRUD, memory CRUD). Pass `mcp_config=MCPServerConfig(...)` to register your own tools, scope
+Pass `mcp_config=MCPServerConfig(...)` to register your own tools, scope
 the built-ins, gate the server, and protect it — all with data, no middleware classes to write:
 
 ```python
@@ -27,7 +43,7 @@ agent_os = AgentOS(
         tools=[my_tool],            # custom tools (plain callables or Agno @tool / Function)
         enable_builtin_tools=False,  # ship ONLY your tools; or scope with:
         # include_tags={"core"},     # keep only tools tagged "core"
-        # exclude_tags={"memory"},   # drop the "memory" tools
+        # exclude_tags={"session"},  # drop the read-only session tools
         authorize=lambda user_id: user_id in OWNER_IDS,  # 401 non-owners before the model runs
         allowed_hosts=["my-app.example.com"],            # DNS-rebinding protection (localhost is automatic)
         # middleware=[Middleware(MyMiddleware)],          # escape hatch for anything else
@@ -35,9 +51,9 @@ agent_os = AgentOS(
 )
 ```
 
-Built-in tools are tagged `core` (config + run_*), `session`, and `memory`. With no `mcp_config`,
-all built-ins are registered (unchanged behavior). Custom tools share the same `/mcp` mount,
-lifespan, and JWT middleware as the built-ins.
+Built-in tools are tagged `core` (config + run/continue/cancel) and `session` (the read-only
+session tools). With no `mcp_config`, all built-ins are registered. Custom tools share the same
+`/mcp` mount, lifespan, and JWT middleware as the built-ins.
 
 **Identity in custom tools.** Declare a `user_id` parameter on a custom tool and AgentOS fills it
 with the authenticated caller's id (the JWT subject), hidden from the client-facing schema so it

--- a/cookbook/05_agent_os/mcp_demo/TEST_LOG.md
+++ b/cookbook/05_agent_os/mcp_demo/TEST_LOG.md
@@ -1,12 +1,21 @@
 # Test Log: mcp_demo
 
-> Tests not yet run. Run each file and update this log.
-
 ### enable_mcp_example.py
 
-**Status:** PENDING
+**Status:** PASS (2026-07-04, v2.7 8-tool surface)
 
-**Description:** Example AgentOS app with MCP enabled.
+**Description:** Example AgentOS app with MCP enabled, tested live end-to-end with a
+Streamable HTTP FastMCP client against the served app.
+
+**Result:** Server boots with the MCP lifespan; `GET /` returns 200 JSON (home route now
+coexists with the root MCP mount). `tools/list` returns exactly the 8 built-in tools with
+read-only/destructive annotations on the wire. `get_agentos_config` payload is ~400 chars.
+`get_sessions` works without `db_id` (single-db default) through the sync-sqlite threadpool
+path. `run_agent` executed a live Claude run: trimmed result was 158 chars total (answer +
+run_id/session_id/status), no transcript/system-prompt leakage, and the client received a
+progress notification. `get_session_runs` with auto-detected session type read the
+conversation back. Bonus check: running without `ANTHROPIC_API_KEY` surfaced the real
+provider auth error through the MCP tool error (error propagation fix).
 
 ---
 
@@ -52,8 +61,14 @@ middlewares are wired (verified with an in-memory FastMCP client). A live model 
 
 ### test_client.py
 
-**Status:** PENDING
+**Status:** PASS (2026-07-04, updated)
 
-**Description:** First run the AgentOS with enable_mcp=True.
+**Description:** Agent operating the AgentOS over MCP (OpenAIResponses/gpt-5.5, per repo
+model rules; stale docstring path and `enable_mcp` flag name fixed).
+
+**Result:** The equivalent client flow (list tools → get_agentos_config → run_agent →
+get_session_runs) was exercised end-to-end against the live server with a raw FastMCP
+client and passed. The agent-driven variant in this file additionally requires
+`OPENAI_API_KEY` for the operator model and was not run in this pass.
 
 ---

--- a/cookbook/05_agent_os/mcp_demo/test_client.py
+++ b/cookbook/05_agent_os/mcp_demo/test_client.py
@@ -1,9 +1,17 @@
 """
-First run the AgentOS with enable_mcp=True
+MCP client example: an agent that operates an AgentOS through its MCP server.
+
+First run the AgentOS with the MCP server enabled:
 
 ```bash
-python cookbook/agent_os/mcp/enable_mcp.py
+.venvs/demo/bin/python cookbook/05_agent_os/mcp_demo/enable_mcp_example.py
 ```
+
+Then run this client in a second terminal. It connects to the AgentOS MCP server
+at /mcp and drives it through the 8 built-in tools: discover the OS
+(get_agentos_config), run components (run_agent / run_team / run_workflow),
+resolve pauses (continue_run), stop runs (cancel_run), and browse conversations
+(get_sessions / get_session_runs).
 """
 
 import asyncio
@@ -11,7 +19,7 @@ from uuid import uuid4
 
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
-from agno.models.openai import OpenAIChat
+from agno.models.openai import OpenAIResponses
 from agno.tools.mcp import MCPTools
 
 # ---------------------------------------------------------------------------
@@ -29,12 +37,12 @@ async def run_agent() -> None:
         transport="streamable-http", url=server_url, timeout_seconds=60
     ) as mcp_tools:
         agent = Agent(
-            model=OpenAIChat(id="gpt-5.2"),
+            model=OpenAIResponses(id="gpt-5.5"),
             tools=[mcp_tools],
             instructions=[
-                "You are a helpful assistant that has access to the configuration of a AgentOS.",
-                "If you are asked to do something, use the appropriate tool to do it. ",
-                "Look up information you need in the AgentOS configuration.",
+                "You operate an AgentOS through its MCP tools.",
+                "Call get_agentos_config first to discover the agents, teams, and workflows you can run.",
+                "Use the run tools to delegate work, and the session tools to review past conversations.",
             ],
             user_id="john@example.com",
             session_id=session_id,
@@ -49,38 +57,19 @@ async def run_agent() -> None:
         )
 
         # await agent.aprint_response(
-        #     input="Use my agent to search the web for the latest news about AI",
+        #     input="Use my web research agent to find the latest news about AI",
         #     stream=True,
         #     markdown=True,
         # )
 
-        ## Memory management
+        ## Session history
         # await agent.aprint_response(
-        #     input="What memories do you have of me?",
-        #     stream=True,
-        #     markdown=True,
-        # )
-
-        # await agent.aprint_response(
-        #     input="I like to ski, remember that of me.",
-        #     stream=True,
-        #     markdown=True,
-        # )
-        # await agent.aprint_response(
-        #     input="Clean up all duplicate memories of me.",
-        #     stream=True,
-        #     markdown=True,
-        # )
-
-        ## Session management
-        # await agent.aprint_response(
-        #     input="How many sessions does my web-research-agent have?",
+        #     input="List my recent sessions and summarize what the last conversation was about.",
         #     stream=True,
         #     markdown=True,
         # )
 
 
-# Example usage
 # ---------------------------------------------------------------------------
 # Run Example
 # ---------------------------------------------------------------------------

--- a/cookbook/05_agent_os/middleware/README.md
+++ b/cookbook/05_agent_os/middleware/README.md
@@ -6,6 +6,7 @@ Examples for `middleware` in AgentOS.
 - `agent_os_with_custom_middleware.py` — This example demonstrates how to add custom middleware to your AgentOS application.
 - `agent_os_with_jwt_middleware.py` — This example demonstrates how to use our JWT middleware with AgentOS.
 - `agent_os_with_jwt_middleware_cookies.py` — This example demonstrates how to use JWT middleware with cookies instead of Authorization headers.
+- `agent_os_with_service_accounts.py` — This example demonstrates service accounts: opaque `agno_pat_...` tokens for machine identities (coding agents, chat apps, CI), minted and revoked over the API, with runs attributed to `sa:<name>`.
 - `custom_fastapi_app_with_jwt_middleware.py` — This example demonstrates how to use our JWT middleware with your custom FastAPI app.
 - `extract_content_middleware.py` — Example for AgentOS to show how to extract content from a response and send it to a notification service.
 - `guardrails_demo.py` — Example demonstrating how to use guardrails with an Agno Agent.

--- a/cookbook/05_agent_os/middleware/TEST_LOG.md
+++ b/cookbook/05_agent_os/middleware/TEST_LOG.md
@@ -26,6 +26,16 @@
 
 ---
 
+### agent_os_with_service_accounts.py
+
+**Status:** PASS
+
+**Description:** Serves an AgentOS with JWT middleware (authorization enabled) and a sqlite db. An admin JWT mints a service account token for `claude-code` via POST /service-accounts; the plaintext `agno_pat_...` token is returned once with default run+read scopes and a 90-day expiry. The token then runs the agent over POST /agents/assistant-agent/runs.
+
+**Result:** Verified end to end on 2026-07-04: mint returned 201 with principal `sa:claude-code`; the PAT-authenticated run COMPLETED with the model response and the run and session attributed to user `sa:claude-code`; the PAT could not mint further tokens (403); DELETE revoked the account (204) and the revoked token was rejected with a uniform 401 on its next request.
+
+---
+
 ### custom_fastapi_app_with_jwt_middleware.py
 
 **Status:** PENDING

--- a/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
+++ b/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
@@ -4,8 +4,12 @@ This example demonstrates service accounts: machine identities for AgentOS.
 Coding agents and chat apps connecting to your AgentOS need long-lived credentials.
 Humans get JWTs; machines get service accounts - opaque `agno_pat_...` tokens
 following the GitHub PAT model. Only the SHA-256 hash is stored in the AgentOS
-database, the plaintext is returned exactly once at creation, and revocation takes
-effect on the token's next request.
+database, and the plaintext is returned exactly once at creation.
+
+Successful verifications are cached in-process for a short TTL (default 30s), so PAT
+auth does not hit the database on every request. Revocation takes effect within that
+TTL across workers - immediately on the worker that processes the revoke. Set
+`AgnoAPISettings(service_account_cache_ttl_seconds=0)` for strict instant revocation.
 
 Runs executed with a service account attribute to it: sessions and traces created
 through a `claude-code` token show `sa:claude-code` as the user.
@@ -13,7 +17,7 @@ through a `claude-code` token show `sa:claude-code` as the user.
 Flow demonstrated here:
 1. An admin (JWT with the admin scope) mints a token for `claude-code`
 2. The machine calls the run endpoint with its `agno_pat_...` token
-3. The admin lists and revokes tokens; revoked tokens get a 401 on the next request
+3. The admin lists and revokes tokens; the revoking worker rejects the token at once
 """
 
 from datetime import UTC, datetime, timedelta

--- a/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
+++ b/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
@@ -1,0 +1,113 @@
+"""
+This example demonstrates service accounts: machine identities for AgentOS.
+
+Coding agents and chat apps connecting to your AgentOS need long-lived credentials.
+Humans get JWTs; machines get service accounts - opaque `agno_pat_...` tokens
+following the GitHub PAT model. Only the SHA-256 hash is stored in the AgentOS
+database, the plaintext is returned exactly once at creation, and revocation takes
+effect on the token's next request.
+
+Runs executed with a service account attribute to it: sessions and traces created
+through a `claude-code` token show `sa:claude-code` as the user.
+
+Flow demonstrated here:
+1. An admin (JWT with the admin scope) mints a token for `claude-code`
+2. The machine calls the run endpoint with its `agno_pat_...` token
+3. The admin lists and revokes tokens; revoked tokens get a 401 on the next request
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.middleware import JWTMiddleware
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = "a-string-secret-at-least-256-bits-long"
+
+# Setup database. Service accounts are stored here, next to sessions and memories.
+db = SqliteDb(db_file="tmp/service_accounts_demo.db")
+
+# Create agent
+assistant_agent = Agent(
+    id="assistant-agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="You are a helpful assistant.",
+)
+
+agent_os = AgentOS(
+    description="AgentOS with service accounts",
+    agents=[assistant_agent],
+    db=db,
+)
+
+# Get the final app
+app = agent_os.get_app()
+
+# Add JWT middleware with authorization enabled. Human callers authenticate with
+# JWTs; bearer tokens starting with `agno_pat_` authenticate as service accounts
+# against the database. Service account scopes are enforced on every request.
+app.add_middleware(
+    JWTMiddleware,
+    verification_keys=[JWT_SECRET],
+    algorithm="HS256",
+    authorization=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Admin JWT, representing a human operator. In production the control plane
+    # mints these; here we sign one locally.
+    payload = {
+        "sub": "demo-admin",
+        "scopes": ["agent_os:admin"],
+        "exp": datetime.now(UTC) + timedelta(hours=24),
+        "iat": datetime.now(UTC),
+    }
+    admin_token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+    print("Admin JWT (human operator):")
+    print(admin_token)
+    print()
+    print("1. Mint a token for the claude-code machine identity:")
+    print(
+        f'   curl -X POST http://localhost:7777/service-accounts -H "Authorization: Bearer {admin_token}"',
+        end="",
+    )
+    print(" -H 'Content-Type: application/json' -d '{\"name\": \"claude-code\"}'")
+    print()
+    print("   The response contains the plaintext token (agno_pat_...) exactly once.")
+    print("   Default scopes: agents:run, teams:run, workflows:run, sessions:read.")
+    print("   Default expiry: 90 days. Write/delete/admin scopes require")
+    print("   allow_privileged_scopes=true and must be held by the minter.")
+    print()
+    print(
+        "2. Run the agent as the machine (replace agno_pat_... with the minted token):"
+    )
+    print("   curl -X POST http://localhost:7777/agents/assistant-agent/runs \\")
+    print(
+        '        -H "Authorization: Bearer agno_pat_..." -F "message=hello" -F "stream=false"'
+    )
+    print()
+    print("   The run's session shows sa:claude-code as the user.")
+    print()
+    print("3. List and revoke tokens (admin JWT again):")
+    print(
+        f'   curl http://localhost:7777/service-accounts -H "Authorization: Bearer {admin_token}"'
+    )
+    print(
+        f'   curl -X DELETE http://localhost:7777/service-accounts/<id> -H "Authorization: Bearer {admin_token}"'
+    )
+    print()
+    agent_os.serve(app="agent_os_with_service_accounts:app", port=7777)

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -52,6 +52,7 @@ class BaseDb(ABC):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         self.id = id or str(uuid4())
@@ -72,6 +73,7 @@ class BaseDb(ABC):
         self.schedule_runs_table_name = schedule_runs_table or "agno_schedule_runs"
         self.approvals_table_name = approvals_table or "agno_approvals"
         self.auth_tokens_table_name = auth_tokens_table or "agno_auth_tokens"
+        self.service_accounts_table_name = service_accounts_table or "agno_service_accounts"
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -96,6 +98,7 @@ class BaseDb(ABC):
             "schedule_runs_table": self.schedule_runs_table_name,
             "approvals_table": self.approvals_table_name,
             "auth_tokens_table": self.auth_tokens_table_name,
+            "service_accounts_table": self.service_accounts_table_name,
         }
 
     @classmethod
@@ -121,6 +124,7 @@ class BaseDb(ABC):
             schedule_runs_table=data.get("schedule_runs_table"),
             approvals_table=data.get("approvals_table"),
             auth_tokens_table=data.get("auth_tokens_table"),
+            service_accounts_table=data.get("service_accounts_table"),
             id=data.get("id"),
         )
 
@@ -1228,6 +1232,48 @@ class BaseDb(ABC):
         """Delete stored OAuth token for a provider/user/service combination. Returns True if deleted."""
         raise NotImplementedError
 
+    # --- Service Accounts (Optional) ---
+    # These methods are optional. Override in subclasses to enable service account persistence.
+
+    def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a service account. Raises on failure (including duplicate active name)."""
+        raise NotImplementedError
+
+    def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by ID."""
+        raise NotImplementedError
+
+    def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash."""
+        raise NotImplementedError
+
+    def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        """Get a service account by name. By default only considers active (non-revoked) accounts."""
+        raise NotImplementedError
+
+    def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List service accounts.
+
+        Returns:
+            Tuple of (service_accounts, total_count)
+        """
+        raise NotImplementedError
+
+    def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Update a service account by ID (e.g. set revoked_at or last_used_at)."""
+        raise NotImplementedError
+
+    def delete_service_account(self, service_account_id: str) -> bool:
+        """Hard-delete a service account by ID. Returns True if deleted."""
+        raise NotImplementedError
+
 
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
@@ -1249,6 +1295,7 @@ class AsyncBaseDb(ABC):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
     ):
         self.id = id or str(uuid4())
         self.session_table_name = session_table or "agno_sessions"
@@ -1265,6 +1312,7 @@ class AsyncBaseDb(ABC):
         self.schedule_runs_table_name = schedule_runs_table or "agno_schedule_runs"
         self.approvals_table_name = approvals_table or "agno_approvals"
         self.auth_tokens_table_name = auth_tokens_table or "agno_auth_tokens"
+        self.service_accounts_table_name = service_accounts_table or "agno_service_accounts"
 
     async def _create_all_tables(self) -> None:
         """Create all tables for this database. Override in subclasses."""
@@ -2067,4 +2115,46 @@ class AsyncBaseDb(ABC):
 
     async def delete_auth_token(self, provider: str, user_id: Optional[str], service: str) -> bool:
         """Delete stored OAuth token for a provider/user/service combination. Returns True if deleted."""
+        raise NotImplementedError
+
+    # --- Service Accounts (Optional) ---
+    # These methods are optional. Override in subclasses to enable service account persistence.
+
+    async def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a service account. Raises on failure (including duplicate active name)."""
+        raise NotImplementedError
+
+    async def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by ID."""
+        raise NotImplementedError
+
+    async def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash."""
+        raise NotImplementedError
+
+    async def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        """Get a service account by name. By default only considers active (non-revoked) accounts."""
+        raise NotImplementedError
+
+    async def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List service accounts.
+
+        Returns:
+            Tuple of (service_accounts, total_count)
+        """
+        raise NotImplementedError
+
+    async def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Update a service account by ID (e.g. set revoked_at or last_used_at)."""
+        raise NotImplementedError
+
+    async def delete_service_account(self, service_account_id: str) -> bool:
+        """Hard-delete a service account by ID. Returns True if deleted."""
         raise NotImplementedError

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3925,6 +3925,12 @@ class AsyncPostgresDb(AsyncBaseDb):
         """
         table = await self._get_table(table_type="service_accounts")
         if table is None:
+            # _get_table swallows connectivity errors and returns None, which is
+            # indistinguishable from "table not created yet". Probe the connection so
+            # a real outage propagates (fail closed) instead of reading as an unknown
+            # token; a genuinely absent table returns None.
+            async with self.async_session_factory() as sess:
+                await sess.execute(text("SELECT 1"))
             return None
         try:
             async with self.async_session_factory() as sess:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -64,6 +64,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         create_schema: bool = True,
     ):
         """
@@ -123,6 +124,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         _engine: Optional[AsyncEngine] = db_engine
@@ -183,6 +185,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -215,6 +218,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -257,6 +261,21 @@ class AsyncPostgresDb(AsyncBaseDb):
             for idx_config in schema_composite_indexes:
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 table.append_constraint(Index(idx_name, *idx_config["columns"]))
+
+            # Partial unique indexes
+            for idx_config in schema_partial_unique_indexes:
+                idx_columns = idx_config["columns"]
+                missing = [c for c in idx_columns if c not in table.c]
+                if missing:
+                    raise ValueError(f"Partial unique index references missing columns in {table_name}: {missing}")
+
+                idx_name = f"{table_name}_{idx_config['name']}"
+                Index(
+                    idx_name,
+                    *[table.c[c] for c in idx_columns],
+                    unique=True,
+                    postgresql_where=text(idx_config["where"]),
+                )
 
             if self.create_schema:
                 async with self.async_session_factory() as sess, sess.begin():
@@ -425,6 +444,14 @@ class AsyncPostgresDb(AsyncBaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        if table_type == "service_accounts":
+            self.service_accounts_table = await self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         raise ValueError(f"Unknown table type: {table_type}")
 
@@ -3861,4 +3888,130 @@ class AsyncPostgresDb(AsyncBaseDb):
                     return result.rowcount > 0  # type: ignore[attr-defined]
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    async def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = await self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service accounts table")
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    async def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.id == service_account_id))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    async def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash.
+
+        Re-raises on DB errors so callers can distinguish an unknown token (None) from a DB failure.
+        """
+        table = await self._get_table(table_type="service_accounts")
+        if table is None:
+            return None
+        try:
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.token_hash == token_hash))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {e}")
+            raise
+
+    async def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    async def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            async with self.async_session_factory() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Get paginated results
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_column = table.c[sort_by]
+                order_by = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                result = await sess.execute(stmt)
+                return [dict(row._mapping) for row in result.fetchall()], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    async def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return await self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    async def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    result = await sess.execute(table.delete().where(table.c.id == service_account_id))
+                    return result.rowcount > 0  # type: ignore[attr-defined]
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -80,6 +80,7 @@ class PostgresDb(BaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
         create_schema: bool = True,
     ):
@@ -157,6 +158,7 @@ class PostgresDb(BaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         self.db_schema: str = db_schema if db_schema is not None else "ai"
@@ -240,6 +242,7 @@ class PostgresDb(BaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -272,6 +275,7 @@ class PostgresDb(BaseDb):
             schema_primary_key = table_schema.pop("__primary_key__", None)
             schema_foreign_keys = table_schema.pop("__foreign_keys__", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Build columns
             for col_name, col_config in table_schema.items():
@@ -368,6 +372,21 @@ class PostgresDb(BaseDb):
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 idx_cols = [table.c[c] for c in idx_config["columns"]]
                 Index(idx_name, *idx_cols)
+
+            # Partial unique indexes
+            for idx_config in schema_partial_unique_indexes:
+                idx_columns = idx_config["columns"]
+                missing = [c for c in idx_columns if c not in table.c]
+                if missing:
+                    raise ValueError(f"Partial unique index references missing columns in {table_name}: {missing}")
+
+                idx_name = f"{table_name}_{idx_config['name']}"
+                Index(
+                    idx_name,
+                    *[table.c[c] for c in idx_columns],
+                    unique=True,
+                    postgresql_where=text(idx_config["where"]),
+                )
 
             # Create schema if requested
             if self.create_schema:
@@ -590,6 +609,14 @@ class PostgresDb(BaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        if table_type == "service_accounts":
+            self.service_accounts_table = self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         raise ValueError(f"Unknown table type: {table_type}")
 
@@ -5216,4 +5243,126 @@ class PostgresDb(BaseDb):
                 return result.rowcount > 0
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service accounts table")
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.id == service_account_id)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by token hash.
+
+        Re-raises on database errors (instead of returning None) so callers can
+        distinguish an unknown token from an unavailable database.
+        """
+        table = self._get_table(table_type="service_accounts")
+        if table is None:
+            return None
+        try:
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.token_hash == token_hash)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {e}")
+            raise
+
+    def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = sess.execute(stmt).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            with self.Session() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Validate sorting parameters
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_col = table.c[sort_by]
+                order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+
+                # Get paginated results
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                results = sess.execute(stmt).fetchall()
+                return [dict(row._mapping) for row in results], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            with self.Session() as sess, sess.begin():
+                result = sess.execute(table.delete().where(table.c.id == service_account_id))
+                return result.rowcount > 0
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -201,6 +201,7 @@ class PostgresDb(BaseDb):
             schedules_table=data.get("schedules_table"),
             schedule_runs_table=data.get("schedule_runs_table"),
             approvals_table=data.get("approvals_table"),
+            service_accounts_table=data.get("service_accounts_table"),
             id=data.get("id"),
         )
 
@@ -5279,6 +5280,12 @@ class PostgresDb(BaseDb):
         """
         table = self._get_table(table_type="service_accounts")
         if table is None:
+            # _get_table swallows connectivity errors and returns None, which is
+            # indistinguishable from "table not created yet". Probe the connection so
+            # a real outage propagates (fail closed) instead of reading as an unknown
+            # token; a genuinely absent table returns None.
+            with self.Session() as sess:
+                sess.execute(text("SELECT 1"))
             return None
         try:
             with self.Session() as sess:

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -322,6 +322,22 @@ AUTH_TOKEN_TABLE_SCHEMA = {
     ],
 }
 
+SERVICE_ACCOUNT_TABLE_SCHEMA = {
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "name": {"type": String, "nullable": False},
+    "token_hash": {"type": String, "nullable": False, "unique": True, "index": True},
+    "token_prefix": {"type": String, "nullable": False},
+    "scopes": {"type": JSONB, "nullable": False},
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+    "expires_at": {"type": BigInteger, "nullable": True},
+    "last_used_at": {"type": BigInteger, "nullable": True},
+    "revoked_at": {"type": BigInteger, "nullable": True},
+    "created_by": {"type": String, "nullable": True},
+    # Names are reusable after revocation (rotation keeps the same identity),
+    # so uniqueness only applies to active accounts.
+    "_partial_unique_indexes": [{"name": "uq_active_name", "columns": ["name"], "where": "revoked_at IS NULL"}],
+}
+
 
 def get_table_schema_definition(
     table_type: str,
@@ -362,6 +378,7 @@ def get_table_schema_definition(
         "schedules": SCHEDULE_TABLE_SCHEMA,
         "approvals": APPROVAL_TABLE_SCHEMA,
         "auth_tokens": AUTH_TOKEN_TABLE_SCHEMA,
+        "service_accounts": SERVICE_ACCOUNT_TABLE_SCHEMA,
     }
 
     schema = schemas.get(table_type, {})

--- a/libs/agno/agno/db/schemas/service_accounts.py
+++ b/libs/agno/agno/db/schemas/service_accounts.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agno.utils.dttm import now_epoch_s, to_epoch_s
+
+# Namespace prepended to the account name to build the principal identifier
+# (the value used as user_id on requests, sessions and traces). Keeping service
+# account principals in a reserved namespace guarantees they can never collide
+# with a human JWT sub.
+SERVICE_ACCOUNT_PRINCIPAL_PREFIX = "sa:"
+
+
+@dataclass
+class ServiceAccount:
+    """Model for a service account: a machine identity authenticated by an opaque token."""
+
+    id: str
+    name: str
+    token_hash: str
+    token_prefix: str
+    scopes: List[str] = field(default_factory=list)
+    created_at: Optional[int] = None
+    expires_at: Optional[int] = None
+    last_used_at: Optional[int] = None
+    revoked_at: Optional[int] = None
+    created_by: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.created_at = now_epoch_s() if self.created_at is None else to_epoch_s(self.created_at)
+        if self.expires_at is not None:
+            self.expires_at = int(self.expires_at)
+        if self.last_used_at is not None:
+            self.last_used_at = int(self.last_used_at)
+        if self.revoked_at is not None:
+            self.revoked_at = int(self.revoked_at)
+
+    @property
+    def principal(self) -> str:
+        """The identifier attached to requests, sessions and traces as user_id."""
+        return f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{self.name}"
+
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+    def is_expired(self, now: Optional[int] = None) -> bool:
+        if self.expires_at is None:
+            return False
+        return self.expires_at <= (now if now is not None else now_epoch_s())
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict. Preserves None values (important for DB updates)."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "token_hash": self.token_hash,
+            "token_prefix": self.token_prefix,
+            "scopes": self.scopes,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "last_used_at": self.last_used_at,
+            "revoked_at": self.revoked_at,
+            "created_by": self.created_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccount":
+        data = dict(data)
+        valid_keys = {
+            "id",
+            "name",
+            "token_hash",
+            "token_prefix",
+            "scopes",
+            "created_at",
+            "expires_at",
+            "last_used_at",
+            "revoked_at",
+            "created_by",
+        }
+        filtered = {k: v for k, v in data.items() if k in valid_keys}
+        if filtered.get("scopes") is None:
+            filtered["scopes"] = []
+        return cls(**filtered)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -4108,6 +4108,12 @@ class AsyncSqliteDb(AsyncBaseDb):
         try:
             table = await self._get_table(table_type="service_accounts")
             if table is None:
+                # _get_table swallows connectivity errors and returns None, which is
+                # indistinguishable from "table not created yet". Probe the connection
+                # so a real outage propagates (fail closed) instead of reading as an
+                # unknown token; a genuinely absent table returns None.
+                async with self.async_session_factory() as sess:
+                    await sess.execute(text("SELECT 1"))
                 return None
             async with self.async_session_factory() as sess:
                 result = await sess.execute(select(table).where(table.c.token_hash == token_hash))

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -68,6 +68,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         """
@@ -120,6 +121,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         _engine: Optional[AsyncEngine] = db_engine
@@ -181,6 +183,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -212,6 +215,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -255,6 +259,22 @@ class AsyncSqliteDb(AsyncBaseDb):
             for idx_config in schema_composite_indexes:
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 table.append_constraint(Index(idx_name, *idx_config["columns"]))
+
+            # Partial unique indexes (unique only for rows matching the where clause)
+            for idx_config in schema_partial_unique_indexes:
+                missing_columns = [col for col in idx_config["columns"] if col not in table.c]
+                if missing_columns:
+                    log_warning(
+                        f"Partial unique index {idx_config['name']} references missing columns {missing_columns}, skipping"
+                    )
+                    continue
+                idx_name = f"{table_name}_{idx_config['name']}"
+                Index(
+                    idx_name,
+                    *[table.c[col] for col in idx_config["columns"]],
+                    unique=True,
+                    sqlite_where=text(idx_config["where"]),
+                )
 
             # Create table
             table_created = False
@@ -411,6 +431,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        elif table_type == "service_accounts":
+            self.service_accounts_table = await self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         else:
             raise ValueError(f"Unknown table type: '{table_type}'")
@@ -4041,4 +4069,133 @@ class AsyncSqliteDb(AsyncBaseDb):
                     return result.rowcount > 0  # type: ignore[attr-defined]
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    async def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = await self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service_accounts table")
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    async def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.id == service_account_id))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    async def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get the service account matching the given token hash.
+
+        Re-raises on database errors (instead of returning None) so callers can
+        distinguish an unknown token from an unavailable database.
+        """
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.token_hash == token_hash))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {str(e)}")
+            raise
+
+    async def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    async def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            async with self.async_session_factory() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Apply sorting
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_column = table.c[sort_by]
+                order_by = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+
+                # Get paginated results
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                result = await sess.execute(stmt)
+                return [dict(row._mapping) for row in result.fetchall()], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    async def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return await self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    async def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    result = await sess.execute(table.delete().where(table.c.id == service_account_id))
+                    return result.rowcount > 0  # type: ignore[attr-defined]
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -284,6 +284,22 @@ AUTH_TOKEN_TABLE_SCHEMA = {
     ],
 }
 
+SERVICE_ACCOUNT_TABLE_SCHEMA = {
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "name": {"type": String, "nullable": False},
+    "token_hash": {"type": String, "nullable": False, "unique": True, "index": True},
+    "token_prefix": {"type": String, "nullable": False},
+    "scopes": {"type": JSON, "nullable": False},
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+    "expires_at": {"type": BigInteger, "nullable": True},
+    "last_used_at": {"type": BigInteger, "nullable": True},
+    "revoked_at": {"type": BigInteger, "nullable": True},
+    "created_by": {"type": String, "nullable": True},
+    # Names are reusable after revocation (rotation keeps the same identity),
+    # so uniqueness only applies to active accounts.
+    "_partial_unique_indexes": [{"name": "uq_active_name", "columns": ["name"], "where": "revoked_at IS NULL"}],
+}
+
 
 def _get_schedule_runs_table_schema(schedules_table_name: str = "agno_schedules") -> dict[str, Any]:
     """Get the schedule runs table schema with a foreign key to the schedules table."""
@@ -349,6 +365,7 @@ def get_table_schema_definition(
         "schedules": SCHEDULE_TABLE_SCHEMA,
         "approvals": APPROVAL_TABLE_SCHEMA,
         "auth_tokens": AUTH_TOKEN_TABLE_SCHEMA,
+        "service_accounts": SERVICE_ACCOUNT_TABLE_SCHEMA,
     }
     schema = schemas.get(table_type, {})
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -70,6 +70,7 @@ class SqliteDb(BaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         """
@@ -128,6 +129,7 @@ class SqliteDb(BaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         _engine: Optional[Engine] = db_engine
@@ -228,6 +230,7 @@ class SqliteDb(BaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -268,6 +271,7 @@ class SqliteDb(BaseDb):
             schema_primary_key = table_schema.pop("__primary_key__", None)
             schema_foreign_keys = table_schema.pop("__foreign_keys__", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Build columns
             for col_name, col_config in table_schema.items():
@@ -363,6 +367,15 @@ class SqliteDb(BaseDb):
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 idx_cols = [table.c[c] for c in idx_config["columns"]]
                 Index(idx_name, *idx_cols)
+
+            # Partial unique indexes
+            for idx_config in schema_partial_unique_indexes:
+                idx_name = f"{table_name}_{idx_config['name']}"
+                missing = [c for c in idx_config["columns"] if c not in table.c]
+                if missing:
+                    raise ValueError(f"Partial unique index references missing columns in {table_name}: {missing}")
+                idx_cols = [table.c[c] for c in idx_config["columns"]]
+                Index(idx_name, *idx_cols, unique=True, sqlite_where=text(idx_config["where"]))
 
             # Create table
             table_created = False
@@ -588,6 +601,14 @@ class SqliteDb(BaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        elif table_type == "service_accounts":
+            self.service_accounts_table = self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         else:
             raise ValueError(f"Unknown table type: '{table_type}'")
@@ -5074,4 +5095,125 @@ class SqliteDb(BaseDb):
                 return result.rowcount > 0
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service accounts table")
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.id == service_account_id)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash.
+
+        Re-raises on DB error so callers can distinguish "unknown token" (None) from "db unavailable" (exception).
+        """
+        table = self._get_table(table_type="service_accounts")
+        if table is None:
+            return None
+        try:
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.token_hash == token_hash)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {e}")
+            raise
+
+    def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = sess.execute(stmt).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            with self.Session() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Apply sorting
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_column = table.c[sort_by]
+                order_by = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+
+                # Get paginated results
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                results = sess.execute(stmt).fetchall()
+                return [dict(row._mapping) for row in results], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            with self.Session() as sess, sess.begin():
+                result = sess.execute(table.delete().where(table.c.id == service_account_id))
+                return result.rowcount > 0
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -189,6 +189,7 @@ class SqliteDb(BaseDb):
             schedules_table=data.get("schedules_table"),
             schedule_runs_table=data.get("schedule_runs_table"),
             approvals_table=data.get("approvals_table"),
+            service_accounts_table=data.get("service_accounts_table"),
             id=data.get("id"),
         )
 
@@ -5130,6 +5131,12 @@ class SqliteDb(BaseDb):
         """
         table = self._get_table(table_type="service_accounts")
         if table is None:
+            # _get_table swallows connectivity errors and returns None, which is
+            # indistinguishable from "table not created yet". Probe the connection so
+            # a real outage propagates (fail closed) instead of reading as an unknown
+            # token; a genuinely absent table returns None.
+            with self.Session() as sess:
+                sess.execute(text("SELECT 1"))
             return None
         try:
             with self.Session() as sess:

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -36,6 +36,7 @@ DB_TABLE_NAME_KEYS: frozenset = frozenset(
         "schedule_runs_table",
         "approvals_table",
         "auth_tokens_table",
+        "service_accounts_table",
     }
 )
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1128,7 +1128,10 @@ class AgentOS:
         if self._service_account_verifier is None:
             from agno.os.service_accounts import ServiceAccountVerifier
 
-            self._service_account_verifier = ServiceAccountVerifier(db=self.db)
+            self._service_account_verifier = ServiceAccountVerifier(
+                db=self.db,
+                cache_ttl_seconds=self.settings.service_account_cache_ttl_seconds,
+            )
         return self._service_account_verifier
 
     def _add_jwt_middleware(self, fastapi_app: FastAPI) -> None:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -56,6 +56,7 @@ from agno.os.routers.memory import get_memory_router
 from agno.os.routers.metrics import get_metrics_router
 from agno.os.routers.registry import get_registry_router
 from agno.os.routers.schedules import get_schedule_router
+from agno.os.routers.service_accounts import get_service_accounts_router
 from agno.os.routers.session import get_session_router
 from agno.os.routers.teams import get_team_router
 from agno.os.routers.traces import get_traces_router
@@ -361,6 +362,11 @@ class AgentOS:
             internal_service_token = secrets.token_urlsafe(32)
         self._internal_service_token = internal_service_token
 
+        # Shared verifier for service account tokens (agno_pat_...), created lazily
+        # when a db is available. One instance per AgentOS so the failed-lookup
+        # limiter and last_used_at throttle are shared across the REST and MCP apps.
+        self._service_account_verifier: Optional[Any] = None
+
         # List of all MCP tools used inside the AgentOS
         self.mcp_tools: List[Any] = []
         self._mcp_app: Optional[Any] = None
@@ -480,11 +486,13 @@ class AgentOS:
                 updated_routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
             updated_routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_approval_router(os_db=self.db, settings=self.settings))
+            updated_routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
         else:
             for prefix, tag in [
                 ("/components", "Components"),
                 ("/schedules", "Schedules"),
                 ("/approvals", "Approvals"),
+                ("/service-accounts", "Service Accounts"),
             ]:
                 updated_routers.append(_get_disabled_feature_router(prefix, tag, "db"))
         # Registry router
@@ -1001,14 +1009,17 @@ class AgentOS:
                 routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
             routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             routers.append(get_approval_router(os_db=self.db, settings=self.settings))
+            routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
         else:
             log_debug(
-                "Components, Scheduler, and Approval routers not enabled: requires a db to be provided to AgentOS"
+                "Components, Scheduler, Approval, and Service Account routers not enabled: "
+                "requires a db to be provided to AgentOS"
             )
             for prefix, tag in [
                 ("/components", "Components"),
                 ("/schedules", "Schedules"),
                 ("/approvals", "Approvals"),
+                ("/service-accounts", "Service Accounts"),
             ]:
                 routers.append(_get_disabled_feature_router(prefix, tag, "db"))
 
@@ -1077,6 +1088,12 @@ class AgentOS:
         if self._internal_service_token:
             fastapi_app.state.internal_service_token = self._internal_service_token
 
+        # Expose the service account verifier for the auth dependency and any
+        # manually added JWTMiddleware.
+        service_account_verifier = self._get_service_account_verifier()
+        if service_account_verifier is not None:
+            fastapi_app.state.service_account_verifier = service_account_verifier
+
         # Add JWT middleware if authorization is enabled
         if self.authorization:
             # Set authorization_enabled flag on settings so security key validation is skipped
@@ -1099,6 +1116,20 @@ class AgentOS:
         fastapi_app.add_middleware(TrailingSlashMiddleware)
 
         return fastapi_app
+
+    def _get_service_account_verifier(self) -> Optional[Any]:
+        """Get (lazily creating) the verifier for service account tokens.
+
+        Returns None when the AgentOS has no db - service accounts live in the
+        AgentOS database, so there is nothing to verify against without one.
+        """
+        if self.db is None:
+            return None
+        if self._service_account_verifier is None:
+            from agno.os.service_accounts import ServiceAccountVerifier
+
+            self._service_account_verifier = ServiceAccountVerifier(db=self.db)
+        return self._service_account_verifier
 
     def _add_jwt_middleware(self, fastapi_app: FastAPI) -> None:
         from agno.os.middleware.jwt import JWTMiddleware, JWTValidator
@@ -1180,6 +1211,9 @@ class AgentOS:
         # so manual app.add_middleware(JWTMiddleware) defaults stay backwards-compatible.
         if user_isolation:
             middleware_kwargs["user_isolation"] = True
+        service_account_verifier = self._get_service_account_verifier()
+        if service_account_verifier is not None:
+            middleware_kwargs["service_account_verifier"] = service_account_verifier
         fastapi_app.add_middleware(JWTMiddleware, **middleware_kwargs)
 
     def get_routes(self) -> List[Any]:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -370,6 +370,9 @@ class AgentOS:
         # List of all MCP tools used inside the AgentOS
         self.mcp_tools: List[Any] = []
         self._mcp_app: Optional[Any] = None
+        # Guards get_app() idempotency when a base_app is supplied (that path mutates
+        # the caller's app in place, so preparing twice would double routes/lifespans).
+        self._base_app_prepared: bool = False
 
         self._initialize_agents()
         self._initialize_teams()
@@ -454,17 +457,30 @@ class AgentOS:
         # Track MCP tools declared on the registry
         collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
 
-        if self.enable_mcp_server:
+        # Reuse the already-started MCP app: its tools close over this AgentOS instance,
+        # so components added since construction are visible without a rebuild. Building
+        # a fresh app here would mount one whose StreamableHTTP lifespan never runs --
+        # every subsequent /mcp request would 500 until restart.
+        if self.enable_mcp_server and self._mcp_app is None:
             from agno.os.mcp import get_mcp_server
 
             self._mcp_app = get_mcp_server(self)
 
         self._reprovision_routers(app=app)
 
+    def _mount_mcp_app(self, app: FastAPI) -> None:
+        """Mount the MCP app at root exactly once (idempotent across get_app/resync calls)."""
+        if self._mcp_app is None:
+            return
+        if any(getattr(route, "app", None) is self._mcp_app for route in app.router.routes):
+            return
+        app.mount("/", self._mcp_app)
+
     def _reprovision_routers(self, app: FastAPI) -> None:
         """Re-provision all routes for the AgentOS."""
+        # The home router is added by _add_built_in_routes below; adding it here too
+        # would duplicate the GET / route on every resync.
         updated_routers = [
-            get_home_router(self),
             get_session_router(dbs=self.dbs),
             get_memory_router(dbs=self.dbs),
             get_learnings_router(dbs=self.dbs, settings=self.settings),
@@ -520,14 +536,14 @@ class AgentOS:
             self._add_router(app, router)
 
         # Mount MCP if needed
-        if self.enable_mcp_server and self._mcp_app:
-            app.mount("/", self._mcp_app)
+        if self.enable_mcp_server:
+            self._mount_mcp_app(app)
 
     def _add_built_in_routes(self, app: FastAPI) -> None:
         """Add all AgentOSbuilt-in routes to the given app."""
-        # Add the home router if MCP server is not enabled
-        if not self.enable_mcp_server:
-            self._add_router(app, get_home_router(self))
+        # Always add the home router: explicit routes win over the root MCP Mount, and
+        # without it GET / falls through to the MCP app's plain-text 404.
+        self._add_router(app, get_home_router(self))
 
         self._add_router(app, get_health_router(health_endpoint="/health"))
         self._add_router(app, get_info_router(self))
@@ -906,8 +922,15 @@ class AgentOS:
         if self.base_app:
             fastapi_app = self.base_app
 
+            # get_app() on a base_app mutates that app in place, so a second call (e.g. via
+            # get_routes()) must not prepare it again: it would nest the combined lifespan
+            # inside a new one (double db init, an orphaned MCP session manager) and mount
+            # a second copy of every route.
+            if self._base_app_prepared:
+                return fastapi_app
+
             # Initialize MCP server if enabled
-            if self.enable_mcp_server:
+            if self.enable_mcp_server and self._mcp_app is None:
                 from agno.os.mcp import get_mcp_server
 
                 self._mcp_app = get_mcp_server(self)
@@ -958,11 +981,13 @@ class AgentOS:
             if self.mcp_tools:
                 lifespans.append(partial(mcp_lifespan, mcp_tools=self.mcp_tools))
 
-            # MCP server lifespan
+            # MCP server lifespan (reuse an app built by an earlier get_app() call -- a
+            # rebuilt one would orphan the started StreamableHTTP session manager)
             if self.enable_mcp_server:
-                from agno.os.mcp import get_mcp_server
+                if self._mcp_app is None:
+                    from agno.os.mcp import get_mcp_server
 
-                self._mcp_app = get_mcp_server(self)
+                    self._mcp_app = get_mcp_server(self)
                 lifespans.append(self._mcp_app.lifespan)
 
             # Async database initialization lifespan
@@ -1034,8 +1059,8 @@ class AgentOS:
             self._add_router(fastapi_app, router)
 
         # Mount MCP if needed
-        if self.enable_mcp_server and self._mcp_app:
-            fastapi_app.mount("/", self._mcp_app)
+        if self.enable_mcp_server:
+            self._mount_mcp_app(fastapi_app)
 
         if not self._app_set:
 
@@ -1114,6 +1139,9 @@ class AgentOS:
         from agno.os.middleware.trailing_slash import TrailingSlashMiddleware
 
         fastapi_app.add_middleware(TrailingSlashMiddleware)
+
+        if self.base_app is not None:
+            self._base_app_prepared = True
 
         return fastapi_app
 

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -6,7 +6,14 @@ from typing import Any, List, Optional, Set
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+from agno.os.scopes import (
+    check_route_scopes,
+    get_accessible_resource_ids,
+    get_default_scope_mappings,
+    has_required_scopes,
+)
+from agno.os.service_accounts import TOKEN_PREFIX as SERVICE_ACCOUNT_TOKEN_PREFIX
+from agno.os.service_accounts import VerificationStatus
 from agno.os.settings import AgnoAPISettings
 
 # Create a global HTTPBearer instance
@@ -51,6 +58,60 @@ def get_auth_token_from_request(request: Request) -> Optional[str]:
     return None
 
 
+async def _authenticate_service_account(request: Request, token: str) -> bool:
+    """
+    Authenticate a service account token (agno_pat_...) outside the JWT middleware,
+    i.e. in os_security_key or open deployments.
+
+    Attaches the account identity to request.state exactly like the JWT middleware
+    does (user_id = the sa:<name> principal, scopes = the account's scopes) and
+    enforces the account's scopes against the default scope mappings. Service account
+    scopes are ACL data owned by this AgentOS instance, so - unlike JWT scopes - they
+    are enforced in every deployment mode.
+    """
+    verifier = getattr(request.app.state, "service_account_verifier", None)
+    if verifier is None:
+        raise HTTPException(status_code=401, detail="Service accounts are not enabled on this AgentOS instance")
+
+    client_key = request.client.host if request.client else None
+    result = await verifier.verify(token, client_key=client_key)
+
+    if result.status == VerificationStatus.THROTTLED:
+        raise HTTPException(status_code=429, detail="Too many failed authentication attempts")
+    if result.status == VerificationStatus.UNAVAILABLE:
+        raise HTTPException(status_code=503, detail="Authentication is temporarily unavailable")
+    account = result.account
+    if not result.ok or account is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired service account token")
+
+    admin_scope_raw = getattr(request.app.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+
+    request.state.authenticated = True
+    request.state.user_id = account.principal
+    request.state.session_id = None
+    request.state.scopes = list(account.scopes)
+    request.state.authorization_enabled = True
+    request.state.service_account_name = account.name
+    if admin_scope:
+        request.state.admin_scope = admin_scope
+
+    scope_check = check_route_scopes(
+        list(account.scopes),
+        get_default_scope_mappings(),
+        request.method,
+        request.url.path,
+        admin_scope=admin_scope,
+    )
+    request.state.required_scopes = scope_check.required_scopes
+    if scope_check.accessible_resource_ids is not None:
+        request.state.accessible_resource_ids = scope_check.accessible_resource_ids
+    if not scope_check.allowed:
+        raise HTTPException(status_code=403, detail=build_insufficient_permissions_detail(scope_check.required_scopes))
+
+    return True
+
+
 def _is_jwt_configured() -> bool:
     """Check if JWT authentication is configured via environment variables.
 
@@ -83,6 +144,13 @@ def get_authentication_dependency(settings: AgnoAPISettings):
         # Check if JWT middleware has already handled authentication
         if getattr(request.state, "authenticated", False):
             return True
+
+        # Service account tokens (agno_pat_...) are verified and scope-checked in
+        # every deployment mode - including os_security_key mode and open dev
+        # instances, where they also provide run attribution.
+        token = credentials.credentials if credentials else None
+        if token and token.startswith(SERVICE_ACCOUNT_TOKEN_PREFIX):
+            return await _authenticate_service_account(request, token)
 
         # Also skip if JWT is configured via environment variables
         if _is_jwt_configured():

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -8,11 +8,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 # the valid values for ``MCPServerConfig.include_tags`` / ``exclude_tags`` without reading
 # ``agno/os/mcp.py``. Keep in sync with the ``tags={...}`` argument on each
 # ``@register_builtin_tool(...)`` in that module.
-MCP_BUILTIN_TAGS: frozenset = frozenset({"core", "session", "memory"})
+MCP_BUILTIN_TAGS: frozenset = frozenset({"core", "session"})
 
 # Type alias for ``include_tags`` / ``exclude_tags`` -- gives IDE autocomplete on the
 # string values while keeping the API stringly-typed (callers still pass ``{"core"}``).
-MCPBuiltinTag = Literal["core", "session", "memory"]
+MCPBuiltinTag = Literal["core", "session"]
 
 
 class MCPServerConfig(BaseModel):
@@ -25,9 +25,13 @@ class MCPServerConfig(BaseModel):
 
     The built-in tools are tagged so they can be scoped as a group. See
     ``MCP_BUILTIN_TAGS`` for the canonical set; current values:
-      - ``"core"``    -> ``get_agentos_config``, ``run_agent``, ``run_team``, ``run_workflow``
-      - ``"session"`` -> session CRUD tools
-      - ``"memory"``  -> memory CRUD tools
+      - ``"core"``    -> ``get_agentos_config``, ``run_agent``, ``run_team``, ``run_workflow``,
+        ``continue_run``, ``cancel_run``
+      - ``"session"`` -> read-only session tools (``get_sessions``, ``get_session_runs``)
+
+    The surface is deliberately small (8 tools): it is an operator surface for LLM
+    frontends, not a database console. Session writes and memory CRUD live on the REST
+    surface; anything else can be registered as a custom tool via ``tools``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -42,7 +46,7 @@ class MCPServerConfig(BaseModel):
     # FastMCP ``Context`` parameter, which FastMCP injects natively.
     tools: Optional[List[Any]] = None
 
-    # Master switch for the ~19 built-in tools. Set to False to ship ONLY your own tools.
+    # Master switch for the 8 built-in tools. Set to False to ship ONLY your own tools.
     enable_builtin_tools: bool = True
 
     # Finer scoping over the built-ins via their tags (see ``MCP_BUILTIN_TAGS``).

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -54,6 +54,16 @@ class MCPServerConfig(BaseModel):
     include_tags: Optional[Set[MCPBuiltinTag]] = None
     exclude_tags: Optional[Set[MCPBuiltinTag]] = None
 
+    # How run_agent / run_team / run_workflow serialize their results.
+    #   "trimmed" (default) -> answer text + generated media as MCP content blocks;
+    #     structuredContent carries only run_id / session_id / status (+ unresolved
+    #     requirements when paused). MCP tool results land directly in the consuming
+    #     model's context window, so the transcript, system prompt, and metrics are
+    #     deliberately not included.
+    #   "full" -> structuredContent is the run's complete ``to_dict()`` (media base64-
+    #     encoded), for programmatic MCP clients that want the whole run.
+    result_mode: Literal["trimmed", "full"] = "trimmed"
+
     # Per-call gate for the MCP server. Given the authenticated caller's user_id, return True
     # to allow the request and False to reject it with 401 -- before any tool or model runs.
     # Runs after JWT verification.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1172,6 +1172,12 @@ def get_mcp_server(
         # REST wiring's pattern so manual JWTMiddleware defaults stay backwards-compatible.
         if os.authorization_config.user_isolation:
             jwt_kwargs["user_isolation"] = True
+        # The MCP app is a separately mounted Starlette app with its own app.state, so the
+        # service account verifier must be passed at construction - the middleware cannot
+        # find it on the main app's state from inside the mount.
+        service_account_verifier = os._get_service_account_verifier()
+        if service_account_verifier is not None:
+            jwt_kwargs["service_account_verifier"] = service_account_verifier
         mcp_app.add_middleware(JWTMiddleware, **jwt_kwargs)
 
     # App-provided middleware, preserving the order they were listed in.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -6,13 +6,15 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 from uuid import uuid4
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.server.http import (
     StarletteWithLifespan,
 )
+from fastmcp.tools.tool import ToolResult
 
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType
 from agno.db.schemas import UserMemory
+from agno.os.mcp_results import build_run_tool_result
 from agno.os.routers.memory.schemas import (
     UserMemorySchema,
 )
@@ -37,9 +39,9 @@ from agno.os.utils import (
     get_workflow_by_id,
 )
 from agno.remote.base import RemoteDb
-from agno.run.agent import RunOutput
-from agno.run.team import TeamRunOutput
-from agno.run.workflow import WorkflowRunOutput
+from agno.run.agent import RunEvent, RunOutput
+from agno.run.team import TeamRunEvent, TeamRunOutput
+from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
 from agno.session import AgentSession, TeamSession, WorkflowSession
 
 if TYPE_CHECKING:
@@ -174,6 +176,168 @@ def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
     return caller_user_id
 
 
+# Events forwarded to the client as progress notifications during agent/team runs.
+# Content deltas are deliberately excluded: MCP progress is a status channel, and
+# per-token notifications would flood clients that request a progress token.
+_TOOL_CALL_PROGRESS_EVENTS = frozenset(
+    {
+        RunEvent.tool_call_started.value,
+        RunEvent.tool_call_completed.value,
+        TeamRunEvent.tool_call_started.value,
+        TeamRunEvent.tool_call_completed.value,
+    }
+)
+
+# Error events captured so a failed run surfaces its real error message. The streaming
+# error paths yield only these events -- the final run output is never yielded on failure.
+_RUN_ERROR_EVENTS = frozenset({RunEvent.run_error.value, TeamRunEvent.run_error.value})
+
+
+async def _report_progress(ctx: Context, progress: float, message: str, total: Optional[float] = None) -> None:
+    """Send a progress notification; a failure here must never break the run.
+
+    FastMCP no-ops when the client did not send a progressToken, so this is safe to
+    call unconditionally.
+    """
+    try:
+        await ctx.report_progress(progress=progress, total=total, message=message)
+    except Exception:
+        logger.debug("Failed to send MCP progress notification", exc_info=True)
+
+
+def _describe_tool_call_event(event: Any) -> str:
+    tool = getattr(event, "tool", None)
+    tool_name = getattr(tool, "tool_name", None) or "tool"
+    verb = "started" if str(getattr(event, "event", "")).endswith("Started") else "completed"
+    return f"Tool call {verb}: {tool_name}"
+
+
+async def _consume_agentic_stream(ctx: Context, stream: Any, label: str) -> Union[RunOutput, TeamRunOutput]:
+    """Drive a streaming agent/team run and return its final output.
+
+    The stream must be created with ``stream=True, stream_events=True,
+    yield_run_output=True`` so tool-call events can be forwarded as progress
+    notifications and the final ``RunOutput`` / ``TeamRunOutput`` arrives as the
+    last yielded item. On failure the stream yields only a run-error event -- its
+    message is captured so the client sees the real error, not a generic one.
+    """
+    final: Optional[Union[RunOutput, TeamRunOutput]] = None
+    error_message: Optional[str] = None
+    ticks = 0
+    await _report_progress(ctx, 0.0, f"{label} started")
+    async for item in stream:
+        if isinstance(item, (RunOutput, TeamRunOutput)):
+            final = item
+            continue
+        event = getattr(item, "event", None)
+        if event in _TOOL_CALL_PROGRESS_EVENTS:
+            ticks += 1
+            await _report_progress(ctx, float(ticks), _describe_tool_call_event(item))
+        elif event in _RUN_ERROR_EVENTS:
+            error_message = getattr(item, "content", None) or "Run failed"
+    if final is None:
+        raise Exception(
+            str(error_message) if error_message else f"{label} finished without producing a final run output"
+        )
+    return final
+
+
+async def _run_agentic_component(
+    ctx: Context, component: Any, message: str, user_id: Optional[str], session_id: Optional[str], label: str
+) -> Union[RunOutput, TeamRunOutput]:
+    """Shared run path for agents and teams: stream with progress, or plain await for remotes.
+
+    Remote components proxy to another AgentOS over HTTP and their streaming ``arun``
+    never yields the final output object, so they take the non-streaming path (no
+    intermediate progress, same result contract).
+    """
+    from agno.agent.remote import RemoteAgent
+    from agno.team.remote import RemoteTeam
+
+    if isinstance(component, (RemoteAgent, RemoteTeam)):
+        return await component.arun(message, user_id=user_id, session_id=session_id)
+
+    stream = component.arun(
+        message,
+        user_id=user_id,
+        session_id=session_id,
+        stream=True,
+        stream_events=True,
+        yield_run_output=True,
+    )
+    return await _consume_agentic_stream(ctx, stream, label=label)
+
+
+def _describe_step_event(event: Any, total_steps: Optional[float]) -> str:
+    verb = "started" if str(getattr(event, "event", "")).endswith("Started") else "completed"
+    step_name = getattr(event, "step_name", None) or "step"
+    step_index = getattr(event, "step_index", None)
+    if isinstance(step_index, tuple) and step_index and isinstance(step_index[0], int):
+        step_index = step_index[0]
+    if isinstance(step_index, int) and total_steps:
+        return f"Step {verb}: {step_name} ({step_index + 1}/{int(total_steps)})"
+    return f"Step {verb}: {step_name}"
+
+
+async def _consume_workflow_stream(
+    ctx: Context,
+    workflow: Any,
+    stream: Any,
+    total_steps: Optional[float],
+    user_id: Optional[str],
+) -> WorkflowRunOutput:
+    """Drive a streaming workflow run and return its final output.
+
+    Workflow streams do not support ``yield_run_output``. Completed runs carry the
+    full ``WorkflowRunOutput`` on the terminal event; paused / cancelled / step-error
+    runs end the stream with NO workflow-level terminal event, so the persisted run
+    is fetched back via ``workflow.aget_run_output`` -- the same source of truth the
+    REST router uses. Events from nested workflows (``nested_depth > 0``) are skipped:
+    terminal handling and progress apply to the outer run only, and a nested failure
+    the outer workflow recovers from must not abort it.
+
+    Progress values are a plain monotonic counter (the MCP spec requires each
+    notification's progress to increase); the step k/n detail lives in the message.
+    """
+    from agno.run.workflow import BaseWorkflowRunOutputEvent
+
+    final: Optional[WorkflowRunOutput] = None
+    error_message: Optional[str] = None
+    run_id: Optional[str] = None
+    session_id: Optional[str] = None
+    ticks = 0.0
+    await _report_progress(ctx, 0.0, "Workflow started")
+    async for item in stream:
+        if isinstance(item, WorkflowRunOutput):
+            final = item
+            continue
+        if getattr(item, "nested_depth", 0):
+            continue
+        if isinstance(item, BaseWorkflowRunOutputEvent):
+            run_id = getattr(item, "run_id", None) or run_id
+            session_id = getattr(item, "session_id", None) or session_id
+        event = getattr(item, "event", None)
+        if event in (WorkflowRunEvent.step_started.value, WorkflowRunEvent.step_completed.value):
+            ticks += 1.0
+            await _report_progress(ctx, ticks, _describe_step_event(item, total_steps))
+        elif event == WorkflowRunEvent.workflow_completed.value:
+            final = getattr(item, "run_output", None) or final
+        elif event == WorkflowRunEvent.workflow_error.value:
+            # Do not raise mid-stream: closing the generator here would skip the
+            # workflow's own error-status persistence. Capture and settle after.
+            error_message = getattr(item, "error", None) or "Workflow run failed"
+    if final is None and run_id is not None:
+        try:
+            final = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
+        except Exception:
+            logger.debug("Could not fetch persisted workflow run %s after stream end", run_id, exc_info=True)
+    if final is None:
+        raise Exception(
+            str(error_message) if error_message else "Workflow run finished without producing a final run output"
+        )
+    return final
+
+
 def build_mcp_server(
     os: "AgentOS",
 ) -> FastMCP:
@@ -191,6 +355,10 @@ def build_mcp_server(
     # Decorator used to register the built-in tools. Honors ``mcp_config`` scoping;
     # behaves exactly like ``mcp.tool`` when no config (or default config) is provided.
     register_builtin_tool = _builtin_tool_registrar(mcp, mcp_config)
+
+    # How the run tools serialize their results ("trimmed" keeps the frontend model's
+    # context clean; "full" is the escape hatch for programmatic clients).
+    result_mode = mcp_config.result_mode if mcp_config is not None else "trimmed"
 
     @register_builtin_tool(
         name="get_agentos_config",
@@ -228,40 +396,64 @@ def build_mcp_server(
     async def run_agent(
         agent_id: str,
         message: str,
+        ctx: Context,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
-    ) -> RunOutput:
+    ) -> ToolResult:
         agent = get_agent_by_id(agent_id, os.agents)
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await agent.arun(message, user_id=user_id, session_id=session_id)  # type: ignore[misc]
+        run_output = await _run_agentic_component(
+            ctx, agent, message, user_id, session_id, label=f"Agent {agent.name or agent_id}"
+        )
+        return build_run_tool_result(run_output, result_mode)
 
     @register_builtin_tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
     async def run_team(
         team_id: str,
         message: str,
+        ctx: Context,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
-    ) -> TeamRunOutput:
+    ) -> ToolResult:
         team = get_team_by_id(team_id, os.teams)
         if team is None:
             raise Exception(f"Team {team_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await team.arun(message, user_id=user_id, session_id=session_id)  # type: ignore[misc]
+        run_output = await _run_agentic_component(
+            ctx, team, message, user_id, session_id, label=f"Team {team.name or team_id}"
+        )
+        return build_run_tool_result(run_output, result_mode)
 
     @register_builtin_tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
     async def run_workflow(
         workflow_id: str,
         message: str,
+        ctx: Context,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
-    ) -> WorkflowRunOutput:
+    ) -> ToolResult:
+        from agno.workflow.remote import RemoteWorkflow
+
         workflow = get_workflow_by_id(workflow_id, os.workflows)
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await workflow.arun(message, user_id=user_id, session_id=session_id)
+        if isinstance(workflow, RemoteWorkflow):
+            run_output = await workflow.arun(message, user_id=user_id, session_id=session_id)
+            return build_run_tool_result(run_output, result_mode)
+        steps = getattr(workflow, "steps", None)
+        total_steps = float(len(steps)) if isinstance(steps, (list, tuple)) and steps else None
+        stream = workflow.arun(
+            message,
+            user_id=user_id,
+            session_id=session_id,
+            stream=True,
+            stream_events=True,
+        )
+        run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, user_id)
+        return build_run_tool_result(run_output, result_mode)
 
     # ==================== Session Management Tools ====================
 

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -3,8 +3,7 @@
 import functools
 import inspect
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
-from uuid import uuid4
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
 from fastmcp import Context, FastMCP
 from fastmcp.server.http import (
@@ -12,26 +11,18 @@ from fastmcp.server.http import (
 )
 from fastmcp.tools.tool import ToolResult
 
-from agno.db.base import AsyncBaseDb, BaseDb, SessionType
-from agno.db.schemas import UserMemory
+from agno.db.base import SessionType
 from agno.os.mcp_results import build_run_tool_result
-from agno.os.routers.memory.schemas import (
-    UserMemorySchema,
-)
 from agno.os.schema import (
-    AgentSessionDetailSchema,
     AgentSummaryResponse,
-    ConfigResponse,
-    InterfaceResponse,
-    RunSchema,
+    PaginatedResponse,
+    PaginationInfo,
     SessionSchema,
-    TeamRunSchema,
-    TeamSessionDetailSchema,
     TeamSummaryResponse,
-    WorkflowRunSchema,
-    WorkflowSessionDetailSchema,
     WorkflowSummaryResponse,
 )
+from agno.os.services import runs as run_service
+from agno.os.services import sessions as session_service
 from agno.os.utils import (
     get_agent_by_id,
     get_db,
@@ -42,7 +33,6 @@ from agno.remote.base import RemoteDb
 from agno.run.agent import RunEvent, RunOutput
 from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
-from agno.session import AgentSession, TeamSession, WorkflowSession
 
 if TYPE_CHECKING:
     from agno.os.app import AgentOS
@@ -176,6 +166,42 @@ def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
     return caller_user_id
 
 
+def _forwarded_auth_headers() -> Optional[Dict[str, str]]:
+    """The caller's bearer token as an Authorization header for downstream RemoteDb calls.
+
+    Mirrors the REST routers, which forward the inbound token on every RemoteDb call so
+    a JWT/PAT-protected downstream AgentOS accepts the request.
+    """
+    from fastmcp.server.dependencies import get_http_request
+
+    from agno.os.auth import get_auth_token_from_request
+
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    token = get_auth_token_from_request(request)
+    return {"Authorization": f"Bearer {token}"} if token else None
+
+
+def _scoped_caller_user_id() -> Optional[str]:
+    """The caller's user_id when they are a non-admin, isolation-scoped principal, else None.
+
+    Reuses the REST scoping rule (:func:`get_scoped_user_id`): admins and
+    non-isolated deployments return None (no per-run ownership gate), while a
+    scoped user returns their id so run-lifecycle tools can enforce ownership.
+    """
+    from fastmcp.server.dependencies import get_http_request
+
+    from agno.os.middleware.user_scope import get_scoped_user_id
+
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    return get_scoped_user_id(request)
+
+
 # Events forwarded to the client as progress notifications during agent/team runs.
 # Content deltas are deliberately excluded: MCP progress is a status channel, and
 # per-token notifications would flood clients that request a progress token.
@@ -191,6 +217,17 @@ _TOOL_CALL_PROGRESS_EVENTS = frozenset(
 # Error events captured so a failed run surfaces its real error message. The streaming
 # error paths yield only these events -- the final run output is never yielded on failure.
 _RUN_ERROR_EVENTS = frozenset({RunEvent.run_error.value, TeamRunEvent.run_error.value})
+
+# Per-run fields kept when rendering conversation history. The full RunSchema carries the
+# message transcript (system prompt included), events, and reasoning traces -- like the run
+# tools, the history tool ships only what a frontend model needs, not the raw internals.
+_SESSION_RUN_HISTORY_FIELDS = ("run_id", "run_input", "content", "status", "created_at", "agent_id", "team_id")
+
+
+def _trim_session_run(run: Any) -> Dict[str, Any]:
+    """Compact view of one persisted run for conversation-history reads."""
+    data = run.model_dump() if hasattr(run, "model_dump") else dict(run)
+    return {key: data[key] for key in _SESSION_RUN_HISTORY_FIELDS if data.get(key) is not None}
 
 
 async def _report_progress(ctx: Context, progress: float, message: str, total: Optional[float] = None) -> None:
@@ -338,6 +375,56 @@ async def _consume_workflow_stream(
     return final
 
 
+def _make_lifecycle_resolver(os: "AgentOS"):
+    """Bind the run-lifecycle component resolver + ownership verifier to an AgentOS.
+
+    Both continue_run and cancel_run must resolve exactly one component and, for a
+    scoped (non-admin) caller, prove the run lives in a session they own -- the same
+    gate the REST cancel/continue endpoints enforce before touching a run.
+    """
+
+    def resolve(
+        agent_id: Optional[str], team_id: Optional[str], workflow_id: Optional[str]
+    ) -> "tuple[Any, Literal['agents', 'teams', 'workflows'], str]":
+        provided = [cid for cid in (agent_id, team_id, workflow_id) if cid]
+        if len(provided) != 1:
+            raise Exception("Provide exactly one of agent_id, team_id, or workflow_id")
+        if agent_id:
+            return get_agent_by_id(agent_id, os.agents), "agents", agent_id
+        if team_id:
+            return get_team_by_id(team_id, os.teams), "teams", team_id
+        assert workflow_id is not None  # exactly-one check above guarantees this
+        return get_workflow_by_id(workflow_id, os.workflows), "workflows", workflow_id
+
+    async def verify(
+        component: Any,
+        component_type: Literal["agents", "teams", "workflows"],
+        component_id: str,
+        session_id: Optional[str],
+        run_id: str,
+    ):
+        if component is None:
+            raise Exception(f"Component {component_id} not found")
+        scoped_user_id = _scoped_caller_user_id()
+        if scoped_user_id is None:
+            return
+        if not session_id:
+            raise Exception("session_id is required to act on this run")
+        try:
+            await session_service.verify_run_ownership(
+                component,
+                session_id=session_id,
+                run_id=run_id,
+                user_id=scoped_user_id,
+                component_type=component_type,
+                component_id=component_id,
+            )
+        except session_service.RunOwnershipError as e:
+            raise Exception(str(e))
+
+    return resolve, verify
+
+
 def build_mcp_server(
     os: "AgentOS",
 ) -> FastMCP:
@@ -360,39 +447,45 @@ def build_mcp_server(
     # context clean; "full" is the escape hatch for programmatic clients).
     result_mode = mcp_config.result_mode if mcp_config is not None else "trimmed"
 
+    # Component resolution + ownership gate shared by continue_run and cancel_run.
+    _resolve_lifecycle_component, _verify_run_ownership = _make_lifecycle_resolver(os)
+
     @register_builtin_tool(
         name="get_agentos_config",
-        description="Get the configuration of the AgentOS",
+        description=(
+            "Discover this AgentOS: the agents, teams, and workflows available to run (with their ids "
+            "and descriptions), and the database ids used by the session tools. Call this first to learn "
+            "what you can operate. The payload is deliberately compact -- the full configuration lives on "
+            "the REST /config endpoint."
+        ),
         tags={"core"},
-        output_schema=ConfigResponse.model_json_schema(),
+        annotations={"readOnlyHint": True, "idempotentHint": True},
     )  # type: ignore
-    async def config() -> ConfigResponse:
-        return ConfigResponse(
-            os_id=os.id or "AgentOS",
-            description=os.description,
-            available_models=os.config.available_models if os.config else [],
-            databases=[db.id for db_list in os.dbs.values() for db in db_list],
-            chat=os.config.chat if os.config else None,
-            manifest=os.config.manifest if os.config else None,
-            session=os._get_session_config(),
-            memory=os._get_memory_config(),
-            learning=os._get_learning_config(),
-            knowledge=os._get_knowledge_config(),
-            evals=os._get_evals_config(),
-            metrics=os._get_metrics_config(),
-            traces=os._get_traces_config(),
-            agents=[AgentSummaryResponse.from_agent(a) for a in os.agents] if os.agents else [],
-            teams=[TeamSummaryResponse.from_team(t) for t in os.teams] if os.teams else [],
-            workflows=[WorkflowSummaryResponse.from_workflow(w) for w in os.workflows] if os.workflows else [],
-            interfaces=[
-                InterfaceResponse(type=interface.type, version=interface.version, route=interface.prefix)
-                for interface in os.interfaces
-            ],
-        )
+    async def config() -> Dict[str, Any]:
+        return {
+            "os_id": os.id or "AgentOS",
+            "description": os.description,
+            "databases": [db.id for db_list in os.dbs.values() for db in db_list],
+            "agents": [AgentSummaryResponse.from_agent(a).model_dump() for a in os.agents] if os.agents else [],
+            "teams": [TeamSummaryResponse.from_team(t).model_dump() for t in os.teams] if os.teams else [],
+            "workflows": [WorkflowSummaryResponse.from_workflow(w).model_dump() for w in os.workflows]
+            if os.workflows
+            else [],
+        }
 
     # ==================== Core Run Tools ====================
 
-    @register_builtin_tool(name="run_agent", description="Run an agent with a message", tags={"core"})  # type: ignore
+    @register_builtin_tool(
+        name="run_agent",
+        description=(
+            "Run an agent with a message and get its response. Pass a session_id from get_sessions to "
+            "continue that conversation; omit it to start a new one (the session_id comes back in "
+            "structuredContent). If the result status is PAUSED, resolve the returned requirements and "
+            "call continue_run. Agent ids come from get_agentos_config."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+    )  # type: ignore
     async def run_agent(
         agent_id: str,
         message: str,
@@ -409,7 +502,15 @@ def build_mcp_server(
         )
         return build_run_tool_result(run_output, result_mode)
 
-    @register_builtin_tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
+    @register_builtin_tool(
+        name="run_team",
+        description=(
+            "Run a team of agents with a message and get its response. Same session and PAUSED semantics "
+            "as run_agent. Team ids come from get_agentos_config."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+    )  # type: ignore
     async def run_team(
         team_id: str,
         message: str,
@@ -426,7 +527,16 @@ def build_mcp_server(
         )
         return build_run_tool_result(run_output, result_mode)
 
-    @register_builtin_tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
+    @register_builtin_tool(
+        name="run_workflow",
+        description=(
+            "Run a workflow with an input message and get its result. Can be long-running: progress is "
+            "reported per step when the client supports it. Same session and PAUSED semantics as "
+            "run_agent. Workflow ids come from get_agentos_config."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+    )  # type: ignore
     async def run_workflow(
         workflow_id: str,
         message: str,
@@ -455,27 +565,98 @@ def build_mcp_server(
         run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, user_id)
         return build_run_tool_result(run_output, result_mode)
 
-    # ==================== Session Management Tools ====================
+    # ==================== Run Lifecycle Tools ====================
+
+    @register_builtin_tool(
+        name="continue_run",
+        description=(
+            "Resume a PAUSED run after resolving its requirements (human-in-the-loop). "
+            "When a run tool returns status=PAUSED, its structuredContent carries the unresolved "
+            "requirements; set the resolution fields on them (e.g. confirmation=true) and pass them "
+            "back here unchanged otherwise. Provide exactly one of agent_id / team_id / workflow_id "
+            "(the component that owns the run) plus the run_id and session_id from the paused result."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "destructiveHint": False},
+    )  # type: ignore
+    async def continue_run(
+        run_id: str,
+        ctx: Context,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        requirements: Optional[List[Dict[str, Any]]] = None,
+        user_id: Optional[str] = None,
+    ) -> ToolResult:
+        component, component_type, component_id = _resolve_lifecycle_component(agent_id, team_id, workflow_id)
+        user_id = _resolve_user_id(user_id)
+        await _verify_run_ownership(component, component_type, component_id, session_id, run_id)
+        await _report_progress(ctx, 0.0, f"Continuing run {run_id}")
+        try:
+            run_output = await run_service.continue_paused_run(
+                component,
+                run_id=run_id,
+                session_id=session_id,
+                user_id=user_id,
+                requirements=requirements,
+            )
+        except run_service.RemoteContinuationUnsupported as e:
+            raise Exception(str(e))
+        return build_run_tool_result(run_output, result_mode)
+
+    @register_builtin_tool(
+        name="cancel_run",
+        description=(
+            "Request cancellation of a running run. Irreversible: the run stops and is marked CANCELLED "
+            "(if it has not started yet, the intent is recorded and applied when it does). Provide the "
+            "run_id, its session_id, and exactly one of agent_id / team_id / workflow_id."
+        ),
+        tags={"core"},
+        annotations={"destructiveHint": True, "idempotentHint": True},
+    )  # type: ignore
+    async def cancel_run(
+        run_id: str,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+    ) -> str:
+        component, component_type, component_id = _resolve_lifecycle_component(agent_id, team_id, workflow_id)
+        await _verify_run_ownership(component, component_type, component_id, session_id, run_id)
+        await run_service.cancel_component_run(component, run_id)
+        return f"Run {run_id} cancellation requested"
+
+    # ==================== Session Tools (read-only) ====================
+    # The MCP session surface is deliberately read-only continuity: run tools create
+    # sessions implicitly, and destructive session management stays on the REST surface.
 
     @register_builtin_tool(
         name="get_sessions",
-        description="Get paginated list of sessions with optional filtering by type, component, user, and name",
+        description=(
+            "List past sessions (conversations), newest first. Filter by session_type, component_id "
+            "(an agent/team/workflow id from get_agentos_config), user, or session_name. Use a returned "
+            "session_id with the run tools to continue that conversation, or with get_session_runs to "
+            "read its history. db_id is only needed when get_agentos_config lists multiple databases."
+        ),
         tags={"session"},
+        annotations={"readOnlyHint": True},
     )  # type: ignore
     async def get_sessions(
-        db_id: str,
-        session_type: str = "agent",
+        session_type: Literal["agent", "team", "workflow"] = "agent",
         component_id: Optional[str] = None,
         user_id: Optional[str] = None,
         session_name: Optional[str] = None,
         limit: int = 20,
         page: int = 1,
         sort_by: str = "created_at",
-        sort_order: str = "desc",
+        sort_order: Literal["asc", "desc"] = "desc",
+        db_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
+
         if isinstance(db, RemoteDb):
             result = await db.get_sessions(
                 session_type=session_type_enum,
@@ -487,199 +668,47 @@ def build_mcp_server(
                 sort_by=sort_by,
                 sort_order=sort_order,
                 db_id=db_id,
+                headers=_forwarded_auth_headers(),
             )
             return result.model_dump()
 
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            sessions, total_count = await db.get_sessions(
-                session_type=session_type_enum,
-                component_id=component_id,
-                user_id=user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-        else:
-            sessions, total_count = db.get_sessions(
-                session_type=session_type_enum,
-                component_id=component_id,
-                user_id=user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-
-        return {
-            "data": [SessionSchema.from_dict(session).model_dump() for session in sessions],  # type: ignore
-            "meta": {
-                "page": page,
-                "limit": limit,
-                "total_count": total_count,
-                "total_pages": (total_count + limit - 1) // limit if limit > 0 else 0,  # type: ignore
-            },
-        }
-
-    @register_builtin_tool(
-        name="get_session",
-        description="Get detailed information about a specific session by ID",
-        tags={"session"},
-    )  # type: ignore
-    async def get_session(
-        session_id: str,
-        db_id: str,
-        session_type: str = "agent",
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.get_session(
-                session_id=session_id,
-                session_type=session_type_enum,
-                user_id=user_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(session_id=session_id, session_type=session_type_enum, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            session = db.get_session(session_id=session_id, session_type=session_type_enum, user_id=user_id)
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-
-    @register_builtin_tool(
-        name="create_session",
-        description="Create a new session for an agent, team, or workflow",
-        tags={"session"},
-    )  # type: ignore
-    async def create_session(
-        db_id: str,
-        session_type: str = "agent",
-        session_id: Optional[str] = None,
-        session_name: Optional[str] = None,
-        session_state: Optional[Dict[str, Any]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        user_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        team_id: Optional[str] = None,
-        workflow_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        import time
-
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        # Generate session_id if not provided
-        session_id = session_id or str(uuid4())
-
-        if isinstance(db, RemoteDb):
-            result = await db.create_session(
-                session_type=session_type_enum,
-                session_id=session_id,
-                session_name=session_name,
-                session_state=session_state,
-                metadata=metadata,
-                user_id=user_id,
-                agent_id=agent_id,
-                team_id=team_id,
-                workflow_id=workflow_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        # Prepare session_data
-        session_data: Dict[str, Any] = {}
-        if session_state is not None:
-            session_data["session_state"] = session_state
-        if session_name is not None:
-            session_data["session_name"] = session_name
-
-        current_time = int(time.time())
-
-        # Create the appropriate session type
-        session: Union[AgentSession, TeamSession, WorkflowSession]
-        if session_type_enum == SessionType.AGENT:
-            session = AgentSession(
-                session_id=session_id,
-                agent_id=agent_id,
-                user_id=user_id,
-                session_data=session_data if session_data else None,
-                metadata=metadata,
-                created_at=current_time,
-                updated_at=current_time,
-            )
-        elif session_type_enum == SessionType.TEAM:
-            session = TeamSession(
-                session_id=session_id,
-                team_id=team_id,
-                user_id=user_id,
-                session_data=session_data if session_data else None,
-                metadata=metadata,
-                created_at=current_time,
-                updated_at=current_time,
-            )
-        else:
-            session = WorkflowSession(
-                session_id=session_id,
-                workflow_id=workflow_id,
-                user_id=user_id,
-                session_data=session_data if session_data else None,
-                metadata=metadata,
-                created_at=current_time,
-                updated_at=current_time,
-            )
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            created_session = await db.upsert_session(session, deserialize=True)
-        else:
-            created_session = db.upsert_session(session, deserialize=True)
-
-        if not created_session:
-            raise Exception("Failed to create session")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(created_session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(created_session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(created_session).model_dump()  # type: ignore
+        sessions, total_count = await session_service.get_sessions_page(
+            db,
+            session_type=session_type_enum,
+            component_id=component_id,
+            user_id=user_id,
+            session_name=session_name,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        total_pages = (total_count + limit - 1) // limit if limit > 0 else 0
+        return PaginatedResponse(
+            data=[SessionSchema.from_dict(session) for session in sessions],
+            meta=PaginationInfo(page=page, limit=limit, total_count=total_count, total_pages=total_pages),
+        ).model_dump()
 
     @register_builtin_tool(
         name="get_session_runs",
-        description="Get all runs for a specific session",
+        description=(
+            "Read a session's conversation history: each run's input and response content with its "
+            "run_id, status, and timestamp, oldest first. Returns the answer content only, not the full "
+            "message transcript. session_type is auto-detected when omitted; db_id is only needed when "
+            "get_agentos_config lists multiple databases."
+        ),
         tags={"session"},
+        annotations={"readOnlyHint": True},
     )  # type: ignore
     async def get_session_runs(
         session_id: str,
-        db_id: str,
-        session_type: str = "agent",
+        session_type: Optional[Literal["agent", "team", "workflow"]] = None,
         user_id: Optional[str] = None,
+        db_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
+        session_type_enum = SessionType(session_type) if session_type else None
 
         if isinstance(db, RemoteDb):
             result = await db.get_session_runs(
@@ -687,532 +716,15 @@ def build_mcp_server(
                 session_type=session_type_enum,
                 user_id=user_id,
                 db_id=db_id,
+                headers=_forwarded_auth_headers(),
             )
-            return [r.model_dump() for r in result]
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-        else:
-            session = db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        runs = session.get("runs")  # type: ignore
-        if not runs:
-            return []
-
-        run_responses: List[Dict[str, Any]] = []
-        for run in runs:
-            if session_type_enum == SessionType.AGENT:
-                run_responses.append(RunSchema.from_dict(run).model_dump())
-            elif session_type_enum == SessionType.TEAM:
-                if run.get("agent_id") is not None:
-                    run_responses.append(RunSchema.from_dict(run).model_dump())
-                else:
-                    run_responses.append(TeamRunSchema.from_dict(run).model_dump())
-            else:
-                if run.get("workflow_id") is not None:
-                    run_responses.append(WorkflowRunSchema.from_dict(run).model_dump())
-                elif run.get("team_id") is not None:
-                    run_responses.append(TeamRunSchema.from_dict(run).model_dump())
-                else:
-                    run_responses.append(RunSchema.from_dict(run).model_dump())
-
-        return run_responses
-
-    @register_builtin_tool(
-        name="get_session_run",
-        description="Get a specific run from a session",
-        tags={"session"},
-    )  # type: ignore
-    async def get_session_run(
-        session_id: str,
-        run_id: str,
-        db_id: str,
-        session_type: str = "agent",
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.get_session_run(
-                session_id=session_id,
-                run_id=run_id,
-                session_type=session_type_enum,
-                user_id=user_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-        else:
-            session = db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        runs = session.get("runs")  # type: ignore
-        if not runs:
-            raise Exception(f"Session {session_id} has no runs")
-
-        target_run = None
-        for run in runs:
-            if run.get("run_id") == run_id:
-                target_run = run
-                break
-
-        if not target_run:
-            raise Exception(f"Run {run_id} not found in session {session_id}")
-
-        if target_run.get("workflow_id") is not None:
-            return WorkflowRunSchema.from_dict(target_run).model_dump()
-        elif target_run.get("team_id") is not None:
-            return TeamRunSchema.from_dict(target_run).model_dump()
-        else:
-            return RunSchema.from_dict(target_run).model_dump()
-
-    @register_builtin_tool(
-        name="rename_session",
-        description="Rename an existing session",
-        tags={"session"},
-    )  # type: ignore
-    async def rename_session(
-        session_id: str,
-        session_name: str,
-        db_id: str,
-        session_type: str = "agent",
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.rename_session(
-                session_id=session_id,
-                session_name=session_name,
-                session_type=session_type_enum,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.rename_session(
-                session_id=session_id, session_type=session_type_enum, session_name=session_name, user_id=user_id
-            )
-        else:
-            db = cast(BaseDb, db)
-            session = db.rename_session(
-                session_id=session_id, session_type=session_type_enum, session_name=session_name, user_id=user_id
-            )
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-
-    @register_builtin_tool(
-        name="update_session",
-        description="Update session properties like name, state, metadata, or summary",
-        tags={"session"},
-    )  # type: ignore
-    async def update_session(
-        session_id: str,
-        db_id: str,
-        session_type: str = "agent",
-        session_name: Optional[str] = None,
-        session_state: Optional[Dict[str, Any]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        summary: Optional[Dict[str, Any]] = None,
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.update_session(
-                session_id=session_id,
-                session_type=session_type_enum,
-                session_name=session_name,
-                session_state=session_state,
-                metadata=metadata,
-                summary=summary,
-                user_id=user_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        # Get the existing session
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            existing_session = await db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=True
-            )
-        else:
-            existing_session = db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=True
-            )
-
-        if not existing_session:
-            raise Exception(f"Session {session_id} not found")
-
-        # Update session properties
-        if session_name is not None:
-            if existing_session.session_data is None:  # type: ignore
-                existing_session.session_data = {}  # type: ignore
-            existing_session.session_data["session_name"] = session_name  # type: ignore
-
-        if session_state is not None:
-            if existing_session.session_data is None:  # type: ignore
-                existing_session.session_data = {}  # type: ignore
-            existing_session.session_data["session_state"] = session_state  # type: ignore
-
-        if metadata is not None:
-            existing_session.metadata = metadata  # type: ignore
-
-        if summary is not None:
-            from agno.session.summary import SessionSummary
-
-            existing_session.summary = SessionSummary.from_dict(summary)  # type: ignore
-
-        # Upsert the updated session
-        if isinstance(db, AsyncBaseDb):
-            updated_session = await db.upsert_session(existing_session, deserialize=True)  # type: ignore
-        else:
-            updated_session = db.upsert_session(existing_session, deserialize=True)  # type: ignore
-
-        if not updated_session:
-            raise Exception("Failed to update session")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(updated_session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(updated_session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(updated_session).model_dump()  # type: ignore
-
-    @register_builtin_tool(
-        name="delete_session",
-        description="Delete a specific session and all its runs",
-        tags={"session"},
-    )  # type: ignore
-    async def delete_session(
-        session_id: str,
-        db_id: str,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            await db.delete_session(session_id=session_id, db_id=db_id)
-            return "Session deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_session(session_id=session_id, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_session(session_id=session_id, user_id=user_id)
-
-        return "Session deleted successfully"
-
-    @register_builtin_tool(
-        name="delete_sessions",
-        description="Delete multiple sessions by their IDs",
-        tags={"session"},
-    )  # type: ignore
-    async def delete_sessions(
-        session_ids: List[str],
-        db_id: str,
-        session_types: Optional[List[str]] = None,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            # Convert session_types strings to SessionType enums
-            session_type_enums = [SessionType(st) for st in session_types] if session_types else []
-            await db.delete_sessions(session_ids=session_ids, session_types=session_type_enums, db_id=db_id)
-            return "Sessions deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_sessions(session_ids=session_ids, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_sessions(session_ids=session_ids, user_id=user_id)
-
-        return "Sessions deleted successfully"
-
-    # ==================== Memory Management Tools ====================
-
-    @register_builtin_tool(name="create_memory", description="Create a new user memory", tags={"memory"})  # type: ignore
-    async def create_memory(
-        db_id: str,
-        memory: str,
-        user_id: str,
-        topics: Optional[List[str]] = None,
-    ) -> UserMemorySchema:
-        user_id = _resolve_user_id(user_id) or user_id
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            return await db.create_memory(
-                memory=memory,
-                topics=topics or [],
-                user_id=user_id,
-                db_id=db_id,
-            )
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memory = await db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=str(uuid4()),
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-        else:
-            db = cast(BaseDb, db)
-            user_memory = db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=str(uuid4()),
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-
-        if not user_memory:
-            raise Exception("Failed to create memory")
-
-        return UserMemorySchema.from_dict(user_memory)  # type: ignore
-
-    @register_builtin_tool(
-        name="get_memory",
-        description="Get a specific memory by ID",
-        tags={"memory"},
-    )  # type: ignore
-    async def get_memory(
-        memory_id: str,
-        db_id: str,
-        user_id: Optional[str] = None,
-    ) -> UserMemorySchema:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            return await db.get_memory(memory_id=memory_id, user_id=user_id, db_id=db_id)
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memory = await db.get_user_memory(memory_id=memory_id, user_id=user_id, deserialize=False)
-        else:
-            db = cast(BaseDb, db)
-            user_memory = db.get_user_memory(memory_id=memory_id, user_id=user_id, deserialize=False)
-
-        if not user_memory:
-            raise Exception(f"Memory {memory_id} not found")
-
-        return UserMemorySchema.from_dict(user_memory)  # type: ignore
-
-    @register_builtin_tool(
-        name="get_memories",
-        description="Get a paginated list of memories with optional filtering",
-        tags={"memory"},
-    )  # type: ignore
-    async def get_memories(
-        db_id: str,
-        user_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        team_id: Optional[str] = None,
-        topics: Optional[List[str]] = None,
-        search_content: Optional[str] = None,
-        limit: int = 20,
-        page: int = 1,
-        sort_by: str = "updated_at",
-        sort_order: str = "desc",
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            result = await db.get_memories(
-                user_id=user_id or "",
-                agent_id=agent_id,
-                team_id=team_id,
-                topics=topics,
-                search_content=search_content,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memories, total_count = await db.get_user_memories(
-                limit=limit,
-                page=page,
-                user_id=user_id,
-                agent_id=agent_id,
-                team_id=team_id,
-                topics=topics,
-                search_content=search_content,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-        else:
-            db = cast(BaseDb, db)
-            user_memories, total_count = db.get_user_memories(
-                limit=limit,
-                page=page,
-                user_id=user_id,
-                agent_id=agent_id,
-                team_id=team_id,
-                topics=topics,
-                search_content=search_content,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-
-        memories = [UserMemorySchema.from_dict(m) for m in user_memories]  # type: ignore
-        return {
-            "data": [m.model_dump() for m in memories if m is not None],
-            "meta": {
-                "page": page,
-                "limit": limit,
-                "total_count": total_count,
-                "total_pages": (total_count + limit - 1) // limit if limit > 0 else 0,  # type: ignore
-            },
-        }
-
-    @register_builtin_tool(name="update_memory", description="Update an existing memory", tags={"memory"})  # type: ignore
-    async def update_memory(
-        db_id: str,
-        memory_id: str,
-        memory: str,
-        user_id: str,
-        topics: Optional[List[str]] = None,
-    ) -> UserMemorySchema:
-        user_id = _resolve_user_id(user_id) or user_id
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            return await db.update_memory(
-                memory_id=memory_id,
-                memory=memory,
-                topics=topics or [],
-                user_id=user_id,
-                db_id=db_id,
-            )
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memory = await db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=memory_id,
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-        else:
-            db = cast(BaseDb, db)
-            user_memory = db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=memory_id,
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-
-        if not user_memory:
-            raise Exception("Failed to update memory")
-
-        return UserMemorySchema.from_dict(user_memory)  # type: ignore
-
-    @register_builtin_tool(name="delete_memory", description="Delete a specific memory by ID", tags={"memory"})  # type: ignore
-    async def delete_memory(
-        db_id: str,
-        memory_id: str,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            await db.delete_memory(memory_id=memory_id, user_id=user_id, db_id=db_id)
-            return "Memory deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_user_memory(memory_id=memory_id, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_user_memory(memory_id=memory_id, user_id=user_id)
-
-        return "Memory deleted successfully"
-
-    @register_builtin_tool(
-        name="delete_memories",
-        description="Delete multiple memories by their IDs",
-        tags={"memory"},
-    )  # type: ignore
-    async def delete_memories(
-        memory_ids: List[str],
-        db_id: str,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            await db.delete_memories(memory_ids=memory_ids, user_id=user_id, db_id=db_id)
-            return "Memories deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-
-        return "Memories deleted successfully"
+            return [_trim_session_run(r) for r in result]
+
+        # SessionNotFoundError propagates as the tool error verbatim ("Session {id} not found").
+        runs = await session_service.get_session_runs(
+            db, session_id=session_id, session_type=session_type_enum, user_id=user_id
+        )
+        return [_trim_session_run(r) for r in runs]
 
     # Register any user-provided custom tools. These share the same server, mount (/mcp),
     # lifespan, and JWT middleware as the built-in tools.

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -1,0 +1,139 @@
+"""Serialization of run outputs into MCP tool results.
+
+The run tools on the AgentOS MCP server return results sized for the consuming
+LLM: MCP tool results are injected directly into the frontend model's context
+window, so the default ("trimmed") mode carries the answer and a minimal set of
+identifiers rather than the full run transcript. Raw dataclass serialization is
+never used -- it dumps internal message history (including the system prompt)
+over the wire and raises on binary media.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from mcp.types import AudioContent, ContentBlock, ImageContent, TextContent
+
+from agno.media import Audio, Image
+from agno.run.agent import RunOutput
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+from agno.utils.media import resolve_image_mime_type
+from agno.utils.serialize import json_serializer
+
+AnyRunOutput = Union[RunOutput, TeamRunOutput, WorkflowRunOutput]
+
+# Default media type when an audio artifact does not carry an explicit mime type.
+_DEFAULT_AUDIO_MIME = "audio/mpeg"
+
+
+def _content_text(run_output: AnyRunOutput) -> str:
+    """The run's answer as plain text (JSON for structured/output_schema content)."""
+    if run_output.content is None:
+        return ""
+    return run_output.get_content_as_string()
+
+
+def _audio_mime(artifact: Audio) -> str:
+    if artifact.mime_type:
+        return artifact.mime_type
+    if artifact.format:
+        return f"audio/{artifact.format.lower()}"
+    return _DEFAULT_AUDIO_MIME
+
+
+def _media_blocks(run_output: AnyRunOutput) -> List[ContentBlock]:
+    """MCP content blocks for generated media that carries raw bytes.
+
+    URL- or filepath-only artifacts are skipped: the bytes are not in hand, and
+    fetching them on the server's behalf is not this layer's job. Their ids remain
+    discoverable via ``result_mode="full"``.
+    """
+    blocks: List[ContentBlock] = []
+    for image in getattr(run_output, "images", None) or []:
+        if isinstance(image, Image) and isinstance(image.content, bytes):
+            data = image.to_base64()
+            if data:
+                blocks.append(
+                    ImageContent(
+                        type="image",
+                        data=data,
+                        mimeType=resolve_image_mime_type(
+                            mime_type=image.mime_type, image_format=image.format, image_bytes=image.content
+                        ),
+                    )
+                )
+    for audio in getattr(run_output, "audio", None) or []:
+        if isinstance(audio, Audio) and isinstance(audio.content, bytes):
+            data = audio.to_base64()
+            if data:
+                blocks.append(AudioContent(type="audio", data=data, mimeType=_audio_mime(audio)))
+    return blocks
+
+
+def _run_status(run_output: AnyRunOutput) -> str:
+    status = getattr(run_output, "status", None)
+    value = getattr(status, "value", status)
+    return str(value) if value is not None else "COMPLETED"
+
+
+def _paused_requirements(run_output: AnyRunOutput) -> Optional[List[Dict[str, Any]]]:
+    """Serialized unresolved requirements when the run is paused, else None."""
+    if not getattr(run_output, "is_paused", False):
+        return None
+    # Agents/teams expose active_requirements; workflows expose active_step_requirements.
+    requirements = (
+        getattr(run_output, "active_requirements", None) or getattr(run_output, "active_step_requirements", None) or []
+    )
+    serialized: List[Dict[str, Any]] = []
+    for requirement in requirements:
+        if hasattr(requirement, "to_dict"):
+            serialized.append(requirement.to_dict())
+        elif isinstance(requirement, dict):
+            serialized.append(requirement)
+    return serialized or None
+
+
+def _json_safe(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Force a dict through JSON so enum/datetime leftovers cannot break the transport."""
+    return json.loads(json.dumps(data, default=json_serializer))
+
+
+def trimmed_structured_content(run_output: AnyRunOutput) -> Dict[str, Any]:
+    structured: Dict[str, Any] = {
+        "run_id": run_output.run_id,
+        "session_id": run_output.session_id,
+        "status": _run_status(run_output),
+    }
+    requirements = _paused_requirements(run_output)
+    if requirements is not None:
+        structured["requirements"] = requirements
+    return _json_safe(structured)
+
+
+def build_run_tool_result(run_output: AnyRunOutput, result_mode: str = "trimmed") -> "Any":
+    """Build the MCP ``ToolResult`` for a completed (or paused) run.
+
+    ``trimmed`` (default): answer text + generated media as MCP content blocks,
+    with ``structuredContent`` limited to run_id / session_id / status and, when
+    paused, the unresolved requirements a continue call must address.
+
+    ``full``: text content with ``structuredContent`` set to the run's complete
+    ``to_dict()`` (media base64-encoded there — no separate media blocks, so large
+    payloads are not shipped twice).
+    """
+    from fastmcp.tools.tool import ToolResult
+
+    text = _content_text(run_output)
+    if not text and getattr(run_output, "is_paused", False):
+        requirements = _paused_requirements(run_output) or []
+        text = f"Run paused: {len(requirements)} requirement(s) awaiting resolution."
+
+    content: List[ContentBlock] = [TextContent(type="text", text=text)]
+
+    if result_mode == "full":
+        structured = _json_safe(run_output.to_dict())
+    else:
+        content.extend(_media_blocks(run_output))
+        structured = trimmed_structured_content(run_output)
+
+    return ToolResult(content=content, structured_content=structured)

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -15,14 +15,18 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from agno.os.auth import INTERNAL_SERVICE_SCOPES, build_insufficient_permissions_detail
 from agno.os.scopes import (
     AgentOSScope,
-    get_accessible_resource_ids,
+    check_route_scopes,
     get_default_scope_mappings,
-    has_required_scopes,
+    get_required_scopes_for_route,
 )
+from agno.os.service_accounts import TOKEN_PREFIX as SERVICE_ACCOUNT_TOKEN_PREFIX
+from agno.os.service_accounts import VerificationStatus
 from agno.utils.log import log_debug, log_warning
 
 if TYPE_CHECKING:
     from jwt import PyJWK
+
+    from agno.os.service_accounts import ServiceAccountVerifier
 
 
 class TokenSource(str, Enum):
@@ -415,6 +419,7 @@ class JWTMiddleware(BaseHTTPMiddleware):
         excluded_route_paths: Optional[List[str]] = None,
         admin_scope: Optional[str] = None,
         user_isolation: bool = False,
+        service_account_verifier: Optional["ServiceAccountVerifier"] = None,
     ):
         """
         Initialize the JWT middleware.
@@ -456,6 +461,15 @@ class JWTMiddleware(BaseHTTPMiddleware):
                            Format: {"POST /agents/*/runs": ["agents:run"], "GET /public": []}
             excluded_route_paths: List of route paths to exclude from JWT/RBAC checks
             admin_scope: The scope that grants admin access (default: "agent_os:admin")
+            service_account_verifier: Verifier for service account tokens (agno_pat_...).
+                When set (or available on app.state.service_account_verifier), bearer
+                tokens with the agno_pat_ prefix authenticate as service accounts
+                instead of JWTs: user_id is the account principal (sa:<name>) and
+                scopes are the account's stored scopes. Service account scopes are
+                first-party ACL data, so they are enforced against the scope mappings
+                even when authorization is disabled. Service account requests carry no
+                request.state.claims/token - factory trusted-claims consumers must
+                treat those as optional.
             user_isolation: Opt in to per-user data isolation (default False).
                 When True, route handlers wrap the DB in a per-request scoped
                 adapter and enforce session/run ownership on non-admin callers.
@@ -526,6 +540,15 @@ class JWTMiddleware(BaseHTTPMiddleware):
         else:
             self.scope_mappings = scope_mappings or {}
 
+        # Service account scopes are enforced even when authorization is disabled
+        # (they are this instance's own ACL data, not third-party claims), so keep
+        # a fully merged scope map regardless of the authorization flag.
+        self.service_account_scope_mappings = get_default_scope_mappings()
+        if scope_mappings is not None:
+            self.service_account_scope_mappings.update(scope_mappings)
+
+        self.service_account_verifier = service_account_verifier
+
         self.excluded_route_paths = (
             excluded_route_paths if excluded_route_paths is not None else self._get_default_excluded_routes()
         )
@@ -593,31 +616,56 @@ class JWTMiddleware(BaseHTTPMiddleware):
             List of required scopes. Empty list [] means no scopes required (allow access).
             Routes not in scope_mappings also return [], allowing access.
         """
-        route_key = f"{method} {path}"
+        return get_required_scopes_for_route(self.scope_mappings, method, path)
 
-        # First, try exact match
-        if route_key in self.scope_mappings:
-            return self.scope_mappings[route_key]
+    def _check_scopes(
+        self,
+        request: Request,
+        method: str,
+        path: str,
+        scopes: List[str],
+        origin: Optional[str],
+        cors_allowed_origins: Optional[List[str]],
+        scope_mappings: Optional[Dict[str, List[str]]] = None,
+    ) -> Optional[JSONResponse]:
+        """
+        Shared RBAC check used by every credential type (JWTs, the internal service
+        token, and service account tokens).
 
-        # Then try pattern matching
-        for pattern, scopes in self.scope_mappings.items():
-            pattern_method, pattern_path = pattern.split(" ", 1)
+        Sets request.state.required_scopes and, for listing endpoints where the caller
+        only holds per-resource scopes, request.state.accessible_resource_ids.
 
-            # Check if method matches
-            if pattern_method != method:
-                continue
+        Returns:
+            An error response when access is denied, None when access is allowed.
+        """
+        mappings = scope_mappings if scope_mappings is not None else self.scope_mappings
+        result = check_route_scopes(scopes, mappings, method, path, admin_scope=self.admin_scope)
 
-            # Convert pattern to fnmatch pattern (replace {param} with *)
-            # This handles both /agents/* and /agents/{agent_id} style patterns
-            normalized_pattern = pattern_path
-            if "{" in normalized_pattern:
-                # Replace {param} with * for pattern matching
-                normalized_pattern = re.sub(r"\{[^}]+\}", "*", normalized_pattern)
+        request.state.required_scopes = result.required_scopes
+        if result.accessible_resource_ids is not None:
+            request.state.accessible_resource_ids = result.accessible_resource_ids
+            if result.accessible_resource_ids:
+                log_debug(f"Caller has specific resource scopes. Accessible IDs: {result.accessible_resource_ids}")
+            else:
+                log_debug("Caller has no matching resource scopes. Will return empty list.")
 
-            if fnmatch.fnmatch(path, normalized_pattern):
-                return scopes
+        if not result.allowed:
+            log_warning(
+                f"Insufficient scopes for {method} {path}. Required: {result.required_scopes}, User has: {scopes}"
+            )
+            return self._create_error_response(
+                403,
+                "Insufficient permissions",
+                origin,
+                cors_allowed_origins,
+                required_scopes=result.required_scopes,
+            )
 
-        return []
+        if result.required_scopes:
+            log_debug(f"Scope check passed for {method} {path}. User scopes: {scopes}")
+        else:
+            log_debug(f"No scopes required for {method} {path}")
+        return None
 
     def _extract_token_from_header(self, request: Request) -> Optional[str]:
         """Extract JWT token from Authorization header."""
@@ -726,6 +774,13 @@ class JWTMiddleware(BaseHTTPMiddleware):
             error_msg = self._get_missing_token_error_message()
             return self._create_error_response(401, error_msg, origin, cors_allowed_origins)
 
+        # Service account tokens (agno_pat_...) are first-party opaque credentials
+        # verified against the AgentOS database rather than decoded as JWTs.
+        if token.startswith(SERVICE_ACCOUNT_TOKEN_PREFIX):
+            return await self._dispatch_service_account(
+                request, token, method, path, origin, cors_allowed_origins, call_next
+            )
+
         # Check for internal service token (used by scheduler executor)
         internal_token = getattr(request.app.state, "internal_service_token", None)
         if internal_token and hmac.compare_digest(token, internal_token):
@@ -740,24 +795,11 @@ class JWTMiddleware(BaseHTTPMiddleware):
 
             # Enforce RBAC for internal token (do not skip scope checks)
             if self.authorization:
-                required_scopes = self._get_required_scopes(method, path)
-                if required_scopes:
-                    if not has_required_scopes(
-                        internal_scopes,
-                        required_scopes,
-                        admin_scope=self.admin_scope,
-                    ):
-                        log_warning(
-                            f"Internal service token denied for {method} {path}. "
-                            f"Required: {required_scopes}, Token has: {internal_scopes}"
-                        )
-                        return self._create_error_response(
-                            403,
-                            "Insufficient permissions",
-                            origin,
-                            cors_allowed_origins,
-                            required_scopes=required_scopes,
-                        )
+                error_response = self._check_scopes(
+                    request, method, path, internal_scopes, origin, cors_allowed_origins
+                )
+                if error_response is not None:
+                    return error_response
 
             return await call_next(request)
 
@@ -820,71 +862,9 @@ class JWTMiddleware(BaseHTTPMiddleware):
 
             # RBAC scope checking (only if enabled)
             if self.authorization:
-                # Extract resource type and ID from path
-                resource_type = None
-                resource_id = None
-
-                if "/agents" in path:
-                    resource_type = "agents"
-                elif "/teams" in path:
-                    resource_type = "teams"
-                elif "/workflows" in path:
-                    resource_type = "workflows"
-
-                if resource_type:
-                    resource_id = self._extract_resource_id_from_path(path, resource_type)
-
-                required_scopes = self._get_required_scopes(method, path)
-                request.state.required_scopes = required_scopes
-
-                # Empty list [] means no scopes required (allow access)
-                if required_scopes:
-                    # Use the scope validation system
-                    has_access = has_required_scopes(
-                        scopes,
-                        required_scopes,
-                        resource_type=resource_type,
-                        resource_id=resource_id,
-                        admin_scope=self.admin_scope,
-                    )
-
-                    # Special handling for listing endpoints (no resource_id)
-                    if not has_access and not resource_id and resource_type:
-                        # For listing endpoints, always allow access but store accessible IDs for filtering
-                        # This allows endpoints to return filtered results (including empty list) instead of 403.
-                        # Pass the action from required_scopes (e.g. "read" for "agents:read") so the cached
-                        # IDs only include resources the user is authorised for under that action — otherwise
-                        # a user with only `agents:run` would leak through `GET /agents`.
-                        required_action: Optional[str] = None
-                        first_required = required_scopes[0]
-                        if ":" in first_required:
-                            required_action = first_required.rsplit(":", 1)[1]
-                        accessible_ids = get_accessible_resource_ids(
-                            scopes, resource_type, admin_scope=self.admin_scope, action=required_action
-                        )
-                        has_access = True  # Always allow listing endpoints
-                        request.state.accessible_resource_ids = accessible_ids
-
-                        if accessible_ids:
-                            log_debug(f"User has specific {resource_type} scopes. Accessible IDs: {accessible_ids}")
-                        else:
-                            log_debug(f"User has no {resource_type} scopes. Will return empty list.")
-
-                    if not has_access:
-                        log_warning(
-                            f"Insufficient scopes for {method} {path}. Required: {required_scopes}, User has: {scopes}"
-                        )
-                        return self._create_error_response(
-                            403,
-                            "Insufficient permissions",
-                            origin,
-                            cors_allowed_origins,
-                            required_scopes=required_scopes,
-                        )
-
-                    log_debug(f"Scope check passed for {method} {path}. User scopes: {scopes}")
-                else:
-                    log_debug(f"No scopes required for {method} {path}")
+                error_response = self._check_scopes(request, method, path, scopes, origin, cors_allowed_origins)
+                if error_response is not None:
+                    return error_response
 
             log_debug(f"JWT decoded successfully for user: {user_id}")
 
@@ -916,6 +896,73 @@ class JWTMiddleware(BaseHTTPMiddleware):
             request.state.authenticated = False
             request.state.token = token
 
+        return await call_next(request)
+
+    async def _dispatch_service_account(
+        self,
+        request: Request,
+        token: str,
+        method: str,
+        path: str,
+        origin: Optional[str],
+        cors_allowed_origins: Optional[List[str]],
+        call_next,
+    ) -> Response:
+        """
+        Authenticate a service account token (agno_pat_...) and enforce its scopes.
+
+        Verification failures all return the same 401 detail - the precise reason
+        (unknown, revoked, expired) is only logged server-side. Scope enforcement
+        always runs, regardless of the authorization flag: unlike JWT claims, service
+        account scopes are ACL data owned by this AgentOS instance.
+        """
+        verifier = self.service_account_verifier or getattr(request.app.state, "service_account_verifier", None)
+        if verifier is None:
+            return self._create_error_response(
+                401, "Service accounts are not enabled on this AgentOS instance", origin, cors_allowed_origins
+            )
+
+        client_key = request.client.host if request.client else None
+        result = await verifier.verify(token, client_key=client_key)
+
+        if result.status == VerificationStatus.THROTTLED:
+            return self._create_error_response(
+                429, "Too many failed authentication attempts", origin, cors_allowed_origins
+            )
+        if result.status == VerificationStatus.UNAVAILABLE:
+            return self._create_error_response(
+                503, "Authentication is temporarily unavailable", origin, cors_allowed_origins
+            )
+        account = result.account
+        if not result.ok or account is None:
+            return self._create_error_response(
+                401, "Invalid or expired service account token", origin, cors_allowed_origins
+            )
+
+        request.state.authenticated = True
+        request.state.user_id = account.principal
+        request.state.session_id = None
+        request.state.scopes = list(account.scopes)
+        # Scope enforcement is always active for service accounts, so route-level
+        # authorization gates (require_resource_access etc.) must be active too.
+        request.state.authorization_enabled = True
+        request.state.admin_scope = self.admin_scope
+        request.state.user_isolation_enabled = self.user_isolation
+        request.state.service_account_name = account.name
+
+        error_response = self._check_scopes(
+            request,
+            method,
+            path,
+            list(account.scopes),
+            origin,
+            cors_allowed_origins,
+            scope_mappings=self.service_account_scope_mappings,
+        )
+        if error_response is not None:
+            return error_response
+
+        log_debug(f"Service account authenticated: {account.principal}")
         return await call_next(request)
 
     def _extract_token(self, request: Request) -> Optional[str]:

--- a/libs/agno/agno/os/routers/service_accounts/__init__.py
+++ b/libs/agno/agno/os/routers/service_accounts/__init__.py
@@ -1,0 +1,3 @@
+from agno.os.routers.service_accounts.router import get_service_accounts_router
+
+__all__ = ["get_service_accounts_router"]

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -14,7 +14,7 @@ from agno.os.routers.service_accounts.schema import (
     ServiceAccountResponse,
 )
 from agno.os.schema import PaginatedResponse, PaginationInfo
-from agno.os.scopes import AgentOSScope, has_required_scopes
+from agno.os.scopes import AgentOSScope, has_required_scopes, parse_scope
 from agno.os.service_accounts import (
     DEFAULT_EXPIRY_DAYS,
     DEFAULT_SERVICE_ACCOUNT_SCOPES,
@@ -41,6 +41,25 @@ def _is_integrity_error(exc: Exception) -> bool:
         return isinstance(exc, IntegrityError)
     except ImportError:
         return False
+
+
+def _caller_holds_scope(caller_scopes: List[str], scope: str, admin_scope: Optional[str]) -> bool:
+    """Whether the caller's scopes cover a single requested scope.
+
+    Per-resource scopes (e.g. agents:my-agent:run) must be checked with their
+    resource context, so a caller holding exactly that scope - or a wildcard/global
+    scope over the resource - is recognised as holding it.
+    """
+    parsed = parse_scope(scope, admin_scope=admin_scope)
+    if parsed.is_per_resource_scope and parsed.resource and parsed.action:
+        return has_required_scopes(
+            caller_scopes,
+            [f"{parsed.resource}:{parsed.action}"],
+            resource_type=parsed.resource,
+            resource_id=parsed.resource_id,
+            admin_scope=admin_scope,
+        )
+    return has_required_scopes(caller_scopes, [scope], admin_scope=admin_scope)
 
 
 def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
@@ -102,9 +121,7 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
         effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
         if effective_admin_scope in caller_scopes:
             return
-        scopes_not_held = [
-            scope for scope in scopes if not has_required_scopes(caller_scopes, [scope], admin_scope=admin_scope)
-        ]
+        scopes_not_held = [scope for scope in scopes if not _caller_holds_scope(caller_scopes, scope, admin_scope)]
         if scopes_not_held:
             raise HTTPException(
                 status_code=403,

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -211,17 +211,28 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
     @router.delete("/service-accounts/{service_account_id}", status_code=204)
     async def revoke_service_account(
         service_account_id: str,
+        request: Request,
         _: bool = Depends(auth_dependency),
     ) -> None:
-        """Revoke a service account. Takes effect on the token's next request. Idempotent."""
+        """Revoke a service account. Idempotent.
+
+        Takes effect immediately on this worker (the local verification cache entry is
+        evicted) and within the cache TTL on other workers.
+        """
         existing = await _db_call("get_service_account", service_account_id)
         if existing is None:
             raise HTTPException(status_code=404, detail=f"Service account '{service_account_id}' not found")
-        if existing.get("revoked_at") is not None:
-            return None
-        updated = await _db_call("update_service_account", service_account_id, revoked_at=int(time.time()))
-        if updated is None:
-            raise HTTPException(status_code=500, detail="Could not revoke service account")
+        if existing.get("revoked_at") is None:
+            updated = await _db_call("update_service_account", service_account_id, revoked_at=int(time.time()))
+            if updated is None:
+                raise HTTPException(status_code=500, detail="Could not revoke service account")
+
+        # Evict the cached verification so this worker rejects the token immediately;
+        # other workers converge as their cached entry ages out within the TTL.
+        verifier = getattr(request.app.state, "service_account_verifier", None)
+        token_hash = existing.get("token_hash")
+        if verifier is not None and token_hash:
+            verifier.invalidate(token_hash)
         return None
 
     return router

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -1,0 +1,210 @@
+"""Service accounts API router - mint, list, and revoke opaque machine tokens."""
+
+import asyncio
+import time
+from typing import Any, List, Literal, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from agno.db.schemas.service_accounts import ServiceAccount
+from agno.os.routers.service_accounts.schema import (
+    ServiceAccountCreate,
+    ServiceAccountCreateResponse,
+    ServiceAccountResponse,
+)
+from agno.os.schema import PaginatedResponse, PaginationInfo
+from agno.os.scopes import AgentOSScope, has_required_scopes
+from agno.os.service_accounts import (
+    DEFAULT_EXPIRY_DAYS,
+    DEFAULT_SERVICE_ACCOUNT_SCOPES,
+    generate_token,
+    get_invalid_scopes,
+    get_privileged_scopes,
+)
+from agno.utils.log import log_error
+
+# Valid DB method names that _db_call can invoke
+_ServiceAccountDbMethod = Literal[
+    "create_service_account",
+    "get_service_account",
+    "get_service_account_by_name",
+    "get_service_accounts",
+    "update_service_account",
+]
+
+
+def _is_integrity_error(exc: Exception) -> bool:
+    try:
+        from sqlalchemy.exc import IntegrityError
+
+        return isinstance(exc, IntegrityError)
+    except ImportError:
+        return False
+
+
+def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
+    """Factory that creates and returns the service accounts router.
+
+    Args:
+        os_db: The AgentOS-level DB adapter (must support service account methods).
+        settings: AgnoAPISettings instance.
+
+    Returns:
+        An APIRouter with all service account endpoints attached.
+    """
+    from agno.os.auth import get_authentication_dependency
+
+    router = APIRouter(tags=["Service Accounts"])
+    auth_dependency = get_authentication_dependency(settings)
+
+    async def _db_call(method_name: _ServiceAccountDbMethod, *args: Any, **kwargs: Any) -> Any:
+        fn = getattr(os_db, method_name, None)
+        if fn is None:
+            raise HTTPException(status_code=503, detail="Service accounts not supported by the configured database")
+        try:
+            if asyncio.iscoroutinefunction(fn):
+                return await fn(*args, **kwargs)
+            return fn(*args, **kwargs)
+        except NotImplementedError:
+            raise HTTPException(status_code=503, detail="Service accounts not supported by the configured database")
+
+    def _get_admin_scope(request: Request) -> Optional[str]:
+        admin_scope_raw = getattr(request.state, "admin_scope", None) or getattr(request.app.state, "admin_scope", None)
+        return admin_scope_raw if isinstance(admin_scope_raw, str) else None
+
+    def _validate_requested_scopes(request: Request, body: ServiceAccountCreate, scopes: List[str]) -> None:
+        """Reject unknown scopes, gate privileged scopes behind the explicit flag, and
+        enforce the subset rule: a caller with scopes can only grant scopes it holds."""
+        admin_scope = _get_admin_scope(request)
+
+        invalid_scopes = get_invalid_scopes(scopes, admin_scope=admin_scope)
+        if invalid_scopes:
+            raise HTTPException(status_code=400, detail=f"Invalid scope(s): {', '.join(invalid_scopes)}")
+
+        privileged_scopes = get_privileged_scopes(scopes, admin_scope=admin_scope)
+        if privileged_scopes and not body.allow_privileged_scopes:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Privileged scope(s) require allow_privileged_scopes=true: {', '.join(privileged_scopes)}. "
+                    "Privileged tokens must be deliberate, never accidental."
+                ),
+            )
+
+        # Subset rule: minted scopes must be held by the creator, so a caller with
+        # only service_accounts:write can never escalate by minting a token more
+        # powerful than itself. Callers without scope context (root os_security_key
+        # or open dev instances) are exempt - they are unscoped by definition.
+        caller_scopes = getattr(request.state, "scopes", None)
+        if caller_scopes is None:
+            return
+        effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
+        if effective_admin_scope in caller_scopes:
+            return
+        scopes_not_held = [
+            scope for scope in scopes if not has_required_scopes(caller_scopes, [scope], admin_scope=admin_scope)
+        ]
+        if scopes_not_held:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Cannot grant scope(s) you do not hold: {', '.join(scopes_not_held)}",
+            )
+
+    @router.post("/service-accounts", response_model=ServiceAccountCreateResponse, status_code=201)
+    async def create_service_account(
+        body: ServiceAccountCreate,
+        request: Request,
+        _: bool = Depends(auth_dependency),
+    ) -> ServiceAccountCreateResponse:
+        """Mint a service account token. The plaintext token is returned exactly once."""
+        scopes = list(body.scopes) if body.scopes is not None else list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
+        _validate_requested_scopes(request, body, scopes)
+
+        existing = await _db_call("get_service_account_by_name", body.name)
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"An active service account named '{body.name}' already exists. Revoke it first to rotate.",
+            )
+
+        now = int(time.time())
+        expires_at: Optional[int] = None
+        if not body.never_expires:
+            expires_in_days = body.expires_in_days if body.expires_in_days is not None else DEFAULT_EXPIRY_DAYS
+            expires_at = now + expires_in_days * 86400
+
+        plaintext_token, token_hash, token_prefix = generate_token()
+        account = ServiceAccount(
+            id=str(uuid4()),
+            name=body.name,
+            token_hash=token_hash,
+            token_prefix=token_prefix,
+            scopes=scopes,
+            created_at=now,
+            expires_at=expires_at,
+            created_by=getattr(request.state, "user_id", None),
+        )
+
+        try:
+            await _db_call("create_service_account", account.to_dict())
+        except HTTPException:
+            raise
+        except Exception as exc:
+            if _is_integrity_error(exc):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"An active service account named '{body.name}' already exists. Revoke it first to rotate.",
+                )
+            log_error(f"Could not create service account: {exc}")
+            raise HTTPException(status_code=500, detail="Could not create service account")
+
+        metadata = ServiceAccountResponse.from_dict(account.to_dict())
+        return ServiceAccountCreateResponse(**metadata.model_dump(), token=plaintext_token)
+
+    @router.get("/service-accounts", response_model=PaginatedResponse[ServiceAccountResponse])
+    async def list_service_accounts(
+        include_revoked: bool = Query(True),
+        limit: int = Query(20, ge=1, le=100),
+        page: int = Query(1, ge=1),
+        sort_by: str = Query("created_at"),
+        sort_order: str = Query("desc"),
+        _: bool = Depends(auth_dependency),
+    ) -> PaginatedResponse[ServiceAccountResponse]:
+        """List service accounts. Returns metadata and display prefixes only - never hashes or plaintext."""
+        accounts, total_count = await _db_call(
+            "get_service_accounts",
+            include_revoked=include_revoked,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
+        return PaginatedResponse(
+            data=[ServiceAccountResponse.from_dict(account) for account in accounts],
+            meta=PaginationInfo(
+                page=page,
+                limit=limit,
+                total_pages=total_pages,
+                total_count=total_count,
+            ),
+        )
+
+    @router.delete("/service-accounts/{service_account_id}", status_code=204)
+    async def revoke_service_account(
+        service_account_id: str,
+        _: bool = Depends(auth_dependency),
+    ) -> None:
+        """Revoke a service account. Takes effect on the token's next request. Idempotent."""
+        existing = await _db_call("get_service_account", service_account_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail=f"Service account '{service_account_id}' not found")
+        if existing.get("revoked_at") is not None:
+            return None
+        updated = await _db_call("update_service_account", service_account_id, revoked_at=int(time.time()))
+        if updated is None:
+            raise HTTPException(status_code=500, detail="Could not revoke service account")
+        return None
+
+    return router

--- a/libs/agno/agno/os/routers/service_accounts/schema.py
+++ b/libs/agno/agno/os/routers/service_accounts/schema.py
@@ -1,0 +1,85 @@
+"""Pydantic request/response models for the service accounts API."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from agno.db.schemas.service_accounts import SERVICE_ACCOUNT_PRINCIPAL_PREFIX
+from agno.os.service_accounts import (
+    DEFAULT_EXPIRY_DAYS,
+    is_valid_service_account_name,
+)
+
+
+class ServiceAccountCreate(BaseModel):
+    name: str = Field(
+        ...,
+        max_length=63,
+        description="Machine identity name (lowercase slug), e.g. 'claude-code' or 'github-actions'",
+    )
+    scopes: Optional[List[str]] = Field(
+        default=None,
+        description="Scopes granted to the token. Defaults to run and read scopes: "
+        "agents:run, teams:run, workflows:run, sessions:read",
+    )
+    expires_in_days: Optional[int] = Field(
+        default=DEFAULT_EXPIRY_DAYS,
+        ge=1,
+        le=3650,
+        description=f"Days until the token expires (default: {DEFAULT_EXPIRY_DAYS})",
+    )
+    never_expires: bool = Field(
+        default=False,
+        description="Mint a non-expiring token. Must be set explicitly; overrides expires_in_days.",
+    )
+    allow_privileged_scopes: bool = Field(
+        default=False,
+        description="Required to grant privileged scopes: any write or delete action, the admin scope, "
+        "or any service_accounts scope. Privileged tokens must be deliberate, never accidental.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not is_valid_service_account_name(v):
+            raise ValueError(
+                "Name must be a lowercase slug: start with a letter or digit, "
+                "then letters, digits, '_' or '-' (max 63 chars)"
+            )
+        return v
+
+
+class ServiceAccountResponse(BaseModel):
+    """Service account metadata. Never includes the token hash or plaintext."""
+
+    id: str
+    name: str
+    principal: str = Field(..., description="The user_id attached to runs made with this token, e.g. 'sa:claude-code'")
+    token_prefix: str = Field(..., description="First characters of the token, for display only")
+    scopes: List[str]
+    created_at: int
+    expires_at: Optional[int] = None
+    last_used_at: Optional[int] = None
+    revoked_at: Optional[int] = None
+    created_by: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccountResponse":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            principal=f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{data['name']}",
+            token_prefix=data["token_prefix"],
+            scopes=data.get("scopes") or [],
+            created_at=data["created_at"],
+            expires_at=data.get("expires_at"),
+            last_used_at=data.get("last_used_at"),
+            revoked_at=data.get("revoked_at"),
+            created_by=data.get("created_by"),
+        )
+
+
+class ServiceAccountCreateResponse(ServiceAccountResponse):
+    """Returned once, at creation. The token is never retrievable again."""
+
+    token: str = Field(..., description="The plaintext token. Shown exactly once - store it securely now.")

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
 
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType
-from agno.db.utils import deserialize_session_by_type, detect_session_type, resolve_session_type
+from agno.db.utils import deserialize_session_by_type, resolve_session_type
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import (
     enforce_owner_on_entity,
@@ -32,6 +32,8 @@ from agno.os.schema import (
     WorkflowRunSchema,
     WorkflowSessionDetailSchema,
 )
+from agno.os.services.sessions import SessionNotFoundError, get_sessions_page
+from agno.os.services.sessions import get_session_runs as get_session_runs_from_service
 from agno.os.settings import AgnoAPISettings
 from agno.remote.base import RemoteDb
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
@@ -140,31 +142,19 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 headers=headers,
             )
 
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            sessions, total_count = await db.get_sessions(
-                session_type=session_type,
-                component_id=component_id,
-                user_id=effective_user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-        else:
-            sessions, total_count = db.get_sessions(  # type: ignore
-                session_type=session_type,
-                component_id=component_id,
-                user_id=effective_user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
+        # Shared with the MCP get_sessions tool: sync-db threadpool offload lives in the
+        # service so neither surface blocks its event loop and the two cannot drift.
+        sessions, total_count = await get_sessions_page(
+            db,
+            session_type=session_type,
+            component_id=component_id,
+            user_id=effective_user_id,
+            session_name=session_name,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
 
         return PaginatedResponse(
             data=[SessionSchema.from_dict(session) for session in sessions],  # type: ignore
@@ -622,78 +612,20 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 headers=headers,
             )
 
-        start_timestamp = created_after
-        end_timestamp = created_before
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(
+        # Shared with the MCP get_session_runs tool: auto-detection, timestamp
+        # filtering, per-run classification, and sync-db threadpool offload all
+        # live in the service so the two surfaces cannot drift.
+        try:
+            return await get_session_runs_from_service(
+                db,
                 session_id=session_id,
                 session_type=session_type,
                 user_id=effective_user_id,
-                deserialize=False,
+                created_after=created_after,
+                created_before=created_before,
             )
-        else:
-            session = db.get_session(
-                session_id=session_id,
-                session_type=session_type,
-                user_id=effective_user_id,
-                deserialize=False,
-            )
-
-        if not session:
+        except SessionNotFoundError:
             raise HTTPException(status_code=404, detail=f"Session with ID {session_id} not found")
-
-        if session_type is None:
-            detected = detect_session_type(session if isinstance(session, dict) else {})
-            session_type = SessionType(detected)
-
-        runs = session.get("runs")  # type: ignore
-        if not runs:
-            return []
-
-        # Filter runs by timestamp if specified
-        # TODO: Move this filtering into the DB layer
-        filtered_runs = []
-        for run in runs:
-            if start_timestamp or end_timestamp:
-                run_created_at = run.get("created_at")
-                if run_created_at:
-                    # created_at is stored as epoch int
-                    if start_timestamp and run_created_at < start_timestamp:
-                        continue
-                    if end_timestamp and run_created_at > end_timestamp:
-                        continue
-
-            filtered_runs.append(run)
-
-        if not filtered_runs:
-            return []
-
-        run_responses: List[Union[RunSchema, TeamRunSchema, WorkflowRunSchema]] = []
-
-        if session_type == SessionType.AGENT:
-            return [RunSchema.from_dict(run) for run in filtered_runs]
-
-        elif session_type == SessionType.TEAM:
-            for run in filtered_runs:
-                if run.get("agent_id") is not None:
-                    run_responses.append(RunSchema.from_dict(run))
-                elif run.get("team_id") is not None:
-                    run_responses.append(TeamRunSchema.from_dict(run))
-            return run_responses
-
-        elif session_type == SessionType.WORKFLOW:
-            for run in filtered_runs:
-                if run.get("workflow_id") is not None:
-                    run_responses.append(WorkflowRunSchema.from_dict(run))
-                elif run.get("team_id") is not None:
-                    run_responses.append(TeamRunSchema.from_dict(run))
-                else:
-                    run_responses.append(RunSchema.from_dict(run))
-            return run_responses
-        else:
-            raise HTTPException(status_code=400, detail=f"Invalid session type: {session_type}")
 
     @router.get(
         "/sessions/{session_id}/runs/{run_id}",

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -635,12 +635,13 @@ def check_route_scopes(
     )
 
     accessible_resource_ids: Optional[Set[str]] = None
-    if not allowed and not resource_id and resource_type:
-        # Listing endpoints always allow access but expose the accessible IDs for
+    if not allowed and method == "GET" and not resource_id and resource_type:
+        # GET listing endpoints always allow access but expose the accessible IDs for
         # filtering, so callers with only per-resource scopes get a filtered list
-        # (including an empty one) instead of a 403. Pass the action from the
-        # required scope (e.g. "read" for "agents:read") so the cached IDs only
-        # include resources the caller is authorised for under that action.
+        # (including an empty one) instead of a 403. Restricted to GET so a non-GET
+        # id-less route (e.g. POST /agents) is never silently allowed through. Pass
+        # the action from the required scope (e.g. "read" for "agents:read") so the
+        # cached IDs only include resources the caller is authorised for under it.
         required_action: Optional[str] = None
         first_required = required_scopes[0]
         if ":" in first_required:

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -22,9 +22,11 @@ Backwards compatibility:
   issued before the rename continue to work. Prefer ``config:*`` in new tokens.
 """
 
+import fnmatch
+import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 # Legacy resource name aliases — keep tokens issued before a rename working.
 # Keys are the legacy resource names, values are the current names.
@@ -67,6 +69,9 @@ class AgentOSScope(str, Enum):
     - evals:write - Create and update evaluation runs
     - evals:delete - Delete evaluation runs
     - traces:read - View traces and trace statistics
+    - service_accounts:read - List service accounts
+    - service_accounts:write - Mint service account tokens
+    - service_accounts:delete - Revoke service account tokens
 
     Per-Resource Scopes (with resource ID):
     - agents:<agent-id>:read - Read specific agent
@@ -470,6 +475,10 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "GET /traces": ["traces:read"],
         "GET /traces/*": ["traces:read"],
         "GET /trace_session_stats": ["traces:read"],
+        # Service account endpoints
+        "POST /service-accounts": ["service_accounts:write"],
+        "GET /service-accounts": ["service_accounts:read"],
+        "DELETE /service-accounts/*": ["service_accounts:delete"],
         # Schedule endpoints
         "GET /schedules": ["schedules:read"],
         "GET /schedules/*": ["schedules:read"],
@@ -513,6 +522,139 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "DELETE /components/*/configs/*": ["components:delete"],
         "POST /components/*/configs/*/set-current": ["components:write"],
     }
+
+
+def get_required_scopes_for_route(scope_mappings: Dict[str, List[str]], method: str, path: str) -> List[str]:
+    """
+    Look up the required scopes for a method and path in a scope-mappings dict.
+
+    Args:
+        scope_mappings: Mapping of "METHOD /path/pattern" to required scope lists
+        method: HTTP method (GET, POST, etc.)
+        path: Request path
+
+    Returns:
+        List of required scopes. Empty list [] means no scopes required (allow access).
+        Routes not present in scope_mappings also return [], allowing access.
+    """
+    route_key = f"{method} {path}"
+
+    # First, try exact match
+    if route_key in scope_mappings:
+        return scope_mappings[route_key]
+
+    # Then try pattern matching
+    for pattern, scopes in scope_mappings.items():
+        pattern_method, pattern_path = pattern.split(" ", 1)
+
+        if pattern_method != method:
+            continue
+
+        # Convert pattern to fnmatch pattern (replace {param} with *)
+        # This handles both /agents/* and /agents/{agent_id} style patterns
+        normalized_pattern = pattern_path
+        if "{" in normalized_pattern:
+            normalized_pattern = re.sub(r"\{[^}]+\}", "*", normalized_pattern)
+
+        if fnmatch.fnmatch(path, normalized_pattern):
+            return scopes
+
+    return []
+
+
+def get_resource_context_from_path(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Extract the resource type and resource ID from a request path.
+
+    Returns:
+        Tuple of (resource_type, resource_id). Either may be None.
+
+    Examples:
+        >>> get_resource_context_from_path("/agents/my-agent/runs")
+        ('agents', 'my-agent')
+        >>> get_resource_context_from_path("/sessions")
+        (None, None)
+    """
+    resource_type = None
+    if "/agents" in path:
+        resource_type = "agents"
+    elif "/teams" in path:
+        resource_type = "teams"
+    elif "/workflows" in path:
+        resource_type = "workflows"
+
+    resource_id = None
+    if resource_type:
+        match = re.search(f"^/{resource_type}/([^/]+)", path)
+        if match:
+            resource_id = match.group(1)
+
+    return resource_type, resource_id
+
+
+@dataclass
+class RouteScopeCheck:
+    """Result of checking a caller's scopes against a route's requirements."""
+
+    allowed: bool
+    required_scopes: List[str]
+    # Set only for listing endpoints where the caller lacks the global scope but may
+    # hold per-resource scopes: the endpoint should filter results to these IDs
+    # (possibly an empty set) instead of rejecting with 403.
+    accessible_resource_ids: Optional[Set[str]] = None
+
+
+def check_route_scopes(
+    user_scopes: List[str],
+    scope_mappings: Dict[str, List[str]],
+    method: str,
+    path: str,
+    admin_scope: Optional[str] = None,
+) -> RouteScopeCheck:
+    """
+    Check a caller's scopes against the scopes required for a route.
+
+    This is the single RBAC decision used for every credential type (JWTs, the internal
+    service token, and service account tokens). Listing endpoints get special handling:
+    a caller without the global scope is still allowed through, with
+    accessible_resource_ids populated so the endpoint returns a filtered (possibly
+    empty) list instead of a 403.
+    """
+    required_scopes = get_required_scopes_for_route(scope_mappings, method, path)
+    if not required_scopes:
+        return RouteScopeCheck(allowed=True, required_scopes=required_scopes)
+
+    resource_type, resource_id = get_resource_context_from_path(path)
+
+    allowed = has_required_scopes(
+        user_scopes,
+        required_scopes,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        admin_scope=admin_scope,
+    )
+
+    accessible_resource_ids: Optional[Set[str]] = None
+    if not allowed and not resource_id and resource_type:
+        # Listing endpoints always allow access but expose the accessible IDs for
+        # filtering, so callers with only per-resource scopes get a filtered list
+        # (including an empty one) instead of a 403. Pass the action from the
+        # required scope (e.g. "read" for "agents:read") so the cached IDs only
+        # include resources the caller is authorised for under that action.
+        required_action: Optional[str] = None
+        first_required = required_scopes[0]
+        if ":" in first_required:
+            required_action = first_required.rsplit(":", 1)[1]
+        accessible_resource_ids = get_accessible_resource_ids(
+            user_scopes, resource_type, admin_scope=admin_scope, action=required_action
+        )
+        allowed = True
+
+    return RouteScopeCheck(
+        allowed=allowed,
+        required_scopes=required_scopes,
+        accessible_resource_ids=accessible_resource_ids,
+    )
 
 
 def get_scope_value(scope: AgentOSScope) -> str:

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -3,7 +3,7 @@
 Service accounts are machine identities (coding agents, chat apps, CI) authenticated by
 opaque tokens following the GitHub PAT model: the token is random, only its SHA-256 hash
 is stored (in the AgentOS database), the plaintext is returned exactly once at creation,
-and revocation takes effect on the next request.
+and revocation is native (see the caching note below for its timing).
 
 Tokens look like ``agno_pat_<base62>`` and authenticate through the same middleware as
 JWTs. A verified service account attaches to the request with ``user_id`` set to its
@@ -11,6 +11,13 @@ principal (``sa:<name>``) and ``scopes`` set to the account's stored scopes. Unl
 claims, service account scopes are first-party ACL data owned by this AgentOS instance,
 so they are enforced in every deployment mode - including ``os_security_key`` mode and
 ``validate=False`` mode, where JWT scopes are not.
+
+Successful verifications are cached in-process for a short TTL (default 30s) so PAT auth
+does not hit the database on every request. Revocation takes effect within that TTL
+across worker processes, and immediately on the worker that processes the revoke (the
+``DELETE`` handler evicts the local cache entry). Set the cache TTL to 0 for strict
+instant revocation - every request verifies against the database. Token expiry is always
+honored, even on a cache hit.
 """
 
 import hashlib
@@ -173,29 +180,98 @@ class _FailedLookupLimiter:
             self._failures.popitem(last=False)
 
 
+class _VerificationCache:
+    """Bounded, TTL'd LRU of successful verifications, keyed by token hash.
+
+    Caches only valid accounts. Token expiry is still honored on every hit (the cached
+    account's expires_at is immutable, so it can be re-checked against the wall clock).
+    Revocation is handled out of band: the worker that processes a revoke evicts its
+    entry immediately via invalidate(); other workers converge as their entry ages out
+    within the TTL. TTL <= 0 disables the cache entirely (strict instant revocation).
+    """
+
+    def __init__(self, ttl_seconds: int, max_entries: int = 2048):
+        self.ttl_seconds = ttl_seconds
+        self.max_entries = max_entries
+        self._entries: "OrderedDict[str, Tuple[ServiceAccount, float]]" = OrderedDict()
+
+    @property
+    def enabled(self) -> bool:
+        return self.ttl_seconds > 0
+
+    def get(self, token_hash: str) -> Optional[ServiceAccount]:
+        if not self.enabled:
+            return None
+        entry = self._entries.get(token_hash)
+        if entry is None:
+            return None
+        account, cached_at = entry
+        if time.monotonic() - cached_at > self.ttl_seconds:
+            self._entries.pop(token_hash, None)
+            return None
+        # Honor expiry even within the TTL window - never serve an expired account.
+        if account.is_expired():
+            self._entries.pop(token_hash, None)
+            return None
+        self._entries.move_to_end(token_hash)
+        return account
+
+    def put(self, token_hash: str, account: ServiceAccount) -> None:
+        if not self.enabled:
+            return
+        self._entries[token_hash] = (account, time.monotonic())
+        self._entries.move_to_end(token_hash)
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+
+    def invalidate(self, token_hash: str) -> None:
+        self._entries.pop(token_hash, None)
+
+
 class ServiceAccountVerifier:
     """Verifies service account tokens against the AgentOS database.
 
     Supports both sync (BaseDb) and async (AsyncBaseDb) databases; sync lookups run in
-    the threadpool so verification never blocks the event loop. Successful lookups also
-    refresh the account's last_used_at, throttled to at most one write per minute per
-    token (per worker process).
+    the threadpool so verification never blocks the event loop. Successful verifications
+    are cached in-process for ``cache_ttl_seconds`` (0 disables the cache), so a valid
+    token does not hit the database on every request; token expiry is still enforced on
+    cache hits, and revoke() callers should invalidate() the entry to evict it locally.
+    Successful lookups also refresh the account's last_used_at, throttled to at most one
+    write per minute per token (per worker process).
     """
 
-    def __init__(self, db: Union[BaseDb, AsyncBaseDb], last_used_write_interval: int = 60):
+    def __init__(
+        self,
+        db: Union[BaseDb, AsyncBaseDb],
+        last_used_write_interval: int = 60,
+        cache_ttl_seconds: int = 30,
+        cache_max_entries: int = 2048,
+    ):
         self.db = db
         self.last_used_write_interval = last_used_write_interval
         self._limiter = _FailedLookupLimiter()
+        self._cache = _VerificationCache(ttl_seconds=cache_ttl_seconds, max_entries=cache_max_entries)
         self._last_used_writes: Dict[str, float] = {}
+
+    def invalidate(self, token_hash: str) -> None:
+        """Evict a cached verification. Call on revoke so it takes effect immediately on
+        this worker; other workers converge within the cache TTL. Idempotent."""
+        self._cache.invalidate(token_hash)
 
     async def verify(self, token: str, client_key: Optional[str] = None) -> ServiceAccountVerification:
         """Verify a plaintext token. Returns a verification result, never raises."""
         key = client_key or "unknown"
+        token_hash = hash_token(token)
+
+        # Serve a recently-verified token from the cache (expiry re-checked in get()).
+        cached = self._cache.get(token_hash)
+        if cached is not None:
+            await self._maybe_touch_last_used(cached)
+            return ServiceAccountVerification(status=VerificationStatus.OK, account=cached)
 
         # The token is always looked up first: a valid token is never blocked by the
         # limiter. The limiter only shapes the FAILURE response (INVALID vs 429) so a
         # flood of bad tokens can't deny service to legitimate holders.
-        token_hash = hash_token(token)
         try:
             if isinstance(self.db, AsyncBaseDb):
                 row = await self.db.get_service_account_by_token_hash(token_hash)
@@ -213,8 +289,11 @@ class ServiceAccountVerifier:
         if row is not None:
             account = ServiceAccount.from_dict(row)
             if not (account.is_revoked() or account.is_expired()):
+                self._cache.put(token_hash, account)
                 await self._maybe_touch_last_used(account)
                 return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+            # Defensive: ensure a now-revoked/expired token is not lingering in cache.
+            self._cache.invalidate(token_hash)
             log_debug("Service account verification failed: token is revoked or expired")
         else:
             log_debug("Service account verification failed: unknown token")

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -1,0 +1,241 @@
+"""Service accounts for AgentOS.
+
+Service accounts are machine identities (coding agents, chat apps, CI) authenticated by
+opaque tokens following the GitHub PAT model: the token is random, only its SHA-256 hash
+is stored (in the AgentOS database), the plaintext is returned exactly once at creation,
+and revocation takes effect on the next request.
+
+Tokens look like ``agno_pat_<base62>`` and authenticate through the same middleware as
+JWTs. A verified service account attaches to the request with ``user_id`` set to its
+principal (``sa:<name>``) and ``scopes`` set to the account's stored scopes. Unlike JWT
+claims, service account scopes are first-party ACL data owned by this AgentOS instance,
+so they are enforced in every deployment mode - including ``os_security_key`` mode and
+``validate=False`` mode, where JWT scopes are not.
+"""
+
+import hashlib
+import re
+import secrets
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple, Union
+
+from starlette.concurrency import run_in_threadpool
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.schemas.service_accounts import SERVICE_ACCOUNT_PRINCIPAL_PREFIX, ServiceAccount
+from agno.os.scopes import AgentOSScope, parse_scope
+from agno.utils.log import log_debug, log_error, log_warning
+
+# Prefix makes tokens greppable for secret scanners.
+TOKEN_PREFIX = "agno_pat_"
+
+# How many characters of the plaintext token are stored for display purposes
+# (the literal prefix plus 7 random characters).
+TOKEN_DISPLAY_PREFIX_LENGTH = 16
+
+# Run and read, nothing else. Anything broader requires an explicit request.
+DEFAULT_SERVICE_ACCOUNT_SCOPES: List[str] = [
+    "agents:run",
+    "teams:run",
+    "workflows:run",
+    "sessions:read",
+]
+
+DEFAULT_EXPIRY_DAYS = 90
+
+# Lowercase slug: no colons (cannot spoof the sa: principal namespace), no leading
+# underscore (cannot collide with internal identities like __scheduler__), no @ or dots
+# (cannot mimic email-shaped human subs).
+SERVICE_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+_BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+# Scope actions that make a token privileged (require an explicit override at mint time).
+_PRIVILEGED_ACTIONS = {"write", "delete"}
+
+# Resource whose scopes are always privileged: tokens that can manage tokens.
+_SERVICE_ACCOUNTS_RESOURCE = "service_accounts"
+
+
+def _base62_encode(data: bytes) -> str:
+    num = int.from_bytes(data, "big")
+    if num == 0:
+        return _BASE62_ALPHABET[0]
+    chars = []
+    while num > 0:
+        num, rem = divmod(num, 62)
+        chars.append(_BASE62_ALPHABET[rem])
+    return "".join(reversed(chars))
+
+
+def hash_token(token: str) -> str:
+    """Return the SHA-256 hex digest of a token. This is the only form ever stored."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_token() -> Tuple[str, str, str]:
+    """Generate a new service account token.
+
+    Returns:
+        Tuple of (plaintext, token_hash, token_prefix). The plaintext must be returned
+        to the caller exactly once and never persisted.
+    """
+    plaintext = TOKEN_PREFIX + _base62_encode(secrets.token_bytes(32))
+    return plaintext, hash_token(plaintext), plaintext[:TOKEN_DISPLAY_PREFIX_LENGTH]
+
+
+def is_valid_service_account_name(name: str) -> bool:
+    """Check a service account name against the allowed slug format."""
+    return bool(SERVICE_ACCOUNT_NAME_PATTERN.match(name))
+
+
+def get_invalid_scopes(scopes: List[str], admin_scope: Optional[str] = None) -> List[str]:
+    """Return the scope strings that do not parse as admin, global, or per-resource scopes."""
+    return [s for s in scopes if parse_scope(s, admin_scope=admin_scope).scope_type == "unknown"]
+
+
+def get_privileged_scopes(scopes: List[str], admin_scope: Optional[str] = None) -> List[str]:
+    """Return the subset of scopes that make a token privileged.
+
+    Privileged means: any write/delete action (2- or 3-part form), the admin scope
+    (default or custom), or any scope over the service_accounts resource (tokens that
+    can mint or revoke tokens).
+    """
+    privileged = []
+    for scope in scopes:
+        parsed = parse_scope(scope, admin_scope=admin_scope)
+        if (
+            parsed.scope_type == "admin"
+            or scope == AgentOSScope.ADMIN.value
+            or (parsed.action in _PRIVILEGED_ACTIONS)
+            or (parsed.resource == _SERVICE_ACCOUNTS_RESOURCE)
+        ):
+            privileged.append(scope)
+    return privileged
+
+
+class VerificationStatus(str, Enum):
+    """Outcome of a service account token verification."""
+
+    OK = "ok"
+    INVALID = "invalid"  # unknown, revoked, or expired token
+    THROTTLED = "throttled"  # too many recent failed lookups from this client
+    UNAVAILABLE = "unavailable"  # the database could not be reached or lacks support
+
+
+@dataclass
+class ServiceAccountVerification:
+    status: VerificationStatus
+    account: Optional[ServiceAccount] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == VerificationStatus.OK
+
+
+class _FailedLookupLimiter:
+    """Sliding-window limiter for failed token lookups.
+
+    In-process and per-worker: with N workers the effective budget is N times larger.
+    Keyed by client address, which is only meaningful behind a proxy when the server
+    runs with proxy headers enabled (e.g. uvicorn --proxy-headers). Only true
+    verification failures count - database errors do not, so a DB blip cannot lock
+    out legitimate clients.
+    """
+
+    def __init__(self, max_failures: int = 20, window_seconds: int = 60, max_entries: int = 1024):
+        self.max_failures = max_failures
+        self.window_seconds = window_seconds
+        self.max_entries = max_entries
+        self._failures: "OrderedDict[str, List[float]]" = OrderedDict()
+
+    def is_limited(self, key: str) -> bool:
+        timestamps = self._failures.get(key)
+        if not timestamps:
+            return False
+        cutoff = time.monotonic() - self.window_seconds
+        fresh = [t for t in timestamps if t > cutoff]
+        if fresh:
+            self._failures[key] = fresh
+        else:
+            self._failures.pop(key, None)
+        return len(fresh) >= self.max_failures
+
+    def record_failure(self, key: str) -> None:
+        timestamps = self._failures.setdefault(key, [])
+        timestamps.append(time.monotonic())
+        self._failures.move_to_end(key)
+        while len(self._failures) > self.max_entries:
+            self._failures.popitem(last=False)
+
+
+class ServiceAccountVerifier:
+    """Verifies service account tokens against the AgentOS database.
+
+    Supports both sync (BaseDb) and async (AsyncBaseDb) databases; sync lookups run in
+    the threadpool so verification never blocks the event loop. Successful lookups also
+    refresh the account's last_used_at, throttled to at most one write per minute per
+    token (per worker process).
+    """
+
+    def __init__(self, db: Union[BaseDb, AsyncBaseDb], last_used_write_interval: int = 60):
+        self.db = db
+        self.last_used_write_interval = last_used_write_interval
+        self._limiter = _FailedLookupLimiter()
+        self._last_used_writes: Dict[str, float] = {}
+
+    async def verify(self, token: str, client_key: Optional[str] = None) -> ServiceAccountVerification:
+        """Verify a plaintext token. Returns a verification result, never raises."""
+        key = client_key or "unknown"
+        if self._limiter.is_limited(key):
+            log_warning("Service account verification throttled: too many failed lookups")
+            return ServiceAccountVerification(status=VerificationStatus.THROTTLED)
+
+        token_hash = hash_token(token)
+        try:
+            if isinstance(self.db, AsyncBaseDb):
+                row = await self.db.get_service_account_by_token_hash(token_hash)
+            else:
+                row = await run_in_threadpool(self.db.get_service_account_by_token_hash, token_hash)
+        except NotImplementedError:
+            log_warning("The configured database does not support service accounts")
+            return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
+        except Exception as e:
+            log_error(f"Service account lookup failed: {e}")
+            return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
+
+        if row is None:
+            self._limiter.record_failure(key)
+            log_debug("Service account verification failed: unknown token")
+            return ServiceAccountVerification(status=VerificationStatus.INVALID)
+
+        account = ServiceAccount.from_dict(row)
+        if account.is_revoked() or account.is_expired():
+            self._limiter.record_failure(key)
+            log_debug(f"Service account verification failed: token for '{account.name}' is revoked or expired")
+            return ServiceAccountVerification(status=VerificationStatus.INVALID)
+
+        await self._maybe_touch_last_used(account)
+        return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+
+    async def _maybe_touch_last_used(self, account: ServiceAccount) -> None:
+        now = time.time()
+        last_write = self._last_used_writes.get(account.id, 0.0)
+        if now - last_write < self.last_used_write_interval:
+            return
+        self._last_used_writes[account.id] = now
+        try:
+            if isinstance(self.db, AsyncBaseDb):
+                await self.db.update_service_account(account.id, last_used_at=int(now))
+            else:
+                await run_in_threadpool(self.db.update_service_account, account.id, last_used_at=int(now))
+        except Exception as e:
+            log_warning(f"Could not update last_used_at for service account '{account.name}': {e}")
+
+
+def get_principal(name: str) -> str:
+    """Build the principal identifier attached to requests as user_id."""
+    return f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{name}"

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -48,8 +48,8 @@ DEFAULT_EXPIRY_DAYS = 90
 
 # Lowercase slug: no colons (cannot spoof the sa: principal namespace), no leading
 # underscore (cannot collide with internal identities like __scheduler__), no @ or dots
-# (cannot mimic email-shaped human subs).
-SERVICE_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+# (cannot mimic email-shaped human subs). \Z (not $) so a trailing newline is rejected.
+SERVICE_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}\Z")
 
 _BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
@@ -139,11 +139,12 @@ class ServiceAccountVerification:
 class _FailedLookupLimiter:
     """Sliding-window limiter for failed token lookups.
 
+    Only throttles the failure RESPONSE - a valid token is never blocked, so a flood
+    of bad tokens cannot lock out legitimate clients even when they share a bucket.
     In-process and per-worker: with N workers the effective budget is N times larger.
     Keyed by client address, which is only meaningful behind a proxy when the server
     runs with proxy headers enabled (e.g. uvicorn --proxy-headers). Only true
-    verification failures count - database errors do not, so a DB blip cannot lock
-    out legitimate clients.
+    verification failures count - database errors do not.
     """
 
     def __init__(self, max_failures: int = 20, window_seconds: int = 60, max_entries: int = 1024):
@@ -190,10 +191,10 @@ class ServiceAccountVerifier:
     async def verify(self, token: str, client_key: Optional[str] = None) -> ServiceAccountVerification:
         """Verify a plaintext token. Returns a verification result, never raises."""
         key = client_key or "unknown"
-        if self._limiter.is_limited(key):
-            log_warning("Service account verification throttled: too many failed lookups")
-            return ServiceAccountVerification(status=VerificationStatus.THROTTLED)
 
+        # The token is always looked up first: a valid token is never blocked by the
+        # limiter. The limiter only shapes the FAILURE response (INVALID vs 429) so a
+        # flood of bad tokens can't deny service to legitimate holders.
         token_hash = hash_token(token)
         try:
             if isinstance(self.db, AsyncBaseDb):
@@ -204,22 +205,26 @@ class ServiceAccountVerifier:
             log_warning("The configured database does not support service accounts")
             return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
         except Exception as e:
+            # Fail closed on database errors: never counts toward the limiter, so a
+            # DB blip cannot lock out legitimate clients.
             log_error(f"Service account lookup failed: {e}")
             return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
 
-        if row is None:
-            self._limiter.record_failure(key)
+        if row is not None:
+            account = ServiceAccount.from_dict(row)
+            if not (account.is_revoked() or account.is_expired()):
+                await self._maybe_touch_last_used(account)
+                return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+            log_debug("Service account verification failed: token is revoked or expired")
+        else:
             log_debug("Service account verification failed: unknown token")
-            return ServiceAccountVerification(status=VerificationStatus.INVALID)
 
-        account = ServiceAccount.from_dict(row)
-        if account.is_revoked() or account.is_expired():
-            self._limiter.record_failure(key)
-            log_debug(f"Service account verification failed: token for '{account.name}' is revoked or expired")
-            return ServiceAccountVerification(status=VerificationStatus.INVALID)
-
-        await self._maybe_touch_last_used(account)
-        return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+        # Verification failed for a reason we count (unknown / revoked / expired).
+        if self._limiter.is_limited(key):
+            log_warning("Service account verification throttled: too many failed lookups")
+            return ServiceAccountVerification(status=VerificationStatus.THROTTLED)
+        self._limiter.record_failure(key)
+        return ServiceAccountVerification(status=VerificationStatus.INVALID)
 
     async def _maybe_touch_last_used(self, account: ServiceAccount) -> None:
         now = time.time()

--- a/libs/agno/agno/os/services/__init__.py
+++ b/libs/agno/agno/os/services/__init__.py
@@ -1,0 +1,8 @@
+"""Shared service layer for AgentOS surfaces.
+
+One implementation of the session-read and run-lifecycle operations, imported by
+both the REST routers and the MCP tools (``from agno.os.services import sessions``
+/ ``runs``) so the two interfaces cannot drift. Service functions take domain
+arguments plus resolved identity and return domain objects / schema objects -- no
+HTTP and no MCP types.
+"""

--- a/libs/agno/agno/os/services/runs.py
+++ b/libs/agno/agno/os/services/runs.py
@@ -1,0 +1,88 @@
+"""Run-lifecycle operations (continue, cancel) shared by REST and MCP surfaces.
+
+The continue payloads mirror what the surfaces hand the client when a run
+pauses: agents/teams ship ``RunRequirement`` dicts, workflows ship
+``StepRequirement`` dicts. The client resolves them (confirmation, input,
+selection) and passes them back verbatim.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from agno.agent.agent import Agent
+from agno.remote.base import BaseRemote
+from agno.run.agent import RunOutput
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+from agno.team.team import Team
+from agno.workflow.workflow import Workflow
+
+AnyRunOutput = Union[RunOutput, TeamRunOutput, WorkflowRunOutput]
+
+
+class RemoteContinuationUnsupported(Exception):
+    """Raised when continue is attempted on a remote component over a surface that
+    cannot forward HITL requirements to it (mirrors the REST 400 guard)."""
+
+
+def parse_run_requirements(requirements: Optional[List[Dict[str, Any]]]) -> Optional[List[RunRequirement]]:
+    if not requirements:
+        return None
+    return [RunRequirement.from_dict(req) if isinstance(req, dict) else req for req in requirements]
+
+
+def parse_step_requirements(requirements: Optional[List[Dict[str, Any]]]) -> Optional[List[Any]]:
+    from agno.workflow.types import StepRequirement
+
+    if not requirements:
+        return None
+    return [StepRequirement.from_dict(req) if isinstance(req, dict) else req for req in requirements]
+
+
+async def continue_paused_run(
+    component: Union[Agent, Team, Workflow],
+    *,
+    run_id: str,
+    session_id: Optional[str],
+    user_id: Optional[str] = None,
+    requirements: Optional[List[Dict[str, Any]]] = None,
+) -> AnyRunOutput:
+    """Resume a paused run on any local component with the client's resolved requirements.
+
+    Remote components are rejected: their ``acontinue_run`` cannot carry resolved
+    requirements (the REST surface 400s the same case), so failing clearly beats the
+    opaque downstream TypeError that forwarding them would raise.
+
+    ``stream=False`` is pinned: run-option resolution is call-site > component.stream >
+    False, so a component configured with ``stream=True`` would otherwise return an
+    async iterator instead of the final run output.
+    """
+    if isinstance(component, BaseRemote):
+        raise RemoteContinuationUnsupported(
+            "Continuing paused runs on remote components is not supported over this interface."
+        )
+    if isinstance(component, Workflow):
+        return await component.acontinue_run(
+            run_id=run_id,
+            session_id=session_id,
+            step_requirements=parse_step_requirements(requirements),
+            stream=False,
+        )
+    return await component.acontinue_run(  # type: ignore[misc, no-any-return]
+        run_id=run_id,
+        session_id=session_id,
+        user_id=user_id,
+        requirements=parse_run_requirements(requirements),
+        stream=False,
+    )
+
+
+async def cancel_component_run(component: Union[Agent, Team, Workflow], run_id: str) -> None:
+    """Request cancellation of ``run_id`` on the component that owns it.
+
+    Agent/team/workflow cancellation all delegate to one process-global cancellation
+    manager that records an intent even for a not-yet-registered run, so this always
+    succeeds -- ownership is enforced by the caller before we get here (mirroring the
+    REST cancel endpoints), which is also what keeps a bogus id from leaking an entry.
+    """
+    await component.acancel_run(run_id=run_id)

--- a/libs/agno/agno/os/services/sessions.py
+++ b/libs/agno/agno/os/services/sessions.py
@@ -1,0 +1,181 @@
+"""Session read operations shared by the REST session router and the MCP tools.
+
+Only the local-database branches live here: the logic that historically drifted
+between surfaces (session-type auto-detection, run classification, sync-db
+handling). ``RemoteDb`` calls are one-line proxies and stay at each surface,
+which also owns forwarding the caller's Authorization header.
+
+Sync ``BaseDb`` calls are offloaded to a threadpool so an async surface (MCP or
+REST) never blocks its event loop on database I/O.
+"""
+
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+from starlette.concurrency import run_in_threadpool
+
+from agno.db.base import AsyncBaseDb, BaseDb, SessionType
+from agno.db.utils import detect_session_type
+from agno.os.schema import RunSchema, TeamRunSchema, WorkflowRunSchema
+
+AnyRunSchema = Union[RunSchema, TeamRunSchema, WorkflowRunSchema]
+
+
+class SessionNotFoundError(Exception):
+    """Raised when a session id does not resolve; surfaces map it to 404 / tool error."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        super().__init__(f"Session {session_id} not found")
+
+
+class RunOwnershipError(Exception):
+    """Raised when a run does not belong to the caller's session (masked as not-found)."""
+
+    def __init__(self) -> None:
+        super().__init__("Run not found")
+
+
+async def verify_run_ownership(
+    component: Any,
+    *,
+    session_id: str,
+    run_id: str,
+    user_id: str,
+    component_type: Literal["agents", "teams", "workflows"],
+    component_id: str,
+) -> None:
+    """Fail closed unless ``run_id`` lives in a ``user_id``-owned session for this component.
+
+    Surface-agnostic twin of the REST ``verify_run_in_session`` (which raises
+    ``HTTPException``); raises :class:`RunOwnershipError` so the MCP layer can present
+    it as a tool error without importing HTTP types.
+    """
+    from agno.os.middleware.user_scope import run_matches_component, session_matches_component
+
+    session = await component.aget_session(session_id=session_id, user_id=user_id)
+    if session is None or not session_matches_component(session, component_type, component_id):
+        raise RunOwnershipError()
+    run = session.get_run(run_id=run_id)
+    if run is None or not run_matches_component(run, component_type, component_id):
+        raise RunOwnershipError()
+
+
+async def get_sessions_page(
+    db: Union[BaseDb, AsyncBaseDb],
+    *,
+    session_type: Optional[SessionType] = None,
+    component_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    session_name: Optional[str] = None,
+    limit: Optional[int] = 20,
+    page: Optional[int] = 1,
+    sort_by: Optional[str] = "created_at",
+    sort_order: Optional[Any] = "desc",
+) -> Tuple[List[Dict[str, Any]], int]:
+    """One page of sessions as raw dicts plus the total count.
+
+    Parameter types mirror the REST query params (all optional/defaulted, ``sort_order``
+    accepts the ``SortOrder`` enum or a plain string) so both surfaces call this unchanged.
+    """
+    kwargs: Dict[str, Any] = dict(
+        session_type=session_type,
+        component_id=component_id,
+        user_id=user_id,
+        session_name=session_name,
+        limit=limit,
+        page=page,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        deserialize=False,
+    )
+    if isinstance(db, AsyncBaseDb):
+        sessions, total_count = await db.get_sessions(**kwargs)
+    else:
+        sessions, total_count = await run_in_threadpool(lambda: db.get_sessions(**kwargs))
+    return sessions, total_count  # type: ignore[return-value]
+
+
+async def _get_session_dict(
+    db: Union[BaseDb, AsyncBaseDb],
+    *,
+    session_id: str,
+    session_type: Optional[SessionType],
+    user_id: Optional[str],
+) -> Tuple[Dict[str, Any], SessionType]:
+    """Fetch a session as a raw dict, auto-detecting its type when not given.
+
+    Auto-detection matters: local ``get_session`` does not filter by type in SQL,
+    so a wrong caller-supplied default silently misparses rather than 404s.
+    """
+    if isinstance(db, AsyncBaseDb):
+        session = await db.get_session(
+            session_id=session_id, session_type=session_type, user_id=user_id, deserialize=False
+        )
+    else:
+        session = await run_in_threadpool(
+            lambda: db.get_session(
+                session_id=session_id,
+                session_type=session_type,
+                user_id=user_id,
+                deserialize=False,
+            )
+        )
+    if not session:
+        raise SessionNotFoundError(session_id)
+    if session_type is None:
+        session_type = SessionType(detect_session_type(session if isinstance(session, dict) else {}))
+    return session, session_type  # type: ignore[return-value]
+
+
+def classify_session_run(run: Dict[str, Any], session_type: SessionType) -> Optional[AnyRunSchema]:
+    """Render one persisted run dict as the schema matching its actual shape.
+
+    Team and workflow sessions can contain member/step runs of other kinds, so
+    classification is per-run (by which component id the run carries), not
+    per-session. Mirrors the REST behavior exactly, including dropping team-session
+    runs that carry neither an agent_id nor a team_id (returns None).
+    """
+    if session_type == SessionType.AGENT:
+        return RunSchema.from_dict(run)
+    if session_type == SessionType.TEAM:
+        if run.get("agent_id") is not None:
+            return RunSchema.from_dict(run)
+        if run.get("team_id") is not None:
+            return TeamRunSchema.from_dict(run)
+        return None
+    if run.get("workflow_id") is not None:
+        return WorkflowRunSchema.from_dict(run)
+    if run.get("team_id") is not None:
+        return TeamRunSchema.from_dict(run)
+    return RunSchema.from_dict(run)
+
+
+async def get_session_runs(
+    db: Union[BaseDb, AsyncBaseDb],
+    *,
+    session_id: str,
+    session_type: Optional[SessionType] = None,
+    user_id: Optional[str] = None,
+    created_after: Optional[int] = None,
+    created_before: Optional[int] = None,
+) -> List[AnyRunSchema]:
+    """All runs of a session as schema objects, with type auto-detection.
+
+    Raises :class:`SessionNotFoundError` when the session does not exist.
+    """
+    session, resolved_type = await _get_session_dict(
+        db, session_id=session_id, session_type=session_type, user_id=user_id
+    )
+
+    runs = session.get("runs") or []
+    filtered: List[Dict[str, Any]] = []
+    for run in runs:
+        created_at = run.get("created_at")
+        if created_after and created_at and created_at < created_after:
+            continue
+        if created_before and created_at and created_at > created_before:
+            continue
+        filtered.append(run)
+
+    classified = (classify_session_run(run, resolved_type) for run in filtered)
+    return [run_schema for run_schema in classified if run_schema is not None]

--- a/libs/agno/agno/os/settings.py
+++ b/libs/agno/agno/os/settings.py
@@ -23,6 +23,14 @@ class AgnoAPISettings(BaseSettings):
     # Authorization flag - when True, JWT middleware handles auth and security key validation is skipped
     authorization_enabled: bool = Field(default=False, description="Whether JWT authorization is enabled")
 
+    # Seconds to cache a successful service-account token verification in-process, to
+    # avoid a database lookup on every request. Revocation takes effect within this
+    # window across worker processes (immediately on the worker that processes the
+    # revoke). Set to 0 for strict instant revocation (verify against the DB every time).
+    service_account_cache_ttl_seconds: int = Field(
+        default=30, description="TTL (seconds) for the in-process service-account verification cache; 0 disables it"
+    )
+
     # Cors origin list to allow requests from.
     # This list is set using the set_cors_origin_list validator
     cors_origin_list: Optional[List[str]] = Field(default=None, validate_default=True)

--- a/libs/agno/tests/integration/db/postgres/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/postgres/test_service_accounts.py
@@ -1,0 +1,98 @@
+"""Integration tests for the service_accounts table in PostgresDb.
+
+Requires a local postgres at localhost:5532 (ai:ai/ai), same as the other
+postgres integration tests. Not run in CI.
+"""
+
+import time
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.schemas.service_accounts import ServiceAccount
+
+
+def _account(account_id: str, name: str, token_hash: str, **overrides):
+    account = ServiceAccount(
+        id=account_id,
+        name=name,
+        token_hash=token_hash,
+        token_prefix="agno_pat_test123",
+        scopes=["agents:run", "sessions:read"],
+        **overrides,
+    )
+    return account.to_dict()
+
+
+class TestServiceAccountsTable:
+    def test_create_table_with_partial_unique_index(self, postgres_db_real):
+        postgres_db_real._create_table(postgres_db_real.service_accounts_table_name, "service_accounts")
+        with postgres_db_real.Session() as sess:
+            result = sess.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table"
+                ),
+                {"schema": postgres_db_real.db_schema, "table": postgres_db_real.service_accounts_table_name},
+            )
+            assert result.fetchone() is not None
+
+            result = sess.execute(
+                text("SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = :schema AND tablename = :table"),
+                {"schema": postgres_db_real.db_schema, "table": postgres_db_real.service_accounts_table_name},
+            )
+            indexes = {row[0]: row[1] for row in result.fetchall()}
+        partial_index_name = f"{postgres_db_real.service_accounts_table_name}_uq_active_name"
+        assert partial_index_name in indexes
+        assert "revoked_at IS NULL" in indexes[partial_index_name]
+
+    def test_crud_roundtrip(self, postgres_db_real):
+        created = postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        assert created["name"] == "claude-code"
+
+        fetched = postgres_db_real.get_service_account("sa-1")
+        assert fetched is not None
+        assert fetched["scopes"] == ["agents:run", "sessions:read"]
+
+        by_hash = postgres_db_real.get_service_account_by_token_hash("hash-1")
+        assert by_hash is not None and by_hash["id"] == "sa-1"
+
+        by_name = postgres_db_real.get_service_account_by_name("claude-code")
+        assert by_name is not None and by_name["id"] == "sa-1"
+
+        updated = postgres_db_real.update_service_account("sa-1", last_used_at=int(time.time()))
+        assert updated is not None and updated["last_used_at"] is not None
+
+        assert postgres_db_real.delete_service_account("sa-1") is True
+        assert postgres_db_real.get_service_account("sa-1") is None
+
+    def test_duplicate_active_name_rejected_but_reusable_after_revocation(self, postgres_db_real):
+        postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+
+        with pytest.raises(IntegrityError):
+            postgres_db_real.create_service_account(_account("sa-2", "claude-code", "hash-2"))
+
+        postgres_db_real.update_service_account("sa-1", revoked_at=int(time.time()))
+        created = postgres_db_real.create_service_account(_account("sa-3", "claude-code", "hash-3"))
+        assert created["id"] == "sa-3"
+
+        active = postgres_db_real.get_service_account_by_name("claude-code")
+        assert active is not None and active["id"] == "sa-3"
+
+    def test_list_pagination_and_revoked_filter(self, postgres_db_real):
+        now = int(time.time())
+        for i in range(3):
+            postgres_db_real.create_service_account(
+                _account(f"sa-{i}", f"account-{i}", f"hash-{i}", created_at=now - i)
+            )
+        postgres_db_real.update_service_account("sa-2", revoked_at=now)
+
+        accounts, total = postgres_db_real.get_service_accounts()
+        assert total == 3
+
+        accounts, total = postgres_db_real.get_service_accounts(include_revoked=False)
+        assert total == 2
+        assert all(account["revoked_at"] is None for account in accounts)
+
+        accounts, _ = postgres_db_real.get_service_accounts(sort_by="name", sort_order="asc")
+        assert [account["name"] for account in accounts] == ["account-0", "account-1", "account-2"]

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -1,0 +1,97 @@
+"""Integration tests for the service_accounts table in SqliteDb."""
+
+import time
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.schemas.service_accounts import ServiceAccount
+
+
+def _account(account_id: str, name: str, token_hash: str, **overrides):
+    account = ServiceAccount(
+        id=account_id,
+        name=name,
+        token_hash=token_hash,
+        token_prefix="agno_pat_test123",
+        scopes=["agents:run", "sessions:read"],
+        **overrides,
+    )
+    return account.to_dict()
+
+
+class TestServiceAccountsTable:
+    def test_create_table_with_partial_unique_index(self, sqlite_db_real):
+        sqlite_db_real._create_table(sqlite_db_real.service_accounts_table_name, "service_accounts")
+        with sqlite_db_real.Session() as sess:
+            result = sess.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name = :table"),
+                {"table": sqlite_db_real.service_accounts_table_name},
+            )
+            assert result.fetchone() is not None
+            result = sess.execute(
+                text("SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name = :table"),
+                {"table": sqlite_db_real.service_accounts_table_name},
+            )
+            indexes = {row[0]: row[1] for row in result.fetchall()}
+        partial_index_name = f"{sqlite_db_real.service_accounts_table_name}_uq_active_name"
+        assert partial_index_name in indexes
+        assert "revoked_at IS NULL" in indexes[partial_index_name]
+
+    def test_crud_roundtrip(self, sqlite_db_real):
+        created = sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        assert created["name"] == "claude-code"
+
+        fetched = sqlite_db_real.get_service_account("sa-1")
+        assert fetched is not None
+        assert fetched["scopes"] == ["agents:run", "sessions:read"]
+
+        by_hash = sqlite_db_real.get_service_account_by_token_hash("hash-1")
+        assert by_hash is not None and by_hash["id"] == "sa-1"
+
+        by_name = sqlite_db_real.get_service_account_by_name("claude-code")
+        assert by_name is not None and by_name["id"] == "sa-1"
+
+        updated = sqlite_db_real.update_service_account("sa-1", last_used_at=int(time.time()))
+        assert updated is not None and updated["last_used_at"] is not None
+
+        assert sqlite_db_real.delete_service_account("sa-1") is True
+        assert sqlite_db_real.get_service_account("sa-1") is None
+
+    def test_unknown_token_hash_returns_none(self, sqlite_db_real):
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        assert sqlite_db_real.get_service_account_by_token_hash("no-such-hash") is None
+
+    def test_duplicate_active_name_rejected_but_reusable_after_revocation(self, sqlite_db_real):
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+
+        with pytest.raises(IntegrityError):
+            sqlite_db_real.create_service_account(_account("sa-2", "claude-code", "hash-2"))
+
+        sqlite_db_real.update_service_account("sa-1", revoked_at=int(time.time()))
+        created = sqlite_db_real.create_service_account(_account("sa-3", "claude-code", "hash-3"))
+        assert created["id"] == "sa-3"
+
+        # Active lookup resolves to the new account
+        active = sqlite_db_real.get_service_account_by_name("claude-code")
+        assert active is not None and active["id"] == "sa-3"
+
+    def test_list_pagination_and_revoked_filter(self, sqlite_db_real):
+        now = int(time.time())
+        for i in range(3):
+            sqlite_db_real.create_service_account(_account(f"sa-{i}", f"account-{i}", f"hash-{i}", created_at=now - i))
+        sqlite_db_real.update_service_account("sa-2", revoked_at=now)
+
+        accounts, total = sqlite_db_real.get_service_accounts()
+        assert total == 3
+
+        accounts, total = sqlite_db_real.get_service_accounts(include_revoked=False)
+        assert total == 2
+        assert all(account["revoked_at"] is None for account in accounts)
+
+        accounts, total = sqlite_db_real.get_service_accounts(limit=2, page=1)
+        assert len(accounts) == 2 and total == 3
+
+        accounts, _ = sqlite_db_real.get_service_accounts(sort_by="name", sort_order="asc")
+        assert [account["name"] for account in accounts] == ["account-0", "account-1", "account-2"]

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -63,6 +63,18 @@ class TestServiceAccountsTable:
         sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
         assert sqlite_db_real.get_service_account_by_token_hash("no-such-hash") is None
 
+    def test_token_hash_lookup_reraises_on_db_error(self, sqlite_db_real):
+        # A dead connection must raise, not return None - the verifier maps a raise to
+        # UNAVAILABLE (503) rather than misreading it as an unknown token (401).
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        sqlite_db_real.db_engine.dispose()
+        sqlite_db_real.db_url = "sqlite:////nonexistent/path/definitely_missing.db"
+        from sqlalchemy import create_engine
+
+        sqlite_db_real.db_engine = create_engine(sqlite_db_real.db_url)
+        with pytest.raises(Exception):
+            sqlite_db_real.get_service_account_by_token_hash("hash-1")
+
     def test_duplicate_active_name_rejected_but_reusable_after_revocation(self, sqlite_db_real):
         sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
 

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -1,0 +1,305 @@
+"""Integration tests for service account (agno_pat_) authentication in AgentOS."""
+
+import time
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.middleware import JWTMiddleware
+from agno.os.settings import AgnoAPISettings
+
+JWT_SECRET = "test-secret-key-for-service-account-tests"
+
+UNIFORM_401_DETAIL = "Invalid or expired service account token"
+
+
+def _make_jwt(scopes, sub="human-admin"):
+    payload = {
+        "sub": sub,
+        "scopes": scopes,
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def _mock_run_output():
+    return type(
+        "MockRunOutput",
+        (),
+        {"to_dict": lambda self: {"content": "ok", "run_id": "test_run_1"}},
+    )()
+
+
+@pytest.fixture
+def sqlite_db(tmp_path):
+    return SqliteDb(db_file=str(tmp_path / "service_accounts_test.db"))
+
+
+@pytest.fixture
+def test_agent(sqlite_db):
+    agent = Agent(id="sa-test-agent", name="sa-test-agent", db=sqlite_db)
+    agent.deep_copy = lambda **kwargs: agent
+    return agent
+
+
+@pytest.fixture
+def jwt_client(test_agent, sqlite_db):
+    """AgentOS with a db and JWT middleware with authorization enabled."""
+    agent_os = AgentOS(agents=[test_agent], db=sqlite_db)
+    app = agent_os.get_app()
+    app.add_middleware(
+        JWTMiddleware,
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        authorization=True,
+    )
+    return TestClient(app)
+
+
+def _mint(client, auth_token, name="claude-code", **body_overrides):
+    body = {"name": name, **body_overrides}
+    return client.post(
+        "/service-accounts",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json=body,
+    )
+
+
+class TestServiceAccountLifecycleWithJWT:
+    def test_admin_mints_pat_and_pat_runs_agent_with_attribution(self, jwt_client, test_agent):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        response = _mint(jwt_client, admin_jwt)
+        assert response.status_code == 201, response.text
+        body = response.json()
+        pat = body["token"]
+        assert pat.startswith("agno_pat_")
+        assert body["principal"] == "sa:claude-code"
+        assert body["created_by"] == "human-admin"
+
+        with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
+            mock_arun.return_value = _mock_run_output()
+            run_response = jwt_client.post(
+                "/agents/sa-test-agent/runs",
+                headers={"Authorization": f"Bearer {pat}"},
+                data={"message": "hello", "stream": "false"},
+            )
+        assert run_response.status_code == 200, run_response.text
+        assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
+
+    def test_pat_default_scopes_allow_session_read_but_not_delete(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        pat = _mint(jwt_client, admin_jwt).json()["token"]
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 200
+
+        response = jwt_client.delete("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 403
+
+    def test_pat_cannot_mint_pats_by_default(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        pat = _mint(jwt_client, admin_jwt).json()["token"]
+        response = _mint(jwt_client, pat, name="sneaky")
+        assert response.status_code == 403
+
+    def test_minter_cannot_escalate_beyond_own_scopes(self, jwt_client):
+        minter_jwt = _make_jwt(["service_accounts:write", "agents:run"], sub="delegated-minter")
+        # Granting a scope the minter holds works
+        response = _mint(jwt_client, minter_jwt, name="ci-bot", scopes=["agents:run"])
+        assert response.status_code == 201
+
+        # Granting a scope the minter does not hold is rejected
+        response = _mint(jwt_client, minter_jwt, name="ci-bot-2", scopes=["teams:run"])
+        assert response.status_code == 403
+
+        # The privileged flag alone cannot escalate either
+        response = _mint(
+            jwt_client, minter_jwt, name="ci-bot-3", scopes=["agent_os:admin"], allow_privileged_scopes=True
+        )
+        assert response.status_code == 403
+
+    def test_revoked_pat_gets_uniform_401(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        minted = _mint(jwt_client, admin_jwt).json()
+
+        revoke = jwt_client.delete(
+            f"/service-accounts/{minted['id']}", headers={"Authorization": f"Bearer {admin_jwt}"}
+        )
+        assert revoke.status_code == 204
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_expired_pat_gets_same_uniform_401(self, jwt_client, sqlite_db):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        minted = _mint(jwt_client, admin_jwt).json()
+        sqlite_db.update_service_account(minted["id"], expires_at=int(time.time()) - 10)
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_unknown_pat_gets_same_uniform_401(self, jwt_client):
+        response = jwt_client.get(
+            "/sessions", headers={"Authorization": "Bearer agno_pat_doesnotexist0000000000000000"}
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_repeated_failed_lookups_get_throttled(self, jwt_client):
+        last_status = None
+        for _ in range(25):
+            response = jwt_client.get(
+                "/sessions", headers={"Authorization": "Bearer agno_pat_bruteforce000000000000000"}
+            )
+            last_status = response.status_code
+        assert last_status == 429
+
+    def test_name_reuse_after_revocation_rotates_identity(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        first = _mint(jwt_client, admin_jwt)
+        assert first.status_code == 201
+
+        # Duplicate active name is rejected
+        duplicate = _mint(jwt_client, admin_jwt)
+        assert duplicate.status_code == 409
+
+        # After revocation the name can be reused (rotation)
+        revoke = jwt_client.delete(
+            f"/service-accounts/{first.json()['id']}", headers={"Authorization": f"Bearer {admin_jwt}"}
+        )
+        assert revoke.status_code == 204
+        rotated = _mint(jwt_client, admin_jwt)
+        assert rotated.status_code == 201
+        assert rotated.json()["principal"] == first.json()["principal"]
+
+    def test_list_never_exposes_hashes_or_tokens(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        pat = _mint(jwt_client, admin_jwt).json()["token"]
+
+        response = jwt_client.get("/service-accounts", headers={"Authorization": f"Bearer {admin_jwt}"})
+        assert response.status_code == 200
+        assert pat not in response.text
+        entry = response.json()["data"][0]
+        assert "token" not in entry
+        assert "token_hash" not in entry
+        assert entry["token_prefix"] == pat[:16]
+
+    def test_jwt_without_scope_cannot_manage_service_accounts(self, jwt_client):
+        plain_jwt = _make_jwt(["agents:run"], sub="regular-user")
+        assert _mint(jwt_client, plain_jwt).status_code == 403
+        response = jwt_client.get("/service-accounts", headers={"Authorization": f"Bearer {plain_jwt}"})
+        assert response.status_code == 403
+
+
+class TestInternalTokenRegression:
+    """The internal scheduler token must behave identically after the RBAC refactor."""
+
+    @pytest.fixture
+    def internal_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db, internal_service_token="internal-test-token")
+        app = agent_os.get_app()
+        app.add_middleware(
+            JWTMiddleware,
+            verification_keys=[JWT_SECRET],
+            algorithm="HS256",
+            authorization=True,
+        )
+        return TestClient(app)
+
+    def test_internal_token_allowed_for_granted_scopes(self, internal_client):
+        response = internal_client.get("/agents", headers={"Authorization": "Bearer internal-test-token"})
+        assert response.status_code == 200
+
+    def test_internal_token_denied_outside_granted_scopes(self, internal_client):
+        response = internal_client.get("/sessions", headers={"Authorization": "Bearer internal-test-token"})
+        assert response.status_code == 403
+
+
+class TestServiceAccountsInSecurityKeyMode:
+    """PATs work without JWT middleware, and their scopes are still enforced."""
+
+    @pytest.fixture
+    def security_key_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(
+            agents=[test_agent],
+            db=sqlite_db,
+            settings=AgnoAPISettings(os_security_key="root-security-key"),
+        )
+        return TestClient(agent_os.get_app())
+
+    def test_security_key_mints_and_pat_runs_with_attribution(self, security_key_client, test_agent):
+        response = _mint(security_key_client, "root-security-key")
+        assert response.status_code == 201, response.text
+        pat = response.json()["token"]
+
+        with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
+            mock_arun.return_value = _mock_run_output()
+            run_response = security_key_client.post(
+                "/agents/sa-test-agent/runs",
+                headers={"Authorization": f"Bearer {pat}"},
+                data={"message": "hello", "stream": "false"},
+            )
+        assert run_response.status_code == 200, run_response.text
+        assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
+
+    def test_pat_scopes_are_enforced_without_jwt_middleware(self, security_key_client):
+        pat = _mint(security_key_client, "root-security-key").json()["token"]
+
+        # Default scopes include sessions:read
+        response = security_key_client.get("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 200
+
+        # But a run-and-read PAT is not a master key: it cannot mint more PATs
+        response = _mint(security_key_client, pat, name="sneaky")
+        assert response.status_code == 403
+
+        # And it cannot delete sessions
+        response = security_key_client.delete("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 403
+
+    def test_revoked_pat_rejected_in_security_key_mode(self, security_key_client):
+        minted = _mint(security_key_client, "root-security-key").json()
+        revoke = security_key_client.delete(
+            f"/service-accounts/{minted['id']}",
+            headers={"Authorization": "Bearer root-security-key"},
+        )
+        assert revoke.status_code == 204
+
+        response = security_key_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+
+class TestServiceAccountsOnOpenInstance:
+    """On an open dev instance PATs still verify and provide attribution."""
+
+    @pytest.fixture
+    def open_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db)
+        return TestClient(agent_os.get_app())
+
+    def test_pat_authenticates_and_attributes_on_open_instance(self, open_client, test_agent):
+        pat = _mint(open_client, "anything-goes").json()["token"]
+
+        with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
+            mock_arun.return_value = _mock_run_output()
+            run_response = open_client.post(
+                "/agents/sa-test-agent/runs",
+                headers={"Authorization": f"Bearer {pat}"},
+                data={"message": "hello", "stream": "false"},
+            )
+        assert run_response.status_code == 200
+        assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
+
+    def test_invalid_pat_rejected_even_on_open_instance(self, open_client):
+        response = open_client.get("/sessions", headers={"Authorization": "Bearer agno_pat_invalid000000000000000000"})
+        assert response.status_code == 401

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -138,6 +138,23 @@ class TestServiceAccountLifecycleWithJWT:
         assert response.status_code == 401
         assert response.json()["detail"] == UNIFORM_401_DETAIL
 
+    def test_revoke_invalidates_cached_token_immediately(self, jwt_client):
+        # Use the token first so it is cached, then revoke: the revoking worker (this
+        # process, default 30s cache TTL) must reject it at once, not serve the cache.
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        minted = _mint(jwt_client, admin_jwt).json()
+
+        assert jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"}).status_code == 200
+
+        revoke = jwt_client.delete(
+            f"/service-accounts/{minted['id']}", headers={"Authorization": f"Bearer {admin_jwt}"}
+        )
+        assert revoke.status_code == 204
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
     def test_expired_pat_gets_same_uniform_401(self, jwt_client, sqlite_db):
         admin_jwt = _make_jwt(["agent_os:admin"])
         minted = _mint(jwt_client, admin_jwt).json()

--- a/libs/agno/tests/system/tests/test_mcp_routes.py
+++ b/libs/agno/tests/system/tests/test_mcp_routes.py
@@ -201,14 +201,33 @@ async def test_list_tools(mcp_client: MCPTestClient):
     expected_tools = [
         "get_agentos_config",
         "run_agent",
+        "run_team",
+        "run_workflow",
+        "continue_run",
+        "cancel_run",
         "get_sessions",
-        "get_session",
-        "create_session",
-        "create_memory",
-        "get_memories",
+        "get_session_runs",
     ]
     for tool_name in expected_tools:
         assert tool_name in tools, f"Missing expected tool: {tool_name}"
+
+    # The v2.7 surface is deliberately trimmed: session writes and memory CRUD are gone.
+    removed_tools = [
+        "get_session",
+        "create_session",
+        "update_session",
+        "rename_session",
+        "delete_session",
+        "delete_sessions",
+        "create_memory",
+        "get_memory",
+        "get_memories",
+        "update_memory",
+        "delete_memory",
+        "delete_memories",
+    ]
+    for tool_name in removed_tools:
+        assert tool_name not in tools, f"Removed tool still present: {tool_name}"
 
 
 # =============================================================================
@@ -221,13 +240,16 @@ async def test_get_agentos_config(mcp_client: MCPTestClient):
     """Test the get_agentos_config tool."""
     result = await mcp_client.call_tool("get_agentos_config", {})
 
+    # The v2.7 config tool is a compact discovery payload: ids/summaries + db ids only.
     assert "os_id" in result
     assert result["os_id"] == "gateway-os"
     assert "agents" in result
     assert "teams" in result
     assert "workflows" in result
-    assert "interfaces" in result
     assert "databases" in result
+    # Heavy per-domain config sections are intentionally not in the MCP payload (REST /config only).
+    for heavy_key in ("interfaces", "learning", "memory", "knowledge", "evals", "metrics", "traces"):
+        assert heavy_key not in result, f"Compact config must not include '{heavy_key}'"
 
     # Verify both local and remote agents are present
     agent_ids = [agent["id"] for agent in result["agents"]]
@@ -243,7 +265,6 @@ async def test_get_agentos_config(mcp_client: MCPTestClient):
     workflow_ids = [workflow["id"] for workflow in result["workflows"]]
     assert "gateway-workflow" in workflow_ids, "Local workflow 'gateway-workflow' should be present"
     assert "qa-workflow" in workflow_ids, "Remote workflow 'qa-workflow' should be present"
-    assert "learning" in result
 
 
 @pytest.mark.asyncio
@@ -342,119 +363,6 @@ async def test_run_remote_workflow(mcp_client: MCPTestClient):
 
 
 @pytest.mark.asyncio
-async def test_create_session(mcp_client: MCPTestClient, db_id: str, test_session_id: str, test_user_id: str):
-    """Test creating a new session with a local agent via MCP."""
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": test_session_id,
-            "session_name": "MCP Test Session",
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-            "session_state": {"test_key": "test_value"},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == test_session_id
-    assert result.get("session_name") == "MCP Test Session"
-
-
-@pytest.mark.asyncio
-async def test_create_session_remote_agent(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a remote agent via MCP."""
-    remote_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": remote_session_id,
-            "session_name": "MCP Remote Agent Test Session",
-            "user_id": test_user_id,
-            "agent_id": "assistant-agent",
-            "session_state": {"remote_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == remote_session_id
-    assert result.get("session_name") == "MCP Remote Agent Test Session"
-    assert result.get("agent_id") == "assistant-agent"
-
-
-@pytest.mark.asyncio
-async def test_create_session_remote_team(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a remote team via MCP."""
-    team_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "team",
-            "session_id": team_session_id,
-            "session_name": "MCP Team Test Session",
-            "user_id": test_user_id,
-            "team_id": "research-team",
-            "session_state": {"team_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == team_session_id
-    assert result.get("session_name") == "MCP Team Test Session"
-    assert result.get("team_id") == "research-team"
-
-
-@pytest.mark.asyncio
-async def test_create_session_local_workflow(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a local workflow via MCP."""
-    workflow_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "workflow",
-            "session_id": workflow_session_id,
-            "session_name": "MCP Local Workflow Test Session",
-            "user_id": test_user_id,
-            "workflow_id": "gateway-workflow",
-            "session_state": {"workflow_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == workflow_session_id
-    assert result.get("session_name") == "MCP Local Workflow Test Session"
-    assert result.get("workflow_id") == "gateway-workflow"
-
-
-@pytest.mark.asyncio
-async def test_create_session_remote_workflow(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a remote workflow via MCP."""
-    workflow_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "workflow",
-            "session_id": workflow_session_id,
-            "session_name": "MCP Remote Workflow Test Session",
-            "user_id": test_user_id,
-            "workflow_id": "qa-workflow",
-            "session_state": {"remote_workflow_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == workflow_session_id
-    assert result.get("session_name") == "MCP Remote Workflow Test Session"
-    assert result.get("workflow_id") == "qa-workflow"
-
-
-@pytest.mark.asyncio
 async def test_get_sessions(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
     """Test getting sessions via MCP."""
     result = await mcp_client.call_tool(
@@ -477,286 +385,35 @@ async def test_get_sessions(mcp_client: MCPTestClient, db_id: str, test_user_id:
 
 
 @pytest.mark.asyncio
-async def test_get_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test getting a specific session via MCP."""
-    # First create a session
+async def test_get_session_runs_after_run(mcp_client: MCPTestClient, test_user_id: str):
+    """Run an agent into a fresh session, then read the conversation back.
+
+    Exercises the v2.7 read-only session path: run tools create sessions implicitly,
+    get_session_runs auto-detects the session type (no session_type passed) and
+    db_id is optional on a single-database AgentOS.
+    """
     session_id = str(uuid4())
     await mcp_client.call_tool(
-        "create_session",
+        "run_agent",
         {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "session_name": "Get Session Test",
-            "user_id": test_user_id,
             "agent_id": "gateway-agent",
-        },
-    )
-
-    # Then get it
-    result = await mcp_client.call_tool(
-        "get_session",
-        {
+            "message": "Say hello in exactly 3 words",
             "session_id": session_id,
-            "db_id": db_id,
-            "session_type": "agent",
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == session_id
-
-
-@pytest.mark.asyncio
-async def test_rename_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test renaming a session via MCP."""
-    # First create a session
-    session_id = str(uuid4())
-    await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "session_name": "Original Name",
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-        },
-    )
-
-    # Then rename it
-    new_name = "Renamed MCP Test Session"
-    result = await mcp_client.call_tool(
-        "rename_session",
-        {
-            "session_id": session_id,
-            "session_name": new_name,
-            "db_id": db_id,
-            "session_type": "agent",
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_name") == new_name
-
-
-@pytest.mark.asyncio
-async def test_update_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test updating a session via MCP."""
-    # First create a session
-    session_id = str(uuid4())
-    await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "session_name": "Update Test Session",
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-        },
-    )
-
-    # Then update it
-    result = await mcp_client.call_tool(
-        "update_session",
-        {
-            "session_id": session_id,
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_state": {"updated_key": "updated_value"},
-            "metadata": {"meta_key": "meta_value"},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_state", {}).get("updated_key") == "updated_value"
-
-
-# =============================================================================
-# Memory Management Tests
-# =============================================================================
-
-
-@pytest.fixture
-def test_memory_id() -> str:
-    """Generate a unique memory ID for testing."""
-    return str(uuid.uuid4())
-
-
-@pytest.mark.asyncio
-async def test_create_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a memory via MCP."""
-    result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "This is a test memory created via MCP",
-            "user_id": test_user_id,
-            "topics": ["test", "mcp"],
-        },
-    )
-
-    assert result is not None
-    assert "memory_id" in result
-    assert result.get("memory") == "This is a test memory created via MCP"
-    assert result.get("user_id") == test_user_id
-
-    # Store memory_id for later tests
-    return result.get("memory_id")
-
-
-@pytest.mark.asyncio
-async def test_get_memories(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test getting memories via MCP."""
-    result = await mcp_client.call_tool(
-        "get_memories",
-        {
-            "db_id": db_id,
-            "user_id": test_user_id,
-            "limit": 10,
-            "page": 1,
-        },
-    )
-
-    assert "data" in result
-    assert "meta" in result
-    assert isinstance(result["data"], list)
-
-
-@pytest.mark.asyncio
-async def test_update_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test updating a memory via MCP."""
-    # First create a memory
-    create_result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "Original memory content",
-            "user_id": test_user_id,
-            "topics": ["original"],
-        },
-    )
-    memory_id = create_result.get("memory_id")
-
-    # Then update it
-    result = await mcp_client.call_tool(
-        "update_memory",
-        {
-            "db_id": db_id,
-            "memory_id": memory_id,
-            "memory": "Updated memory content",
-            "user_id": test_user_id,
-            "topics": ["updated"],
-        },
-    )
-
-    assert result is not None
-    assert result.get("memory") == "Updated memory content"
-
-
-@pytest.mark.asyncio
-async def test_get_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test getting a specific memory via MCP."""
-    # First create a memory
-    create_result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "Memory to retrieve",
             "user_id": test_user_id,
         },
     )
-    memory_id = create_result.get("memory_id")
 
-    # Then get it
-    result = await mcp_client.call_tool(
-        "get_memory",
-        {
-            "memory_id": memory_id,
-            "db_id": db_id,
-        },
-    )
-
-    assert result is not None
-    assert result.get("memory_id") == memory_id
-    assert result.get("memory") == "Memory to retrieve"
+    result = await mcp_client.call_tool("get_session_runs", {"session_id": session_id})
+    runs = result if isinstance(result, list) else [result]
+    assert len(runs) >= 1
 
 
 @pytest.mark.asyncio
-async def test_delete_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test deleting a memory via MCP."""
-    # First create a memory
-    create_result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "Memory to delete",
-            "user_id": test_user_id,
-        },
-    )
-    memory_id = create_result.get("memory_id")
-
-    # Delete it
-    result = await mcp_client.call_tool(
-        "delete_memory",
-        {
-            "db_id": db_id,
-            "memory_id": memory_id,
-        },
-    )
-
-    # Result should indicate successful deletion
-    assert result is not None
-    assert "deleted successfully" in result.lower() or result in ["", "null", None]
-
-
-@pytest.mark.asyncio
-async def test_delete_memories_bulk(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test bulk deleting memories via MCP."""
-    # Create multiple memories
-    memory_ids = []
-    for i in range(3):
-        create_result = await mcp_client.call_tool(
-            "create_memory",
-            {
-                "db_id": db_id,
-                "memory": f"Bulk delete memory {i}",
-                "user_id": test_user_id,
-            },
-        )
-        memory_ids.append(create_result.get("memory_id"))
-
-    # Delete them in bulk
-    result = await mcp_client.call_tool(
-        "delete_memories",
-        {
-            "memory_ids": memory_ids,
-            "db_id": db_id,
-        },
-    )
-
-    # Result should indicate successful deletion
-    assert result is not None
-    assert "deleted successfully" in result.lower() or result in ["", "null", None]
-
-
-@pytest.mark.skip(reason="get_user_memory_stats tool not yet implemented in MCP server")
-@pytest.mark.asyncio
-async def test_get_user_memory_stats(mcp_client: MCPTestClient, db_id: str):
-    """Test getting user memory statistics via MCP."""
-    result = await mcp_client.call_tool(
-        "get_user_memory_stats",
-        {
-            "db_id": db_id,
-            "limit": 10,
-            "page": 1,
-        },
-    )
-
-    assert "data" in result
-    assert "meta" in result
-    assert isinstance(result["data"], list)
+async def test_get_session_runs_not_found(mcp_client: MCPTestClient):
+    """Reading history of a non-existent session returns a tool error."""
+    with pytest.raises(Exception) as exc_info:
+        await mcp_client.call_tool("get_session_runs", {"session_id": "non-existent-session"})
+    assert "not found" in str(exc_info.value).lower()
 
 
 # =============================================================================
@@ -863,54 +520,9 @@ async def test_refresh_metrics(mcp_client: MCPTestClient, db_id: str):
 # =============================================================================
 
 
-@pytest.mark.asyncio
-async def test_cleanup_delete_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Clean up: delete the test session."""
-    # Create a session to delete
-    session_id = str(uuid4())
-    await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-        },
-    )
-
-    # Delete it
-    result = await mcp_client.call_tool(
-        "delete_session",
-        {
-            "session_id": session_id,
-            "db_id": db_id,
-        },
-    )
-
-    # Result should indicate successful deletion
-    assert result is not None
-    assert "deleted successfully" in result.lower() or result in ["", "null", None]
-
-
 # =============================================================================
 # Error Handling Tests
 # =============================================================================
-
-
-@pytest.mark.asyncio
-async def test_get_session_not_found(mcp_client: MCPTestClient, db_id: str):
-    """Test getting a non-existent session returns appropriate error."""
-    with pytest.raises(Exception) as exc_info:
-        await mcp_client.call_tool(
-            "get_session",
-            {
-                "session_id": "non-existent-session-id",
-                "db_id": db_id,
-                "session_type": "agent",
-            },
-        )
-    assert "not found" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio
@@ -922,20 +534,6 @@ async def test_run_agent_not_found(mcp_client: MCPTestClient):
             {
                 "agent_id": "non-existent-agent",
                 "message": "Hello",
-            },
-        )
-    assert "not found" in str(exc_info.value).lower()
-
-
-@pytest.mark.asyncio
-async def test_get_memory_not_found(mcp_client: MCPTestClient, db_id: str):
-    """Test getting a non-existent memory returns appropriate error."""
-    with pytest.raises(Exception) as exc_info:
-        await mcp_client.call_tool(
-            "get_memory",
-            {
-                "memory_id": "non-existent-memory-id",
-                "db_id": db_id,
             },
         )
     assert "not found" in str(exc_info.value).lower()

--- a/libs/agno/tests/system/tests/test_mcp_routes.py
+++ b/libs/agno/tests/system/tests/test_mcp_routes.py
@@ -259,8 +259,9 @@ async def test_run_agent(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a RunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -276,8 +277,9 @@ async def test_run_remote_agent(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a RunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -293,8 +295,9 @@ async def test_run_remote_team(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a TeamRunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -310,8 +313,9 @@ async def test_run_local_workflow(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a WorkflowRunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -327,8 +331,9 @@ async def test_run_remote_workflow(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a WorkflowRunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -187,6 +187,18 @@ class TestCreateServiceAccountSubsetRule:
         response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
         assert response.status_code == 201
 
+    def test_caller_can_grant_exact_per_resource_scope_it_holds(self, mock_db, settings):
+        # Least-privilege delegation: holding exactly agents:my-agent:run must be
+        # enough to grant agents:my-agent:run.
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:my-agent:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
+        assert response.status_code == 201
+
+    def test_caller_cannot_grant_per_resource_scope_for_other_resource(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:my-agent:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:other-agent:run"]})
+        assert response.status_code == 403
+
     def test_unscoped_root_caller_is_exempt(self, mock_db, settings):
         # No request.state.scopes (os_security_key or open dev instance)
         app = FastAPI()

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -1,0 +1,255 @@
+"""Tests for the service accounts REST API router."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from agno.os.routers.service_accounts import get_service_accounts_router
+from agno.os.service_accounts import DEFAULT_EXPIRY_DAYS, DEFAULT_SERVICE_ACCOUNT_SCOPES, TOKEN_PREFIX
+from agno.os.settings import AgnoAPISettings
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _make_account_dict(**overrides):
+    now = int(time.time())
+    d = {
+        "id": "sa-1",
+        "name": "claude-code",
+        "token_hash": "a" * 64,
+        "token_prefix": "agno_pat_abc1234",
+        "scopes": list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
+        "created_at": now,
+        "expires_at": now + 90 * 86400,
+        "last_used_at": None,
+        "revoked_at": None,
+        "created_by": "admin-user",
+    }
+    d.update(overrides)
+    return d
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.get_service_accounts = MagicMock(return_value=([], 0))
+    db.get_service_account = MagicMock(return_value=None)
+    db.get_service_account_by_name = MagicMock(return_value=None)
+    db.create_service_account = MagicMock(side_effect=lambda data: data)
+    db.update_service_account = MagicMock(return_value=_make_account_dict(revoked_at=int(time.time())))
+    return db
+
+
+@pytest.fixture
+def settings():
+    return AgnoAPISettings()
+
+
+@pytest.fixture
+def client(mock_db, settings):
+    app = FastAPI()
+    router = get_service_accounts_router(os_db=mock_db, settings=settings)
+    app.include_router(router)
+    return TestClient(app)
+
+
+# =============================================================================
+# Tests: POST /service-accounts
+# =============================================================================
+
+
+class TestCreateServiceAccount:
+    def test_mint_with_defaults(self, client, mock_db):
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["name"] == "claude-code"
+        assert body["principal"] == "sa:claude-code"
+        assert body["scopes"] == DEFAULT_SERVICE_ACCOUNT_SCOPES
+        assert body["token"].startswith(TOKEN_PREFIX)
+        assert body["token_prefix"] == body["token"][:16]
+        # Default expiry ~90 days out
+        assert body["expires_at"] is not None
+        expected = int(time.time()) + DEFAULT_EXPIRY_DAYS * 86400
+        assert abs(body["expires_at"] - expected) < 60
+        # Only the hash is persisted, never the plaintext
+        stored = mock_db.create_service_account.call_args.args[0]
+        assert body["token"] not in str(stored)
+        assert stored["token_hash"] != body["token"]
+
+    def test_custom_expiry(self, client):
+        response = client.post("/service-accounts", json={"name": "cursor", "expires_in_days": 7})
+        assert response.status_code == 201
+        expected = int(time.time()) + 7 * 86400
+        assert abs(response.json()["expires_at"] - expected) < 60
+
+    def test_never_expires_requires_explicit_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "cursor", "never_expires": True})
+        assert response.status_code == 201
+        assert response.json()["expires_at"] is None
+
+    def test_invalid_name_rejected(self, client):
+        for bad_name in ["Claude-Code", "__scheduler__", "sa:claude", "user@example.com"]:
+            response = client.post("/service-accounts", json={"name": bad_name})
+            assert response.status_code == 422, bad_name
+
+    def test_unknown_scope_rejected(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["bogus"]})
+        assert response.status_code == 400
+        assert "Invalid scope" in response.json()["detail"]
+
+    def test_privileged_scope_requires_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["sessions:write"]})
+        assert response.status_code == 400
+        assert "allow_privileged_scopes" in response.json()["detail"]
+
+    def test_admin_scope_requires_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agent_os:admin"]})
+        assert response.status_code == 400
+
+    def test_service_accounts_scope_requires_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["service_accounts:write"]})
+        assert response.status_code == 400
+
+    def test_privileged_scope_allowed_with_flag(self, client):
+        response = client.post(
+            "/service-accounts",
+            json={"name": "ci", "scopes": ["sessions:write"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 201
+        assert response.json()["scopes"] == ["sessions:write"]
+
+    def test_duplicate_active_name_conflicts(self, client, mock_db):
+        mock_db.get_service_account_by_name = MagicMock(return_value=_make_account_dict())
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 409
+
+    def test_integrity_error_maps_to_conflict(self, client, mock_db):
+        mock_db.create_service_account = MagicMock(
+            side_effect=IntegrityError("UNIQUE constraint failed", None, Exception())
+        )
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 409
+
+    def test_db_without_support_returns_503(self, settings):
+        db = MagicMock()
+        db.get_service_account_by_name = MagicMock(side_effect=NotImplementedError)
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=db, settings=settings))
+        response = TestClient(app).post("/service-accounts", json={"name": "ci"})
+        assert response.status_code == 503
+
+
+class TestCreateServiceAccountSubsetRule:
+    """The minted scopes must be held by the creator (unless admin or unscoped root)."""
+
+    def _client_with_state(self, mock_db, settings, caller_scopes):
+        from fastapi import Request
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def set_scopes(request: Request, call_next):
+            request.state.scopes = caller_scopes
+            request.state.authenticated = True
+            return await call_next(request)
+
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        return TestClient(app)
+
+    def test_caller_cannot_grant_scopes_it_does_not_hold(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["teams:run"]})
+        assert response.status_code == 403
+        assert "teams:run" in response.json()["detail"]
+
+    def test_caller_can_grant_subset_of_own_scopes(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:run", "sessions:read"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:run"]})
+        assert response.status_code == 201
+
+    def test_admin_caller_can_grant_anything(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["agent_os:admin"])
+        response = client.post(
+            "/service-accounts",
+            json={"name": "ci", "scopes": ["sessions:delete"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 201
+
+    def test_wildcard_scope_covers_per_resource_grant(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["agents:*:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
+        assert response.status_code == 201
+
+    def test_unscoped_root_caller_is_exempt(self, mock_db, settings):
+        # No request.state.scopes (os_security_key or open dev instance)
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        response = TestClient(app).post("/service-accounts", json={"name": "ci", "scopes": ["teams:run"]})
+        assert response.status_code == 201
+
+
+# =============================================================================
+# Tests: GET /service-accounts
+# =============================================================================
+
+
+class TestListServiceAccounts:
+    def test_empty_list(self, client):
+        response = client.get("/service-accounts")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"] == []
+        assert body["meta"]["total_count"] == 0
+
+    def test_list_returns_metadata_never_secrets(self, client, mock_db):
+        mock_db.get_service_accounts = MagicMock(return_value=([_make_account_dict()], 1))
+        response = client.get("/service-accounts")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 1
+        entry = body["data"][0]
+        assert entry["token_prefix"] == "agno_pat_abc1234"
+        assert entry["principal"] == "sa:claude-code"
+        assert "token" not in entry
+        assert "token_hash" not in entry
+        assert "a" * 64 not in response.text
+
+    def test_pagination_params_forwarded(self, client, mock_db):
+        client.get("/service-accounts?limit=5&page=2&include_revoked=false&sort_by=name&sort_order=asc")
+        kwargs = mock_db.get_service_accounts.call_args.kwargs
+        assert kwargs["limit"] == 5
+        assert kwargs["page"] == 2
+        assert kwargs["include_revoked"] is False
+        assert kwargs["sort_by"] == "name"
+        assert kwargs["sort_order"] == "asc"
+
+
+# =============================================================================
+# Tests: DELETE /service-accounts/{id}
+# =============================================================================
+
+
+class TestRevokeServiceAccount:
+    def test_unknown_id_returns_404(self, client):
+        response = client.delete("/service-accounts/nope")
+        assert response.status_code == 404
+
+    def test_revoke_sets_revoked_at(self, client, mock_db):
+        mock_db.get_service_account = MagicMock(return_value=_make_account_dict())
+        response = client.delete("/service-accounts/sa-1")
+        assert response.status_code == 204
+        kwargs = mock_db.update_service_account.call_args.kwargs
+        assert kwargs["revoked_at"] is not None
+
+    def test_already_revoked_is_idempotent(self, client, mock_db):
+        mock_db.get_service_account = MagicMock(return_value=_make_account_dict(revoked_at=int(time.time())))
+        response = client.delete("/service-accounts/sa-1")
+        assert response.status_code == 204
+        mock_db.update_service_account.assert_not_called()

--- a/libs/agno/tests/unit/os/test_mcp_run_results.py
+++ b/libs/agno/tests/unit/os/test_mcp_run_results.py
@@ -1,0 +1,341 @@
+"""Unit tests for the MCP run tools' result serialization and progress reporting.
+
+The run tools return trimmed results by default: MCP tool results are injected into
+the consuming model's context, so the transcript, system prompt, and metrics must not
+leak into them. ``result_mode="full"`` is the opt-in escape hatch. Runs are driven as
+streams so tool-call / step events surface as MCP progress notifications.
+"""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastmcp import Client  # noqa: E402
+
+from agno.agent import Agent  # noqa: E402
+from agno.media import Image  # noqa: E402
+from agno.models.message import Message  # noqa: E402
+from agno.models.response import ToolExecution  # noqa: E402
+from agno.os import AgentOS, MCPServerConfig  # noqa: E402
+from agno.os.mcp import build_mcp_server  # noqa: E402
+from agno.run.agent import RunErrorEvent, RunEvent, RunOutput, ToolCallStartedEvent  # noqa: E402
+from agno.run.base import RunStatus  # noqa: E402
+from agno.run.requirement import RunRequirement  # noqa: E402
+from agno.run.workflow import (  # noqa: E402
+    StepStartedEvent,
+    WorkflowCompletedEvent,
+    WorkflowErrorEvent,
+    WorkflowRunOutput,
+)
+from agno.workflow.step import Step  # noqa: E402
+from agno.workflow.workflow import Workflow  # noqa: E402
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n_fake_image_payload"
+
+
+def _agent() -> Agent:
+    return Agent(id="demo-agent", name="Demo Agent")
+
+
+def _stub_arun_stream(component, *items):
+    """Replace ``component.arun`` with an async generator yielding ``items`` in order."""
+
+    async def fake_arun(message, **kwargs):
+        for item in items:
+            yield item
+
+    component.arun = fake_arun  # type: ignore[method-assign]
+
+
+def _full_run_output() -> RunOutput:
+    """A run output carrying everything the trimmed mode must NOT ship to the client."""
+    return RunOutput(
+        run_id="run-1",
+        session_id="sess-1",
+        content="the answer",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="system", content="SECRET_SYSTEM_PROMPT"),
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="the answer"),
+        ],
+    )
+
+
+async def _call_run_agent(os: AgentOS, **kwargs):
+    async with Client(build_mcp_server(os)) as client:
+        return await client.call_tool("run_agent", {"agent_id": "demo-agent", "message": "hi"}, **kwargs)
+
+
+# ==================== Trimmed mode (default) ====================
+
+
+async def test_trimmed_result_carries_answer_and_ids_only():
+    agent = _agent()
+    _stub_arun_stream(agent, _full_run_output())
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    assert result.content[0].text == "the answer"
+    assert result.structured_content == {
+        "run_id": "run-1",
+        "session_id": "sess-1",
+        "status": "COMPLETED",
+    }
+
+
+async def test_trimmed_result_does_not_leak_transcript_or_system_prompt():
+    agent = _agent()
+    _stub_arun_stream(agent, _full_run_output())
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    serialized = str(result.content) + str(result.structured_content)
+    assert "SECRET_SYSTEM_PROMPT" not in serialized
+    assert "messages" not in (result.structured_content or {})
+
+
+async def test_binary_media_becomes_image_content_block():
+    """A run with raw image bytes serializes as an MCP image block instead of erroring."""
+    run_output = _full_run_output()
+    run_output.images = [Image(content=_PNG_BYTES, mime_type="image/png")]
+    agent = _agent()
+    _stub_arun_stream(agent, run_output)
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    image_blocks = [b for b in result.content if getattr(b, "type", None) == "image"]
+    assert len(image_blocks) == 1
+    assert image_blocks[0].mimeType == "image/png"
+    assert image_blocks[0].data  # base64 payload present
+
+
+async def test_paused_run_reports_requirements():
+    run_output = RunOutput(
+        run_id="run-p",
+        session_id="sess-p",
+        status=RunStatus.paused,
+        requirements=[RunRequirement(tool_execution=ToolExecution(tool_name="send_email", requires_confirmation=True))],
+    )
+    agent = _agent()
+    _stub_arun_stream(agent, run_output)
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    structured = result.structured_content or {}
+    assert structured["status"] == "PAUSED"
+    assert len(structured["requirements"]) == 1
+    assert "paused" in result.content[0].text.lower()
+
+
+# ==================== Full mode (escape hatch) ====================
+
+
+async def test_full_mode_ships_complete_run_output():
+    agent = _agent()
+    _stub_arun_stream(agent, _full_run_output())
+    os = AgentOS(
+        agents=[agent],
+        enable_mcp_server=True,
+        mcp_config=MCPServerConfig(result_mode="full"),
+    )
+
+    result = await _call_run_agent(os)
+
+    structured = result.structured_content or {}
+    assert structured["run_id"] == "run-1"
+    assert len(structured["messages"]) == 3  # full mode keeps the transcript, by choice
+    assert result.content[0].text == "the answer"
+
+
+async def test_full_mode_survives_binary_media():
+    """Full mode must route through to_dict() so raw bytes cannot break serialization."""
+    run_output = _full_run_output()
+    run_output.images = [Image(content=_PNG_BYTES, mime_type="image/png")]
+    agent = _agent()
+    _stub_arun_stream(agent, run_output)
+    os = AgentOS(
+        agents=[agent],
+        enable_mcp_server=True,
+        mcp_config=MCPServerConfig(result_mode="full"),
+    )
+
+    result = await _call_run_agent(os)
+
+    assert (result.structured_content or {})["run_id"] == "run-1"
+
+
+# ==================== Progress notifications ====================
+
+
+async def test_tool_call_events_are_forwarded_as_progress():
+    agent = _agent()
+    started_event = ToolCallStartedEvent(
+        event=RunEvent.tool_call_started.value,
+        tool=ToolExecution(tool_name="duckduckgo_search"),
+    )
+    _stub_arun_stream(agent, started_event, _full_run_output())
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    messages = []
+
+    async def on_progress(progress, total, message):
+        messages.append(message)
+
+    result = await _call_run_agent(os, progress_handler=on_progress)
+
+    assert result.content[0].text == "the answer"
+    assert any("started" in (m or "") for m in messages)
+    assert any("duckduckgo_search" in (m or "") for m in messages)
+
+
+# ==================== Workflow runs ====================
+
+
+async def test_workflow_result_built_from_completed_event():
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    completed = WorkflowCompletedEvent(
+        run_id="wf-run-1",
+        session_id="wf-sess-1",
+        content="workflow done",
+        run_output=WorkflowRunOutput(
+            run_id="wf-run-1",
+            session_id="wf-sess-1",
+            content="workflow done",
+            status=RunStatus.completed,
+        ),
+    )
+    _stub_arun_stream(workflow, completed)
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_workflow", {"workflow_id": "demo-wf", "message": "go"})
+
+    assert result.content[0].text == "workflow done"
+    structured = result.structured_content or {}
+    assert structured["run_id"] == "wf-run-1"
+    assert structured["status"] == "COMPLETED"
+
+
+async def test_run_finishing_without_output_raises_tool_error():
+    """A stream that ends without a final output surfaces as a tool error, not a hang."""
+    agent = _agent()
+    _stub_arun_stream(agent)  # yields nothing
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os, raise_on_error=False)
+    assert result.is_error
+
+
+# ==================== Error and pause propagation ====================
+
+
+async def test_failed_run_surfaces_real_error_message():
+    """The streaming error path yields only a RunErrorEvent; its message must reach the client."""
+    agent = _agent()
+    _stub_arun_stream(agent, RunErrorEvent(content="Incorrect API key provided"))
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os, raise_on_error=False)
+
+    assert result.is_error
+    assert "Incorrect API key provided" in result.content[0].text
+
+
+async def test_paused_workflow_recovered_from_persisted_run():
+    """Foreground workflow streams end WITHOUT a terminal event on HITL pause; the tool
+    must fetch the persisted run so the client gets run_id + requirements to continue."""
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    _stub_arun_stream(workflow, StepStartedEvent(run_id="wf-run-p", session_id="wf-sess-p", step_name="approve"))
+
+    paused = WorkflowRunOutput(run_id="wf-run-p", session_id="wf-sess-p", content=None, status=RunStatus.paused)
+    fetched = {}
+
+    async def fake_aget_run_output(run_id, session_id=None, user_id=None):
+        fetched["run_id"] = run_id
+        fetched["session_id"] = session_id
+        return paused
+
+    workflow.aget_run_output = fake_aget_run_output  # type: ignore[method-assign]
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_workflow", {"workflow_id": "demo-wf", "message": "go"})
+
+    assert fetched == {"run_id": "wf-run-p", "session_id": "wf-sess-p"}
+    assert (result.structured_content or {})["status"] == "PAUSED"
+
+
+async def test_nested_workflow_error_does_not_abort_outer_run():
+    """A nested workflow's error event (nested_depth > 0) must not kill an outer run
+    that recovers from it."""
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    outer_output = WorkflowRunOutput(
+        run_id="wf-outer", session_id="wf-sess", content="recovered", status=RunStatus.completed
+    )
+    _stub_arun_stream(
+        workflow,
+        WorkflowErrorEvent(run_id="wf-nested", error="nested boom", nested_depth=1),
+        WorkflowCompletedEvent(run_id="wf-outer", session_id="wf-sess", content="recovered", run_output=outer_output),
+    )
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_workflow", {"workflow_id": "demo-wf", "message": "go"})
+
+    structured = result.structured_content or {}
+    assert structured["run_id"] == "wf-outer"
+    assert structured["status"] == "COMPLETED"
+
+
+async def test_workflow_progress_is_strictly_increasing():
+    """MCP requires progress to increase per notification, even when step indexes repeat
+    (loops) or reset (nested steps)."""
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    events = [
+        StepStartedEvent(run_id="r", session_id="s", step_name="a", step_index=0),
+        StepStartedEvent(run_id="r", session_id="s", step_name="a", step_index=0),  # loop iteration repeats index
+        StepStartedEvent(run_id="r", session_id="s", step_name="b", step_index=1),
+        WorkflowCompletedEvent(
+            run_id="r",
+            session_id="s",
+            content="done",
+            run_output=WorkflowRunOutput(run_id="r", session_id="s", content="done", status=RunStatus.completed),
+        ),
+    ]
+    _stub_arun_stream(workflow, *events)
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    values = []
+
+    async def on_progress(progress, total, message):
+        values.append(progress)
+
+    async with Client(build_mcp_server(os)) as client:
+        await client.call_tool(
+            "run_workflow", {"workflow_id": "demo-wf", "message": "go"}, progress_handler=on_progress
+        )
+
+    assert values == sorted(values)
+    assert len(values) == len(set(values)), f"progress values must strictly increase, got {values}"
+
+
+async def test_paused_workflow_fallback_text_counts_step_requirements():
+    """The paused fallback text must count workflow step_requirements, not just
+    agent/team requirements."""
+    from agno.os.mcp_results import build_run_tool_result
+    from agno.workflow.types import StepRequirement
+
+    paused = WorkflowRunOutput(run_id="r", session_id="s", content=None, status=RunStatus.paused)
+    paused.step_requirements = [
+        StepRequirement(step_id="step-1", step_name="approve", step_type="Step", requires_confirmation=True)
+    ]
+
+    result = build_run_tool_result(paused, "trimmed")
+
+    text = result.content[0].text
+    assert "1 requirement" in text

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -66,14 +66,22 @@ async def _call_tool(os: AgentOS, name: str, args: dict):
 
 
 def _stub_arun(component, run_output):
-    """Replace ``component.arun`` with a stub that records the identity kwargs it was called with."""
+    """Replace ``component.arun`` with a streaming stub that records the identity kwargs.
+
+    The run tools consume ``arun`` as a stream (``stream=True, yield_run_output=True``),
+    so the stub is an async generator whose last item is the final run output.
+    """
     captured: dict = {}
 
     async def fake_arun(message, **kwargs):
         captured["message"] = message
         captured["user_id"] = kwargs.get("user_id")
         captured["session_id"] = kwargs.get("session_id")
-        return run_output
+        # Agent/team tools must request the final output explicitly; workflows have no
+        # yield_run_output kwarg (the consumer accepts a bare WorkflowRunOutput instead).
+        # Gating on this catches a regression where the tools stop passing it.
+        if kwargs.get("yield_run_output") or isinstance(run_output, WorkflowRunOutput):
+            yield run_output
 
     component.arun = fake_arun  # type: ignore[method-assign]
     return captured

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -34,21 +34,11 @@ from agno.tools import tool  # noqa: E402
 from agno.workflow.step import Step  # noqa: E402
 from agno.workflow.workflow import Workflow  # noqa: E402
 
-# The full set of built-in tools, keyed by their tag group.
-CORE_TOOLS = {"get_agentos_config", "run_agent", "run_team", "run_workflow"}
-SESSION_TOOLS = {
-    "get_sessions",
-    "get_session",
-    "create_session",
-    "get_session_runs",
-    "get_session_run",
-    "rename_session",
-    "update_session",
-    "delete_session",
-    "delete_sessions",
-}
-MEMORY_TOOLS = {"create_memory", "get_memory", "get_memories", "update_memory", "delete_memory", "delete_memories"}
-ALL_BUILTIN_TOOLS = CORE_TOOLS | SESSION_TOOLS | MEMORY_TOOLS
+# The full set of built-in tools, keyed by their tag group. The surface is deliberately
+# 8 tools: an operator surface for LLM frontends, not a database console.
+CORE_TOOLS = {"get_agentos_config", "run_agent", "run_team", "run_workflow", "continue_run", "cancel_run"}
+SESSION_TOOLS = {"get_sessions", "get_session_runs"}
+ALL_BUILTIN_TOOLS = CORE_TOOLS | SESSION_TOOLS
 
 
 def _agent() -> Agent:
@@ -171,30 +161,30 @@ async def test_include_tags_scopes_builtins_to_core():
     assert await _tool_names(os) == CORE_TOOLS
 
 
-async def test_exclude_tags_drops_memory_builtins():
-    os = AgentOS(agents=[_agent()], enable_mcp_server=True, mcp_config=MCPServerConfig(exclude_tags={"memory"}))
+async def test_exclude_tags_drops_session_builtins():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True, mcp_config=MCPServerConfig(exclude_tags={"session"}))
     names = await _tool_names(os)
-    assert names == CORE_TOOLS | SESSION_TOOLS
-    assert not (names & MEMORY_TOOLS)
+    assert names == CORE_TOOLS
+    assert not (names & SESSION_TOOLS)
 
 
 def test_unknown_include_tag_is_rejected():
     """A typo like ``{"sessions"}`` (plural) would silently produce an empty server. The
     ``MCPBuiltinTag`` Literal makes pydantic reject it at construction."""
-    with pytest.raises(ValueError, match="Input should be 'core', 'session' or 'memory'"):
+    with pytest.raises(ValueError, match="Input should be 'core' or 'session'"):
         MCPServerConfig(include_tags={"sessions"})
 
 
-def test_unknown_exclude_tag_is_rejected():
-    """Same protection on ``exclude_tags`` -- a typo would silently exclude nothing.
-    Tag matching is case-sensitive (``"Memory"`` is not ``"memory"``)."""
-    with pytest.raises(ValueError, match="Input should be 'core', 'session' or 'memory'"):
-        MCPServerConfig(exclude_tags={"Memory"})
+def test_removed_memory_tag_is_rejected():
+    """The memory tools were removed from the MCP surface; the old tag must fail loudly
+    instead of silently scoping nothing."""
+    with pytest.raises(ValueError, match="Input should be 'core' or 'session'"):
+        MCPServerConfig(exclude_tags={"memory"})
 
 
 def test_known_tags_are_accepted():
     """Sanity: the typed fields don't fight the documented values."""
-    MCPServerConfig(include_tags={"core", "session", "memory"})
+    MCPServerConfig(include_tags={"core", "session"})
     MCPServerConfig(exclude_tags={"core"})
 
 

--- a/libs/agno/tests/unit/os/test_mcp_surface_v2.py
+++ b/libs/agno/tests/unit/os/test_mcp_surface_v2.py
@@ -1,0 +1,314 @@
+"""Unit tests for the v2.7 MCP surface: run-lifecycle tools, read-only session tools
+backed by the shared service layer, tool annotations, and the app wiring fixes.
+"""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from fastmcp import Client  # noqa: E402
+
+import agno.os.mcp as mcp_mod  # noqa: E402
+from agno.agent import Agent  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.mcp import build_mcp_server  # noqa: E402
+from agno.os.services.sessions import SessionNotFoundError, get_session_runs, get_sessions_page  # noqa: E402
+from agno.run.agent import RunOutput  # noqa: E402
+from agno.run.base import RunStatus  # noqa: E402
+from agno.run.requirement import RunRequirement  # noqa: E402
+from agno.workflow.step import Step  # noqa: E402
+from agno.workflow.workflow import Workflow  # noqa: E402
+
+
+def _agent() -> Agent:
+    return Agent(id="demo-agent", name="Demo Agent")
+
+
+# ==================== Tool annotations ====================
+
+
+async def test_annotations_mark_reads_and_destructive_tools():
+    """Clients use readOnlyHint/destructiveHint for permission UX; reads and the one
+    destructive tool must be distinguishable."""
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        tools = {t.name: t for t in await client.list_tools()}
+
+    assert tools["get_agentos_config"].annotations.readOnlyHint is True
+    assert tools["get_sessions"].annotations.readOnlyHint is True
+    assert tools["get_session_runs"].annotations.readOnlyHint is True
+    assert tools["cancel_run"].annotations.destructiveHint is True
+    assert tools["run_agent"].annotations.readOnlyHint is False
+
+
+async def test_config_payload_is_compact():
+    """get_agentos_config is a discovery payload: ids and summaries, not the full config."""
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    os.get_app()  # populates db discovery (os.dbs), as at serve time
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("get_agentos_config", {})
+
+    structured = result.structured_content or {}
+    payload = structured.get("result", structured)
+    assert payload["agents"][0]["id"] == "demo-agent"
+    for heavy_key in ("session", "memory", "knowledge", "evals", "metrics", "traces"):
+        assert heavy_key not in payload
+
+
+# ==================== continue_run / cancel_run ====================
+
+
+async def test_continue_run_requires_exactly_one_component():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("continue_run", {"run_id": "r1"}, raise_on_error=False)
+        assert result.is_error
+        result = await client.call_tool(
+            "continue_run",
+            {"run_id": "r1", "agent_id": "demo-agent", "team_id": "demo-team"},
+            raise_on_error=False,
+        )
+        assert result.is_error
+
+
+async def test_continue_run_threads_identity_and_parses_requirements(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "jwt-alice")
+    agent = _agent()
+    captured = {}
+
+    async def fake_acontinue_run(*, run_id, session_id, user_id, requirements, stream=False):
+        captured.update(run_id=run_id, session_id=session_id, user_id=user_id, requirements=requirements, stream=stream)
+        return RunOutput(run_id=run_id, session_id=session_id, content="resumed", status=RunStatus.completed)
+
+    agent.acontinue_run = fake_acontinue_run  # type: ignore[method-assign]
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    requirement_dict = {"tool_execution": {"tool_name": "send_email"}, "confirmation": True}
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "continue_run",
+            {
+                "run_id": "run-9",
+                "session_id": "sess-9",
+                "agent_id": "demo-agent",
+                "requirements": [requirement_dict],
+            },
+        )
+
+    assert captured["run_id"] == "run-9"
+    assert captured["user_id"] == "jwt-alice"
+    assert captured["stream"] is False  # pinned so a stream=True agent can't return an iterator
+    assert isinstance(captured["requirements"][0], RunRequirement)
+    assert result.content[0].text == "resumed"
+    assert (result.structured_content or {})["status"] == "COMPLETED"
+
+
+async def test_continue_run_dispatches_workflow_step_requirements():
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    captured = {}
+
+    async def fake_acontinue_run(*, run_id, session_id, step_requirements, stream=False):
+        captured.update(run_id=run_id, step_requirements=step_requirements, stream=stream)
+        from agno.run.workflow import WorkflowRunOutput
+
+        return WorkflowRunOutput(run_id=run_id, session_id=session_id, content="wf resumed")
+
+    workflow.acontinue_run = fake_acontinue_run  # type: ignore[method-assign]
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    step_requirement = {"step_id": "s1", "step_name": "approve", "step_type": "Step", "requires_confirmation": True}
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "continue_run",
+            {"run_id": "wf-run-9", "workflow_id": "demo-wf", "requirements": [step_requirement]},
+        )
+
+    assert captured["run_id"] == "wf-run-9"
+    assert captured["step_requirements"][0].step_id == "s1"
+    assert result.content[0].text == "wf resumed"
+
+
+async def test_cancel_run_requires_exactly_one_component():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("cancel_run", {"run_id": "r1"}, raise_on_error=False)
+    assert result.is_error
+
+
+async def test_cancel_run_requests_cancellation_on_the_named_component():
+    agent = _agent()
+    captured = {}
+
+    async def fake_acancel_run(run_id):
+        captured["run_id"] = run_id
+        return True
+
+    agent.acancel_run = fake_acancel_run  # type: ignore[method-assign]
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("cancel_run", {"run_id": "run-x", "agent_id": "demo-agent"})
+    assert captured["run_id"] == "run-x"
+    assert "cancellation requested" in result.content[0].text
+
+
+async def test_continue_run_rejects_remote_component(monkeypatch):
+    """Remote components can't carry resolved requirements downstream; continue must fail
+    clearly (like the REST 400) rather than crash."""
+    from agno.agent.remote import RemoteAgent
+
+    remote = RemoteAgent(base_url="http://example.invalid", agent_id="remote-agent")
+    monkeypatch.setattr(mcp_mod, "get_agent_by_id", lambda cid, agents: remote)
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "continue_run",
+            {"run_id": "r1", "session_id": "s1", "agent_id": "remote-agent"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert "remote" in result.content[0].text.lower()
+
+
+async def test_lifecycle_ownership_gate_blocks_other_users(monkeypatch):
+    """A scoped (non-admin) caller cannot cancel a run in a session they do not own."""
+    monkeypatch.setattr(mcp_mod, "_scoped_caller_user_id", lambda: "user-b")
+    agent = _agent()
+    cancelled = {"called": False}
+
+    async def fake_acancel_run(run_id):
+        cancelled["called"] = True
+        return True
+
+    async def fake_aget_session(session_id, user_id):
+        return None  # user-b owns no such session
+
+    agent.acancel_run = fake_acancel_run  # type: ignore[method-assign]
+    agent.aget_session = fake_aget_session  # type: ignore[method-assign]
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "cancel_run",
+            {"run_id": "run-a", "session_id": "sess-a", "agent_id": "demo-agent"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert cancelled["called"] is False  # never reached the cancellation registry
+
+
+async def test_get_session_runs_history_is_trimmed():
+    """History reads must not ship the message transcript / system prompt to the client."""
+    session = {
+        "session_id": "s1",
+        "agent_id": "a-1",
+        "runs": [
+            {
+                "run_id": "r1",
+                "agent_id": "a-1",
+                "run_input": "hello",
+                "content": "hi there",
+                "status": "COMPLETED",
+                "messages": [{"role": "system", "content": "SECRET_PROMPT"}],
+                "events": [{"event": "x"}],
+            }
+        ],
+    }
+    from agno.os.schema import RunSchema
+
+    trimmed = mcp_mod._trim_session_run(RunSchema.from_dict(session["runs"][0]))
+    assert trimmed["content"] == "hi there"
+    assert trimmed["status"] == "COMPLETED"
+    assert "messages" not in trimmed
+    assert "events" not in trimmed
+    assert "SECRET_PROMPT" not in str(trimmed)
+
+
+# ==================== Session service ====================
+
+
+class _FakeSyncDb:
+    """Sync BaseDb-shaped stub: exercises the threadpool path in the service."""
+
+    def __init__(self, session=None, sessions=None):
+        self._session = session
+        self._sessions = sessions or []
+
+    def get_session(self, session_id, session_type, user_id, deserialize):
+        return self._session
+
+    def get_sessions(self, **kwargs):
+        return self._sessions, len(self._sessions)
+
+
+async def test_service_auto_detects_workflow_session_and_classifies_runs():
+    session = {
+        "session_id": "s1",
+        "workflow_id": "wf-1",
+        "runs": [
+            {"run_id": "r1", "workflow_id": "wf-1", "content": "wf run"},
+            {"run_id": "r2", "agent_id": "a-1", "content": "member agent run"},
+        ],
+    }
+    runs = await get_session_runs(_FakeSyncDb(session=session), session_id="s1", session_type=None)  # type: ignore[arg-type]
+
+    # workflow_id run renders as a workflow run, the bare agent run falls back to RunSchema
+    assert runs[0].__class__.__name__ == "WorkflowRunSchema"
+    assert runs[1].__class__.__name__ == "RunSchema"
+
+
+async def test_service_raises_session_not_found():
+    with pytest.raises(SessionNotFoundError):
+        await get_session_runs(_FakeSyncDb(session=None), session_id="missing")  # type: ignore[arg-type]
+
+
+async def test_service_lists_sessions_via_threadpool():
+    from agno.db.base import SessionType
+
+    db = _FakeSyncDb(sessions=[{"session_id": "s1", "session_type": "agent"}])
+    sessions, total = await get_sessions_page(db, session_type=SessionType.AGENT)  # type: ignore[arg-type]
+    assert total == 1
+    assert sessions[0]["session_id"] == "s1"
+
+
+# ==================== App wiring ====================
+
+
+def test_resync_reuses_started_mcp_app_and_mount():
+    """resync() must not replace the MCP app (a fresh one's lifespan never runs) and
+    must not accumulate duplicate mounts."""
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    app = os.get_app()
+    mcp_app_before = os._mcp_app
+    assert mcp_app_before is not None
+
+    os.resync(app=app)
+
+    assert os._mcp_app is mcp_app_before
+    mounts = [r for r in app.router.routes if getattr(r, "app", None) is mcp_app_before]
+    assert len(mounts) == 1
+
+
+def test_home_route_works_with_mcp_enabled():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    app = os.get_app()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "AgentOS" in response.text
+
+
+def test_get_app_idempotent_with_base_app():
+    base_app = FastAPI()
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True, base_app=base_app)
+    first = os.get_app()
+    route_count = len(first.router.routes)
+    mcp_app_first = os._mcp_app
+
+    second = os.get_app()
+
+    assert second is first
+    assert len(second.router.routes) == route_count
+    assert os._mcp_app is mcp_app_first
+    mounts = [r for r in second.router.routes if getattr(r, "app", None) is mcp_app_first]
+    assert len(mounts) == 1

--- a/libs/agno/tests/unit/os/test_scopes.py
+++ b/libs/agno/tests/unit/os/test_scopes.py
@@ -2,11 +2,37 @@
 
 from agno.os.scopes import (
     LEGACY_RESOURCE_ALIASES,
+    check_route_scopes,
     get_accessible_resource_ids,
     get_default_scope_mappings,
     has_required_scopes,
     parse_scope,
 )
+
+
+class TestCheckRouteScopes:
+    def test_get_listing_allows_through_with_accessible_ids(self):
+        # A caller lacking the global scope but holding per-resource scopes gets a
+        # filtered listing, not a 403.
+        result = check_route_scopes(["agents:a1:read"], get_default_scope_mappings(), "GET", "/agents")
+        assert result.allowed is True
+        assert result.accessible_resource_ids == {"a1"}
+
+    def test_non_get_idless_route_is_not_allowed_through(self):
+        # Regression: the listing allow-through must be GET-only. A create endpoint
+        # (POST /agents requires agents:write) must 403, never silently allow through.
+        result = check_route_scopes(["agents:a1:read"], get_default_scope_mappings(), "POST", "/agents")
+        assert result.allowed is False
+        assert result.accessible_resource_ids is None
+
+    def test_caller_with_required_scope_is_allowed(self):
+        result = check_route_scopes(["agents:write"], get_default_scope_mappings(), "POST", "/agents")
+        assert result.allowed is True
+
+    def test_unmapped_route_allowed(self):
+        result = check_route_scopes([], get_default_scope_mappings(), "GET", "/totally/unmapped")
+        assert result.allowed is True
+        assert result.required_scopes == []
 
 
 class TestParseScope:

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -90,8 +90,10 @@ class TestNameValidation:
             "user@example.com",  # email shape
             "-leading-dash",
             "a" * 64,  # too long
+            "github-actions\n",  # trailing newline must not sneak past the anchor
+            "claude\ncode",  # embedded newline
         ]:
-            assert not is_valid_service_account_name(name), name
+            assert not is_valid_service_account_name(name), repr(name)
 
 
 class TestPrincipal:
@@ -214,6 +216,20 @@ class TestVerifier:
         # A different client is unaffected
         result = await verifier.verify("agno_pat_bad", client_key="5.6.7.8")
         assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_valid_token_never_blocked_by_limiter(self, sync_db):
+        # A flood of bad tokens must not deny service to a valid token from the same key.
+        plaintext, token_hash, _ = generate_token()
+        verifier = ServiceAccountVerifier(db=sync_db)
+        verifier._limiter.max_failures = 3
+        for _ in range(10):
+            result = await verifier.verify("agno_pat_bad", client_key="1.2.3.4")
+            assert result.status in (VerificationStatus.INVALID, VerificationStatus.THROTTLED)
+        # The valid token still authenticates despite the throttled bucket.
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        result = await verifier.verify(plaintext, client_key="1.2.3.4")
+        assert result.ok
 
     @pytest.mark.asyncio
     async def test_async_db_lookup_is_awaited(self):

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -1,0 +1,237 @@
+"""Unit tests for service account token utils and the ServiceAccountVerifier."""
+
+import time
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.schemas.service_accounts import ServiceAccount
+from agno.os.service_accounts import (
+    DEFAULT_SERVICE_ACCOUNT_SCOPES,
+    TOKEN_DISPLAY_PREFIX_LENGTH,
+    TOKEN_PREFIX,
+    ServiceAccountVerifier,
+    VerificationStatus,
+    generate_token,
+    get_invalid_scopes,
+    get_principal,
+    get_privileged_scopes,
+    hash_token,
+    is_valid_service_account_name,
+)
+
+
+def _make_mock_db_class(base_class):
+    abstract_methods = {}
+    for name in dir(base_class):
+        attr = getattr(base_class, name, None)
+        if getattr(attr, "__isabstractmethod__", False):
+            abstract_methods[name] = MagicMock()
+    return type("MockDb", (base_class,), abstract_methods)
+
+
+def _account_row(
+    name: str = "claude-code",
+    token_hash: str = "hash",
+    expires_at: Optional[int] = None,
+    revoked_at: Optional[int] = None,
+) -> Dict[str, Any]:
+    return {
+        "id": "sa-id-1",
+        "name": name,
+        "token_hash": token_hash,
+        "token_prefix": "agno_pat_abc1234",
+        "scopes": list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
+        "created_at": int(time.time()) - 100,
+        "expires_at": expires_at,
+        "last_used_at": None,
+        "revoked_at": revoked_at,
+        "created_by": "admin-user",
+    }
+
+
+class TestTokenGeneration:
+    def test_token_format(self):
+        plaintext, token_hash, token_prefix = generate_token()
+        assert plaintext.startswith(TOKEN_PREFIX)
+        assert len(token_prefix) == TOKEN_DISPLAY_PREFIX_LENGTH
+        assert plaintext.startswith(token_prefix)
+        assert token_hash == hash_token(plaintext)
+
+    def test_token_random_part_is_base62(self):
+        plaintext, _, _ = generate_token()
+        random_part = plaintext[len(TOKEN_PREFIX) :]
+        assert len(random_part) >= 40
+        assert all(c.isalnum() for c in random_part)
+
+    def test_tokens_are_unique(self):
+        tokens = {generate_token()[0] for _ in range(50)}
+        assert len(tokens) == 50
+
+    def test_hash_is_sha256_hex(self):
+        token_hash = hash_token("agno_pat_test")
+        assert len(token_hash) == 64
+        assert int(token_hash, 16) is not None
+
+
+class TestNameValidation:
+    def test_valid_names(self):
+        for name in ["claude-code", "cursor", "github-actions", "a", "ci_bot-2"]:
+            assert is_valid_service_account_name(name), name
+
+    def test_invalid_names(self):
+        for name in [
+            "",
+            "Claude-Code",  # uppercase
+            "__scheduler__",  # leading underscore
+            "sa:claude-code",  # colon (principal namespace)
+            "user@example.com",  # email shape
+            "-leading-dash",
+            "a" * 64,  # too long
+        ]:
+            assert not is_valid_service_account_name(name), name
+
+
+class TestPrincipal:
+    def test_principal_is_namespaced(self):
+        assert get_principal("claude-code") == "sa:claude-code"
+
+    def test_dataclass_principal_matches(self):
+        account = ServiceAccount.from_dict(_account_row(name="cursor"))
+        assert account.principal == "sa:cursor"
+
+
+class TestScopeHelpers:
+    def test_invalid_scopes_detected(self):
+        assert get_invalid_scopes(["agents:run", "bogus"]) == ["bogus"]
+        assert get_invalid_scopes(["a:b:c:d"]) == ["a:b:c:d"]
+        assert get_invalid_scopes(DEFAULT_SERVICE_ACCOUNT_SCOPES) == []
+
+    def test_privileged_scopes_two_part(self):
+        assert get_privileged_scopes(["sessions:write"]) == ["sessions:write"]
+        assert get_privileged_scopes(["memories:delete"]) == ["memories:delete"]
+        assert get_privileged_scopes(["agents:run", "sessions:read"]) == []
+
+    def test_privileged_scopes_three_part(self):
+        assert get_privileged_scopes(["sessions:*:delete"]) == ["sessions:*:delete"]
+        assert get_privileged_scopes(["agents:my-agent:run"]) == []
+
+    def test_admin_scope_is_privileged(self):
+        assert get_privileged_scopes(["agent_os:admin"]) == ["agent_os:admin"]
+
+    def test_custom_admin_scope_is_privileged(self):
+        assert get_privileged_scopes(["custom:admin:scope"], admin_scope="custom:admin:scope") == ["custom:admin:scope"]
+
+    def test_service_accounts_scopes_are_privileged(self):
+        assert get_privileged_scopes(["service_accounts:read"]) == ["service_accounts:read"]
+        assert get_privileged_scopes(["service_accounts:write"]) == ["service_accounts:write"]
+
+
+class TestVerifier:
+    @pytest.fixture
+    def sync_db(self):
+        MockDbClass = _make_mock_db_class(BaseDb)
+        db = MockDbClass()
+        db.get_service_account_by_token_hash = MagicMock(return_value=None)
+        db.update_service_account = MagicMock(return_value=None)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_is_invalid(self, sync_db):
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify("agno_pat_unknown", client_key="1.2.3.4")
+        assert result.status == VerificationStatus.INVALID
+        assert result.account is None
+
+    @pytest.mark.asyncio
+    async def test_valid_token_ok_and_touches_last_used(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify(plaintext, client_key="1.2.3.4")
+        assert result.ok
+        assert result.account is not None
+        assert result.account.principal == "sa:claude-code"
+        sync_db.get_service_account_by_token_hash.assert_called_once_with(token_hash)
+        sync_db.update_service_account.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_last_used_write_is_throttled(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db)
+        await verifier.verify(plaintext)
+        await verifier.verify(plaintext)
+        assert sync_db.update_service_account.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_revoked_token_is_invalid(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(
+            token_hash=token_hash, revoked_at=int(time.time())
+        )
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify(plaintext)
+        assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_expired_token_is_invalid(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(
+            token_hash=token_hash, expires_at=int(time.time()) - 10
+        )
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify(plaintext)
+        assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_db_error_is_unavailable_and_not_counted(self, sync_db):
+        sync_db.get_service_account_by_token_hash.side_effect = RuntimeError("connection refused")
+        verifier = ServiceAccountVerifier(db=sync_db)
+        verifier._limiter.max_failures = 2
+        for _ in range(5):
+            result = await verifier.verify("agno_pat_whatever", client_key="1.2.3.4")
+            assert result.status == VerificationStatus.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_not_implemented_is_unavailable(self, sync_db):
+        sync_db.get_service_account_by_token_hash.side_effect = NotImplementedError
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify("agno_pat_whatever")
+        assert result.status == VerificationStatus.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_failed_lookups_are_rate_limited(self, sync_db):
+        verifier = ServiceAccountVerifier(db=sync_db)
+        verifier._limiter.max_failures = 3
+        for _ in range(3):
+            result = await verifier.verify("agno_pat_bad", client_key="1.2.3.4")
+            assert result.status == VerificationStatus.INVALID
+        result = await verifier.verify("agno_pat_bad", client_key="1.2.3.4")
+        assert result.status == VerificationStatus.THROTTLED
+        # A different client is unaffected
+        result = await verifier.verify("agno_pat_bad", client_key="5.6.7.8")
+        assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_async_db_lookup_is_awaited(self):
+        MockDbClass = _make_mock_db_class(AsyncBaseDb)
+        db = MockDbClass()
+        plaintext, token_hash, _ = generate_token()
+        row = _account_row(token_hash=token_hash)
+
+        async def _get_by_hash(t):
+            assert t == token_hash
+            return row
+
+        async def _update(account_id, **kwargs):
+            assert kwargs.get("last_used_at") is not None
+            return row
+
+        db.get_service_account_by_token_hash = _get_by_hash
+        db.update_service_account = _update
+        verifier = ServiceAccountVerifier(db=db)
+        result = await verifier.verify(plaintext)
+        assert result.ok

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -14,6 +14,7 @@ from agno.os.service_accounts import (
     TOKEN_PREFIX,
     ServiceAccountVerifier,
     VerificationStatus,
+    _VerificationCache,
     generate_token,
     get_invalid_scopes,
     get_principal,
@@ -131,6 +132,54 @@ class TestScopeHelpers:
         assert get_privileged_scopes(["service_accounts:write"]) == ["service_accounts:write"]
 
 
+class TestVerificationCache:
+    def _account(self, name="claude-code", expires_at=None):
+        return ServiceAccount.from_dict(_account_row(name=name, expires_at=expires_at))
+
+    def test_put_then_get_hits(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        cache.put("h1", self._account())
+        assert cache.get("h1") is not None
+
+    def test_ttl_zero_never_stores_or_serves(self):
+        cache = _VerificationCache(ttl_seconds=0)
+        assert cache.enabled is False
+        cache.put("h1", self._account())
+        assert cache.get("h1") is None
+
+    def test_ttl_expiry_evicts(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        # Force the cached-at timestamp into the past beyond the TTL.
+        cache._entries["h1"] = (self._account(), time.monotonic() - 100)
+        assert cache.get("h1") is None
+        assert "h1" not in cache._entries
+
+    def test_expired_account_not_served_within_ttl(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        # Fresh cache entry (within TTL) but the account itself has expired.
+        cache._entries["h1"] = (self._account(expires_at=int(time.time()) - 10), time.monotonic())
+        assert cache.get("h1") is None
+        assert "h1" not in cache._entries
+
+    def test_lru_eviction(self):
+        cache = _VerificationCache(ttl_seconds=30, max_entries=2)
+        cache.put("h1", self._account("a"))
+        cache.put("h2", self._account("b"))
+        cache.get("h1")  # h1 becomes most-recently-used
+        cache.put("h3", self._account("c"))  # evicts the LRU entry (h2)
+        assert cache.get("h1") is not None
+        assert cache.get("h2") is None
+        assert cache.get("h3") is not None
+
+    def test_invalidate_removes_entry(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        cache.put("h1", self._account())
+        cache.invalidate("h1")
+        assert cache.get("h1") is None
+        # Idempotent
+        cache.invalidate("h1")
+
+
 class TestVerifier:
     @pytest.fixture
     def sync_db(self):
@@ -230,6 +279,55 @@ class TestVerifier:
         sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
         result = await verifier.verify(plaintext, client_key="1.2.3.4")
         assert result.ok
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_avoids_second_db_lookup(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=30)
+        first = await verifier.verify(plaintext)
+        second = await verifier.verify(plaintext)
+        assert first.ok and second.ok
+        # The DB is consulted only once; the second verify is served from cache.
+        sync_db.get_service_account_by_token_hash.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ttl_zero_disables_cache(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=0)
+        await verifier.verify(plaintext)
+        await verifier.verify(plaintext)
+        assert sync_db.get_service_account_by_token_hash.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_invalidate_forces_next_verify_to_hit_db(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=30)
+        await verifier.verify(plaintext)
+        verifier.invalidate(token_hash)
+        await verifier.verify(plaintext)
+        assert sync_db.get_service_account_by_token_hash.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_revoked_after_cache_served_until_invalidated(self, sync_db):
+        # Convergence semantics: a token cached as valid keeps authenticating within the
+        # TTL until the local cache is evicted; once evicted it reflects the revocation.
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=30)
+        assert (await verifier.verify(plaintext)).ok
+
+        # Account is revoked in the DB, but the cached entry still authenticates.
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(
+            token_hash=token_hash, revoked_at=int(time.time())
+        )
+        assert (await verifier.verify(plaintext)).ok
+
+        # After eviction, the next verify reflects the revocation.
+        verifier.invalidate(token_hash)
+        assert (await verifier.verify(plaintext)).status == VerificationStatus.INVALID
 
     @pytest.mark.asyncio
     async def test_async_db_lookup_is_awaited(self):


### PR DESCRIPTION
## Summary

Five parts: service accounts (PAT auth), trimmed MCP run results + progress, the 8-tool MCP surface with run lifecycle (`continue_run`/`cancel_run`), a shared service layer behind REST and MCP, and wiring/ergonomics/cookbook fixes.

### Part 1 — Service accounts (PAT auth)

Machine identities (coding agents, chat apps, CI) authenticated by opaque `agno_pat_...` tokens, following the GitHub PAT model. Human tokens keep flowing through the existing JWT path unchanged; the middleware accepts either.

- **Token format** — `agno_pat_` prefix (greppable for secret scanners) + 32 bytes CSPRNG, base62. Only the SHA-256 hash is stored plus a 16-char display prefix; plaintext returned exactly once at mint.
- **Storage** — new `service_accounts` table in postgres / async-postgres / sqlite / async-sqlite adapters. Name uniqueness applies to *active* accounts only (partial unique index), so names can be reused to rotate credentials.
- **Auth path** — a PAT branch in `JWTMiddleware` (and the `os_security_key` dependency) attaches identity like the JWT path: `user_id` = `sa:<name>` principal, `scopes` = stored scopes. RBAC decision refactored into one shared helper used by JWT, internal-token, and PAT branches. PAT scopes are first-party ACL data, so they are enforced in **every** deployment mode — including `os_security_key` mode where JWT scopes are not.
- **Attribution** — runs made with a `claude-code` token show `sa:claude-code` on sessions and traces. The `sa:` namespace guarantees a PAT can never impersonate a human JWT `sub` under `user_isolation`.
- **API** — `POST /service-accounts` (mint; conservative default scopes, privileged scopes require an explicit flag, minted scopes must be a subset of the caller's own, default 90-day expiry), `GET /service-accounts` (metadata only), `DELETE /service-accounts/{id}` (soft revoke, idempotent).
- **Verification cache** — bounded TTL'd LRU keyed by token hash (default 30s; `0` = strict instant revocation). Revocation evicts locally at once; other workers converge within TTL.
- **Security defaults** — uniform 401 for all verification failures, fail-closed 503 on DB errors, per-client failed-lookup rate limiter that never blocks a valid token.

### Part 2 — MCP run tools v2: trimmed results + progress

The `/mcp` run tools (`run_agent`, `run_team`, `run_workflow`) previously returned the raw `RunOutput` dataclass: the full transcript (including the agent's system prompt), per-message metrics, and member responses — ~8k tokens injected into the frontend model's context for a ~370-token answer, and a hard serialization error whenever a run produced binary media.

Now:

- **Trimmed results by default** (`agno/os/mcp_results.py`). The tool result carries the answer as a text block, generated images/audio as proper MCP content blocks (base64 via the media-safe path — binary media no longer errors), and `structuredContent` limited to `run_id` / `session_id` / `status`, plus the unresolved requirements when a run pauses for HITL. The transcript, system prompt, and metrics never reach the client.
- **`MCPServerConfig.result_mode: "trimmed" | "full"`** — `"full"` is the escape hatch for programmatic clients: complete `to_dict()` in `structuredContent`, media-safe.
- **Progress notifications.** Run tools now drive agno's event stream internally and forward tool-call events (agents/teams) and step started/completed events (workflows, step `k/n` in the message) as MCP progress notifications, with strictly increasing progress values per the MCP spec. Clients that send a `progressToken` get liveness and timeout-resets during long runs; clients that don't are unaffected (FastMCP no-ops without a token).
- **Terminal-state coverage** (hardened by an 8-angle adversarial review of the diff): failed runs surface the real error message from the run-error event instead of a generic failure; paused and cancelled workflows — whose foreground streams end with **no** terminal event — are recovered from the persisted run via `workflow.aget_run_output` (the REST router's source of truth), so the client keeps the `run_id` and requirements needed to continue; nested-workflow events are depth-filtered so a nested failure the outer workflow recovers from cannot abort the run; remote agents/teams/workflows (whose streams never yield a final output) take the non-streaming path.

**Breaking change (intentional):** MCP clients that parsed the old raw-`RunOutput` structure from the run tools must either read the trimmed shape or set `result_mode="full"`. The old default was wrong for the primary consumer — an LLM frontend — and also leaked the system prompt to any connected client.

### Part 3 — The 8-tool surface (19 → 8) + run lifecycle

The MCP surface is redesigned around what a frontend actually does — discover, run, continue, cancel, review history — instead of mirroring the REST database console:

| Tool | Tag | Notes |
|------|-----|-------|
| `get_agentos_config` | `core` | Discovery: component ids + db ids. Payload now ~400 chars (was a 15KB inline schema + full config dump). |
| `run_agent` / `run_team` / `run_workflow` | `core` | As in Part 2. |
| `continue_run` **(new)** | `core` | Resume a PAUSED (HITL) run: the paused result's `requirements` round-trip back after the client resolves them (`RunRequirement` for agents/teams, `StepRequirement` for workflows). Remote components are rejected (mirrors the REST 400) rather than crashing on requirement forwarding. |
| `cancel_run` **(new)** | `core` | Request cancellation on a named component. Both lifecycle tools take exactly one component id and enforce run ownership for scoped (non-admin) callers via the same session check the REST cancel/continue endpoints use. |
| `get_sessions` / `get_session_runs` | `session` | Read-only continuity. `session_type` auto-detected on reads; `db_id` optional (single-db default). `get_session_runs` returns per-run content only — never the message transcript / system prompt. |

**Removed (11 tools):** all 6 memory tools and all 5 session-write tools plus `get_session`. Memory is managed inside runs; sessions are created implicitly by run tools. This also deletes the two confirmed history-wiping footguns (`create_session`/`update_session` on existing sessions). `MCP_BUILTIN_TAGS` collapses to `{core, session}` — the removed `memory` tag now fails validation loudly instead of silently scoping nothing. Anything removed remains available on REST or as a custom tool via `MCPServerConfig.tools`.

### Part 4 — Shared service layer (`agno/os/services/`)

The MCP session tools were a hand-copied fork of the REST routers (7 confirmed drift bugs in review: wrong `session_type` defaults, dropped RemoteDb auth, event-loop blocking). Now one implementation backs both surfaces:

- `services/sessions.py` — session listing, type auto-detection, per-run classification (mirrors REST exactly, including dropping team-session runs with neither agent nor team id), timestamp filtering, and **threadpool offload for sync DBs** so neither surface blocks its event loop. The REST `get_session_runs` handler now delegates to it.
- `services/runs.py` — `continue_paused_run` (dispatches `RunRequirement` vs `StepRequirement` by component type; rejects remote components; pins `stream=False`) and `cancel_component_run` (one call to the named component — the agent/team/workflow cancellation registries are process-global, so ownership is enforced by the caller, matching REST).
- `services/sessions.py` also owns the surface-agnostic ownership check (`verify_run_ownership`) used by both lifecycle tools.
- MCP RemoteDb calls now forward the caller's `Authorization` header, matching REST — a JWT/PAT-protected downstream AgentOS works over `/mcp`.

### Part 5 — Wiring fixes + LLM ergonomics + cookbook

**Wiring (`app.py`):**
- `resync()` no longer rebuilds the MCP app — the tools close over the live AgentOS (new components are visible without a rebuild), and the rebuilt app's StreamableHTTP lifespan never ran, 500-ing every `/mcp` request until restart.
- `_mount_mcp_app()` is idempotent; `get_app()` with a `base_app` is now idempotent too (previously: duplicated mounts, doubled lifespans → double db init + orphaned MCP session manager).
- The home router is always registered: `GET /` returns the API-info JSON instead of falling through to the MCP app's plain-text 404.

**Ergonomics:** every tool carries MCP annotations (`readOnlyHint` on config/reads, `destructiveHint` on `cancel_run`) so clients can shape permission prompts; descriptions state the operating workflow ("call `get_agentos_config` first…", PAUSED → `continue_run`); `session_type` is a `Literal` so invalid values fail at the schema; `db_id` is optional.

**Cookbook (`cookbook/05_agent_os/mcp_demo/`):** README documents the 8-tool surface; `test_client.py` fixed (OpenAIResponses/gpt-5.5 per repo rules, stale docstring path/flag corrected); TEST_LOG updated from a **live end-to-end run** — see Additional Notes.

---

## Type of change

- [x] New feature
- [x] Breaking change (MCP run tool result shape; `result_mode="full"` escape hatch)
- [x] Improvement

---

## How to review

Review by area; the commits are separated by stream.

**Area 1 — service accounts** (reviewed adversarially pre-merge; confirmed findings fixed with regression tests):
1. `agno/os/service_accounts.py` — token format, hashing, verifier, cache, rate limiter.
2. `agno/os/middleware/jwt.py` — `_dispatch_service_account` and the shared `_check_scopes` RBAC helper. Invariant: PAT scopes enforced in all modes; uniform 401s.
3. `agno/os/routers/service_accounts/` — mint/list/revoke; invariant: subset rule + explicit privileged flag = no escalation.
4. DB adapters (`agno/db/*/`) — partial unique index semantics.

**Area 2 — MCP run results** (also adversarially reviewed pre-merge; the 8-angle review's confirmed findings — swallowed run errors, paused-workflow dead-end, nested-event bleed-through, non-monotonic progress, remote-component breakage — are all fixed with regression tests):
1. `agno/os/mcp_results.py` — the serializer. Invariant: nothing from `messages` (transcript/system prompt) can reach trimmed output; bytes are always base64'd before pydantic sees them.
2. `agno/os/mcp.py` — `_consume_agentic_stream` / `_consume_workflow_stream` (stream driving + progress + error capture), `_run_agentic_component` (remote fallback), and the three run tool bodies. Invariant: every terminal state (completed/paused/cancelled/error) produces either a `ToolResult` or a raised tool error carrying the real failure message — never a hang, never a silent generic error.
3. `agno/os/config.py` — `result_mode` on `MCPServerConfig`.

**Area 3 — surface trim + services + wiring** (also adversarially reviewed pre-merge):
1. `agno/os/services/sessions.py` + `runs.py` — the shared layer. Invariants: classification mirrors REST exactly; sync DB calls never run on the event loop; `stream=False` pinned on continue.
2. `agno/os/mcp.py` — the 8 tools end-state: annotations, descriptions, optional `db_id`, `Literal` types, auth-header forwarding on RemoteDb branches.
3. `agno/os/app.py` — `_mount_mcp_app`, the `resync()` reuse, `_base_app_prepared`, always-on home router. Invariant: exactly one mount, exactly one started MCP lifespan, across any get_app/resync sequence.
4. `agno/os/routers/session/session.py` — REST `get_session_runs` delegating to the service (behavior-preserving).

**Run the tests:**
```bash
source .venv/bin/activate
pytest libs/agno/tests/unit/os/  # includes test_mcp_server, test_mcp_run_results, test_mcp_surface_v2
```

**Manual smoke (performed live, see TEST_LOG):** run `cookbook/05_agent_os/mcp_demo/enable_mcp_example.py`, connect an MCP client to `http://localhost:7777/mcp`: `tools/list` shows exactly 8 tools with annotations; `run_agent` returns content + ids only (158 chars for a hello-world run) with a progress notification; `get_session_runs` reads the conversation back with no `session_type`/`db_id`.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests** — Service accounts: unit (token utils, verifier incl. cache/rate-limiter/DB-error handling, router, scopes), integration over sqlite (JWT mints PAT → PAT runs agent → `sa:` attribution; 403/uniform-401; security-key and open-instance modes), DB-adapter tests on sqlite and postgres. MCP: 13 result-serialization tests + 12 v2-surface tests (annotations on the wire, compact config, continue_run identity/requirement parsing for agents AND workflows, cancel intent semantics, service auto-detection/classification/threadpool/not-found, resync reuse, home route, base_app idempotency) + the server tests updated to the 8-tool surface — full OS unit suite green (**1415 passed**). System tests rewritten to the v2.7 surface (removed-tool absence asserted; `get_session_runs` happy/not-found paths added). Integration failures in `test_output_schema_override`/`test_backround_tasks`/`test_knowledge` are pre-existing on the branch (verified identical on a clean tree).

**Live verification** — the flagship cookbook was run end-to-end with a real MCP client and a live Claude agent: 8 tools listed with annotations, config payload ~400 chars, `run_agent` wire payload **158 chars** (vs ~16.7k tokens before Part 2) with zero transcript leakage and a delivered progress notification, session history read back via auto-detection, and the missing-API-key case surfacing the real provider error through the tool error.

**Migrations** — none; the `service_accounts` table auto-creates via `_create_all_tables`.

**Known limitations** — WebSocket endpoints don't accept PATs yet (verifier is on `app.state`; clean follow-up). Workflow streaming lacks `yield_run_output`, so the MCP layer reconstructs the final output from terminal events — consider adding `yield_run_output` to `Workflow.arun` as a follow-up and deleting the reconstruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)