### PR TITLE
feat: add agnoctl, the unified Agno CLI (connect, tokens, create, infra)

### DIFF
--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -1,7 +1,7 @@
 import asyncio
 import hmac
 from os import getenv
-from typing import Any, List, Optional, Set
+from typing import Any, List, Literal, Optional, Set
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -118,6 +118,30 @@ def _is_jwt_configured() -> bool:
     This covers cases where JWT middleware is set up manually (not via authorization=True).
     """
     return bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
+
+
+def get_effective_auth_mode(
+    settings: Optional[AgnoAPISettings], authorization: bool = False
+) -> Literal["none", "security_key", "jwt"]:
+    """Return the authentication mode effectively enforced by the OS.
+
+    Mirrors the precedence used by ``get_authentication_dependency``:
+    JWT (via authorization=True on AgentOS or JWT environment variables) takes
+    precedence over the security key, which takes precedence over no auth.
+
+    Args:
+        settings: The API settings containing the security key and authorization flag
+        authorization: The AgentOS authorization flag (JWT middleware enabled)
+
+    Returns:
+        "jwt" when JWT authorization is effectively active, "security_key" when
+        only the OS security key is enforced, "none" when authentication is disabled.
+    """
+    if authorization or (settings is not None and settings.authorization_enabled) or _is_jwt_configured():
+        return "jwt"
+    if settings is not None and settings.os_security_key:
+        return "security_key"
+    return "none"
 
 
 def get_authentication_dependency(settings: AgnoAPISettings):

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -755,6 +755,104 @@ def _add_authorize_middleware(mcp_app: StarletteWithLifespan, authorize: Callabl
     mcp_app.add_middleware(_MCPAuthorizeMiddleware)
 
 
+def _add_key_auth_middleware(
+    mcp_app: StarletteWithLifespan,
+    security_key: Optional[str],
+    service_account_verifier: Optional[Any],
+) -> None:
+    """Enforce the REST auth rules over ``/mcp`` in non-JWT deployments.
+
+    The REST surface enforces ``OS_SECURITY_KEY`` and service account tokens through a
+    FastAPI router dependency (``agno.os.auth.get_authentication_dependency``), but router
+    dependencies never run for mounted sub-apps -- without this middleware the MCP surface
+    would be completely open in security-key mode. Mirrors the dependency's rules: a bearer
+    (or raw) token is accepted when it matches the security key or is a valid service
+    account token (``agno_pat_...``); with no security key configured, requests without a
+    service account token pass through, matching REST's open mode.
+
+    The verifier is captured at construction because the mounted MCP app has its own
+    ``app.state`` -- the middleware cannot find it on the main app's state from inside
+    the mount.
+    """
+    import hmac
+
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse
+
+    from agno.os.auth import _is_jwt_configured
+    from agno.os.service_accounts import TOKEN_PREFIX, VerificationStatus
+
+    class _MCPKeyAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+            # Skip CORS preflight, mirroring the JWT middleware.
+            if request.method == "OPTIONS":
+                return await call_next(request)
+
+            # A JWT middleware on the parent app may have already authenticated the
+            # request (request.state is carried through the mount); mirror the REST
+            # dependency and let it through.
+            if getattr(request.state, "authenticated", False):
+                return await call_next(request)
+
+            # Accept both "Bearer <token>" and a raw token, like the JWT middleware.
+            authorization = request.headers.get("Authorization", "")
+            if authorization.lower().startswith("bearer "):
+                token = authorization[7:].strip()
+            else:
+                token = authorization.strip()
+
+            # Service account tokens are verified in every deployment mode (mirrors REST).
+            if token.startswith(TOKEN_PREFIX):
+                return await self._dispatch_service_account(request, token, call_next)
+
+            # JWT configured via environment variables (manual middleware setup): the
+            # REST dependency skips security key validation in this case; do the same.
+            if _is_jwt_configured():
+                return await call_next(request)
+
+            # No security key configured: open instance, matching REST.
+            if not security_key:
+                return await call_next(request)
+
+            if not token:
+                return JSONResponse({"detail": "Authorization header required"}, status_code=401)
+
+            if hmac.compare_digest(token, security_key):
+                return await call_next(request)
+
+            return JSONResponse({"detail": "Invalid authentication token"}, status_code=401)
+
+        async def _dispatch_service_account(self, request, token, call_next):  # type: ignore[no-untyped-def]
+            # Mirrors agno.os.auth._authenticate_service_account: uniform 401 detail for
+            # unknown/revoked/expired tokens, 429 when throttled, 503 when the database
+            # cannot be reached.
+            if service_account_verifier is None:
+                return JSONResponse(
+                    {"detail": "Service accounts are not enabled on this AgentOS instance"}, status_code=401
+                )
+
+            client_key = request.client.host if request.client else None
+            result = await service_account_verifier.verify(token, client_key=client_key)
+
+            if result.status == VerificationStatus.THROTTLED:
+                return JSONResponse({"detail": "Too many failed authentication attempts"}, status_code=429)
+            if result.status == VerificationStatus.UNAVAILABLE:
+                return JSONResponse({"detail": "Authentication is temporarily unavailable"}, status_code=503)
+            account = result.account
+            if not result.ok or account is None:
+                return JSONResponse({"detail": "Invalid or expired service account token"}, status_code=401)
+
+            # Attribution: _resolve_user_id reads request.state.user_id for tool calls.
+            request.state.authenticated = True
+            request.state.user_id = account.principal
+            request.state.session_id = None
+            request.state.scopes = list(account.scopes)
+            request.state.service_account_name = account.name
+            return await call_next(request)
+
+    mcp_app.add_middleware(_MCPKeyAuthMiddleware)
+
+
 # Localhost defaults so a desktop / local MCP server is protected with zero extra config.
 _MCP_LOCALHOST_HOSTS = ("127.0.0.1", "localhost", "[::1]")
 
@@ -822,8 +920,9 @@ def get_mcp_server(
     """Build the MCP HTTP app served at ``/mcp``.
 
     Wraps :func:`build_mcp_server` with the Streamable HTTP transport and layers on (from the
-    inside out) the JWT middleware (when authorization is enabled), the optional ``authorize``
-    gate, any app-provided middleware, and the built-in DNS-rebinding protection -- all from
+    inside out) the JWT middleware (when authorization is enabled) or the security-key /
+    service-account auth middleware (otherwise), the optional ``authorize`` gate, any
+    app-provided middleware, and the built-in DNS-rebinding protection -- all from
     ``mcp_config``.
     """
     mcp = build_mcp_server(os)
@@ -883,6 +982,18 @@ def get_mcp_server(
         if service_account_verifier is not None:
             jwt_kwargs["service_account_verifier"] = service_account_verifier
         mcp_app.add_middleware(JWTMiddleware, **jwt_kwargs)
+    else:
+        # Non-JWT deployments: the REST surface enforces OS_SECURITY_KEY and service
+        # account tokens through a router dependency, which never runs for mounted
+        # sub-apps -- without this, /mcp would be completely open in security-key mode.
+        # Added in the same layer position as the JWT middleware above, so transport
+        # security still runs outermost and the authorize gate sees the verified
+        # identity. Nothing is added when auth is fully disabled (no security key and
+        # no service account verifier), matching REST's open mode.
+        security_key = os.settings.os_security_key if os.settings else None
+        service_account_verifier = os._get_service_account_verifier()
+        if security_key or service_account_verifier is not None:
+            _add_key_auth_middleware(mcp_app, security_key, service_account_verifier)
 
     # App-provided middleware, preserving the order they were listed in.
     if mcp_config is not None and mcp_config.middleware:

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -12,7 +12,7 @@ from agno import __version__ as agno_version
 from agno.agent.factory import AgentFactory
 from agno.agent.protocol import AgentProtocol
 from agno.exceptions import RemoteServerUnavailableError
-from agno.os.auth import get_authentication_dependency, validate_websocket_token
+from agno.os.auth import get_authentication_dependency, get_effective_auth_mode, validate_websocket_token
 from agno.os.managers import websocket_manager
 from agno.os.middleware.jwt import JWTValidator
 from agno.os.middleware.user_scope import (
@@ -32,6 +32,7 @@ from agno.os.schema import (
     InfoResponse,
     InterfaceResponse,
     InternalServerErrorResponse,
+    McpInfo,
     Model,
     NotFoundResponse,
     TeamSummaryResponse,
@@ -265,11 +266,14 @@ def get_info_router(os: "AgentOS") -> APIRouter:
         response_model=InfoResponse,
     )
     async def get_info() -> InfoResponse:
+        mcp_enabled = bool(os.enable_mcp_server)
         return InfoResponse(
             agno_version=agno_version,
             agent_count=len(os.agents or []),
             team_count=len(os.teams or []),
             workflow_count=len(os.workflows or []),
+            mcp=McpInfo(enabled=mcp_enabled, path="/mcp" if mcp_enabled else None),
+            auth_mode=get_effective_auth_mode(settings=os.settings, authorization=os.authorization),
         )
 
     return router

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -225,6 +225,13 @@ class WorkflowSummaryResponse(BaseModel):
         )
 
 
+class McpInfo(BaseModel):
+    """MCP server availability for the /info endpoint."""
+
+    enabled: bool = Field(False, description="Whether the MCP server is enabled on this OS instance")
+    path: Optional[str] = Field(None, description="Path where the MCP server is mounted, null when disabled")
+
+
 class InfoResponse(BaseModel):
     """Response schema for the /info endpoint returning lightweight OS metadata."""
 
@@ -232,6 +239,10 @@ class InfoResponse(BaseModel):
     agent_count: int = Field(0, description="Number of agents registered in the OS")
     team_count: int = Field(0, description="Number of teams registered in the OS")
     workflow_count: int = Field(0, description="Number of workflows registered in the OS")
+    mcp: McpInfo = Field(default_factory=McpInfo, description="MCP server availability for this OS instance")
+    auth_mode: Literal["none", "security_key", "jwt"] = Field(
+        "none", description="Authentication mode effectively enforced by this OS instance"
+    )
 
 
 class ConfigResponse(BaseModel):

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -2,6 +2,7 @@
 
 import time
 from datetime import UTC, datetime, timedelta
+from importlib.util import find_spec
 from unittest.mock import AsyncMock, patch
 
 import jwt
@@ -320,3 +321,90 @@ class TestServiceAccountsOnOpenInstance:
     def test_invalid_pat_rejected_even_on_open_instance(self, open_client):
         response = open_client.get("/sessions", headers={"Authorization": "Bearer agno_pat_invalid000000000000000000"})
         assert response.status_code == 401
+
+
+# A minimal MCP initialize request - enough to reach (or be blocked before) the MCP machinery.
+MCP_INIT_BODY = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1"},
+    },
+}
+MCP_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+
+
+@pytest.mark.skipif(find_spec("fastmcp") is None, reason="fastmcp is not installed")
+class TestServiceAccountsOverMCP:
+    """The mounted /mcp app enforces the same auth rules as REST in non-JWT modes.
+
+    Router dependencies never run for mounted sub-apps, so /mcp carries its own auth
+    middleware. These tests drive the full AgentOS app end to end: mint over REST,
+    then call the MCP endpoint.
+    """
+
+    @pytest.fixture
+    def mcp_security_key_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(
+            agents=[test_agent],
+            db=sqlite_db,
+            enable_mcp_server=True,
+            settings=AgnoAPISettings(os_security_key="root-security-key"),
+        )
+        # Context manager so the MCP session manager lifespan runs.
+        with TestClient(agent_os.get_app()) as client:
+            yield client
+
+    @pytest.fixture
+    def mcp_open_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db, enable_mcp_server=True)
+        with TestClient(agent_os.get_app()) as client:
+            yield client
+
+    def _mcp_post(self, client, token=None):
+        headers = dict(MCP_HEADERS)
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+        return client.post("/mcp", json=MCP_INIT_BODY, headers=headers)
+
+    def test_mcp_rejects_request_without_token(self, mcp_security_key_client):
+        response = self._mcp_post(mcp_security_key_client)
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Authorization header required"
+
+    def test_mcp_rejects_bad_token(self, mcp_security_key_client):
+        response = self._mcp_post(mcp_security_key_client, token="not-the-key")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication token"
+
+    def test_mcp_accepts_security_key(self, mcp_security_key_client):
+        response = self._mcp_post(mcp_security_key_client, token="root-security-key")
+        assert response.status_code == 200
+
+    def test_mcp_accepts_valid_pat(self, mcp_security_key_client):
+        pat = _mint(mcp_security_key_client, "root-security-key").json()["token"]
+        response = self._mcp_post(mcp_security_key_client, token=pat)
+        assert response.status_code == 200
+
+    def test_mcp_rejects_revoked_pat(self, mcp_security_key_client):
+        minted = _mint(mcp_security_key_client, "root-security-key").json()
+        revoke = mcp_security_key_client.delete(
+            f"/service-accounts/{minted['id']}",
+            headers={"Authorization": "Bearer root-security-key"},
+        )
+        assert revoke.status_code == 204
+
+        response = self._mcp_post(mcp_security_key_client, token=minted["token"])
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_mcp_stays_open_without_security_key(self, mcp_open_client):
+        assert self._mcp_post(mcp_open_client).status_code == 200
+
+    def test_mcp_rejects_invalid_pat_even_on_open_instance(self, mcp_open_client):
+        response = self._mcp_post(mcp_open_client, token="agno_pat_invalid000000000000000000")
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL

--- a/libs/agno/tests/unit/os/test_info_endpoint.py
+++ b/libs/agno/tests/unit/os/test_info_endpoint.py
@@ -1,0 +1,111 @@
+"""Tests for the unauthenticated GET /info endpoint.
+
+Covers the discovery fields used by external tooling (e.g. the agno CLI):
+MCP server availability (enabled + mount path) and the effective auth mode
+("none" / "security_key" / "jwt").
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.os import AgentOS
+from agno.os.auth import get_effective_auth_mode
+from agno.os.config import AuthorizationConfig
+from agno.os.settings import AgnoAPISettings
+
+JWT_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture(autouse=True)
+def clean_auth_env(monkeypatch):
+    """Keep ambient auth env vars from leaking into these tests."""
+    monkeypatch.delenv("OS_SECURITY_KEY", raising=False)
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+
+
+def _build_client(**kwargs) -> TestClient:
+    agent = Agent(name="Info Agent", id="info-agent", telemetry=False)
+    os_instance = AgentOS(agents=[agent], telemetry=False, **kwargs)
+    return TestClient(os_instance.get_app())
+
+
+class TestInfoEndpointBasics:
+    def test_returns_version_and_counts(self):
+        client = _build_client()
+        resp = client.get("/info")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["agno_version"]
+        assert body["agent_count"] == 1
+        assert body["team_count"] == 0
+        assert body["workflow_count"] == 0
+
+
+class TestInfoEndpointMcpDiscovery:
+    def test_mcp_disabled_by_default(self):
+        client = _build_client()
+        body = client.get("/info").json()
+        assert body["mcp"] == {"enabled": False, "path": None}
+
+    def test_mcp_enabled_reports_path(self):
+        pytest.importorskip("fastmcp")
+        client = _build_client(enable_mcp_server=True)
+        body = client.get("/info").json()
+        assert body["mcp"] == {"enabled": True, "path": "/mcp"}
+
+
+class TestInfoEndpointAuthMode:
+    def test_auth_mode_none_by_default(self):
+        client = _build_client()
+        body = client.get("/info").json()
+        assert body["auth_mode"] == "none"
+
+    def test_auth_mode_security_key(self):
+        client = _build_client(settings=AgnoAPISettings(os_security_key="test-key"))
+        resp = client.get("/info")
+        # /info stays unauthenticated even when a security key is enforced
+        assert resp.status_code == 200
+        assert resp.json()["auth_mode"] == "security_key"
+
+    def test_auth_mode_jwt_via_authorization_flag(self):
+        client = _build_client(
+            authorization=True,
+            authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+        )
+        resp = client.get("/info")
+        # /info is excluded from JWT middleware and stays unauthenticated
+        assert resp.status_code == 200
+        assert resp.json()["auth_mode"] == "jwt"
+
+    def test_auth_mode_jwt_via_env_takes_precedence_over_security_key(self, monkeypatch):
+        monkeypatch.setenv("JWT_VERIFICATION_KEY", JWT_SECRET)
+        client = _build_client(settings=AgnoAPISettings(os_security_key="test-key"))
+        body = client.get("/info").json()
+        # JWT configured via env vars is effectively enforced, even without authorization=True
+        assert body["auth_mode"] == "jwt"
+
+
+class TestGetEffectiveAuthMode:
+    def test_none_when_settings_missing(self):
+        assert get_effective_auth_mode(settings=None) == "none"
+
+    def test_none_when_nothing_configured(self):
+        assert get_effective_auth_mode(settings=AgnoAPISettings()) == "none"
+
+    def test_security_key(self):
+        settings = AgnoAPISettings(os_security_key="test-key")
+        assert get_effective_auth_mode(settings=settings) == "security_key"
+
+    def test_jwt_via_authorization_flag(self):
+        settings = AgnoAPISettings(os_security_key="test-key")
+        assert get_effective_auth_mode(settings=settings, authorization=True) == "jwt"
+
+    def test_jwt_via_settings_flag(self):
+        settings = AgnoAPISettings(authorization_enabled=True)
+        assert get_effective_auth_mode(settings=settings) == "jwt"
+
+    def test_jwt_via_jwks_env_var(self, monkeypatch):
+        monkeypatch.setenv("JWT_JWKS_FILE", "/tmp/jwks.json")
+        assert get_effective_auth_mode(settings=AgnoAPISettings()) == "jwt"

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -13,8 +13,10 @@ import pytest
 
 pytest.importorskip("fastmcp")
 
+import time  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 from typing import Optional  # noqa: E402
+from uuid import uuid4  # noqa: E402
 
 import httpx  # noqa: E402
 from fastmcp import Client, Context  # noqa: E402
@@ -23,9 +25,12 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 
 import agno.os.mcp as mcp_mod  # noqa: E402
 from agno.agent import Agent  # noqa: E402
+from agno.db.schemas.service_accounts import ServiceAccount  # noqa: E402
 from agno.os import AgentOS, MCPServerConfig  # noqa: E402
 from agno.os.config import AuthorizationConfig  # noqa: E402
 from agno.os.mcp import _resolve_user_id, build_mcp_server, get_mcp_server  # noqa: E402
+from agno.os.service_accounts import ServiceAccountVerification, VerificationStatus, generate_token  # noqa: E402
+from agno.os.settings import AgnoAPISettings  # noqa: E402
 from agno.run.agent import RunOutput  # noqa: E402
 from agno.run.team import TeamRunOutput  # noqa: E402
 from agno.run.workflow import WorkflowRunOutput  # noqa: E402
@@ -563,3 +568,200 @@ async def test_no_transport_security_when_unset():
     async with _mcp_http_client(_security_os()) as client:
         response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_headers(host="anything.example.com"))
     assert response.status_code == 200
+
+
+# ==================== Security key + service account auth (non-JWT modes) ====================
+
+# Router dependencies never run for mounted sub-apps, so in non-JWT modes /mcp gets its own
+# middleware mirroring the REST rules (agno.os.auth.get_authentication_dependency).
+
+
+def _sqlite_db(tmp_path):
+    from agno.db.sqlite import SqliteDb
+
+    return SqliteDb(db_file=str(tmp_path / "mcp_auth_test.db"))
+
+
+def _mint_pat(db, name="mcp-bot", revoked=False):
+    """Create a service account directly in the db and return its plaintext token."""
+    plaintext, token_hash, token_prefix = generate_token()
+    now = int(time.time())
+    account = ServiceAccount(
+        id=str(uuid4()),
+        name=name,
+        token_hash=token_hash,
+        token_prefix=token_prefix,
+        scopes=["agents:run"],
+        created_at=now,
+        revoked_at=now if revoked else None,
+    )
+    db.create_service_account(account.to_dict())
+    return plaintext
+
+
+def _auth_os(security_key=None, db=None, **config_kwargs) -> AgentOS:
+    return AgentOS(
+        agents=[_agent()],
+        db=db,
+        enable_mcp_server=True,
+        settings=AgnoAPISettings(os_security_key=security_key),
+        mcp_config=MCPServerConfig(tools=[_ok_tool], enable_builtin_tools=False, **config_kwargs),
+    )
+
+
+def _bearer(token: str) -> dict:
+    return {**_MCP_HEADERS, "Authorization": f"Bearer {token}"}
+
+
+async def test_security_key_mode_rejects_missing_token():
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authorization header required"
+
+
+async def test_security_key_mode_rejects_invalid_token():
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("wrong-key"))
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid authentication token"
+
+
+async def test_security_key_mode_accepts_the_key():
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("test-key"))
+    assert response.status_code == 200
+
+
+async def test_security_key_mode_accepts_raw_token():
+    """A raw (non-Bearer) Authorization header is accepted, like the JWT middleware."""
+    headers = {**_MCP_HEADERS, "Authorization": "test-key"}
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=headers)
+    assert response.status_code == 200
+
+
+async def test_security_key_mode_accepts_valid_pat_and_attributes(tmp_path):
+    """A valid agno_pat token authenticates, and the account principal + scopes land on
+    request.state so _resolve_user_id attributes tool calls to sa:<name>."""
+    db = _sqlite_db(tmp_path)
+    pat = _mint_pat(db)
+    captured: dict = {}
+
+    class _CaptureState(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+            response = await call_next(request)
+            captured["user_id"] = getattr(request.state, "user_id", None)
+            captured["scopes"] = getattr(request.state, "scopes", None)
+            return response
+
+    os = _auth_os(security_key="test-key", db=db, middleware=[Middleware(_CaptureState)])
+    async with _mcp_http_client(os) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer(pat))
+
+    assert response.status_code == 200
+    assert captured["user_id"] == "sa:mcp-bot"
+    assert captured["scopes"] == ["agents:run"]
+
+
+async def test_security_key_mode_rejects_revoked_pat(tmp_path):
+    db = _sqlite_db(tmp_path)
+    pat = _mint_pat(db, revoked=True)
+    async with _mcp_http_client(_auth_os(security_key="test-key", db=db)) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer(pat))
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired service account token"
+
+
+async def test_pat_without_db_gets_service_accounts_disabled_401():
+    """Without a db there is no verifier: a PAT gets REST's 'not enabled' 401, not a key check."""
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_notenabled0000000"))
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Service accounts are not enabled on this AgentOS instance"
+
+
+async def test_open_mode_with_db_stays_open_but_verifies_pats(tmp_path):
+    """No security key: requests without a PAT pass through (open, matching REST), but a
+    presented PAT is still verified and rejected when invalid."""
+    db = _sqlite_db(tmp_path)
+    async with _mcp_http_client(_auth_os(security_key=None, db=db)) as client:
+        open_response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
+        bad_pat_response = await client.post(
+            "/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_invalid00000000000")
+        )
+    assert open_response.status_code == 200
+    assert bad_pat_response.status_code == 401
+    assert bad_pat_response.json()["detail"] == "Invalid or expired service account token"
+
+
+def test_no_auth_mode_adds_no_key_auth_middleware():
+    """No security key and no db (no verifier): nothing is added and /mcp stays open."""
+    mcp_app = get_mcp_server(_auth_os(security_key=None))
+    assert not any(m.cls.__name__ == "_MCPKeyAuthMiddleware" for m in mcp_app.user_middleware)
+
+
+async def test_no_auth_mode_stays_open():
+    async with _mcp_http_client(_auth_os(security_key=None)) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
+    assert response.status_code == 200
+
+
+def test_jwt_mode_does_not_add_key_auth_middleware():
+    """JWT mode is unchanged: the JWT middleware handles /mcp auth, key auth is not added."""
+    os = AgentOS(
+        agents=[_agent()],
+        enable_mcp_server=True,
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=["dummy"]),
+        settings=AgnoAPISettings(os_security_key="test-key"),
+    )
+    names = [m.cls.__name__ for m in get_mcp_server(os).user_middleware]
+    assert "JWTMiddleware" in names
+    assert "_MCPKeyAuthMiddleware" not in names
+
+
+class _FakeVerifier:
+    def __init__(self, status):
+        self.status = status
+
+    async def verify(self, token, client_key=None):
+        return ServiceAccountVerification(status=self.status)
+
+
+@pytest.mark.parametrize(
+    "status,expected_status_code",
+    [(VerificationStatus.THROTTLED, 429), (VerificationStatus.UNAVAILABLE, 503)],
+)
+async def test_pat_verifier_statuses_map_like_rest(tmp_path, status, expected_status_code):
+    """THROTTLED -> 429 and UNAVAILABLE -> 503, matching the REST path in agno.os.auth."""
+    os = _auth_os(security_key="test-key", db=_sqlite_db(tmp_path))
+    os._service_account_verifier = _FakeVerifier(status)
+    async with _mcp_http_client(os) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_whatever0000000000"))
+    assert response.status_code == expected_status_code
+
+
+def test_key_auth_middleware_layer_position():
+    """Key auth sits where JWT would: inside transport security and app-provided middleware,
+    outside the authorize gate (add_middleware wraps outside-in)."""
+
+    class _Passthrough(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+            return await call_next(request)
+
+    os = _auth_os(
+        security_key="test-key",
+        allowed_hosts=[],
+        middleware=[Middleware(_Passthrough)],
+        authorize=lambda user_id: True,
+    )
+    names = [m.cls.__name__ for m in get_mcp_server(os).user_middleware]
+    expected_order = [
+        "_MCPTransportSecurityMiddleware",
+        "_Passthrough",
+        "_MCPKeyAuthMiddleware",
+        "_MCPAuthorizeMiddleware",
+    ]
+    positions = [names.index(name) for name in expected_order]
+    assert positions == sorted(positions), f"unexpected middleware order: {names}"

--- a/libs/agno_cli/LICENSE
+++ b/libs/agno_cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025-2026 Agno Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libs/agno_cli/README.md
+++ b/libs/agno_cli/README.md
@@ -13,9 +13,15 @@ This discovers the AgentOS (default `http://localhost:7777`), mints one service-
 ## Commands
 
 ```bash
+agno create NAME [-t agentos-docker|agentos-aws|agentos-railway] [-u REPO_URL] [--json]
+
+agno infra up [--file FILE] [--pull] [--dry-run] [--json]
+agno infra down [--file FILE] [--volumes] [--dry-run] [--json]
+agno infra restart [--file FILE] [--pull] [--dry-run] [--json]
+
 agno connect [--url URL] [--clients claude-code,codex,cursor] [--name NAME]
-             [--scopes SCOPE ...] [--expires 90d] [--rotate | --skip-existing]
-             [--server-name agno] [--project] [--json]
+             [--scopes SCOPE ...] [--expires 90d] [--privileged]
+             [--rotate | --skip-existing] [--server-name agno] [--project] [--json]
 
 agno tokens create NAME [--scopes SCOPE ...] [--expires 90d|never] [--privileged] [--json]
 agno tokens list [--json]
@@ -24,11 +30,16 @@ agno tokens revoke NAME [--json]
 agno status [--url URL] [--json]
 ```
 
+`create` scaffolds an AgentOS project from a starter template (git clone, history stripped,
+example secrets copied into place). `infra` runs the project's compose file — the legacy
+`ag infra` resource engine (per-resource Docker/AWS orchestration) is not ported; it is
+under redesign and will plug in via the `agno_cli.plugins` entry-point group.
+
 Admin credential resolution (for minting): `AGNO_ADMIN_TOKEN` env var, then `OS_SECURITY_KEY` env var, then an interactive prompt. When the target AgentOS has authorization disabled (local dev), minting is skipped and configs are written without credentials.
 
 ## Design rules
 
-- Built to be driven by coding agents: `--json` on every command, deterministic exit codes (0 ok, 1 failure, 2 partial), no prompts in `--json` mode.
+- Built to be driven by coding agents: `--json` on every command, deterministic exit codes (0 ok, 1 failure, 2 usage error, 3 partial success), no prompts in `--json` mode.
 - Talks plain HTTP to the AgentOS REST API. Never imports the `agno` framework.
 - Truthful outcomes: no command reports success it did not verify.
 - Secrets never go to logs; `connect` writes tokens straight into client configs and never prints them. `tokens create` prints the plaintext exactly once.

--- a/libs/agno_cli/README.md
+++ b/libs/agno_cli/README.md
@@ -1,0 +1,43 @@
+# agnoctl — the Agno CLI
+
+The operating surface for [AgentOS](https://docs.agno.com), built for humans and coding agents equally.
+
+The headline command connects a running AgentOS to your coding agents as an MCP server, authenticated with freshly minted service accounts:
+
+```bash
+uvx agno connect
+```
+
+This discovers the AgentOS (default `http://localhost:7777`), mints one service-account token per client (`claude-code`, `codex`, `cursor`), writes each client's MCP configuration, and verifies the connection end to end with a real MCP `tools/list` call. Re-running is safe: existing working connections are detected and skipped, broken ones are rotated.
+
+## Commands
+
+```bash
+agno connect [--url URL] [--clients claude-code,codex,cursor] [--name NAME]
+             [--scopes SCOPE ...] [--expires 90d] [--rotate | --skip-existing]
+             [--server-name agno] [--project] [--json]
+
+agno tokens create NAME [--scopes SCOPE ...] [--expires 90d|never] [--privileged] [--json]
+agno tokens list [--json]
+agno tokens revoke NAME [--json]
+
+agno status [--url URL] [--json]
+```
+
+Admin credential resolution (for minting): `AGNO_ADMIN_TOKEN` env var, then `OS_SECURITY_KEY` env var, then an interactive prompt. When the target AgentOS has authorization disabled (local dev), minting is skipped and configs are written without credentials.
+
+## Design rules
+
+- Built to be driven by coding agents: `--json` on every command, deterministic exit codes (0 ok, 1 failure, 2 partial), no prompts in `--json` mode.
+- Talks plain HTTP to the AgentOS REST API. Never imports the `agno` framework.
+- Truthful outcomes: no command reports success it did not verify.
+- Secrets never go to logs; `connect` writes tokens straight into client configs and never prints them. `tokens create` prints the plaintext exactly once.
+
+## Plugins
+
+Other distributions can add subcommands by exposing a `typer.Typer` under the `agno_cli.plugins` entry-point group:
+
+```toml
+[project.entry-points."agno_cli.plugins"]
+infra = "agno_infra.cli:infra_app"
+```

--- a/libs/agno_cli/README.md
+++ b/libs/agno_cli/README.md
@@ -15,9 +15,9 @@ This discovers the AgentOS (default `http://localhost:7777`), mints one service-
 ```bash
 agno create NAME [-t agentos-docker|agentos-aws|agentos-railway] [-u REPO_URL] [--json]
 
-agno infra up [--file FILE] [--pull] [--dry-run] [--json]
-agno infra down [--file FILE] [--volumes] [--dry-run] [--json]
-agno infra restart [--file FILE] [--pull] [--dry-run] [--json]
+agno up [--file FILE] [--pull] [--dry-run] [--json]
+agno down [--file FILE] [--volumes] [--dry-run] [--json]
+agno restart [--file FILE] [--pull] [--dry-run] [--json]
 
 agno connect [--url URL] [--clients claude-code,codex,cursor] [--name NAME]
              [--scopes SCOPE ...] [--expires 90d] [--privileged]
@@ -31,7 +31,7 @@ agno status [--url URL] [--json]
 ```
 
 `create` scaffolds an AgentOS project from a starter template (git clone, history stripped,
-example secrets copied into place). `infra` runs the project's compose file — the legacy
+example secrets copied into place). `up`/`down`/`restart` run the project's compose file — the legacy
 `ag infra` resource engine (per-resource Docker/AWS orchestration) is not ported; it is
 under redesign and will plug in via the `agno_cli.plugins` entry-point group.
 

--- a/libs/agno_cli/agno_cli/__init__.py
+++ b/libs/agno_cli/agno_cli/__init__.py
@@ -1,0 +1,3 @@
+"""agnoctl: the Agno CLI. Connect and operate AgentOS from the terminal."""
+
+__version__ = "0.1.0"

--- a/libs/agno_cli/agno_cli/clients/__init__.py
+++ b/libs/agno_cli/agno_cli/clients/__init__.py
@@ -1,0 +1,31 @@
+"""Client adapters: how each coding agent stores MCP server configuration."""
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult
+from agno_cli.clients.claude_code import ClaudeCodeAdapter
+from agno_cli.clients.codex import CodexAdapter
+from agno_cli.clients.cursor import CursorAdapter
+
+# Accepted spellings for --clients, mapped to canonical adapter keys.
+CLIENT_ALIASES = {
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "codex": "codex",
+    "cursor": "cursor",
+}
+
+
+def build_adapters(
+    home: Optional[Path] = None,
+    cwd: Optional[Path] = None,
+    project: bool = False,
+) -> Dict[str, ClientAdapter]:
+    """All known adapters keyed by canonical client key."""
+    claude_scope = "project" if project else "user"
+    return {
+        "claude-code": ClaudeCodeAdapter(home=home, cwd=cwd, scope=claude_scope),
+        "codex": CodexAdapter(home=home),
+        "cursor": CursorAdapter(home=home, cwd=cwd, project=project),
+    }

--- a/libs/agno_cli/agno_cli/clients/base.py
+++ b/libs/agno_cli/agno_cli/clients/base.py
@@ -25,6 +25,16 @@ class WriteResult:
 
     method: str  # "cli" (client's own CLI did the write) | "file" (we edited the config file)
     location: str
+    note: Optional[str] = None  # caveat worth surfacing to the user (e.g. VCS-shared file)
+
+
+def servers_table(config: object) -> dict:
+    """The mcpServers mapping from a parsed config, tolerating malformed shapes."""
+    if isinstance(config, dict):
+        servers = config.get("mcpServers")
+        if isinstance(servers, dict):
+            return servers
+    return {}
 
 
 def bearer_header(token: str) -> str:

--- a/libs/agno_cli/agno_cli/clients/base.py
+++ b/libs/agno_cli/agno_cli/clients/base.py
@@ -1,0 +1,57 @@
+"""Shared shapes for coding-agent client adapters.
+
+An adapter knows how one coding agent (Claude Code, Codex, Cursor) stores MCP server
+configuration: how to detect the client on this machine, read an existing entry back
+(for idempotent re-runs), and write an entry pointing at an AgentOS MCP endpoint.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ExistingEntry:
+    """An MCP server entry found in a client's configuration."""
+
+    url: str
+    token: Optional[str]
+    location: str  # human-readable: file path or config scope it was found in
+
+
+@dataclass
+class WriteResult:
+    """How and where a config write landed."""
+
+    method: str  # "cli" (client's own CLI did the write) | "file" (we edited the config file)
+    location: str
+
+
+def bearer_header(token: str) -> str:
+    return "Bearer " + token
+
+
+def token_from_authorization(value: Optional[str]) -> Optional[str]:
+    """Extract the raw token from an Authorization header value."""
+    if not value:
+        return None
+    if value.lower().startswith("bearer "):
+        return value[len("bearer ") :].strip() or None
+    return value.strip() or None
+
+
+class ClientAdapter(ABC):
+    key: str
+    display_name: str
+
+    @abstractmethod
+    def detect(self) -> bool:
+        """Whether this client appears to be installed or configured on this machine."""
+
+    @abstractmethod
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        """Return the existing MCP entry for server_name, if any."""
+
+    @abstractmethod
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        """Create or replace the MCP entry for server_name. Must be idempotent."""

--- a/libs/agno_cli/agno_cli/clients/claude_code.py
+++ b/libs/agno_cli/agno_cli/clients/claude_code.py
@@ -1,12 +1,18 @@
 """Claude Code adapter.
 
-Preferred path: the `claude mcp add` CLI (it owns its config files and handles scope
-placement). Fallback when the binary is missing: write the project-scoped .mcp.json,
-which Claude Code reads from the project root and which is safe for us to edit.
+Preferred write path: the `claude mcp add` CLI (the sanctioned interface; it owns config
+placement). Fallback when the binary is missing: edit the config file for the requested
+scope directly — ~/.claude.json (user scope) or <cwd>/.mcp.json (project scope).
 
-Config locations read for idempotency checks:
-- ~/.claude.json: top-level "mcpServers" (user scope) and projects.<cwd>.mcpServers (local scope)
-- <cwd>/.mcp.json: "mcpServers" (project scope)
+Reads follow Claude Code's same-name resolution precedence: local scope
+(~/.claude.json projects.<cwd>.mcpServers) > project (.mcp.json) > user
+(~/.claude.json mcpServers). Getting this order right matters: the entry this
+adapter reports is the one Claude Code will actually use, which is how connect
+detects stale shadowing entries after a write.
+
+Note: the CLI write path passes the Authorization header via argv, which is transiently
+visible in the local process list. The file fallback avoids this; both paths end with a
+read-back so a write that did not take effect is reported, never assumed.
 """
 
 import json
@@ -15,11 +21,20 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.clients.base import (
+    ClientAdapter,
+    ExistingEntry,
+    WriteResult,
+    bearer_header,
+    servers_table,
+    token_from_authorization,
+)
 from agno_cli.errors import CLIError
 
+SUBPROCESS_TIMEOUT = 60.0
 
-def _entry_from_config(servers: Dict[str, Any], server_name: str, location: str) -> Optional[ExistingEntry]:
+
+def _entry_from_servers(servers: Dict[str, Any], server_name: str, location: str) -> Optional[ExistingEntry]:
     entry = servers.get(server_name)
     if not isinstance(entry, dict):
         return None
@@ -62,39 +77,55 @@ class ClaudeCodeAdapter(ClientAdapter):
         return self._which("claude") is not None or self._user_config_path.exists()
 
     def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
-        project_config = self._read_json(self._project_config_path)
-        if project_config:
-            entry = _entry_from_config(
-                project_config.get("mcpServers") or {}, server_name, str(self._project_config_path)
-            )
-            if entry:
-                return entry
+        """Return the entry Claude Code would resolve: local > project > user scope."""
+        user_config = self._read_json_lenient(self._user_config_path)
 
-        user_config = self._read_json(self._user_config_path)
         if user_config:
-            entry = _entry_from_config(
-                user_config.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (user scope)"
-            )
-            if entry:
-                return entry
             projects = user_config.get("projects")
             if isinstance(projects, dict):
                 project = projects.get(str(self.cwd))
                 if isinstance(project, dict):
-                    entry = _entry_from_config(
-                        project.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (local scope)"
+                    entry = _entry_from_servers(
+                        servers_table(project), server_name, str(self._user_config_path) + " (local scope)"
                     )
                     if entry:
                         return entry
+
+        project_config = self._read_json_lenient(self._project_config_path)
+        if project_config:
+            entry = _entry_from_servers(servers_table(project_config), server_name, str(self._project_config_path))
+            if entry:
+                return entry
+
+        if user_config:
+            entry = _entry_from_servers(
+                servers_table(user_config), server_name, str(self._user_config_path) + " (user scope)"
+            )
+            if entry:
+                return entry
         return None
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         if self._which("claude") is not None:
             self._write_via_cli(server_name, url, token)
             return WriteResult(method="cli", location="claude mcp add (scope: " + self.scope + ")")
-        return self._write_project_file(server_name, url, token)
+        if self.scope == "project":
+            return self._write_config_file(self._project_config_path, server_name, url, token, top_level=True)
+        return self._write_config_file(self._user_config_path, server_name, url, token, top_level=True)
 
     # -- CLI path ---------------------------------------------------------------
+
+    def _run_claude(self, args: List[str]) -> "subprocess.CompletedProcess[str]":
+        try:
+            return self._runner(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=SUBPROCESS_TIMEOUT,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise CLIError("The claude CLI did not respond within " + str(int(SUBPROCESS_TIMEOUT)) + "s: " + args[2])
 
     def _write_via_cli(self, server_name: str, url: str, token: Optional[str]) -> None:
         # Variadic flags (--header) must come after the name and URL, or Claude Code's
@@ -103,32 +134,42 @@ class ClaudeCodeAdapter(ClientAdapter):
         if token:
             add_args += ["--header", "Authorization: " + bearer_header(token)]
 
-        result = self._runner(add_args, capture_output=True, text=True)
+        result = self._run_claude(add_args)
         if result.returncode != 0 and "already exists" in (result.stderr or "").lower():
-            remove = self._runner(
-                ["claude", "mcp", "remove", "--scope", self.scope, server_name], capture_output=True, text=True
-            )
+            remove = self._run_claude(["claude", "mcp", "remove", "--scope", self.scope, server_name])
             if remove.returncode == 0:
-                result = self._runner(add_args, capture_output=True, text=True)
+                result = self._run_claude(add_args)
         if result.returncode != 0:
             detail = (result.stderr or result.stdout or "").strip()
             raise CLIError("claude mcp add failed: " + (detail or "unknown error"))
 
     # -- File fallback ------------------------------------------------------------
 
-    def _write_project_file(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
-        path = self._project_config_path
-        config = self._read_json(path) or {}
-        servers = config.setdefault("mcpServers", {})
+    def _write_config_file(
+        self, path: Path, server_name: str, url: str, token: Optional[str], top_level: bool
+    ) -> WriteResult:
+        config = self._read_json_strict(path)
+        servers = config.get("mcpServers")
+        if servers is None:
+            servers = {}
+            config["mcpServers"] = servers
+        elif not isinstance(servers, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": 'mcpServers' is not an object.")
         entry: Dict[str, Any] = {"type": "http", "url": url}
         if token:
             entry["headers"] = {"Authorization": bearer_header(token)}
         servers[server_name] = entry
         path.write_text(json.dumps(config, indent=2) + "\n")
-        return WriteResult(method="file", location=str(path))
+        if token:
+            path.chmod(0o600)
+        note = None
+        if path == self._project_config_path and token:
+            note = str(path) + " is project-scoped and often committed to version control; it now contains a token."
+        return WriteResult(method="file", location=str(path), note=note)
 
     @staticmethod
-    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    def _read_json_lenient(path: Path) -> Optional[Dict[str, Any]]:
+        """For reads: a missing or malformed file simply means no entry found."""
         if not path.exists():
             return None
         try:
@@ -136,3 +177,19 @@ class ClaudeCodeAdapter(ClientAdapter):
         except (OSError, json.JSONDecodeError):
             return None
         return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
+    def _read_json_strict(path: Path) -> Dict[str, Any]:
+        """For writes: refuse to clobber a file we cannot parse."""
+        if not path.exists():
+            return {}
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            raise CLIError(
+                "Refusing to modify " + str(path) + ": the existing file is not valid JSON (" + str(e) + ").",
+                hint="Fix or move the file, then re-run.",
+            )
+        if not isinstance(parsed, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": expected a JSON object at the top level.")
+        return parsed

--- a/libs/agno_cli/agno_cli/clients/claude_code.py
+++ b/libs/agno_cli/agno_cli/clients/claude_code.py
@@ -1,0 +1,138 @@
+"""Claude Code adapter.
+
+Preferred path: the `claude mcp add` CLI (it owns its config files and handles scope
+placement). Fallback when the binary is missing: write the project-scoped .mcp.json,
+which Claude Code reads from the project root and which is safe for us to edit.
+
+Config locations read for idempotency checks:
+- ~/.claude.json: top-level "mcpServers" (user scope) and projects.<cwd>.mcpServers (local scope)
+- <cwd>/.mcp.json: "mcpServers" (project scope)
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.errors import CLIError
+
+
+def _entry_from_config(servers: Dict[str, Any], server_name: str, location: str) -> Optional[ExistingEntry]:
+    entry = servers.get(server_name)
+    if not isinstance(entry, dict):
+        return None
+    url = entry.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    headers = entry.get("headers")
+    if not isinstance(headers, dict):
+        headers = {}
+    return ExistingEntry(url=url, token=token_from_authorization(headers.get("Authorization")), location=location)
+
+
+class ClaudeCodeAdapter(ClientAdapter):
+    key = "claude-code"
+    display_name = "Claude Code"
+
+    def __init__(
+        self,
+        home: Optional[Path] = None,
+        cwd: Optional[Path] = None,
+        scope: str = "user",
+        which: Callable[[str], Optional[str]] = shutil.which,
+        runner: Callable[..., "subprocess.CompletedProcess[str]"] = subprocess.run,
+    ):
+        self.home = home or Path.home()
+        self.cwd = cwd or Path.cwd()
+        self.scope = scope
+        self._which = which
+        self._runner = runner
+
+    @property
+    def _user_config_path(self) -> Path:
+        return self.home / ".claude.json"
+
+    @property
+    def _project_config_path(self) -> Path:
+        return self.cwd / ".mcp.json"
+
+    def detect(self) -> bool:
+        return self._which("claude") is not None or self._user_config_path.exists()
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        project_config = self._read_json(self._project_config_path)
+        if project_config:
+            entry = _entry_from_config(
+                project_config.get("mcpServers") or {}, server_name, str(self._project_config_path)
+            )
+            if entry:
+                return entry
+
+        user_config = self._read_json(self._user_config_path)
+        if user_config:
+            entry = _entry_from_config(
+                user_config.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (user scope)"
+            )
+            if entry:
+                return entry
+            projects = user_config.get("projects")
+            if isinstance(projects, dict):
+                project = projects.get(str(self.cwd))
+                if isinstance(project, dict):
+                    entry = _entry_from_config(
+                        project.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (local scope)"
+                    )
+                    if entry:
+                        return entry
+        return None
+
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        if self._which("claude") is not None:
+            self._write_via_cli(server_name, url, token)
+            return WriteResult(method="cli", location="claude mcp add (scope: " + self.scope + ")")
+        return self._write_project_file(server_name, url, token)
+
+    # -- CLI path ---------------------------------------------------------------
+
+    def _write_via_cli(self, server_name: str, url: str, token: Optional[str]) -> None:
+        # Variadic flags (--header) must come after the name and URL, or Claude Code's
+        # parser consumes the positional arguments.
+        add_args: List[str] = ["claude", "mcp", "add", "--transport", "http", "--scope", self.scope, server_name, url]
+        if token:
+            add_args += ["--header", "Authorization: " + bearer_header(token)]
+
+        result = self._runner(add_args, capture_output=True, text=True)
+        if result.returncode != 0 and "already exists" in (result.stderr or "").lower():
+            remove = self._runner(
+                ["claude", "mcp", "remove", "--scope", self.scope, server_name], capture_output=True, text=True
+            )
+            if remove.returncode == 0:
+                result = self._runner(add_args, capture_output=True, text=True)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise CLIError("claude mcp add failed: " + (detail or "unknown error"))
+
+    # -- File fallback ------------------------------------------------------------
+
+    def _write_project_file(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        path = self._project_config_path
+        config = self._read_json(path) or {}
+        servers = config.setdefault("mcpServers", {})
+        entry: Dict[str, Any] = {"type": "http", "url": url}
+        if token:
+            entry["headers"] = {"Authorization": bearer_header(token)}
+        servers[server_name] = entry
+        path.write_text(json.dumps(config, indent=2) + "\n")
+        return WriteResult(method="file", location=str(path))
+
+    @staticmethod
+    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+        if not path.exists():
+            return None
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None

--- a/libs/agno_cli/agno_cli/clients/codex.py
+++ b/libs/agno_cli/agno_cli/clients/codex.py
@@ -71,6 +71,18 @@ class CodexAdapter(ClientAdapter):
         block = "\n".join(block_lines) + "\n"
 
         existing_text = self.config_path.read_text() if self.config_path.exists() else ""
+        if existing_text:
+            try:
+                tomllib.loads(existing_text)
+            except tomllib.TOMLDecodeError as e:
+                raise CLIError(
+                    "Refusing to modify "
+                    + str(self.config_path)
+                    + ": the existing TOML does not parse ("
+                    + str(e)
+                    + ").",
+                    hint="Fix or move the file, then re-run.",
+                )
         new_text = self._replace_section(existing_text, server_name, block)
 
         try:
@@ -81,9 +93,8 @@ class CodexAdapter(ClientAdapter):
             )
 
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
-        created = not self.config_path.exists()
         self.config_path.write_text(new_text)
-        if created:
+        if token:
             self.config_path.chmod(0o600)
         return WriteResult(method="file", location=str(self.config_path))
 
@@ -99,25 +110,47 @@ class CodexAdapter(ClientAdapter):
 
     @staticmethod
     def _replace_section(text: str, server_name: str, block: str) -> str:
-        """Replace (or append) the [mcp_servers.<name>] section, including dotted subtables."""
+        """Replace (or append) the [mcp_servers.<name>] section, including dotted subtables.
+
+        Every table header — [table] and [[array-of-tables]] alike — ends the previous
+        section, so content following the managed section is never swallowed. Trailing
+        comment/blank lines inside the managed section that lead into the next header
+        are preserved, since they usually describe what follows.
+        """
         section_prefix = "[mcp_servers." + server_name
         lines = text.splitlines()
         kept: List[str] = []
+        dropped: List[str] = []
         insert_at: Optional[int] = None
         in_section = False
+
+        def flush_trailing_comments() -> None:
+            trailing: List[str] = []
+            for dropped_line in reversed(dropped):
+                if dropped_line.strip() == "" or dropped_line.lstrip().startswith("#"):
+                    trailing.append(dropped_line)
+                else:
+                    break
+            kept.extend(reversed(trailing))
+            dropped.clear()
+
         for line in lines:
             stripped = line.strip()
-            is_header = stripped.startswith("[") and not stripped.startswith("[[")
-            if is_header:
+            if stripped.startswith("["):
                 owns = stripped.startswith(section_prefix + "]") or stripped.startswith(section_prefix + ".")
+                if in_section and not owns:
+                    flush_trailing_comments()
+                in_section = owns
                 if owns:
-                    in_section = True
                     if insert_at is None:
                         insert_at = len(kept)
                     continue
-                in_section = False
-            if not in_section:
+            if in_section:
+                dropped.append(line)
+            else:
                 kept.append(line)
+        if in_section:
+            dropped.clear()
 
         block_lines = block.rstrip("\n").splitlines()
         if insert_at is not None:

--- a/libs/agno_cli/agno_cli/clients/codex.py
+++ b/libs/agno_cli/agno_cli/clients/codex.py
@@ -1,0 +1,129 @@
+"""OpenAI Codex adapter.
+
+Codex reads MCP servers from ~/.codex/config.toml as [mcp_servers.<name>] tables. The
+`codex mcp add` CLI cannot set static HTTP headers (only --bearer-token-env-var, which
+requires the user to manage an environment variable), so this adapter edits the config
+file directly, using a static http_headers table for zero-setup authentication.
+
+The edit is a section-scoped text replacement: only lines belonging to
+[mcp_servers.<name>] (and its dotted subtables) are touched, so user comments and other
+servers survive. The result is validated by re-parsing before it is written.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.errors import CLIError
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+def _toml_string(value: str) -> str:
+    # TOML basic strings share JSON's escaping rules for the characters that matter here.
+    return json.dumps(value)
+
+
+class CodexAdapter(ClientAdapter):
+    key = "codex"
+    display_name = "Codex"
+
+    def __init__(self, home: Optional[Path] = None):
+        self.home = home or Path.home()
+
+    @property
+    def config_path(self) -> Path:
+        return self.home / ".codex" / "config.toml"
+
+    def detect(self) -> bool:
+        return (self.home / ".codex").is_dir()
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        parsed = self._parse_config()
+        if parsed is None:
+            return None
+        entry = (parsed.get("mcp_servers") or {}).get(server_name)
+        if not isinstance(entry, dict):
+            return None
+        url = entry.get("url")
+        if not isinstance(url, str) or not url:
+            return None
+        headers = entry.get("http_headers")
+        if not isinstance(headers, dict):
+            headers = {}
+        return ExistingEntry(
+            url=url,
+            token=token_from_authorization(headers.get("Authorization")),
+            location=str(self.config_path),
+        )
+
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        block_lines = ["[mcp_servers." + server_name + "]", "url = " + _toml_string(url)]
+        if token:
+            block_lines.append(
+                "http_headers = { " + _toml_string("Authorization") + " = " + _toml_string(bearer_header(token)) + " }"
+            )
+        block = "\n".join(block_lines) + "\n"
+
+        existing_text = self.config_path.read_text() if self.config_path.exists() else ""
+        new_text = self._replace_section(existing_text, server_name, block)
+
+        try:
+            tomllib.loads(new_text)
+        except tomllib.TOMLDecodeError as e:
+            raise CLIError(
+                "Refusing to write " + str(self.config_path) + ": the resulting TOML would be invalid (" + str(e) + ")."
+            )
+
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        created = not self.config_path.exists()
+        self.config_path.write_text(new_text)
+        if created:
+            self.config_path.chmod(0o600)
+        return WriteResult(method="file", location=str(self.config_path))
+
+    # -- Internals -----------------------------------------------------------------
+
+    def _parse_config(self) -> Optional[Dict[str, Any]]:
+        if not self.config_path.exists():
+            return None
+        try:
+            return tomllib.loads(self.config_path.read_text())
+        except (OSError, tomllib.TOMLDecodeError):
+            return None
+
+    @staticmethod
+    def _replace_section(text: str, server_name: str, block: str) -> str:
+        """Replace (or append) the [mcp_servers.<name>] section, including dotted subtables."""
+        section_prefix = "[mcp_servers." + server_name
+        lines = text.splitlines()
+        kept: List[str] = []
+        insert_at: Optional[int] = None
+        in_section = False
+        for line in lines:
+            stripped = line.strip()
+            is_header = stripped.startswith("[") and not stripped.startswith("[[")
+            if is_header:
+                owns = stripped.startswith(section_prefix + "]") or stripped.startswith(section_prefix + ".")
+                if owns:
+                    in_section = True
+                    if insert_at is None:
+                        insert_at = len(kept)
+                    continue
+                in_section = False
+            if not in_section:
+                kept.append(line)
+
+        block_lines = block.rstrip("\n").splitlines()
+        if insert_at is not None:
+            kept[insert_at:insert_at] = block_lines
+        else:
+            if kept and kept[-1].strip():
+                kept.append("")
+            kept.extend(block_lines)
+        return "\n".join(kept).rstrip("\n") + "\n"

--- a/libs/agno_cli/agno_cli/clients/cursor.py
+++ b/libs/agno_cli/agno_cli/clients/cursor.py
@@ -10,7 +10,15 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.clients.base import (
+    ClientAdapter,
+    ExistingEntry,
+    WriteResult,
+    bearer_header,
+    servers_table,
+    token_from_authorization,
+)
+from agno_cli.errors import CLIError
 
 
 class CursorAdapter(ClientAdapter):
@@ -34,10 +42,10 @@ class CursorAdapter(ClientAdapter):
     def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
         # Project config wins on collisions, so check it first even in global mode.
         for path in (self.cwd / ".cursor" / "mcp.json", self.home / ".cursor" / "mcp.json"):
-            config = self._read_json(path)
-            if not config:
+            config = self._read_json_lenient(path)
+            if config is None:
                 continue
-            entry = (config.get("mcpServers") or {}).get(server_name)
+            entry = servers_table(config).get(server_name)
             if not isinstance(entry, dict):
                 continue
             url = entry.get("url")
@@ -55,22 +63,30 @@ class CursorAdapter(ClientAdapter):
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         path = self.config_path
-        config = self._read_json(path) or {}
-        servers = config.setdefault("mcpServers", {})
+        config = self._read_json_strict(path)
+        servers = config.get("mcpServers")
+        if servers is None:
+            servers = {}
+            config["mcpServers"] = servers
+        elif not isinstance(servers, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": 'mcpServers' is not an object.")
         entry: Dict[str, Any] = {"url": url}
         if token:
             entry["headers"] = {"Authorization": bearer_header(token)}
         servers[server_name] = entry
 
         path.parent.mkdir(parents=True, exist_ok=True)
-        created = not path.exists()
         path.write_text(json.dumps(config, indent=2) + "\n")
-        if created:
+        if token:
             path.chmod(0o600)
-        return WriteResult(method="file", location=str(path))
+        note = None
+        if self.project and token:
+            note = str(path) + " is project-scoped; keep it out of version control (it now contains a token)."
+        return WriteResult(method="file", location=str(path), note=note)
 
     @staticmethod
-    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    def _read_json_lenient(path: Path) -> Optional[Dict[str, Any]]:
+        """For reads: a missing or malformed file simply means no entry found."""
         if not path.exists():
             return None
         try:
@@ -78,3 +94,19 @@ class CursorAdapter(ClientAdapter):
         except (OSError, json.JSONDecodeError):
             return None
         return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
+    def _read_json_strict(path: Path) -> Dict[str, Any]:
+        """For writes: refuse to clobber a file we cannot parse."""
+        if not path.exists():
+            return {}
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            raise CLIError(
+                "Refusing to modify " + str(path) + ": the existing file is not valid JSON (" + str(e) + ").",
+                hint="Fix or move the file, then re-run.",
+            )
+        if not isinstance(parsed, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": expected a JSON object at the top level.")
+        return parsed

--- a/libs/agno_cli/agno_cli/clients/cursor.py
+++ b/libs/agno_cli/agno_cli/clients/cursor.py
@@ -1,0 +1,80 @@
+"""Cursor adapter.
+
+Cursor has no CLI for adding MCP servers; the supported programmatic path is editing
+mcp.json directly: ~/.cursor/mcp.json (global, all projects) or <project>/.cursor/mcp.json
+(project-scoped, wins on name collisions). Remote servers are configured with a url and
+optional headers; transport is inferred from the presence of url.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+
+
+class CursorAdapter(ClientAdapter):
+    key = "cursor"
+    display_name = "Cursor"
+
+    def __init__(self, home: Optional[Path] = None, cwd: Optional[Path] = None, project: bool = False):
+        self.home = home or Path.home()
+        self.cwd = cwd or Path.cwd()
+        self.project = project
+
+    @property
+    def config_path(self) -> Path:
+        if self.project:
+            return self.cwd / ".cursor" / "mcp.json"
+        return self.home / ".cursor" / "mcp.json"
+
+    def detect(self) -> bool:
+        return (self.home / ".cursor").is_dir()
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        # Project config wins on collisions, so check it first even in global mode.
+        for path in (self.cwd / ".cursor" / "mcp.json", self.home / ".cursor" / "mcp.json"):
+            config = self._read_json(path)
+            if not config:
+                continue
+            entry = (config.get("mcpServers") or {}).get(server_name)
+            if not isinstance(entry, dict):
+                continue
+            url = entry.get("url")
+            if not isinstance(url, str) or not url:
+                continue
+            headers = entry.get("headers")
+            if not isinstance(headers, dict):
+                headers = {}
+            return ExistingEntry(
+                url=url,
+                token=token_from_authorization(headers.get("Authorization")),
+                location=str(path),
+            )
+        return None
+
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        path = self.config_path
+        config = self._read_json(path) or {}
+        servers = config.setdefault("mcpServers", {})
+        entry: Dict[str, Any] = {"url": url}
+        if token:
+            entry["headers"] = {"Authorization": bearer_header(token)}
+        servers[server_name] = entry
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        created = not path.exists()
+        path.write_text(json.dumps(config, indent=2) + "\n")
+        if created:
+            path.chmod(0o600)
+        return WriteResult(method="file", location=str(path))
+
+    @staticmethod
+    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+        if not path.exists():
+            return None
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None

--- a/libs/agno_cli/agno_cli/commands/_common.py
+++ b/libs/agno_cli/agno_cli/commands/_common.py
@@ -11,6 +11,18 @@ from agno_cli.errors import CLIError
 ADMIN_TOKEN_ENV = "AGNO_ADMIN_TOKEN"
 SECURITY_KEY_ENV = "OS_SECURITY_KEY"
 
+_SERVER_NAME_ALLOWED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+
+def validate_server_name(server_name: str) -> None:
+    """MCP server entry names must stay flat: a dotted name would create nested TOML
+    tables in Codex's config that later reads could never find."""
+    if not server_name or not set(server_name) <= _SERVER_NAME_ALLOWED:
+        raise CLIError(
+            "Invalid --server-name: " + server_name,
+            hint="Use letters, digits, '-' and '_' only.",
+        )
+
 
 def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
     """Resolve the admin credential used to call the service-accounts API.

--- a/libs/agno_cli/agno_cli/commands/_common.py
+++ b/libs/agno_cli/agno_cli/commands/_common.py
@@ -1,0 +1,66 @@
+"""Helpers shared by CLI commands."""
+
+import os
+import sys
+from typing import Optional, Tuple
+
+import typer
+
+from agno_cli.errors import CLIError
+
+ADMIN_TOKEN_ENV = "AGNO_ADMIN_TOKEN"
+SECURITY_KEY_ENV = "OS_SECURITY_KEY"
+
+
+def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
+    """Resolve the admin credential used to call the service-accounts API.
+
+    Order: AGNO_ADMIN_TOKEN env, OS_SECURITY_KEY env, interactive prompt. Prompting is
+    disabled in --json mode and when stdin is not a TTY, so agent-driven runs fail with
+    a clear instruction instead of hanging.
+    """
+    if auth_mode == "none":
+        return None
+    token = os.environ.get(ADMIN_TOKEN_ENV) or os.environ.get(SECURITY_KEY_ENV)
+    if token:
+        return token
+    if json_mode or not sys.stdin.isatty():
+        raise CLIError(
+            "This AgentOS requires an admin credential to mint tokens (auth mode: " + auth_mode + ").",
+            hint="Set " + ADMIN_TOKEN_ENV + " (or " + SECURITY_KEY_ENV + ") and re-run.",
+        )
+    return typer.prompt("Admin credential for this AgentOS", hide_input=True)
+
+
+def parse_expires(value: str) -> Tuple[Optional[int], bool]:
+    """Parse an --expires value into (expires_in_days, never_expires).
+
+    Accepts a bare number of days ("90"), a d-suffixed form ("90d"), or "never".
+    """
+    cleaned = value.strip().lower()
+    if cleaned == "never":
+        return None, True
+    if cleaned.endswith("d"):
+        cleaned = cleaned[:-1]
+    if not cleaned.isdigit() or int(cleaned) < 1:
+        raise CLIError(
+            "Invalid --expires value: " + value,
+            hint="Use a number of days like '90' or '90d', or 'never'.",
+        )
+    return int(cleaned), False
+
+
+def handle_cli_error(error: CLIError, json_mode: bool) -> "typer.Exit":
+    """Print a CLIError appropriately for the output mode and return the Exit to raise."""
+    from agno_cli.console import emit_json, print_error, print_warning
+
+    if json_mode:
+        payload = {"error": error.message}
+        if error.hint:
+            payload["hint"] = error.hint
+        emit_json(payload)
+    else:
+        print_error(error.message)
+        if error.hint:
+            print_warning(error.hint)
+    return typer.Exit(error.exit_code)

--- a/libs/agno_cli/agno_cli/commands/connect.py
+++ b/libs/agno_cli/agno_cli/commands/connect.py
@@ -1,9 +1,9 @@
 """`agno connect`: wire a running AgentOS into coding agents as an MCP server.
 
 Flow: discover the AgentOS -> resolve admin credential -> mint one service account per
-client -> write each client's MCP config -> verify each connection with a real MCP
-tools/list call -> report. Re-runs are safe: entries that already verify are skipped,
-broken or stale ones are rotated (revoke + re-mint + rewrite).
+client -> write each client's MCP config -> read the config back and verify the entry
+the client will actually use, with a real MCP tools/list call -> report. Re-runs are
+safe: entries that already verify are skipped, broken or stale ones are rotated.
 """
 
 import sys
@@ -13,12 +13,20 @@ import typer
 
 from agno_cli.clients import CLIENT_ALIASES, build_adapters
 from agno_cli.clients.base import ClientAdapter
-from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
+from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token, validate_server_name
 from agno_cli.console import emit_json, print_error, print_info, print_success, print_warning
 from agno_cli.discovery import MCP_ENABLE_INSTRUCTIONS, OSInfo, discover
 from agno_cli.errors import CLIError, ConflictError
 from agno_cli.http import AgentOSAPI, ServiceAccount
 from agno_cli.mcp_client import verify_mcp
+
+# Exit codes: 0 = all connected, 1 = nothing connected, 2 = usage error (click's
+# convention, raised by typer itself), 3 = partial success.
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_PARTIAL = 3
+
+ROTATE_HINT = "Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched."
 
 
 def _resolve_clients(clients: Optional[str], adapters: Dict[str, ClientAdapter]) -> List[ClientAdapter]:
@@ -48,6 +56,7 @@ def _mint(
     scopes: Optional[List[str]],
     expires_in_days: Optional[int],
     never_expires: bool,
+    privileged: bool,
     rotate: bool,
     skip_existing: bool,
     json_mode: bool,
@@ -62,13 +71,15 @@ def _mint(
             scopes=scopes,
             expires_in_days=expires_in_days,
             never_expires=never_expires,
+            allow_privileged_scopes=privileged,
         )
-    except ConflictError:
+    except ConflictError as e:
         if skip_existing:
             return None
         if not rotate:
             interactive = not json_mode and sys.stdin.isatty()
             if not interactive:
+                e.hint = ROTATE_HINT
                 raise
             if not typer.confirm(
                 "Service account '" + account_name + "' already exists. Revoke and re-mint it?", default=False
@@ -82,6 +93,7 @@ def _mint(
             scopes=scopes,
             expires_in_days=expires_in_days,
             never_expires=never_expires,
+            allow_privileged_scopes=privileged,
         )
 
 
@@ -97,6 +109,9 @@ def connect(
         [], "--scopes", "-s", help="Scope to grant (repeatable). Default: the server's run + read scopes."
     ),
     expires: str = typer.Option("90d", "--expires", help="Token lifetime in days ('90d', '30') or 'never'."),
+    privileged: bool = typer.Option(
+        False, "--privileged", help="Required when --scopes grants write/delete/admin or service_accounts scopes."
+    ),
     server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name written to client configs."),
     project: bool = typer.Option(
         False, "--project", help="Write project-scoped configs (.mcp.json / .cursor/mcp.json) instead of user-level."
@@ -115,6 +130,7 @@ def connect(
             name=name,
             scopes=list(scopes) or None,
             expires=expires,
+            privileged=privileged,
             server_name=server_name,
             project=project,
             rotate=rotate,
@@ -131,12 +147,14 @@ def _connect(
     name: Optional[str],
     scopes: Optional[List[str]],
     expires: str,
+    privileged: bool,
     server_name: str,
     project: bool,
     rotate: bool,
     skip_existing: bool,
     json_mode: bool,
 ) -> None:
+    validate_server_name(server_name)
     expires_in_days, never_expires = parse_expires(expires)
 
     os_info = discover(url)
@@ -175,77 +193,136 @@ def _connect(
 
     shared_account: Optional[ServiceAccount] = None
     results: List[Dict[str, Any]] = []
-    revoke_hints: List[str] = []
 
     try:
         for adapter in selected:
             result: Dict[str, Any] = {"client": adapter.key, "status": "failed", "error": None}
             try:
-                account_name = name or adapter.key
-                existing = adapter.read_existing(server_name)
-
-                # Idempotency: an entry already pointing at this OS that still verifies is left alone.
-                if existing is not None and existing.url == os_info.mcp_url and not rotate:
-                    check = verify_mcp(os_info.mcp_url, token=existing.token)
-                    if check.ok and (existing.token is not None or not minting):
-                        result.update(
-                            status="already-connected",
-                            location=existing.location,
-                            verify=check.public_dict(),
-                        )
-                        results.append(result)
-                        continue
-                    if skip_existing:
-                        result.update(
-                            status="skipped",
-                            error="Existing entry no longer verifies; re-run without --skip-existing to rotate.",
-                        )
-                        results.append(result)
-                        continue
-
-                token: Optional[str] = None
-                account: Optional[ServiceAccount] = None
-                if minting and api is not None:
-                    if name is not None and shared_account is not None:
-                        account = shared_account
-                    else:
-                        account = _mint(
-                            api,
-                            account_name,
-                            scopes,
-                            expires_in_days,
-                            never_expires,
-                            rotate=rotate,
-                            skip_existing=skip_existing,
-                            json_mode=json_mode,
-                        )
-                        if account is None:
-                            result.update(status="skipped", error="Service account exists; kept untouched.")
-                            results.append(result)
-                            continue
-                        if name is not None:
-                            shared_account = account
-                    token = account.token
-
-                write_result = adapter.write(server_name, os_info.mcp_url, token)
-                verify_result = verify_mcp(os_info.mcp_url, token=token)
-
-                result.update(location=write_result.location, verify=verify_result.public_dict())
-                if account is not None:
-                    result["account"] = account.public_dict()
-                    revoke_hints.append(account.name)
-                if verify_result.ok:
-                    result["status"] = "connected"
-                else:
-                    result["error"] = verify_result.error
+                _connect_one(
+                    adapter=adapter,
+                    result=result,
+                    os_info=os_info,
+                    api=api,
+                    server_name=server_name,
+                    name=name,
+                    scopes=scopes,
+                    expires_in_days=expires_in_days,
+                    never_expires=never_expires,
+                    privileged=privileged,
+                    rotate=rotate,
+                    skip_existing=skip_existing,
+                    json_mode=json_mode,
+                    minting=minting,
+                    shared_account=shared_account,
+                )
+                account = result.pop("_account", None)
+                if name is not None and account is not None:
+                    shared_account = account
             except CLIError as e:
-                result["error"] = e.message
+                result["error"] = e.message + ((" " + e.hint) if e.hint else "")
+            except Exception as e:  # one client's failure must never abort the run
+                result["error"] = "Unexpected error (" + type(e).__name__ + "): " + str(e)
+            finally:
+                result.pop("_account", None)
             results.append(result)
     finally:
         if api is not None:
             api.close()
 
     _report(os_info, results, server_name, open_mcp_warning, json_mode)
+
+
+def _connect_one(
+    adapter: ClientAdapter,
+    result: Dict[str, Any],
+    os_info: OSInfo,
+    api: Optional[AgentOSAPI],
+    server_name: str,
+    name: Optional[str],
+    scopes: Optional[List[str]],
+    expires_in_days: Optional[int],
+    never_expires: bool,
+    privileged: bool,
+    rotate: bool,
+    skip_existing: bool,
+    json_mode: bool,
+    minting: bool,
+    shared_account: Optional[ServiceAccount],
+) -> None:
+    account_name = name or adapter.key
+    existing = adapter.read_existing(server_name)
+
+    if existing is not None:
+        if existing.url == os_info.mcp_url and not rotate:
+            # Idempotency: an entry already pointing at this OS that still verifies is left alone.
+            check = verify_mcp(os_info.mcp_url, token=existing.token)
+            if check.ok and (existing.token is not None or not minting):
+                result.update(status="already-connected", location=existing.location, verify=check.public_dict())
+                return
+            if skip_existing:
+                result.update(
+                    status="skipped",
+                    error="Existing entry no longer verifies; re-run without --skip-existing to rotate.",
+                )
+                return
+        elif existing.url != os_info.mcp_url:
+            # The entry points at a different AgentOS; never touch it under --skip-existing.
+            if skip_existing:
+                result.update(
+                    status="skipped",
+                    location=existing.location,
+                    error="Existing entry points at " + existing.url + "; left untouched.",
+                )
+                return
+            result["replaced_url"] = existing.url
+
+    token: Optional[str] = None
+    account: Optional[ServiceAccount] = None
+    if minting and api is not None:
+        if name is not None and shared_account is not None:
+            account = shared_account
+        else:
+            account = _mint(
+                api,
+                account_name,
+                scopes,
+                expires_in_days,
+                never_expires,
+                privileged=privileged,
+                rotate=rotate,
+                skip_existing=skip_existing,
+                json_mode=json_mode,
+            )
+            if account is None:
+                result.update(status="skipped", error="Service account exists; kept untouched.")
+                return
+        token = account.token
+
+    write_result = adapter.write(server_name, os_info.mcp_url, token)
+    result["location"] = write_result.location
+    if write_result.note:
+        result["note"] = write_result.note
+    if account is not None:
+        result["account"] = account.public_dict()
+        result["_account"] = account
+
+    # Verify what the client will actually use, not what we intended to write: the
+    # read-back catches shadowing entries and writes that silently did not take effect.
+    readback = adapter.read_existing(server_name)
+    if readback is None or readback.url != os_info.mcp_url or (token is not None and readback.token != token):
+        found = (readback.location + " -> " + readback.url) if readback is not None else "no entry"
+        result["error"] = (
+            "The config write did not take effect for '" + server_name + "' (found: " + found + "). "
+            "Another entry may shadow it; remove the stale entry and re-run."
+        )
+        return
+
+    verify_result = verify_mcp(os_info.mcp_url, token=readback.token)
+    result["verify"] = verify_result.public_dict()
+    if verify_result.ok:
+        result["status"] = "connected"
+    else:
+        result["error"] = verify_result.error
 
 
 def _report(
@@ -258,11 +335,11 @@ def _report(
     ok_statuses = ("connected", "already-connected")
     ok_count = sum(1 for r in results if r["status"] in ok_statuses)
     if ok_count == len(results):
-        exit_code = 0
+        exit_code = EXIT_OK
     elif ok_count == 0:
-        exit_code = 1
+        exit_code = EXIT_FAILURE
     else:
-        exit_code = 2
+        exit_code = EXIT_PARTIAL
 
     if json_mode:
         emit_json(
@@ -289,6 +366,10 @@ def _report(
             print_warning("  skipped        " + label + "  (" + str(r.get("error") or "") + ")")
         else:
             print_error("  failed         " + label + "  (" + str(r.get("error") or "unknown error") + ")")
+        if r.get("note"):
+            print_warning("                 note: " + str(r["note"]))
+        if r.get("replaced_url"):
+            print_warning("                 replaced an entry that pointed at " + str(r["replaced_url"]))
 
     accounts = sorted({r["account"]["name"] for r in results if r.get("account")})
     if accounts:

--- a/libs/agno_cli/agno_cli/commands/connect.py
+++ b/libs/agno_cli/agno_cli/commands/connect.py
@@ -1,0 +1,301 @@
+"""`agno connect`: wire a running AgentOS into coding agents as an MCP server.
+
+Flow: discover the AgentOS -> resolve admin credential -> mint one service account per
+client -> write each client's MCP config -> verify each connection with a real MCP
+tools/list call -> report. Re-runs are safe: entries that already verify are skipped,
+broken or stale ones are rotated (revoke + re-mint + rewrite).
+"""
+
+import sys
+from typing import Any, Dict, List, Optional
+
+import typer
+
+from agno_cli.clients import CLIENT_ALIASES, build_adapters
+from agno_cli.clients.base import ClientAdapter
+from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
+from agno_cli.console import emit_json, print_error, print_info, print_success, print_warning
+from agno_cli.discovery import MCP_ENABLE_INSTRUCTIONS, OSInfo, discover
+from agno_cli.errors import CLIError, ConflictError
+from agno_cli.http import AgentOSAPI, ServiceAccount
+from agno_cli.mcp_client import verify_mcp
+
+
+def _resolve_clients(clients: Optional[str], adapters: Dict[str, ClientAdapter]) -> List[ClientAdapter]:
+    if clients:
+        selected: List[ClientAdapter] = []
+        for raw in clients.split(","):
+            key = CLIENT_ALIASES.get(raw.strip().lower())
+            if key is None:
+                supported = ", ".join(sorted(set(CLIENT_ALIASES.keys())))
+                raise CLIError("Unknown client: " + raw.strip(), hint="Supported clients: " + supported)
+            adapter = adapters[key]
+            if adapter not in selected:
+                selected.append(adapter)
+        return selected
+    detected = [adapter for adapter in adapters.values() if adapter.detect()]
+    if not detected:
+        raise CLIError(
+            "No supported coding agents detected on this machine.",
+            hint="Install Claude Code, Codex, or Cursor, or pass --clients explicitly.",
+        )
+    return detected
+
+
+def _mint(
+    api: AgentOSAPI,
+    account_name: str,
+    scopes: Optional[List[str]],
+    expires_in_days: Optional[int],
+    never_expires: bool,
+    rotate: bool,
+    skip_existing: bool,
+    json_mode: bool,
+) -> Optional[ServiceAccount]:
+    """Mint a service account, resolving name conflicts per the idempotency policy.
+
+    Returns None when the caller should skip this client (existing account kept).
+    """
+    try:
+        return api.create_service_account(
+            name=account_name,
+            scopes=scopes,
+            expires_in_days=expires_in_days,
+            never_expires=never_expires,
+        )
+    except ConflictError:
+        if skip_existing:
+            return None
+        if not rotate:
+            interactive = not json_mode and sys.stdin.isatty()
+            if not interactive:
+                raise
+            if not typer.confirm(
+                "Service account '" + account_name + "' already exists. Revoke and re-mint it?", default=False
+            ):
+                return None
+        existing = api.find_service_account(account_name)
+        if existing is not None:
+            api.revoke_service_account(existing.id)
+        return api.create_service_account(
+            name=account_name,
+            scopes=scopes,
+            expires_in_days=expires_in_days,
+            never_expires=never_expires,
+        )
+
+
+def connect(
+    url: Optional[str] = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost)."),
+    clients: Optional[str] = typer.Option(
+        None, "--clients", help="Comma-separated clients to configure (claude-code,codex,cursor). Default: detected."
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Use one shared service account with this name instead of one per client."
+    ),
+    scopes: List[str] = typer.Option(
+        [], "--scopes", "-s", help="Scope to grant (repeatable). Default: the server's run + read scopes."
+    ),
+    expires: str = typer.Option("90d", "--expires", help="Token lifetime in days ('90d', '30') or 'never'."),
+    server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name written to client configs."),
+    project: bool = typer.Option(
+        False, "--project", help="Write project-scoped configs (.mcp.json / .cursor/mcp.json) instead of user-level."
+    ),
+    rotate: bool = typer.Option(False, "--rotate", help="Revoke and re-mint existing accounts without asking."),
+    skip_existing: bool = typer.Option(
+        False, "--skip-existing", help="Never touch existing accounts or config entries."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Connect this machine's coding agents to a running AgentOS over MCP."""
+    try:
+        _connect(
+            url=url,
+            clients=clients,
+            name=name,
+            scopes=list(scopes) or None,
+            expires=expires,
+            server_name=server_name,
+            project=project,
+            rotate=rotate,
+            skip_existing=skip_existing,
+            json_mode=json_output,
+        )
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+
+def _connect(
+    url: Optional[str],
+    clients: Optional[str],
+    name: Optional[str],
+    scopes: Optional[List[str]],
+    expires: str,
+    server_name: str,
+    project: bool,
+    rotate: bool,
+    skip_existing: bool,
+    json_mode: bool,
+) -> None:
+    expires_in_days, never_expires = parse_expires(expires)
+
+    os_info = discover(url)
+    if not os_info.mcp_enabled:
+        raise CLIError(
+            "Found an AgentOS at "
+            + os_info.base_url
+            + ", but its MCP server is not enabled.\n\n"
+            + MCP_ENABLE_INSTRUCTIONS
+        )
+    if not json_mode:
+        version = " (agno " + os_info.version + ")" if os_info.version else ""
+        print_info("AgentOS at " + os_info.base_url + version + ", MCP at " + os_info.mcp_url)
+
+    adapters = build_adapters(project=project)
+    selected = _resolve_clients(clients, adapters)
+
+    minting = os_info.auth_mode not in ("none",)
+    admin_token = resolve_admin_token(os_info.auth_mode, json_mode) if minting else None
+    if not minting and not json_mode:
+        print_info("Authorization is disabled on this AgentOS; connecting without credentials.")
+
+    # Truthful-outcome check: if the OS enforces auth but /mcp answers without a token,
+    # the server predates MCP token enforcement and minted headers are decorative.
+    open_mcp_warning: Optional[str] = None
+    if minting:
+        open_probe = verify_mcp(os_info.mcp_url, token=None)
+        if open_probe.ok:
+            open_mcp_warning = (
+                "This AgentOS accepts unauthenticated MCP requests: its agno version predates "
+                "token enforcement on /mcp. Tokens were still minted and configured; upgrade "
+                "agno to make them meaningful."
+            )
+
+    api = AgentOSAPI(os_info.base_url, admin_token=admin_token) if minting else None
+
+    shared_account: Optional[ServiceAccount] = None
+    results: List[Dict[str, Any]] = []
+    revoke_hints: List[str] = []
+
+    try:
+        for adapter in selected:
+            result: Dict[str, Any] = {"client": adapter.key, "status": "failed", "error": None}
+            try:
+                account_name = name or adapter.key
+                existing = adapter.read_existing(server_name)
+
+                # Idempotency: an entry already pointing at this OS that still verifies is left alone.
+                if existing is not None and existing.url == os_info.mcp_url and not rotate:
+                    check = verify_mcp(os_info.mcp_url, token=existing.token)
+                    if check.ok and (existing.token is not None or not minting):
+                        result.update(
+                            status="already-connected",
+                            location=existing.location,
+                            verify=check.public_dict(),
+                        )
+                        results.append(result)
+                        continue
+                    if skip_existing:
+                        result.update(
+                            status="skipped",
+                            error="Existing entry no longer verifies; re-run without --skip-existing to rotate.",
+                        )
+                        results.append(result)
+                        continue
+
+                token: Optional[str] = None
+                account: Optional[ServiceAccount] = None
+                if minting and api is not None:
+                    if name is not None and shared_account is not None:
+                        account = shared_account
+                    else:
+                        account = _mint(
+                            api,
+                            account_name,
+                            scopes,
+                            expires_in_days,
+                            never_expires,
+                            rotate=rotate,
+                            skip_existing=skip_existing,
+                            json_mode=json_mode,
+                        )
+                        if account is None:
+                            result.update(status="skipped", error="Service account exists; kept untouched.")
+                            results.append(result)
+                            continue
+                        if name is not None:
+                            shared_account = account
+                    token = account.token
+
+                write_result = adapter.write(server_name, os_info.mcp_url, token)
+                verify_result = verify_mcp(os_info.mcp_url, token=token)
+
+                result.update(location=write_result.location, verify=verify_result.public_dict())
+                if account is not None:
+                    result["account"] = account.public_dict()
+                    revoke_hints.append(account.name)
+                if verify_result.ok:
+                    result["status"] = "connected"
+                else:
+                    result["error"] = verify_result.error
+            except CLIError as e:
+                result["error"] = e.message
+            results.append(result)
+    finally:
+        if api is not None:
+            api.close()
+
+    _report(os_info, results, server_name, open_mcp_warning, json_mode)
+
+
+def _report(
+    os_info: OSInfo,
+    results: List[Dict[str, Any]],
+    server_name: str,
+    open_mcp_warning: Optional[str],
+    json_mode: bool,
+) -> None:
+    ok_statuses = ("connected", "already-connected")
+    ok_count = sum(1 for r in results if r["status"] in ok_statuses)
+    if ok_count == len(results):
+        exit_code = 0
+    elif ok_count == 0:
+        exit_code = 1
+    else:
+        exit_code = 2
+
+    if json_mode:
+        emit_json(
+            {
+                "os": os_info.public_dict(),
+                "server_name": server_name,
+                "results": results,
+                "warning": open_mcp_warning,
+                "exit_code": exit_code,
+            }
+        )
+        raise typer.Exit(exit_code)
+
+    print_info("")
+    for r in results:
+        label = r["client"]
+        if r["status"] == "connected":
+            tools = (r.get("verify") or {}).get("tools")
+            suffix = " (" + str(tools) + " tools)" if tools else ""
+            print_success("  connected      " + label + suffix + "  ->  " + str(r.get("location", "")))
+        elif r["status"] == "already-connected":
+            print_success("  already ok     " + label + "  ->  " + str(r.get("location", "")))
+        elif r["status"] == "skipped":
+            print_warning("  skipped        " + label + "  (" + str(r.get("error") or "") + ")")
+        else:
+            print_error("  failed         " + label + "  (" + str(r.get("error") or "unknown error") + ")")
+
+    accounts = sorted({r["account"]["name"] for r in results if r.get("account")})
+    if accounts:
+        print_info("")
+        print_info("Revoke any time with: agno tokens revoke <name>  (accounts: " + ", ".join(accounts) + ")")
+    if open_mcp_warning:
+        print_info("")
+        print_warning(open_mcp_warning)
+
+    raise typer.Exit(exit_code)

--- a/libs/agno_cli/agno_cli/commands/create.py
+++ b/libs/agno_cli/agno_cli/commands/create.py
@@ -1,0 +1,110 @@
+"""`agno create`: scaffold a new AgentOS project from a starter template.
+
+The mechanism is deliberately simple (inherited from `ag infra create`): shallow-clone
+the template repository, strip its git history, and copy example secrets into place.
+No registry file is kept — commands operate on the current directory.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import typer
+
+from agno_cli.commands._common import handle_cli_error
+from agno_cli.console import emit_json, print_info, print_success
+from agno_cli.errors import CLIError
+
+TEMPLATES: Dict[str, str] = {
+    "agentos-docker": "https://github.com/agno-agi/agentos-docker-template",
+    "agentos-aws": "https://github.com/agno-agi/agentos-aws-template",
+    "agentos-railway": "https://github.com/agno-agi/agentos-railway-template",
+}
+
+DEFAULT_TEMPLATE = "agentos-docker"
+
+GIT_TIMEOUT = 300.0
+
+
+def _clone(repo_url: str, target: Path) -> None:
+    if shutil.which("git") is None:
+        raise CLIError("git is required to create a project from a template.", hint="Install git and re-run.")
+    try:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, str(target)],
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        raise CLIError("git clone timed out after " + str(int(GIT_TIMEOUT)) + "s: " + repo_url)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise CLIError("git clone failed: " + (detail or repo_url))
+    shutil.rmtree(target / ".git", ignore_errors=True)
+
+
+def _copy_example_secrets(project_dir: Path) -> Optional[str]:
+    """Copy infra/example_secrets -> infra/secrets when the template ships one."""
+    example = project_dir / "infra" / "example_secrets"
+    secrets = project_dir / "infra" / "secrets"
+    if example.is_dir() and not secrets.exists():
+        shutil.copytree(example, secrets)
+        return str(secrets)
+    return None
+
+
+def create(
+    name: str = typer.Argument(..., help="Directory name for the new AgentOS project."),
+    template: str = typer.Option(
+        DEFAULT_TEMPLATE, "--template", "-t", help="Starter template: " + ", ".join(sorted(TEMPLATES)) + "."
+    ),
+    template_url: Optional[str] = typer.Option(
+        None, "--url", "-u", help="Clone from a custom template repository URL instead."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Create a new AgentOS project from a starter template."""
+    try:
+        payload = _create(name=name, template=template, template_url=template_url)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        emit_json(payload)
+        return
+    print_success("Created " + str(payload["path"]) + " from " + str(payload["template"]))
+    if payload.get("secrets"):
+        print_info("Example secrets copied to " + str(payload["secrets"]) + " - fill them in before deploying.")
+    print_info("")
+    print_info("Next steps:")
+    print_info("  cd " + name)
+    print_info("  agno infra up      # start it with docker compose")
+    print_info("  agno connect       # make it available in your coding agents")
+
+
+def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, Any]:
+    target = Path.cwd() / name
+    if target.exists():
+        raise CLIError(
+            "The directory " + str(target) + " already exists.",
+            hint="Pick a different name or remove the existing directory.",
+        )
+
+    if template_url:
+        repo_url = template_url
+        template_label = template_url
+    else:
+        repo_url = TEMPLATES.get(template, "")
+        if not repo_url:
+            raise CLIError(
+                "Unknown template: " + template,
+                hint="Available templates: " + ", ".join(sorted(TEMPLATES)) + ", or pass --url for a custom repo.",
+            )
+        template_label = template
+
+    _clone(repo_url, target)
+    secrets = _copy_example_secrets(target)
+    return {"path": str(target), "template": template_label, "secrets": secrets}

--- a/libs/agno_cli/agno_cli/commands/create.py
+++ b/libs/agno_cli/agno_cli/commands/create.py
@@ -81,7 +81,7 @@ def create(
     print_info("")
     print_info("Next steps:")
     print_info("  cd " + name)
-    print_info("  agno infra up      # start it with docker compose")
+    print_info("  agno up            # start it with docker compose")
     print_info("  agno connect       # make it available in your coding agents")
 
 

--- a/libs/agno_cli/agno_cli/commands/infra.py
+++ b/libs/agno_cli/agno_cli/commands/infra.py
@@ -1,0 +1,148 @@
+"""`agno infra`: run the project's infrastructure with docker compose.
+
+This ports the path of the legacy `ag infra` CLI that real projects use: templates ship
+a compose file, and up/down/restart shell out to `docker compose`. The legacy Python
+resource engine (per-resource Docker/AWS orchestration) is intentionally not ported —
+its production path is under redesign (see the agno-infra 2.0 spec); when that lands it
+plugs into this CLI via the agno_cli.plugins entry-point group.
+"""
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import typer
+
+from agno_cli.commands._common import handle_cli_error
+from agno_cli.console import emit_json, print_info, print_success
+from agno_cli.errors import CLIError
+
+infra_app = typer.Typer(name="infra", help="Start and stop the project's infrastructure (docker compose).")
+
+# Same names and order the legacy CLI recognized.
+COMPOSE_FILE_NAMES = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"]
+
+COMPOSE_TIMEOUT = 600.0
+
+JsonOption = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption.")
+FileOption = typer.Option(None, "--file", "-f", help="Compose file to use (default: autodetect in ./ and ./infra).")
+DryRunOption = typer.Option(False, "--dry-run", "-dr", help="Print the docker compose command without running it.")
+
+
+def find_compose_file(explicit: Optional[str] = None, cwd: Optional[Path] = None) -> Path:
+    base = cwd or Path.cwd()
+    if explicit:
+        path = Path(explicit)
+        if not path.is_absolute():
+            path = base / path
+        if not path.exists():
+            raise CLIError("Compose file not found: " + str(path))
+        return path
+    for directory in (base, base / "infra"):
+        for name in COMPOSE_FILE_NAMES:
+            candidate = directory / name
+            if candidate.exists():
+                return candidate
+    raise CLIError(
+        "No compose file found in " + str(base) + " or " + str(base / "infra") + ".",
+        hint="Run from an AgentOS project (agno create <name>) or pass --file.",
+    )
+
+
+def _run_compose(compose_file: Path, args: List[str], dry_run: bool, json_mode: bool) -> Dict[str, Any]:
+    command = ["docker", "compose", "-f", str(compose_file)] + args
+    if dry_run:
+        return {"command": command, "compose_file": str(compose_file), "dry_run": True}
+    if shutil.which("docker") is None:
+        raise CLIError("docker is required.", hint="Install Docker and make sure `docker` is on PATH.")
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(compose_file.parent),
+            timeout=COMPOSE_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            capture_output=json_mode,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        raise CLIError("docker compose timed out after " + str(int(COMPOSE_TIMEOUT)) + "s.")
+    if result.returncode != 0:
+        detail = ((result.stderr or "") if json_mode else "").strip()
+        raise CLIError(
+            "docker compose exited with code " + str(result.returncode) + ((": " + detail) if detail else "."),
+        )
+    return {"command": command, "compose_file": str(compose_file), "dry_run": False}
+
+
+@infra_app.command("up")
+def up(
+    file: Optional[str] = FileOption,
+    pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images."),
+    dry_run: bool = DryRunOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Start the project's infrastructure: docker compose up -d --build."""
+    try:
+        compose_file = find_compose_file(file)
+        args = ["up", "-d", "--build"]
+        if pull:
+            args += ["--pull", "always"]
+        payload = _run_compose(compose_file, args, dry_run, json_output)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+    _finish(payload, "Infrastructure is up (" + str(payload["compose_file"]) + ").", json_output)
+
+
+@infra_app.command("down")
+def down(
+    file: Optional[str] = FileOption,
+    volumes: bool = typer.Option(False, "--volumes", "-v", help="Also remove named volumes (destroys data)."),
+    dry_run: bool = DryRunOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Stop the project's infrastructure: docker compose down."""
+    try:
+        compose_file = find_compose_file(file)
+        args = ["down"]
+        if volumes:
+            args += ["--volumes"]
+        payload = _run_compose(compose_file, args, dry_run, json_output)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+    _finish(payload, "Infrastructure is down (" + str(payload["compose_file"]) + ").", json_output)
+
+
+@infra_app.command("restart")
+def restart(
+    file: Optional[str] = FileOption,
+    pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images on the way back up."),
+    dry_run: bool = DryRunOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Restart the project's infrastructure: down, then up."""
+    try:
+        compose_file = find_compose_file(file)
+        down_payload = _run_compose(compose_file, ["down"], dry_run, json_output)
+        if not dry_run:
+            time.sleep(2)
+        up_args = ["up", "-d", "--build"]
+        if pull:
+            up_args += ["--pull", "always"]
+        up_payload = _run_compose(compose_file, up_args, dry_run, json_output)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+    payload = {"down": down_payload, "up": up_payload, "compose_file": str(compose_file), "dry_run": dry_run}
+    _finish(payload, "Infrastructure restarted (" + str(compose_file) + ").", json_output)
+
+
+def _finish(payload: Dict[str, Any], message: str, json_mode: bool) -> None:
+    if json_mode:
+        emit_json(payload)
+        return
+    if payload.get("dry_run"):
+        command = payload.get("command") or (payload.get("up") or {}).get("command")
+        print_info("Would run: " + " ".join(command or []))
+        return
+    print_success(message)

--- a/libs/agno_cli/agno_cli/commands/lifecycle.py
+++ b/libs/agno_cli/agno_cli/commands/lifecycle.py
@@ -1,4 +1,4 @@
-"""`agno infra`: run the project's infrastructure with docker compose.
+"""`agno up/down/restart`: run the project with docker compose.
 
 This ports the path of the legacy `ag infra` CLI that real projects use: templates ship
 a compose file, and up/down/restart shell out to `docker compose`. The legacy Python
@@ -18,8 +18,6 @@ import typer
 from agno_cli.commands._common import handle_cli_error
 from agno_cli.console import emit_json, print_info, print_success
 from agno_cli.errors import CLIError
-
-infra_app = typer.Typer(name="infra", help="Start and stop the project's infrastructure (docker compose).")
 
 # Same names and order the legacy CLI recognized.
 COMPOSE_FILE_NAMES = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"]
@@ -76,14 +74,13 @@ def _run_compose(compose_file: Path, args: List[str], dry_run: bool, json_mode: 
     return {"command": command, "compose_file": str(compose_file), "dry_run": False}
 
 
-@infra_app.command("up")
 def up(
     file: Optional[str] = FileOption,
     pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images."),
     dry_run: bool = DryRunOption,
     json_output: bool = JsonOption,
 ) -> None:
-    """Start the project's infrastructure: docker compose up -d --build."""
+    """Start the project: docker compose up -d --build."""
     try:
         compose_file = find_compose_file(file)
         args = ["up", "-d", "--build"]
@@ -92,17 +89,16 @@ def up(
         payload = _run_compose(compose_file, args, dry_run, json_output)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
-    _finish(payload, "Infrastructure is up (" + str(payload["compose_file"]) + ").", json_output)
+    _finish(payload, "Project is up (" + str(payload["compose_file"]) + ").", json_output)
 
 
-@infra_app.command("down")
 def down(
     file: Optional[str] = FileOption,
     volumes: bool = typer.Option(False, "--volumes", "-v", help="Also remove named volumes (destroys data)."),
     dry_run: bool = DryRunOption,
     json_output: bool = JsonOption,
 ) -> None:
-    """Stop the project's infrastructure: docker compose down."""
+    """Stop the project: docker compose down."""
     try:
         compose_file = find_compose_file(file)
         args = ["down"]
@@ -111,17 +107,16 @@ def down(
         payload = _run_compose(compose_file, args, dry_run, json_output)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
-    _finish(payload, "Infrastructure is down (" + str(payload["compose_file"]) + ").", json_output)
+    _finish(payload, "Project is down (" + str(payload["compose_file"]) + ").", json_output)
 
 
-@infra_app.command("restart")
 def restart(
     file: Optional[str] = FileOption,
     pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images on the way back up."),
     dry_run: bool = DryRunOption,
     json_output: bool = JsonOption,
 ) -> None:
-    """Restart the project's infrastructure: down, then up."""
+    """Restart the project: down, then up."""
     try:
         compose_file = find_compose_file(file)
         down_payload = _run_compose(compose_file, ["down"], dry_run, json_output)
@@ -134,7 +129,7 @@ def restart(
     except CLIError as e:
         raise handle_cli_error(e, json_output)
     payload = {"down": down_payload, "up": up_payload, "compose_file": str(compose_file), "dry_run": dry_run}
-    _finish(payload, "Infrastructure restarted (" + str(compose_file) + ").", json_output)
+    _finish(payload, "Project restarted (" + str(compose_file) + ").", json_output)
 
 
 def _finish(payload: Dict[str, Any], message: str, json_mode: bool) -> None:

--- a/libs/agno_cli/agno_cli/commands/status.py
+++ b/libs/agno_cli/agno_cli/commands/status.py
@@ -1,0 +1,54 @@
+"""`agno status`: orientation — what OS is running, how it is secured, what is connected."""
+
+from typing import Optional
+
+import typer
+
+from agno_cli.clients import build_adapters
+from agno_cli.commands._common import handle_cli_error
+from agno_cli.console import emit_json, print_info, print_success
+from agno_cli.discovery import discover
+from agno_cli.errors import CLIError
+
+
+def status(
+    url: Optional[str] = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost)."),
+    server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name to look for in clients."),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Show the discovered AgentOS and which coding agents are connected to it."""
+    try:
+        os_info = discover(url)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    adapters = build_adapters()
+    clients = []
+    for adapter in adapters.values():
+        entry = adapter.read_existing(server_name) if adapter.detect() else None
+        clients.append(
+            {
+                "client": adapter.key,
+                "detected": adapter.detect(),
+                "configured": entry is not None,
+                "location": entry.location if entry else None,
+            }
+        )
+
+    if json_output:
+        emit_json({"os": os_info.public_dict(), "clients": clients})
+        return
+
+    version = " (agno " + os_info.version + ")" if os_info.version else ""
+    print_success("AgentOS: " + os_info.base_url + version)
+    mcp = os_info.mcp_url if os_info.mcp_enabled else "disabled"
+    print_info("  MCP: " + mcp)
+    print_info("  Auth mode: " + os_info.auth_mode)
+    print_info("")
+    for c in clients:
+        if not c["detected"]:
+            print_info("  " + str(c["client"]) + ": not detected")
+        elif c["configured"]:
+            print_info("  " + str(c["client"]) + ": configured (" + str(c["location"]) + ")")
+        else:
+            print_info("  " + str(c["client"]) + ": detected, not connected (run: agno connect)")

--- a/libs/agno_cli/agno_cli/commands/tokens.py
+++ b/libs/agno_cli/agno_cli/commands/tokens.py
@@ -1,0 +1,129 @@
+"""`agno tokens`: thin wrappers over the AgentOS service-accounts API."""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import typer
+
+from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
+from agno_cli.console import console, emit_json, print_info, print_success, print_warning
+from agno_cli.discovery import discover
+from agno_cli.errors import CLIError
+from agno_cli.http import AgentOSAPI
+
+tokens_app = typer.Typer(name="tokens", help="Mint, list, and revoke AgentOS service-account tokens.")
+
+UrlOption = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost).")
+JsonOption = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption.")
+
+
+def _timestamp(value: Optional[int]) -> str:
+    if not value:
+        return "-"
+    return datetime.fromtimestamp(value, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _api_for(url: Optional[str], json_mode: bool) -> AgentOSAPI:
+    os_info = discover(url)
+    admin_token = resolve_admin_token(os_info.auth_mode, json_mode)
+    return AgentOSAPI(os_info.base_url, admin_token=admin_token)
+
+
+@tokens_app.command("create")
+def create(
+    name: str = typer.Argument(..., help="Service account name (lowercase slug, e.g. 'ci-runner')."),
+    scopes: List[str] = typer.Option([], "--scopes", "-s", help="Scope to grant (repeatable). Default: run + read."),
+    expires: str = typer.Option("90d", "--expires", help="Days until expiry ('90d', '30') or 'never'."),
+    privileged: bool = typer.Option(
+        False, "--privileged", help="Required to grant write/delete/admin or service_accounts scopes."
+    ),
+    url: Optional[str] = UrlOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Mint a service-account token. The plaintext is shown exactly once."""
+    try:
+        expires_in_days, never_expires = parse_expires(expires)
+        with _api_for(url, json_output) as api:
+            account = api.create_service_account(
+                name=name,
+                scopes=list(scopes) or None,
+                expires_in_days=expires_in_days,
+                never_expires=never_expires,
+                allow_privileged_scopes=privileged,
+            )
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        payload = account.public_dict()
+        payload["token"] = account.token
+        emit_json(payload)
+        return
+
+    print_success("Service account '" + account.name + "' created (principal: " + account.principal + ").")
+    print_info("Scopes: " + ", ".join(account.scopes))
+    print_info("Expires: " + _timestamp(account.expires_at))
+    print_warning("This token is shown once and cannot be retrieved again. Save it now:")
+    console.print()
+    console.print("    " + (account.token or ""), style="bold", highlight=False)
+    console.print()
+
+
+@tokens_app.command("list")
+def list_(
+    url: Optional[str] = UrlOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """List service accounts (metadata and display prefixes only, never tokens)."""
+    try:
+        with _api_for(url, json_output) as api:
+            accounts = api.list_service_accounts()
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        emit_json({"service_accounts": [a.public_dict() for a in accounts]})
+        return
+
+    if not accounts:
+        print_info("No service accounts found.")
+        return
+
+    from rich.table import Table
+
+    table = Table(box=None, header_style="bold")
+    for column in ("Name", "Token", "Scopes", "Expires", "Last used", "Status"):
+        table.add_column(column)
+    for a in accounts:
+        status = "revoked" if a.revoked_at else "active"
+        table.add_row(
+            a.name,
+            a.token_prefix + "…",
+            ", ".join(a.scopes),
+            _timestamp(a.expires_at),
+            _timestamp(a.last_used_at),
+            status,
+        )
+    console.print(table)
+
+
+@tokens_app.command("revoke")
+def revoke(
+    name: str = typer.Argument(..., help="Name of the service account to revoke."),
+    url: Optional[str] = UrlOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Revoke a service account. Takes effect on the account's next request."""
+    try:
+        with _api_for(url, json_output) as api:
+            account = api.find_service_account(name)
+            if account is None:
+                raise CLIError("No service account named '" + name + "' found.")
+            api.revoke_service_account(account.id)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        emit_json({"revoked": account.public_dict()})
+        return
+    print_success("Service account '" + name + "' revoked. Existing tokens stop working on their next request.")

--- a/libs/agno_cli/agno_cli/commands/tokens.py
+++ b/libs/agno_cli/agno_cli/commands/tokens.py
@@ -8,7 +8,7 @@ import typer
 from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
 from agno_cli.console import console, emit_json, print_info, print_success, print_warning
 from agno_cli.discovery import discover
-from agno_cli.errors import CLIError
+from agno_cli.errors import CLIError, ConflictError
 from agno_cli.http import AgentOSAPI
 
 tokens_app = typer.Typer(name="tokens", help="Mint, list, and revoke AgentOS service-account tokens.")
@@ -44,13 +44,17 @@ def create(
     try:
         expires_in_days, never_expires = parse_expires(expires)
         with _api_for(url, json_output) as api:
-            account = api.create_service_account(
-                name=name,
-                scopes=list(scopes) or None,
-                expires_in_days=expires_in_days,
-                never_expires=never_expires,
-                allow_privileged_scopes=privileged,
-            )
+            try:
+                account = api.create_service_account(
+                    name=name,
+                    scopes=list(scopes) or None,
+                    expires_in_days=expires_in_days,
+                    never_expires=never_expires,
+                    allow_privileged_scopes=privileged,
+                )
+            except ConflictError as e:
+                e.hint = "Revoke it first (agno tokens revoke " + name + ") or pick a different name."
+                raise
     except CLIError as e:
         raise handle_cli_error(e, json_output)
 

--- a/libs/agno_cli/agno_cli/console.py
+++ b/libs/agno_cli/agno_cli/console.py
@@ -1,0 +1,39 @@
+"""Console output helpers.
+
+Two output modes exist for every command: human (rich, colored, informative) and machine
+(--json: a single JSON document on stdout, nothing else). Commands build a payload dict as
+they work; in JSON mode only emit_json touches stdout, so output stays parseable.
+"""
+
+import json
+from typing import Any, Dict
+
+from rich.console import Console
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def print_heading(msg: str) -> None:
+    console.print(msg, style="green bold")
+
+
+def print_info(msg: str) -> None:
+    console.print(msg)
+
+
+def print_success(msg: str) -> None:
+    console.print(msg, style="chartreuse3")
+
+
+def print_warning(msg: str) -> None:
+    err_console.print(msg, style="magenta")
+
+
+def print_error(msg: str) -> None:
+    err_console.print(msg, style="red")
+
+
+def emit_json(payload: Dict[str, Any]) -> None:
+    """Print the machine-readable result document. The only stdout writer in --json mode."""
+    print(json.dumps(payload, indent=2, sort_keys=False, default=str))

--- a/libs/agno_cli/agno_cli/discovery.py
+++ b/libs/agno_cli/agno_cli/discovery.py
@@ -1,0 +1,119 @@
+"""AgentOS discovery: find a running OS and learn its capabilities before touching it.
+
+Prefers the structured discovery fields on GET /info (agno >= the /info discovery release):
+``mcp: {enabled, path}`` and ``auth_mode``. Falls back to probing for older servers:
+POST to /mcp distinguishes mounted-vs-404, and an unauthenticated GET /config
+distinguishes the auth modes by status code and 401 detail wording.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno_cli.errors import CLIError
+from agno_cli.http import AgentOSAPI, build_client
+
+# AgentOS.serve() defaults to port 7777; 8000 covers bare-uvicorn setups.
+DEFAULT_URLS = ["http://localhost:7777", "http://localhost:8000"]
+
+URL_ENV_VAR = "AGNO_OS_URL"
+
+
+@dataclass
+class OSInfo:
+    base_url: str
+    version: Optional[str]
+    mcp_enabled: bool
+    mcp_path: Optional[str]
+    auth_mode: str  # "none" | "security_key" | "jwt" | "unknown"
+    discovered_via: str  # "info" | "probe"
+
+    @property
+    def mcp_url(self) -> str:
+        path = self.mcp_path or "/mcp"
+        return self.base_url.rstrip("/") + path
+
+    def public_dict(self) -> Dict[str, Any]:
+        return {
+            "url": self.base_url,
+            "version": self.version,
+            "mcp": {"enabled": self.mcp_enabled, "path": self.mcp_path},
+            "auth_mode": self.auth_mode,
+            "discovered_via": self.discovered_via,
+        }
+
+
+def _candidate_urls(url: Optional[str]) -> List[str]:
+    if url:
+        return [url.rstrip("/")]
+    env_url = os.environ.get(URL_ENV_VAR)
+    if env_url:
+        return [env_url.rstrip("/")]
+    return list(DEFAULT_URLS)
+
+
+def _probe_mcp(base_url: str) -> bool:
+    """True when something MCP-shaped is mounted at /mcp.
+
+    A FastAPI app without the MCP mount returns 404 for any method on /mcp; the
+    streamable-HTTP endpoint answers POSTs with anything but 404 (200, 400, 401, 406...).
+    """
+    try:
+        with build_client(base_url=base_url, timeout=5.0) as client:
+            response = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 0, "method": "ping"},
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+    except httpx.HTTPError:
+        return False
+    return response.status_code != 404
+
+
+def discover(url: Optional[str] = None) -> OSInfo:
+    """Find a running AgentOS and return what the CLI needs to know about it."""
+    candidates = _candidate_urls(url)
+    for candidate in candidates:
+        with AgentOSAPI(candidate) as api:
+            if api.health() is None:
+                continue
+            info = api.info() or {}
+
+            mcp_field = info.get("mcp")
+            auth_mode = info.get("auth_mode")
+            if isinstance(mcp_field, dict) and isinstance(auth_mode, str):
+                return OSInfo(
+                    base_url=candidate,
+                    version=info.get("agno_version"),
+                    mcp_enabled=bool(mcp_field.get("enabled")),
+                    mcp_path=mcp_field.get("path") or ("/mcp" if mcp_field.get("enabled") else None),
+                    auth_mode=auth_mode,
+                    discovered_via="info",
+                )
+
+            mcp_enabled = _probe_mcp(candidate)
+            return OSInfo(
+                base_url=candidate,
+                version=info.get("agno_version"),
+                mcp_enabled=mcp_enabled,
+                mcp_path="/mcp" if mcp_enabled else None,
+                auth_mode=api.probe_auth_mode(),
+                discovered_via="probe",
+            )
+
+    tried = ", ".join(candidates)
+    raise CLIError(
+        "No running AgentOS found (tried: " + tried + ").",
+        hint="Start your AgentOS (agent_os.serve()) or pass --url / set " + URL_ENV_VAR + ".",
+    )
+
+
+MCP_ENABLE_INSTRUCTIONS = """MCP is not enabled on this AgentOS. Enable it and restart:
+
+    agent_os = AgentOS(
+        agents=[...],
+        enable_mcp_server=True,  # add this line
+    )
+"""

--- a/libs/agno_cli/agno_cli/errors.py
+++ b/libs/agno_cli/agno_cli/errors.py
@@ -1,0 +1,28 @@
+"""Error types shared across CLI commands."""
+
+from typing import Optional
+
+
+class CLIError(Exception):
+    """A user-facing failure. Commands catch this, print the message, and exit with exit_code."""
+
+    def __init__(self, message: str, exit_code: int = 1, hint: Optional[str] = None):
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+        self.hint = hint
+
+
+class APIError(CLIError):
+    """An AgentOS API call failed."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, hint: Optional[str] = None):
+        super().__init__(message, exit_code=1, hint=hint)
+        self.status_code = status_code
+
+
+class ConflictError(APIError):
+    """The AgentOS reported a conflict (e.g. a service account with this name already exists)."""
+
+    def __init__(self, message: str, hint: Optional[str] = None):
+        super().__init__(message, status_code=409, hint=hint)

--- a/libs/agno_cli/agno_cli/http.py
+++ b/libs/agno_cli/agno_cli/http.py
@@ -1,0 +1,247 @@
+"""Thin HTTP client for the AgentOS REST API.
+
+This module talks plain HTTP to a running AgentOS. It deliberately does not import the
+agno framework: the CLI must stay installable and fast under `uvx` with nothing but
+httpx, rich, and typer.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno_cli import __version__
+from agno_cli.errors import APIError, ConflictError
+
+# Test hook: tests set this to an httpx.MockTransport so every client in the CLI
+# (API, discovery, MCP verification) talks to an in-memory fake AgentOS.
+_transport_override: Optional[httpx.BaseTransport] = None
+
+DEFAULT_TIMEOUT = 10.0
+
+
+def build_client(base_url: str = "", timeout: float = DEFAULT_TIMEOUT) -> httpx.Client:
+    return httpx.Client(
+        base_url=base_url,
+        timeout=timeout,
+        transport=_transport_override,
+        headers={"user-agent": "agnoctl/" + __version__},
+        follow_redirects=True,
+    )
+
+
+@dataclass
+class ServiceAccount:
+    id: str
+    name: str
+    principal: str
+    token_prefix: str
+    scopes: List[str] = field(default_factory=list)
+    created_at: Optional[int] = None
+    expires_at: Optional[int] = None
+    last_used_at: Optional[int] = None
+    revoked_at: Optional[int] = None
+    created_by: Optional[str] = None
+    # Present only on the create response; never persisted by the CLI.
+    token: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccount":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            principal=data.get("principal") or "sa:" + data["name"],
+            token_prefix=data.get("token_prefix") or "",
+            scopes=data.get("scopes") or [],
+            created_at=data.get("created_at"),
+            expires_at=data.get("expires_at"),
+            last_used_at=data.get("last_used_at"),
+            revoked_at=data.get("revoked_at"),
+            created_by=data.get("created_by"),
+            token=data.get("token"),
+        )
+
+    def public_dict(self) -> Dict[str, Any]:
+        """The account as a JSON-safe dict, always excluding the plaintext token."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "principal": self.principal,
+            "token_prefix": self.token_prefix,
+            "scopes": self.scopes,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "last_used_at": self.last_used_at,
+            "revoked_at": self.revoked_at,
+        }
+
+
+def _error_detail(response: httpx.Response) -> str:
+    try:
+        detail = response.json().get("detail")
+        if isinstance(detail, str) and detail:
+            return detail
+    except Exception:
+        pass
+    return "HTTP " + str(response.status_code)
+
+
+class AgentOSAPI:
+    """Sync client for the AgentOS endpoints the CLI needs.
+
+    The CLI is a short-lived terminal process making a handful of sequential calls, so a
+    sync client is the right shape; programs embedding Agno should use agno.client instead.
+    """
+
+    def __init__(self, base_url: str, admin_token: Optional[str] = None, timeout: float = DEFAULT_TIMEOUT):
+        self.base_url = base_url.rstrip("/")
+        self.admin_token = admin_token
+        self._client = build_client(base_url=self.base_url, timeout=timeout)
+
+    def _headers(self) -> Dict[str, str]:
+        if self.admin_token:
+            return {"Authorization": "Bearer " + self.admin_token}
+        return {}
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "AgentOSAPI":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.close()
+
+    # -- Probes ------------------------------------------------------------------
+
+    def health(self) -> Optional[Dict[str, Any]]:
+        """GET /health. Returns the payload, or None when unreachable or not an AgentOS."""
+        try:
+            response = self._client.get("/health")
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        try:
+            payload = response.json()
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def info(self) -> Optional[Dict[str, Any]]:
+        """GET /info (unauthenticated). Returns the payload, or None when unavailable."""
+        try:
+            response = self._client.get("/info")
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        try:
+            payload = response.json()
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def probe_auth_mode(self) -> str:
+        """Detect the auth mode by probing GET /config without credentials.
+
+        Fallback for servers whose /info predates the mcp/auth_mode discovery fields.
+        The 401 detail strings are the only externally observable distinction between
+        security-key mode and JWT mode on older servers.
+        """
+        try:
+            response = self._client.get("/config")
+        except httpx.HTTPError:
+            return "unknown"
+        if response.status_code == 200:
+            return "none"
+        if response.status_code == 401:
+            detail = _error_detail(response)
+            if "required" in detail.lower():
+                return "security_key"
+            return "jwt"
+        return "unknown"
+
+    # -- Service accounts ----------------------------------------------------------
+
+    def create_service_account(
+        self,
+        name: str,
+        scopes: Optional[List[str]] = None,
+        expires_in_days: Optional[int] = None,
+        never_expires: bool = False,
+        allow_privileged_scopes: bool = False,
+    ) -> ServiceAccount:
+        body: Dict[str, Any] = {"name": name}
+        if scopes:
+            body["scopes"] = scopes
+        if never_expires:
+            body["never_expires"] = True
+        elif expires_in_days is not None:
+            body["expires_in_days"] = expires_in_days
+        if allow_privileged_scopes:
+            body["allow_privileged_scopes"] = True
+
+        response = self._request("POST", "/service-accounts", json=body)
+        if response.status_code == 409:
+            raise ConflictError(
+                "A service account named '" + name + "' already exists.",
+                hint="Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched.",
+            )
+        if response.status_code != 201:
+            raise APIError(
+                "Could not create service account '" + name + "': " + _error_detail(response),
+                status_code=response.status_code,
+            )
+        return ServiceAccount.from_dict(response.json())
+
+    def list_service_accounts(self) -> List[ServiceAccount]:
+        accounts: List[ServiceAccount] = []
+        page = 1
+        while True:
+            response = self._request("GET", "/service-accounts", params={"page": page, "limit": 100})
+            if response.status_code != 200:
+                raise APIError(
+                    "Could not list service accounts: " + _error_detail(response),
+                    status_code=response.status_code,
+                )
+            payload = response.json()
+            data = payload.get("data") if isinstance(payload, dict) else payload
+            if not isinstance(data, list):
+                break
+            accounts.extend(ServiceAccount.from_dict(item) for item in data)
+            meta = payload.get("meta") if isinstance(payload, dict) else None
+            total_pages = (meta or {}).get("total_pages") if isinstance(meta, dict) else None
+            if not total_pages or page >= int(total_pages):
+                break
+            page += 1
+        return accounts
+
+    def find_service_account(self, name: str) -> Optional[ServiceAccount]:
+        for account in self.list_service_accounts():
+            if account.name == name:
+                return account
+        return None
+
+    def revoke_service_account(self, account_id: str) -> None:
+        response = self._request("DELETE", "/service-accounts/" + account_id)
+        if response.status_code not in (200, 204):
+            raise APIError(
+                "Could not revoke service account: " + _error_detail(response),
+                status_code=response.status_code,
+            )
+
+    # -- Internals -----------------------------------------------------------------
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            response = self._client.request(method, path, headers=self._headers(), **kwargs)
+        except httpx.HTTPError as e:
+            raise APIError("Could not reach the AgentOS at " + self.base_url + ": " + str(e)) from e
+        if response.status_code in (401, 403):
+            raise APIError(
+                "The AgentOS rejected the admin credential (" + _error_detail(response) + ").",
+                status_code=response.status_code,
+                hint="Set AGNO_ADMIN_TOKEN (or OS_SECURITY_KEY) to a credential with admin access.",
+            )
+        return response

--- a/libs/agno_cli/agno_cli/http.py
+++ b/libs/agno_cli/agno_cli/http.py
@@ -184,16 +184,13 @@ class AgentOSAPI:
 
         response = self._request("POST", "/service-accounts", json=body)
         if response.status_code == 409:
-            raise ConflictError(
-                "A service account named '" + name + "' already exists.",
-                hint="Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched.",
-            )
+            raise ConflictError("A service account named '" + name + "' already exists.")
         if response.status_code != 201:
             raise APIError(
                 "Could not create service account '" + name + "': " + _error_detail(response),
                 status_code=response.status_code,
             )
-        return ServiceAccount.from_dict(response.json())
+        return self._parse_account(response)
 
     def list_service_accounts(self) -> List[ServiceAccount]:
         accounts: List[ServiceAccount] = []
@@ -205,11 +202,16 @@ class AgentOSAPI:
                     "Could not list service accounts: " + _error_detail(response),
                     status_code=response.status_code,
                 )
-            payload = response.json()
+            payload = self._parse_json(response)
             data = payload.get("data") if isinstance(payload, dict) else payload
             if not isinstance(data, list):
                 break
-            accounts.extend(ServiceAccount.from_dict(item) for item in data)
+            for item in data:
+                if isinstance(item, dict):
+                    try:
+                        accounts.append(ServiceAccount.from_dict(item))
+                    except KeyError as e:
+                        raise APIError("The AgentOS returned a malformed service account (missing " + str(e) + ").")
             meta = payload.get("meta") if isinstance(payload, dict) else None
             total_pages = (meta or {}).get("total_pages") if isinstance(meta, dict) else None
             if not total_pages or page >= int(total_pages):
@@ -232,6 +234,27 @@ class AgentOSAPI:
             )
 
     # -- Internals -----------------------------------------------------------------
+
+    def _parse_json(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except Exception:
+            raise APIError(
+                "The server at "
+                + self.base_url
+                + " returned a non-JSON response (HTTP "
+                + str(response.status_code)
+                + ") - is this really an AgentOS?"
+            )
+
+    def _parse_account(self, response: httpx.Response) -> ServiceAccount:
+        payload = self._parse_json(response)
+        if not isinstance(payload, dict):
+            raise APIError("The AgentOS returned an unexpected service-account payload.")
+        try:
+            return ServiceAccount.from_dict(payload)
+        except KeyError as e:
+            raise APIError("The AgentOS returned a malformed service account (missing " + str(e) + ").")
 
     def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         try:

--- a/libs/agno_cli/agno_cli/main.py
+++ b/libs/agno_cli/agno_cli/main.py
@@ -7,7 +7,7 @@ import typer
 from agno_cli import __version__
 from agno_cli.commands.connect import connect
 from agno_cli.commands.create import create
-from agno_cli.commands.infra import infra_app
+from agno_cli.commands.lifecycle import down, restart, up
 from agno_cli.commands.status import status
 from agno_cli.commands.tokens import tokens_app
 from agno_cli.console import print_info, print_warning
@@ -26,7 +26,9 @@ app.command(name="connect")(connect)
 app.command(name="create")(create)
 app.command(name="status")(status)
 app.add_typer(tokens_app, name="tokens")
-app.add_typer(infra_app, name="infra")
+app.command(name="up")(up)
+app.command(name="down")(down)
+app.command(name="restart")(restart)
 
 
 def _load_plugins() -> None:

--- a/libs/agno_cli/agno_cli/main.py
+++ b/libs/agno_cli/agno_cli/main.py
@@ -1,0 +1,73 @@
+"""The `agno` command: root Typer app and plugin loader."""
+
+from typing import Optional
+
+import typer
+
+from agno_cli import __version__
+from agno_cli.commands.connect import connect
+from agno_cli.commands.status import status
+from agno_cli.commands.tokens import tokens_app
+from agno_cli.console import print_info, print_warning
+
+PLUGIN_GROUP = "agno_cli.plugins"
+
+app = typer.Typer(
+    name="agno",
+    help="The Agno CLI: connect and operate AgentOS, built for humans and coding agents.",
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_show_locals=False,
+)
+
+app.command(name="connect")(connect)
+app.command(name="status")(status)
+app.add_typer(tokens_app, name="tokens")
+
+
+def _load_plugins() -> None:
+    """Mount subcommand groups exposed by other installed distributions.
+
+    A plugin is an entry point in the `agno_cli.plugins` group resolving to a
+    typer.Typer; the entry-point name becomes the subcommand name. A broken plugin
+    must never take the core CLI down, so failures are reported and skipped.
+    """
+    from importlib.metadata import entry_points
+
+    try:
+        plugin_entry_points = entry_points(group=PLUGIN_GROUP)
+    except TypeError:  # Python 3.9: entry_points() takes no kwargs and returns a dict
+        plugin_entry_points = entry_points().get(PLUGIN_GROUP, [])  # type: ignore[arg-type,attr-defined]
+
+    for entry_point in plugin_entry_points:
+        try:
+            plugin = entry_point.load()
+        except Exception as e:
+            print_warning("Skipping CLI plugin '" + entry_point.name + "': " + str(e))
+            continue
+        if isinstance(plugin, typer.Typer):
+            app.add_typer(plugin, name=entry_point.name)
+        else:
+            print_warning("Skipping CLI plugin '" + entry_point.name + "': not a typer.Typer")
+
+
+_load_plugins()
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        print_info("agnoctl " + __version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=_version_callback, is_eager=True, help="Print the CLI version and exit."
+    ),
+) -> None:
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/libs/agno_cli/agno_cli/main.py
+++ b/libs/agno_cli/agno_cli/main.py
@@ -6,6 +6,8 @@ import typer
 
 from agno_cli import __version__
 from agno_cli.commands.connect import connect
+from agno_cli.commands.create import create
+from agno_cli.commands.infra import infra_app
 from agno_cli.commands.status import status
 from agno_cli.commands.tokens import tokens_app
 from agno_cli.console import print_info, print_warning
@@ -21,8 +23,10 @@ app = typer.Typer(
 )
 
 app.command(name="connect")(connect)
+app.command(name="create")(create)
 app.command(name="status")(status)
 app.add_typer(tokens_app, name="tokens")
+app.add_typer(infra_app, name="infra")
 
 
 def _load_plugins() -> None:

--- a/libs/agno_cli/agno_cli/mcp_client.py
+++ b/libs/agno_cli/agno_cli/mcp_client.py
@@ -57,9 +57,16 @@ def _parse_jsonrpc_body(response: httpx.Response) -> Optional[Dict[str, Any]]:
 def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0) -> MCPVerifyResult:
     """Handshake with an MCP streamable-HTTP endpoint and list its tools.
 
-    Never raises: connection problems come back as a failed MCPVerifyResult so callers
-    can report per-client outcomes.
+    Never raises: connection problems and malformed payloads come back as a failed
+    MCPVerifyResult so callers can report per-client outcomes.
     """
+    try:
+        return _verify_mcp(mcp_url, token, timeout)
+    except Exception as e:  # never-raises contract
+        return MCPVerifyResult(ok=False, error="MCP verification failed: " + str(e))
+
+
+def _verify_mcp(mcp_url: str, token: Optional[str], timeout: float) -> MCPVerifyResult:
     headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
@@ -131,9 +138,11 @@ def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0)
                     status_code=tools_response.status_code,
                     error="MCP tools/list returned an unexpected payload.",
                 )
-            tools = [
-                tool.get("name", "") for tool in tools_message["result"].get("tools", []) if isinstance(tool, dict)
-            ]
+            result = tools_message["result"]
+            raw_tools = result.get("tools", []) if isinstance(result, dict) else []
+            if not isinstance(raw_tools, list):
+                raw_tools = []
+            tools = [tool.get("name", "") for tool in raw_tools if isinstance(tool, dict)]
             return MCPVerifyResult(ok=True, tools=tools, status_code=tools_response.status_code)
     except httpx.HTTPError as e:
         return MCPVerifyResult(ok=False, error="Could not reach the MCP endpoint: " + str(e))

--- a/libs/agno_cli/agno_cli/mcp_client.py
+++ b/libs/agno_cli/agno_cli/mcp_client.py
@@ -1,0 +1,139 @@
+"""Minimal MCP streamable-HTTP client, used only to verify connections.
+
+Speaks just enough JSON-RPC over streamable HTTP (initialize -> notifications/initialized
+-> tools/list) to prove that a written client config would actually work. Implemented on
+plain httpx so the CLI does not depend on the mcp package.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno_cli import __version__
+from agno_cli.http import build_client
+
+PROTOCOL_VERSION = "2025-03-26"
+
+SESSION_HEADER = "mcp-session-id"
+
+
+@dataclass
+class MCPVerifyResult:
+    ok: bool
+    tools: List[str] = field(default_factory=list)
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+
+    def public_dict(self) -> Dict[str, Any]:
+        return {"ok": self.ok, "tools": len(self.tools), "status_code": self.status_code, "error": self.error}
+
+
+def _parse_jsonrpc_body(response: httpx.Response) -> Optional[Dict[str, Any]]:
+    """Extract the first JSON-RPC message from a JSON or SSE response body."""
+    content_type = response.headers.get("content-type", "")
+    text = response.text
+    if "text/event-stream" in content_type:
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                if payload:
+                    try:
+                        parsed = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(parsed, dict):
+                        return parsed
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0) -> MCPVerifyResult:
+    """Handshake with an MCP streamable-HTTP endpoint and list its tools.
+
+    Never raises: connection problems come back as a failed MCPVerifyResult so callers
+    can report per-client outcomes.
+    """
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if token:
+        headers["Authorization"] = "Bearer " + token
+
+    try:
+        with build_client(timeout=timeout) as client:
+            init_response = client.post(
+                mcp_url,
+                headers=headers,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "agnoctl", "version": __version__},
+                    },
+                },
+            )
+            if init_response.status_code in (401, 403):
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=init_response.status_code,
+                    error="The MCP endpoint rejected the credential (HTTP " + str(init_response.status_code) + ").",
+                )
+            if init_response.status_code >= 400:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=init_response.status_code,
+                    error="MCP initialize failed with HTTP " + str(init_response.status_code) + ".",
+                )
+            init_message = _parse_jsonrpc_body(init_response)
+            if init_message is None or "result" not in init_message:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=init_response.status_code,
+                    error="MCP initialize returned an unexpected payload.",
+                )
+
+            session_id = init_response.headers.get(SESSION_HEADER)
+            if session_id:
+                headers[SESSION_HEADER] = session_id
+
+            client.post(
+                mcp_url,
+                headers=headers,
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+
+            tools_response = client.post(
+                mcp_url,
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            )
+            if tools_response.status_code >= 400:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=tools_response.status_code,
+                    error="MCP tools/list failed with HTTP " + str(tools_response.status_code) + ".",
+                )
+            tools_message = _parse_jsonrpc_body(tools_response)
+            if tools_message is None or "result" not in tools_message:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=tools_response.status_code,
+                    error="MCP tools/list returned an unexpected payload.",
+                )
+            tools = [
+                tool.get("name", "") for tool in tools_message["result"].get("tools", []) if isinstance(tool, dict)
+            ]
+            return MCPVerifyResult(ok=True, tools=tools, status_code=tools_response.status_code)
+    except httpx.HTTPError as e:
+        return MCPVerifyResult(ok=False, error="Could not reach the MCP endpoint: " + str(e))

--- a/libs/agno_cli/pyproject.toml
+++ b/libs/agno_cli/pyproject.toml
@@ -1,0 +1,73 @@
+[project]
+name = "agnoctl"
+version = "0.1.0"
+description = "The Agno CLI: connect and operate AgentOS from the terminal, built for humans and coding agents"
+requires-python = ">=3.9,<4"
+readme = "README.md"
+license = { file = "LICENSE" }
+authors = [
+  {name = "Ashpreet Bedi", email = "ashpreet@agno.com"}
+]
+keywords = ["agno", "agentos", "cli", "mcp", "agents"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Environment :: Console",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+  "httpx",
+  "rich",
+  "typer",
+  "tomli; python_version < '3.11'",
+]
+
+[project.optional-dependencies]
+dev = [
+  "mypy",
+  "pytest",
+  "ruff",
+]
+
+[project.scripts]
+agno = "agno_cli.main:app"
+agnoctl = "agno_cli.main:app"
+
+[project.urls]
+homepage = "https://agno.com"
+documentation = "https://docs.agno.com"
+repository = "https://github.com/agno-agi/agno"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["agno_cli*"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.mypy]
+check_untyped_defs = true
+no_implicit_optional = true
+warn_unused_configs = true
+exclude = ["tests*", "build*"]
+
+[[tool.mypy.overrides]]
+module = ["tomli.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/libs/agno_cli/scripts/_utils.sh
+++ b/libs/agno_cli/scripts/_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+############################################################################
+# Collection of helper functions to import in other scripts
+############################################################################
+
+space_to_continue() {
+  read -n1 -r -p "Press Enter/Space to continue...  " key
+  if [ "$key" = '' ]; then
+    # Space pressed, pass
+    :
+  else
+    exit 1
+  fi
+  echo ""
+}
+
+print_horizontal_line() {
+  echo "------------------------------------------------------------"
+}
+
+print_heading() {
+  print_horizontal_line
+  echo "-*- $1"
+  print_horizontal_line
+}
+
+print_info() {
+  echo "-*- $1"
+}

--- a/libs/agno_cli/scripts/format.sh
+++ b/libs/agno_cli/scripts/format.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+############################################################################
+# Format the agno_cli library using ruff
+# Usage: ./libs/agno_cli/scripts/format.sh
+############################################################################
+
+CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGNO_CLI_DIR="$(dirname ${CURR_DIR})"
+source ${CURR_DIR}/_utils.sh
+
+print_heading "Formatting agno_cli"
+
+print_heading "Running: ruff format ${AGNO_CLI_DIR}"
+ruff format ${AGNO_CLI_DIR}
+
+print_heading "Running: ruff check --select I --fix ${AGNO_CLI_DIR}"
+ruff check --select I --fix ${AGNO_CLI_DIR}

--- a/libs/agno_cli/scripts/validate.sh
+++ b/libs/agno_cli/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+############################################################################
+# Validate the agno_cli library using ruff and mypy
+# Usage: ./libs/agno_cli/scripts/validate.sh
+############################################################################
+
+CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGNO_CLI_DIR="$(dirname ${CURR_DIR})"
+source ${CURR_DIR}/_utils.sh
+
+print_heading "Validating agno_cli"
+
+print_heading "Running: ruff check ${AGNO_CLI_DIR}"
+ruff check ${AGNO_CLI_DIR}
+
+print_heading "Running: mypy ${AGNO_CLI_DIR}/agno_cli --config-file ${AGNO_CLI_DIR}/pyproject.toml"
+mypy ${AGNO_CLI_DIR}/agno_cli --config-file ${AGNO_CLI_DIR}/pyproject.toml

--- a/libs/agno_cli/tests/conftest.py
+++ b/libs/agno_cli/tests/conftest.py
@@ -1,0 +1,200 @@
+"""Test fixtures: an in-memory fake AgentOS served through httpx.MockTransport."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+
+class FakeAgentOS:
+    """Simulates the AgentOS endpoints the CLI touches.
+
+    auth_mode: "none" | "security_key" | "jwt"
+    info_discovery: serve the mcp/auth_mode fields on /info (newer servers)
+    mcp_requires_token: enforce tokens on /mcp (False models servers predating enforcement)
+    """
+
+    def __init__(
+        self,
+        auth_mode: str = "security_key",
+        security_key: str = "test-admin-key",
+        mcp_enabled: bool = True,
+        info_discovery: bool = True,
+        mcp_requires_token: bool = True,
+        sse_responses: bool = False,
+        agno_version: str = "2.7.0",
+    ):
+        self.auth_mode = auth_mode
+        self.security_key = security_key
+        self.mcp_enabled = mcp_enabled
+        self.info_discovery = info_discovery
+        self.mcp_requires_token = mcp_requires_token
+        self.sse_responses = sse_responses
+        self.agno_version = agno_version
+
+        self.accounts: Dict[str, Dict[str, Any]] = {}  # name -> account dict (with plaintext token)
+        self.create_calls = 0
+        self.mcp_tools = ["run_agent", "run_team", "run_workflow", "get_agentos_config"]
+        self._next_id = 1
+
+    # -- helpers -------------------------------------------------------------------
+
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self.handler)
+
+    def active_tokens(self) -> List[str]:
+        return [a["token"] for a in self.accounts.values() if not a.get("revoked_at")]
+
+    def _bearer(self, request: httpx.Request) -> Optional[str]:
+        value = request.headers.get("Authorization")
+        if value and value.lower().startswith("bearer "):
+            return value[len("bearer ") :]
+        return value
+
+    def _is_admin(self, request: httpx.Request) -> bool:
+        if self.auth_mode == "none":
+            return True
+        return self._bearer(request) == self.security_key
+
+    def _account_response(self, account: Dict[str, Any], include_token: bool = False) -> Dict[str, Any]:
+        payload = {k: v for k, v in account.items() if k != "token"}
+        if include_token:
+            payload["token"] = account["token"]
+        return payload
+
+    def _jsonrpc_response(self, payload: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> httpx.Response:
+        if self.sse_responses:
+            body = "event: message\ndata: " + json.dumps(payload) + "\n\n"
+            return httpx.Response(
+                200, content=body.encode(), headers={"content-type": "text/event-stream", **(headers or {})}
+            )
+        return httpx.Response(200, json=payload, headers=headers or {})
+
+    # -- request handler -----------------------------------------------------------
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+
+        if path == "/health":
+            return httpx.Response(200, json={"status": "ok", "instantiated_at": "2026-07-04T00:00:00Z"})
+
+        if path == "/info":
+            payload: Dict[str, Any] = {"agno_version": self.agno_version, "agents": 1, "teams": 0, "workflows": 0}
+            if self.info_discovery:
+                payload["mcp"] = {"enabled": self.mcp_enabled, "path": "/mcp" if self.mcp_enabled else None}
+                payload["auth_mode"] = self.auth_mode
+            return httpx.Response(200, json=payload)
+
+        if path == "/config":
+            if self.auth_mode == "none":
+                return httpx.Response(200, json={"os_id": "fake"})
+            if self._bearer(request) == self.security_key:
+                return httpx.Response(200, json={"os_id": "fake"})
+            detail = (
+                "Authorization header required" if self.auth_mode == "security_key" else "Authorization header missing"
+            )
+            return httpx.Response(401, json={"detail": detail})
+
+        if path == "/service-accounts" and method == "POST":
+            if not self._is_admin(request):
+                return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            body = json.loads(request.content)
+            name = body["name"]
+            if name in self.accounts and not self.accounts[name].get("revoked_at"):
+                return httpx.Response(409, json={"detail": "Service account '" + name + "' already exists"})
+            self.create_calls += 1
+            # Realistic length: real tokens are agno_pat_ + 43 base62 chars, so the
+            # 16-char display prefix must never contain the whole token.
+            token = "agno_pat_" + (name.replace("-", "") + str(self._next_id) + "x" * 40)[:43]
+            account = {
+                "id": "sa-" + str(self._next_id),
+                "name": name,
+                "principal": "sa:" + name,
+                "token_prefix": token[:16],
+                "scopes": body.get("scopes") or ["agents:run", "teams:run", "workflows:run", "sessions:read"],
+                "created_at": 1780000000,
+                "expires_at": None if body.get("never_expires") else 1790000000,
+                "last_used_at": None,
+                "revoked_at": None,
+                "created_by": None,
+                "token": token,
+            }
+            self._next_id += 1
+            self.accounts[name] = account
+            return httpx.Response(201, json=self._account_response(account, include_token=True))
+
+        if path == "/service-accounts" and method == "GET":
+            if not self._is_admin(request):
+                return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            data = [self._account_response(a) for a in self.accounts.values()]
+            return httpx.Response(
+                200,
+                json={"data": data, "meta": {"page": 1, "limit": 100, "total_pages": 1, "total_count": len(data)}},
+            )
+
+        if path.startswith("/service-accounts/") and method == "DELETE":
+            if not self._is_admin(request):
+                return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            account_id = path.rsplit("/", 1)[1]
+            for account in self.accounts.values():
+                if account["id"] == account_id:
+                    account["revoked_at"] = 1780000001
+                    return httpx.Response(204)
+            return httpx.Response(404, json={"detail": "Service account not found"})
+
+        if path == "/mcp":
+            if not self.mcp_enabled:
+                return httpx.Response(404, json={"detail": "Not Found"})
+            if self.mcp_requires_token and self.auth_mode != "none":
+                token = self._bearer(request)
+                if token != self.security_key and token not in self.active_tokens():
+                    return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            message = json.loads(request.content) if request.content else {}
+            rpc_method = message.get("method")
+            if rpc_method == "initialize":
+                return self._jsonrpc_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "result": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "FakeAgentOS", "version": self.agno_version},
+                        },
+                    },
+                    headers={"mcp-session-id": "fake-session-1"},
+                )
+            if rpc_method == "notifications/initialized":
+                return httpx.Response(202)
+            if rpc_method == "tools/list":
+                return self._jsonrpc_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "result": {"tools": [{"name": name} for name in self.mcp_tools]},
+                    }
+                )
+            return self._jsonrpc_response(
+                {"jsonrpc": "2.0", "id": message.get("id"), "error": {"code": -32601, "message": "Method not found"}}
+            )
+
+        return httpx.Response(404, json={"detail": "Not Found"})
+
+
+@pytest.fixture
+def fake_os(monkeypatch: pytest.MonkeyPatch) -> FakeAgentOS:
+    """A security-key-mode fake AgentOS wired into every CLI HTTP client."""
+    fake = FakeAgentOS()
+    install_fake(monkeypatch, fake)
+    return fake
+
+
+def install_fake(monkeypatch: pytest.MonkeyPatch, fake: FakeAgentOS) -> None:
+    import agno_cli.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", fake.transport())
+    # Keep host-machine credentials and URL overrides out of tests.
+    for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGNO_OS_URL"):
+        monkeypatch.delenv(var, raising=False)

--- a/libs/agno_cli/tests/test_adapters.py
+++ b/libs/agno_cli/tests/test_adapters.py
@@ -1,0 +1,247 @@
+"""Client adapters: config reads/writes for Claude Code, Codex, and Cursor."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+from agno_cli.clients.claude_code import ClaudeCodeAdapter
+from agno_cli.clients.codex import CodexAdapter
+from agno_cli.clients.cursor import CursorAdapter
+
+URL = "http://localhost:7777/mcp"
+TOKEN = "agno_pat_test123"
+
+
+class FakeRunner:
+    """Records subprocess invocations and plays back scripted results."""
+
+    def __init__(self, results: Optional[List[subprocess.CompletedProcess]] = None):
+        self.calls: List[List[str]] = []
+        self.results = results or []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append(list(args))
+        if self.results:
+            return self.results.pop(0)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+# -- Claude Code -----------------------------------------------------------------------
+
+
+def test_claude_write_via_cli_flag_order(tmp_path: Path):
+    runner = FakeRunner()
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: "/usr/bin/claude", runner=runner)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "cli"
+    args = runner.calls[0]
+    assert args[:3] == ["claude", "mcp", "add"]
+    # Variadic --header must come after the positional name and URL.
+    assert args.index("--header") > args.index("agno") > args.index("--transport")
+    assert args.index("--header") > args.index(URL)
+    assert "Authorization: Bearer " + TOKEN in args
+
+
+def test_claude_write_cli_retries_on_already_exists(tmp_path: Path):
+    runner = FakeRunner(
+        results=[
+            subprocess.CompletedProcess([], 1, stdout="", stderr="MCP server agno already exists"),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+    )
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: "/usr/bin/claude", runner=runner)
+    adapter.write("agno", URL, TOKEN)
+    assert runner.calls[1][:3] == ["claude", "mcp", "remove"]
+    assert runner.calls[2][:3] == ["claude", "mcp", "add"]
+
+
+def test_claude_write_file_fallback_without_binary(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "file"
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    entry = config["mcpServers"]["agno"]
+    assert entry["url"] == URL
+    assert entry["headers"]["Authorization"] == "Bearer " + TOKEN
+
+
+def test_claude_write_without_token_omits_headers(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    adapter.write("agno", URL, None)
+    entry = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]["agno"]
+    assert "headers" not in entry
+
+
+def test_claude_read_existing_project_file(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    adapter.write("agno", URL, TOKEN)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == URL
+    assert entry.token == TOKEN
+
+
+def test_claude_read_existing_user_scope(tmp_path: Path):
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {"mcpServers": {"agno": {"type": "http", "url": URL, "headers": {"Authorization": "Bearer " + TOKEN}}}}
+        )
+    )
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.token == TOKEN
+
+
+def test_claude_read_existing_local_scope(tmp_path: Path):
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    (tmp_path / ".claude.json").write_text(json.dumps({"projects": {str(cwd): {"mcpServers": {"agno": {"url": URL}}}}}))
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=cwd, which=lambda name: None)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.token is None
+
+
+def test_claude_detect(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    assert adapter.detect() is False
+    (tmp_path / ".claude.json").write_text("{}")
+    assert adapter.detect() is True
+
+
+# -- Codex -----------------------------------------------------------------------------
+
+
+def test_codex_write_creates_config(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "file"
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert parsed["mcp_servers"]["agno"]["http_headers"]["Authorization"] == "Bearer " + TOKEN
+    assert (adapter.config_path.stat().st_mode & 0o777) == 0o600
+
+
+def test_codex_write_preserves_other_content(tmp_path: Path):
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        '# my settings\nmodel = "o5"\n\n[mcp_servers.other]\nurl = "https://example.com/mcp"\n'
+    )
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    text = adapter.config_path.read_text()
+    assert "# my settings" in text
+    parsed = tomllib.loads(text)
+    assert parsed["model"] == "o5"
+    assert parsed["mcp_servers"]["other"]["url"] == "https://example.com/mcp"
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+
+
+def test_codex_write_replaces_existing_entry(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", "http://old:1/mcp", "agno_pat_old")
+    adapter.write("agno", URL, TOKEN)
+
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert parsed["mcp_servers"]["agno"]["http_headers"]["Authorization"] == "Bearer " + TOKEN
+    assert adapter.config_path.read_text().count("[mcp_servers.agno]") == 1
+
+
+def test_codex_replaces_dotted_subtables(tmp_path: Path):
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        '[mcp_servers.agno]\nurl = "http://old:1/mcp"\n\n[mcp_servers.agno.http_headers]\nAuthorization = "Bearer old"\n\n[mcp_servers.keep]\nurl = "https://keep/mcp"\n'
+    )
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert parsed["mcp_servers"]["keep"]["url"] == "https://keep/mcp"
+    assert "Bearer old" not in adapter.config_path.read_text()
+
+
+def test_codex_read_existing_roundtrip(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == URL
+    assert entry.token == TOKEN
+
+
+def test_codex_read_missing_or_malformed(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    assert adapter.read_existing("agno") is None
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text("this is [not valid toml")
+    assert adapter.read_existing("agno") is None
+
+
+# -- Cursor ----------------------------------------------------------------------------
+
+
+def test_cursor_write_global(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "file"
+    config = json.loads((tmp_path / ".cursor" / "mcp.json").read_text())
+    assert config["mcpServers"]["agno"]["url"] == URL
+    assert config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer " + TOKEN
+    assert ((tmp_path / ".cursor" / "mcp.json").stat().st_mode & 0o777) == 0o600
+
+
+def test_cursor_write_project_scope(tmp_path: Path):
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    adapter = CursorAdapter(home=tmp_path, cwd=cwd, project=True)
+    adapter.write("agno", URL, TOKEN)
+    assert (cwd / ".cursor" / "mcp.json").exists()
+
+
+def test_cursor_write_preserves_other_servers(tmp_path: Path):
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    (config_dir / "mcp.json").write_text(json.dumps({"mcpServers": {"other": {"url": "https://other/mcp"}}}))
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    config = json.loads((config_dir / "mcp.json").read_text())
+    assert config["mcpServers"]["other"]["url"] == "https://other/mcp"
+    assert config["mcpServers"]["agno"]["url"] == URL
+
+
+def test_cursor_read_prefers_project_config(tmp_path: Path):
+    cwd = tmp_path / "project"
+    (cwd / ".cursor").mkdir(parents=True)
+    (tmp_path / ".cursor").mkdir()
+    (cwd / ".cursor" / "mcp.json").write_text(json.dumps({"mcpServers": {"agno": {"url": "http://project/mcp"}}}))
+    (tmp_path / ".cursor" / "mcp.json").write_text(json.dumps({"mcpServers": {"agno": {"url": "http://global/mcp"}}}))
+    adapter = CursorAdapter(home=tmp_path, cwd=cwd)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == "http://project/mcp"
+
+
+def test_cursor_detect(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    assert adapter.detect() is False
+    (tmp_path / ".cursor").mkdir()
+    assert adapter.detect() is True

--- a/libs/agno_cli/tests/test_adapters.py
+++ b/libs/agno_cli/tests/test_adapters.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+import pytest
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -14,6 +16,7 @@ else:
 from agno_cli.clients.claude_code import ClaudeCodeAdapter
 from agno_cli.clients.codex import CodexAdapter
 from agno_cli.clients.cursor import CursorAdapter
+from agno_cli.errors import CLIError
 
 URL = "http://localhost:7777/mcp"
 TOKEN = "agno_pat_test123"
@@ -64,31 +67,77 @@ def test_claude_write_cli_retries_on_already_exists(tmp_path: Path):
     assert runner.calls[2][:3] == ["claude", "mcp", "add"]
 
 
-def test_claude_write_file_fallback_without_binary(tmp_path: Path):
+def test_claude_write_file_fallback_user_scope(tmp_path: Path):
+    """Without the binary, user-scope writes land in ~/.claude.json, never a VCS-shared file."""
     adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
     result = adapter.write("agno", URL, TOKEN)
 
     assert result.method == "file"
-    config = json.loads((tmp_path / ".mcp.json").read_text())
+    config = json.loads((tmp_path / ".claude.json").read_text())
     entry = config["mcpServers"]["agno"]
     assert entry["url"] == URL
     assert entry["headers"]["Authorization"] == "Bearer " + TOKEN
+    assert ((tmp_path / ".claude.json").stat().st_mode & 0o777) == 0o600
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+def test_claude_write_file_fallback_project_scope_warns(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, scope="project", which=lambda name: None)
+    result = adapter.write("agno", URL, TOKEN)
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    assert config["mcpServers"]["agno"]["url"] == URL
+    assert result.note is not None and "version control" in result.note
+
+
+def test_claude_write_preserves_unrelated_user_config(tmp_path: Path):
+    (tmp_path / ".claude.json").write_text(json.dumps({"onboarding": True, "projects": {"/x": {}}}))
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    adapter.write("agno", URL, TOKEN)
+    config = json.loads((tmp_path / ".claude.json").read_text())
+    assert config["onboarding"] is True
+    assert config["projects"] == {"/x": {}}
+    assert config["mcpServers"]["agno"]["url"] == URL
+
+
+def test_claude_write_refuses_corrupt_config(tmp_path: Path):
+    (tmp_path / ".claude.json").write_text("{not json")
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    with pytest.raises(CLIError) as exc_info:
+        adapter.write("agno", URL, TOKEN)
+    assert "Refusing to modify" in exc_info.value.message
+    assert (tmp_path / ".claude.json").read_text() == "{not json"
 
 
 def test_claude_write_without_token_omits_headers(tmp_path: Path):
     adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
     adapter.write("agno", URL, None)
-    entry = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]["agno"]
+    entry = json.loads((tmp_path / ".claude.json").read_text())["mcpServers"]["agno"]
     assert "headers" not in entry
 
 
-def test_claude_read_existing_project_file(tmp_path: Path):
+def test_claude_read_existing_roundtrip(tmp_path: Path):
     adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
     adapter.write("agno", URL, TOKEN)
     entry = adapter.read_existing("agno")
     assert entry is not None
     assert entry.url == URL
     assert entry.token == TOKEN
+
+
+def test_claude_local_scope_wins_over_user_scope(tmp_path: Path):
+    """Claude Code resolves local > project > user; read_existing must match."""
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {"agno": {"url": "http://user-scope/mcp"}},
+                "projects": {str(tmp_path): {"mcpServers": {"agno": {"url": "http://local-scope/mcp"}}}},
+            }
+        )
+    )
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == "http://local-scope/mcp"
 
 
 def test_claude_read_existing_user_scope(tmp_path: Path):
@@ -194,6 +243,35 @@ def test_codex_read_missing_or_malformed(tmp_path: Path):
     assert adapter.read_existing("agno") is None
 
 
+def test_codex_write_refuses_corrupt_config(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text("this is [not valid toml")
+    with pytest.raises(CLIError) as exc_info:
+        adapter.write("agno", URL, TOKEN)
+    assert "Refusing to modify" in exc_info.value.message
+
+
+def test_codex_preserves_array_of_tables_after_section(tmp_path: Path):
+    """[[array-of-tables]] following the managed section must survive a rewrite."""
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    original = (
+        '[mcp_servers.agno]\nurl = "http://old:1/mcp"\n\n'
+        "# profiles below\n"
+        '[[profiles]]\nname = "work"\n\n'
+        '[[profiles]]\nname = "personal"\n'
+    )
+    (config_dir / "config.toml").write_text(original)
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert [p["name"] for p in parsed["profiles"]] == ["work", "personal"]
+    assert "# profiles below" in adapter.config_path.read_text()
+
+
 # -- Cursor ----------------------------------------------------------------------------
 
 
@@ -245,3 +323,24 @@ def test_cursor_detect(tmp_path: Path):
     assert adapter.detect() is False
     (tmp_path / ".cursor").mkdir()
     assert adapter.detect() is True
+
+
+def test_cursor_write_refuses_corrupt_config(tmp_path: Path):
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    (config_dir / "mcp.json").write_text("{broken")
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    with pytest.raises(CLIError) as exc_info:
+        adapter.write("agno", URL, TOKEN)
+    assert "Refusing to modify" in exc_info.value.message
+    assert (config_dir / "mcp.json").read_text() == "{broken"
+
+
+def test_cursor_malformed_servers_shape_is_tolerated_on_read(tmp_path: Path):
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    (config_dir / "mcp.json").write_text(json.dumps({"mcpServers": ["not", "a", "dict"]}))
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    assert adapter.read_existing("agno") is None
+    with pytest.raises(CLIError):
+        adapter.write("agno", URL, TOKEN)

--- a/libs/agno_cli/tests/test_connect_cmd.py
+++ b/libs/agno_cli/tests/test_connect_cmd.py
@@ -56,8 +56,8 @@ def test_connect_happy_path(monkeypatch, fake_os, fake_clients):
     for account in fake_os.accounts.values():
         assert account["token"] not in result.output
 
-    # Tokens landed in the client configs.
-    claude_config = json.loads((fake_clients / ".mcp.json").read_text())
+    # Tokens landed in the client configs (Claude user scope = ~/.claude.json).
+    claude_config = json.loads((fake_clients / ".claude.json").read_text())
     assert claude_config["mcpServers"]["agno"]["url"] == MCP_URL
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
     token = cursor_config["mcpServers"]["agno"]["headers"]["Authorization"]
@@ -82,7 +82,7 @@ def test_connect_conflict_without_rotate_fails_noninteractive(monkeypatch, fake_
     assert _connect().exit_code == 0
 
     # Wipe client configs but keep server-side accounts: mint now conflicts.
-    (fake_clients / ".mcp.json").unlink()
+    (fake_clients / ".claude.json").write_text("{}")
     (fake_clients / ".codex" / "config.toml").unlink()
     (fake_clients / ".cursor" / "mcp.json").unlink()
 
@@ -190,4 +190,60 @@ def test_connect_skip_existing_leaves_broken_entry(monkeypatch, fake_os, fake_cl
     result = _connect(["--skip-existing"])
     payload = json.loads(result.output)
     assert all(r["status"] == "skipped" for r in payload["results"])
+    assert result.exit_code == 1
+
+
+def test_connect_skip_existing_never_touches_foreign_entry(monkeypatch, fake_os, fake_clients):
+    """An entry pointing at a DIFFERENT AgentOS is untouchable under --skip-existing."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp", "headers": {"Authorization": "Bearer keep"}}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
+
+    result = _connect(["--clients", "cursor", "--skip-existing"])
+    payload = json.loads(result.output)
+    assert payload["results"][0]["status"] == "skipped"
+    assert "other-os" in payload["results"][0]["error"]
+    config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert config["mcpServers"]["agno"]["url"] == "http://other-os:9999/mcp"
+    assert config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer keep"
+    assert fake_os.create_calls == 0
+
+
+def test_connect_replacing_foreign_entry_is_reported(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp"}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
+
+    result = _connect(["--clients", "cursor"])
+    payload = json.loads(result.output)
+    assert payload["results"][0]["status"] == "connected"
+    assert payload["results"][0]["replaced_url"] == "http://other-os:9999/mcp"
+
+
+def test_connect_partial_failure_keeps_json_contract(monkeypatch, fake_os, fake_clients):
+    """One corrupt client config fails that client only; output stays one JSON document, exit 3."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".cursor" / "mcp.json").write_text("{corrupt")
+
+    result = _connect()
+    payload = json.loads(result.output)
+    by_client = {r["client"]: r for r in payload["results"]}
+    assert by_client["cursor"]["status"] == "failed"
+    assert "Refusing to modify" in by_client["cursor"]["error"]
+    assert by_client["claude-code"]["status"] == "connected"
+    assert by_client["codex"]["status"] == "connected"
+    assert result.exit_code == 3
+
+
+def test_connect_detects_shadowing_claude_local_entry(monkeypatch, fake_os, fake_clients):
+    """A stale local-scope entry shadows the user-scope write; connect must fail loudly, not lie."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".claude.json").write_text(
+        json.dumps({"projects": {str(fake_clients): {"mcpServers": {"agno": {"url": "http://stale:1/mcp"}}}}})
+    )
+
+    result = _connect(["--clients", "claude-code", "--rotate"])
+    payload = json.loads(result.output)
+    assert payload["results"][0]["status"] == "failed"
+    assert "shadow" in payload["results"][0]["error"]
     assert result.exit_code == 1

--- a/libs/agno_cli/tests/test_connect_cmd.py
+++ b/libs/agno_cli/tests/test_connect_cmd.py
@@ -1,0 +1,193 @@
+"""`agno connect` end-to-end flows against the fake AgentOS and tmp client configs."""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import agno_cli.commands.connect as connect_module
+from agno_cli.clients.claude_code import ClaudeCodeAdapter
+from agno_cli.clients.codex import CodexAdapter
+from agno_cli.clients.cursor import CursorAdapter
+from agno_cli.main import app
+from tests.conftest import FakeAgentOS, install_fake
+
+runner = CliRunner()
+
+URL_ARGS = ["--url", "http://localhost:7777"]
+MCP_URL = "http://localhost:7777/mcp"
+
+
+@pytest.fixture
+def fake_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """All three clients 'installed' under a tmp home, wired into the connect command."""
+    (tmp_path / ".claude.json").write_text("{}")
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".cursor").mkdir()
+
+    def build(home=None, cwd=None, project=False):
+        return {
+            "claude-code": ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None),
+            "codex": CodexAdapter(home=tmp_path),
+            "cursor": CursorAdapter(home=tmp_path, cwd=tmp_path, project=project),
+        }
+
+    monkeypatch.setattr(connect_module, "build_adapters", build)
+    return tmp_path
+
+
+def _connect(args=(), **kwargs):
+    return runner.invoke(app, ["connect", "--json"] + URL_ARGS + list(args), **kwargs)
+
+
+def test_connect_happy_path(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    assert {r["client"] for r in payload["results"]} == {"claude-code", "codex", "cursor"}
+    assert all(r["status"] == "connected" for r in payload["results"])
+    assert all(r["verify"]["ok"] for r in payload["results"])
+    assert sorted(fake_os.accounts.keys()) == ["claude-code", "codex", "cursor"]
+
+    # No plaintext token anywhere in the report.
+    for account in fake_os.accounts.values():
+        assert account["token"] not in result.output
+
+    # Tokens landed in the client configs.
+    claude_config = json.loads((fake_clients / ".mcp.json").read_text())
+    assert claude_config["mcpServers"]["agno"]["url"] == MCP_URL
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    token = cursor_config["mcpServers"]["agno"]["headers"]["Authorization"]
+    assert token == "Bearer " + fake_os.accounts["cursor"]["token"]
+
+
+def test_connect_rerun_is_idempotent(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    first = _connect()
+    assert first.exit_code == 0, first.output
+    creates_after_first = fake_os.create_calls
+
+    second = _connect()
+    assert second.exit_code == 0, second.output
+    payload = json.loads(second.output)
+    assert all(r["status"] == "already-connected" for r in payload["results"])
+    assert fake_os.create_calls == creates_after_first
+
+
+def test_connect_conflict_without_rotate_fails_noninteractive(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+
+    # Wipe client configs but keep server-side accounts: mint now conflicts.
+    (fake_clients / ".mcp.json").unlink()
+    (fake_clients / ".codex" / "config.toml").unlink()
+    (fake_clients / ".cursor" / "mcp.json").unlink()
+
+    result = _connect()
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert all("already exists" in (r["error"] or "") for r in payload["results"])
+
+
+def test_connect_rotate_replaces_accounts(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    old_token = fake_os.accounts["cursor"]["token"]
+
+    result = _connect(["--rotate"])
+    assert result.exit_code == 0, result.output
+    new_token = fake_os.accounts["cursor"]["token"]
+    assert new_token != old_token
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer " + new_token
+
+
+def test_connect_rotates_stale_entry(monkeypatch, fake_os, fake_clients):
+    """A config entry whose token was revoked server-side gets rotated on re-run."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    for account in list(fake_os.accounts.values()):
+        account["revoked_at"] = 1780000001
+
+    result = _connect(["--rotate"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "connected" for r in payload["results"])
+
+
+def test_connect_no_auth_mode(monkeypatch, fake_clients):
+    fake = FakeAgentOS(auth_mode="none")
+    install_fake(monkeypatch, fake)
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "connected" for r in payload["results"])
+    assert fake.create_calls == 0
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "headers" not in cursor_config["mcpServers"]["agno"]
+
+
+def test_connect_mcp_disabled(monkeypatch, fake_clients):
+    fake = FakeAgentOS(mcp_enabled=False)
+    install_fake(monkeypatch, fake)
+    result = _connect()
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "enable_mcp_server=True" in payload["error"]
+
+
+def test_connect_warns_when_mcp_unauthenticated(monkeypatch, fake_clients):
+    fake = FakeAgentOS(mcp_requires_token=False)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["warning"] is not None
+    assert "unauthenticated" in payload["warning"]
+
+
+def test_connect_shared_account_with_name(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _connect(["--name", "my-machine"])
+    assert result.exit_code == 0, result.output
+    assert list(fake_os.accounts.keys()) == ["my-machine"]
+    assert fake_os.create_calls == 1
+
+
+def test_connect_explicit_client_selection(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [r["client"] for r in payload["results"]] == ["cursor"]
+    assert list(fake_os.accounts.keys()) == ["cursor"]
+
+
+def test_connect_unknown_client(monkeypatch, fake_os, fake_clients):
+    result = _connect(["--clients", "emacs"])
+    assert result.exit_code == 1
+    assert "Unknown client" in json.loads(result.output)["error"]
+
+
+def test_connect_missing_admin_credential(monkeypatch, fake_os, fake_clients):
+    result = _connect()
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "AGNO_ADMIN_TOKEN" in payload["hint"]
+
+
+def test_connect_skip_existing_leaves_broken_entry(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    for account in list(fake_os.accounts.values()):
+        account["revoked_at"] = 1780000001
+
+    result = _connect(["--skip-existing"])
+    payload = json.loads(result.output)
+    assert all(r["status"] == "skipped" for r in payload["results"])
+    assert result.exit_code == 1

--- a/libs/agno_cli/tests/test_create_infra.py
+++ b/libs/agno_cli/tests/test_create_infra.py
@@ -1,0 +1,168 @@
+"""`agno create` and `agno infra` behavior (git and docker are faked)."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import agno_cli.commands.create as create_module
+import agno_cli.commands.infra as infra_module
+from agno_cli.commands.infra import find_compose_file
+from agno_cli.errors import CLIError
+from agno_cli.main import app
+
+runner = CliRunner()
+
+
+class FakeGit:
+    """Simulates `git clone` by scaffolding a template directory."""
+
+    def __init__(self, with_secrets: bool = True, returncode: int = 0):
+        self.with_secrets = with_secrets
+        self.returncode = returncode
+        self.calls = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append(list(args))
+        if self.returncode == 0 and args[:2] == ["git", "clone"]:
+            target = Path(args[-1])
+            (target / ".git").mkdir(parents=True)
+            (target / "docker-compose.yml").write_text("services: {}\n")
+            if self.with_secrets:
+                (target / "infra" / "example_secrets").mkdir(parents=True)
+                (target / "infra" / "example_secrets" / "example.env").write_text("KEY=value\n")
+        return subprocess.CompletedProcess(args, self.returncode, stdout="", stderr="boom" if self.returncode else "")
+
+
+@pytest.fixture
+def fake_git(monkeypatch, tmp_path):
+    fake = FakeGit()
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+    return fake
+
+
+def test_create_scaffolds_project(fake_git, tmp_path):
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    assert payload["template"] == "agentos-docker"
+    project = tmp_path / "my-os"
+    assert (project / "docker-compose.yml").exists()
+    assert not (project / ".git").exists()
+    assert (project / "infra" / "secrets" / "example.env").exists()
+    clone_args = fake_git.calls[0]
+    assert "https://github.com/agno-agi/agentos-docker-template" in clone_args
+
+
+def test_create_refuses_existing_directory(fake_git, tmp_path):
+    (tmp_path / "my-os").mkdir()
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+    assert result.exit_code == 1
+    assert "already exists" in json.loads(result.output)["error"]
+
+
+def test_create_unknown_template(fake_git):
+    result = runner.invoke(app, ["create", "my-os", "-t", "nope", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "Unknown template" in payload["error"]
+    assert "agentos-docker" in payload["hint"]
+
+
+def test_create_custom_url(fake_git):
+    result = runner.invoke(app, ["create", "my-os", "-u", "https://example.com/custom.git", "--json"])
+    assert result.exit_code == 0, result.output
+    assert "https://example.com/custom.git" in fake_git.calls[0]
+
+
+def test_create_clone_failure(monkeypatch, tmp_path):
+    fake = FakeGit(returncode=128)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+    assert result.exit_code == 1
+    assert "git clone failed" in json.loads(result.output)["error"]
+
+
+# -- infra -----------------------------------------------------------------------------
+
+
+def test_find_compose_file_autodetect(tmp_path):
+    (tmp_path / "infra").mkdir()
+    (tmp_path / "infra" / "compose.yaml").write_text("services: {}\n")
+    assert find_compose_file(cwd=tmp_path) == tmp_path / "infra" / "compose.yaml"
+    # Root-level files win over infra/ ones.
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    assert find_compose_file(cwd=tmp_path) == tmp_path / "docker-compose.yml"
+
+
+def test_find_compose_file_missing(tmp_path):
+    with pytest.raises(CLIError) as exc_info:
+        find_compose_file(cwd=tmp_path)
+    assert "No compose file" in exc_info.value.message
+
+
+def test_infra_up_dry_run_command(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["infra", "up", "--pull", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["command"] == [
+        "docker",
+        "compose",
+        "-f",
+        str(tmp_path / "docker-compose.yml"),
+        "up",
+        "-d",
+        "--build",
+        "--pull",
+        "always",
+    ]
+    assert payload["dry_run"] is True
+
+
+def test_infra_down_dry_run_volumes(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["infra", "down", "-v", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["command"][-2:] == ["down", "--volumes"]
+
+
+def test_infra_up_runs_compose(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((list(args), kwargs.get("cwd")))
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(infra_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["infra", "up", "--json"])
+    assert result.exit_code == 0, result.output
+    args, cwd = calls[0]
+    assert args[:4] == ["docker", "compose", "-f", str(tmp_path / "docker-compose.yml")]
+    assert cwd == str(tmp_path)
+
+
+def test_infra_compose_failure_maps_to_exit_1(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        infra_module.subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 17, stdout="", stderr="broken"),
+    )
+    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["infra", "up", "--json"])
+    assert result.exit_code == 1
+    assert "exited with code 17" in json.loads(result.output)["error"]

--- a/libs/agno_cli/tests/test_create_lifecycle.py
+++ b/libs/agno_cli/tests/test_create_lifecycle.py
@@ -1,4 +1,4 @@
-"""`agno create` and `agno infra` behavior (git and docker are faked)."""
+"""`agno create` and `agno up/down/restart` behavior (git and docker are faked)."""
 
 import json
 import subprocess
@@ -8,8 +8,8 @@ import pytest
 from typer.testing import CliRunner
 
 import agno_cli.commands.create as create_module
-import agno_cli.commands.infra as infra_module
-from agno_cli.commands.infra import find_compose_file
+import agno_cli.commands.lifecycle as lifecycle_module
+from agno_cli.commands.lifecycle import find_compose_file
 from agno_cli.errors import CLIError
 from agno_cli.main import app
 
@@ -111,7 +111,7 @@ def test_find_compose_file_missing(tmp_path):
 def test_infra_up_dry_run_command(monkeypatch, tmp_path):
     (tmp_path / "docker-compose.yml").write_text("services: {}\n")
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["infra", "up", "--pull", "--dry-run", "--json"])
+    result = runner.invoke(app, ["up", "--pull", "--dry-run", "--json"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["command"] == [
@@ -131,7 +131,7 @@ def test_infra_up_dry_run_command(monkeypatch, tmp_path):
 def test_infra_down_dry_run_volumes(monkeypatch, tmp_path):
     (tmp_path / "docker-compose.yml").write_text("services: {}\n")
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["infra", "down", "-v", "--dry-run", "--json"])
+    result = runner.invoke(app, ["down", "-v", "--dry-run", "--json"])
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["command"][-2:] == ["down", "--volumes"]
 
@@ -145,9 +145,9 @@ def test_infra_up_runs_compose(monkeypatch, tmp_path):
         calls.append((list(args), kwargs.get("cwd")))
         return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
-    monkeypatch.setattr(infra_module.subprocess, "run", fake_run)
-    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
-    result = runner.invoke(app, ["infra", "up", "--json"])
+    monkeypatch.setattr(lifecycle_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(lifecycle_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["up", "--json"])
     assert result.exit_code == 0, result.output
     args, cwd = calls[0]
     assert args[:4] == ["docker", "compose", "-f", str(tmp_path / "docker-compose.yml")]
@@ -158,11 +158,11 @@ def test_infra_compose_failure_maps_to_exit_1(monkeypatch, tmp_path):
     (tmp_path / "docker-compose.yml").write_text("services: {}\n")
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        infra_module.subprocess,
+        lifecycle_module.subprocess,
         "run",
         lambda args, **kwargs: subprocess.CompletedProcess(args, 17, stdout="", stderr="broken"),
     )
-    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
-    result = runner.invoke(app, ["infra", "up", "--json"])
+    monkeypatch.setattr(lifecycle_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["up", "--json"])
     assert result.exit_code == 1
     assert "exited with code 17" in json.loads(result.output)["error"]

--- a/libs/agno_cli/tests/test_discovery.py
+++ b/libs/agno_cli/tests/test_discovery.py
@@ -1,0 +1,67 @@
+"""Discovery: structured /info fields, probe fallbacks, and failure modes."""
+
+import httpx
+import pytest
+
+from agno_cli.discovery import discover
+from agno_cli.errors import CLIError
+from tests.conftest import FakeAgentOS, install_fake
+
+
+def test_discover_via_info_fields(fake_os):
+    info = discover("http://localhost:7777")
+    assert info.discovered_via == "info"
+    assert info.mcp_enabled is True
+    assert info.mcp_url == "http://localhost:7777/mcp"
+    assert info.auth_mode == "security_key"
+    assert info.version == "2.7.0"
+
+
+def test_discover_probe_fallback_security_key(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False)
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.discovered_via == "probe"
+    assert info.mcp_enabled is True
+    assert info.auth_mode == "security_key"
+
+
+def test_discover_probe_fallback_jwt(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False, auth_mode="jwt")
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.auth_mode == "jwt"
+
+
+def test_discover_probe_fallback_none_auth(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False, auth_mode="none")
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.auth_mode == "none"
+
+
+def test_discover_probe_detects_mcp_disabled(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False, mcp_enabled=False)
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.mcp_enabled is False
+    assert info.mcp_path is None
+
+
+def test_discover_unreachable_raises(monkeypatch):
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    import agno_cli.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(refuse))
+    monkeypatch.delenv("AGNO_OS_URL", raising=False)
+    with pytest.raises(CLIError) as exc_info:
+        discover(None)
+    assert "No running AgentOS" in exc_info.value.message
+
+
+def test_discover_env_var_url(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_OS_URL", "http://envhost:9000")
+    info = discover(None)
+    assert info.base_url == "http://envhost:9000"

--- a/libs/agno_cli/tests/test_mcp_client.py
+++ b/libs/agno_cli/tests/test_mcp_client.py
@@ -45,3 +45,25 @@ def test_verify_404_when_mcp_disabled(monkeypatch):
     result = verify_mcp(MCP_URL, token=fake.security_key)
     assert result.ok is False
     assert result.status_code == 404
+
+
+def test_verify_never_raises_on_malformed_result(monkeypatch):
+    """A server returning a garbage tools/list result must yield a failed result, not a traceback."""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json as json_module
+
+        message = json_module.loads(request.content) if request.content else {}
+        if message.get("method") == "initialize":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": {}})
+        if message.get("method") == "tools/list":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 2, "result": "not-a-dict"})
+        return httpx.Response(202)
+
+    import agno_cli.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
+    result = verify_mcp(MCP_URL, token="anything")
+    assert result.ok is True
+    assert result.tools == []

--- a/libs/agno_cli/tests/test_mcp_client.py
+++ b/libs/agno_cli/tests/test_mcp_client.py
@@ -1,0 +1,47 @@
+"""MCP verification client: JSON and SSE payloads, auth failures."""
+
+from agno_cli.mcp_client import verify_mcp
+from tests.conftest import FakeAgentOS, install_fake
+
+MCP_URL = "http://localhost:7777/mcp"
+
+
+def test_verify_ok_with_valid_token(monkeypatch, fake_os):
+    result = verify_mcp(MCP_URL, token=fake_os.security_key)
+    assert result.ok is True
+    assert "run_agent" in result.tools
+
+
+def test_verify_rejected_without_token(monkeypatch, fake_os):
+    result = verify_mcp(MCP_URL, token=None)
+    assert result.ok is False
+    assert result.status_code == 401
+
+
+def test_verify_rejected_with_bad_token(monkeypatch, fake_os):
+    result = verify_mcp(MCP_URL, token="agno_pat_wrong")
+    assert result.ok is False
+    assert result.status_code == 401
+
+
+def test_verify_parses_sse_responses(monkeypatch):
+    fake = FakeAgentOS(sse_responses=True)
+    install_fake(monkeypatch, fake)
+    result = verify_mcp(MCP_URL, token=fake.security_key)
+    assert result.ok is True
+    assert result.tools == fake.mcp_tools
+
+
+def test_verify_open_server_no_token(monkeypatch):
+    fake = FakeAgentOS(auth_mode="none")
+    install_fake(monkeypatch, fake)
+    result = verify_mcp(MCP_URL, token=None)
+    assert result.ok is True
+
+
+def test_verify_404_when_mcp_disabled(monkeypatch):
+    fake = FakeAgentOS(mcp_enabled=False)
+    install_fake(monkeypatch, fake)
+    result = verify_mcp(MCP_URL, token=fake.security_key)
+    assert result.ok is False
+    assert result.status_code == 404

--- a/libs/agno_cli/tests/test_tokens_cmd.py
+++ b/libs/agno_cli/tests/test_tokens_cmd.py
@@ -34,13 +34,16 @@ def test_create_human_output_prints_token(monkeypatch, fake_os):
     assert "shown once" in result.output
 
 
-def test_create_conflict_errors(monkeypatch, fake_os):
+def test_create_conflict_errors_with_tokens_hint(monkeypatch, fake_os):
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
     _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
     result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
     assert result.exit_code == 1
     payload = json.loads(result.output)
     assert "already exists" in payload["error"]
+    # The hint must reference flags this command actually has.
+    assert "agno tokens revoke ci-runner" in payload["hint"]
+    assert "--rotate" not in payload["hint"]
 
 
 def test_list_never_exposes_tokens(monkeypatch, fake_os):

--- a/libs/agno_cli/tests/test_tokens_cmd.py
+++ b/libs/agno_cli/tests/test_tokens_cmd.py
@@ -1,0 +1,90 @@
+"""`agno tokens` command behavior."""
+
+import json
+
+from typer.testing import CliRunner
+
+from agno_cli.main import app
+
+runner = CliRunner()
+
+URL_ARGS = ["--url", "http://localhost:7777"]
+
+
+def _run(args, **kwargs):
+    return runner.invoke(app, args, **kwargs)
+
+
+def test_create_json_includes_token_once(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["name"] == "ci-runner"
+    assert payload["token"].startswith("agno_pat_")
+    assert payload["principal"] == "sa:ci-runner"
+
+
+def test_create_human_output_prints_token(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner"] + URL_ARGS)
+    assert result.exit_code == 0, result.output
+    token = fake_os.accounts["ci-runner"]["token"]
+    assert token in result.output
+    assert "shown once" in result.output
+
+
+def test_create_conflict_errors(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "already exists" in payload["error"]
+
+
+def test_list_never_exposes_tokens(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "list", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload["service_accounts"]) == 1
+    assert "token" not in payload["service_accounts"][0]
+    assert payload["service_accounts"][0]["token_prefix"]
+
+
+def test_revoke_by_name(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "revoke", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    assert fake_os.accounts["ci-runner"]["revoked_at"] is not None
+
+
+def test_revoke_unknown_name(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "revoke", "ghost", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    assert "No service account named" in json.loads(result.output)["error"]
+
+
+def test_missing_admin_credential_fails_with_hint(monkeypatch, fake_os):
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "AGNO_ADMIN_TOKEN" in payload["hint"]
+
+
+def test_expires_never(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner", "--expires", "never", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    assert json.loads(result.output)["expires_at"] is None
+
+
+def test_expires_invalid(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner", "--expires", "soon", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    assert "Invalid --expires" in json.loads(result.output)["error"]

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,11 +8,13 @@
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${CURR_DIR}")"
 AGNO_DIR="${REPO_ROOT}/libs/agno"
+AGNO_CLI_DIR="${REPO_ROOT}/libs/agno_cli"
 AGNO_INFRA_DIR="${REPO_ROOT}/libs/agno_infra"
 COOKBOOK_DIR="${REPO_ROOT}/cookbook"
 source ${CURR_DIR}/_utils.sh
 
 print_heading "Formatting all libraries"
 source ${AGNO_DIR}/scripts/format.sh
+source ${AGNO_CLI_DIR}/scripts/format.sh
 source ${AGNO_INFRA_DIR}/scripts/format.sh
 source ${COOKBOOK_DIR}/scripts/format.sh

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -8,11 +8,13 @@
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${CURR_DIR}")"
 AGNO_DIR="${REPO_ROOT}/libs/agno"
+AGNO_CLI_DIR="${REPO_ROOT}/libs/agno_cli"
 AGNO_INFRA_DIR="${REPO_ROOT}/libs/agno_infra"
 COOKBOOK_DIR="${REPO_ROOT}/cookbook"
 source ${CURR_DIR}/_utils.sh
 
 print_heading "Validating all libraries"
 source ${AGNO_DIR}/scripts/validate.sh
+source ${AGNO_CLI_DIR}/scripts/validate.sh
 source ${AGNO_INFRA_DIR}/scripts/validate.sh
 source ${COOKBOOK_DIR}/scripts/validate.sh


### PR DESCRIPTION
## Summary

One command from a running AgentOS to connected coding agents:

```bash
uvx agno connect
```

This PR adds **`agnoctl`** — a new distribution at `libs/agno_cli` (module `agno_cli`, command `agno`) — plus the two server-side changes it needs. It is **stacked on `feat/service-accounts`** (the tokens it mints are the `agno_pat_*` service accounts from that branch) and is destined for `feat/v2.7`.

Design doc: `specs/agno/features/agno-cli/` (private specs repo).

### The CLI (`libs/agno_cli`, PyPI name `agnoctl`)

- **`agno connect`** — discovers the AgentOS (structured `/info` fields, probe fallback for older servers; tries `:7777` then `:8000`), mints one service account per client (`claude-code`, `codex`, `cursor`; `--name` for one shared account), writes each client's MCP config (Claude Code via `claude mcp add` with file fallback; Codex via section-scoped `~/.codex/config.toml` edit; Cursor via `mcp.json` merge), then **reads the config back and verifies the entry the client will actually use** with a real MCP `initialize` + `tools/list` handshake. Idempotent: working entries are skipped, broken ones rotated (`--rotate` / `--skip-existing` for non-interactive control). Tokens are never printed or logged.
- **`agno tokens create/list/revoke`** — thin wrappers over `POST/GET/DELETE /service-accounts`. `create` prints the plaintext exactly once.
- **`agno create NAME [-t agentos-docker|agentos-aws|agentos-railway] [-u URL]`** — template scaffolding (shallow clone, history stripped, example secrets copied), ported from `ag infra create`. The `~/.config/ag/config.json` registry is deliberately dropped; commands are cwd-based.
- **`agno up/down/restart`** — the docker compose path of the legacy `ag infra` CLI (same file detection and command lines), promoted to root verbs, with `--file`, `--volumes`, `--dry-run`, `--json`. The legacy per-resource Docker/AWS engine is deliberately **not** ported (its production path is under redesign); it can return via the `agno_cli.plugins` entry-point group, which lets any installed distribution mount subcommands.
- **`agno status`** — discovered OS, auth mode, MCP URL, per-client connection state.

CLI contract (built to be driven by coding agents as well as humans): `--json` on every command, deterministic exit codes (0 ok / 1 failure / 2 usage / 3 partial), no prompts in `--json` mode, truthful outcomes (nothing is reported connected that did not verify).

Dependencies: httpx, rich, typer (+ tomli on Python < 3.11) — no dependency on the `agno` framework, so the package stays uvx-fast. `uvx agno connect` (via the core `agno` package) becomes literal with a follow-up two-line change in `libs/agno/pyproject.toml` once `agnoctl` is published; until then: `uvx agnoctl connect`.

### Server-side changes (`libs/agno`)

- **`GET /info` discovery fields**: `mcp: {enabled, path}` and `auth_mode: "none" | "security_key" | "jwt"` (reflecting effective enforcement precedence), so tools can discover capabilities without probing or parsing 401 messages. `/info` remains unauthenticated.
- **`/mcp` auth in non-JWT modes**: the MCP sub-app previously performed no bearer validation when JWT authorization was off (the `OS_SECURITY_KEY` check is a router dependency, which does not apply to mounted sub-apps). A dedicated middleware now accepts the security key (constant-time compare) or a valid service-account token on `/mcp`, mirroring REST semantics; open dev instances stay open; JWT mode is unchanged.

## Type of change

- [x] New feature
- [x] Bug fix (the `/mcp` unauthenticated-in-security-key-mode gap)

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings, `libs/agno_cli/README.md`)
- [ ] Examples and guides: cookbook example to follow with the v2.7 docs pass
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Verification**

- 78 CLI unit tests against an in-memory fake AgentOS (httpx.MockTransport) and tmp config dirs; 1430 `libs/agno` unit tests pass; 26 service-accounts integration tests pass (including new end-to-end MCP-over-service-account cases: mint via REST, call `/mcp`, revoke, rejected).
- Live golden path against a real AgentOS (FastMCP, SQLite, security-key mode): `agno connect --json` → 3 accounts minted, 3 configs written, all 8 tools of the MCP surface-v2 contract verified per client; re-run reports `already-connected` with zero new accounts; `agno tokens revoke claude-code` → the revoked token is rejected (401) on the next MCP call while other clients keep working. `agno create` verified against the real `agentos-docker-template` (which already ships AGENTS.md/CLAUDE.md), and `agno up --dry-run` resolves its `compose.yaml`.
- The CLI code was reviewed by a 29-agent adversarial pass (4 dimensions, every finding independently verified); all 23 confirmed findings are fixed with regression tests — including a TOML rewrite that could drop `[[array-of-tables]]` sections, corrupt-config clobbering, inverted Claude Code scope precedence, and per-client error isolation for the `--json` contract.

**Known/pre-existing**

- `validate.sh` shows 6 mypy errors in unrelated `libs/agno` tools files (httpx type-stub issues: jina, zoom, desi_vocal, clickup, calcom, azure_openai); these reproduce identically on the base branch.

**Release sequencing (to avoid a window with two CLIs)**

1. Publish `agnoctl` to PyPI.
2. Same-day `agno-infra` release drops its `ag`/`agno` console scripts (its used surface — create + compose up/down — is fully covered here).
3. Core `agno` release adds `agnoctl` as a dependency plus `[project.scripts] agno = "agno_cli.main:app"`, making `uvx agno connect` live (both mechanisms validated against current uv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
