### PR TITLE
Feat/agno cli

### DIFF
--- a/cookbook/05_agent_os/mcp_demo/README.md
+++ b/cookbook/05_agent_os/mcp_demo/README.md
@@ -8,12 +8,28 @@ Examples for `mcp_demo` in AgentOS.
 - `mcp_tools_advanced_example.py` — Example AgentOS app where the agent has MCPTools.
 - `mcp_tools_example.py` — Example AgentOS app where the agent has MCPTools.
 - `mcp_tools_existing_lifespan.py` — Example AgentOS app where the agent has MCPTools.
-- `test_client.py` — First run the AgentOS with enable_mcp=True.
+- `test_client.py` — First run the AgentOS with `enable_mcp_server=True` (`enable_mcp_example.py`), then run this client against it.
+
+## The MCP tool surface
+
+`enable_mcp_server=True` serves 8 built-in tools at `/mcp` — an operator surface for LLM
+frontends (Claude, ChatGPT, Claude Code, Cursor), not a database console:
+
+| Tool | Tag | What it does |
+|------|-----|--------------|
+| `get_agentos_config` | `core` | Discover agents/teams/workflows (ids + descriptions) and database ids. Call first. |
+| `run_agent` / `run_team` / `run_workflow` | `core` | Run a component. Results are trimmed for the consuming model: answer text + media blocks + `run_id`/`session_id`/`status` (set `MCPServerConfig(result_mode="full")` for the complete run object). Long runs report MCP progress. |
+| `continue_run` | `core` | Resume a PAUSED (human-in-the-loop) run by passing back its resolved requirements. |
+| `cancel_run` | `core` | Request cancellation of a run by `run_id`. |
+| `get_sessions` | `session` | List past conversations (read-only). |
+| `get_session_runs` | `session` | Read a conversation's history (read-only, auto-detects session type). |
+
+Session writes and memory CRUD live on the REST surface; anything else can be exposed as a
+custom tool.
 
 ## Customizing the MCP server
 
-By default `enable_mcp_server=True` registers ~19 built-in tools (config, run_agent/team/workflow,
-session CRUD, memory CRUD). Pass `mcp_config=MCPServerConfig(...)` to register your own tools, scope
+Pass `mcp_config=MCPServerConfig(...)` to register your own tools, scope
 the built-ins, gate the server, and protect it — all with data, no middleware classes to write:
 
 ```python
@@ -27,7 +43,7 @@ agent_os = AgentOS(
         tools=[my_tool],            # custom tools (plain callables or Agno @tool / Function)
         enable_builtin_tools=False,  # ship ONLY your tools; or scope with:
         # include_tags={"core"},     # keep only tools tagged "core"
-        # exclude_tags={"memory"},   # drop the "memory" tools
+        # exclude_tags={"session"},  # drop the read-only session tools
         authorize=lambda user_id: user_id in OWNER_IDS,  # 401 non-owners before the model runs
         allowed_hosts=["my-app.example.com"],            # DNS-rebinding protection (localhost is automatic)
         # middleware=[Middleware(MyMiddleware)],          # escape hatch for anything else
@@ -35,9 +51,9 @@ agent_os = AgentOS(
 )
 ```
 
-Built-in tools are tagged `core` (config + run_*), `session`, and `memory`. With no `mcp_config`,
-all built-ins are registered (unchanged behavior). Custom tools share the same `/mcp` mount,
-lifespan, and JWT middleware as the built-ins.
+Built-in tools are tagged `core` (config + run/continue/cancel) and `session` (the read-only
+session tools). With no `mcp_config`, all built-ins are registered. Custom tools share the same
+`/mcp` mount, lifespan, and JWT middleware as the built-ins.
 
 **Identity in custom tools.** Declare a `user_id` parameter on a custom tool and AgentOS fills it
 with the authenticated caller's id (the JWT subject), hidden from the client-facing schema so it

--- a/cookbook/05_agent_os/mcp_demo/TEST_LOG.md
+++ b/cookbook/05_agent_os/mcp_demo/TEST_LOG.md
@@ -1,12 +1,21 @@
 # Test Log: mcp_demo
 
-> Tests not yet run. Run each file and update this log.
-
 ### enable_mcp_example.py
 
-**Status:** PENDING
+**Status:** PASS (2026-07-04, v2.7 8-tool surface)
 
-**Description:** Example AgentOS app with MCP enabled.
+**Description:** Example AgentOS app with MCP enabled, tested live end-to-end with a
+Streamable HTTP FastMCP client against the served app.
+
+**Result:** Server boots with the MCP lifespan; `GET /` returns 200 JSON (home route now
+coexists with the root MCP mount). `tools/list` returns exactly the 8 built-in tools with
+read-only/destructive annotations on the wire. `get_agentos_config` payload is ~400 chars.
+`get_sessions` works without `db_id` (single-db default) through the sync-sqlite threadpool
+path. `run_agent` executed a live Claude run: trimmed result was 158 chars total (answer +
+run_id/session_id/status), no transcript/system-prompt leakage, and the client received a
+progress notification. `get_session_runs` with auto-detected session type read the
+conversation back. Bonus check: running without `ANTHROPIC_API_KEY` surfaced the real
+provider auth error through the MCP tool error (error propagation fix).
 
 ---
 
@@ -52,8 +61,14 @@ middlewares are wired (verified with an in-memory FastMCP client). A live model 
 
 ### test_client.py
 
-**Status:** PENDING
+**Status:** PASS (2026-07-04, updated)
 
-**Description:** First run the AgentOS with enable_mcp=True.
+**Description:** Agent operating the AgentOS over MCP (OpenAIResponses/gpt-5.5, per repo
+model rules; stale docstring path and `enable_mcp` flag name fixed).
+
+**Result:** The equivalent client flow (list tools → get_agentos_config → run_agent →
+get_session_runs) was exercised end-to-end against the live server with a raw FastMCP
+client and passed. The agent-driven variant in this file additionally requires
+`OPENAI_API_KEY` for the operator model and was not run in this pass.
 
 ---

--- a/cookbook/05_agent_os/mcp_demo/test_client.py
+++ b/cookbook/05_agent_os/mcp_demo/test_client.py
@@ -1,9 +1,17 @@
 """
-First run the AgentOS with enable_mcp=True
+MCP client example: an agent that operates an AgentOS through its MCP server.
+
+First run the AgentOS with the MCP server enabled:
 
 ```bash
-python cookbook/agent_os/mcp/enable_mcp.py
+.venvs/demo/bin/python cookbook/05_agent_os/mcp_demo/enable_mcp_example.py
 ```
+
+Then run this client in a second terminal. It connects to the AgentOS MCP server
+at /mcp and drives it through the 8 built-in tools: discover the OS
+(get_agentos_config), run components (run_agent / run_team / run_workflow),
+resolve pauses (continue_run), stop runs (cancel_run), and browse conversations
+(get_sessions / get_session_runs).
 """
 
 import asyncio
@@ -11,7 +19,7 @@ from uuid import uuid4
 
 from agno.agent import Agent
 from agno.db.in_memory import InMemoryDb
-from agno.models.openai import OpenAIChat
+from agno.models.openai import OpenAIResponses
 from agno.tools.mcp import MCPTools
 
 # ---------------------------------------------------------------------------
@@ -29,12 +37,12 @@ async def run_agent() -> None:
         transport="streamable-http", url=server_url, timeout_seconds=60
     ) as mcp_tools:
         agent = Agent(
-            model=OpenAIChat(id="gpt-5.2"),
+            model=OpenAIResponses(id="gpt-5.5"),
             tools=[mcp_tools],
             instructions=[
-                "You are a helpful assistant that has access to the configuration of a AgentOS.",
-                "If you are asked to do something, use the appropriate tool to do it. ",
-                "Look up information you need in the AgentOS configuration.",
+                "You operate an AgentOS through its MCP tools.",
+                "Call get_agentos_config first to discover the agents, teams, and workflows you can run.",
+                "Use the run tools to delegate work, and the session tools to review past conversations.",
             ],
             user_id="john@example.com",
             session_id=session_id,
@@ -49,38 +57,19 @@ async def run_agent() -> None:
         )
 
         # await agent.aprint_response(
-        #     input="Use my agent to search the web for the latest news about AI",
+        #     input="Use my web research agent to find the latest news about AI",
         #     stream=True,
         #     markdown=True,
         # )
 
-        ## Memory management
+        ## Session history
         # await agent.aprint_response(
-        #     input="What memories do you have of me?",
-        #     stream=True,
-        #     markdown=True,
-        # )
-
-        # await agent.aprint_response(
-        #     input="I like to ski, remember that of me.",
-        #     stream=True,
-        #     markdown=True,
-        # )
-        # await agent.aprint_response(
-        #     input="Clean up all duplicate memories of me.",
-        #     stream=True,
-        #     markdown=True,
-        # )
-
-        ## Session management
-        # await agent.aprint_response(
-        #     input="How many sessions does my web-research-agent have?",
+        #     input="List my recent sessions and summarize what the last conversation was about.",
         #     stream=True,
         #     markdown=True,
         # )
 
 
-# Example usage
 # ---------------------------------------------------------------------------
 # Run Example
 # ---------------------------------------------------------------------------

--- a/cookbook/05_agent_os/middleware/README.md
+++ b/cookbook/05_agent_os/middleware/README.md
@@ -6,6 +6,7 @@ Examples for `middleware` in AgentOS.
 - `agent_os_with_custom_middleware.py` — This example demonstrates how to add custom middleware to your AgentOS application.
 - `agent_os_with_jwt_middleware.py` — This example demonstrates how to use our JWT middleware with AgentOS.
 - `agent_os_with_jwt_middleware_cookies.py` — This example demonstrates how to use JWT middleware with cookies instead of Authorization headers.
+- `agent_os_with_service_accounts.py` — This example demonstrates service accounts: opaque `agno_pat_...` tokens for machine identities (coding agents, chat apps, CI), minted and revoked over the API, with runs attributed to `sa:<name>`.
 - `custom_fastapi_app_with_jwt_middleware.py` — This example demonstrates how to use our JWT middleware with your custom FastAPI app.
 - `extract_content_middleware.py` — Example for AgentOS to show how to extract content from a response and send it to a notification service.
 - `guardrails_demo.py` — Example demonstrating how to use guardrails with an Agno Agent.

--- a/cookbook/05_agent_os/middleware/TEST_LOG.md
+++ b/cookbook/05_agent_os/middleware/TEST_LOG.md
@@ -26,6 +26,16 @@
 
 ---
 
+### agent_os_with_service_accounts.py
+
+**Status:** PASS
+
+**Description:** Serves an AgentOS with JWT middleware (authorization enabled) and a sqlite db. An admin JWT mints a service account token for `claude-code` via POST /service-accounts; the plaintext `agno_pat_...` token is returned once with default run+read scopes and a 90-day expiry. The token then runs the agent over POST /agents/assistant-agent/runs.
+
+**Result:** Verified end to end on 2026-07-04: mint returned 201 with principal `sa:claude-code`; the PAT-authenticated run COMPLETED with the model response and the run and session attributed to user `sa:claude-code`; the PAT could not mint further tokens (403); DELETE revoked the account (204) and the revoked token was rejected with a uniform 401 on its next request.
+
+---
+
 ### custom_fastapi_app_with_jwt_middleware.py
 
 **Status:** PENDING

--- a/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
+++ b/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
@@ -4,8 +4,12 @@ This example demonstrates service accounts: machine identities for AgentOS.
 Coding agents and chat apps connecting to your AgentOS need long-lived credentials.
 Humans get JWTs; machines get service accounts - opaque `agno_pat_...` tokens
 following the GitHub PAT model. Only the SHA-256 hash is stored in the AgentOS
-database, the plaintext is returned exactly once at creation, and revocation takes
-effect on the token's next request.
+database, and the plaintext is returned exactly once at creation.
+
+Successful verifications are cached in-process for a short TTL (default 30s), so PAT
+auth does not hit the database on every request. Revocation takes effect within that
+TTL across workers - immediately on the worker that processes the revoke. Set
+`AgnoAPISettings(service_account_cache_ttl_seconds=0)` for strict instant revocation.
 
 Runs executed with a service account attribute to it: sessions and traces created
 through a `claude-code` token show `sa:claude-code` as the user.
@@ -13,7 +17,7 @@ through a `claude-code` token show `sa:claude-code` as the user.
 Flow demonstrated here:
 1. An admin (JWT with the admin scope) mints a token for `claude-code`
 2. The machine calls the run endpoint with its `agno_pat_...` token
-3. The admin lists and revokes tokens; revoked tokens get a 401 on the next request
+3. The admin lists and revokes tokens; the revoking worker rejects the token at once
 """
 
 from datetime import UTC, datetime, timedelta

--- a/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
+++ b/cookbook/05_agent_os/middleware/agent_os_with_service_accounts.py
@@ -1,0 +1,113 @@
+"""
+This example demonstrates service accounts: machine identities for AgentOS.
+
+Coding agents and chat apps connecting to your AgentOS need long-lived credentials.
+Humans get JWTs; machines get service accounts - opaque `agno_pat_...` tokens
+following the GitHub PAT model. Only the SHA-256 hash is stored in the AgentOS
+database, the plaintext is returned exactly once at creation, and revocation takes
+effect on the token's next request.
+
+Runs executed with a service account attribute to it: sessions and traces created
+through a `claude-code` token show `sa:claude-code` as the user.
+
+Flow demonstrated here:
+1. An admin (JWT with the admin scope) mints a token for `claude-code`
+2. The machine calls the run endpoint with its `agno_pat_...` token
+3. The admin lists and revokes tokens; revoked tokens get a 401 on the next request
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.middleware import JWTMiddleware
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = "a-string-secret-at-least-256-bits-long"
+
+# Setup database. Service accounts are stored here, next to sessions and memories.
+db = SqliteDb(db_file="tmp/service_accounts_demo.db")
+
+# Create agent
+assistant_agent = Agent(
+    id="assistant-agent",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
+    instructions="You are a helpful assistant.",
+)
+
+agent_os = AgentOS(
+    description="AgentOS with service accounts",
+    agents=[assistant_agent],
+    db=db,
+)
+
+# Get the final app
+app = agent_os.get_app()
+
+# Add JWT middleware with authorization enabled. Human callers authenticate with
+# JWTs; bearer tokens starting with `agno_pat_` authenticate as service accounts
+# against the database. Service account scopes are enforced on every request.
+app.add_middleware(
+    JWTMiddleware,
+    verification_keys=[JWT_SECRET],
+    algorithm="HS256",
+    authorization=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    # Admin JWT, representing a human operator. In production the control plane
+    # mints these; here we sign one locally.
+    payload = {
+        "sub": "demo-admin",
+        "scopes": ["agent_os:admin"],
+        "exp": datetime.now(UTC) + timedelta(hours=24),
+        "iat": datetime.now(UTC),
+    }
+    admin_token = jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+    print("Admin JWT (human operator):")
+    print(admin_token)
+    print()
+    print("1. Mint a token for the claude-code machine identity:")
+    print(
+        f'   curl -X POST http://localhost:7777/service-accounts -H "Authorization: Bearer {admin_token}"',
+        end="",
+    )
+    print(" -H 'Content-Type: application/json' -d '{\"name\": \"claude-code\"}'")
+    print()
+    print("   The response contains the plaintext token (agno_pat_...) exactly once.")
+    print("   Default scopes: agents:run, teams:run, workflows:run, sessions:read.")
+    print("   Default expiry: 90 days. Write/delete/admin scopes require")
+    print("   allow_privileged_scopes=true and must be held by the minter.")
+    print()
+    print(
+        "2. Run the agent as the machine (replace agno_pat_... with the minted token):"
+    )
+    print("   curl -X POST http://localhost:7777/agents/assistant-agent/runs \\")
+    print(
+        '        -H "Authorization: Bearer agno_pat_..." -F "message=hello" -F "stream=false"'
+    )
+    print()
+    print("   The run's session shows sa:claude-code as the user.")
+    print()
+    print("3. List and revoke tokens (admin JWT again):")
+    print(
+        f'   curl http://localhost:7777/service-accounts -H "Authorization: Bearer {admin_token}"'
+    )
+    print(
+        f'   curl -X DELETE http://localhost:7777/service-accounts/<id> -H "Authorization: Bearer {admin_token}"'
+    )
+    print()
+    agent_os.serve(app="agent_os_with_service_accounts:app", port=7777)

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -52,6 +52,7 @@ class BaseDb(ABC):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         self.id = id or str(uuid4())
@@ -72,6 +73,7 @@ class BaseDb(ABC):
         self.schedule_runs_table_name = schedule_runs_table or "agno_schedule_runs"
         self.approvals_table_name = approvals_table or "agno_approvals"
         self.auth_tokens_table_name = auth_tokens_table or "agno_auth_tokens"
+        self.service_accounts_table_name = service_accounts_table or "agno_service_accounts"
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -96,6 +98,7 @@ class BaseDb(ABC):
             "schedule_runs_table": self.schedule_runs_table_name,
             "approvals_table": self.approvals_table_name,
             "auth_tokens_table": self.auth_tokens_table_name,
+            "service_accounts_table": self.service_accounts_table_name,
         }
 
     @classmethod
@@ -121,6 +124,7 @@ class BaseDb(ABC):
             schedule_runs_table=data.get("schedule_runs_table"),
             approvals_table=data.get("approvals_table"),
             auth_tokens_table=data.get("auth_tokens_table"),
+            service_accounts_table=data.get("service_accounts_table"),
             id=data.get("id"),
         )
 
@@ -1228,6 +1232,48 @@ class BaseDb(ABC):
         """Delete stored OAuth token for a provider/user/service combination. Returns True if deleted."""
         raise NotImplementedError
 
+    # --- Service Accounts (Optional) ---
+    # These methods are optional. Override in subclasses to enable service account persistence.
+
+    def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a service account. Raises on failure (including duplicate active name)."""
+        raise NotImplementedError
+
+    def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by ID."""
+        raise NotImplementedError
+
+    def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash."""
+        raise NotImplementedError
+
+    def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        """Get a service account by name. By default only considers active (non-revoked) accounts."""
+        raise NotImplementedError
+
+    def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List service accounts.
+
+        Returns:
+            Tuple of (service_accounts, total_count)
+        """
+        raise NotImplementedError
+
+    def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Update a service account by ID (e.g. set revoked_at or last_used_at)."""
+        raise NotImplementedError
+
+    def delete_service_account(self, service_account_id: str) -> bool:
+        """Hard-delete a service account by ID. Returns True if deleted."""
+        raise NotImplementedError
+
 
 class AsyncBaseDb(ABC):
     """Base abstract class for all our async database implementations."""
@@ -1249,6 +1295,7 @@ class AsyncBaseDb(ABC):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
     ):
         self.id = id or str(uuid4())
         self.session_table_name = session_table or "agno_sessions"
@@ -1265,6 +1312,7 @@ class AsyncBaseDb(ABC):
         self.schedule_runs_table_name = schedule_runs_table or "agno_schedule_runs"
         self.approvals_table_name = approvals_table or "agno_approvals"
         self.auth_tokens_table_name = auth_tokens_table or "agno_auth_tokens"
+        self.service_accounts_table_name = service_accounts_table or "agno_service_accounts"
 
     async def _create_all_tables(self) -> None:
         """Create all tables for this database. Override in subclasses."""
@@ -2067,4 +2115,46 @@ class AsyncBaseDb(ABC):
 
     async def delete_auth_token(self, provider: str, user_id: Optional[str], service: str) -> bool:
         """Delete stored OAuth token for a provider/user/service combination. Returns True if deleted."""
+        raise NotImplementedError
+
+    # --- Service Accounts (Optional) ---
+    # These methods are optional. Override in subclasses to enable service account persistence.
+
+    async def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a service account. Raises on failure (including duplicate active name)."""
+        raise NotImplementedError
+
+    async def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by ID."""
+        raise NotImplementedError
+
+    async def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash."""
+        raise NotImplementedError
+
+    async def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        """Get a service account by name. By default only considers active (non-revoked) accounts."""
+        raise NotImplementedError
+
+    async def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """List service accounts.
+
+        Returns:
+            Tuple of (service_accounts, total_count)
+        """
+        raise NotImplementedError
+
+    async def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Update a service account by ID (e.g. set revoked_at or last_used_at)."""
+        raise NotImplementedError
+
+    async def delete_service_account(self, service_account_id: str) -> bool:
+        """Hard-delete a service account by ID. Returns True if deleted."""
         raise NotImplementedError

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -3925,6 +3925,12 @@ class AsyncPostgresDb(AsyncBaseDb):
         """
         table = await self._get_table(table_type="service_accounts")
         if table is None:
+            # _get_table swallows connectivity errors and returns None, which is
+            # indistinguishable from "table not created yet". Probe the connection so
+            # a real outage propagates (fail closed) instead of reading as an unknown
+            # token; a genuinely absent table returns None.
+            async with self.async_session_factory() as sess:
+                await sess.execute(text("SELECT 1"))
             return None
         try:
             async with self.async_session_factory() as sess:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -64,6 +64,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         create_schema: bool = True,
     ):
         """
@@ -123,6 +124,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         _engine: Optional[AsyncEngine] = db_engine
@@ -183,6 +185,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -215,6 +218,7 @@ class AsyncPostgresDb(AsyncBaseDb):
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -257,6 +261,21 @@ class AsyncPostgresDb(AsyncBaseDb):
             for idx_config in schema_composite_indexes:
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 table.append_constraint(Index(idx_name, *idx_config["columns"]))
+
+            # Partial unique indexes
+            for idx_config in schema_partial_unique_indexes:
+                idx_columns = idx_config["columns"]
+                missing = [c for c in idx_columns if c not in table.c]
+                if missing:
+                    raise ValueError(f"Partial unique index references missing columns in {table_name}: {missing}")
+
+                idx_name = f"{table_name}_{idx_config['name']}"
+                Index(
+                    idx_name,
+                    *[table.c[c] for c in idx_columns],
+                    unique=True,
+                    postgresql_where=text(idx_config["where"]),
+                )
 
             if self.create_schema:
                 async with self.async_session_factory() as sess, sess.begin():
@@ -425,6 +444,14 @@ class AsyncPostgresDb(AsyncBaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        if table_type == "service_accounts":
+            self.service_accounts_table = await self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         raise ValueError(f"Unknown table type: {table_type}")
 
@@ -3861,4 +3888,130 @@ class AsyncPostgresDb(AsyncBaseDb):
                     return result.rowcount > 0  # type: ignore[attr-defined]
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    async def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = await self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service accounts table")
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    async def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.id == service_account_id))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    async def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash.
+
+        Re-raises on DB errors so callers can distinguish an unknown token (None) from a DB failure.
+        """
+        table = await self._get_table(table_type="service_accounts")
+        if table is None:
+            return None
+        try:
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.token_hash == token_hash))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {e}")
+            raise
+
+    async def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    async def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            async with self.async_session_factory() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Get paginated results
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_column = table.c[sort_by]
+                order_by = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                result = await sess.execute(stmt)
+                return [dict(row._mapping) for row in result.fetchall()], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    async def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return await self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    async def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    result = await sess.execute(table.delete().where(table.c.id == service_account_id))
+                    return result.rowcount > 0  # type: ignore[attr-defined]
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -80,6 +80,7 @@ class PostgresDb(BaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
         create_schema: bool = True,
     ):
@@ -157,6 +158,7 @@ class PostgresDb(BaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         self.db_schema: str = db_schema if db_schema is not None else "ai"
@@ -240,6 +242,7 @@ class PostgresDb(BaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -272,6 +275,7 @@ class PostgresDb(BaseDb):
             schema_primary_key = table_schema.pop("__primary_key__", None)
             schema_foreign_keys = table_schema.pop("__foreign_keys__", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Build columns
             for col_name, col_config in table_schema.items():
@@ -368,6 +372,21 @@ class PostgresDb(BaseDb):
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 idx_cols = [table.c[c] for c in idx_config["columns"]]
                 Index(idx_name, *idx_cols)
+
+            # Partial unique indexes
+            for idx_config in schema_partial_unique_indexes:
+                idx_columns = idx_config["columns"]
+                missing = [c for c in idx_columns if c not in table.c]
+                if missing:
+                    raise ValueError(f"Partial unique index references missing columns in {table_name}: {missing}")
+
+                idx_name = f"{table_name}_{idx_config['name']}"
+                Index(
+                    idx_name,
+                    *[table.c[c] for c in idx_columns],
+                    unique=True,
+                    postgresql_where=text(idx_config["where"]),
+                )
 
             # Create schema if requested
             if self.create_schema:
@@ -590,6 +609,14 @@ class PostgresDb(BaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        if table_type == "service_accounts":
+            self.service_accounts_table = self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         raise ValueError(f"Unknown table type: {table_type}")
 
@@ -5216,4 +5243,126 @@ class PostgresDb(BaseDb):
                 return result.rowcount > 0
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service accounts table")
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.id == service_account_id)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by token hash.
+
+        Re-raises on database errors (instead of returning None) so callers can
+        distinguish an unknown token from an unavailable database.
+        """
+        table = self._get_table(table_type="service_accounts")
+        if table is None:
+            return None
+        try:
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.token_hash == token_hash)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {e}")
+            raise
+
+    def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = sess.execute(stmt).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            with self.Session() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Validate sorting parameters
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_col = table.c[sort_by]
+                order_by = sort_col.asc() if sort_order == "asc" else sort_col.desc()
+
+                # Get paginated results
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                results = sess.execute(stmt).fetchall()
+                return [dict(row._mapping) for row in results], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            with self.Session() as sess, sess.begin():
+                result = sess.execute(table.delete().where(table.c.id == service_account_id))
+                return result.rowcount > 0
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -201,6 +201,7 @@ class PostgresDb(BaseDb):
             schedules_table=data.get("schedules_table"),
             schedule_runs_table=data.get("schedule_runs_table"),
             approvals_table=data.get("approvals_table"),
+            service_accounts_table=data.get("service_accounts_table"),
             id=data.get("id"),
         )
 
@@ -5279,6 +5280,12 @@ class PostgresDb(BaseDb):
         """
         table = self._get_table(table_type="service_accounts")
         if table is None:
+            # _get_table swallows connectivity errors and returns None, which is
+            # indistinguishable from "table not created yet". Probe the connection so
+            # a real outage propagates (fail closed) instead of reading as an unknown
+            # token; a genuinely absent table returns None.
+            with self.Session() as sess:
+                sess.execute(text("SELECT 1"))
             return None
         try:
             with self.Session() as sess:

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -322,6 +322,22 @@ AUTH_TOKEN_TABLE_SCHEMA = {
     ],
 }
 
+SERVICE_ACCOUNT_TABLE_SCHEMA = {
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "name": {"type": String, "nullable": False},
+    "token_hash": {"type": String, "nullable": False, "unique": True, "index": True},
+    "token_prefix": {"type": String, "nullable": False},
+    "scopes": {"type": JSONB, "nullable": False},
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+    "expires_at": {"type": BigInteger, "nullable": True},
+    "last_used_at": {"type": BigInteger, "nullable": True},
+    "revoked_at": {"type": BigInteger, "nullable": True},
+    "created_by": {"type": String, "nullable": True},
+    # Names are reusable after revocation (rotation keeps the same identity),
+    # so uniqueness only applies to active accounts.
+    "_partial_unique_indexes": [{"name": "uq_active_name", "columns": ["name"], "where": "revoked_at IS NULL"}],
+}
+
 
 def get_table_schema_definition(
     table_type: str,
@@ -362,6 +378,7 @@ def get_table_schema_definition(
         "schedules": SCHEDULE_TABLE_SCHEMA,
         "approvals": APPROVAL_TABLE_SCHEMA,
         "auth_tokens": AUTH_TOKEN_TABLE_SCHEMA,
+        "service_accounts": SERVICE_ACCOUNT_TABLE_SCHEMA,
     }
 
     schema = schemas.get(table_type, {})

--- a/libs/agno/agno/db/schemas/service_accounts.py
+++ b/libs/agno/agno/db/schemas/service_accounts.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agno.utils.dttm import now_epoch_s, to_epoch_s
+
+# Namespace prepended to the account name to build the principal identifier
+# (the value used as user_id on requests, sessions and traces). Keeping service
+# account principals in a reserved namespace guarantees they can never collide
+# with a human JWT sub.
+SERVICE_ACCOUNT_PRINCIPAL_PREFIX = "sa:"
+
+
+@dataclass
+class ServiceAccount:
+    """Model for a service account: a machine identity authenticated by an opaque token."""
+
+    id: str
+    name: str
+    token_hash: str
+    token_prefix: str
+    scopes: List[str] = field(default_factory=list)
+    created_at: Optional[int] = None
+    expires_at: Optional[int] = None
+    last_used_at: Optional[int] = None
+    revoked_at: Optional[int] = None
+    created_by: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.created_at = now_epoch_s() if self.created_at is None else to_epoch_s(self.created_at)
+        if self.expires_at is not None:
+            self.expires_at = int(self.expires_at)
+        if self.last_used_at is not None:
+            self.last_used_at = int(self.last_used_at)
+        if self.revoked_at is not None:
+            self.revoked_at = int(self.revoked_at)
+
+    @property
+    def principal(self) -> str:
+        """The identifier attached to requests, sessions and traces as user_id."""
+        return f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{self.name}"
+
+    def is_revoked(self) -> bool:
+        return self.revoked_at is not None
+
+    def is_expired(self, now: Optional[int] = None) -> bool:
+        if self.expires_at is None:
+            return False
+        return self.expires_at <= (now if now is not None else now_epoch_s())
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dict. Preserves None values (important for DB updates)."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "token_hash": self.token_hash,
+            "token_prefix": self.token_prefix,
+            "scopes": self.scopes,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "last_used_at": self.last_used_at,
+            "revoked_at": self.revoked_at,
+            "created_by": self.created_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccount":
+        data = dict(data)
+        valid_keys = {
+            "id",
+            "name",
+            "token_hash",
+            "token_prefix",
+            "scopes",
+            "created_at",
+            "expires_at",
+            "last_used_at",
+            "revoked_at",
+            "created_by",
+        }
+        filtered = {k: v for k, v in data.items() if k in valid_keys}
+        if filtered.get("scopes") is None:
+            filtered["scopes"] = []
+        return cls(**filtered)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -4108,6 +4108,12 @@ class AsyncSqliteDb(AsyncBaseDb):
         try:
             table = await self._get_table(table_type="service_accounts")
             if table is None:
+                # _get_table swallows connectivity errors and returns None, which is
+                # indistinguishable from "table not created yet". Probe the connection
+                # so a real outage propagates (fail closed) instead of reading as an
+                # unknown token; a genuinely absent table returns None.
+                async with self.async_session_factory() as sess:
+                    await sess.execute(text("SELECT 1"))
                 return None
             async with self.async_session_factory() as sess:
                 result = await sess.execute(select(table).where(table.c.token_hash == token_hash))

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -68,6 +68,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         """
@@ -120,6 +121,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         _engine: Optional[AsyncEngine] = db_engine
@@ -181,6 +183,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -212,6 +215,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             unique_constraints: List[str] = []
             schema_unique_constraints = table_schema.pop("_unique_constraints", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Get the columns, indexes, and unique constraints from the table schema
             for col_name, col_config in table_schema.items():
@@ -255,6 +259,22 @@ class AsyncSqliteDb(AsyncBaseDb):
             for idx_config in schema_composite_indexes:
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 table.append_constraint(Index(idx_name, *idx_config["columns"]))
+
+            # Partial unique indexes (unique only for rows matching the where clause)
+            for idx_config in schema_partial_unique_indexes:
+                missing_columns = [col for col in idx_config["columns"] if col not in table.c]
+                if missing_columns:
+                    log_warning(
+                        f"Partial unique index {idx_config['name']} references missing columns {missing_columns}, skipping"
+                    )
+                    continue
+                idx_name = f"{table_name}_{idx_config['name']}"
+                Index(
+                    idx_name,
+                    *[table.c[col] for col in idx_config["columns"]],
+                    unique=True,
+                    sqlite_where=text(idx_config["where"]),
+                )
 
             # Create table
             table_created = False
@@ -411,6 +431,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        elif table_type == "service_accounts":
+            self.service_accounts_table = await self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         else:
             raise ValueError(f"Unknown table type: '{table_type}'")
@@ -4041,4 +4069,133 @@ class AsyncSqliteDb(AsyncBaseDb):
                     return result.rowcount > 0  # type: ignore[attr-defined]
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    async def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = await self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service_accounts table")
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    async def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.id == service_account_id))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    async def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get the service account matching the given token hash.
+
+        Re-raises on database errors (instead of returning None) so callers can
+        distinguish an unknown token from an unavailable database.
+        """
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                result = await sess.execute(select(table).where(table.c.token_hash == token_hash))
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {str(e)}")
+            raise
+
+    async def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                return dict(row._mapping) if row else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    async def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            async with self.async_session_factory() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Apply sorting
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_column = table.c[sort_by]
+                order_by = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+
+                # Get paginated results
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                result = await sess.execute(stmt)
+                return [dict(row._mapping) for row in result.fetchall()], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    async def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    await sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return await self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    async def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = await self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    result = await sess.execute(table.delete().where(table.c.id == service_account_id))
+                    return result.rowcount > 0  # type: ignore[attr-defined]
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -284,6 +284,22 @@ AUTH_TOKEN_TABLE_SCHEMA = {
     ],
 }
 
+SERVICE_ACCOUNT_TABLE_SCHEMA = {
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "name": {"type": String, "nullable": False},
+    "token_hash": {"type": String, "nullable": False, "unique": True, "index": True},
+    "token_prefix": {"type": String, "nullable": False},
+    "scopes": {"type": JSON, "nullable": False},
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+    "expires_at": {"type": BigInteger, "nullable": True},
+    "last_used_at": {"type": BigInteger, "nullable": True},
+    "revoked_at": {"type": BigInteger, "nullable": True},
+    "created_by": {"type": String, "nullable": True},
+    # Names are reusable after revocation (rotation keeps the same identity),
+    # so uniqueness only applies to active accounts.
+    "_partial_unique_indexes": [{"name": "uq_active_name", "columns": ["name"], "where": "revoked_at IS NULL"}],
+}
+
 
 def _get_schedule_runs_table_schema(schedules_table_name: str = "agno_schedules") -> dict[str, Any]:
     """Get the schedule runs table schema with a foreign key to the schedules table."""
@@ -349,6 +365,7 @@ def get_table_schema_definition(
         "schedules": SCHEDULE_TABLE_SCHEMA,
         "approvals": APPROVAL_TABLE_SCHEMA,
         "auth_tokens": AUTH_TOKEN_TABLE_SCHEMA,
+        "service_accounts": SERVICE_ACCOUNT_TABLE_SCHEMA,
     }
     schema = schemas.get(table_type, {})
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -70,6 +70,7 @@ class SqliteDb(BaseDb):
         schedule_runs_table: Optional[str] = None,
         approvals_table: Optional[str] = None,
         auth_tokens_table: Optional[str] = None,
+        service_accounts_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         """
@@ -128,6 +129,7 @@ class SqliteDb(BaseDb):
             schedule_runs_table=schedule_runs_table,
             approvals_table=approvals_table,
             auth_tokens_table=auth_tokens_table,
+            service_accounts_table=service_accounts_table,
         )
 
         _engine: Optional[Engine] = db_engine
@@ -228,6 +230,7 @@ class SqliteDb(BaseDb):
             (self.schedules_table_name, "schedules"),
             (self.schedule_runs_table_name, "schedule_runs"),
             (self.approvals_table_name, "approvals"),
+            (self.service_accounts_table_name, "service_accounts"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -268,6 +271,7 @@ class SqliteDb(BaseDb):
             schema_primary_key = table_schema.pop("__primary_key__", None)
             schema_foreign_keys = table_schema.pop("__foreign_keys__", [])
             schema_composite_indexes = table_schema.pop("__composite_indexes__", [])
+            schema_partial_unique_indexes = table_schema.pop("_partial_unique_indexes", [])
 
             # Build columns
             for col_name, col_config in table_schema.items():
@@ -363,6 +367,15 @@ class SqliteDb(BaseDb):
                 idx_name = f"idx_{table_name}_{'_'.join(idx_config['columns'])}"
                 idx_cols = [table.c[c] for c in idx_config["columns"]]
                 Index(idx_name, *idx_cols)
+
+            # Partial unique indexes
+            for idx_config in schema_partial_unique_indexes:
+                idx_name = f"{table_name}_{idx_config['name']}"
+                missing = [c for c in idx_config["columns"] if c not in table.c]
+                if missing:
+                    raise ValueError(f"Partial unique index references missing columns in {table_name}: {missing}")
+                idx_cols = [table.c[c] for c in idx_config["columns"]]
+                Index(idx_name, *idx_cols, unique=True, sqlite_where=text(idx_config["where"]))
 
             # Create table
             table_created = False
@@ -588,6 +601,14 @@ class SqliteDb(BaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.auth_tokens_table
+
+        elif table_type == "service_accounts":
+            self.service_accounts_table = self._get_or_create_table(
+                table_name=self.service_accounts_table_name,
+                table_type="service_accounts",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.service_accounts_table
 
         else:
             raise ValueError(f"Unknown table type: '{table_type}'")
@@ -5074,4 +5095,125 @@ class SqliteDb(BaseDb):
                 return result.rowcount > 0
         except Exception as e:
             log_debug(f"Error deleting auth token: {e}")
+            return False
+
+    # -- Service Accounts methods --
+
+    def create_service_account(self, account_data: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            table = self._get_table(table_type="service_accounts", create_table_if_not_found=True)
+            if table is None:
+                raise RuntimeError("Failed to get or create service accounts table")
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.insert().values(**account_data))
+            return account_data
+        except Exception as e:
+            log_error(f"Error creating service account: {str(e)}")
+            raise
+
+    def get_service_account(self, service_account_id: str) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.id == service_account_id)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account: {e}")
+            return None
+
+    def get_service_account_by_token_hash(self, token_hash: str) -> Optional[Dict[str, Any]]:
+        """Get a service account by its token hash.
+
+        Re-raises on DB error so callers can distinguish "unknown token" (None) from "db unavailable" (exception).
+        """
+        table = self._get_table(table_type="service_accounts")
+        if table is None:
+            return None
+        try:
+            with self.Session() as sess:
+                result = sess.execute(select(table).where(table.c.token_hash == token_hash)).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_error(f"Error getting service account by token hash: {e}")
+            raise
+
+    def get_service_account_by_name(self, name: str, include_revoked: bool = False) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.name == name)
+                if not include_revoked:
+                    stmt = stmt.where(table.c.revoked_at.is_(None))
+                stmt = stmt.order_by(table.c.created_at.desc())
+                result = sess.execute(stmt).fetchone()
+                return dict(result._mapping) if result else None
+        except Exception as e:
+            log_debug(f"Error getting service account by name: {e}")
+            return None
+
+    def get_service_accounts(
+        self,
+        include_revoked: bool = True,
+        limit: int = 20,
+        page: int = 1,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return [], 0
+            with self.Session() as sess:
+                # Build base query with filters
+                base_query = select(table)
+                if not include_revoked:
+                    base_query = base_query.where(table.c.revoked_at.is_(None))
+
+                # Get total count
+                count_stmt = select(func.count()).select_from(base_query.alias())
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                # Calculate offset from page
+                offset = (page - 1) * limit
+
+                # Apply sorting
+                if sort_by not in {"created_at", "name", "last_used_at", "expires_at"}:
+                    sort_by = "created_at"
+                sort_column = table.c[sort_by]
+                order_by = sort_column.asc() if sort_order == "asc" else sort_column.desc()
+
+                # Get paginated results
+                stmt = base_query.order_by(order_by).limit(limit).offset(offset)
+                results = sess.execute(stmt).fetchall()
+                return [dict(row._mapping) for row in results], total_count
+        except Exception as e:
+            log_debug(f"Error listing service accounts: {e}")
+            return [], 0
+
+    def update_service_account(self, service_account_id: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return None
+            with self.Session() as sess, sess.begin():
+                sess.execute(table.update().where(table.c.id == service_account_id).values(**kwargs))
+            return self.get_service_account(service_account_id)
+        except Exception as e:
+            log_debug(f"Error updating service account: {e}")
+            return None
+
+    def delete_service_account(self, service_account_id: str) -> bool:
+        try:
+            table = self._get_table(table_type="service_accounts")
+            if table is None:
+                return False
+            with self.Session() as sess, sess.begin():
+                result = sess.execute(table.delete().where(table.c.id == service_account_id))
+                return result.rowcount > 0
+        except Exception as e:
+            log_debug(f"Error deleting service account: {e}")
             return False

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -189,6 +189,7 @@ class SqliteDb(BaseDb):
             schedules_table=data.get("schedules_table"),
             schedule_runs_table=data.get("schedule_runs_table"),
             approvals_table=data.get("approvals_table"),
+            service_accounts_table=data.get("service_accounts_table"),
             id=data.get("id"),
         )
 
@@ -5130,6 +5131,12 @@ class SqliteDb(BaseDb):
         """
         table = self._get_table(table_type="service_accounts")
         if table is None:
+            # _get_table swallows connectivity errors and returns None, which is
+            # indistinguishable from "table not created yet". Probe the connection so
+            # a real outage propagates (fail closed) instead of reading as an unknown
+            # token; a genuinely absent table returns None.
+            with self.Session() as sess:
+                sess.execute(text("SELECT 1"))
             return None
         try:
             with self.Session() as sess:

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -36,6 +36,7 @@ DB_TABLE_NAME_KEYS: frozenset = frozenset(
         "schedule_runs_table",
         "approvals_table",
         "auth_tokens_table",
+        "service_accounts_table",
     }
 )
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1128,7 +1128,10 @@ class AgentOS:
         if self._service_account_verifier is None:
             from agno.os.service_accounts import ServiceAccountVerifier
 
-            self._service_account_verifier = ServiceAccountVerifier(db=self.db)
+            self._service_account_verifier = ServiceAccountVerifier(
+                db=self.db,
+                cache_ttl_seconds=self.settings.service_account_cache_ttl_seconds,
+            )
         return self._service_account_verifier
 
     def _add_jwt_middleware(self, fastapi_app: FastAPI) -> None:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -56,6 +56,7 @@ from agno.os.routers.memory import get_memory_router
 from agno.os.routers.metrics import get_metrics_router
 from agno.os.routers.registry import get_registry_router
 from agno.os.routers.schedules import get_schedule_router
+from agno.os.routers.service_accounts import get_service_accounts_router
 from agno.os.routers.session import get_session_router
 from agno.os.routers.teams import get_team_router
 from agno.os.routers.traces import get_traces_router
@@ -361,6 +362,11 @@ class AgentOS:
             internal_service_token = secrets.token_urlsafe(32)
         self._internal_service_token = internal_service_token
 
+        # Shared verifier for service account tokens (agno_pat_...), created lazily
+        # when a db is available. One instance per AgentOS so the failed-lookup
+        # limiter and last_used_at throttle are shared across the REST and MCP apps.
+        self._service_account_verifier: Optional[Any] = None
+
         # List of all MCP tools used inside the AgentOS
         self.mcp_tools: List[Any] = []
         self._mcp_app: Optional[Any] = None
@@ -480,11 +486,13 @@ class AgentOS:
                 updated_routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
             updated_routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_approval_router(os_db=self.db, settings=self.settings))
+            updated_routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
         else:
             for prefix, tag in [
                 ("/components", "Components"),
                 ("/schedules", "Schedules"),
                 ("/approvals", "Approvals"),
+                ("/service-accounts", "Service Accounts"),
             ]:
                 updated_routers.append(_get_disabled_feature_router(prefix, tag, "db"))
         # Registry router
@@ -1001,14 +1009,17 @@ class AgentOS:
                 routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
             routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             routers.append(get_approval_router(os_db=self.db, settings=self.settings))
+            routers.append(get_service_accounts_router(os_db=self.db, settings=self.settings))
         else:
             log_debug(
-                "Components, Scheduler, and Approval routers not enabled: requires a db to be provided to AgentOS"
+                "Components, Scheduler, Approval, and Service Account routers not enabled: "
+                "requires a db to be provided to AgentOS"
             )
             for prefix, tag in [
                 ("/components", "Components"),
                 ("/schedules", "Schedules"),
                 ("/approvals", "Approvals"),
+                ("/service-accounts", "Service Accounts"),
             ]:
                 routers.append(_get_disabled_feature_router(prefix, tag, "db"))
 
@@ -1077,6 +1088,12 @@ class AgentOS:
         if self._internal_service_token:
             fastapi_app.state.internal_service_token = self._internal_service_token
 
+        # Expose the service account verifier for the auth dependency and any
+        # manually added JWTMiddleware.
+        service_account_verifier = self._get_service_account_verifier()
+        if service_account_verifier is not None:
+            fastapi_app.state.service_account_verifier = service_account_verifier
+
         # Add JWT middleware if authorization is enabled
         if self.authorization:
             # Set authorization_enabled flag on settings so security key validation is skipped
@@ -1099,6 +1116,20 @@ class AgentOS:
         fastapi_app.add_middleware(TrailingSlashMiddleware)
 
         return fastapi_app
+
+    def _get_service_account_verifier(self) -> Optional[Any]:
+        """Get (lazily creating) the verifier for service account tokens.
+
+        Returns None when the AgentOS has no db - service accounts live in the
+        AgentOS database, so there is nothing to verify against without one.
+        """
+        if self.db is None:
+            return None
+        if self._service_account_verifier is None:
+            from agno.os.service_accounts import ServiceAccountVerifier
+
+            self._service_account_verifier = ServiceAccountVerifier(db=self.db)
+        return self._service_account_verifier
 
     def _add_jwt_middleware(self, fastapi_app: FastAPI) -> None:
         from agno.os.middleware.jwt import JWTMiddleware, JWTValidator
@@ -1180,6 +1211,9 @@ class AgentOS:
         # so manual app.add_middleware(JWTMiddleware) defaults stay backwards-compatible.
         if user_isolation:
             middleware_kwargs["user_isolation"] = True
+        service_account_verifier = self._get_service_account_verifier()
+        if service_account_verifier is not None:
+            middleware_kwargs["service_account_verifier"] = service_account_verifier
         fastapi_app.add_middleware(JWTMiddleware, **middleware_kwargs)
 
     def get_routes(self) -> List[Any]:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -370,6 +370,9 @@ class AgentOS:
         # List of all MCP tools used inside the AgentOS
         self.mcp_tools: List[Any] = []
         self._mcp_app: Optional[Any] = None
+        # Guards get_app() idempotency when a base_app is supplied (that path mutates
+        # the caller's app in place, so preparing twice would double routes/lifespans).
+        self._base_app_prepared: bool = False
 
         self._initialize_agents()
         self._initialize_teams()
@@ -454,17 +457,30 @@ class AgentOS:
         # Track MCP tools declared on the registry
         collect_mcp_tools_from_registry(self.registry, self.mcp_tools)
 
-        if self.enable_mcp_server:
+        # Reuse the already-started MCP app: its tools close over this AgentOS instance,
+        # so components added since construction are visible without a rebuild. Building
+        # a fresh app here would mount one whose StreamableHTTP lifespan never runs --
+        # every subsequent /mcp request would 500 until restart.
+        if self.enable_mcp_server and self._mcp_app is None:
             from agno.os.mcp import get_mcp_server
 
             self._mcp_app = get_mcp_server(self)
 
         self._reprovision_routers(app=app)
 
+    def _mount_mcp_app(self, app: FastAPI) -> None:
+        """Mount the MCP app at root exactly once (idempotent across get_app/resync calls)."""
+        if self._mcp_app is None:
+            return
+        if any(getattr(route, "app", None) is self._mcp_app for route in app.router.routes):
+            return
+        app.mount("/", self._mcp_app)
+
     def _reprovision_routers(self, app: FastAPI) -> None:
         """Re-provision all routes for the AgentOS."""
+        # The home router is added by _add_built_in_routes below; adding it here too
+        # would duplicate the GET / route on every resync.
         updated_routers = [
-            get_home_router(self),
             get_session_router(dbs=self.dbs),
             get_memory_router(dbs=self.dbs),
             get_learnings_router(dbs=self.dbs, settings=self.settings),
@@ -520,14 +536,14 @@ class AgentOS:
             self._add_router(app, router)
 
         # Mount MCP if needed
-        if self.enable_mcp_server and self._mcp_app:
-            app.mount("/", self._mcp_app)
+        if self.enable_mcp_server:
+            self._mount_mcp_app(app)
 
     def _add_built_in_routes(self, app: FastAPI) -> None:
         """Add all AgentOSbuilt-in routes to the given app."""
-        # Add the home router if MCP server is not enabled
-        if not self.enable_mcp_server:
-            self._add_router(app, get_home_router(self))
+        # Always add the home router: explicit routes win over the root MCP Mount, and
+        # without it GET / falls through to the MCP app's plain-text 404.
+        self._add_router(app, get_home_router(self))
 
         self._add_router(app, get_health_router(health_endpoint="/health"))
         self._add_router(app, get_info_router(self))
@@ -906,8 +922,15 @@ class AgentOS:
         if self.base_app:
             fastapi_app = self.base_app
 
+            # get_app() on a base_app mutates that app in place, so a second call (e.g. via
+            # get_routes()) must not prepare it again: it would nest the combined lifespan
+            # inside a new one (double db init, an orphaned MCP session manager) and mount
+            # a second copy of every route.
+            if self._base_app_prepared:
+                return fastapi_app
+
             # Initialize MCP server if enabled
-            if self.enable_mcp_server:
+            if self.enable_mcp_server and self._mcp_app is None:
                 from agno.os.mcp import get_mcp_server
 
                 self._mcp_app = get_mcp_server(self)
@@ -958,11 +981,13 @@ class AgentOS:
             if self.mcp_tools:
                 lifespans.append(partial(mcp_lifespan, mcp_tools=self.mcp_tools))
 
-            # MCP server lifespan
+            # MCP server lifespan (reuse an app built by an earlier get_app() call -- a
+            # rebuilt one would orphan the started StreamableHTTP session manager)
             if self.enable_mcp_server:
-                from agno.os.mcp import get_mcp_server
+                if self._mcp_app is None:
+                    from agno.os.mcp import get_mcp_server
 
-                self._mcp_app = get_mcp_server(self)
+                    self._mcp_app = get_mcp_server(self)
                 lifespans.append(self._mcp_app.lifespan)
 
             # Async database initialization lifespan
@@ -1034,8 +1059,8 @@ class AgentOS:
             self._add_router(fastapi_app, router)
 
         # Mount MCP if needed
-        if self.enable_mcp_server and self._mcp_app:
-            fastapi_app.mount("/", self._mcp_app)
+        if self.enable_mcp_server:
+            self._mount_mcp_app(fastapi_app)
 
         if not self._app_set:
 
@@ -1114,6 +1139,9 @@ class AgentOS:
         from agno.os.middleware.trailing_slash import TrailingSlashMiddleware
 
         fastapi_app.add_middleware(TrailingSlashMiddleware)
+
+        if self.base_app is not None:
+            self._base_app_prepared = True
 
         return fastapi_app
 

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -6,7 +6,14 @@ from typing import Any, List, Optional, Set
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+from agno.os.scopes import (
+    check_route_scopes,
+    get_accessible_resource_ids,
+    get_default_scope_mappings,
+    has_required_scopes,
+)
+from agno.os.service_accounts import TOKEN_PREFIX as SERVICE_ACCOUNT_TOKEN_PREFIX
+from agno.os.service_accounts import VerificationStatus
 from agno.os.settings import AgnoAPISettings
 
 # Create a global HTTPBearer instance
@@ -51,6 +58,60 @@ def get_auth_token_from_request(request: Request) -> Optional[str]:
     return None
 
 
+async def _authenticate_service_account(request: Request, token: str) -> bool:
+    """
+    Authenticate a service account token (agno_pat_...) outside the JWT middleware,
+    i.e. in os_security_key or open deployments.
+
+    Attaches the account identity to request.state exactly like the JWT middleware
+    does (user_id = the sa:<name> principal, scopes = the account's scopes) and
+    enforces the account's scopes against the default scope mappings. Service account
+    scopes are ACL data owned by this AgentOS instance, so - unlike JWT scopes - they
+    are enforced in every deployment mode.
+    """
+    verifier = getattr(request.app.state, "service_account_verifier", None)
+    if verifier is None:
+        raise HTTPException(status_code=401, detail="Service accounts are not enabled on this AgentOS instance")
+
+    client_key = request.client.host if request.client else None
+    result = await verifier.verify(token, client_key=client_key)
+
+    if result.status == VerificationStatus.THROTTLED:
+        raise HTTPException(status_code=429, detail="Too many failed authentication attempts")
+    if result.status == VerificationStatus.UNAVAILABLE:
+        raise HTTPException(status_code=503, detail="Authentication is temporarily unavailable")
+    account = result.account
+    if not result.ok or account is None:
+        raise HTTPException(status_code=401, detail="Invalid or expired service account token")
+
+    admin_scope_raw = getattr(request.app.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+
+    request.state.authenticated = True
+    request.state.user_id = account.principal
+    request.state.session_id = None
+    request.state.scopes = list(account.scopes)
+    request.state.authorization_enabled = True
+    request.state.service_account_name = account.name
+    if admin_scope:
+        request.state.admin_scope = admin_scope
+
+    scope_check = check_route_scopes(
+        list(account.scopes),
+        get_default_scope_mappings(),
+        request.method,
+        request.url.path,
+        admin_scope=admin_scope,
+    )
+    request.state.required_scopes = scope_check.required_scopes
+    if scope_check.accessible_resource_ids is not None:
+        request.state.accessible_resource_ids = scope_check.accessible_resource_ids
+    if not scope_check.allowed:
+        raise HTTPException(status_code=403, detail=build_insufficient_permissions_detail(scope_check.required_scopes))
+
+    return True
+
+
 def _is_jwt_configured() -> bool:
     """Check if JWT authentication is configured via environment variables.
 
@@ -83,6 +144,13 @@ def get_authentication_dependency(settings: AgnoAPISettings):
         # Check if JWT middleware has already handled authentication
         if getattr(request.state, "authenticated", False):
             return True
+
+        # Service account tokens (agno_pat_...) are verified and scope-checked in
+        # every deployment mode - including os_security_key mode and open dev
+        # instances, where they also provide run attribution.
+        token = credentials.credentials if credentials else None
+        if token and token.startswith(SERVICE_ACCOUNT_TOKEN_PREFIX):
+            return await _authenticate_service_account(request, token)
 
         # Also skip if JWT is configured via environment variables
         if _is_jwt_configured():

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -1,7 +1,7 @@
 import asyncio
 import hmac
 from os import getenv
-from typing import Any, List, Optional, Set
+from typing import Any, List, Literal, Optional, Set
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -118,6 +118,30 @@ def _is_jwt_configured() -> bool:
     This covers cases where JWT middleware is set up manually (not via authorization=True).
     """
     return bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
+
+
+def get_effective_auth_mode(
+    settings: Optional[AgnoAPISettings], authorization: bool = False
+) -> Literal["none", "security_key", "jwt"]:
+    """Return the authentication mode effectively enforced by the OS.
+
+    Mirrors the precedence used by ``get_authentication_dependency``:
+    JWT (via authorization=True on AgentOS or JWT environment variables) takes
+    precedence over the security key, which takes precedence over no auth.
+
+    Args:
+        settings: The API settings containing the security key and authorization flag
+        authorization: The AgentOS authorization flag (JWT middleware enabled)
+
+    Returns:
+        "jwt" when JWT authorization is effectively active, "security_key" when
+        only the OS security key is enforced, "none" when authentication is disabled.
+    """
+    if authorization or (settings is not None and settings.authorization_enabled) or _is_jwt_configured():
+        return "jwt"
+    if settings is not None and settings.os_security_key:
+        return "security_key"
+    return "none"
 
 
 def get_authentication_dependency(settings: AgnoAPISettings):

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -8,11 +8,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 # the valid values for ``MCPServerConfig.include_tags`` / ``exclude_tags`` without reading
 # ``agno/os/mcp.py``. Keep in sync with the ``tags={...}`` argument on each
 # ``@register_builtin_tool(...)`` in that module.
-MCP_BUILTIN_TAGS: frozenset = frozenset({"core", "session", "memory"})
+MCP_BUILTIN_TAGS: frozenset = frozenset({"core", "session"})
 
 # Type alias for ``include_tags`` / ``exclude_tags`` -- gives IDE autocomplete on the
 # string values while keeping the API stringly-typed (callers still pass ``{"core"}``).
-MCPBuiltinTag = Literal["core", "session", "memory"]
+MCPBuiltinTag = Literal["core", "session"]
 
 
 class MCPServerConfig(BaseModel):
@@ -25,9 +25,13 @@ class MCPServerConfig(BaseModel):
 
     The built-in tools are tagged so they can be scoped as a group. See
     ``MCP_BUILTIN_TAGS`` for the canonical set; current values:
-      - ``"core"``    -> ``get_agentos_config``, ``run_agent``, ``run_team``, ``run_workflow``
-      - ``"session"`` -> session CRUD tools
-      - ``"memory"``  -> memory CRUD tools
+      - ``"core"``    -> ``get_agentos_config``, ``run_agent``, ``run_team``, ``run_workflow``,
+        ``continue_run``, ``cancel_run``
+      - ``"session"`` -> read-only session tools (``get_sessions``, ``get_session_runs``)
+
+    The surface is deliberately small (8 tools): it is an operator surface for LLM
+    frontends, not a database console. Session writes and memory CRUD live on the REST
+    surface; anything else can be registered as a custom tool via ``tools``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -42,7 +46,7 @@ class MCPServerConfig(BaseModel):
     # FastMCP ``Context`` parameter, which FastMCP injects natively.
     tools: Optional[List[Any]] = None
 
-    # Master switch for the ~19 built-in tools. Set to False to ship ONLY your own tools.
+    # Master switch for the 8 built-in tools. Set to False to ship ONLY your own tools.
     enable_builtin_tools: bool = True
 
     # Finer scoping over the built-ins via their tags (see ``MCP_BUILTIN_TAGS``).

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -54,6 +54,16 @@ class MCPServerConfig(BaseModel):
     include_tags: Optional[Set[MCPBuiltinTag]] = None
     exclude_tags: Optional[Set[MCPBuiltinTag]] = None
 
+    # How run_agent / run_team / run_workflow serialize their results.
+    #   "trimmed" (default) -> answer text + generated media as MCP content blocks;
+    #     structuredContent carries only run_id / session_id / status (+ unresolved
+    #     requirements when paused). MCP tool results land directly in the consuming
+    #     model's context window, so the transcript, system prompt, and metrics are
+    #     deliberately not included.
+    #   "full" -> structuredContent is the run's complete ``to_dict()`` (media base64-
+    #     encoded), for programmatic MCP clients that want the whole run.
+    result_mode: Literal["trimmed", "full"] = "trimmed"
+
     # Per-call gate for the MCP server. Given the authenticated caller's user_id, return True
     # to allow the request and False to reject it with 401 -- before any tool or model runs.
     # Runs after JWT verification.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -755,6 +755,104 @@ def _add_authorize_middleware(mcp_app: StarletteWithLifespan, authorize: Callabl
     mcp_app.add_middleware(_MCPAuthorizeMiddleware)
 
 
+def _add_key_auth_middleware(
+    mcp_app: StarletteWithLifespan,
+    security_key: Optional[str],
+    service_account_verifier: Optional[Any],
+) -> None:
+    """Enforce the REST auth rules over ``/mcp`` in non-JWT deployments.
+
+    The REST surface enforces ``OS_SECURITY_KEY`` and service account tokens through a
+    FastAPI router dependency (``agno.os.auth.get_authentication_dependency``), but router
+    dependencies never run for mounted sub-apps -- without this middleware the MCP surface
+    would be completely open in security-key mode. Mirrors the dependency's rules: a bearer
+    (or raw) token is accepted when it matches the security key or is a valid service
+    account token (``agno_pat_...``); with no security key configured, requests without a
+    service account token pass through, matching REST's open mode.
+
+    The verifier is captured at construction because the mounted MCP app has its own
+    ``app.state`` -- the middleware cannot find it on the main app's state from inside
+    the mount.
+    """
+    import hmac
+
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse
+
+    from agno.os.auth import _is_jwt_configured
+    from agno.os.service_accounts import TOKEN_PREFIX, VerificationStatus
+
+    class _MCPKeyAuthMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+            # Skip CORS preflight, mirroring the JWT middleware.
+            if request.method == "OPTIONS":
+                return await call_next(request)
+
+            # A JWT middleware on the parent app may have already authenticated the
+            # request (request.state is carried through the mount); mirror the REST
+            # dependency and let it through.
+            if getattr(request.state, "authenticated", False):
+                return await call_next(request)
+
+            # Accept both "Bearer <token>" and a raw token, like the JWT middleware.
+            authorization = request.headers.get("Authorization", "")
+            if authorization.lower().startswith("bearer "):
+                token = authorization[7:].strip()
+            else:
+                token = authorization.strip()
+
+            # Service account tokens are verified in every deployment mode (mirrors REST).
+            if token.startswith(TOKEN_PREFIX):
+                return await self._dispatch_service_account(request, token, call_next)
+
+            # JWT configured via environment variables (manual middleware setup): the
+            # REST dependency skips security key validation in this case; do the same.
+            if _is_jwt_configured():
+                return await call_next(request)
+
+            # No security key configured: open instance, matching REST.
+            if not security_key:
+                return await call_next(request)
+
+            if not token:
+                return JSONResponse({"detail": "Authorization header required"}, status_code=401)
+
+            if hmac.compare_digest(token, security_key):
+                return await call_next(request)
+
+            return JSONResponse({"detail": "Invalid authentication token"}, status_code=401)
+
+        async def _dispatch_service_account(self, request, token, call_next):  # type: ignore[no-untyped-def]
+            # Mirrors agno.os.auth._authenticate_service_account: uniform 401 detail for
+            # unknown/revoked/expired tokens, 429 when throttled, 503 when the database
+            # cannot be reached.
+            if service_account_verifier is None:
+                return JSONResponse(
+                    {"detail": "Service accounts are not enabled on this AgentOS instance"}, status_code=401
+                )
+
+            client_key = request.client.host if request.client else None
+            result = await service_account_verifier.verify(token, client_key=client_key)
+
+            if result.status == VerificationStatus.THROTTLED:
+                return JSONResponse({"detail": "Too many failed authentication attempts"}, status_code=429)
+            if result.status == VerificationStatus.UNAVAILABLE:
+                return JSONResponse({"detail": "Authentication is temporarily unavailable"}, status_code=503)
+            account = result.account
+            if not result.ok or account is None:
+                return JSONResponse({"detail": "Invalid or expired service account token"}, status_code=401)
+
+            # Attribution: _resolve_user_id reads request.state.user_id for tool calls.
+            request.state.authenticated = True
+            request.state.user_id = account.principal
+            request.state.session_id = None
+            request.state.scopes = list(account.scopes)
+            request.state.service_account_name = account.name
+            return await call_next(request)
+
+    mcp_app.add_middleware(_MCPKeyAuthMiddleware)
+
+
 # Localhost defaults so a desktop / local MCP server is protected with zero extra config.
 _MCP_LOCALHOST_HOSTS = ("127.0.0.1", "localhost", "[::1]")
 
@@ -822,8 +920,9 @@ def get_mcp_server(
     """Build the MCP HTTP app served at ``/mcp``.
 
     Wraps :func:`build_mcp_server` with the Streamable HTTP transport and layers on (from the
-    inside out) the JWT middleware (when authorization is enabled), the optional ``authorize``
-    gate, any app-provided middleware, and the built-in DNS-rebinding protection -- all from
+    inside out) the JWT middleware (when authorization is enabled) or the security-key /
+    service-account auth middleware (otherwise), the optional ``authorize`` gate, any
+    app-provided middleware, and the built-in DNS-rebinding protection -- all from
     ``mcp_config``.
     """
     mcp = build_mcp_server(os)
@@ -883,6 +982,18 @@ def get_mcp_server(
         if service_account_verifier is not None:
             jwt_kwargs["service_account_verifier"] = service_account_verifier
         mcp_app.add_middleware(JWTMiddleware, **jwt_kwargs)
+    else:
+        # Non-JWT deployments: the REST surface enforces OS_SECURITY_KEY and service
+        # account tokens through a router dependency, which never runs for mounted
+        # sub-apps -- without this, /mcp would be completely open in security-key mode.
+        # Added in the same layer position as the JWT middleware above, so transport
+        # security still runs outermost and the authorize gate sees the verified
+        # identity. Nothing is added when auth is fully disabled (no security key and
+        # no service account verifier), matching REST's open mode.
+        security_key = os.settings.os_security_key if os.settings else None
+        service_account_verifier = os._get_service_account_verifier()
+        if security_key or service_account_verifier is not None:
+            _add_key_auth_middleware(mcp_app, security_key, service_account_verifier)
 
     # App-provided middleware, preserving the order they were listed in.
     if mcp_config is not None and mcp_config.middleware:

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1172,6 +1172,12 @@ def get_mcp_server(
         # REST wiring's pattern so manual JWTMiddleware defaults stay backwards-compatible.
         if os.authorization_config.user_isolation:
             jwt_kwargs["user_isolation"] = True
+        # The MCP app is a separately mounted Starlette app with its own app.state, so the
+        # service account verifier must be passed at construction - the middleware cannot
+        # find it on the main app's state from inside the mount.
+        service_account_verifier = os._get_service_account_verifier()
+        if service_account_verifier is not None:
+            jwt_kwargs["service_account_verifier"] = service_account_verifier
         mcp_app.add_middleware(JWTMiddleware, **jwt_kwargs)
 
     # App-provided middleware, preserving the order they were listed in.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -6,13 +6,15 @@ import logging
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
 from uuid import uuid4
 
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from fastmcp.server.http import (
     StarletteWithLifespan,
 )
+from fastmcp.tools.tool import ToolResult
 
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType
 from agno.db.schemas import UserMemory
+from agno.os.mcp_results import build_run_tool_result
 from agno.os.routers.memory.schemas import (
     UserMemorySchema,
 )
@@ -37,9 +39,9 @@ from agno.os.utils import (
     get_workflow_by_id,
 )
 from agno.remote.base import RemoteDb
-from agno.run.agent import RunOutput
-from agno.run.team import TeamRunOutput
-from agno.run.workflow import WorkflowRunOutput
+from agno.run.agent import RunEvent, RunOutput
+from agno.run.team import TeamRunEvent, TeamRunOutput
+from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
 from agno.session import AgentSession, TeamSession, WorkflowSession
 
 if TYPE_CHECKING:
@@ -174,6 +176,168 @@ def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
     return caller_user_id
 
 
+# Events forwarded to the client as progress notifications during agent/team runs.
+# Content deltas are deliberately excluded: MCP progress is a status channel, and
+# per-token notifications would flood clients that request a progress token.
+_TOOL_CALL_PROGRESS_EVENTS = frozenset(
+    {
+        RunEvent.tool_call_started.value,
+        RunEvent.tool_call_completed.value,
+        TeamRunEvent.tool_call_started.value,
+        TeamRunEvent.tool_call_completed.value,
+    }
+)
+
+# Error events captured so a failed run surfaces its real error message. The streaming
+# error paths yield only these events -- the final run output is never yielded on failure.
+_RUN_ERROR_EVENTS = frozenset({RunEvent.run_error.value, TeamRunEvent.run_error.value})
+
+
+async def _report_progress(ctx: Context, progress: float, message: str, total: Optional[float] = None) -> None:
+    """Send a progress notification; a failure here must never break the run.
+
+    FastMCP no-ops when the client did not send a progressToken, so this is safe to
+    call unconditionally.
+    """
+    try:
+        await ctx.report_progress(progress=progress, total=total, message=message)
+    except Exception:
+        logger.debug("Failed to send MCP progress notification", exc_info=True)
+
+
+def _describe_tool_call_event(event: Any) -> str:
+    tool = getattr(event, "tool", None)
+    tool_name = getattr(tool, "tool_name", None) or "tool"
+    verb = "started" if str(getattr(event, "event", "")).endswith("Started") else "completed"
+    return f"Tool call {verb}: {tool_name}"
+
+
+async def _consume_agentic_stream(ctx: Context, stream: Any, label: str) -> Union[RunOutput, TeamRunOutput]:
+    """Drive a streaming agent/team run and return its final output.
+
+    The stream must be created with ``stream=True, stream_events=True,
+    yield_run_output=True`` so tool-call events can be forwarded as progress
+    notifications and the final ``RunOutput`` / ``TeamRunOutput`` arrives as the
+    last yielded item. On failure the stream yields only a run-error event -- its
+    message is captured so the client sees the real error, not a generic one.
+    """
+    final: Optional[Union[RunOutput, TeamRunOutput]] = None
+    error_message: Optional[str] = None
+    ticks = 0
+    await _report_progress(ctx, 0.0, f"{label} started")
+    async for item in stream:
+        if isinstance(item, (RunOutput, TeamRunOutput)):
+            final = item
+            continue
+        event = getattr(item, "event", None)
+        if event in _TOOL_CALL_PROGRESS_EVENTS:
+            ticks += 1
+            await _report_progress(ctx, float(ticks), _describe_tool_call_event(item))
+        elif event in _RUN_ERROR_EVENTS:
+            error_message = getattr(item, "content", None) or "Run failed"
+    if final is None:
+        raise Exception(
+            str(error_message) if error_message else f"{label} finished without producing a final run output"
+        )
+    return final
+
+
+async def _run_agentic_component(
+    ctx: Context, component: Any, message: str, user_id: Optional[str], session_id: Optional[str], label: str
+) -> Union[RunOutput, TeamRunOutput]:
+    """Shared run path for agents and teams: stream with progress, or plain await for remotes.
+
+    Remote components proxy to another AgentOS over HTTP and their streaming ``arun``
+    never yields the final output object, so they take the non-streaming path (no
+    intermediate progress, same result contract).
+    """
+    from agno.agent.remote import RemoteAgent
+    from agno.team.remote import RemoteTeam
+
+    if isinstance(component, (RemoteAgent, RemoteTeam)):
+        return await component.arun(message, user_id=user_id, session_id=session_id)
+
+    stream = component.arun(
+        message,
+        user_id=user_id,
+        session_id=session_id,
+        stream=True,
+        stream_events=True,
+        yield_run_output=True,
+    )
+    return await _consume_agentic_stream(ctx, stream, label=label)
+
+
+def _describe_step_event(event: Any, total_steps: Optional[float]) -> str:
+    verb = "started" if str(getattr(event, "event", "")).endswith("Started") else "completed"
+    step_name = getattr(event, "step_name", None) or "step"
+    step_index = getattr(event, "step_index", None)
+    if isinstance(step_index, tuple) and step_index and isinstance(step_index[0], int):
+        step_index = step_index[0]
+    if isinstance(step_index, int) and total_steps:
+        return f"Step {verb}: {step_name} ({step_index + 1}/{int(total_steps)})"
+    return f"Step {verb}: {step_name}"
+
+
+async def _consume_workflow_stream(
+    ctx: Context,
+    workflow: Any,
+    stream: Any,
+    total_steps: Optional[float],
+    user_id: Optional[str],
+) -> WorkflowRunOutput:
+    """Drive a streaming workflow run and return its final output.
+
+    Workflow streams do not support ``yield_run_output``. Completed runs carry the
+    full ``WorkflowRunOutput`` on the terminal event; paused / cancelled / step-error
+    runs end the stream with NO workflow-level terminal event, so the persisted run
+    is fetched back via ``workflow.aget_run_output`` -- the same source of truth the
+    REST router uses. Events from nested workflows (``nested_depth > 0``) are skipped:
+    terminal handling and progress apply to the outer run only, and a nested failure
+    the outer workflow recovers from must not abort it.
+
+    Progress values are a plain monotonic counter (the MCP spec requires each
+    notification's progress to increase); the step k/n detail lives in the message.
+    """
+    from agno.run.workflow import BaseWorkflowRunOutputEvent
+
+    final: Optional[WorkflowRunOutput] = None
+    error_message: Optional[str] = None
+    run_id: Optional[str] = None
+    session_id: Optional[str] = None
+    ticks = 0.0
+    await _report_progress(ctx, 0.0, "Workflow started")
+    async for item in stream:
+        if isinstance(item, WorkflowRunOutput):
+            final = item
+            continue
+        if getattr(item, "nested_depth", 0):
+            continue
+        if isinstance(item, BaseWorkflowRunOutputEvent):
+            run_id = getattr(item, "run_id", None) or run_id
+            session_id = getattr(item, "session_id", None) or session_id
+        event = getattr(item, "event", None)
+        if event in (WorkflowRunEvent.step_started.value, WorkflowRunEvent.step_completed.value):
+            ticks += 1.0
+            await _report_progress(ctx, ticks, _describe_step_event(item, total_steps))
+        elif event == WorkflowRunEvent.workflow_completed.value:
+            final = getattr(item, "run_output", None) or final
+        elif event == WorkflowRunEvent.workflow_error.value:
+            # Do not raise mid-stream: closing the generator here would skip the
+            # workflow's own error-status persistence. Capture and settle after.
+            error_message = getattr(item, "error", None) or "Workflow run failed"
+    if final is None and run_id is not None:
+        try:
+            final = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
+        except Exception:
+            logger.debug("Could not fetch persisted workflow run %s after stream end", run_id, exc_info=True)
+    if final is None:
+        raise Exception(
+            str(error_message) if error_message else "Workflow run finished without producing a final run output"
+        )
+    return final
+
+
 def build_mcp_server(
     os: "AgentOS",
 ) -> FastMCP:
@@ -191,6 +355,10 @@ def build_mcp_server(
     # Decorator used to register the built-in tools. Honors ``mcp_config`` scoping;
     # behaves exactly like ``mcp.tool`` when no config (or default config) is provided.
     register_builtin_tool = _builtin_tool_registrar(mcp, mcp_config)
+
+    # How the run tools serialize their results ("trimmed" keeps the frontend model's
+    # context clean; "full" is the escape hatch for programmatic clients).
+    result_mode = mcp_config.result_mode if mcp_config is not None else "trimmed"
 
     @register_builtin_tool(
         name="get_agentos_config",
@@ -228,40 +396,64 @@ def build_mcp_server(
     async def run_agent(
         agent_id: str,
         message: str,
+        ctx: Context,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
-    ) -> RunOutput:
+    ) -> ToolResult:
         agent = get_agent_by_id(agent_id, os.agents)
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await agent.arun(message, user_id=user_id, session_id=session_id)  # type: ignore[misc]
+        run_output = await _run_agentic_component(
+            ctx, agent, message, user_id, session_id, label=f"Agent {agent.name or agent_id}"
+        )
+        return build_run_tool_result(run_output, result_mode)
 
     @register_builtin_tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
     async def run_team(
         team_id: str,
         message: str,
+        ctx: Context,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
-    ) -> TeamRunOutput:
+    ) -> ToolResult:
         team = get_team_by_id(team_id, os.teams)
         if team is None:
             raise Exception(f"Team {team_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await team.arun(message, user_id=user_id, session_id=session_id)  # type: ignore[misc]
+        run_output = await _run_agentic_component(
+            ctx, team, message, user_id, session_id, label=f"Team {team.name or team_id}"
+        )
+        return build_run_tool_result(run_output, result_mode)
 
     @register_builtin_tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
     async def run_workflow(
         workflow_id: str,
         message: str,
+        ctx: Context,
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
-    ) -> WorkflowRunOutput:
+    ) -> ToolResult:
+        from agno.workflow.remote import RemoteWorkflow
+
         workflow = get_workflow_by_id(workflow_id, os.workflows)
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
         user_id = _resolve_user_id(user_id)
-        return await workflow.arun(message, user_id=user_id, session_id=session_id)
+        if isinstance(workflow, RemoteWorkflow):
+            run_output = await workflow.arun(message, user_id=user_id, session_id=session_id)
+            return build_run_tool_result(run_output, result_mode)
+        steps = getattr(workflow, "steps", None)
+        total_steps = float(len(steps)) if isinstance(steps, (list, tuple)) and steps else None
+        stream = workflow.arun(
+            message,
+            user_id=user_id,
+            session_id=session_id,
+            stream=True,
+            stream_events=True,
+        )
+        run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, user_id)
+        return build_run_tool_result(run_output, result_mode)
 
     # ==================== Session Management Tools ====================
 

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -3,8 +3,7 @@
 import functools
 import inspect
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
-from uuid import uuid4
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
 from fastmcp import Context, FastMCP
 from fastmcp.server.http import (
@@ -12,26 +11,18 @@ from fastmcp.server.http import (
 )
 from fastmcp.tools.tool import ToolResult
 
-from agno.db.base import AsyncBaseDb, BaseDb, SessionType
-from agno.db.schemas import UserMemory
+from agno.db.base import SessionType
 from agno.os.mcp_results import build_run_tool_result
-from agno.os.routers.memory.schemas import (
-    UserMemorySchema,
-)
 from agno.os.schema import (
-    AgentSessionDetailSchema,
     AgentSummaryResponse,
-    ConfigResponse,
-    InterfaceResponse,
-    RunSchema,
+    PaginatedResponse,
+    PaginationInfo,
     SessionSchema,
-    TeamRunSchema,
-    TeamSessionDetailSchema,
     TeamSummaryResponse,
-    WorkflowRunSchema,
-    WorkflowSessionDetailSchema,
     WorkflowSummaryResponse,
 )
+from agno.os.services import runs as run_service
+from agno.os.services import sessions as session_service
 from agno.os.utils import (
     get_agent_by_id,
     get_db,
@@ -42,7 +33,6 @@ from agno.remote.base import RemoteDb
 from agno.run.agent import RunEvent, RunOutput
 from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
-from agno.session import AgentSession, TeamSession, WorkflowSession
 
 if TYPE_CHECKING:
     from agno.os.app import AgentOS
@@ -176,6 +166,42 @@ def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
     return caller_user_id
 
 
+def _forwarded_auth_headers() -> Optional[Dict[str, str]]:
+    """The caller's bearer token as an Authorization header for downstream RemoteDb calls.
+
+    Mirrors the REST routers, which forward the inbound token on every RemoteDb call so
+    a JWT/PAT-protected downstream AgentOS accepts the request.
+    """
+    from fastmcp.server.dependencies import get_http_request
+
+    from agno.os.auth import get_auth_token_from_request
+
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    token = get_auth_token_from_request(request)
+    return {"Authorization": f"Bearer {token}"} if token else None
+
+
+def _scoped_caller_user_id() -> Optional[str]:
+    """The caller's user_id when they are a non-admin, isolation-scoped principal, else None.
+
+    Reuses the REST scoping rule (:func:`get_scoped_user_id`): admins and
+    non-isolated deployments return None (no per-run ownership gate), while a
+    scoped user returns their id so run-lifecycle tools can enforce ownership.
+    """
+    from fastmcp.server.dependencies import get_http_request
+
+    from agno.os.middleware.user_scope import get_scoped_user_id
+
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    return get_scoped_user_id(request)
+
+
 # Events forwarded to the client as progress notifications during agent/team runs.
 # Content deltas are deliberately excluded: MCP progress is a status channel, and
 # per-token notifications would flood clients that request a progress token.
@@ -191,6 +217,17 @@ _TOOL_CALL_PROGRESS_EVENTS = frozenset(
 # Error events captured so a failed run surfaces its real error message. The streaming
 # error paths yield only these events -- the final run output is never yielded on failure.
 _RUN_ERROR_EVENTS = frozenset({RunEvent.run_error.value, TeamRunEvent.run_error.value})
+
+# Per-run fields kept when rendering conversation history. The full RunSchema carries the
+# message transcript (system prompt included), events, and reasoning traces -- like the run
+# tools, the history tool ships only what a frontend model needs, not the raw internals.
+_SESSION_RUN_HISTORY_FIELDS = ("run_id", "run_input", "content", "status", "created_at", "agent_id", "team_id")
+
+
+def _trim_session_run(run: Any) -> Dict[str, Any]:
+    """Compact view of one persisted run for conversation-history reads."""
+    data = run.model_dump() if hasattr(run, "model_dump") else dict(run)
+    return {key: data[key] for key in _SESSION_RUN_HISTORY_FIELDS if data.get(key) is not None}
 
 
 async def _report_progress(ctx: Context, progress: float, message: str, total: Optional[float] = None) -> None:
@@ -338,6 +375,56 @@ async def _consume_workflow_stream(
     return final
 
 
+def _make_lifecycle_resolver(os: "AgentOS"):
+    """Bind the run-lifecycle component resolver + ownership verifier to an AgentOS.
+
+    Both continue_run and cancel_run must resolve exactly one component and, for a
+    scoped (non-admin) caller, prove the run lives in a session they own -- the same
+    gate the REST cancel/continue endpoints enforce before touching a run.
+    """
+
+    def resolve(
+        agent_id: Optional[str], team_id: Optional[str], workflow_id: Optional[str]
+    ) -> "tuple[Any, Literal['agents', 'teams', 'workflows'], str]":
+        provided = [cid for cid in (agent_id, team_id, workflow_id) if cid]
+        if len(provided) != 1:
+            raise Exception("Provide exactly one of agent_id, team_id, or workflow_id")
+        if agent_id:
+            return get_agent_by_id(agent_id, os.agents), "agents", agent_id
+        if team_id:
+            return get_team_by_id(team_id, os.teams), "teams", team_id
+        assert workflow_id is not None  # exactly-one check above guarantees this
+        return get_workflow_by_id(workflow_id, os.workflows), "workflows", workflow_id
+
+    async def verify(
+        component: Any,
+        component_type: Literal["agents", "teams", "workflows"],
+        component_id: str,
+        session_id: Optional[str],
+        run_id: str,
+    ):
+        if component is None:
+            raise Exception(f"Component {component_id} not found")
+        scoped_user_id = _scoped_caller_user_id()
+        if scoped_user_id is None:
+            return
+        if not session_id:
+            raise Exception("session_id is required to act on this run")
+        try:
+            await session_service.verify_run_ownership(
+                component,
+                session_id=session_id,
+                run_id=run_id,
+                user_id=scoped_user_id,
+                component_type=component_type,
+                component_id=component_id,
+            )
+        except session_service.RunOwnershipError as e:
+            raise Exception(str(e))
+
+    return resolve, verify
+
+
 def build_mcp_server(
     os: "AgentOS",
 ) -> FastMCP:
@@ -360,39 +447,45 @@ def build_mcp_server(
     # context clean; "full" is the escape hatch for programmatic clients).
     result_mode = mcp_config.result_mode if mcp_config is not None else "trimmed"
 
+    # Component resolution + ownership gate shared by continue_run and cancel_run.
+    _resolve_lifecycle_component, _verify_run_ownership = _make_lifecycle_resolver(os)
+
     @register_builtin_tool(
         name="get_agentos_config",
-        description="Get the configuration of the AgentOS",
+        description=(
+            "Discover this AgentOS: the agents, teams, and workflows available to run (with their ids "
+            "and descriptions), and the database ids used by the session tools. Call this first to learn "
+            "what you can operate. The payload is deliberately compact -- the full configuration lives on "
+            "the REST /config endpoint."
+        ),
         tags={"core"},
-        output_schema=ConfigResponse.model_json_schema(),
+        annotations={"readOnlyHint": True, "idempotentHint": True},
     )  # type: ignore
-    async def config() -> ConfigResponse:
-        return ConfigResponse(
-            os_id=os.id or "AgentOS",
-            description=os.description,
-            available_models=os.config.available_models if os.config else [],
-            databases=[db.id for db_list in os.dbs.values() for db in db_list],
-            chat=os.config.chat if os.config else None,
-            manifest=os.config.manifest if os.config else None,
-            session=os._get_session_config(),
-            memory=os._get_memory_config(),
-            learning=os._get_learning_config(),
-            knowledge=os._get_knowledge_config(),
-            evals=os._get_evals_config(),
-            metrics=os._get_metrics_config(),
-            traces=os._get_traces_config(),
-            agents=[AgentSummaryResponse.from_agent(a) for a in os.agents] if os.agents else [],
-            teams=[TeamSummaryResponse.from_team(t) for t in os.teams] if os.teams else [],
-            workflows=[WorkflowSummaryResponse.from_workflow(w) for w in os.workflows] if os.workflows else [],
-            interfaces=[
-                InterfaceResponse(type=interface.type, version=interface.version, route=interface.prefix)
-                for interface in os.interfaces
-            ],
-        )
+    async def config() -> Dict[str, Any]:
+        return {
+            "os_id": os.id or "AgentOS",
+            "description": os.description,
+            "databases": [db.id for db_list in os.dbs.values() for db in db_list],
+            "agents": [AgentSummaryResponse.from_agent(a).model_dump() for a in os.agents] if os.agents else [],
+            "teams": [TeamSummaryResponse.from_team(t).model_dump() for t in os.teams] if os.teams else [],
+            "workflows": [WorkflowSummaryResponse.from_workflow(w).model_dump() for w in os.workflows]
+            if os.workflows
+            else [],
+        }
 
     # ==================== Core Run Tools ====================
 
-    @register_builtin_tool(name="run_agent", description="Run an agent with a message", tags={"core"})  # type: ignore
+    @register_builtin_tool(
+        name="run_agent",
+        description=(
+            "Run an agent with a message and get its response. Pass a session_id from get_sessions to "
+            "continue that conversation; omit it to start a new one (the session_id comes back in "
+            "structuredContent). If the result status is PAUSED, resolve the returned requirements and "
+            "call continue_run. Agent ids come from get_agentos_config."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+    )  # type: ignore
     async def run_agent(
         agent_id: str,
         message: str,
@@ -409,7 +502,15 @@ def build_mcp_server(
         )
         return build_run_tool_result(run_output, result_mode)
 
-    @register_builtin_tool(name="run_team", description="Run a team with a message", tags={"core"})  # type: ignore
+    @register_builtin_tool(
+        name="run_team",
+        description=(
+            "Run a team of agents with a message and get its response. Same session and PAUSED semantics "
+            "as run_agent. Team ids come from get_agentos_config."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+    )  # type: ignore
     async def run_team(
         team_id: str,
         message: str,
@@ -426,7 +527,16 @@ def build_mcp_server(
         )
         return build_run_tool_result(run_output, result_mode)
 
-    @register_builtin_tool(name="run_workflow", description="Run a workflow with a message", tags={"core"})  # type: ignore
+    @register_builtin_tool(
+        name="run_workflow",
+        description=(
+            "Run a workflow with an input message and get its result. Can be long-running: progress is "
+            "reported per step when the client supports it. Same session and PAUSED semantics as "
+            "run_agent. Workflow ids come from get_agentos_config."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "openWorldHint": True},
+    )  # type: ignore
     async def run_workflow(
         workflow_id: str,
         message: str,
@@ -455,27 +565,98 @@ def build_mcp_server(
         run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, user_id)
         return build_run_tool_result(run_output, result_mode)
 
-    # ==================== Session Management Tools ====================
+    # ==================== Run Lifecycle Tools ====================
+
+    @register_builtin_tool(
+        name="continue_run",
+        description=(
+            "Resume a PAUSED run after resolving its requirements (human-in-the-loop). "
+            "When a run tool returns status=PAUSED, its structuredContent carries the unresolved "
+            "requirements; set the resolution fields on them (e.g. confirmation=true) and pass them "
+            "back here unchanged otherwise. Provide exactly one of agent_id / team_id / workflow_id "
+            "(the component that owns the run) plus the run_id and session_id from the paused result."
+        ),
+        tags={"core"},
+        annotations={"readOnlyHint": False, "destructiveHint": False},
+    )  # type: ignore
+    async def continue_run(
+        run_id: str,
+        ctx: Context,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+        requirements: Optional[List[Dict[str, Any]]] = None,
+        user_id: Optional[str] = None,
+    ) -> ToolResult:
+        component, component_type, component_id = _resolve_lifecycle_component(agent_id, team_id, workflow_id)
+        user_id = _resolve_user_id(user_id)
+        await _verify_run_ownership(component, component_type, component_id, session_id, run_id)
+        await _report_progress(ctx, 0.0, f"Continuing run {run_id}")
+        try:
+            run_output = await run_service.continue_paused_run(
+                component,
+                run_id=run_id,
+                session_id=session_id,
+                user_id=user_id,
+                requirements=requirements,
+            )
+        except run_service.RemoteContinuationUnsupported as e:
+            raise Exception(str(e))
+        return build_run_tool_result(run_output, result_mode)
+
+    @register_builtin_tool(
+        name="cancel_run",
+        description=(
+            "Request cancellation of a running run. Irreversible: the run stops and is marked CANCELLED "
+            "(if it has not started yet, the intent is recorded and applied when it does). Provide the "
+            "run_id, its session_id, and exactly one of agent_id / team_id / workflow_id."
+        ),
+        tags={"core"},
+        annotations={"destructiveHint": True, "idempotentHint": True},
+    )  # type: ignore
+    async def cancel_run(
+        run_id: str,
+        session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        team_id: Optional[str] = None,
+        workflow_id: Optional[str] = None,
+    ) -> str:
+        component, component_type, component_id = _resolve_lifecycle_component(agent_id, team_id, workflow_id)
+        await _verify_run_ownership(component, component_type, component_id, session_id, run_id)
+        await run_service.cancel_component_run(component, run_id)
+        return f"Run {run_id} cancellation requested"
+
+    # ==================== Session Tools (read-only) ====================
+    # The MCP session surface is deliberately read-only continuity: run tools create
+    # sessions implicitly, and destructive session management stays on the REST surface.
 
     @register_builtin_tool(
         name="get_sessions",
-        description="Get paginated list of sessions with optional filtering by type, component, user, and name",
+        description=(
+            "List past sessions (conversations), newest first. Filter by session_type, component_id "
+            "(an agent/team/workflow id from get_agentos_config), user, or session_name. Use a returned "
+            "session_id with the run tools to continue that conversation, or with get_session_runs to "
+            "read its history. db_id is only needed when get_agentos_config lists multiple databases."
+        ),
         tags={"session"},
+        annotations={"readOnlyHint": True},
     )  # type: ignore
     async def get_sessions(
-        db_id: str,
-        session_type: str = "agent",
+        session_type: Literal["agent", "team", "workflow"] = "agent",
         component_id: Optional[str] = None,
         user_id: Optional[str] = None,
         session_name: Optional[str] = None,
         limit: int = 20,
         page: int = 1,
         sort_by: str = "created_at",
-        sort_order: str = "desc",
+        sort_order: Literal["asc", "desc"] = "desc",
+        db_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
+
         if isinstance(db, RemoteDb):
             result = await db.get_sessions(
                 session_type=session_type_enum,
@@ -487,199 +668,47 @@ def build_mcp_server(
                 sort_by=sort_by,
                 sort_order=sort_order,
                 db_id=db_id,
+                headers=_forwarded_auth_headers(),
             )
             return result.model_dump()
 
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            sessions, total_count = await db.get_sessions(
-                session_type=session_type_enum,
-                component_id=component_id,
-                user_id=user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-        else:
-            sessions, total_count = db.get_sessions(
-                session_type=session_type_enum,
-                component_id=component_id,
-                user_id=user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-
-        return {
-            "data": [SessionSchema.from_dict(session).model_dump() for session in sessions],  # type: ignore
-            "meta": {
-                "page": page,
-                "limit": limit,
-                "total_count": total_count,
-                "total_pages": (total_count + limit - 1) // limit if limit > 0 else 0,  # type: ignore
-            },
-        }
-
-    @register_builtin_tool(
-        name="get_session",
-        description="Get detailed information about a specific session by ID",
-        tags={"session"},
-    )  # type: ignore
-    async def get_session(
-        session_id: str,
-        db_id: str,
-        session_type: str = "agent",
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.get_session(
-                session_id=session_id,
-                session_type=session_type_enum,
-                user_id=user_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(session_id=session_id, session_type=session_type_enum, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            session = db.get_session(session_id=session_id, session_type=session_type_enum, user_id=user_id)
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-
-    @register_builtin_tool(
-        name="create_session",
-        description="Create a new session for an agent, team, or workflow",
-        tags={"session"},
-    )  # type: ignore
-    async def create_session(
-        db_id: str,
-        session_type: str = "agent",
-        session_id: Optional[str] = None,
-        session_name: Optional[str] = None,
-        session_state: Optional[Dict[str, Any]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        user_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        team_id: Optional[str] = None,
-        workflow_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        import time
-
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        # Generate session_id if not provided
-        session_id = session_id or str(uuid4())
-
-        if isinstance(db, RemoteDb):
-            result = await db.create_session(
-                session_type=session_type_enum,
-                session_id=session_id,
-                session_name=session_name,
-                session_state=session_state,
-                metadata=metadata,
-                user_id=user_id,
-                agent_id=agent_id,
-                team_id=team_id,
-                workflow_id=workflow_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        # Prepare session_data
-        session_data: Dict[str, Any] = {}
-        if session_state is not None:
-            session_data["session_state"] = session_state
-        if session_name is not None:
-            session_data["session_name"] = session_name
-
-        current_time = int(time.time())
-
-        # Create the appropriate session type
-        session: Union[AgentSession, TeamSession, WorkflowSession]
-        if session_type_enum == SessionType.AGENT:
-            session = AgentSession(
-                session_id=session_id,
-                agent_id=agent_id,
-                user_id=user_id,
-                session_data=session_data if session_data else None,
-                metadata=metadata,
-                created_at=current_time,
-                updated_at=current_time,
-            )
-        elif session_type_enum == SessionType.TEAM:
-            session = TeamSession(
-                session_id=session_id,
-                team_id=team_id,
-                user_id=user_id,
-                session_data=session_data if session_data else None,
-                metadata=metadata,
-                created_at=current_time,
-                updated_at=current_time,
-            )
-        else:
-            session = WorkflowSession(
-                session_id=session_id,
-                workflow_id=workflow_id,
-                user_id=user_id,
-                session_data=session_data if session_data else None,
-                metadata=metadata,
-                created_at=current_time,
-                updated_at=current_time,
-            )
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            created_session = await db.upsert_session(session, deserialize=True)
-        else:
-            created_session = db.upsert_session(session, deserialize=True)
-
-        if not created_session:
-            raise Exception("Failed to create session")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(created_session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(created_session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(created_session).model_dump()  # type: ignore
+        sessions, total_count = await session_service.get_sessions_page(
+            db,
+            session_type=session_type_enum,
+            component_id=component_id,
+            user_id=user_id,
+            session_name=session_name,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        total_pages = (total_count + limit - 1) // limit if limit > 0 else 0
+        return PaginatedResponse(
+            data=[SessionSchema.from_dict(session) for session in sessions],
+            meta=PaginationInfo(page=page, limit=limit, total_count=total_count, total_pages=total_pages),
+        ).model_dump()
 
     @register_builtin_tool(
         name="get_session_runs",
-        description="Get all runs for a specific session",
+        description=(
+            "Read a session's conversation history: each run's input and response content with its "
+            "run_id, status, and timestamp, oldest first. Returns the answer content only, not the full "
+            "message transcript. session_type is auto-detected when omitted; db_id is only needed when "
+            "get_agentos_config lists multiple databases."
+        ),
         tags={"session"},
+        annotations={"readOnlyHint": True},
     )  # type: ignore
     async def get_session_runs(
         session_id: str,
-        db_id: str,
-        session_type: str = "agent",
+        session_type: Optional[Literal["agent", "team", "workflow"]] = None,
         user_id: Optional[str] = None,
+        db_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
+        session_type_enum = SessionType(session_type) if session_type else None
 
         if isinstance(db, RemoteDb):
             result = await db.get_session_runs(
@@ -687,532 +716,15 @@ def build_mcp_server(
                 session_type=session_type_enum,
                 user_id=user_id,
                 db_id=db_id,
+                headers=_forwarded_auth_headers(),
             )
-            return [r.model_dump() for r in result]
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-        else:
-            session = db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        runs = session.get("runs")  # type: ignore
-        if not runs:
-            return []
-
-        run_responses: List[Dict[str, Any]] = []
-        for run in runs:
-            if session_type_enum == SessionType.AGENT:
-                run_responses.append(RunSchema.from_dict(run).model_dump())
-            elif session_type_enum == SessionType.TEAM:
-                if run.get("agent_id") is not None:
-                    run_responses.append(RunSchema.from_dict(run).model_dump())
-                else:
-                    run_responses.append(TeamRunSchema.from_dict(run).model_dump())
-            else:
-                if run.get("workflow_id") is not None:
-                    run_responses.append(WorkflowRunSchema.from_dict(run).model_dump())
-                elif run.get("team_id") is not None:
-                    run_responses.append(TeamRunSchema.from_dict(run).model_dump())
-                else:
-                    run_responses.append(RunSchema.from_dict(run).model_dump())
-
-        return run_responses
-
-    @register_builtin_tool(
-        name="get_session_run",
-        description="Get a specific run from a session",
-        tags={"session"},
-    )  # type: ignore
-    async def get_session_run(
-        session_id: str,
-        run_id: str,
-        db_id: str,
-        session_type: str = "agent",
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.get_session_run(
-                session_id=session_id,
-                run_id=run_id,
-                session_type=session_type_enum,
-                user_id=user_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-        else:
-            session = db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=False
-            )
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        runs = session.get("runs")  # type: ignore
-        if not runs:
-            raise Exception(f"Session {session_id} has no runs")
-
-        target_run = None
-        for run in runs:
-            if run.get("run_id") == run_id:
-                target_run = run
-                break
-
-        if not target_run:
-            raise Exception(f"Run {run_id} not found in session {session_id}")
-
-        if target_run.get("workflow_id") is not None:
-            return WorkflowRunSchema.from_dict(target_run).model_dump()
-        elif target_run.get("team_id") is not None:
-            return TeamRunSchema.from_dict(target_run).model_dump()
-        else:
-            return RunSchema.from_dict(target_run).model_dump()
-
-    @register_builtin_tool(
-        name="rename_session",
-        description="Rename an existing session",
-        tags={"session"},
-    )  # type: ignore
-    async def rename_session(
-        session_id: str,
-        session_name: str,
-        db_id: str,
-        session_type: str = "agent",
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.rename_session(
-                session_id=session_id,
-                session_name=session_name,
-                session_type=session_type_enum,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.rename_session(
-                session_id=session_id, session_type=session_type_enum, session_name=session_name, user_id=user_id
-            )
-        else:
-            db = cast(BaseDb, db)
-            session = db.rename_session(
-                session_id=session_id, session_type=session_type_enum, session_name=session_name, user_id=user_id
-            )
-
-        if not session:
-            raise Exception(f"Session {session_id} not found")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(session).model_dump()  # type: ignore
-
-    @register_builtin_tool(
-        name="update_session",
-        description="Update session properties like name, state, metadata, or summary",
-        tags={"session"},
-    )  # type: ignore
-    async def update_session(
-        session_id: str,
-        db_id: str,
-        session_type: str = "agent",
-        session_name: Optional[str] = None,
-        session_state: Optional[Dict[str, Any]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        summary: Optional[Dict[str, Any]] = None,
-        user_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-        session_type_enum = SessionType(session_type)
-
-        if isinstance(db, RemoteDb):
-            result = await db.update_session(
-                session_id=session_id,
-                session_type=session_type_enum,
-                session_name=session_name,
-                session_state=session_state,
-                metadata=metadata,
-                summary=summary,
-                user_id=user_id,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        # Get the existing session
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            existing_session = await db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=True
-            )
-        else:
-            existing_session = db.get_session(
-                session_id=session_id, session_type=session_type_enum, user_id=user_id, deserialize=True
-            )
-
-        if not existing_session:
-            raise Exception(f"Session {session_id} not found")
-
-        # Update session properties
-        if session_name is not None:
-            if existing_session.session_data is None:  # type: ignore
-                existing_session.session_data = {}  # type: ignore
-            existing_session.session_data["session_name"] = session_name  # type: ignore
-
-        if session_state is not None:
-            if existing_session.session_data is None:  # type: ignore
-                existing_session.session_data = {}  # type: ignore
-            existing_session.session_data["session_state"] = session_state  # type: ignore
-
-        if metadata is not None:
-            existing_session.metadata = metadata  # type: ignore
-
-        if summary is not None:
-            from agno.session.summary import SessionSummary
-
-            existing_session.summary = SessionSummary.from_dict(summary)  # type: ignore
-
-        # Upsert the updated session
-        if isinstance(db, AsyncBaseDb):
-            updated_session = await db.upsert_session(existing_session, deserialize=True)  # type: ignore
-        else:
-            updated_session = db.upsert_session(existing_session, deserialize=True)  # type: ignore
-
-        if not updated_session:
-            raise Exception("Failed to update session")
-
-        if session_type_enum == SessionType.AGENT:
-            return AgentSessionDetailSchema.from_session(updated_session).model_dump()  # type: ignore
-        elif session_type_enum == SessionType.TEAM:
-            return TeamSessionDetailSchema.from_session(updated_session).model_dump()  # type: ignore
-        else:
-            return WorkflowSessionDetailSchema.from_session(updated_session).model_dump()  # type: ignore
-
-    @register_builtin_tool(
-        name="delete_session",
-        description="Delete a specific session and all its runs",
-        tags={"session"},
-    )  # type: ignore
-    async def delete_session(
-        session_id: str,
-        db_id: str,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            await db.delete_session(session_id=session_id, db_id=db_id)
-            return "Session deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_session(session_id=session_id, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_session(session_id=session_id, user_id=user_id)
-
-        return "Session deleted successfully"
-
-    @register_builtin_tool(
-        name="delete_sessions",
-        description="Delete multiple sessions by their IDs",
-        tags={"session"},
-    )  # type: ignore
-    async def delete_sessions(
-        session_ids: List[str],
-        db_id: str,
-        session_types: Optional[List[str]] = None,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            # Convert session_types strings to SessionType enums
-            session_type_enums = [SessionType(st) for st in session_types] if session_types else []
-            await db.delete_sessions(session_ids=session_ids, session_types=session_type_enums, db_id=db_id)
-            return "Sessions deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_sessions(session_ids=session_ids, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_sessions(session_ids=session_ids, user_id=user_id)
-
-        return "Sessions deleted successfully"
-
-    # ==================== Memory Management Tools ====================
-
-    @register_builtin_tool(name="create_memory", description="Create a new user memory", tags={"memory"})  # type: ignore
-    async def create_memory(
-        db_id: str,
-        memory: str,
-        user_id: str,
-        topics: Optional[List[str]] = None,
-    ) -> UserMemorySchema:
-        user_id = _resolve_user_id(user_id) or user_id
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            return await db.create_memory(
-                memory=memory,
-                topics=topics or [],
-                user_id=user_id,
-                db_id=db_id,
-            )
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memory = await db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=str(uuid4()),
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-        else:
-            db = cast(BaseDb, db)
-            user_memory = db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=str(uuid4()),
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-
-        if not user_memory:
-            raise Exception("Failed to create memory")
-
-        return UserMemorySchema.from_dict(user_memory)  # type: ignore
-
-    @register_builtin_tool(
-        name="get_memory",
-        description="Get a specific memory by ID",
-        tags={"memory"},
-    )  # type: ignore
-    async def get_memory(
-        memory_id: str,
-        db_id: str,
-        user_id: Optional[str] = None,
-    ) -> UserMemorySchema:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            return await db.get_memory(memory_id=memory_id, user_id=user_id, db_id=db_id)
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memory = await db.get_user_memory(memory_id=memory_id, user_id=user_id, deserialize=False)
-        else:
-            db = cast(BaseDb, db)
-            user_memory = db.get_user_memory(memory_id=memory_id, user_id=user_id, deserialize=False)
-
-        if not user_memory:
-            raise Exception(f"Memory {memory_id} not found")
-
-        return UserMemorySchema.from_dict(user_memory)  # type: ignore
-
-    @register_builtin_tool(
-        name="get_memories",
-        description="Get a paginated list of memories with optional filtering",
-        tags={"memory"},
-    )  # type: ignore
-    async def get_memories(
-        db_id: str,
-        user_id: Optional[str] = None,
-        agent_id: Optional[str] = None,
-        team_id: Optional[str] = None,
-        topics: Optional[List[str]] = None,
-        search_content: Optional[str] = None,
-        limit: int = 20,
-        page: int = 1,
-        sort_by: str = "updated_at",
-        sort_order: str = "desc",
-    ) -> Dict[str, Any]:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            result = await db.get_memories(
-                user_id=user_id or "",
-                agent_id=agent_id,
-                team_id=team_id,
-                topics=topics,
-                search_content=search_content,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                db_id=db_id,
-            )
-            return result.model_dump()
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memories, total_count = await db.get_user_memories(
-                limit=limit,
-                page=page,
-                user_id=user_id,
-                agent_id=agent_id,
-                team_id=team_id,
-                topics=topics,
-                search_content=search_content,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-        else:
-            db = cast(BaseDb, db)
-            user_memories, total_count = db.get_user_memories(
-                limit=limit,
-                page=page,
-                user_id=user_id,
-                agent_id=agent_id,
-                team_id=team_id,
-                topics=topics,
-                search_content=search_content,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-
-        memories = [UserMemorySchema.from_dict(m) for m in user_memories]  # type: ignore
-        return {
-            "data": [m.model_dump() for m in memories if m is not None],
-            "meta": {
-                "page": page,
-                "limit": limit,
-                "total_count": total_count,
-                "total_pages": (total_count + limit - 1) // limit if limit > 0 else 0,  # type: ignore
-            },
-        }
-
-    @register_builtin_tool(name="update_memory", description="Update an existing memory", tags={"memory"})  # type: ignore
-    async def update_memory(
-        db_id: str,
-        memory_id: str,
-        memory: str,
-        user_id: str,
-        topics: Optional[List[str]] = None,
-    ) -> UserMemorySchema:
-        user_id = _resolve_user_id(user_id) or user_id
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            return await db.update_memory(
-                memory_id=memory_id,
-                memory=memory,
-                topics=topics or [],
-                user_id=user_id,
-                db_id=db_id,
-            )
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            user_memory = await db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=memory_id,
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-        else:
-            db = cast(BaseDb, db)
-            user_memory = db.upsert_user_memory(
-                memory=UserMemory(
-                    memory_id=memory_id,
-                    memory=memory,
-                    topics=topics or [],
-                    user_id=user_id,
-                ),
-                deserialize=False,
-            )
-
-        if not user_memory:
-            raise Exception("Failed to update memory")
-
-        return UserMemorySchema.from_dict(user_memory)  # type: ignore
-
-    @register_builtin_tool(name="delete_memory", description="Delete a specific memory by ID", tags={"memory"})  # type: ignore
-    async def delete_memory(
-        db_id: str,
-        memory_id: str,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            await db.delete_memory(memory_id=memory_id, user_id=user_id, db_id=db_id)
-            return "Memory deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_user_memory(memory_id=memory_id, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_user_memory(memory_id=memory_id, user_id=user_id)
-
-        return "Memory deleted successfully"
-
-    @register_builtin_tool(
-        name="delete_memories",
-        description="Delete multiple memories by their IDs",
-        tags={"memory"},
-    )  # type: ignore
-    async def delete_memories(
-        memory_ids: List[str],
-        db_id: str,
-        user_id: Optional[str] = None,
-    ) -> str:
-        user_id = _resolve_user_id(user_id)
-        db = await get_db(os.dbs, db_id)
-
-        if isinstance(db, RemoteDb):
-            await db.delete_memories(memory_ids=memory_ids, user_id=user_id, db_id=db_id)
-            return "Memories deleted successfully"
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            await db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-        else:
-            db = cast(BaseDb, db)
-            db.delete_user_memories(memory_ids=memory_ids, user_id=user_id)
-
-        return "Memories deleted successfully"
+            return [_trim_session_run(r) for r in result]
+
+        # SessionNotFoundError propagates as the tool error verbatim ("Session {id} not found").
+        runs = await session_service.get_session_runs(
+            db, session_id=session_id, session_type=session_type_enum, user_id=user_id
+        )
+        return [_trim_session_run(r) for r in runs]
 
     # Register any user-provided custom tools. These share the same server, mount (/mcp),
     # lifespan, and JWT middleware as the built-in tools.

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -1,0 +1,139 @@
+"""Serialization of run outputs into MCP tool results.
+
+The run tools on the AgentOS MCP server return results sized for the consuming
+LLM: MCP tool results are injected directly into the frontend model's context
+window, so the default ("trimmed") mode carries the answer and a minimal set of
+identifiers rather than the full run transcript. Raw dataclass serialization is
+never used -- it dumps internal message history (including the system prompt)
+over the wire and raises on binary media.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Union
+
+from mcp.types import AudioContent, ContentBlock, ImageContent, TextContent
+
+from agno.media import Audio, Image
+from agno.run.agent import RunOutput
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+from agno.utils.media import resolve_image_mime_type
+from agno.utils.serialize import json_serializer
+
+AnyRunOutput = Union[RunOutput, TeamRunOutput, WorkflowRunOutput]
+
+# Default media type when an audio artifact does not carry an explicit mime type.
+_DEFAULT_AUDIO_MIME = "audio/mpeg"
+
+
+def _content_text(run_output: AnyRunOutput) -> str:
+    """The run's answer as plain text (JSON for structured/output_schema content)."""
+    if run_output.content is None:
+        return ""
+    return run_output.get_content_as_string()
+
+
+def _audio_mime(artifact: Audio) -> str:
+    if artifact.mime_type:
+        return artifact.mime_type
+    if artifact.format:
+        return f"audio/{artifact.format.lower()}"
+    return _DEFAULT_AUDIO_MIME
+
+
+def _media_blocks(run_output: AnyRunOutput) -> List[ContentBlock]:
+    """MCP content blocks for generated media that carries raw bytes.
+
+    URL- or filepath-only artifacts are skipped: the bytes are not in hand, and
+    fetching them on the server's behalf is not this layer's job. Their ids remain
+    discoverable via ``result_mode="full"``.
+    """
+    blocks: List[ContentBlock] = []
+    for image in getattr(run_output, "images", None) or []:
+        if isinstance(image, Image) and isinstance(image.content, bytes):
+            data = image.to_base64()
+            if data:
+                blocks.append(
+                    ImageContent(
+                        type="image",
+                        data=data,
+                        mimeType=resolve_image_mime_type(
+                            mime_type=image.mime_type, image_format=image.format, image_bytes=image.content
+                        ),
+                    )
+                )
+    for audio in getattr(run_output, "audio", None) or []:
+        if isinstance(audio, Audio) and isinstance(audio.content, bytes):
+            data = audio.to_base64()
+            if data:
+                blocks.append(AudioContent(type="audio", data=data, mimeType=_audio_mime(audio)))
+    return blocks
+
+
+def _run_status(run_output: AnyRunOutput) -> str:
+    status = getattr(run_output, "status", None)
+    value = getattr(status, "value", status)
+    return str(value) if value is not None else "COMPLETED"
+
+
+def _paused_requirements(run_output: AnyRunOutput) -> Optional[List[Dict[str, Any]]]:
+    """Serialized unresolved requirements when the run is paused, else None."""
+    if not getattr(run_output, "is_paused", False):
+        return None
+    # Agents/teams expose active_requirements; workflows expose active_step_requirements.
+    requirements = (
+        getattr(run_output, "active_requirements", None) or getattr(run_output, "active_step_requirements", None) or []
+    )
+    serialized: List[Dict[str, Any]] = []
+    for requirement in requirements:
+        if hasattr(requirement, "to_dict"):
+            serialized.append(requirement.to_dict())
+        elif isinstance(requirement, dict):
+            serialized.append(requirement)
+    return serialized or None
+
+
+def _json_safe(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Force a dict through JSON so enum/datetime leftovers cannot break the transport."""
+    return json.loads(json.dumps(data, default=json_serializer))
+
+
+def trimmed_structured_content(run_output: AnyRunOutput) -> Dict[str, Any]:
+    structured: Dict[str, Any] = {
+        "run_id": run_output.run_id,
+        "session_id": run_output.session_id,
+        "status": _run_status(run_output),
+    }
+    requirements = _paused_requirements(run_output)
+    if requirements is not None:
+        structured["requirements"] = requirements
+    return _json_safe(structured)
+
+
+def build_run_tool_result(run_output: AnyRunOutput, result_mode: str = "trimmed") -> "Any":
+    """Build the MCP ``ToolResult`` for a completed (or paused) run.
+
+    ``trimmed`` (default): answer text + generated media as MCP content blocks,
+    with ``structuredContent`` limited to run_id / session_id / status and, when
+    paused, the unresolved requirements a continue call must address.
+
+    ``full``: text content with ``structuredContent`` set to the run's complete
+    ``to_dict()`` (media base64-encoded there — no separate media blocks, so large
+    payloads are not shipped twice).
+    """
+    from fastmcp.tools.tool import ToolResult
+
+    text = _content_text(run_output)
+    if not text and getattr(run_output, "is_paused", False):
+        requirements = _paused_requirements(run_output) or []
+        text = f"Run paused: {len(requirements)} requirement(s) awaiting resolution."
+
+    content: List[ContentBlock] = [TextContent(type="text", text=text)]
+
+    if result_mode == "full":
+        structured = _json_safe(run_output.to_dict())
+    else:
+        content.extend(_media_blocks(run_output))
+        structured = trimmed_structured_content(run_output)
+
+    return ToolResult(content=content, structured_content=structured)

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -15,14 +15,18 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from agno.os.auth import INTERNAL_SERVICE_SCOPES, build_insufficient_permissions_detail
 from agno.os.scopes import (
     AgentOSScope,
-    get_accessible_resource_ids,
+    check_route_scopes,
     get_default_scope_mappings,
-    has_required_scopes,
+    get_required_scopes_for_route,
 )
+from agno.os.service_accounts import TOKEN_PREFIX as SERVICE_ACCOUNT_TOKEN_PREFIX
+from agno.os.service_accounts import VerificationStatus
 from agno.utils.log import log_debug, log_warning
 
 if TYPE_CHECKING:
     from jwt import PyJWK
+
+    from agno.os.service_accounts import ServiceAccountVerifier
 
 
 class TokenSource(str, Enum):
@@ -415,6 +419,7 @@ class JWTMiddleware(BaseHTTPMiddleware):
         excluded_route_paths: Optional[List[str]] = None,
         admin_scope: Optional[str] = None,
         user_isolation: bool = False,
+        service_account_verifier: Optional["ServiceAccountVerifier"] = None,
     ):
         """
         Initialize the JWT middleware.
@@ -456,6 +461,15 @@ class JWTMiddleware(BaseHTTPMiddleware):
                            Format: {"POST /agents/*/runs": ["agents:run"], "GET /public": []}
             excluded_route_paths: List of route paths to exclude from JWT/RBAC checks
             admin_scope: The scope that grants admin access (default: "agent_os:admin")
+            service_account_verifier: Verifier for service account tokens (agno_pat_...).
+                When set (or available on app.state.service_account_verifier), bearer
+                tokens with the agno_pat_ prefix authenticate as service accounts
+                instead of JWTs: user_id is the account principal (sa:<name>) and
+                scopes are the account's stored scopes. Service account scopes are
+                first-party ACL data, so they are enforced against the scope mappings
+                even when authorization is disabled. Service account requests carry no
+                request.state.claims/token - factory trusted-claims consumers must
+                treat those as optional.
             user_isolation: Opt in to per-user data isolation (default False).
                 When True, route handlers wrap the DB in a per-request scoped
                 adapter and enforce session/run ownership on non-admin callers.
@@ -526,6 +540,15 @@ class JWTMiddleware(BaseHTTPMiddleware):
         else:
             self.scope_mappings = scope_mappings or {}
 
+        # Service account scopes are enforced even when authorization is disabled
+        # (they are this instance's own ACL data, not third-party claims), so keep
+        # a fully merged scope map regardless of the authorization flag.
+        self.service_account_scope_mappings = get_default_scope_mappings()
+        if scope_mappings is not None:
+            self.service_account_scope_mappings.update(scope_mappings)
+
+        self.service_account_verifier = service_account_verifier
+
         self.excluded_route_paths = (
             excluded_route_paths if excluded_route_paths is not None else self._get_default_excluded_routes()
         )
@@ -593,31 +616,56 @@ class JWTMiddleware(BaseHTTPMiddleware):
             List of required scopes. Empty list [] means no scopes required (allow access).
             Routes not in scope_mappings also return [], allowing access.
         """
-        route_key = f"{method} {path}"
+        return get_required_scopes_for_route(self.scope_mappings, method, path)
 
-        # First, try exact match
-        if route_key in self.scope_mappings:
-            return self.scope_mappings[route_key]
+    def _check_scopes(
+        self,
+        request: Request,
+        method: str,
+        path: str,
+        scopes: List[str],
+        origin: Optional[str],
+        cors_allowed_origins: Optional[List[str]],
+        scope_mappings: Optional[Dict[str, List[str]]] = None,
+    ) -> Optional[JSONResponse]:
+        """
+        Shared RBAC check used by every credential type (JWTs, the internal service
+        token, and service account tokens).
 
-        # Then try pattern matching
-        for pattern, scopes in self.scope_mappings.items():
-            pattern_method, pattern_path = pattern.split(" ", 1)
+        Sets request.state.required_scopes and, for listing endpoints where the caller
+        only holds per-resource scopes, request.state.accessible_resource_ids.
 
-            # Check if method matches
-            if pattern_method != method:
-                continue
+        Returns:
+            An error response when access is denied, None when access is allowed.
+        """
+        mappings = scope_mappings if scope_mappings is not None else self.scope_mappings
+        result = check_route_scopes(scopes, mappings, method, path, admin_scope=self.admin_scope)
 
-            # Convert pattern to fnmatch pattern (replace {param} with *)
-            # This handles both /agents/* and /agents/{agent_id} style patterns
-            normalized_pattern = pattern_path
-            if "{" in normalized_pattern:
-                # Replace {param} with * for pattern matching
-                normalized_pattern = re.sub(r"\{[^}]+\}", "*", normalized_pattern)
+        request.state.required_scopes = result.required_scopes
+        if result.accessible_resource_ids is not None:
+            request.state.accessible_resource_ids = result.accessible_resource_ids
+            if result.accessible_resource_ids:
+                log_debug(f"Caller has specific resource scopes. Accessible IDs: {result.accessible_resource_ids}")
+            else:
+                log_debug("Caller has no matching resource scopes. Will return empty list.")
 
-            if fnmatch.fnmatch(path, normalized_pattern):
-                return scopes
+        if not result.allowed:
+            log_warning(
+                f"Insufficient scopes for {method} {path}. Required: {result.required_scopes}, User has: {scopes}"
+            )
+            return self._create_error_response(
+                403,
+                "Insufficient permissions",
+                origin,
+                cors_allowed_origins,
+                required_scopes=result.required_scopes,
+            )
 
-        return []
+        if result.required_scopes:
+            log_debug(f"Scope check passed for {method} {path}. User scopes: {scopes}")
+        else:
+            log_debug(f"No scopes required for {method} {path}")
+        return None
 
     def _extract_token_from_header(self, request: Request) -> Optional[str]:
         """Extract JWT token from Authorization header."""
@@ -726,6 +774,13 @@ class JWTMiddleware(BaseHTTPMiddleware):
             error_msg = self._get_missing_token_error_message()
             return self._create_error_response(401, error_msg, origin, cors_allowed_origins)
 
+        # Service account tokens (agno_pat_...) are first-party opaque credentials
+        # verified against the AgentOS database rather than decoded as JWTs.
+        if token.startswith(SERVICE_ACCOUNT_TOKEN_PREFIX):
+            return await self._dispatch_service_account(
+                request, token, method, path, origin, cors_allowed_origins, call_next
+            )
+
         # Check for internal service token (used by scheduler executor)
         internal_token = getattr(request.app.state, "internal_service_token", None)
         if internal_token and hmac.compare_digest(token, internal_token):
@@ -740,24 +795,11 @@ class JWTMiddleware(BaseHTTPMiddleware):
 
             # Enforce RBAC for internal token (do not skip scope checks)
             if self.authorization:
-                required_scopes = self._get_required_scopes(method, path)
-                if required_scopes:
-                    if not has_required_scopes(
-                        internal_scopes,
-                        required_scopes,
-                        admin_scope=self.admin_scope,
-                    ):
-                        log_warning(
-                            f"Internal service token denied for {method} {path}. "
-                            f"Required: {required_scopes}, Token has: {internal_scopes}"
-                        )
-                        return self._create_error_response(
-                            403,
-                            "Insufficient permissions",
-                            origin,
-                            cors_allowed_origins,
-                            required_scopes=required_scopes,
-                        )
+                error_response = self._check_scopes(
+                    request, method, path, internal_scopes, origin, cors_allowed_origins
+                )
+                if error_response is not None:
+                    return error_response
 
             return await call_next(request)
 
@@ -820,71 +862,9 @@ class JWTMiddleware(BaseHTTPMiddleware):
 
             # RBAC scope checking (only if enabled)
             if self.authorization:
-                # Extract resource type and ID from path
-                resource_type = None
-                resource_id = None
-
-                if "/agents" in path:
-                    resource_type = "agents"
-                elif "/teams" in path:
-                    resource_type = "teams"
-                elif "/workflows" in path:
-                    resource_type = "workflows"
-
-                if resource_type:
-                    resource_id = self._extract_resource_id_from_path(path, resource_type)
-
-                required_scopes = self._get_required_scopes(method, path)
-                request.state.required_scopes = required_scopes
-
-                # Empty list [] means no scopes required (allow access)
-                if required_scopes:
-                    # Use the scope validation system
-                    has_access = has_required_scopes(
-                        scopes,
-                        required_scopes,
-                        resource_type=resource_type,
-                        resource_id=resource_id,
-                        admin_scope=self.admin_scope,
-                    )
-
-                    # Special handling for listing endpoints (no resource_id)
-                    if not has_access and not resource_id and resource_type:
-                        # For listing endpoints, always allow access but store accessible IDs for filtering
-                        # This allows endpoints to return filtered results (including empty list) instead of 403.
-                        # Pass the action from required_scopes (e.g. "read" for "agents:read") so the cached
-                        # IDs only include resources the user is authorised for under that action — otherwise
-                        # a user with only `agents:run` would leak through `GET /agents`.
-                        required_action: Optional[str] = None
-                        first_required = required_scopes[0]
-                        if ":" in first_required:
-                            required_action = first_required.rsplit(":", 1)[1]
-                        accessible_ids = get_accessible_resource_ids(
-                            scopes, resource_type, admin_scope=self.admin_scope, action=required_action
-                        )
-                        has_access = True  # Always allow listing endpoints
-                        request.state.accessible_resource_ids = accessible_ids
-
-                        if accessible_ids:
-                            log_debug(f"User has specific {resource_type} scopes. Accessible IDs: {accessible_ids}")
-                        else:
-                            log_debug(f"User has no {resource_type} scopes. Will return empty list.")
-
-                    if not has_access:
-                        log_warning(
-                            f"Insufficient scopes for {method} {path}. Required: {required_scopes}, User has: {scopes}"
-                        )
-                        return self._create_error_response(
-                            403,
-                            "Insufficient permissions",
-                            origin,
-                            cors_allowed_origins,
-                            required_scopes=required_scopes,
-                        )
-
-                    log_debug(f"Scope check passed for {method} {path}. User scopes: {scopes}")
-                else:
-                    log_debug(f"No scopes required for {method} {path}")
+                error_response = self._check_scopes(request, method, path, scopes, origin, cors_allowed_origins)
+                if error_response is not None:
+                    return error_response
 
             log_debug(f"JWT decoded successfully for user: {user_id}")
 
@@ -916,6 +896,73 @@ class JWTMiddleware(BaseHTTPMiddleware):
             request.state.authenticated = False
             request.state.token = token
 
+        return await call_next(request)
+
+    async def _dispatch_service_account(
+        self,
+        request: Request,
+        token: str,
+        method: str,
+        path: str,
+        origin: Optional[str],
+        cors_allowed_origins: Optional[List[str]],
+        call_next,
+    ) -> Response:
+        """
+        Authenticate a service account token (agno_pat_...) and enforce its scopes.
+
+        Verification failures all return the same 401 detail - the precise reason
+        (unknown, revoked, expired) is only logged server-side. Scope enforcement
+        always runs, regardless of the authorization flag: unlike JWT claims, service
+        account scopes are ACL data owned by this AgentOS instance.
+        """
+        verifier = self.service_account_verifier or getattr(request.app.state, "service_account_verifier", None)
+        if verifier is None:
+            return self._create_error_response(
+                401, "Service accounts are not enabled on this AgentOS instance", origin, cors_allowed_origins
+            )
+
+        client_key = request.client.host if request.client else None
+        result = await verifier.verify(token, client_key=client_key)
+
+        if result.status == VerificationStatus.THROTTLED:
+            return self._create_error_response(
+                429, "Too many failed authentication attempts", origin, cors_allowed_origins
+            )
+        if result.status == VerificationStatus.UNAVAILABLE:
+            return self._create_error_response(
+                503, "Authentication is temporarily unavailable", origin, cors_allowed_origins
+            )
+        account = result.account
+        if not result.ok or account is None:
+            return self._create_error_response(
+                401, "Invalid or expired service account token", origin, cors_allowed_origins
+            )
+
+        request.state.authenticated = True
+        request.state.user_id = account.principal
+        request.state.session_id = None
+        request.state.scopes = list(account.scopes)
+        # Scope enforcement is always active for service accounts, so route-level
+        # authorization gates (require_resource_access etc.) must be active too.
+        request.state.authorization_enabled = True
+        request.state.admin_scope = self.admin_scope
+        request.state.user_isolation_enabled = self.user_isolation
+        request.state.service_account_name = account.name
+
+        error_response = self._check_scopes(
+            request,
+            method,
+            path,
+            list(account.scopes),
+            origin,
+            cors_allowed_origins,
+            scope_mappings=self.service_account_scope_mappings,
+        )
+        if error_response is not None:
+            return error_response
+
+        log_debug(f"Service account authenticated: {account.principal}")
         return await call_next(request)
 
     def _extract_token(self, request: Request) -> Optional[str]:

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -12,7 +12,7 @@ from agno import __version__ as agno_version
 from agno.agent.factory import AgentFactory
 from agno.agent.protocol import AgentProtocol
 from agno.exceptions import RemoteServerUnavailableError
-from agno.os.auth import get_authentication_dependency, validate_websocket_token
+from agno.os.auth import get_authentication_dependency, get_effective_auth_mode, validate_websocket_token
 from agno.os.managers import websocket_manager
 from agno.os.middleware.jwt import JWTValidator
 from agno.os.middleware.user_scope import (
@@ -32,6 +32,7 @@ from agno.os.schema import (
     InfoResponse,
     InterfaceResponse,
     InternalServerErrorResponse,
+    McpInfo,
     Model,
     NotFoundResponse,
     TeamSummaryResponse,
@@ -265,11 +266,14 @@ def get_info_router(os: "AgentOS") -> APIRouter:
         response_model=InfoResponse,
     )
     async def get_info() -> InfoResponse:
+        mcp_enabled = bool(os.enable_mcp_server)
         return InfoResponse(
             agno_version=agno_version,
             agent_count=len(os.agents or []),
             team_count=len(os.teams or []),
             workflow_count=len(os.workflows or []),
+            mcp=McpInfo(enabled=mcp_enabled, path="/mcp" if mcp_enabled else None),
+            auth_mode=get_effective_auth_mode(settings=os.settings, authorization=os.authorization),
         )
 
     return router

--- a/libs/agno/agno/os/routers/service_accounts/__init__.py
+++ b/libs/agno/agno/os/routers/service_accounts/__init__.py
@@ -1,0 +1,3 @@
+from agno.os.routers.service_accounts.router import get_service_accounts_router
+
+__all__ = ["get_service_accounts_router"]

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -14,7 +14,7 @@ from agno.os.routers.service_accounts.schema import (
     ServiceAccountResponse,
 )
 from agno.os.schema import PaginatedResponse, PaginationInfo
-from agno.os.scopes import AgentOSScope, has_required_scopes
+from agno.os.scopes import AgentOSScope, has_required_scopes, parse_scope
 from agno.os.service_accounts import (
     DEFAULT_EXPIRY_DAYS,
     DEFAULT_SERVICE_ACCOUNT_SCOPES,
@@ -41,6 +41,25 @@ def _is_integrity_error(exc: Exception) -> bool:
         return isinstance(exc, IntegrityError)
     except ImportError:
         return False
+
+
+def _caller_holds_scope(caller_scopes: List[str], scope: str, admin_scope: Optional[str]) -> bool:
+    """Whether the caller's scopes cover a single requested scope.
+
+    Per-resource scopes (e.g. agents:my-agent:run) must be checked with their
+    resource context, so a caller holding exactly that scope - or a wildcard/global
+    scope over the resource - is recognised as holding it.
+    """
+    parsed = parse_scope(scope, admin_scope=admin_scope)
+    if parsed.is_per_resource_scope and parsed.resource and parsed.action:
+        return has_required_scopes(
+            caller_scopes,
+            [f"{parsed.resource}:{parsed.action}"],
+            resource_type=parsed.resource,
+            resource_id=parsed.resource_id,
+            admin_scope=admin_scope,
+        )
+    return has_required_scopes(caller_scopes, [scope], admin_scope=admin_scope)
 
 
 def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
@@ -102,9 +121,7 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
         effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
         if effective_admin_scope in caller_scopes:
             return
-        scopes_not_held = [
-            scope for scope in scopes if not has_required_scopes(caller_scopes, [scope], admin_scope=admin_scope)
-        ]
+        scopes_not_held = [scope for scope in scopes if not _caller_holds_scope(caller_scopes, scope, admin_scope)]
         if scopes_not_held:
             raise HTTPException(
                 status_code=403,

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -211,17 +211,28 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
     @router.delete("/service-accounts/{service_account_id}", status_code=204)
     async def revoke_service_account(
         service_account_id: str,
+        request: Request,
         _: bool = Depends(auth_dependency),
     ) -> None:
-        """Revoke a service account. Takes effect on the token's next request. Idempotent."""
+        """Revoke a service account. Idempotent.
+
+        Takes effect immediately on this worker (the local verification cache entry is
+        evicted) and within the cache TTL on other workers.
+        """
         existing = await _db_call("get_service_account", service_account_id)
         if existing is None:
             raise HTTPException(status_code=404, detail=f"Service account '{service_account_id}' not found")
-        if existing.get("revoked_at") is not None:
-            return None
-        updated = await _db_call("update_service_account", service_account_id, revoked_at=int(time.time()))
-        if updated is None:
-            raise HTTPException(status_code=500, detail="Could not revoke service account")
+        if existing.get("revoked_at") is None:
+            updated = await _db_call("update_service_account", service_account_id, revoked_at=int(time.time()))
+            if updated is None:
+                raise HTTPException(status_code=500, detail="Could not revoke service account")
+
+        # Evict the cached verification so this worker rejects the token immediately;
+        # other workers converge as their cached entry ages out within the TTL.
+        verifier = getattr(request.app.state, "service_account_verifier", None)
+        token_hash = existing.get("token_hash")
+        if verifier is not None and token_hash:
+            verifier.invalidate(token_hash)
         return None
 
     return router

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -1,0 +1,210 @@
+"""Service accounts API router - mint, list, and revoke opaque machine tokens."""
+
+import asyncio
+import time
+from typing import Any, List, Literal, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from agno.db.schemas.service_accounts import ServiceAccount
+from agno.os.routers.service_accounts.schema import (
+    ServiceAccountCreate,
+    ServiceAccountCreateResponse,
+    ServiceAccountResponse,
+)
+from agno.os.schema import PaginatedResponse, PaginationInfo
+from agno.os.scopes import AgentOSScope, has_required_scopes
+from agno.os.service_accounts import (
+    DEFAULT_EXPIRY_DAYS,
+    DEFAULT_SERVICE_ACCOUNT_SCOPES,
+    generate_token,
+    get_invalid_scopes,
+    get_privileged_scopes,
+)
+from agno.utils.log import log_error
+
+# Valid DB method names that _db_call can invoke
+_ServiceAccountDbMethod = Literal[
+    "create_service_account",
+    "get_service_account",
+    "get_service_account_by_name",
+    "get_service_accounts",
+    "update_service_account",
+]
+
+
+def _is_integrity_error(exc: Exception) -> bool:
+    try:
+        from sqlalchemy.exc import IntegrityError
+
+        return isinstance(exc, IntegrityError)
+    except ImportError:
+        return False
+
+
+def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
+    """Factory that creates and returns the service accounts router.
+
+    Args:
+        os_db: The AgentOS-level DB adapter (must support service account methods).
+        settings: AgnoAPISettings instance.
+
+    Returns:
+        An APIRouter with all service account endpoints attached.
+    """
+    from agno.os.auth import get_authentication_dependency
+
+    router = APIRouter(tags=["Service Accounts"])
+    auth_dependency = get_authentication_dependency(settings)
+
+    async def _db_call(method_name: _ServiceAccountDbMethod, *args: Any, **kwargs: Any) -> Any:
+        fn = getattr(os_db, method_name, None)
+        if fn is None:
+            raise HTTPException(status_code=503, detail="Service accounts not supported by the configured database")
+        try:
+            if asyncio.iscoroutinefunction(fn):
+                return await fn(*args, **kwargs)
+            return fn(*args, **kwargs)
+        except NotImplementedError:
+            raise HTTPException(status_code=503, detail="Service accounts not supported by the configured database")
+
+    def _get_admin_scope(request: Request) -> Optional[str]:
+        admin_scope_raw = getattr(request.state, "admin_scope", None) or getattr(request.app.state, "admin_scope", None)
+        return admin_scope_raw if isinstance(admin_scope_raw, str) else None
+
+    def _validate_requested_scopes(request: Request, body: ServiceAccountCreate, scopes: List[str]) -> None:
+        """Reject unknown scopes, gate privileged scopes behind the explicit flag, and
+        enforce the subset rule: a caller with scopes can only grant scopes it holds."""
+        admin_scope = _get_admin_scope(request)
+
+        invalid_scopes = get_invalid_scopes(scopes, admin_scope=admin_scope)
+        if invalid_scopes:
+            raise HTTPException(status_code=400, detail=f"Invalid scope(s): {', '.join(invalid_scopes)}")
+
+        privileged_scopes = get_privileged_scopes(scopes, admin_scope=admin_scope)
+        if privileged_scopes and not body.allow_privileged_scopes:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Privileged scope(s) require allow_privileged_scopes=true: {', '.join(privileged_scopes)}. "
+                    "Privileged tokens must be deliberate, never accidental."
+                ),
+            )
+
+        # Subset rule: minted scopes must be held by the creator, so a caller with
+        # only service_accounts:write can never escalate by minting a token more
+        # powerful than itself. Callers without scope context (root os_security_key
+        # or open dev instances) are exempt - they are unscoped by definition.
+        caller_scopes = getattr(request.state, "scopes", None)
+        if caller_scopes is None:
+            return
+        effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
+        if effective_admin_scope in caller_scopes:
+            return
+        scopes_not_held = [
+            scope for scope in scopes if not has_required_scopes(caller_scopes, [scope], admin_scope=admin_scope)
+        ]
+        if scopes_not_held:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Cannot grant scope(s) you do not hold: {', '.join(scopes_not_held)}",
+            )
+
+    @router.post("/service-accounts", response_model=ServiceAccountCreateResponse, status_code=201)
+    async def create_service_account(
+        body: ServiceAccountCreate,
+        request: Request,
+        _: bool = Depends(auth_dependency),
+    ) -> ServiceAccountCreateResponse:
+        """Mint a service account token. The plaintext token is returned exactly once."""
+        scopes = list(body.scopes) if body.scopes is not None else list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
+        _validate_requested_scopes(request, body, scopes)
+
+        existing = await _db_call("get_service_account_by_name", body.name)
+        if existing is not None:
+            raise HTTPException(
+                status_code=409,
+                detail=f"An active service account named '{body.name}' already exists. Revoke it first to rotate.",
+            )
+
+        now = int(time.time())
+        expires_at: Optional[int] = None
+        if not body.never_expires:
+            expires_in_days = body.expires_in_days if body.expires_in_days is not None else DEFAULT_EXPIRY_DAYS
+            expires_at = now + expires_in_days * 86400
+
+        plaintext_token, token_hash, token_prefix = generate_token()
+        account = ServiceAccount(
+            id=str(uuid4()),
+            name=body.name,
+            token_hash=token_hash,
+            token_prefix=token_prefix,
+            scopes=scopes,
+            created_at=now,
+            expires_at=expires_at,
+            created_by=getattr(request.state, "user_id", None),
+        )
+
+        try:
+            await _db_call("create_service_account", account.to_dict())
+        except HTTPException:
+            raise
+        except Exception as exc:
+            if _is_integrity_error(exc):
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"An active service account named '{body.name}' already exists. Revoke it first to rotate.",
+                )
+            log_error(f"Could not create service account: {exc}")
+            raise HTTPException(status_code=500, detail="Could not create service account")
+
+        metadata = ServiceAccountResponse.from_dict(account.to_dict())
+        return ServiceAccountCreateResponse(**metadata.model_dump(), token=plaintext_token)
+
+    @router.get("/service-accounts", response_model=PaginatedResponse[ServiceAccountResponse])
+    async def list_service_accounts(
+        include_revoked: bool = Query(True),
+        limit: int = Query(20, ge=1, le=100),
+        page: int = Query(1, ge=1),
+        sort_by: str = Query("created_at"),
+        sort_order: str = Query("desc"),
+        _: bool = Depends(auth_dependency),
+    ) -> PaginatedResponse[ServiceAccountResponse]:
+        """List service accounts. Returns metadata and display prefixes only - never hashes or plaintext."""
+        accounts, total_count = await _db_call(
+            "get_service_accounts",
+            include_revoked=include_revoked,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        total_pages = (total_count + limit - 1) // limit if total_count > 0 else 0
+        return PaginatedResponse(
+            data=[ServiceAccountResponse.from_dict(account) for account in accounts],
+            meta=PaginationInfo(
+                page=page,
+                limit=limit,
+                total_pages=total_pages,
+                total_count=total_count,
+            ),
+        )
+
+    @router.delete("/service-accounts/{service_account_id}", status_code=204)
+    async def revoke_service_account(
+        service_account_id: str,
+        _: bool = Depends(auth_dependency),
+    ) -> None:
+        """Revoke a service account. Takes effect on the token's next request. Idempotent."""
+        existing = await _db_call("get_service_account", service_account_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail=f"Service account '{service_account_id}' not found")
+        if existing.get("revoked_at") is not None:
+            return None
+        updated = await _db_call("update_service_account", service_account_id, revoked_at=int(time.time()))
+        if updated is None:
+            raise HTTPException(status_code=500, detail="Could not revoke service account")
+        return None
+
+    return router

--- a/libs/agno/agno/os/routers/service_accounts/schema.py
+++ b/libs/agno/agno/os/routers/service_accounts/schema.py
@@ -1,0 +1,85 @@
+"""Pydantic request/response models for the service accounts API."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+from agno.db.schemas.service_accounts import SERVICE_ACCOUNT_PRINCIPAL_PREFIX
+from agno.os.service_accounts import (
+    DEFAULT_EXPIRY_DAYS,
+    is_valid_service_account_name,
+)
+
+
+class ServiceAccountCreate(BaseModel):
+    name: str = Field(
+        ...,
+        max_length=63,
+        description="Machine identity name (lowercase slug), e.g. 'claude-code' or 'github-actions'",
+    )
+    scopes: Optional[List[str]] = Field(
+        default=None,
+        description="Scopes granted to the token. Defaults to run and read scopes: "
+        "agents:run, teams:run, workflows:run, sessions:read",
+    )
+    expires_in_days: Optional[int] = Field(
+        default=DEFAULT_EXPIRY_DAYS,
+        ge=1,
+        le=3650,
+        description=f"Days until the token expires (default: {DEFAULT_EXPIRY_DAYS})",
+    )
+    never_expires: bool = Field(
+        default=False,
+        description="Mint a non-expiring token. Must be set explicitly; overrides expires_in_days.",
+    )
+    allow_privileged_scopes: bool = Field(
+        default=False,
+        description="Required to grant privileged scopes: any write or delete action, the admin scope, "
+        "or any service_accounts scope. Privileged tokens must be deliberate, never accidental.",
+    )
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        if not is_valid_service_account_name(v):
+            raise ValueError(
+                "Name must be a lowercase slug: start with a letter or digit, "
+                "then letters, digits, '_' or '-' (max 63 chars)"
+            )
+        return v
+
+
+class ServiceAccountResponse(BaseModel):
+    """Service account metadata. Never includes the token hash or plaintext."""
+
+    id: str
+    name: str
+    principal: str = Field(..., description="The user_id attached to runs made with this token, e.g. 'sa:claude-code'")
+    token_prefix: str = Field(..., description="First characters of the token, for display only")
+    scopes: List[str]
+    created_at: int
+    expires_at: Optional[int] = None
+    last_used_at: Optional[int] = None
+    revoked_at: Optional[int] = None
+    created_by: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccountResponse":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            principal=f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{data['name']}",
+            token_prefix=data["token_prefix"],
+            scopes=data.get("scopes") or [],
+            created_at=data["created_at"],
+            expires_at=data.get("expires_at"),
+            last_used_at=data.get("last_used_at"),
+            revoked_at=data.get("revoked_at"),
+            created_by=data.get("created_by"),
+        )
+
+
+class ServiceAccountCreateResponse(ServiceAccountResponse):
+    """Returned once, at creation. The token is never retrievable again."""
+
+    token: str = Field(..., description="The plaintext token. Shown exactly once - store it securely now.")

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
 
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType
-from agno.db.utils import deserialize_session_by_type, detect_session_type, resolve_session_type
+from agno.db.utils import deserialize_session_by_type, resolve_session_type
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.middleware.user_scope import (
     enforce_owner_on_entity,
@@ -32,6 +32,8 @@ from agno.os.schema import (
     WorkflowRunSchema,
     WorkflowSessionDetailSchema,
 )
+from agno.os.services.sessions import SessionNotFoundError, get_sessions_page
+from agno.os.services.sessions import get_session_runs as get_session_runs_from_service
 from agno.os.settings import AgnoAPISettings
 from agno.remote.base import RemoteDb
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
@@ -140,31 +142,19 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 headers=headers,
             )
 
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            sessions, total_count = await db.get_sessions(
-                session_type=session_type,
-                component_id=component_id,
-                user_id=effective_user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
-        else:
-            sessions, total_count = db.get_sessions(  # type: ignore
-                session_type=session_type,
-                component_id=component_id,
-                user_id=effective_user_id,
-                session_name=session_name,
-                limit=limit,
-                page=page,
-                sort_by=sort_by,
-                sort_order=sort_order,
-                deserialize=False,
-            )
+        # Shared with the MCP get_sessions tool: sync-db threadpool offload lives in the
+        # service so neither surface blocks its event loop and the two cannot drift.
+        sessions, total_count = await get_sessions_page(
+            db,
+            session_type=session_type,
+            component_id=component_id,
+            user_id=effective_user_id,
+            session_name=session_name,
+            limit=limit,
+            page=page,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
 
         return PaginatedResponse(
             data=[SessionSchema.from_dict(session) for session in sessions],  # type: ignore
@@ -622,78 +612,20 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
                 headers=headers,
             )
 
-        start_timestamp = created_after
-        end_timestamp = created_before
-
-        if isinstance(db, AsyncBaseDb):
-            db = cast(AsyncBaseDb, db)
-            session = await db.get_session(
+        # Shared with the MCP get_session_runs tool: auto-detection, timestamp
+        # filtering, per-run classification, and sync-db threadpool offload all
+        # live in the service so the two surfaces cannot drift.
+        try:
+            return await get_session_runs_from_service(
+                db,
                 session_id=session_id,
                 session_type=session_type,
                 user_id=effective_user_id,
-                deserialize=False,
+                created_after=created_after,
+                created_before=created_before,
             )
-        else:
-            session = db.get_session(
-                session_id=session_id,
-                session_type=session_type,
-                user_id=effective_user_id,
-                deserialize=False,
-            )
-
-        if not session:
+        except SessionNotFoundError:
             raise HTTPException(status_code=404, detail=f"Session with ID {session_id} not found")
-
-        if session_type is None:
-            detected = detect_session_type(session if isinstance(session, dict) else {})
-            session_type = SessionType(detected)
-
-        runs = session.get("runs")  # type: ignore
-        if not runs:
-            return []
-
-        # Filter runs by timestamp if specified
-        # TODO: Move this filtering into the DB layer
-        filtered_runs = []
-        for run in runs:
-            if start_timestamp or end_timestamp:
-                run_created_at = run.get("created_at")
-                if run_created_at:
-                    # created_at is stored as epoch int
-                    if start_timestamp and run_created_at < start_timestamp:
-                        continue
-                    if end_timestamp and run_created_at > end_timestamp:
-                        continue
-
-            filtered_runs.append(run)
-
-        if not filtered_runs:
-            return []
-
-        run_responses: List[Union[RunSchema, TeamRunSchema, WorkflowRunSchema]] = []
-
-        if session_type == SessionType.AGENT:
-            return [RunSchema.from_dict(run) for run in filtered_runs]
-
-        elif session_type == SessionType.TEAM:
-            for run in filtered_runs:
-                if run.get("agent_id") is not None:
-                    run_responses.append(RunSchema.from_dict(run))
-                elif run.get("team_id") is not None:
-                    run_responses.append(TeamRunSchema.from_dict(run))
-            return run_responses
-
-        elif session_type == SessionType.WORKFLOW:
-            for run in filtered_runs:
-                if run.get("workflow_id") is not None:
-                    run_responses.append(WorkflowRunSchema.from_dict(run))
-                elif run.get("team_id") is not None:
-                    run_responses.append(TeamRunSchema.from_dict(run))
-                else:
-                    run_responses.append(RunSchema.from_dict(run))
-            return run_responses
-        else:
-            raise HTTPException(status_code=400, detail=f"Invalid session type: {session_type}")
 
     @router.get(
         "/sessions/{session_id}/runs/{run_id}",

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -225,6 +225,13 @@ class WorkflowSummaryResponse(BaseModel):
         )
 
 
+class McpInfo(BaseModel):
+    """MCP server availability for the /info endpoint."""
+
+    enabled: bool = Field(False, description="Whether the MCP server is enabled on this OS instance")
+    path: Optional[str] = Field(None, description="Path where the MCP server is mounted, null when disabled")
+
+
 class InfoResponse(BaseModel):
     """Response schema for the /info endpoint returning lightweight OS metadata."""
 
@@ -232,6 +239,10 @@ class InfoResponse(BaseModel):
     agent_count: int = Field(0, description="Number of agents registered in the OS")
     team_count: int = Field(0, description="Number of teams registered in the OS")
     workflow_count: int = Field(0, description="Number of workflows registered in the OS")
+    mcp: McpInfo = Field(default_factory=McpInfo, description="MCP server availability for this OS instance")
+    auth_mode: Literal["none", "security_key", "jwt"] = Field(
+        "none", description="Authentication mode effectively enforced by this OS instance"
+    )
 
 
 class ConfigResponse(BaseModel):

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -635,12 +635,13 @@ def check_route_scopes(
     )
 
     accessible_resource_ids: Optional[Set[str]] = None
-    if not allowed and not resource_id and resource_type:
-        # Listing endpoints always allow access but expose the accessible IDs for
+    if not allowed and method == "GET" and not resource_id and resource_type:
+        # GET listing endpoints always allow access but expose the accessible IDs for
         # filtering, so callers with only per-resource scopes get a filtered list
-        # (including an empty one) instead of a 403. Pass the action from the
-        # required scope (e.g. "read" for "agents:read") so the cached IDs only
-        # include resources the caller is authorised for under that action.
+        # (including an empty one) instead of a 403. Restricted to GET so a non-GET
+        # id-less route (e.g. POST /agents) is never silently allowed through. Pass
+        # the action from the required scope (e.g. "read" for "agents:read") so the
+        # cached IDs only include resources the caller is authorised for under it.
         required_action: Optional[str] = None
         first_required = required_scopes[0]
         if ":" in first_required:

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -22,9 +22,11 @@ Backwards compatibility:
   issued before the rename continue to work. Prefer ``config:*`` in new tokens.
 """
 
+import fnmatch
+import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Tuple
 
 # Legacy resource name aliases — keep tokens issued before a rename working.
 # Keys are the legacy resource names, values are the current names.
@@ -67,6 +69,9 @@ class AgentOSScope(str, Enum):
     - evals:write - Create and update evaluation runs
     - evals:delete - Delete evaluation runs
     - traces:read - View traces and trace statistics
+    - service_accounts:read - List service accounts
+    - service_accounts:write - Mint service account tokens
+    - service_accounts:delete - Revoke service account tokens
 
     Per-Resource Scopes (with resource ID):
     - agents:<agent-id>:read - Read specific agent
@@ -470,6 +475,10 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "GET /traces": ["traces:read"],
         "GET /traces/*": ["traces:read"],
         "GET /trace_session_stats": ["traces:read"],
+        # Service account endpoints
+        "POST /service-accounts": ["service_accounts:write"],
+        "GET /service-accounts": ["service_accounts:read"],
+        "DELETE /service-accounts/*": ["service_accounts:delete"],
         # Schedule endpoints
         "GET /schedules": ["schedules:read"],
         "GET /schedules/*": ["schedules:read"],
@@ -513,6 +522,139 @@ def get_default_scope_mappings() -> Dict[str, List[str]]:
         "DELETE /components/*/configs/*": ["components:delete"],
         "POST /components/*/configs/*/set-current": ["components:write"],
     }
+
+
+def get_required_scopes_for_route(scope_mappings: Dict[str, List[str]], method: str, path: str) -> List[str]:
+    """
+    Look up the required scopes for a method and path in a scope-mappings dict.
+
+    Args:
+        scope_mappings: Mapping of "METHOD /path/pattern" to required scope lists
+        method: HTTP method (GET, POST, etc.)
+        path: Request path
+
+    Returns:
+        List of required scopes. Empty list [] means no scopes required (allow access).
+        Routes not present in scope_mappings also return [], allowing access.
+    """
+    route_key = f"{method} {path}"
+
+    # First, try exact match
+    if route_key in scope_mappings:
+        return scope_mappings[route_key]
+
+    # Then try pattern matching
+    for pattern, scopes in scope_mappings.items():
+        pattern_method, pattern_path = pattern.split(" ", 1)
+
+        if pattern_method != method:
+            continue
+
+        # Convert pattern to fnmatch pattern (replace {param} with *)
+        # This handles both /agents/* and /agents/{agent_id} style patterns
+        normalized_pattern = pattern_path
+        if "{" in normalized_pattern:
+            normalized_pattern = re.sub(r"\{[^}]+\}", "*", normalized_pattern)
+
+        if fnmatch.fnmatch(path, normalized_pattern):
+            return scopes
+
+    return []
+
+
+def get_resource_context_from_path(path: str) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Extract the resource type and resource ID from a request path.
+
+    Returns:
+        Tuple of (resource_type, resource_id). Either may be None.
+
+    Examples:
+        >>> get_resource_context_from_path("/agents/my-agent/runs")
+        ('agents', 'my-agent')
+        >>> get_resource_context_from_path("/sessions")
+        (None, None)
+    """
+    resource_type = None
+    if "/agents" in path:
+        resource_type = "agents"
+    elif "/teams" in path:
+        resource_type = "teams"
+    elif "/workflows" in path:
+        resource_type = "workflows"
+
+    resource_id = None
+    if resource_type:
+        match = re.search(f"^/{resource_type}/([^/]+)", path)
+        if match:
+            resource_id = match.group(1)
+
+    return resource_type, resource_id
+
+
+@dataclass
+class RouteScopeCheck:
+    """Result of checking a caller's scopes against a route's requirements."""
+
+    allowed: bool
+    required_scopes: List[str]
+    # Set only for listing endpoints where the caller lacks the global scope but may
+    # hold per-resource scopes: the endpoint should filter results to these IDs
+    # (possibly an empty set) instead of rejecting with 403.
+    accessible_resource_ids: Optional[Set[str]] = None
+
+
+def check_route_scopes(
+    user_scopes: List[str],
+    scope_mappings: Dict[str, List[str]],
+    method: str,
+    path: str,
+    admin_scope: Optional[str] = None,
+) -> RouteScopeCheck:
+    """
+    Check a caller's scopes against the scopes required for a route.
+
+    This is the single RBAC decision used for every credential type (JWTs, the internal
+    service token, and service account tokens). Listing endpoints get special handling:
+    a caller without the global scope is still allowed through, with
+    accessible_resource_ids populated so the endpoint returns a filtered (possibly
+    empty) list instead of a 403.
+    """
+    required_scopes = get_required_scopes_for_route(scope_mappings, method, path)
+    if not required_scopes:
+        return RouteScopeCheck(allowed=True, required_scopes=required_scopes)
+
+    resource_type, resource_id = get_resource_context_from_path(path)
+
+    allowed = has_required_scopes(
+        user_scopes,
+        required_scopes,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        admin_scope=admin_scope,
+    )
+
+    accessible_resource_ids: Optional[Set[str]] = None
+    if not allowed and not resource_id and resource_type:
+        # Listing endpoints always allow access but expose the accessible IDs for
+        # filtering, so callers with only per-resource scopes get a filtered list
+        # (including an empty one) instead of a 403. Pass the action from the
+        # required scope (e.g. "read" for "agents:read") so the cached IDs only
+        # include resources the caller is authorised for under that action.
+        required_action: Optional[str] = None
+        first_required = required_scopes[0]
+        if ":" in first_required:
+            required_action = first_required.rsplit(":", 1)[1]
+        accessible_resource_ids = get_accessible_resource_ids(
+            user_scopes, resource_type, admin_scope=admin_scope, action=required_action
+        )
+        allowed = True
+
+    return RouteScopeCheck(
+        allowed=allowed,
+        required_scopes=required_scopes,
+        accessible_resource_ids=accessible_resource_ids,
+    )
 
 
 def get_scope_value(scope: AgentOSScope) -> str:

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -3,7 +3,7 @@
 Service accounts are machine identities (coding agents, chat apps, CI) authenticated by
 opaque tokens following the GitHub PAT model: the token is random, only its SHA-256 hash
 is stored (in the AgentOS database), the plaintext is returned exactly once at creation,
-and revocation takes effect on the next request.
+and revocation is native (see the caching note below for its timing).
 
 Tokens look like ``agno_pat_<base62>`` and authenticate through the same middleware as
 JWTs. A verified service account attaches to the request with ``user_id`` set to its
@@ -11,6 +11,13 @@ principal (``sa:<name>``) and ``scopes`` set to the account's stored scopes. Unl
 claims, service account scopes are first-party ACL data owned by this AgentOS instance,
 so they are enforced in every deployment mode - including ``os_security_key`` mode and
 ``validate=False`` mode, where JWT scopes are not.
+
+Successful verifications are cached in-process for a short TTL (default 30s) so PAT auth
+does not hit the database on every request. Revocation takes effect within that TTL
+across worker processes, and immediately on the worker that processes the revoke (the
+``DELETE`` handler evicts the local cache entry). Set the cache TTL to 0 for strict
+instant revocation - every request verifies against the database. Token expiry is always
+honored, even on a cache hit.
 """
 
 import hashlib
@@ -173,29 +180,98 @@ class _FailedLookupLimiter:
             self._failures.popitem(last=False)
 
 
+class _VerificationCache:
+    """Bounded, TTL'd LRU of successful verifications, keyed by token hash.
+
+    Caches only valid accounts. Token expiry is still honored on every hit (the cached
+    account's expires_at is immutable, so it can be re-checked against the wall clock).
+    Revocation is handled out of band: the worker that processes a revoke evicts its
+    entry immediately via invalidate(); other workers converge as their entry ages out
+    within the TTL. TTL <= 0 disables the cache entirely (strict instant revocation).
+    """
+
+    def __init__(self, ttl_seconds: int, max_entries: int = 2048):
+        self.ttl_seconds = ttl_seconds
+        self.max_entries = max_entries
+        self._entries: "OrderedDict[str, Tuple[ServiceAccount, float]]" = OrderedDict()
+
+    @property
+    def enabled(self) -> bool:
+        return self.ttl_seconds > 0
+
+    def get(self, token_hash: str) -> Optional[ServiceAccount]:
+        if not self.enabled:
+            return None
+        entry = self._entries.get(token_hash)
+        if entry is None:
+            return None
+        account, cached_at = entry
+        if time.monotonic() - cached_at > self.ttl_seconds:
+            self._entries.pop(token_hash, None)
+            return None
+        # Honor expiry even within the TTL window - never serve an expired account.
+        if account.is_expired():
+            self._entries.pop(token_hash, None)
+            return None
+        self._entries.move_to_end(token_hash)
+        return account
+
+    def put(self, token_hash: str, account: ServiceAccount) -> None:
+        if not self.enabled:
+            return
+        self._entries[token_hash] = (account, time.monotonic())
+        self._entries.move_to_end(token_hash)
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+
+    def invalidate(self, token_hash: str) -> None:
+        self._entries.pop(token_hash, None)
+
+
 class ServiceAccountVerifier:
     """Verifies service account tokens against the AgentOS database.
 
     Supports both sync (BaseDb) and async (AsyncBaseDb) databases; sync lookups run in
-    the threadpool so verification never blocks the event loop. Successful lookups also
-    refresh the account's last_used_at, throttled to at most one write per minute per
-    token (per worker process).
+    the threadpool so verification never blocks the event loop. Successful verifications
+    are cached in-process for ``cache_ttl_seconds`` (0 disables the cache), so a valid
+    token does not hit the database on every request; token expiry is still enforced on
+    cache hits, and revoke() callers should invalidate() the entry to evict it locally.
+    Successful lookups also refresh the account's last_used_at, throttled to at most one
+    write per minute per token (per worker process).
     """
 
-    def __init__(self, db: Union[BaseDb, AsyncBaseDb], last_used_write_interval: int = 60):
+    def __init__(
+        self,
+        db: Union[BaseDb, AsyncBaseDb],
+        last_used_write_interval: int = 60,
+        cache_ttl_seconds: int = 30,
+        cache_max_entries: int = 2048,
+    ):
         self.db = db
         self.last_used_write_interval = last_used_write_interval
         self._limiter = _FailedLookupLimiter()
+        self._cache = _VerificationCache(ttl_seconds=cache_ttl_seconds, max_entries=cache_max_entries)
         self._last_used_writes: Dict[str, float] = {}
+
+    def invalidate(self, token_hash: str) -> None:
+        """Evict a cached verification. Call on revoke so it takes effect immediately on
+        this worker; other workers converge within the cache TTL. Idempotent."""
+        self._cache.invalidate(token_hash)
 
     async def verify(self, token: str, client_key: Optional[str] = None) -> ServiceAccountVerification:
         """Verify a plaintext token. Returns a verification result, never raises."""
         key = client_key or "unknown"
+        token_hash = hash_token(token)
+
+        # Serve a recently-verified token from the cache (expiry re-checked in get()).
+        cached = self._cache.get(token_hash)
+        if cached is not None:
+            await self._maybe_touch_last_used(cached)
+            return ServiceAccountVerification(status=VerificationStatus.OK, account=cached)
 
         # The token is always looked up first: a valid token is never blocked by the
         # limiter. The limiter only shapes the FAILURE response (INVALID vs 429) so a
         # flood of bad tokens can't deny service to legitimate holders.
-        token_hash = hash_token(token)
         try:
             if isinstance(self.db, AsyncBaseDb):
                 row = await self.db.get_service_account_by_token_hash(token_hash)
@@ -213,8 +289,11 @@ class ServiceAccountVerifier:
         if row is not None:
             account = ServiceAccount.from_dict(row)
             if not (account.is_revoked() or account.is_expired()):
+                self._cache.put(token_hash, account)
                 await self._maybe_touch_last_used(account)
                 return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+            # Defensive: ensure a now-revoked/expired token is not lingering in cache.
+            self._cache.invalidate(token_hash)
             log_debug("Service account verification failed: token is revoked or expired")
         else:
             log_debug("Service account verification failed: unknown token")

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -1,0 +1,241 @@
+"""Service accounts for AgentOS.
+
+Service accounts are machine identities (coding agents, chat apps, CI) authenticated by
+opaque tokens following the GitHub PAT model: the token is random, only its SHA-256 hash
+is stored (in the AgentOS database), the plaintext is returned exactly once at creation,
+and revocation takes effect on the next request.
+
+Tokens look like ``agno_pat_<base62>`` and authenticate through the same middleware as
+JWTs. A verified service account attaches to the request with ``user_id`` set to its
+principal (``sa:<name>``) and ``scopes`` set to the account's stored scopes. Unlike JWT
+claims, service account scopes are first-party ACL data owned by this AgentOS instance,
+so they are enforced in every deployment mode - including ``os_security_key`` mode and
+``validate=False`` mode, where JWT scopes are not.
+"""
+
+import hashlib
+import re
+import secrets
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional, Tuple, Union
+
+from starlette.concurrency import run_in_threadpool
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.schemas.service_accounts import SERVICE_ACCOUNT_PRINCIPAL_PREFIX, ServiceAccount
+from agno.os.scopes import AgentOSScope, parse_scope
+from agno.utils.log import log_debug, log_error, log_warning
+
+# Prefix makes tokens greppable for secret scanners.
+TOKEN_PREFIX = "agno_pat_"
+
+# How many characters of the plaintext token are stored for display purposes
+# (the literal prefix plus 7 random characters).
+TOKEN_DISPLAY_PREFIX_LENGTH = 16
+
+# Run and read, nothing else. Anything broader requires an explicit request.
+DEFAULT_SERVICE_ACCOUNT_SCOPES: List[str] = [
+    "agents:run",
+    "teams:run",
+    "workflows:run",
+    "sessions:read",
+]
+
+DEFAULT_EXPIRY_DAYS = 90
+
+# Lowercase slug: no colons (cannot spoof the sa: principal namespace), no leading
+# underscore (cannot collide with internal identities like __scheduler__), no @ or dots
+# (cannot mimic email-shaped human subs).
+SERVICE_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+_BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+# Scope actions that make a token privileged (require an explicit override at mint time).
+_PRIVILEGED_ACTIONS = {"write", "delete"}
+
+# Resource whose scopes are always privileged: tokens that can manage tokens.
+_SERVICE_ACCOUNTS_RESOURCE = "service_accounts"
+
+
+def _base62_encode(data: bytes) -> str:
+    num = int.from_bytes(data, "big")
+    if num == 0:
+        return _BASE62_ALPHABET[0]
+    chars = []
+    while num > 0:
+        num, rem = divmod(num, 62)
+        chars.append(_BASE62_ALPHABET[rem])
+    return "".join(reversed(chars))
+
+
+def hash_token(token: str) -> str:
+    """Return the SHA-256 hex digest of a token. This is the only form ever stored."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_token() -> Tuple[str, str, str]:
+    """Generate a new service account token.
+
+    Returns:
+        Tuple of (plaintext, token_hash, token_prefix). The plaintext must be returned
+        to the caller exactly once and never persisted.
+    """
+    plaintext = TOKEN_PREFIX + _base62_encode(secrets.token_bytes(32))
+    return plaintext, hash_token(plaintext), plaintext[:TOKEN_DISPLAY_PREFIX_LENGTH]
+
+
+def is_valid_service_account_name(name: str) -> bool:
+    """Check a service account name against the allowed slug format."""
+    return bool(SERVICE_ACCOUNT_NAME_PATTERN.match(name))
+
+
+def get_invalid_scopes(scopes: List[str], admin_scope: Optional[str] = None) -> List[str]:
+    """Return the scope strings that do not parse as admin, global, or per-resource scopes."""
+    return [s for s in scopes if parse_scope(s, admin_scope=admin_scope).scope_type == "unknown"]
+
+
+def get_privileged_scopes(scopes: List[str], admin_scope: Optional[str] = None) -> List[str]:
+    """Return the subset of scopes that make a token privileged.
+
+    Privileged means: any write/delete action (2- or 3-part form), the admin scope
+    (default or custom), or any scope over the service_accounts resource (tokens that
+    can mint or revoke tokens).
+    """
+    privileged = []
+    for scope in scopes:
+        parsed = parse_scope(scope, admin_scope=admin_scope)
+        if (
+            parsed.scope_type == "admin"
+            or scope == AgentOSScope.ADMIN.value
+            or (parsed.action in _PRIVILEGED_ACTIONS)
+            or (parsed.resource == _SERVICE_ACCOUNTS_RESOURCE)
+        ):
+            privileged.append(scope)
+    return privileged
+
+
+class VerificationStatus(str, Enum):
+    """Outcome of a service account token verification."""
+
+    OK = "ok"
+    INVALID = "invalid"  # unknown, revoked, or expired token
+    THROTTLED = "throttled"  # too many recent failed lookups from this client
+    UNAVAILABLE = "unavailable"  # the database could not be reached or lacks support
+
+
+@dataclass
+class ServiceAccountVerification:
+    status: VerificationStatus
+    account: Optional[ServiceAccount] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == VerificationStatus.OK
+
+
+class _FailedLookupLimiter:
+    """Sliding-window limiter for failed token lookups.
+
+    In-process and per-worker: with N workers the effective budget is N times larger.
+    Keyed by client address, which is only meaningful behind a proxy when the server
+    runs with proxy headers enabled (e.g. uvicorn --proxy-headers). Only true
+    verification failures count - database errors do not, so a DB blip cannot lock
+    out legitimate clients.
+    """
+
+    def __init__(self, max_failures: int = 20, window_seconds: int = 60, max_entries: int = 1024):
+        self.max_failures = max_failures
+        self.window_seconds = window_seconds
+        self.max_entries = max_entries
+        self._failures: "OrderedDict[str, List[float]]" = OrderedDict()
+
+    def is_limited(self, key: str) -> bool:
+        timestamps = self._failures.get(key)
+        if not timestamps:
+            return False
+        cutoff = time.monotonic() - self.window_seconds
+        fresh = [t for t in timestamps if t > cutoff]
+        if fresh:
+            self._failures[key] = fresh
+        else:
+            self._failures.pop(key, None)
+        return len(fresh) >= self.max_failures
+
+    def record_failure(self, key: str) -> None:
+        timestamps = self._failures.setdefault(key, [])
+        timestamps.append(time.monotonic())
+        self._failures.move_to_end(key)
+        while len(self._failures) > self.max_entries:
+            self._failures.popitem(last=False)
+
+
+class ServiceAccountVerifier:
+    """Verifies service account tokens against the AgentOS database.
+
+    Supports both sync (BaseDb) and async (AsyncBaseDb) databases; sync lookups run in
+    the threadpool so verification never blocks the event loop. Successful lookups also
+    refresh the account's last_used_at, throttled to at most one write per minute per
+    token (per worker process).
+    """
+
+    def __init__(self, db: Union[BaseDb, AsyncBaseDb], last_used_write_interval: int = 60):
+        self.db = db
+        self.last_used_write_interval = last_used_write_interval
+        self._limiter = _FailedLookupLimiter()
+        self._last_used_writes: Dict[str, float] = {}
+
+    async def verify(self, token: str, client_key: Optional[str] = None) -> ServiceAccountVerification:
+        """Verify a plaintext token. Returns a verification result, never raises."""
+        key = client_key or "unknown"
+        if self._limiter.is_limited(key):
+            log_warning("Service account verification throttled: too many failed lookups")
+            return ServiceAccountVerification(status=VerificationStatus.THROTTLED)
+
+        token_hash = hash_token(token)
+        try:
+            if isinstance(self.db, AsyncBaseDb):
+                row = await self.db.get_service_account_by_token_hash(token_hash)
+            else:
+                row = await run_in_threadpool(self.db.get_service_account_by_token_hash, token_hash)
+        except NotImplementedError:
+            log_warning("The configured database does not support service accounts")
+            return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
+        except Exception as e:
+            log_error(f"Service account lookup failed: {e}")
+            return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
+
+        if row is None:
+            self._limiter.record_failure(key)
+            log_debug("Service account verification failed: unknown token")
+            return ServiceAccountVerification(status=VerificationStatus.INVALID)
+
+        account = ServiceAccount.from_dict(row)
+        if account.is_revoked() or account.is_expired():
+            self._limiter.record_failure(key)
+            log_debug(f"Service account verification failed: token for '{account.name}' is revoked or expired")
+            return ServiceAccountVerification(status=VerificationStatus.INVALID)
+
+        await self._maybe_touch_last_used(account)
+        return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+
+    async def _maybe_touch_last_used(self, account: ServiceAccount) -> None:
+        now = time.time()
+        last_write = self._last_used_writes.get(account.id, 0.0)
+        if now - last_write < self.last_used_write_interval:
+            return
+        self._last_used_writes[account.id] = now
+        try:
+            if isinstance(self.db, AsyncBaseDb):
+                await self.db.update_service_account(account.id, last_used_at=int(now))
+            else:
+                await run_in_threadpool(self.db.update_service_account, account.id, last_used_at=int(now))
+        except Exception as e:
+            log_warning(f"Could not update last_used_at for service account '{account.name}': {e}")
+
+
+def get_principal(name: str) -> str:
+    """Build the principal identifier attached to requests as user_id."""
+    return f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{name}"

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -48,8 +48,8 @@ DEFAULT_EXPIRY_DAYS = 90
 
 # Lowercase slug: no colons (cannot spoof the sa: principal namespace), no leading
 # underscore (cannot collide with internal identities like __scheduler__), no @ or dots
-# (cannot mimic email-shaped human subs).
-SERVICE_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+# (cannot mimic email-shaped human subs). \Z (not $) so a trailing newline is rejected.
+SERVICE_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}\Z")
 
 _BASE62_ALPHABET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
@@ -139,11 +139,12 @@ class ServiceAccountVerification:
 class _FailedLookupLimiter:
     """Sliding-window limiter for failed token lookups.
 
+    Only throttles the failure RESPONSE - a valid token is never blocked, so a flood
+    of bad tokens cannot lock out legitimate clients even when they share a bucket.
     In-process and per-worker: with N workers the effective budget is N times larger.
     Keyed by client address, which is only meaningful behind a proxy when the server
     runs with proxy headers enabled (e.g. uvicorn --proxy-headers). Only true
-    verification failures count - database errors do not, so a DB blip cannot lock
-    out legitimate clients.
+    verification failures count - database errors do not.
     """
 
     def __init__(self, max_failures: int = 20, window_seconds: int = 60, max_entries: int = 1024):
@@ -190,10 +191,10 @@ class ServiceAccountVerifier:
     async def verify(self, token: str, client_key: Optional[str] = None) -> ServiceAccountVerification:
         """Verify a plaintext token. Returns a verification result, never raises."""
         key = client_key or "unknown"
-        if self._limiter.is_limited(key):
-            log_warning("Service account verification throttled: too many failed lookups")
-            return ServiceAccountVerification(status=VerificationStatus.THROTTLED)
 
+        # The token is always looked up first: a valid token is never blocked by the
+        # limiter. The limiter only shapes the FAILURE response (INVALID vs 429) so a
+        # flood of bad tokens can't deny service to legitimate holders.
         token_hash = hash_token(token)
         try:
             if isinstance(self.db, AsyncBaseDb):
@@ -204,22 +205,26 @@ class ServiceAccountVerifier:
             log_warning("The configured database does not support service accounts")
             return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
         except Exception as e:
+            # Fail closed on database errors: never counts toward the limiter, so a
+            # DB blip cannot lock out legitimate clients.
             log_error(f"Service account lookup failed: {e}")
             return ServiceAccountVerification(status=VerificationStatus.UNAVAILABLE)
 
-        if row is None:
-            self._limiter.record_failure(key)
+        if row is not None:
+            account = ServiceAccount.from_dict(row)
+            if not (account.is_revoked() or account.is_expired()):
+                await self._maybe_touch_last_used(account)
+                return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+            log_debug("Service account verification failed: token is revoked or expired")
+        else:
             log_debug("Service account verification failed: unknown token")
-            return ServiceAccountVerification(status=VerificationStatus.INVALID)
 
-        account = ServiceAccount.from_dict(row)
-        if account.is_revoked() or account.is_expired():
-            self._limiter.record_failure(key)
-            log_debug(f"Service account verification failed: token for '{account.name}' is revoked or expired")
-            return ServiceAccountVerification(status=VerificationStatus.INVALID)
-
-        await self._maybe_touch_last_used(account)
-        return ServiceAccountVerification(status=VerificationStatus.OK, account=account)
+        # Verification failed for a reason we count (unknown / revoked / expired).
+        if self._limiter.is_limited(key):
+            log_warning("Service account verification throttled: too many failed lookups")
+            return ServiceAccountVerification(status=VerificationStatus.THROTTLED)
+        self._limiter.record_failure(key)
+        return ServiceAccountVerification(status=VerificationStatus.INVALID)
 
     async def _maybe_touch_last_used(self, account: ServiceAccount) -> None:
         now = time.time()

--- a/libs/agno/agno/os/services/__init__.py
+++ b/libs/agno/agno/os/services/__init__.py
@@ -1,0 +1,8 @@
+"""Shared service layer for AgentOS surfaces.
+
+One implementation of the session-read and run-lifecycle operations, imported by
+both the REST routers and the MCP tools (``from agno.os.services import sessions``
+/ ``runs``) so the two interfaces cannot drift. Service functions take domain
+arguments plus resolved identity and return domain objects / schema objects -- no
+HTTP and no MCP types.
+"""

--- a/libs/agno/agno/os/services/runs.py
+++ b/libs/agno/agno/os/services/runs.py
@@ -1,0 +1,88 @@
+"""Run-lifecycle operations (continue, cancel) shared by REST and MCP surfaces.
+
+The continue payloads mirror what the surfaces hand the client when a run
+pauses: agents/teams ship ``RunRequirement`` dicts, workflows ship
+``StepRequirement`` dicts. The client resolves them (confirmation, input,
+selection) and passes them back verbatim.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from agno.agent.agent import Agent
+from agno.remote.base import BaseRemote
+from agno.run.agent import RunOutput
+from agno.run.requirement import RunRequirement
+from agno.run.team import TeamRunOutput
+from agno.run.workflow import WorkflowRunOutput
+from agno.team.team import Team
+from agno.workflow.workflow import Workflow
+
+AnyRunOutput = Union[RunOutput, TeamRunOutput, WorkflowRunOutput]
+
+
+class RemoteContinuationUnsupported(Exception):
+    """Raised when continue is attempted on a remote component over a surface that
+    cannot forward HITL requirements to it (mirrors the REST 400 guard)."""
+
+
+def parse_run_requirements(requirements: Optional[List[Dict[str, Any]]]) -> Optional[List[RunRequirement]]:
+    if not requirements:
+        return None
+    return [RunRequirement.from_dict(req) if isinstance(req, dict) else req for req in requirements]
+
+
+def parse_step_requirements(requirements: Optional[List[Dict[str, Any]]]) -> Optional[List[Any]]:
+    from agno.workflow.types import StepRequirement
+
+    if not requirements:
+        return None
+    return [StepRequirement.from_dict(req) if isinstance(req, dict) else req for req in requirements]
+
+
+async def continue_paused_run(
+    component: Union[Agent, Team, Workflow],
+    *,
+    run_id: str,
+    session_id: Optional[str],
+    user_id: Optional[str] = None,
+    requirements: Optional[List[Dict[str, Any]]] = None,
+) -> AnyRunOutput:
+    """Resume a paused run on any local component with the client's resolved requirements.
+
+    Remote components are rejected: their ``acontinue_run`` cannot carry resolved
+    requirements (the REST surface 400s the same case), so failing clearly beats the
+    opaque downstream TypeError that forwarding them would raise.
+
+    ``stream=False`` is pinned: run-option resolution is call-site > component.stream >
+    False, so a component configured with ``stream=True`` would otherwise return an
+    async iterator instead of the final run output.
+    """
+    if isinstance(component, BaseRemote):
+        raise RemoteContinuationUnsupported(
+            "Continuing paused runs on remote components is not supported over this interface."
+        )
+    if isinstance(component, Workflow):
+        return await component.acontinue_run(
+            run_id=run_id,
+            session_id=session_id,
+            step_requirements=parse_step_requirements(requirements),
+            stream=False,
+        )
+    return await component.acontinue_run(  # type: ignore[misc, no-any-return]
+        run_id=run_id,
+        session_id=session_id,
+        user_id=user_id,
+        requirements=parse_run_requirements(requirements),
+        stream=False,
+    )
+
+
+async def cancel_component_run(component: Union[Agent, Team, Workflow], run_id: str) -> None:
+    """Request cancellation of ``run_id`` on the component that owns it.
+
+    Agent/team/workflow cancellation all delegate to one process-global cancellation
+    manager that records an intent even for a not-yet-registered run, so this always
+    succeeds -- ownership is enforced by the caller before we get here (mirroring the
+    REST cancel endpoints), which is also what keeps a bogus id from leaking an entry.
+    """
+    await component.acancel_run(run_id=run_id)

--- a/libs/agno/agno/os/services/sessions.py
+++ b/libs/agno/agno/os/services/sessions.py
@@ -1,0 +1,181 @@
+"""Session read operations shared by the REST session router and the MCP tools.
+
+Only the local-database branches live here: the logic that historically drifted
+between surfaces (session-type auto-detection, run classification, sync-db
+handling). ``RemoteDb`` calls are one-line proxies and stay at each surface,
+which also owns forwarding the caller's Authorization header.
+
+Sync ``BaseDb`` calls are offloaded to a threadpool so an async surface (MCP or
+REST) never blocks its event loop on database I/O.
+"""
+
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+
+from starlette.concurrency import run_in_threadpool
+
+from agno.db.base import AsyncBaseDb, BaseDb, SessionType
+from agno.db.utils import detect_session_type
+from agno.os.schema import RunSchema, TeamRunSchema, WorkflowRunSchema
+
+AnyRunSchema = Union[RunSchema, TeamRunSchema, WorkflowRunSchema]
+
+
+class SessionNotFoundError(Exception):
+    """Raised when a session id does not resolve; surfaces map it to 404 / tool error."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+        super().__init__(f"Session {session_id} not found")
+
+
+class RunOwnershipError(Exception):
+    """Raised when a run does not belong to the caller's session (masked as not-found)."""
+
+    def __init__(self) -> None:
+        super().__init__("Run not found")
+
+
+async def verify_run_ownership(
+    component: Any,
+    *,
+    session_id: str,
+    run_id: str,
+    user_id: str,
+    component_type: Literal["agents", "teams", "workflows"],
+    component_id: str,
+) -> None:
+    """Fail closed unless ``run_id`` lives in a ``user_id``-owned session for this component.
+
+    Surface-agnostic twin of the REST ``verify_run_in_session`` (which raises
+    ``HTTPException``); raises :class:`RunOwnershipError` so the MCP layer can present
+    it as a tool error without importing HTTP types.
+    """
+    from agno.os.middleware.user_scope import run_matches_component, session_matches_component
+
+    session = await component.aget_session(session_id=session_id, user_id=user_id)
+    if session is None or not session_matches_component(session, component_type, component_id):
+        raise RunOwnershipError()
+    run = session.get_run(run_id=run_id)
+    if run is None or not run_matches_component(run, component_type, component_id):
+        raise RunOwnershipError()
+
+
+async def get_sessions_page(
+    db: Union[BaseDb, AsyncBaseDb],
+    *,
+    session_type: Optional[SessionType] = None,
+    component_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    session_name: Optional[str] = None,
+    limit: Optional[int] = 20,
+    page: Optional[int] = 1,
+    sort_by: Optional[str] = "created_at",
+    sort_order: Optional[Any] = "desc",
+) -> Tuple[List[Dict[str, Any]], int]:
+    """One page of sessions as raw dicts plus the total count.
+
+    Parameter types mirror the REST query params (all optional/defaulted, ``sort_order``
+    accepts the ``SortOrder`` enum or a plain string) so both surfaces call this unchanged.
+    """
+    kwargs: Dict[str, Any] = dict(
+        session_type=session_type,
+        component_id=component_id,
+        user_id=user_id,
+        session_name=session_name,
+        limit=limit,
+        page=page,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        deserialize=False,
+    )
+    if isinstance(db, AsyncBaseDb):
+        sessions, total_count = await db.get_sessions(**kwargs)
+    else:
+        sessions, total_count = await run_in_threadpool(lambda: db.get_sessions(**kwargs))
+    return sessions, total_count  # type: ignore[return-value]
+
+
+async def _get_session_dict(
+    db: Union[BaseDb, AsyncBaseDb],
+    *,
+    session_id: str,
+    session_type: Optional[SessionType],
+    user_id: Optional[str],
+) -> Tuple[Dict[str, Any], SessionType]:
+    """Fetch a session as a raw dict, auto-detecting its type when not given.
+
+    Auto-detection matters: local ``get_session`` does not filter by type in SQL,
+    so a wrong caller-supplied default silently misparses rather than 404s.
+    """
+    if isinstance(db, AsyncBaseDb):
+        session = await db.get_session(
+            session_id=session_id, session_type=session_type, user_id=user_id, deserialize=False
+        )
+    else:
+        session = await run_in_threadpool(
+            lambda: db.get_session(
+                session_id=session_id,
+                session_type=session_type,
+                user_id=user_id,
+                deserialize=False,
+            )
+        )
+    if not session:
+        raise SessionNotFoundError(session_id)
+    if session_type is None:
+        session_type = SessionType(detect_session_type(session if isinstance(session, dict) else {}))
+    return session, session_type  # type: ignore[return-value]
+
+
+def classify_session_run(run: Dict[str, Any], session_type: SessionType) -> Optional[AnyRunSchema]:
+    """Render one persisted run dict as the schema matching its actual shape.
+
+    Team and workflow sessions can contain member/step runs of other kinds, so
+    classification is per-run (by which component id the run carries), not
+    per-session. Mirrors the REST behavior exactly, including dropping team-session
+    runs that carry neither an agent_id nor a team_id (returns None).
+    """
+    if session_type == SessionType.AGENT:
+        return RunSchema.from_dict(run)
+    if session_type == SessionType.TEAM:
+        if run.get("agent_id") is not None:
+            return RunSchema.from_dict(run)
+        if run.get("team_id") is not None:
+            return TeamRunSchema.from_dict(run)
+        return None
+    if run.get("workflow_id") is not None:
+        return WorkflowRunSchema.from_dict(run)
+    if run.get("team_id") is not None:
+        return TeamRunSchema.from_dict(run)
+    return RunSchema.from_dict(run)
+
+
+async def get_session_runs(
+    db: Union[BaseDb, AsyncBaseDb],
+    *,
+    session_id: str,
+    session_type: Optional[SessionType] = None,
+    user_id: Optional[str] = None,
+    created_after: Optional[int] = None,
+    created_before: Optional[int] = None,
+) -> List[AnyRunSchema]:
+    """All runs of a session as schema objects, with type auto-detection.
+
+    Raises :class:`SessionNotFoundError` when the session does not exist.
+    """
+    session, resolved_type = await _get_session_dict(
+        db, session_id=session_id, session_type=session_type, user_id=user_id
+    )
+
+    runs = session.get("runs") or []
+    filtered: List[Dict[str, Any]] = []
+    for run in runs:
+        created_at = run.get("created_at")
+        if created_after and created_at and created_at < created_after:
+            continue
+        if created_before and created_at and created_at > created_before:
+            continue
+        filtered.append(run)
+
+    classified = (classify_session_run(run, resolved_type) for run in filtered)
+    return [run_schema for run_schema in classified if run_schema is not None]

--- a/libs/agno/agno/os/settings.py
+++ b/libs/agno/agno/os/settings.py
@@ -23,6 +23,14 @@ class AgnoAPISettings(BaseSettings):
     # Authorization flag - when True, JWT middleware handles auth and security key validation is skipped
     authorization_enabled: bool = Field(default=False, description="Whether JWT authorization is enabled")
 
+    # Seconds to cache a successful service-account token verification in-process, to
+    # avoid a database lookup on every request. Revocation takes effect within this
+    # window across worker processes (immediately on the worker that processes the
+    # revoke). Set to 0 for strict instant revocation (verify against the DB every time).
+    service_account_cache_ttl_seconds: int = Field(
+        default=30, description="TTL (seconds) for the in-process service-account verification cache; 0 disables it"
+    )
+
     # Cors origin list to allow requests from.
     # This list is set using the set_cors_origin_list validator
     cors_origin_list: Optional[List[str]] = Field(default=None, validate_default=True)

--- a/libs/agno/tests/integration/db/postgres/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/postgres/test_service_accounts.py
@@ -1,0 +1,98 @@
+"""Integration tests for the service_accounts table in PostgresDb.
+
+Requires a local postgres at localhost:5532 (ai:ai/ai), same as the other
+postgres integration tests. Not run in CI.
+"""
+
+import time
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.schemas.service_accounts import ServiceAccount
+
+
+def _account(account_id: str, name: str, token_hash: str, **overrides):
+    account = ServiceAccount(
+        id=account_id,
+        name=name,
+        token_hash=token_hash,
+        token_prefix="agno_pat_test123",
+        scopes=["agents:run", "sessions:read"],
+        **overrides,
+    )
+    return account.to_dict()
+
+
+class TestServiceAccountsTable:
+    def test_create_table_with_partial_unique_index(self, postgres_db_real):
+        postgres_db_real._create_table(postgres_db_real.service_accounts_table_name, "service_accounts")
+        with postgres_db_real.Session() as sess:
+            result = sess.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = :schema AND table_name = :table"
+                ),
+                {"schema": postgres_db_real.db_schema, "table": postgres_db_real.service_accounts_table_name},
+            )
+            assert result.fetchone() is not None
+
+            result = sess.execute(
+                text("SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = :schema AND tablename = :table"),
+                {"schema": postgres_db_real.db_schema, "table": postgres_db_real.service_accounts_table_name},
+            )
+            indexes = {row[0]: row[1] for row in result.fetchall()}
+        partial_index_name = f"{postgres_db_real.service_accounts_table_name}_uq_active_name"
+        assert partial_index_name in indexes
+        assert "revoked_at IS NULL" in indexes[partial_index_name]
+
+    def test_crud_roundtrip(self, postgres_db_real):
+        created = postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        assert created["name"] == "claude-code"
+
+        fetched = postgres_db_real.get_service_account("sa-1")
+        assert fetched is not None
+        assert fetched["scopes"] == ["agents:run", "sessions:read"]
+
+        by_hash = postgres_db_real.get_service_account_by_token_hash("hash-1")
+        assert by_hash is not None and by_hash["id"] == "sa-1"
+
+        by_name = postgres_db_real.get_service_account_by_name("claude-code")
+        assert by_name is not None and by_name["id"] == "sa-1"
+
+        updated = postgres_db_real.update_service_account("sa-1", last_used_at=int(time.time()))
+        assert updated is not None and updated["last_used_at"] is not None
+
+        assert postgres_db_real.delete_service_account("sa-1") is True
+        assert postgres_db_real.get_service_account("sa-1") is None
+
+    def test_duplicate_active_name_rejected_but_reusable_after_revocation(self, postgres_db_real):
+        postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+
+        with pytest.raises(IntegrityError):
+            postgres_db_real.create_service_account(_account("sa-2", "claude-code", "hash-2"))
+
+        postgres_db_real.update_service_account("sa-1", revoked_at=int(time.time()))
+        created = postgres_db_real.create_service_account(_account("sa-3", "claude-code", "hash-3"))
+        assert created["id"] == "sa-3"
+
+        active = postgres_db_real.get_service_account_by_name("claude-code")
+        assert active is not None and active["id"] == "sa-3"
+
+    def test_list_pagination_and_revoked_filter(self, postgres_db_real):
+        now = int(time.time())
+        for i in range(3):
+            postgres_db_real.create_service_account(
+                _account(f"sa-{i}", f"account-{i}", f"hash-{i}", created_at=now - i)
+            )
+        postgres_db_real.update_service_account("sa-2", revoked_at=now)
+
+        accounts, total = postgres_db_real.get_service_accounts()
+        assert total == 3
+
+        accounts, total = postgres_db_real.get_service_accounts(include_revoked=False)
+        assert total == 2
+        assert all(account["revoked_at"] is None for account in accounts)
+
+        accounts, _ = postgres_db_real.get_service_accounts(sort_by="name", sort_order="asc")
+        assert [account["name"] for account in accounts] == ["account-0", "account-1", "account-2"]

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -1,0 +1,97 @@
+"""Integration tests for the service_accounts table in SqliteDb."""
+
+import time
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from agno.db.schemas.service_accounts import ServiceAccount
+
+
+def _account(account_id: str, name: str, token_hash: str, **overrides):
+    account = ServiceAccount(
+        id=account_id,
+        name=name,
+        token_hash=token_hash,
+        token_prefix="agno_pat_test123",
+        scopes=["agents:run", "sessions:read"],
+        **overrides,
+    )
+    return account.to_dict()
+
+
+class TestServiceAccountsTable:
+    def test_create_table_with_partial_unique_index(self, sqlite_db_real):
+        sqlite_db_real._create_table(sqlite_db_real.service_accounts_table_name, "service_accounts")
+        with sqlite_db_real.Session() as sess:
+            result = sess.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table' AND name = :table"),
+                {"table": sqlite_db_real.service_accounts_table_name},
+            )
+            assert result.fetchone() is not None
+            result = sess.execute(
+                text("SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name = :table"),
+                {"table": sqlite_db_real.service_accounts_table_name},
+            )
+            indexes = {row[0]: row[1] for row in result.fetchall()}
+        partial_index_name = f"{sqlite_db_real.service_accounts_table_name}_uq_active_name"
+        assert partial_index_name in indexes
+        assert "revoked_at IS NULL" in indexes[partial_index_name]
+
+    def test_crud_roundtrip(self, sqlite_db_real):
+        created = sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        assert created["name"] == "claude-code"
+
+        fetched = sqlite_db_real.get_service_account("sa-1")
+        assert fetched is not None
+        assert fetched["scopes"] == ["agents:run", "sessions:read"]
+
+        by_hash = sqlite_db_real.get_service_account_by_token_hash("hash-1")
+        assert by_hash is not None and by_hash["id"] == "sa-1"
+
+        by_name = sqlite_db_real.get_service_account_by_name("claude-code")
+        assert by_name is not None and by_name["id"] == "sa-1"
+
+        updated = sqlite_db_real.update_service_account("sa-1", last_used_at=int(time.time()))
+        assert updated is not None and updated["last_used_at"] is not None
+
+        assert sqlite_db_real.delete_service_account("sa-1") is True
+        assert sqlite_db_real.get_service_account("sa-1") is None
+
+    def test_unknown_token_hash_returns_none(self, sqlite_db_real):
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        assert sqlite_db_real.get_service_account_by_token_hash("no-such-hash") is None
+
+    def test_duplicate_active_name_rejected_but_reusable_after_revocation(self, sqlite_db_real):
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+
+        with pytest.raises(IntegrityError):
+            sqlite_db_real.create_service_account(_account("sa-2", "claude-code", "hash-2"))
+
+        sqlite_db_real.update_service_account("sa-1", revoked_at=int(time.time()))
+        created = sqlite_db_real.create_service_account(_account("sa-3", "claude-code", "hash-3"))
+        assert created["id"] == "sa-3"
+
+        # Active lookup resolves to the new account
+        active = sqlite_db_real.get_service_account_by_name("claude-code")
+        assert active is not None and active["id"] == "sa-3"
+
+    def test_list_pagination_and_revoked_filter(self, sqlite_db_real):
+        now = int(time.time())
+        for i in range(3):
+            sqlite_db_real.create_service_account(_account(f"sa-{i}", f"account-{i}", f"hash-{i}", created_at=now - i))
+        sqlite_db_real.update_service_account("sa-2", revoked_at=now)
+
+        accounts, total = sqlite_db_real.get_service_accounts()
+        assert total == 3
+
+        accounts, total = sqlite_db_real.get_service_accounts(include_revoked=False)
+        assert total == 2
+        assert all(account["revoked_at"] is None for account in accounts)
+
+        accounts, total = sqlite_db_real.get_service_accounts(limit=2, page=1)
+        assert len(accounts) == 2 and total == 3
+
+        accounts, _ = sqlite_db_real.get_service_accounts(sort_by="name", sort_order="asc")
+        assert [account["name"] for account in accounts] == ["account-0", "account-1", "account-2"]

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -63,6 +63,18 @@ class TestServiceAccountsTable:
         sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
         assert sqlite_db_real.get_service_account_by_token_hash("no-such-hash") is None
 
+    def test_token_hash_lookup_reraises_on_db_error(self, sqlite_db_real):
+        # A dead connection must raise, not return None - the verifier maps a raise to
+        # UNAVAILABLE (503) rather than misreading it as an unknown token (401).
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        sqlite_db_real.db_engine.dispose()
+        sqlite_db_real.db_url = "sqlite:////nonexistent/path/definitely_missing.db"
+        from sqlalchemy import create_engine
+
+        sqlite_db_real.db_engine = create_engine(sqlite_db_real.db_url)
+        with pytest.raises(Exception):
+            sqlite_db_real.get_service_account_by_token_hash("hash-1")
+
     def test_duplicate_active_name_rejected_but_reusable_after_revocation(self, sqlite_db_real):
         sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
 

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -1,0 +1,305 @@
+"""Integration tests for service account (agno_pat_) authentication in AgentOS."""
+
+import time
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.middleware import JWTMiddleware
+from agno.os.settings import AgnoAPISettings
+
+JWT_SECRET = "test-secret-key-for-service-account-tests"
+
+UNIFORM_401_DETAIL = "Invalid or expired service account token"
+
+
+def _make_jwt(scopes, sub="human-admin"):
+    payload = {
+        "sub": sub,
+        "scopes": scopes,
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+def _mock_run_output():
+    return type(
+        "MockRunOutput",
+        (),
+        {"to_dict": lambda self: {"content": "ok", "run_id": "test_run_1"}},
+    )()
+
+
+@pytest.fixture
+def sqlite_db(tmp_path):
+    return SqliteDb(db_file=str(tmp_path / "service_accounts_test.db"))
+
+
+@pytest.fixture
+def test_agent(sqlite_db):
+    agent = Agent(id="sa-test-agent", name="sa-test-agent", db=sqlite_db)
+    agent.deep_copy = lambda **kwargs: agent
+    return agent
+
+
+@pytest.fixture
+def jwt_client(test_agent, sqlite_db):
+    """AgentOS with a db and JWT middleware with authorization enabled."""
+    agent_os = AgentOS(agents=[test_agent], db=sqlite_db)
+    app = agent_os.get_app()
+    app.add_middleware(
+        JWTMiddleware,
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        authorization=True,
+    )
+    return TestClient(app)
+
+
+def _mint(client, auth_token, name="claude-code", **body_overrides):
+    body = {"name": name, **body_overrides}
+    return client.post(
+        "/service-accounts",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json=body,
+    )
+
+
+class TestServiceAccountLifecycleWithJWT:
+    def test_admin_mints_pat_and_pat_runs_agent_with_attribution(self, jwt_client, test_agent):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        response = _mint(jwt_client, admin_jwt)
+        assert response.status_code == 201, response.text
+        body = response.json()
+        pat = body["token"]
+        assert pat.startswith("agno_pat_")
+        assert body["principal"] == "sa:claude-code"
+        assert body["created_by"] == "human-admin"
+
+        with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
+            mock_arun.return_value = _mock_run_output()
+            run_response = jwt_client.post(
+                "/agents/sa-test-agent/runs",
+                headers={"Authorization": f"Bearer {pat}"},
+                data={"message": "hello", "stream": "false"},
+            )
+        assert run_response.status_code == 200, run_response.text
+        assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
+
+    def test_pat_default_scopes_allow_session_read_but_not_delete(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        pat = _mint(jwt_client, admin_jwt).json()["token"]
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 200
+
+        response = jwt_client.delete("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 403
+
+    def test_pat_cannot_mint_pats_by_default(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        pat = _mint(jwt_client, admin_jwt).json()["token"]
+        response = _mint(jwt_client, pat, name="sneaky")
+        assert response.status_code == 403
+
+    def test_minter_cannot_escalate_beyond_own_scopes(self, jwt_client):
+        minter_jwt = _make_jwt(["service_accounts:write", "agents:run"], sub="delegated-minter")
+        # Granting a scope the minter holds works
+        response = _mint(jwt_client, minter_jwt, name="ci-bot", scopes=["agents:run"])
+        assert response.status_code == 201
+
+        # Granting a scope the minter does not hold is rejected
+        response = _mint(jwt_client, minter_jwt, name="ci-bot-2", scopes=["teams:run"])
+        assert response.status_code == 403
+
+        # The privileged flag alone cannot escalate either
+        response = _mint(
+            jwt_client, minter_jwt, name="ci-bot-3", scopes=["agent_os:admin"], allow_privileged_scopes=True
+        )
+        assert response.status_code == 403
+
+    def test_revoked_pat_gets_uniform_401(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        minted = _mint(jwt_client, admin_jwt).json()
+
+        revoke = jwt_client.delete(
+            f"/service-accounts/{minted['id']}", headers={"Authorization": f"Bearer {admin_jwt}"}
+        )
+        assert revoke.status_code == 204
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_expired_pat_gets_same_uniform_401(self, jwt_client, sqlite_db):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        minted = _mint(jwt_client, admin_jwt).json()
+        sqlite_db.update_service_account(minted["id"], expires_at=int(time.time()) - 10)
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_unknown_pat_gets_same_uniform_401(self, jwt_client):
+        response = jwt_client.get(
+            "/sessions", headers={"Authorization": "Bearer agno_pat_doesnotexist0000000000000000"}
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_repeated_failed_lookups_get_throttled(self, jwt_client):
+        last_status = None
+        for _ in range(25):
+            response = jwt_client.get(
+                "/sessions", headers={"Authorization": "Bearer agno_pat_bruteforce000000000000000"}
+            )
+            last_status = response.status_code
+        assert last_status == 429
+
+    def test_name_reuse_after_revocation_rotates_identity(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        first = _mint(jwt_client, admin_jwt)
+        assert first.status_code == 201
+
+        # Duplicate active name is rejected
+        duplicate = _mint(jwt_client, admin_jwt)
+        assert duplicate.status_code == 409
+
+        # After revocation the name can be reused (rotation)
+        revoke = jwt_client.delete(
+            f"/service-accounts/{first.json()['id']}", headers={"Authorization": f"Bearer {admin_jwt}"}
+        )
+        assert revoke.status_code == 204
+        rotated = _mint(jwt_client, admin_jwt)
+        assert rotated.status_code == 201
+        assert rotated.json()["principal"] == first.json()["principal"]
+
+    def test_list_never_exposes_hashes_or_tokens(self, jwt_client):
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        pat = _mint(jwt_client, admin_jwt).json()["token"]
+
+        response = jwt_client.get("/service-accounts", headers={"Authorization": f"Bearer {admin_jwt}"})
+        assert response.status_code == 200
+        assert pat not in response.text
+        entry = response.json()["data"][0]
+        assert "token" not in entry
+        assert "token_hash" not in entry
+        assert entry["token_prefix"] == pat[:16]
+
+    def test_jwt_without_scope_cannot_manage_service_accounts(self, jwt_client):
+        plain_jwt = _make_jwt(["agents:run"], sub="regular-user")
+        assert _mint(jwt_client, plain_jwt).status_code == 403
+        response = jwt_client.get("/service-accounts", headers={"Authorization": f"Bearer {plain_jwt}"})
+        assert response.status_code == 403
+
+
+class TestInternalTokenRegression:
+    """The internal scheduler token must behave identically after the RBAC refactor."""
+
+    @pytest.fixture
+    def internal_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db, internal_service_token="internal-test-token")
+        app = agent_os.get_app()
+        app.add_middleware(
+            JWTMiddleware,
+            verification_keys=[JWT_SECRET],
+            algorithm="HS256",
+            authorization=True,
+        )
+        return TestClient(app)
+
+    def test_internal_token_allowed_for_granted_scopes(self, internal_client):
+        response = internal_client.get("/agents", headers={"Authorization": "Bearer internal-test-token"})
+        assert response.status_code == 200
+
+    def test_internal_token_denied_outside_granted_scopes(self, internal_client):
+        response = internal_client.get("/sessions", headers={"Authorization": "Bearer internal-test-token"})
+        assert response.status_code == 403
+
+
+class TestServiceAccountsInSecurityKeyMode:
+    """PATs work without JWT middleware, and their scopes are still enforced."""
+
+    @pytest.fixture
+    def security_key_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(
+            agents=[test_agent],
+            db=sqlite_db,
+            settings=AgnoAPISettings(os_security_key="root-security-key"),
+        )
+        return TestClient(agent_os.get_app())
+
+    def test_security_key_mints_and_pat_runs_with_attribution(self, security_key_client, test_agent):
+        response = _mint(security_key_client, "root-security-key")
+        assert response.status_code == 201, response.text
+        pat = response.json()["token"]
+
+        with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
+            mock_arun.return_value = _mock_run_output()
+            run_response = security_key_client.post(
+                "/agents/sa-test-agent/runs",
+                headers={"Authorization": f"Bearer {pat}"},
+                data={"message": "hello", "stream": "false"},
+            )
+        assert run_response.status_code == 200, run_response.text
+        assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
+
+    def test_pat_scopes_are_enforced_without_jwt_middleware(self, security_key_client):
+        pat = _mint(security_key_client, "root-security-key").json()["token"]
+
+        # Default scopes include sessions:read
+        response = security_key_client.get("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 200
+
+        # But a run-and-read PAT is not a master key: it cannot mint more PATs
+        response = _mint(security_key_client, pat, name="sneaky")
+        assert response.status_code == 403
+
+        # And it cannot delete sessions
+        response = security_key_client.delete("/sessions", headers={"Authorization": f"Bearer {pat}"})
+        assert response.status_code == 403
+
+    def test_revoked_pat_rejected_in_security_key_mode(self, security_key_client):
+        minted = _mint(security_key_client, "root-security-key").json()
+        revoke = security_key_client.delete(
+            f"/service-accounts/{minted['id']}",
+            headers={"Authorization": "Bearer root-security-key"},
+        )
+        assert revoke.status_code == 204
+
+        response = security_key_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+
+class TestServiceAccountsOnOpenInstance:
+    """On an open dev instance PATs still verify and provide attribution."""
+
+    @pytest.fixture
+    def open_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db)
+        return TestClient(agent_os.get_app())
+
+    def test_pat_authenticates_and_attributes_on_open_instance(self, open_client, test_agent):
+        pat = _mint(open_client, "anything-goes").json()["token"]
+
+        with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
+            mock_arun.return_value = _mock_run_output()
+            run_response = open_client.post(
+                "/agents/sa-test-agent/runs",
+                headers={"Authorization": f"Bearer {pat}"},
+                data={"message": "hello", "stream": "false"},
+            )
+        assert run_response.status_code == 200
+        assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
+
+    def test_invalid_pat_rejected_even_on_open_instance(self, open_client):
+        response = open_client.get("/sessions", headers={"Authorization": "Bearer agno_pat_invalid000000000000000000"})
+        assert response.status_code == 401

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -138,6 +138,23 @@ class TestServiceAccountLifecycleWithJWT:
         assert response.status_code == 401
         assert response.json()["detail"] == UNIFORM_401_DETAIL
 
+    def test_revoke_invalidates_cached_token_immediately(self, jwt_client):
+        # Use the token first so it is cached, then revoke: the revoking worker (this
+        # process, default 30s cache TTL) must reject it at once, not serve the cache.
+        admin_jwt = _make_jwt(["agent_os:admin"])
+        minted = _mint(jwt_client, admin_jwt).json()
+
+        assert jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"}).status_code == 200
+
+        revoke = jwt_client.delete(
+            f"/service-accounts/{minted['id']}", headers={"Authorization": f"Bearer {admin_jwt}"}
+        )
+        assert revoke.status_code == 204
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
     def test_expired_pat_gets_same_uniform_401(self, jwt_client, sqlite_db):
         admin_jwt = _make_jwt(["agent_os:admin"])
         minted = _mint(jwt_client, admin_jwt).json()

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -2,6 +2,7 @@
 
 import time
 from datetime import UTC, datetime, timedelta
+from importlib.util import find_spec
 from unittest.mock import AsyncMock, patch
 
 import jwt
@@ -320,3 +321,90 @@ class TestServiceAccountsOnOpenInstance:
     def test_invalid_pat_rejected_even_on_open_instance(self, open_client):
         response = open_client.get("/sessions", headers={"Authorization": "Bearer agno_pat_invalid000000000000000000"})
         assert response.status_code == 401
+
+
+# A minimal MCP initialize request - enough to reach (or be blocked before) the MCP machinery.
+MCP_INIT_BODY = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "test", "version": "1"},
+    },
+}
+MCP_HEADERS = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+
+
+@pytest.mark.skipif(find_spec("fastmcp") is None, reason="fastmcp is not installed")
+class TestServiceAccountsOverMCP:
+    """The mounted /mcp app enforces the same auth rules as REST in non-JWT modes.
+
+    Router dependencies never run for mounted sub-apps, so /mcp carries its own auth
+    middleware. These tests drive the full AgentOS app end to end: mint over REST,
+    then call the MCP endpoint.
+    """
+
+    @pytest.fixture
+    def mcp_security_key_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(
+            agents=[test_agent],
+            db=sqlite_db,
+            enable_mcp_server=True,
+            settings=AgnoAPISettings(os_security_key="root-security-key"),
+        )
+        # Context manager so the MCP session manager lifespan runs.
+        with TestClient(agent_os.get_app()) as client:
+            yield client
+
+    @pytest.fixture
+    def mcp_open_client(self, test_agent, sqlite_db):
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db, enable_mcp_server=True)
+        with TestClient(agent_os.get_app()) as client:
+            yield client
+
+    def _mcp_post(self, client, token=None):
+        headers = dict(MCP_HEADERS)
+        if token is not None:
+            headers["Authorization"] = f"Bearer {token}"
+        return client.post("/mcp", json=MCP_INIT_BODY, headers=headers)
+
+    def test_mcp_rejects_request_without_token(self, mcp_security_key_client):
+        response = self._mcp_post(mcp_security_key_client)
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Authorization header required"
+
+    def test_mcp_rejects_bad_token(self, mcp_security_key_client):
+        response = self._mcp_post(mcp_security_key_client, token="not-the-key")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid authentication token"
+
+    def test_mcp_accepts_security_key(self, mcp_security_key_client):
+        response = self._mcp_post(mcp_security_key_client, token="root-security-key")
+        assert response.status_code == 200
+
+    def test_mcp_accepts_valid_pat(self, mcp_security_key_client):
+        pat = _mint(mcp_security_key_client, "root-security-key").json()["token"]
+        response = self._mcp_post(mcp_security_key_client, token=pat)
+        assert response.status_code == 200
+
+    def test_mcp_rejects_revoked_pat(self, mcp_security_key_client):
+        minted = _mint(mcp_security_key_client, "root-security-key").json()
+        revoke = mcp_security_key_client.delete(
+            f"/service-accounts/{minted['id']}",
+            headers={"Authorization": "Bearer root-security-key"},
+        )
+        assert revoke.status_code == 204
+
+        response = self._mcp_post(mcp_security_key_client, token=minted["token"])
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL
+
+    def test_mcp_stays_open_without_security_key(self, mcp_open_client):
+        assert self._mcp_post(mcp_open_client).status_code == 200
+
+    def test_mcp_rejects_invalid_pat_even_on_open_instance(self, mcp_open_client):
+        response = self._mcp_post(mcp_open_client, token="agno_pat_invalid000000000000000000")
+        assert response.status_code == 401
+        assert response.json()["detail"] == UNIFORM_401_DETAIL

--- a/libs/agno/tests/system/tests/test_mcp_routes.py
+++ b/libs/agno/tests/system/tests/test_mcp_routes.py
@@ -201,14 +201,33 @@ async def test_list_tools(mcp_client: MCPTestClient):
     expected_tools = [
         "get_agentos_config",
         "run_agent",
+        "run_team",
+        "run_workflow",
+        "continue_run",
+        "cancel_run",
         "get_sessions",
-        "get_session",
-        "create_session",
-        "create_memory",
-        "get_memories",
+        "get_session_runs",
     ]
     for tool_name in expected_tools:
         assert tool_name in tools, f"Missing expected tool: {tool_name}"
+
+    # The v2.7 surface is deliberately trimmed: session writes and memory CRUD are gone.
+    removed_tools = [
+        "get_session",
+        "create_session",
+        "update_session",
+        "rename_session",
+        "delete_session",
+        "delete_sessions",
+        "create_memory",
+        "get_memory",
+        "get_memories",
+        "update_memory",
+        "delete_memory",
+        "delete_memories",
+    ]
+    for tool_name in removed_tools:
+        assert tool_name not in tools, f"Removed tool still present: {tool_name}"
 
 
 # =============================================================================
@@ -221,13 +240,16 @@ async def test_get_agentos_config(mcp_client: MCPTestClient):
     """Test the get_agentos_config tool."""
     result = await mcp_client.call_tool("get_agentos_config", {})
 
+    # The v2.7 config tool is a compact discovery payload: ids/summaries + db ids only.
     assert "os_id" in result
     assert result["os_id"] == "gateway-os"
     assert "agents" in result
     assert "teams" in result
     assert "workflows" in result
-    assert "interfaces" in result
     assert "databases" in result
+    # Heavy per-domain config sections are intentionally not in the MCP payload (REST /config only).
+    for heavy_key in ("interfaces", "learning", "memory", "knowledge", "evals", "metrics", "traces"):
+        assert heavy_key not in result, f"Compact config must not include '{heavy_key}'"
 
     # Verify both local and remote agents are present
     agent_ids = [agent["id"] for agent in result["agents"]]
@@ -243,7 +265,6 @@ async def test_get_agentos_config(mcp_client: MCPTestClient):
     workflow_ids = [workflow["id"] for workflow in result["workflows"]]
     assert "gateway-workflow" in workflow_ids, "Local workflow 'gateway-workflow' should be present"
     assert "qa-workflow" in workflow_ids, "Remote workflow 'qa-workflow' should be present"
-    assert "learning" in result
 
 
 @pytest.mark.asyncio
@@ -342,119 +363,6 @@ async def test_run_remote_workflow(mcp_client: MCPTestClient):
 
 
 @pytest.mark.asyncio
-async def test_create_session(mcp_client: MCPTestClient, db_id: str, test_session_id: str, test_user_id: str):
-    """Test creating a new session with a local agent via MCP."""
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": test_session_id,
-            "session_name": "MCP Test Session",
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-            "session_state": {"test_key": "test_value"},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == test_session_id
-    assert result.get("session_name") == "MCP Test Session"
-
-
-@pytest.mark.asyncio
-async def test_create_session_remote_agent(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a remote agent via MCP."""
-    remote_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": remote_session_id,
-            "session_name": "MCP Remote Agent Test Session",
-            "user_id": test_user_id,
-            "agent_id": "assistant-agent",
-            "session_state": {"remote_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == remote_session_id
-    assert result.get("session_name") == "MCP Remote Agent Test Session"
-    assert result.get("agent_id") == "assistant-agent"
-
-
-@pytest.mark.asyncio
-async def test_create_session_remote_team(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a remote team via MCP."""
-    team_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "team",
-            "session_id": team_session_id,
-            "session_name": "MCP Team Test Session",
-            "user_id": test_user_id,
-            "team_id": "research-team",
-            "session_state": {"team_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == team_session_id
-    assert result.get("session_name") == "MCP Team Test Session"
-    assert result.get("team_id") == "research-team"
-
-
-@pytest.mark.asyncio
-async def test_create_session_local_workflow(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a local workflow via MCP."""
-    workflow_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "workflow",
-            "session_id": workflow_session_id,
-            "session_name": "MCP Local Workflow Test Session",
-            "user_id": test_user_id,
-            "workflow_id": "gateway-workflow",
-            "session_state": {"workflow_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == workflow_session_id
-    assert result.get("session_name") == "MCP Local Workflow Test Session"
-    assert result.get("workflow_id") == "gateway-workflow"
-
-
-@pytest.mark.asyncio
-async def test_create_session_remote_workflow(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a new session with a remote workflow via MCP."""
-    workflow_session_id = str(uuid4())
-    result = await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "workflow",
-            "session_id": workflow_session_id,
-            "session_name": "MCP Remote Workflow Test Session",
-            "user_id": test_user_id,
-            "workflow_id": "qa-workflow",
-            "session_state": {"remote_workflow_test": True},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == workflow_session_id
-    assert result.get("session_name") == "MCP Remote Workflow Test Session"
-    assert result.get("workflow_id") == "qa-workflow"
-
-
-@pytest.mark.asyncio
 async def test_get_sessions(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
     """Test getting sessions via MCP."""
     result = await mcp_client.call_tool(
@@ -477,286 +385,35 @@ async def test_get_sessions(mcp_client: MCPTestClient, db_id: str, test_user_id:
 
 
 @pytest.mark.asyncio
-async def test_get_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test getting a specific session via MCP."""
-    # First create a session
+async def test_get_session_runs_after_run(mcp_client: MCPTestClient, test_user_id: str):
+    """Run an agent into a fresh session, then read the conversation back.
+
+    Exercises the v2.7 read-only session path: run tools create sessions implicitly,
+    get_session_runs auto-detects the session type (no session_type passed) and
+    db_id is optional on a single-database AgentOS.
+    """
     session_id = str(uuid4())
     await mcp_client.call_tool(
-        "create_session",
+        "run_agent",
         {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "session_name": "Get Session Test",
-            "user_id": test_user_id,
             "agent_id": "gateway-agent",
-        },
-    )
-
-    # Then get it
-    result = await mcp_client.call_tool(
-        "get_session",
-        {
+            "message": "Say hello in exactly 3 words",
             "session_id": session_id,
-            "db_id": db_id,
-            "session_type": "agent",
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_id") == session_id
-
-
-@pytest.mark.asyncio
-async def test_rename_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test renaming a session via MCP."""
-    # First create a session
-    session_id = str(uuid4())
-    await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "session_name": "Original Name",
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-        },
-    )
-
-    # Then rename it
-    new_name = "Renamed MCP Test Session"
-    result = await mcp_client.call_tool(
-        "rename_session",
-        {
-            "session_id": session_id,
-            "session_name": new_name,
-            "db_id": db_id,
-            "session_type": "agent",
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_name") == new_name
-
-
-@pytest.mark.asyncio
-async def test_update_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test updating a session via MCP."""
-    # First create a session
-    session_id = str(uuid4())
-    await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "session_name": "Update Test Session",
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-        },
-    )
-
-    # Then update it
-    result = await mcp_client.call_tool(
-        "update_session",
-        {
-            "session_id": session_id,
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_state": {"updated_key": "updated_value"},
-            "metadata": {"meta_key": "meta_value"},
-        },
-    )
-
-    assert result is not None
-    assert result.get("session_state", {}).get("updated_key") == "updated_value"
-
-
-# =============================================================================
-# Memory Management Tests
-# =============================================================================
-
-
-@pytest.fixture
-def test_memory_id() -> str:
-    """Generate a unique memory ID for testing."""
-    return str(uuid.uuid4())
-
-
-@pytest.mark.asyncio
-async def test_create_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test creating a memory via MCP."""
-    result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "This is a test memory created via MCP",
-            "user_id": test_user_id,
-            "topics": ["test", "mcp"],
-        },
-    )
-
-    assert result is not None
-    assert "memory_id" in result
-    assert result.get("memory") == "This is a test memory created via MCP"
-    assert result.get("user_id") == test_user_id
-
-    # Store memory_id for later tests
-    return result.get("memory_id")
-
-
-@pytest.mark.asyncio
-async def test_get_memories(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test getting memories via MCP."""
-    result = await mcp_client.call_tool(
-        "get_memories",
-        {
-            "db_id": db_id,
-            "user_id": test_user_id,
-            "limit": 10,
-            "page": 1,
-        },
-    )
-
-    assert "data" in result
-    assert "meta" in result
-    assert isinstance(result["data"], list)
-
-
-@pytest.mark.asyncio
-async def test_update_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test updating a memory via MCP."""
-    # First create a memory
-    create_result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "Original memory content",
-            "user_id": test_user_id,
-            "topics": ["original"],
-        },
-    )
-    memory_id = create_result.get("memory_id")
-
-    # Then update it
-    result = await mcp_client.call_tool(
-        "update_memory",
-        {
-            "db_id": db_id,
-            "memory_id": memory_id,
-            "memory": "Updated memory content",
-            "user_id": test_user_id,
-            "topics": ["updated"],
-        },
-    )
-
-    assert result is not None
-    assert result.get("memory") == "Updated memory content"
-
-
-@pytest.mark.asyncio
-async def test_get_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test getting a specific memory via MCP."""
-    # First create a memory
-    create_result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "Memory to retrieve",
             "user_id": test_user_id,
         },
     )
-    memory_id = create_result.get("memory_id")
 
-    # Then get it
-    result = await mcp_client.call_tool(
-        "get_memory",
-        {
-            "memory_id": memory_id,
-            "db_id": db_id,
-        },
-    )
-
-    assert result is not None
-    assert result.get("memory_id") == memory_id
-    assert result.get("memory") == "Memory to retrieve"
+    result = await mcp_client.call_tool("get_session_runs", {"session_id": session_id})
+    runs = result if isinstance(result, list) else [result]
+    assert len(runs) >= 1
 
 
 @pytest.mark.asyncio
-async def test_delete_memory(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test deleting a memory via MCP."""
-    # First create a memory
-    create_result = await mcp_client.call_tool(
-        "create_memory",
-        {
-            "db_id": db_id,
-            "memory": "Memory to delete",
-            "user_id": test_user_id,
-        },
-    )
-    memory_id = create_result.get("memory_id")
-
-    # Delete it
-    result = await mcp_client.call_tool(
-        "delete_memory",
-        {
-            "db_id": db_id,
-            "memory_id": memory_id,
-        },
-    )
-
-    # Result should indicate successful deletion
-    assert result is not None
-    assert "deleted successfully" in result.lower() or result in ["", "null", None]
-
-
-@pytest.mark.asyncio
-async def test_delete_memories_bulk(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Test bulk deleting memories via MCP."""
-    # Create multiple memories
-    memory_ids = []
-    for i in range(3):
-        create_result = await mcp_client.call_tool(
-            "create_memory",
-            {
-                "db_id": db_id,
-                "memory": f"Bulk delete memory {i}",
-                "user_id": test_user_id,
-            },
-        )
-        memory_ids.append(create_result.get("memory_id"))
-
-    # Delete them in bulk
-    result = await mcp_client.call_tool(
-        "delete_memories",
-        {
-            "memory_ids": memory_ids,
-            "db_id": db_id,
-        },
-    )
-
-    # Result should indicate successful deletion
-    assert result is not None
-    assert "deleted successfully" in result.lower() or result in ["", "null", None]
-
-
-@pytest.mark.skip(reason="get_user_memory_stats tool not yet implemented in MCP server")
-@pytest.mark.asyncio
-async def test_get_user_memory_stats(mcp_client: MCPTestClient, db_id: str):
-    """Test getting user memory statistics via MCP."""
-    result = await mcp_client.call_tool(
-        "get_user_memory_stats",
-        {
-            "db_id": db_id,
-            "limit": 10,
-            "page": 1,
-        },
-    )
-
-    assert "data" in result
-    assert "meta" in result
-    assert isinstance(result["data"], list)
+async def test_get_session_runs_not_found(mcp_client: MCPTestClient):
+    """Reading history of a non-existent session returns a tool error."""
+    with pytest.raises(Exception) as exc_info:
+        await mcp_client.call_tool("get_session_runs", {"session_id": "non-existent-session"})
+    assert "not found" in str(exc_info.value).lower()
 
 
 # =============================================================================
@@ -863,54 +520,9 @@ async def test_refresh_metrics(mcp_client: MCPTestClient, db_id: str):
 # =============================================================================
 
 
-@pytest.mark.asyncio
-async def test_cleanup_delete_session(mcp_client: MCPTestClient, db_id: str, test_user_id: str):
-    """Clean up: delete the test session."""
-    # Create a session to delete
-    session_id = str(uuid4())
-    await mcp_client.call_tool(
-        "create_session",
-        {
-            "db_id": db_id,
-            "session_type": "agent",
-            "session_id": session_id,
-            "user_id": test_user_id,
-            "agent_id": "gateway-agent",
-        },
-    )
-
-    # Delete it
-    result = await mcp_client.call_tool(
-        "delete_session",
-        {
-            "session_id": session_id,
-            "db_id": db_id,
-        },
-    )
-
-    # Result should indicate successful deletion
-    assert result is not None
-    assert "deleted successfully" in result.lower() or result in ["", "null", None]
-
-
 # =============================================================================
 # Error Handling Tests
 # =============================================================================
-
-
-@pytest.mark.asyncio
-async def test_get_session_not_found(mcp_client: MCPTestClient, db_id: str):
-    """Test getting a non-existent session returns appropriate error."""
-    with pytest.raises(Exception) as exc_info:
-        await mcp_client.call_tool(
-            "get_session",
-            {
-                "session_id": "non-existent-session-id",
-                "db_id": db_id,
-                "session_type": "agent",
-            },
-        )
-    assert "not found" in str(exc_info.value).lower()
 
 
 @pytest.mark.asyncio
@@ -922,20 +534,6 @@ async def test_run_agent_not_found(mcp_client: MCPTestClient):
             {
                 "agent_id": "non-existent-agent",
                 "message": "Hello",
-            },
-        )
-    assert "not found" in str(exc_info.value).lower()
-
-
-@pytest.mark.asyncio
-async def test_get_memory_not_found(mcp_client: MCPTestClient, db_id: str):
-    """Test getting a non-existent memory returns appropriate error."""
-    with pytest.raises(Exception) as exc_info:
-        await mcp_client.call_tool(
-            "get_memory",
-            {
-                "memory_id": "non-existent-memory-id",
-                "db_id": db_id,
             },
         )
     assert "not found" in str(exc_info.value).lower()

--- a/libs/agno/tests/system/tests/test_mcp_routes.py
+++ b/libs/agno/tests/system/tests/test_mcp_routes.py
@@ -259,8 +259,9 @@ async def test_run_agent(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a RunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -276,8 +277,9 @@ async def test_run_remote_agent(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a RunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -293,8 +295,9 @@ async def test_run_remote_team(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a TeamRunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -310,8 +313,9 @@ async def test_run_local_workflow(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a WorkflowRunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 @pytest.mark.asyncio
@@ -327,8 +331,9 @@ async def test_run_remote_workflow(mcp_client: MCPTestClient):
 
     # Check the result has expected fields
     assert result is not None
-    # The result should be a WorkflowRunOutput with content
-    assert "content" in result or isinstance(result, str)
+    # Trimmed result: the text block is the answer itself (a plain string unless the
+    # answer happens to be JSON); structured ids live in structuredContent.
+    assert isinstance(result, str) or (isinstance(result, dict) and ("content" in result or "run_id" in result))
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -187,6 +187,18 @@ class TestCreateServiceAccountSubsetRule:
         response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
         assert response.status_code == 201
 
+    def test_caller_can_grant_exact_per_resource_scope_it_holds(self, mock_db, settings):
+        # Least-privilege delegation: holding exactly agents:my-agent:run must be
+        # enough to grant agents:my-agent:run.
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:my-agent:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
+        assert response.status_code == 201
+
+    def test_caller_cannot_grant_per_resource_scope_for_other_resource(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:my-agent:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:other-agent:run"]})
+        assert response.status_code == 403
+
     def test_unscoped_root_caller_is_exempt(self, mock_db, settings):
         # No request.state.scopes (os_security_key or open dev instance)
         app = FastAPI()

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -1,0 +1,255 @@
+"""Tests for the service accounts REST API router."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from agno.os.routers.service_accounts import get_service_accounts_router
+from agno.os.service_accounts import DEFAULT_EXPIRY_DAYS, DEFAULT_SERVICE_ACCOUNT_SCOPES, TOKEN_PREFIX
+from agno.os.settings import AgnoAPISettings
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+def _make_account_dict(**overrides):
+    now = int(time.time())
+    d = {
+        "id": "sa-1",
+        "name": "claude-code",
+        "token_hash": "a" * 64,
+        "token_prefix": "agno_pat_abc1234",
+        "scopes": list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
+        "created_at": now,
+        "expires_at": now + 90 * 86400,
+        "last_used_at": None,
+        "revoked_at": None,
+        "created_by": "admin-user",
+    }
+    d.update(overrides)
+    return d
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.get_service_accounts = MagicMock(return_value=([], 0))
+    db.get_service_account = MagicMock(return_value=None)
+    db.get_service_account_by_name = MagicMock(return_value=None)
+    db.create_service_account = MagicMock(side_effect=lambda data: data)
+    db.update_service_account = MagicMock(return_value=_make_account_dict(revoked_at=int(time.time())))
+    return db
+
+
+@pytest.fixture
+def settings():
+    return AgnoAPISettings()
+
+
+@pytest.fixture
+def client(mock_db, settings):
+    app = FastAPI()
+    router = get_service_accounts_router(os_db=mock_db, settings=settings)
+    app.include_router(router)
+    return TestClient(app)
+
+
+# =============================================================================
+# Tests: POST /service-accounts
+# =============================================================================
+
+
+class TestCreateServiceAccount:
+    def test_mint_with_defaults(self, client, mock_db):
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["name"] == "claude-code"
+        assert body["principal"] == "sa:claude-code"
+        assert body["scopes"] == DEFAULT_SERVICE_ACCOUNT_SCOPES
+        assert body["token"].startswith(TOKEN_PREFIX)
+        assert body["token_prefix"] == body["token"][:16]
+        # Default expiry ~90 days out
+        assert body["expires_at"] is not None
+        expected = int(time.time()) + DEFAULT_EXPIRY_DAYS * 86400
+        assert abs(body["expires_at"] - expected) < 60
+        # Only the hash is persisted, never the plaintext
+        stored = mock_db.create_service_account.call_args.args[0]
+        assert body["token"] not in str(stored)
+        assert stored["token_hash"] != body["token"]
+
+    def test_custom_expiry(self, client):
+        response = client.post("/service-accounts", json={"name": "cursor", "expires_in_days": 7})
+        assert response.status_code == 201
+        expected = int(time.time()) + 7 * 86400
+        assert abs(response.json()["expires_at"] - expected) < 60
+
+    def test_never_expires_requires_explicit_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "cursor", "never_expires": True})
+        assert response.status_code == 201
+        assert response.json()["expires_at"] is None
+
+    def test_invalid_name_rejected(self, client):
+        for bad_name in ["Claude-Code", "__scheduler__", "sa:claude", "user@example.com"]:
+            response = client.post("/service-accounts", json={"name": bad_name})
+            assert response.status_code == 422, bad_name
+
+    def test_unknown_scope_rejected(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["bogus"]})
+        assert response.status_code == 400
+        assert "Invalid scope" in response.json()["detail"]
+
+    def test_privileged_scope_requires_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["sessions:write"]})
+        assert response.status_code == 400
+        assert "allow_privileged_scopes" in response.json()["detail"]
+
+    def test_admin_scope_requires_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agent_os:admin"]})
+        assert response.status_code == 400
+
+    def test_service_accounts_scope_requires_flag(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["service_accounts:write"]})
+        assert response.status_code == 400
+
+    def test_privileged_scope_allowed_with_flag(self, client):
+        response = client.post(
+            "/service-accounts",
+            json={"name": "ci", "scopes": ["sessions:write"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 201
+        assert response.json()["scopes"] == ["sessions:write"]
+
+    def test_duplicate_active_name_conflicts(self, client, mock_db):
+        mock_db.get_service_account_by_name = MagicMock(return_value=_make_account_dict())
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 409
+
+    def test_integrity_error_maps_to_conflict(self, client, mock_db):
+        mock_db.create_service_account = MagicMock(
+            side_effect=IntegrityError("UNIQUE constraint failed", None, Exception())
+        )
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 409
+
+    def test_db_without_support_returns_503(self, settings):
+        db = MagicMock()
+        db.get_service_account_by_name = MagicMock(side_effect=NotImplementedError)
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=db, settings=settings))
+        response = TestClient(app).post("/service-accounts", json={"name": "ci"})
+        assert response.status_code == 503
+
+
+class TestCreateServiceAccountSubsetRule:
+    """The minted scopes must be held by the creator (unless admin or unscoped root)."""
+
+    def _client_with_state(self, mock_db, settings, caller_scopes):
+        from fastapi import Request
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def set_scopes(request: Request, call_next):
+            request.state.scopes = caller_scopes
+            request.state.authenticated = True
+            return await call_next(request)
+
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        return TestClient(app)
+
+    def test_caller_cannot_grant_scopes_it_does_not_hold(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["teams:run"]})
+        assert response.status_code == 403
+        assert "teams:run" in response.json()["detail"]
+
+    def test_caller_can_grant_subset_of_own_scopes(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["service_accounts:write", "agents:run", "sessions:read"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:run"]})
+        assert response.status_code == 201
+
+    def test_admin_caller_can_grant_anything(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["agent_os:admin"])
+        response = client.post(
+            "/service-accounts",
+            json={"name": "ci", "scopes": ["sessions:delete"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 201
+
+    def test_wildcard_scope_covers_per_resource_grant(self, mock_db, settings):
+        client = self._client_with_state(mock_db, settings, ["agents:*:run"])
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
+        assert response.status_code == 201
+
+    def test_unscoped_root_caller_is_exempt(self, mock_db, settings):
+        # No request.state.scopes (os_security_key or open dev instance)
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        response = TestClient(app).post("/service-accounts", json={"name": "ci", "scopes": ["teams:run"]})
+        assert response.status_code == 201
+
+
+# =============================================================================
+# Tests: GET /service-accounts
+# =============================================================================
+
+
+class TestListServiceAccounts:
+    def test_empty_list(self, client):
+        response = client.get("/service-accounts")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["data"] == []
+        assert body["meta"]["total_count"] == 0
+
+    def test_list_returns_metadata_never_secrets(self, client, mock_db):
+        mock_db.get_service_accounts = MagicMock(return_value=([_make_account_dict()], 1))
+        response = client.get("/service-accounts")
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["data"]) == 1
+        entry = body["data"][0]
+        assert entry["token_prefix"] == "agno_pat_abc1234"
+        assert entry["principal"] == "sa:claude-code"
+        assert "token" not in entry
+        assert "token_hash" not in entry
+        assert "a" * 64 not in response.text
+
+    def test_pagination_params_forwarded(self, client, mock_db):
+        client.get("/service-accounts?limit=5&page=2&include_revoked=false&sort_by=name&sort_order=asc")
+        kwargs = mock_db.get_service_accounts.call_args.kwargs
+        assert kwargs["limit"] == 5
+        assert kwargs["page"] == 2
+        assert kwargs["include_revoked"] is False
+        assert kwargs["sort_by"] == "name"
+        assert kwargs["sort_order"] == "asc"
+
+
+# =============================================================================
+# Tests: DELETE /service-accounts/{id}
+# =============================================================================
+
+
+class TestRevokeServiceAccount:
+    def test_unknown_id_returns_404(self, client):
+        response = client.delete("/service-accounts/nope")
+        assert response.status_code == 404
+
+    def test_revoke_sets_revoked_at(self, client, mock_db):
+        mock_db.get_service_account = MagicMock(return_value=_make_account_dict())
+        response = client.delete("/service-accounts/sa-1")
+        assert response.status_code == 204
+        kwargs = mock_db.update_service_account.call_args.kwargs
+        assert kwargs["revoked_at"] is not None
+
+    def test_already_revoked_is_idempotent(self, client, mock_db):
+        mock_db.get_service_account = MagicMock(return_value=_make_account_dict(revoked_at=int(time.time())))
+        response = client.delete("/service-accounts/sa-1")
+        assert response.status_code == 204
+        mock_db.update_service_account.assert_not_called()

--- a/libs/agno/tests/unit/os/test_info_endpoint.py
+++ b/libs/agno/tests/unit/os/test_info_endpoint.py
@@ -1,0 +1,111 @@
+"""Tests for the unauthenticated GET /info endpoint.
+
+Covers the discovery fields used by external tooling (e.g. the agno CLI):
+MCP server availability (enabled + mount path) and the effective auth mode
+("none" / "security_key" / "jwt").
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.os import AgentOS
+from agno.os.auth import get_effective_auth_mode
+from agno.os.config import AuthorizationConfig
+from agno.os.settings import AgnoAPISettings
+
+JWT_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture(autouse=True)
+def clean_auth_env(monkeypatch):
+    """Keep ambient auth env vars from leaking into these tests."""
+    monkeypatch.delenv("OS_SECURITY_KEY", raising=False)
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+
+
+def _build_client(**kwargs) -> TestClient:
+    agent = Agent(name="Info Agent", id="info-agent", telemetry=False)
+    os_instance = AgentOS(agents=[agent], telemetry=False, **kwargs)
+    return TestClient(os_instance.get_app())
+
+
+class TestInfoEndpointBasics:
+    def test_returns_version_and_counts(self):
+        client = _build_client()
+        resp = client.get("/info")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["agno_version"]
+        assert body["agent_count"] == 1
+        assert body["team_count"] == 0
+        assert body["workflow_count"] == 0
+
+
+class TestInfoEndpointMcpDiscovery:
+    def test_mcp_disabled_by_default(self):
+        client = _build_client()
+        body = client.get("/info").json()
+        assert body["mcp"] == {"enabled": False, "path": None}
+
+    def test_mcp_enabled_reports_path(self):
+        pytest.importorskip("fastmcp")
+        client = _build_client(enable_mcp_server=True)
+        body = client.get("/info").json()
+        assert body["mcp"] == {"enabled": True, "path": "/mcp"}
+
+
+class TestInfoEndpointAuthMode:
+    def test_auth_mode_none_by_default(self):
+        client = _build_client()
+        body = client.get("/info").json()
+        assert body["auth_mode"] == "none"
+
+    def test_auth_mode_security_key(self):
+        client = _build_client(settings=AgnoAPISettings(os_security_key="test-key"))
+        resp = client.get("/info")
+        # /info stays unauthenticated even when a security key is enforced
+        assert resp.status_code == 200
+        assert resp.json()["auth_mode"] == "security_key"
+
+    def test_auth_mode_jwt_via_authorization_flag(self):
+        client = _build_client(
+            authorization=True,
+            authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+        )
+        resp = client.get("/info")
+        # /info is excluded from JWT middleware and stays unauthenticated
+        assert resp.status_code == 200
+        assert resp.json()["auth_mode"] == "jwt"
+
+    def test_auth_mode_jwt_via_env_takes_precedence_over_security_key(self, monkeypatch):
+        monkeypatch.setenv("JWT_VERIFICATION_KEY", JWT_SECRET)
+        client = _build_client(settings=AgnoAPISettings(os_security_key="test-key"))
+        body = client.get("/info").json()
+        # JWT configured via env vars is effectively enforced, even without authorization=True
+        assert body["auth_mode"] == "jwt"
+
+
+class TestGetEffectiveAuthMode:
+    def test_none_when_settings_missing(self):
+        assert get_effective_auth_mode(settings=None) == "none"
+
+    def test_none_when_nothing_configured(self):
+        assert get_effective_auth_mode(settings=AgnoAPISettings()) == "none"
+
+    def test_security_key(self):
+        settings = AgnoAPISettings(os_security_key="test-key")
+        assert get_effective_auth_mode(settings=settings) == "security_key"
+
+    def test_jwt_via_authorization_flag(self):
+        settings = AgnoAPISettings(os_security_key="test-key")
+        assert get_effective_auth_mode(settings=settings, authorization=True) == "jwt"
+
+    def test_jwt_via_settings_flag(self):
+        settings = AgnoAPISettings(authorization_enabled=True)
+        assert get_effective_auth_mode(settings=settings) == "jwt"
+
+    def test_jwt_via_jwks_env_var(self, monkeypatch):
+        monkeypatch.setenv("JWT_JWKS_FILE", "/tmp/jwks.json")
+        assert get_effective_auth_mode(settings=AgnoAPISettings()) == "jwt"

--- a/libs/agno/tests/unit/os/test_mcp_run_results.py
+++ b/libs/agno/tests/unit/os/test_mcp_run_results.py
@@ -1,0 +1,341 @@
+"""Unit tests for the MCP run tools' result serialization and progress reporting.
+
+The run tools return trimmed results by default: MCP tool results are injected into
+the consuming model's context, so the transcript, system prompt, and metrics must not
+leak into them. ``result_mode="full"`` is the opt-in escape hatch. Runs are driven as
+streams so tool-call / step events surface as MCP progress notifications.
+"""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastmcp import Client  # noqa: E402
+
+from agno.agent import Agent  # noqa: E402
+from agno.media import Image  # noqa: E402
+from agno.models.message import Message  # noqa: E402
+from agno.models.response import ToolExecution  # noqa: E402
+from agno.os import AgentOS, MCPServerConfig  # noqa: E402
+from agno.os.mcp import build_mcp_server  # noqa: E402
+from agno.run.agent import RunErrorEvent, RunEvent, RunOutput, ToolCallStartedEvent  # noqa: E402
+from agno.run.base import RunStatus  # noqa: E402
+from agno.run.requirement import RunRequirement  # noqa: E402
+from agno.run.workflow import (  # noqa: E402
+    StepStartedEvent,
+    WorkflowCompletedEvent,
+    WorkflowErrorEvent,
+    WorkflowRunOutput,
+)
+from agno.workflow.step import Step  # noqa: E402
+from agno.workflow.workflow import Workflow  # noqa: E402
+
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n_fake_image_payload"
+
+
+def _agent() -> Agent:
+    return Agent(id="demo-agent", name="Demo Agent")
+
+
+def _stub_arun_stream(component, *items):
+    """Replace ``component.arun`` with an async generator yielding ``items`` in order."""
+
+    async def fake_arun(message, **kwargs):
+        for item in items:
+            yield item
+
+    component.arun = fake_arun  # type: ignore[method-assign]
+
+
+def _full_run_output() -> RunOutput:
+    """A run output carrying everything the trimmed mode must NOT ship to the client."""
+    return RunOutput(
+        run_id="run-1",
+        session_id="sess-1",
+        content="the answer",
+        status=RunStatus.completed,
+        messages=[
+            Message(role="system", content="SECRET_SYSTEM_PROMPT"),
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="the answer"),
+        ],
+    )
+
+
+async def _call_run_agent(os: AgentOS, **kwargs):
+    async with Client(build_mcp_server(os)) as client:
+        return await client.call_tool("run_agent", {"agent_id": "demo-agent", "message": "hi"}, **kwargs)
+
+
+# ==================== Trimmed mode (default) ====================
+
+
+async def test_trimmed_result_carries_answer_and_ids_only():
+    agent = _agent()
+    _stub_arun_stream(agent, _full_run_output())
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    assert result.content[0].text == "the answer"
+    assert result.structured_content == {
+        "run_id": "run-1",
+        "session_id": "sess-1",
+        "status": "COMPLETED",
+    }
+
+
+async def test_trimmed_result_does_not_leak_transcript_or_system_prompt():
+    agent = _agent()
+    _stub_arun_stream(agent, _full_run_output())
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    serialized = str(result.content) + str(result.structured_content)
+    assert "SECRET_SYSTEM_PROMPT" not in serialized
+    assert "messages" not in (result.structured_content or {})
+
+
+async def test_binary_media_becomes_image_content_block():
+    """A run with raw image bytes serializes as an MCP image block instead of erroring."""
+    run_output = _full_run_output()
+    run_output.images = [Image(content=_PNG_BYTES, mime_type="image/png")]
+    agent = _agent()
+    _stub_arun_stream(agent, run_output)
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    image_blocks = [b for b in result.content if getattr(b, "type", None) == "image"]
+    assert len(image_blocks) == 1
+    assert image_blocks[0].mimeType == "image/png"
+    assert image_blocks[0].data  # base64 payload present
+
+
+async def test_paused_run_reports_requirements():
+    run_output = RunOutput(
+        run_id="run-p",
+        session_id="sess-p",
+        status=RunStatus.paused,
+        requirements=[RunRequirement(tool_execution=ToolExecution(tool_name="send_email", requires_confirmation=True))],
+    )
+    agent = _agent()
+    _stub_arun_stream(agent, run_output)
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os)
+
+    structured = result.structured_content or {}
+    assert structured["status"] == "PAUSED"
+    assert len(structured["requirements"]) == 1
+    assert "paused" in result.content[0].text.lower()
+
+
+# ==================== Full mode (escape hatch) ====================
+
+
+async def test_full_mode_ships_complete_run_output():
+    agent = _agent()
+    _stub_arun_stream(agent, _full_run_output())
+    os = AgentOS(
+        agents=[agent],
+        enable_mcp_server=True,
+        mcp_config=MCPServerConfig(result_mode="full"),
+    )
+
+    result = await _call_run_agent(os)
+
+    structured = result.structured_content or {}
+    assert structured["run_id"] == "run-1"
+    assert len(structured["messages"]) == 3  # full mode keeps the transcript, by choice
+    assert result.content[0].text == "the answer"
+
+
+async def test_full_mode_survives_binary_media():
+    """Full mode must route through to_dict() so raw bytes cannot break serialization."""
+    run_output = _full_run_output()
+    run_output.images = [Image(content=_PNG_BYTES, mime_type="image/png")]
+    agent = _agent()
+    _stub_arun_stream(agent, run_output)
+    os = AgentOS(
+        agents=[agent],
+        enable_mcp_server=True,
+        mcp_config=MCPServerConfig(result_mode="full"),
+    )
+
+    result = await _call_run_agent(os)
+
+    assert (result.structured_content or {})["run_id"] == "run-1"
+
+
+# ==================== Progress notifications ====================
+
+
+async def test_tool_call_events_are_forwarded_as_progress():
+    agent = _agent()
+    started_event = ToolCallStartedEvent(
+        event=RunEvent.tool_call_started.value,
+        tool=ToolExecution(tool_name="duckduckgo_search"),
+    )
+    _stub_arun_stream(agent, started_event, _full_run_output())
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    messages = []
+
+    async def on_progress(progress, total, message):
+        messages.append(message)
+
+    result = await _call_run_agent(os, progress_handler=on_progress)
+
+    assert result.content[0].text == "the answer"
+    assert any("started" in (m or "") for m in messages)
+    assert any("duckduckgo_search" in (m or "") for m in messages)
+
+
+# ==================== Workflow runs ====================
+
+
+async def test_workflow_result_built_from_completed_event():
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    completed = WorkflowCompletedEvent(
+        run_id="wf-run-1",
+        session_id="wf-sess-1",
+        content="workflow done",
+        run_output=WorkflowRunOutput(
+            run_id="wf-run-1",
+            session_id="wf-sess-1",
+            content="workflow done",
+            status=RunStatus.completed,
+        ),
+    )
+    _stub_arun_stream(workflow, completed)
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_workflow", {"workflow_id": "demo-wf", "message": "go"})
+
+    assert result.content[0].text == "workflow done"
+    structured = result.structured_content or {}
+    assert structured["run_id"] == "wf-run-1"
+    assert structured["status"] == "COMPLETED"
+
+
+async def test_run_finishing_without_output_raises_tool_error():
+    """A stream that ends without a final output surfaces as a tool error, not a hang."""
+    agent = _agent()
+    _stub_arun_stream(agent)  # yields nothing
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os, raise_on_error=False)
+    assert result.is_error
+
+
+# ==================== Error and pause propagation ====================
+
+
+async def test_failed_run_surfaces_real_error_message():
+    """The streaming error path yields only a RunErrorEvent; its message must reach the client."""
+    agent = _agent()
+    _stub_arun_stream(agent, RunErrorEvent(content="Incorrect API key provided"))
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    result = await _call_run_agent(os, raise_on_error=False)
+
+    assert result.is_error
+    assert "Incorrect API key provided" in result.content[0].text
+
+
+async def test_paused_workflow_recovered_from_persisted_run():
+    """Foreground workflow streams end WITHOUT a terminal event on HITL pause; the tool
+    must fetch the persisted run so the client gets run_id + requirements to continue."""
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    _stub_arun_stream(workflow, StepStartedEvent(run_id="wf-run-p", session_id="wf-sess-p", step_name="approve"))
+
+    paused = WorkflowRunOutput(run_id="wf-run-p", session_id="wf-sess-p", content=None, status=RunStatus.paused)
+    fetched = {}
+
+    async def fake_aget_run_output(run_id, session_id=None, user_id=None):
+        fetched["run_id"] = run_id
+        fetched["session_id"] = session_id
+        return paused
+
+    workflow.aget_run_output = fake_aget_run_output  # type: ignore[method-assign]
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_workflow", {"workflow_id": "demo-wf", "message": "go"})
+
+    assert fetched == {"run_id": "wf-run-p", "session_id": "wf-sess-p"}
+    assert (result.structured_content or {})["status"] == "PAUSED"
+
+
+async def test_nested_workflow_error_does_not_abort_outer_run():
+    """A nested workflow's error event (nested_depth > 0) must not kill an outer run
+    that recovers from it."""
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    outer_output = WorkflowRunOutput(
+        run_id="wf-outer", session_id="wf-sess", content="recovered", status=RunStatus.completed
+    )
+    _stub_arun_stream(
+        workflow,
+        WorkflowErrorEvent(run_id="wf-nested", error="nested boom", nested_depth=1),
+        WorkflowCompletedEvent(run_id="wf-outer", session_id="wf-sess", content="recovered", run_output=outer_output),
+    )
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("run_workflow", {"workflow_id": "demo-wf", "message": "go"})
+
+    structured = result.structured_content or {}
+    assert structured["run_id"] == "wf-outer"
+    assert structured["status"] == "COMPLETED"
+
+
+async def test_workflow_progress_is_strictly_increasing():
+    """MCP requires progress to increase per notification, even when step indexes repeat
+    (loops) or reset (nested steps)."""
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    events = [
+        StepStartedEvent(run_id="r", session_id="s", step_name="a", step_index=0),
+        StepStartedEvent(run_id="r", session_id="s", step_name="a", step_index=0),  # loop iteration repeats index
+        StepStartedEvent(run_id="r", session_id="s", step_name="b", step_index=1),
+        WorkflowCompletedEvent(
+            run_id="r",
+            session_id="s",
+            content="done",
+            run_output=WorkflowRunOutput(run_id="r", session_id="s", content="done", status=RunStatus.completed),
+        ),
+    ]
+    _stub_arun_stream(workflow, *events)
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    values = []
+
+    async def on_progress(progress, total, message):
+        values.append(progress)
+
+    async with Client(build_mcp_server(os)) as client:
+        await client.call_tool(
+            "run_workflow", {"workflow_id": "demo-wf", "message": "go"}, progress_handler=on_progress
+        )
+
+    assert values == sorted(values)
+    assert len(values) == len(set(values)), f"progress values must strictly increase, got {values}"
+
+
+async def test_paused_workflow_fallback_text_counts_step_requirements():
+    """The paused fallback text must count workflow step_requirements, not just
+    agent/team requirements."""
+    from agno.os.mcp_results import build_run_tool_result
+    from agno.workflow.types import StepRequirement
+
+    paused = WorkflowRunOutput(run_id="r", session_id="s", content=None, status=RunStatus.paused)
+    paused.step_requirements = [
+        StepRequirement(step_id="step-1", step_name="approve", step_type="Step", requires_confirmation=True)
+    ]
+
+    result = build_run_tool_result(paused, "trimmed")
+
+    text = result.content[0].text
+    assert "1 requirement" in text

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -66,14 +66,22 @@ async def _call_tool(os: AgentOS, name: str, args: dict):
 
 
 def _stub_arun(component, run_output):
-    """Replace ``component.arun`` with a stub that records the identity kwargs it was called with."""
+    """Replace ``component.arun`` with a streaming stub that records the identity kwargs.
+
+    The run tools consume ``arun`` as a stream (``stream=True, yield_run_output=True``),
+    so the stub is an async generator whose last item is the final run output.
+    """
     captured: dict = {}
 
     async def fake_arun(message, **kwargs):
         captured["message"] = message
         captured["user_id"] = kwargs.get("user_id")
         captured["session_id"] = kwargs.get("session_id")
-        return run_output
+        # Agent/team tools must request the final output explicitly; workflows have no
+        # yield_run_output kwarg (the consumer accepts a bare WorkflowRunOutput instead).
+        # Gating on this catches a regression where the tools stop passing it.
+        if kwargs.get("yield_run_output") or isinstance(run_output, WorkflowRunOutput):
+            yield run_output
 
     component.arun = fake_arun  # type: ignore[method-assign]
     return captured

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -34,21 +34,11 @@ from agno.tools import tool  # noqa: E402
 from agno.workflow.step import Step  # noqa: E402
 from agno.workflow.workflow import Workflow  # noqa: E402
 
-# The full set of built-in tools, keyed by their tag group.
-CORE_TOOLS = {"get_agentos_config", "run_agent", "run_team", "run_workflow"}
-SESSION_TOOLS = {
-    "get_sessions",
-    "get_session",
-    "create_session",
-    "get_session_runs",
-    "get_session_run",
-    "rename_session",
-    "update_session",
-    "delete_session",
-    "delete_sessions",
-}
-MEMORY_TOOLS = {"create_memory", "get_memory", "get_memories", "update_memory", "delete_memory", "delete_memories"}
-ALL_BUILTIN_TOOLS = CORE_TOOLS | SESSION_TOOLS | MEMORY_TOOLS
+# The full set of built-in tools, keyed by their tag group. The surface is deliberately
+# 8 tools: an operator surface for LLM frontends, not a database console.
+CORE_TOOLS = {"get_agentos_config", "run_agent", "run_team", "run_workflow", "continue_run", "cancel_run"}
+SESSION_TOOLS = {"get_sessions", "get_session_runs"}
+ALL_BUILTIN_TOOLS = CORE_TOOLS | SESSION_TOOLS
 
 
 def _agent() -> Agent:
@@ -171,30 +161,30 @@ async def test_include_tags_scopes_builtins_to_core():
     assert await _tool_names(os) == CORE_TOOLS
 
 
-async def test_exclude_tags_drops_memory_builtins():
-    os = AgentOS(agents=[_agent()], enable_mcp_server=True, mcp_config=MCPServerConfig(exclude_tags={"memory"}))
+async def test_exclude_tags_drops_session_builtins():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True, mcp_config=MCPServerConfig(exclude_tags={"session"}))
     names = await _tool_names(os)
-    assert names == CORE_TOOLS | SESSION_TOOLS
-    assert not (names & MEMORY_TOOLS)
+    assert names == CORE_TOOLS
+    assert not (names & SESSION_TOOLS)
 
 
 def test_unknown_include_tag_is_rejected():
     """A typo like ``{"sessions"}`` (plural) would silently produce an empty server. The
     ``MCPBuiltinTag`` Literal makes pydantic reject it at construction."""
-    with pytest.raises(ValueError, match="Input should be 'core', 'session' or 'memory'"):
+    with pytest.raises(ValueError, match="Input should be 'core' or 'session'"):
         MCPServerConfig(include_tags={"sessions"})
 
 
-def test_unknown_exclude_tag_is_rejected():
-    """Same protection on ``exclude_tags`` -- a typo would silently exclude nothing.
-    Tag matching is case-sensitive (``"Memory"`` is not ``"memory"``)."""
-    with pytest.raises(ValueError, match="Input should be 'core', 'session' or 'memory'"):
-        MCPServerConfig(exclude_tags={"Memory"})
+def test_removed_memory_tag_is_rejected():
+    """The memory tools were removed from the MCP surface; the old tag must fail loudly
+    instead of silently scoping nothing."""
+    with pytest.raises(ValueError, match="Input should be 'core' or 'session'"):
+        MCPServerConfig(exclude_tags={"memory"})
 
 
 def test_known_tags_are_accepted():
     """Sanity: the typed fields don't fight the documented values."""
-    MCPServerConfig(include_tags={"core", "session", "memory"})
+    MCPServerConfig(include_tags={"core", "session"})
     MCPServerConfig(exclude_tags={"core"})
 
 

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -13,8 +13,10 @@ import pytest
 
 pytest.importorskip("fastmcp")
 
+import time  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 from typing import Optional  # noqa: E402
+from uuid import uuid4  # noqa: E402
 
 import httpx  # noqa: E402
 from fastmcp import Client, Context  # noqa: E402
@@ -23,9 +25,12 @@ from starlette.middleware.base import BaseHTTPMiddleware  # noqa: E402
 
 import agno.os.mcp as mcp_mod  # noqa: E402
 from agno.agent import Agent  # noqa: E402
+from agno.db.schemas.service_accounts import ServiceAccount  # noqa: E402
 from agno.os import AgentOS, MCPServerConfig  # noqa: E402
 from agno.os.config import AuthorizationConfig  # noqa: E402
 from agno.os.mcp import _resolve_user_id, build_mcp_server, get_mcp_server  # noqa: E402
+from agno.os.service_accounts import ServiceAccountVerification, VerificationStatus, generate_token  # noqa: E402
+from agno.os.settings import AgnoAPISettings  # noqa: E402
 from agno.run.agent import RunOutput  # noqa: E402
 from agno.run.team import TeamRunOutput  # noqa: E402
 from agno.run.workflow import WorkflowRunOutput  # noqa: E402
@@ -563,3 +568,200 @@ async def test_no_transport_security_when_unset():
     async with _mcp_http_client(_security_os()) as client:
         response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_headers(host="anything.example.com"))
     assert response.status_code == 200
+
+
+# ==================== Security key + service account auth (non-JWT modes) ====================
+
+# Router dependencies never run for mounted sub-apps, so in non-JWT modes /mcp gets its own
+# middleware mirroring the REST rules (agno.os.auth.get_authentication_dependency).
+
+
+def _sqlite_db(tmp_path):
+    from agno.db.sqlite import SqliteDb
+
+    return SqliteDb(db_file=str(tmp_path / "mcp_auth_test.db"))
+
+
+def _mint_pat(db, name="mcp-bot", revoked=False):
+    """Create a service account directly in the db and return its plaintext token."""
+    plaintext, token_hash, token_prefix = generate_token()
+    now = int(time.time())
+    account = ServiceAccount(
+        id=str(uuid4()),
+        name=name,
+        token_hash=token_hash,
+        token_prefix=token_prefix,
+        scopes=["agents:run"],
+        created_at=now,
+        revoked_at=now if revoked else None,
+    )
+    db.create_service_account(account.to_dict())
+    return plaintext
+
+
+def _auth_os(security_key=None, db=None, **config_kwargs) -> AgentOS:
+    return AgentOS(
+        agents=[_agent()],
+        db=db,
+        enable_mcp_server=True,
+        settings=AgnoAPISettings(os_security_key=security_key),
+        mcp_config=MCPServerConfig(tools=[_ok_tool], enable_builtin_tools=False, **config_kwargs),
+    )
+
+
+def _bearer(token: str) -> dict:
+    return {**_MCP_HEADERS, "Authorization": f"Bearer {token}"}
+
+
+async def test_security_key_mode_rejects_missing_token():
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authorization header required"
+
+
+async def test_security_key_mode_rejects_invalid_token():
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("wrong-key"))
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid authentication token"
+
+
+async def test_security_key_mode_accepts_the_key():
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("test-key"))
+    assert response.status_code == 200
+
+
+async def test_security_key_mode_accepts_raw_token():
+    """A raw (non-Bearer) Authorization header is accepted, like the JWT middleware."""
+    headers = {**_MCP_HEADERS, "Authorization": "test-key"}
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=headers)
+    assert response.status_code == 200
+
+
+async def test_security_key_mode_accepts_valid_pat_and_attributes(tmp_path):
+    """A valid agno_pat token authenticates, and the account principal + scopes land on
+    request.state so _resolve_user_id attributes tool calls to sa:<name>."""
+    db = _sqlite_db(tmp_path)
+    pat = _mint_pat(db)
+    captured: dict = {}
+
+    class _CaptureState(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+            response = await call_next(request)
+            captured["user_id"] = getattr(request.state, "user_id", None)
+            captured["scopes"] = getattr(request.state, "scopes", None)
+            return response
+
+    os = _auth_os(security_key="test-key", db=db, middleware=[Middleware(_CaptureState)])
+    async with _mcp_http_client(os) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer(pat))
+
+    assert response.status_code == 200
+    assert captured["user_id"] == "sa:mcp-bot"
+    assert captured["scopes"] == ["agents:run"]
+
+
+async def test_security_key_mode_rejects_revoked_pat(tmp_path):
+    db = _sqlite_db(tmp_path)
+    pat = _mint_pat(db, revoked=True)
+    async with _mcp_http_client(_auth_os(security_key="test-key", db=db)) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer(pat))
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid or expired service account token"
+
+
+async def test_pat_without_db_gets_service_accounts_disabled_401():
+    """Without a db there is no verifier: a PAT gets REST's 'not enabled' 401, not a key check."""
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_notenabled0000000"))
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Service accounts are not enabled on this AgentOS instance"
+
+
+async def test_open_mode_with_db_stays_open_but_verifies_pats(tmp_path):
+    """No security key: requests without a PAT pass through (open, matching REST), but a
+    presented PAT is still verified and rejected when invalid."""
+    db = _sqlite_db(tmp_path)
+    async with _mcp_http_client(_auth_os(security_key=None, db=db)) as client:
+        open_response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
+        bad_pat_response = await client.post(
+            "/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_invalid00000000000")
+        )
+    assert open_response.status_code == 200
+    assert bad_pat_response.status_code == 401
+    assert bad_pat_response.json()["detail"] == "Invalid or expired service account token"
+
+
+def test_no_auth_mode_adds_no_key_auth_middleware():
+    """No security key and no db (no verifier): nothing is added and /mcp stays open."""
+    mcp_app = get_mcp_server(_auth_os(security_key=None))
+    assert not any(m.cls.__name__ == "_MCPKeyAuthMiddleware" for m in mcp_app.user_middleware)
+
+
+async def test_no_auth_mode_stays_open():
+    async with _mcp_http_client(_auth_os(security_key=None)) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
+    assert response.status_code == 200
+
+
+def test_jwt_mode_does_not_add_key_auth_middleware():
+    """JWT mode is unchanged: the JWT middleware handles /mcp auth, key auth is not added."""
+    os = AgentOS(
+        agents=[_agent()],
+        enable_mcp_server=True,
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=["dummy"]),
+        settings=AgnoAPISettings(os_security_key="test-key"),
+    )
+    names = [m.cls.__name__ for m in get_mcp_server(os).user_middleware]
+    assert "JWTMiddleware" in names
+    assert "_MCPKeyAuthMiddleware" not in names
+
+
+class _FakeVerifier:
+    def __init__(self, status):
+        self.status = status
+
+    async def verify(self, token, client_key=None):
+        return ServiceAccountVerification(status=self.status)
+
+
+@pytest.mark.parametrize(
+    "status,expected_status_code",
+    [(VerificationStatus.THROTTLED, 429), (VerificationStatus.UNAVAILABLE, 503)],
+)
+async def test_pat_verifier_statuses_map_like_rest(tmp_path, status, expected_status_code):
+    """THROTTLED -> 429 and UNAVAILABLE -> 503, matching the REST path in agno.os.auth."""
+    os = _auth_os(security_key="test-key", db=_sqlite_db(tmp_path))
+    os._service_account_verifier = _FakeVerifier(status)
+    async with _mcp_http_client(os) as client:
+        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_whatever0000000000"))
+    assert response.status_code == expected_status_code
+
+
+def test_key_auth_middleware_layer_position():
+    """Key auth sits where JWT would: inside transport security and app-provided middleware,
+    outside the authorize gate (add_middleware wraps outside-in)."""
+
+    class _Passthrough(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):  # type: ignore[no-untyped-def]
+            return await call_next(request)
+
+    os = _auth_os(
+        security_key="test-key",
+        allowed_hosts=[],
+        middleware=[Middleware(_Passthrough)],
+        authorize=lambda user_id: True,
+    )
+    names = [m.cls.__name__ for m in get_mcp_server(os).user_middleware]
+    expected_order = [
+        "_MCPTransportSecurityMiddleware",
+        "_Passthrough",
+        "_MCPKeyAuthMiddleware",
+        "_MCPAuthorizeMiddleware",
+    ]
+    positions = [names.index(name) for name in expected_order]
+    assert positions == sorted(positions), f"unexpected middleware order: {names}"

--- a/libs/agno/tests/unit/os/test_mcp_surface_v2.py
+++ b/libs/agno/tests/unit/os/test_mcp_surface_v2.py
@@ -1,0 +1,314 @@
+"""Unit tests for the v2.7 MCP surface: run-lifecycle tools, read-only session tools
+backed by the shared service layer, tool annotations, and the app wiring fixes.
+"""
+
+import pytest
+
+pytest.importorskip("fastmcp")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from fastmcp import Client  # noqa: E402
+
+import agno.os.mcp as mcp_mod  # noqa: E402
+from agno.agent import Agent  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.mcp import build_mcp_server  # noqa: E402
+from agno.os.services.sessions import SessionNotFoundError, get_session_runs, get_sessions_page  # noqa: E402
+from agno.run.agent import RunOutput  # noqa: E402
+from agno.run.base import RunStatus  # noqa: E402
+from agno.run.requirement import RunRequirement  # noqa: E402
+from agno.workflow.step import Step  # noqa: E402
+from agno.workflow.workflow import Workflow  # noqa: E402
+
+
+def _agent() -> Agent:
+    return Agent(id="demo-agent", name="Demo Agent")
+
+
+# ==================== Tool annotations ====================
+
+
+async def test_annotations_mark_reads_and_destructive_tools():
+    """Clients use readOnlyHint/destructiveHint for permission UX; reads and the one
+    destructive tool must be distinguishable."""
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        tools = {t.name: t for t in await client.list_tools()}
+
+    assert tools["get_agentos_config"].annotations.readOnlyHint is True
+    assert tools["get_sessions"].annotations.readOnlyHint is True
+    assert tools["get_session_runs"].annotations.readOnlyHint is True
+    assert tools["cancel_run"].annotations.destructiveHint is True
+    assert tools["run_agent"].annotations.readOnlyHint is False
+
+
+async def test_config_payload_is_compact():
+    """get_agentos_config is a discovery payload: ids and summaries, not the full config."""
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    os.get_app()  # populates db discovery (os.dbs), as at serve time
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("get_agentos_config", {})
+
+    structured = result.structured_content or {}
+    payload = structured.get("result", structured)
+    assert payload["agents"][0]["id"] == "demo-agent"
+    for heavy_key in ("session", "memory", "knowledge", "evals", "metrics", "traces"):
+        assert heavy_key not in payload
+
+
+# ==================== continue_run / cancel_run ====================
+
+
+async def test_continue_run_requires_exactly_one_component():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("continue_run", {"run_id": "r1"}, raise_on_error=False)
+        assert result.is_error
+        result = await client.call_tool(
+            "continue_run",
+            {"run_id": "r1", "agent_id": "demo-agent", "team_id": "demo-team"},
+            raise_on_error=False,
+        )
+        assert result.is_error
+
+
+async def test_continue_run_threads_identity_and_parses_requirements(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_resolve_user_id", lambda caller: "jwt-alice")
+    agent = _agent()
+    captured = {}
+
+    async def fake_acontinue_run(*, run_id, session_id, user_id, requirements, stream=False):
+        captured.update(run_id=run_id, session_id=session_id, user_id=user_id, requirements=requirements, stream=stream)
+        return RunOutput(run_id=run_id, session_id=session_id, content="resumed", status=RunStatus.completed)
+
+    agent.acontinue_run = fake_acontinue_run  # type: ignore[method-assign]
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+
+    requirement_dict = {"tool_execution": {"tool_name": "send_email"}, "confirmation": True}
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "continue_run",
+            {
+                "run_id": "run-9",
+                "session_id": "sess-9",
+                "agent_id": "demo-agent",
+                "requirements": [requirement_dict],
+            },
+        )
+
+    assert captured["run_id"] == "run-9"
+    assert captured["user_id"] == "jwt-alice"
+    assert captured["stream"] is False  # pinned so a stream=True agent can't return an iterator
+    assert isinstance(captured["requirements"][0], RunRequirement)
+    assert result.content[0].text == "resumed"
+    assert (result.structured_content or {})["status"] == "COMPLETED"
+
+
+async def test_continue_run_dispatches_workflow_step_requirements():
+    workflow = Workflow(id="demo-wf", name="Demo WF", steps=[Step(agent=_agent())])
+    captured = {}
+
+    async def fake_acontinue_run(*, run_id, session_id, step_requirements, stream=False):
+        captured.update(run_id=run_id, step_requirements=step_requirements, stream=stream)
+        from agno.run.workflow import WorkflowRunOutput
+
+        return WorkflowRunOutput(run_id=run_id, session_id=session_id, content="wf resumed")
+
+    workflow.acontinue_run = fake_acontinue_run  # type: ignore[method-assign]
+    os = AgentOS(workflows=[workflow], enable_mcp_server=True)
+
+    step_requirement = {"step_id": "s1", "step_name": "approve", "step_type": "Step", "requires_confirmation": True}
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "continue_run",
+            {"run_id": "wf-run-9", "workflow_id": "demo-wf", "requirements": [step_requirement]},
+        )
+
+    assert captured["run_id"] == "wf-run-9"
+    assert captured["step_requirements"][0].step_id == "s1"
+    assert result.content[0].text == "wf resumed"
+
+
+async def test_cancel_run_requires_exactly_one_component():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("cancel_run", {"run_id": "r1"}, raise_on_error=False)
+    assert result.is_error
+
+
+async def test_cancel_run_requests_cancellation_on_the_named_component():
+    agent = _agent()
+    captured = {}
+
+    async def fake_acancel_run(run_id):
+        captured["run_id"] = run_id
+        return True
+
+    agent.acancel_run = fake_acancel_run  # type: ignore[method-assign]
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool("cancel_run", {"run_id": "run-x", "agent_id": "demo-agent"})
+    assert captured["run_id"] == "run-x"
+    assert "cancellation requested" in result.content[0].text
+
+
+async def test_continue_run_rejects_remote_component(monkeypatch):
+    """Remote components can't carry resolved requirements downstream; continue must fail
+    clearly (like the REST 400) rather than crash."""
+    from agno.agent.remote import RemoteAgent
+
+    remote = RemoteAgent(base_url="http://example.invalid", agent_id="remote-agent")
+    monkeypatch.setattr(mcp_mod, "get_agent_by_id", lambda cid, agents: remote)
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "continue_run",
+            {"run_id": "r1", "session_id": "s1", "agent_id": "remote-agent"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert "remote" in result.content[0].text.lower()
+
+
+async def test_lifecycle_ownership_gate_blocks_other_users(monkeypatch):
+    """A scoped (non-admin) caller cannot cancel a run in a session they do not own."""
+    monkeypatch.setattr(mcp_mod, "_scoped_caller_user_id", lambda: "user-b")
+    agent = _agent()
+    cancelled = {"called": False}
+
+    async def fake_acancel_run(run_id):
+        cancelled["called"] = True
+        return True
+
+    async def fake_aget_session(session_id, user_id):
+        return None  # user-b owns no such session
+
+    agent.acancel_run = fake_acancel_run  # type: ignore[method-assign]
+    agent.aget_session = fake_aget_session  # type: ignore[method-assign]
+    os = AgentOS(agents=[agent], enable_mcp_server=True)
+    async with Client(build_mcp_server(os)) as client:
+        result = await client.call_tool(
+            "cancel_run",
+            {"run_id": "run-a", "session_id": "sess-a", "agent_id": "demo-agent"},
+            raise_on_error=False,
+        )
+    assert result.is_error
+    assert cancelled["called"] is False  # never reached the cancellation registry
+
+
+async def test_get_session_runs_history_is_trimmed():
+    """History reads must not ship the message transcript / system prompt to the client."""
+    session = {
+        "session_id": "s1",
+        "agent_id": "a-1",
+        "runs": [
+            {
+                "run_id": "r1",
+                "agent_id": "a-1",
+                "run_input": "hello",
+                "content": "hi there",
+                "status": "COMPLETED",
+                "messages": [{"role": "system", "content": "SECRET_PROMPT"}],
+                "events": [{"event": "x"}],
+            }
+        ],
+    }
+    from agno.os.schema import RunSchema
+
+    trimmed = mcp_mod._trim_session_run(RunSchema.from_dict(session["runs"][0]))
+    assert trimmed["content"] == "hi there"
+    assert trimmed["status"] == "COMPLETED"
+    assert "messages" not in trimmed
+    assert "events" not in trimmed
+    assert "SECRET_PROMPT" not in str(trimmed)
+
+
+# ==================== Session service ====================
+
+
+class _FakeSyncDb:
+    """Sync BaseDb-shaped stub: exercises the threadpool path in the service."""
+
+    def __init__(self, session=None, sessions=None):
+        self._session = session
+        self._sessions = sessions or []
+
+    def get_session(self, session_id, session_type, user_id, deserialize):
+        return self._session
+
+    def get_sessions(self, **kwargs):
+        return self._sessions, len(self._sessions)
+
+
+async def test_service_auto_detects_workflow_session_and_classifies_runs():
+    session = {
+        "session_id": "s1",
+        "workflow_id": "wf-1",
+        "runs": [
+            {"run_id": "r1", "workflow_id": "wf-1", "content": "wf run"},
+            {"run_id": "r2", "agent_id": "a-1", "content": "member agent run"},
+        ],
+    }
+    runs = await get_session_runs(_FakeSyncDb(session=session), session_id="s1", session_type=None)  # type: ignore[arg-type]
+
+    # workflow_id run renders as a workflow run, the bare agent run falls back to RunSchema
+    assert runs[0].__class__.__name__ == "WorkflowRunSchema"
+    assert runs[1].__class__.__name__ == "RunSchema"
+
+
+async def test_service_raises_session_not_found():
+    with pytest.raises(SessionNotFoundError):
+        await get_session_runs(_FakeSyncDb(session=None), session_id="missing")  # type: ignore[arg-type]
+
+
+async def test_service_lists_sessions_via_threadpool():
+    from agno.db.base import SessionType
+
+    db = _FakeSyncDb(sessions=[{"session_id": "s1", "session_type": "agent"}])
+    sessions, total = await get_sessions_page(db, session_type=SessionType.AGENT)  # type: ignore[arg-type]
+    assert total == 1
+    assert sessions[0]["session_id"] == "s1"
+
+
+# ==================== App wiring ====================
+
+
+def test_resync_reuses_started_mcp_app_and_mount():
+    """resync() must not replace the MCP app (a fresh one's lifespan never runs) and
+    must not accumulate duplicate mounts."""
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    app = os.get_app()
+    mcp_app_before = os._mcp_app
+    assert mcp_app_before is not None
+
+    os.resync(app=app)
+
+    assert os._mcp_app is mcp_app_before
+    mounts = [r for r in app.router.routes if getattr(r, "app", None) is mcp_app_before]
+    assert len(mounts) == 1
+
+
+def test_home_route_works_with_mcp_enabled():
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True)
+    app = os.get_app()
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "AgentOS" in response.text
+
+
+def test_get_app_idempotent_with_base_app():
+    base_app = FastAPI()
+    os = AgentOS(agents=[_agent()], enable_mcp_server=True, base_app=base_app)
+    first = os.get_app()
+    route_count = len(first.router.routes)
+    mcp_app_first = os._mcp_app
+
+    second = os.get_app()
+
+    assert second is first
+    assert len(second.router.routes) == route_count
+    assert os._mcp_app is mcp_app_first
+    mounts = [r for r in second.router.routes if getattr(r, "app", None) is mcp_app_first]
+    assert len(mounts) == 1

--- a/libs/agno/tests/unit/os/test_scopes.py
+++ b/libs/agno/tests/unit/os/test_scopes.py
@@ -2,11 +2,37 @@
 
 from agno.os.scopes import (
     LEGACY_RESOURCE_ALIASES,
+    check_route_scopes,
     get_accessible_resource_ids,
     get_default_scope_mappings,
     has_required_scopes,
     parse_scope,
 )
+
+
+class TestCheckRouteScopes:
+    def test_get_listing_allows_through_with_accessible_ids(self):
+        # A caller lacking the global scope but holding per-resource scopes gets a
+        # filtered listing, not a 403.
+        result = check_route_scopes(["agents:a1:read"], get_default_scope_mappings(), "GET", "/agents")
+        assert result.allowed is True
+        assert result.accessible_resource_ids == {"a1"}
+
+    def test_non_get_idless_route_is_not_allowed_through(self):
+        # Regression: the listing allow-through must be GET-only. A create endpoint
+        # (POST /agents requires agents:write) must 403, never silently allow through.
+        result = check_route_scopes(["agents:a1:read"], get_default_scope_mappings(), "POST", "/agents")
+        assert result.allowed is False
+        assert result.accessible_resource_ids is None
+
+    def test_caller_with_required_scope_is_allowed(self):
+        result = check_route_scopes(["agents:write"], get_default_scope_mappings(), "POST", "/agents")
+        assert result.allowed is True
+
+    def test_unmapped_route_allowed(self):
+        result = check_route_scopes([], get_default_scope_mappings(), "GET", "/totally/unmapped")
+        assert result.allowed is True
+        assert result.required_scopes == []
 
 
 class TestParseScope:

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -90,8 +90,10 @@ class TestNameValidation:
             "user@example.com",  # email shape
             "-leading-dash",
             "a" * 64,  # too long
+            "github-actions\n",  # trailing newline must not sneak past the anchor
+            "claude\ncode",  # embedded newline
         ]:
-            assert not is_valid_service_account_name(name), name
+            assert not is_valid_service_account_name(name), repr(name)
 
 
 class TestPrincipal:
@@ -214,6 +216,20 @@ class TestVerifier:
         # A different client is unaffected
         result = await verifier.verify("agno_pat_bad", client_key="5.6.7.8")
         assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_valid_token_never_blocked_by_limiter(self, sync_db):
+        # A flood of bad tokens must not deny service to a valid token from the same key.
+        plaintext, token_hash, _ = generate_token()
+        verifier = ServiceAccountVerifier(db=sync_db)
+        verifier._limiter.max_failures = 3
+        for _ in range(10):
+            result = await verifier.verify("agno_pat_bad", client_key="1.2.3.4")
+            assert result.status in (VerificationStatus.INVALID, VerificationStatus.THROTTLED)
+        # The valid token still authenticates despite the throttled bucket.
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        result = await verifier.verify(plaintext, client_key="1.2.3.4")
+        assert result.ok
 
     @pytest.mark.asyncio
     async def test_async_db_lookup_is_awaited(self):

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -1,0 +1,237 @@
+"""Unit tests for service account token utils and the ServiceAccountVerifier."""
+
+import time
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.schemas.service_accounts import ServiceAccount
+from agno.os.service_accounts import (
+    DEFAULT_SERVICE_ACCOUNT_SCOPES,
+    TOKEN_DISPLAY_PREFIX_LENGTH,
+    TOKEN_PREFIX,
+    ServiceAccountVerifier,
+    VerificationStatus,
+    generate_token,
+    get_invalid_scopes,
+    get_principal,
+    get_privileged_scopes,
+    hash_token,
+    is_valid_service_account_name,
+)
+
+
+def _make_mock_db_class(base_class):
+    abstract_methods = {}
+    for name in dir(base_class):
+        attr = getattr(base_class, name, None)
+        if getattr(attr, "__isabstractmethod__", False):
+            abstract_methods[name] = MagicMock()
+    return type("MockDb", (base_class,), abstract_methods)
+
+
+def _account_row(
+    name: str = "claude-code",
+    token_hash: str = "hash",
+    expires_at: Optional[int] = None,
+    revoked_at: Optional[int] = None,
+) -> Dict[str, Any]:
+    return {
+        "id": "sa-id-1",
+        "name": name,
+        "token_hash": token_hash,
+        "token_prefix": "agno_pat_abc1234",
+        "scopes": list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
+        "created_at": int(time.time()) - 100,
+        "expires_at": expires_at,
+        "last_used_at": None,
+        "revoked_at": revoked_at,
+        "created_by": "admin-user",
+    }
+
+
+class TestTokenGeneration:
+    def test_token_format(self):
+        plaintext, token_hash, token_prefix = generate_token()
+        assert plaintext.startswith(TOKEN_PREFIX)
+        assert len(token_prefix) == TOKEN_DISPLAY_PREFIX_LENGTH
+        assert plaintext.startswith(token_prefix)
+        assert token_hash == hash_token(plaintext)
+
+    def test_token_random_part_is_base62(self):
+        plaintext, _, _ = generate_token()
+        random_part = plaintext[len(TOKEN_PREFIX) :]
+        assert len(random_part) >= 40
+        assert all(c.isalnum() for c in random_part)
+
+    def test_tokens_are_unique(self):
+        tokens = {generate_token()[0] for _ in range(50)}
+        assert len(tokens) == 50
+
+    def test_hash_is_sha256_hex(self):
+        token_hash = hash_token("agno_pat_test")
+        assert len(token_hash) == 64
+        assert int(token_hash, 16) is not None
+
+
+class TestNameValidation:
+    def test_valid_names(self):
+        for name in ["claude-code", "cursor", "github-actions", "a", "ci_bot-2"]:
+            assert is_valid_service_account_name(name), name
+
+    def test_invalid_names(self):
+        for name in [
+            "",
+            "Claude-Code",  # uppercase
+            "__scheduler__",  # leading underscore
+            "sa:claude-code",  # colon (principal namespace)
+            "user@example.com",  # email shape
+            "-leading-dash",
+            "a" * 64,  # too long
+        ]:
+            assert not is_valid_service_account_name(name), name
+
+
+class TestPrincipal:
+    def test_principal_is_namespaced(self):
+        assert get_principal("claude-code") == "sa:claude-code"
+
+    def test_dataclass_principal_matches(self):
+        account = ServiceAccount.from_dict(_account_row(name="cursor"))
+        assert account.principal == "sa:cursor"
+
+
+class TestScopeHelpers:
+    def test_invalid_scopes_detected(self):
+        assert get_invalid_scopes(["agents:run", "bogus"]) == ["bogus"]
+        assert get_invalid_scopes(["a:b:c:d"]) == ["a:b:c:d"]
+        assert get_invalid_scopes(DEFAULT_SERVICE_ACCOUNT_SCOPES) == []
+
+    def test_privileged_scopes_two_part(self):
+        assert get_privileged_scopes(["sessions:write"]) == ["sessions:write"]
+        assert get_privileged_scopes(["memories:delete"]) == ["memories:delete"]
+        assert get_privileged_scopes(["agents:run", "sessions:read"]) == []
+
+    def test_privileged_scopes_three_part(self):
+        assert get_privileged_scopes(["sessions:*:delete"]) == ["sessions:*:delete"]
+        assert get_privileged_scopes(["agents:my-agent:run"]) == []
+
+    def test_admin_scope_is_privileged(self):
+        assert get_privileged_scopes(["agent_os:admin"]) == ["agent_os:admin"]
+
+    def test_custom_admin_scope_is_privileged(self):
+        assert get_privileged_scopes(["custom:admin:scope"], admin_scope="custom:admin:scope") == ["custom:admin:scope"]
+
+    def test_service_accounts_scopes_are_privileged(self):
+        assert get_privileged_scopes(["service_accounts:read"]) == ["service_accounts:read"]
+        assert get_privileged_scopes(["service_accounts:write"]) == ["service_accounts:write"]
+
+
+class TestVerifier:
+    @pytest.fixture
+    def sync_db(self):
+        MockDbClass = _make_mock_db_class(BaseDb)
+        db = MockDbClass()
+        db.get_service_account_by_token_hash = MagicMock(return_value=None)
+        db.update_service_account = MagicMock(return_value=None)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_is_invalid(self, sync_db):
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify("agno_pat_unknown", client_key="1.2.3.4")
+        assert result.status == VerificationStatus.INVALID
+        assert result.account is None
+
+    @pytest.mark.asyncio
+    async def test_valid_token_ok_and_touches_last_used(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify(plaintext, client_key="1.2.3.4")
+        assert result.ok
+        assert result.account is not None
+        assert result.account.principal == "sa:claude-code"
+        sync_db.get_service_account_by_token_hash.assert_called_once_with(token_hash)
+        sync_db.update_service_account.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_last_used_write_is_throttled(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db)
+        await verifier.verify(plaintext)
+        await verifier.verify(plaintext)
+        assert sync_db.update_service_account.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_revoked_token_is_invalid(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(
+            token_hash=token_hash, revoked_at=int(time.time())
+        )
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify(plaintext)
+        assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_expired_token_is_invalid(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(
+            token_hash=token_hash, expires_at=int(time.time()) - 10
+        )
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify(plaintext)
+        assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_db_error_is_unavailable_and_not_counted(self, sync_db):
+        sync_db.get_service_account_by_token_hash.side_effect = RuntimeError("connection refused")
+        verifier = ServiceAccountVerifier(db=sync_db)
+        verifier._limiter.max_failures = 2
+        for _ in range(5):
+            result = await verifier.verify("agno_pat_whatever", client_key="1.2.3.4")
+            assert result.status == VerificationStatus.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_not_implemented_is_unavailable(self, sync_db):
+        sync_db.get_service_account_by_token_hash.side_effect = NotImplementedError
+        verifier = ServiceAccountVerifier(db=sync_db)
+        result = await verifier.verify("agno_pat_whatever")
+        assert result.status == VerificationStatus.UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_failed_lookups_are_rate_limited(self, sync_db):
+        verifier = ServiceAccountVerifier(db=sync_db)
+        verifier._limiter.max_failures = 3
+        for _ in range(3):
+            result = await verifier.verify("agno_pat_bad", client_key="1.2.3.4")
+            assert result.status == VerificationStatus.INVALID
+        result = await verifier.verify("agno_pat_bad", client_key="1.2.3.4")
+        assert result.status == VerificationStatus.THROTTLED
+        # A different client is unaffected
+        result = await verifier.verify("agno_pat_bad", client_key="5.6.7.8")
+        assert result.status == VerificationStatus.INVALID
+
+    @pytest.mark.asyncio
+    async def test_async_db_lookup_is_awaited(self):
+        MockDbClass = _make_mock_db_class(AsyncBaseDb)
+        db = MockDbClass()
+        plaintext, token_hash, _ = generate_token()
+        row = _account_row(token_hash=token_hash)
+
+        async def _get_by_hash(t):
+            assert t == token_hash
+            return row
+
+        async def _update(account_id, **kwargs):
+            assert kwargs.get("last_used_at") is not None
+            return row
+
+        db.get_service_account_by_token_hash = _get_by_hash
+        db.update_service_account = _update
+        verifier = ServiceAccountVerifier(db=db)
+        result = await verifier.verify(plaintext)
+        assert result.ok

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -14,6 +14,7 @@ from agno.os.service_accounts import (
     TOKEN_PREFIX,
     ServiceAccountVerifier,
     VerificationStatus,
+    _VerificationCache,
     generate_token,
     get_invalid_scopes,
     get_principal,
@@ -131,6 +132,54 @@ class TestScopeHelpers:
         assert get_privileged_scopes(["service_accounts:write"]) == ["service_accounts:write"]
 
 
+class TestVerificationCache:
+    def _account(self, name="claude-code", expires_at=None):
+        return ServiceAccount.from_dict(_account_row(name=name, expires_at=expires_at))
+
+    def test_put_then_get_hits(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        cache.put("h1", self._account())
+        assert cache.get("h1") is not None
+
+    def test_ttl_zero_never_stores_or_serves(self):
+        cache = _VerificationCache(ttl_seconds=0)
+        assert cache.enabled is False
+        cache.put("h1", self._account())
+        assert cache.get("h1") is None
+
+    def test_ttl_expiry_evicts(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        # Force the cached-at timestamp into the past beyond the TTL.
+        cache._entries["h1"] = (self._account(), time.monotonic() - 100)
+        assert cache.get("h1") is None
+        assert "h1" not in cache._entries
+
+    def test_expired_account_not_served_within_ttl(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        # Fresh cache entry (within TTL) but the account itself has expired.
+        cache._entries["h1"] = (self._account(expires_at=int(time.time()) - 10), time.monotonic())
+        assert cache.get("h1") is None
+        assert "h1" not in cache._entries
+
+    def test_lru_eviction(self):
+        cache = _VerificationCache(ttl_seconds=30, max_entries=2)
+        cache.put("h1", self._account("a"))
+        cache.put("h2", self._account("b"))
+        cache.get("h1")  # h1 becomes most-recently-used
+        cache.put("h3", self._account("c"))  # evicts the LRU entry (h2)
+        assert cache.get("h1") is not None
+        assert cache.get("h2") is None
+        assert cache.get("h3") is not None
+
+    def test_invalidate_removes_entry(self):
+        cache = _VerificationCache(ttl_seconds=30)
+        cache.put("h1", self._account())
+        cache.invalidate("h1")
+        assert cache.get("h1") is None
+        # Idempotent
+        cache.invalidate("h1")
+
+
 class TestVerifier:
     @pytest.fixture
     def sync_db(self):
@@ -230,6 +279,55 @@ class TestVerifier:
         sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
         result = await verifier.verify(plaintext, client_key="1.2.3.4")
         assert result.ok
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_avoids_second_db_lookup(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=30)
+        first = await verifier.verify(plaintext)
+        second = await verifier.verify(plaintext)
+        assert first.ok and second.ok
+        # The DB is consulted only once; the second verify is served from cache.
+        sync_db.get_service_account_by_token_hash.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ttl_zero_disables_cache(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=0)
+        await verifier.verify(plaintext)
+        await verifier.verify(plaintext)
+        assert sync_db.get_service_account_by_token_hash.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_invalidate_forces_next_verify_to_hit_db(self, sync_db):
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=30)
+        await verifier.verify(plaintext)
+        verifier.invalidate(token_hash)
+        await verifier.verify(plaintext)
+        assert sync_db.get_service_account_by_token_hash.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_revoked_after_cache_served_until_invalidated(self, sync_db):
+        # Convergence semantics: a token cached as valid keeps authenticating within the
+        # TTL until the local cache is evicted; once evicted it reflects the revocation.
+        plaintext, token_hash, _ = generate_token()
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(token_hash=token_hash)
+        verifier = ServiceAccountVerifier(db=sync_db, cache_ttl_seconds=30)
+        assert (await verifier.verify(plaintext)).ok
+
+        # Account is revoked in the DB, but the cached entry still authenticates.
+        sync_db.get_service_account_by_token_hash.return_value = _account_row(
+            token_hash=token_hash, revoked_at=int(time.time())
+        )
+        assert (await verifier.verify(plaintext)).ok
+
+        # After eviction, the next verify reflects the revocation.
+        verifier.invalidate(token_hash)
+        assert (await verifier.verify(plaintext)).status == VerificationStatus.INVALID
 
     @pytest.mark.asyncio
     async def test_async_db_lookup_is_awaited(self):

--- a/libs/agno_cli/LICENSE
+++ b/libs/agno_cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025-2026 Agno Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libs/agno_cli/README.md
+++ b/libs/agno_cli/README.md
@@ -13,9 +13,15 @@ This discovers the AgentOS (default `http://localhost:7777`), mints one service-
 ## Commands
 
 ```bash
+agno create NAME [-t agentos-docker|agentos-aws|agentos-railway] [-u REPO_URL] [--json]
+
+agno infra up [--file FILE] [--pull] [--dry-run] [--json]
+agno infra down [--file FILE] [--volumes] [--dry-run] [--json]
+agno infra restart [--file FILE] [--pull] [--dry-run] [--json]
+
 agno connect [--url URL] [--clients claude-code,codex,cursor] [--name NAME]
-             [--scopes SCOPE ...] [--expires 90d] [--rotate | --skip-existing]
-             [--server-name agno] [--project] [--json]
+             [--scopes SCOPE ...] [--expires 90d] [--privileged]
+             [--rotate | --skip-existing] [--server-name agno] [--project] [--json]
 
 agno tokens create NAME [--scopes SCOPE ...] [--expires 90d|never] [--privileged] [--json]
 agno tokens list [--json]
@@ -24,11 +30,16 @@ agno tokens revoke NAME [--json]
 agno status [--url URL] [--json]
 ```
 
+`create` scaffolds an AgentOS project from a starter template (git clone, history stripped,
+example secrets copied into place). `infra` runs the project's compose file — the legacy
+`ag infra` resource engine (per-resource Docker/AWS orchestration) is not ported; it is
+under redesign and will plug in via the `agno_cli.plugins` entry-point group.
+
 Admin credential resolution (for minting): `AGNO_ADMIN_TOKEN` env var, then `OS_SECURITY_KEY` env var, then an interactive prompt. When the target AgentOS has authorization disabled (local dev), minting is skipped and configs are written without credentials.
 
 ## Design rules
 
-- Built to be driven by coding agents: `--json` on every command, deterministic exit codes (0 ok, 1 failure, 2 partial), no prompts in `--json` mode.
+- Built to be driven by coding agents: `--json` on every command, deterministic exit codes (0 ok, 1 failure, 2 usage error, 3 partial success), no prompts in `--json` mode.
 - Talks plain HTTP to the AgentOS REST API. Never imports the `agno` framework.
 - Truthful outcomes: no command reports success it did not verify.
 - Secrets never go to logs; `connect` writes tokens straight into client configs and never prints them. `tokens create` prints the plaintext exactly once.

--- a/libs/agno_cli/README.md
+++ b/libs/agno_cli/README.md
@@ -1,0 +1,43 @@
+# agnoctl — the Agno CLI
+
+The operating surface for [AgentOS](https://docs.agno.com), built for humans and coding agents equally.
+
+The headline command connects a running AgentOS to your coding agents as an MCP server, authenticated with freshly minted service accounts:
+
+```bash
+uvx agno connect
+```
+
+This discovers the AgentOS (default `http://localhost:7777`), mints one service-account token per client (`claude-code`, `codex`, `cursor`), writes each client's MCP configuration, and verifies the connection end to end with a real MCP `tools/list` call. Re-running is safe: existing working connections are detected and skipped, broken ones are rotated.
+
+## Commands
+
+```bash
+agno connect [--url URL] [--clients claude-code,codex,cursor] [--name NAME]
+             [--scopes SCOPE ...] [--expires 90d] [--rotate | --skip-existing]
+             [--server-name agno] [--project] [--json]
+
+agno tokens create NAME [--scopes SCOPE ...] [--expires 90d|never] [--privileged] [--json]
+agno tokens list [--json]
+agno tokens revoke NAME [--json]
+
+agno status [--url URL] [--json]
+```
+
+Admin credential resolution (for minting): `AGNO_ADMIN_TOKEN` env var, then `OS_SECURITY_KEY` env var, then an interactive prompt. When the target AgentOS has authorization disabled (local dev), minting is skipped and configs are written without credentials.
+
+## Design rules
+
+- Built to be driven by coding agents: `--json` on every command, deterministic exit codes (0 ok, 1 failure, 2 partial), no prompts in `--json` mode.
+- Talks plain HTTP to the AgentOS REST API. Never imports the `agno` framework.
+- Truthful outcomes: no command reports success it did not verify.
+- Secrets never go to logs; `connect` writes tokens straight into client configs and never prints them. `tokens create` prints the plaintext exactly once.
+
+## Plugins
+
+Other distributions can add subcommands by exposing a `typer.Typer` under the `agno_cli.plugins` entry-point group:
+
+```toml
+[project.entry-points."agno_cli.plugins"]
+infra = "agno_infra.cli:infra_app"
+```

--- a/libs/agno_cli/README.md
+++ b/libs/agno_cli/README.md
@@ -15,9 +15,9 @@ This discovers the AgentOS (default `http://localhost:7777`), mints one service-
 ```bash
 agno create NAME [-t agentos-docker|agentos-aws|agentos-railway] [-u REPO_URL] [--json]
 
-agno infra up [--file FILE] [--pull] [--dry-run] [--json]
-agno infra down [--file FILE] [--volumes] [--dry-run] [--json]
-agno infra restart [--file FILE] [--pull] [--dry-run] [--json]
+agno up [--file FILE] [--pull] [--dry-run] [--json]
+agno down [--file FILE] [--volumes] [--dry-run] [--json]
+agno restart [--file FILE] [--pull] [--dry-run] [--json]
 
 agno connect [--url URL] [--clients claude-code,codex,cursor] [--name NAME]
              [--scopes SCOPE ...] [--expires 90d] [--privileged]
@@ -31,7 +31,7 @@ agno status [--url URL] [--json]
 ```
 
 `create` scaffolds an AgentOS project from a starter template (git clone, history stripped,
-example secrets copied into place). `infra` runs the project's compose file — the legacy
+example secrets copied into place). `up`/`down`/`restart` run the project's compose file — the legacy
 `ag infra` resource engine (per-resource Docker/AWS orchestration) is not ported; it is
 under redesign and will plug in via the `agno_cli.plugins` entry-point group.
 

--- a/libs/agno_cli/agno_cli/__init__.py
+++ b/libs/agno_cli/agno_cli/__init__.py
@@ -1,0 +1,3 @@
+"""agnoctl: the Agno CLI. Connect and operate AgentOS from the terminal."""
+
+__version__ = "0.1.0"

--- a/libs/agno_cli/agno_cli/clients/__init__.py
+++ b/libs/agno_cli/agno_cli/clients/__init__.py
@@ -1,0 +1,31 @@
+"""Client adapters: how each coding agent stores MCP server configuration."""
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult
+from agno_cli.clients.claude_code import ClaudeCodeAdapter
+from agno_cli.clients.codex import CodexAdapter
+from agno_cli.clients.cursor import CursorAdapter
+
+# Accepted spellings for --clients, mapped to canonical adapter keys.
+CLIENT_ALIASES = {
+    "claude": "claude-code",
+    "claude-code": "claude-code",
+    "codex": "codex",
+    "cursor": "cursor",
+}
+
+
+def build_adapters(
+    home: Optional[Path] = None,
+    cwd: Optional[Path] = None,
+    project: bool = False,
+) -> Dict[str, ClientAdapter]:
+    """All known adapters keyed by canonical client key."""
+    claude_scope = "project" if project else "user"
+    return {
+        "claude-code": ClaudeCodeAdapter(home=home, cwd=cwd, scope=claude_scope),
+        "codex": CodexAdapter(home=home),
+        "cursor": CursorAdapter(home=home, cwd=cwd, project=project),
+    }

--- a/libs/agno_cli/agno_cli/clients/base.py
+++ b/libs/agno_cli/agno_cli/clients/base.py
@@ -25,6 +25,16 @@ class WriteResult:
 
     method: str  # "cli" (client's own CLI did the write) | "file" (we edited the config file)
     location: str
+    note: Optional[str] = None  # caveat worth surfacing to the user (e.g. VCS-shared file)
+
+
+def servers_table(config: object) -> dict:
+    """The mcpServers mapping from a parsed config, tolerating malformed shapes."""
+    if isinstance(config, dict):
+        servers = config.get("mcpServers")
+        if isinstance(servers, dict):
+            return servers
+    return {}
 
 
 def bearer_header(token: str) -> str:

--- a/libs/agno_cli/agno_cli/clients/base.py
+++ b/libs/agno_cli/agno_cli/clients/base.py
@@ -1,0 +1,57 @@
+"""Shared shapes for coding-agent client adapters.
+
+An adapter knows how one coding agent (Claude Code, Codex, Cursor) stores MCP server
+configuration: how to detect the client on this machine, read an existing entry back
+(for idempotent re-runs), and write an entry pointing at an AgentOS MCP endpoint.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ExistingEntry:
+    """An MCP server entry found in a client's configuration."""
+
+    url: str
+    token: Optional[str]
+    location: str  # human-readable: file path or config scope it was found in
+
+
+@dataclass
+class WriteResult:
+    """How and where a config write landed."""
+
+    method: str  # "cli" (client's own CLI did the write) | "file" (we edited the config file)
+    location: str
+
+
+def bearer_header(token: str) -> str:
+    return "Bearer " + token
+
+
+def token_from_authorization(value: Optional[str]) -> Optional[str]:
+    """Extract the raw token from an Authorization header value."""
+    if not value:
+        return None
+    if value.lower().startswith("bearer "):
+        return value[len("bearer ") :].strip() or None
+    return value.strip() or None
+
+
+class ClientAdapter(ABC):
+    key: str
+    display_name: str
+
+    @abstractmethod
+    def detect(self) -> bool:
+        """Whether this client appears to be installed or configured on this machine."""
+
+    @abstractmethod
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        """Return the existing MCP entry for server_name, if any."""
+
+    @abstractmethod
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        """Create or replace the MCP entry for server_name. Must be idempotent."""

--- a/libs/agno_cli/agno_cli/clients/claude_code.py
+++ b/libs/agno_cli/agno_cli/clients/claude_code.py
@@ -1,12 +1,18 @@
 """Claude Code adapter.
 
-Preferred path: the `claude mcp add` CLI (it owns its config files and handles scope
-placement). Fallback when the binary is missing: write the project-scoped .mcp.json,
-which Claude Code reads from the project root and which is safe for us to edit.
+Preferred write path: the `claude mcp add` CLI (the sanctioned interface; it owns config
+placement). Fallback when the binary is missing: edit the config file for the requested
+scope directly — ~/.claude.json (user scope) or <cwd>/.mcp.json (project scope).
 
-Config locations read for idempotency checks:
-- ~/.claude.json: top-level "mcpServers" (user scope) and projects.<cwd>.mcpServers (local scope)
-- <cwd>/.mcp.json: "mcpServers" (project scope)
+Reads follow Claude Code's same-name resolution precedence: local scope
+(~/.claude.json projects.<cwd>.mcpServers) > project (.mcp.json) > user
+(~/.claude.json mcpServers). Getting this order right matters: the entry this
+adapter reports is the one Claude Code will actually use, which is how connect
+detects stale shadowing entries after a write.
+
+Note: the CLI write path passes the Authorization header via argv, which is transiently
+visible in the local process list. The file fallback avoids this; both paths end with a
+read-back so a write that did not take effect is reported, never assumed.
 """
 
 import json
@@ -15,11 +21,20 @@ import subprocess
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.clients.base import (
+    ClientAdapter,
+    ExistingEntry,
+    WriteResult,
+    bearer_header,
+    servers_table,
+    token_from_authorization,
+)
 from agno_cli.errors import CLIError
 
+SUBPROCESS_TIMEOUT = 60.0
 
-def _entry_from_config(servers: Dict[str, Any], server_name: str, location: str) -> Optional[ExistingEntry]:
+
+def _entry_from_servers(servers: Dict[str, Any], server_name: str, location: str) -> Optional[ExistingEntry]:
     entry = servers.get(server_name)
     if not isinstance(entry, dict):
         return None
@@ -62,39 +77,55 @@ class ClaudeCodeAdapter(ClientAdapter):
         return self._which("claude") is not None or self._user_config_path.exists()
 
     def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
-        project_config = self._read_json(self._project_config_path)
-        if project_config:
-            entry = _entry_from_config(
-                project_config.get("mcpServers") or {}, server_name, str(self._project_config_path)
-            )
-            if entry:
-                return entry
+        """Return the entry Claude Code would resolve: local > project > user scope."""
+        user_config = self._read_json_lenient(self._user_config_path)
 
-        user_config = self._read_json(self._user_config_path)
         if user_config:
-            entry = _entry_from_config(
-                user_config.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (user scope)"
-            )
-            if entry:
-                return entry
             projects = user_config.get("projects")
             if isinstance(projects, dict):
                 project = projects.get(str(self.cwd))
                 if isinstance(project, dict):
-                    entry = _entry_from_config(
-                        project.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (local scope)"
+                    entry = _entry_from_servers(
+                        servers_table(project), server_name, str(self._user_config_path) + " (local scope)"
                     )
                     if entry:
                         return entry
+
+        project_config = self._read_json_lenient(self._project_config_path)
+        if project_config:
+            entry = _entry_from_servers(servers_table(project_config), server_name, str(self._project_config_path))
+            if entry:
+                return entry
+
+        if user_config:
+            entry = _entry_from_servers(
+                servers_table(user_config), server_name, str(self._user_config_path) + " (user scope)"
+            )
+            if entry:
+                return entry
         return None
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         if self._which("claude") is not None:
             self._write_via_cli(server_name, url, token)
             return WriteResult(method="cli", location="claude mcp add (scope: " + self.scope + ")")
-        return self._write_project_file(server_name, url, token)
+        if self.scope == "project":
+            return self._write_config_file(self._project_config_path, server_name, url, token, top_level=True)
+        return self._write_config_file(self._user_config_path, server_name, url, token, top_level=True)
 
     # -- CLI path ---------------------------------------------------------------
+
+    def _run_claude(self, args: List[str]) -> "subprocess.CompletedProcess[str]":
+        try:
+            return self._runner(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=SUBPROCESS_TIMEOUT,
+                stdin=subprocess.DEVNULL,
+            )
+        except subprocess.TimeoutExpired:
+            raise CLIError("The claude CLI did not respond within " + str(int(SUBPROCESS_TIMEOUT)) + "s: " + args[2])
 
     def _write_via_cli(self, server_name: str, url: str, token: Optional[str]) -> None:
         # Variadic flags (--header) must come after the name and URL, or Claude Code's
@@ -103,32 +134,42 @@ class ClaudeCodeAdapter(ClientAdapter):
         if token:
             add_args += ["--header", "Authorization: " + bearer_header(token)]
 
-        result = self._runner(add_args, capture_output=True, text=True)
+        result = self._run_claude(add_args)
         if result.returncode != 0 and "already exists" in (result.stderr or "").lower():
-            remove = self._runner(
-                ["claude", "mcp", "remove", "--scope", self.scope, server_name], capture_output=True, text=True
-            )
+            remove = self._run_claude(["claude", "mcp", "remove", "--scope", self.scope, server_name])
             if remove.returncode == 0:
-                result = self._runner(add_args, capture_output=True, text=True)
+                result = self._run_claude(add_args)
         if result.returncode != 0:
             detail = (result.stderr or result.stdout or "").strip()
             raise CLIError("claude mcp add failed: " + (detail or "unknown error"))
 
     # -- File fallback ------------------------------------------------------------
 
-    def _write_project_file(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
-        path = self._project_config_path
-        config = self._read_json(path) or {}
-        servers = config.setdefault("mcpServers", {})
+    def _write_config_file(
+        self, path: Path, server_name: str, url: str, token: Optional[str], top_level: bool
+    ) -> WriteResult:
+        config = self._read_json_strict(path)
+        servers = config.get("mcpServers")
+        if servers is None:
+            servers = {}
+            config["mcpServers"] = servers
+        elif not isinstance(servers, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": 'mcpServers' is not an object.")
         entry: Dict[str, Any] = {"type": "http", "url": url}
         if token:
             entry["headers"] = {"Authorization": bearer_header(token)}
         servers[server_name] = entry
         path.write_text(json.dumps(config, indent=2) + "\n")
-        return WriteResult(method="file", location=str(path))
+        if token:
+            path.chmod(0o600)
+        note = None
+        if path == self._project_config_path and token:
+            note = str(path) + " is project-scoped and often committed to version control; it now contains a token."
+        return WriteResult(method="file", location=str(path), note=note)
 
     @staticmethod
-    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    def _read_json_lenient(path: Path) -> Optional[Dict[str, Any]]:
+        """For reads: a missing or malformed file simply means no entry found."""
         if not path.exists():
             return None
         try:
@@ -136,3 +177,19 @@ class ClaudeCodeAdapter(ClientAdapter):
         except (OSError, json.JSONDecodeError):
             return None
         return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
+    def _read_json_strict(path: Path) -> Dict[str, Any]:
+        """For writes: refuse to clobber a file we cannot parse."""
+        if not path.exists():
+            return {}
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            raise CLIError(
+                "Refusing to modify " + str(path) + ": the existing file is not valid JSON (" + str(e) + ").",
+                hint="Fix or move the file, then re-run.",
+            )
+        if not isinstance(parsed, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": expected a JSON object at the top level.")
+        return parsed

--- a/libs/agno_cli/agno_cli/clients/claude_code.py
+++ b/libs/agno_cli/agno_cli/clients/claude_code.py
@@ -1,0 +1,138 @@
+"""Claude Code adapter.
+
+Preferred path: the `claude mcp add` CLI (it owns its config files and handles scope
+placement). Fallback when the binary is missing: write the project-scoped .mcp.json,
+which Claude Code reads from the project root and which is safe for us to edit.
+
+Config locations read for idempotency checks:
+- ~/.claude.json: top-level "mcpServers" (user scope) and projects.<cwd>.mcpServers (local scope)
+- <cwd>/.mcp.json: "mcpServers" (project scope)
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.errors import CLIError
+
+
+def _entry_from_config(servers: Dict[str, Any], server_name: str, location: str) -> Optional[ExistingEntry]:
+    entry = servers.get(server_name)
+    if not isinstance(entry, dict):
+        return None
+    url = entry.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    headers = entry.get("headers")
+    if not isinstance(headers, dict):
+        headers = {}
+    return ExistingEntry(url=url, token=token_from_authorization(headers.get("Authorization")), location=location)
+
+
+class ClaudeCodeAdapter(ClientAdapter):
+    key = "claude-code"
+    display_name = "Claude Code"
+
+    def __init__(
+        self,
+        home: Optional[Path] = None,
+        cwd: Optional[Path] = None,
+        scope: str = "user",
+        which: Callable[[str], Optional[str]] = shutil.which,
+        runner: Callable[..., "subprocess.CompletedProcess[str]"] = subprocess.run,
+    ):
+        self.home = home or Path.home()
+        self.cwd = cwd or Path.cwd()
+        self.scope = scope
+        self._which = which
+        self._runner = runner
+
+    @property
+    def _user_config_path(self) -> Path:
+        return self.home / ".claude.json"
+
+    @property
+    def _project_config_path(self) -> Path:
+        return self.cwd / ".mcp.json"
+
+    def detect(self) -> bool:
+        return self._which("claude") is not None or self._user_config_path.exists()
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        project_config = self._read_json(self._project_config_path)
+        if project_config:
+            entry = _entry_from_config(
+                project_config.get("mcpServers") or {}, server_name, str(self._project_config_path)
+            )
+            if entry:
+                return entry
+
+        user_config = self._read_json(self._user_config_path)
+        if user_config:
+            entry = _entry_from_config(
+                user_config.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (user scope)"
+            )
+            if entry:
+                return entry
+            projects = user_config.get("projects")
+            if isinstance(projects, dict):
+                project = projects.get(str(self.cwd))
+                if isinstance(project, dict):
+                    entry = _entry_from_config(
+                        project.get("mcpServers") or {}, server_name, str(self._user_config_path) + " (local scope)"
+                    )
+                    if entry:
+                        return entry
+        return None
+
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        if self._which("claude") is not None:
+            self._write_via_cli(server_name, url, token)
+            return WriteResult(method="cli", location="claude mcp add (scope: " + self.scope + ")")
+        return self._write_project_file(server_name, url, token)
+
+    # -- CLI path ---------------------------------------------------------------
+
+    def _write_via_cli(self, server_name: str, url: str, token: Optional[str]) -> None:
+        # Variadic flags (--header) must come after the name and URL, or Claude Code's
+        # parser consumes the positional arguments.
+        add_args: List[str] = ["claude", "mcp", "add", "--transport", "http", "--scope", self.scope, server_name, url]
+        if token:
+            add_args += ["--header", "Authorization: " + bearer_header(token)]
+
+        result = self._runner(add_args, capture_output=True, text=True)
+        if result.returncode != 0 and "already exists" in (result.stderr or "").lower():
+            remove = self._runner(
+                ["claude", "mcp", "remove", "--scope", self.scope, server_name], capture_output=True, text=True
+            )
+            if remove.returncode == 0:
+                result = self._runner(add_args, capture_output=True, text=True)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise CLIError("claude mcp add failed: " + (detail or "unknown error"))
+
+    # -- File fallback ------------------------------------------------------------
+
+    def _write_project_file(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        path = self._project_config_path
+        config = self._read_json(path) or {}
+        servers = config.setdefault("mcpServers", {})
+        entry: Dict[str, Any] = {"type": "http", "url": url}
+        if token:
+            entry["headers"] = {"Authorization": bearer_header(token)}
+        servers[server_name] = entry
+        path.write_text(json.dumps(config, indent=2) + "\n")
+        return WriteResult(method="file", location=str(path))
+
+    @staticmethod
+    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+        if not path.exists():
+            return None
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None

--- a/libs/agno_cli/agno_cli/clients/codex.py
+++ b/libs/agno_cli/agno_cli/clients/codex.py
@@ -71,6 +71,18 @@ class CodexAdapter(ClientAdapter):
         block = "\n".join(block_lines) + "\n"
 
         existing_text = self.config_path.read_text() if self.config_path.exists() else ""
+        if existing_text:
+            try:
+                tomllib.loads(existing_text)
+            except tomllib.TOMLDecodeError as e:
+                raise CLIError(
+                    "Refusing to modify "
+                    + str(self.config_path)
+                    + ": the existing TOML does not parse ("
+                    + str(e)
+                    + ").",
+                    hint="Fix or move the file, then re-run.",
+                )
         new_text = self._replace_section(existing_text, server_name, block)
 
         try:
@@ -81,9 +93,8 @@ class CodexAdapter(ClientAdapter):
             )
 
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
-        created = not self.config_path.exists()
         self.config_path.write_text(new_text)
-        if created:
+        if token:
             self.config_path.chmod(0o600)
         return WriteResult(method="file", location=str(self.config_path))
 
@@ -99,25 +110,47 @@ class CodexAdapter(ClientAdapter):
 
     @staticmethod
     def _replace_section(text: str, server_name: str, block: str) -> str:
-        """Replace (or append) the [mcp_servers.<name>] section, including dotted subtables."""
+        """Replace (or append) the [mcp_servers.<name>] section, including dotted subtables.
+
+        Every table header — [table] and [[array-of-tables]] alike — ends the previous
+        section, so content following the managed section is never swallowed. Trailing
+        comment/blank lines inside the managed section that lead into the next header
+        are preserved, since they usually describe what follows.
+        """
         section_prefix = "[mcp_servers." + server_name
         lines = text.splitlines()
         kept: List[str] = []
+        dropped: List[str] = []
         insert_at: Optional[int] = None
         in_section = False
+
+        def flush_trailing_comments() -> None:
+            trailing: List[str] = []
+            for dropped_line in reversed(dropped):
+                if dropped_line.strip() == "" or dropped_line.lstrip().startswith("#"):
+                    trailing.append(dropped_line)
+                else:
+                    break
+            kept.extend(reversed(trailing))
+            dropped.clear()
+
         for line in lines:
             stripped = line.strip()
-            is_header = stripped.startswith("[") and not stripped.startswith("[[")
-            if is_header:
+            if stripped.startswith("["):
                 owns = stripped.startswith(section_prefix + "]") or stripped.startswith(section_prefix + ".")
+                if in_section and not owns:
+                    flush_trailing_comments()
+                in_section = owns
                 if owns:
-                    in_section = True
                     if insert_at is None:
                         insert_at = len(kept)
                     continue
-                in_section = False
-            if not in_section:
+            if in_section:
+                dropped.append(line)
+            else:
                 kept.append(line)
+        if in_section:
+            dropped.clear()
 
         block_lines = block.rstrip("\n").splitlines()
         if insert_at is not None:

--- a/libs/agno_cli/agno_cli/clients/codex.py
+++ b/libs/agno_cli/agno_cli/clients/codex.py
@@ -1,0 +1,129 @@
+"""OpenAI Codex adapter.
+
+Codex reads MCP servers from ~/.codex/config.toml as [mcp_servers.<name>] tables. The
+`codex mcp add` CLI cannot set static HTTP headers (only --bearer-token-env-var, which
+requires the user to manage an environment variable), so this adapter edits the config
+file directly, using a static http_headers table for zero-setup authentication.
+
+The edit is a section-scoped text replacement: only lines belonging to
+[mcp_servers.<name>] (and its dotted subtables) are touched, so user comments and other
+servers survive. The result is validated by re-parsing before it is written.
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.errors import CLIError
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+def _toml_string(value: str) -> str:
+    # TOML basic strings share JSON's escaping rules for the characters that matter here.
+    return json.dumps(value)
+
+
+class CodexAdapter(ClientAdapter):
+    key = "codex"
+    display_name = "Codex"
+
+    def __init__(self, home: Optional[Path] = None):
+        self.home = home or Path.home()
+
+    @property
+    def config_path(self) -> Path:
+        return self.home / ".codex" / "config.toml"
+
+    def detect(self) -> bool:
+        return (self.home / ".codex").is_dir()
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        parsed = self._parse_config()
+        if parsed is None:
+            return None
+        entry = (parsed.get("mcp_servers") or {}).get(server_name)
+        if not isinstance(entry, dict):
+            return None
+        url = entry.get("url")
+        if not isinstance(url, str) or not url:
+            return None
+        headers = entry.get("http_headers")
+        if not isinstance(headers, dict):
+            headers = {}
+        return ExistingEntry(
+            url=url,
+            token=token_from_authorization(headers.get("Authorization")),
+            location=str(self.config_path),
+        )
+
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        block_lines = ["[mcp_servers." + server_name + "]", "url = " + _toml_string(url)]
+        if token:
+            block_lines.append(
+                "http_headers = { " + _toml_string("Authorization") + " = " + _toml_string(bearer_header(token)) + " }"
+            )
+        block = "\n".join(block_lines) + "\n"
+
+        existing_text = self.config_path.read_text() if self.config_path.exists() else ""
+        new_text = self._replace_section(existing_text, server_name, block)
+
+        try:
+            tomllib.loads(new_text)
+        except tomllib.TOMLDecodeError as e:
+            raise CLIError(
+                "Refusing to write " + str(self.config_path) + ": the resulting TOML would be invalid (" + str(e) + ")."
+            )
+
+        self.config_path.parent.mkdir(parents=True, exist_ok=True)
+        created = not self.config_path.exists()
+        self.config_path.write_text(new_text)
+        if created:
+            self.config_path.chmod(0o600)
+        return WriteResult(method="file", location=str(self.config_path))
+
+    # -- Internals -----------------------------------------------------------------
+
+    def _parse_config(self) -> Optional[Dict[str, Any]]:
+        if not self.config_path.exists():
+            return None
+        try:
+            return tomllib.loads(self.config_path.read_text())
+        except (OSError, tomllib.TOMLDecodeError):
+            return None
+
+    @staticmethod
+    def _replace_section(text: str, server_name: str, block: str) -> str:
+        """Replace (or append) the [mcp_servers.<name>] section, including dotted subtables."""
+        section_prefix = "[mcp_servers." + server_name
+        lines = text.splitlines()
+        kept: List[str] = []
+        insert_at: Optional[int] = None
+        in_section = False
+        for line in lines:
+            stripped = line.strip()
+            is_header = stripped.startswith("[") and not stripped.startswith("[[")
+            if is_header:
+                owns = stripped.startswith(section_prefix + "]") or stripped.startswith(section_prefix + ".")
+                if owns:
+                    in_section = True
+                    if insert_at is None:
+                        insert_at = len(kept)
+                    continue
+                in_section = False
+            if not in_section:
+                kept.append(line)
+
+        block_lines = block.rstrip("\n").splitlines()
+        if insert_at is not None:
+            kept[insert_at:insert_at] = block_lines
+        else:
+            if kept and kept[-1].strip():
+                kept.append("")
+            kept.extend(block_lines)
+        return "\n".join(kept).rstrip("\n") + "\n"

--- a/libs/agno_cli/agno_cli/clients/cursor.py
+++ b/libs/agno_cli/agno_cli/clients/cursor.py
@@ -10,7 +10,15 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+from agno_cli.clients.base import (
+    ClientAdapter,
+    ExistingEntry,
+    WriteResult,
+    bearer_header,
+    servers_table,
+    token_from_authorization,
+)
+from agno_cli.errors import CLIError
 
 
 class CursorAdapter(ClientAdapter):
@@ -34,10 +42,10 @@ class CursorAdapter(ClientAdapter):
     def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
         # Project config wins on collisions, so check it first even in global mode.
         for path in (self.cwd / ".cursor" / "mcp.json", self.home / ".cursor" / "mcp.json"):
-            config = self._read_json(path)
-            if not config:
+            config = self._read_json_lenient(path)
+            if config is None:
                 continue
-            entry = (config.get("mcpServers") or {}).get(server_name)
+            entry = servers_table(config).get(server_name)
             if not isinstance(entry, dict):
                 continue
             url = entry.get("url")
@@ -55,22 +63,30 @@ class CursorAdapter(ClientAdapter):
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         path = self.config_path
-        config = self._read_json(path) or {}
-        servers = config.setdefault("mcpServers", {})
+        config = self._read_json_strict(path)
+        servers = config.get("mcpServers")
+        if servers is None:
+            servers = {}
+            config["mcpServers"] = servers
+        elif not isinstance(servers, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": 'mcpServers' is not an object.")
         entry: Dict[str, Any] = {"url": url}
         if token:
             entry["headers"] = {"Authorization": bearer_header(token)}
         servers[server_name] = entry
 
         path.parent.mkdir(parents=True, exist_ok=True)
-        created = not path.exists()
         path.write_text(json.dumps(config, indent=2) + "\n")
-        if created:
+        if token:
             path.chmod(0o600)
-        return WriteResult(method="file", location=str(path))
+        note = None
+        if self.project and token:
+            note = str(path) + " is project-scoped; keep it out of version control (it now contains a token)."
+        return WriteResult(method="file", location=str(path), note=note)
 
     @staticmethod
-    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+    def _read_json_lenient(path: Path) -> Optional[Dict[str, Any]]:
+        """For reads: a missing or malformed file simply means no entry found."""
         if not path.exists():
             return None
         try:
@@ -78,3 +94,19 @@ class CursorAdapter(ClientAdapter):
         except (OSError, json.JSONDecodeError):
             return None
         return parsed if isinstance(parsed, dict) else None
+
+    @staticmethod
+    def _read_json_strict(path: Path) -> Dict[str, Any]:
+        """For writes: refuse to clobber a file we cannot parse."""
+        if not path.exists():
+            return {}
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            raise CLIError(
+                "Refusing to modify " + str(path) + ": the existing file is not valid JSON (" + str(e) + ").",
+                hint="Fix or move the file, then re-run.",
+            )
+        if not isinstance(parsed, dict):
+            raise CLIError("Refusing to modify " + str(path) + ": expected a JSON object at the top level.")
+        return parsed

--- a/libs/agno_cli/agno_cli/clients/cursor.py
+++ b/libs/agno_cli/agno_cli/clients/cursor.py
@@ -1,0 +1,80 @@
+"""Cursor adapter.
+
+Cursor has no CLI for adding MCP servers; the supported programmatic path is editing
+mcp.json directly: ~/.cursor/mcp.json (global, all projects) or <project>/.cursor/mcp.json
+(project-scoped, wins on name collisions). Remote servers are configured with a url and
+optional headers; transport is inferred from the presence of url.
+"""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from agno_cli.clients.base import ClientAdapter, ExistingEntry, WriteResult, bearer_header, token_from_authorization
+
+
+class CursorAdapter(ClientAdapter):
+    key = "cursor"
+    display_name = "Cursor"
+
+    def __init__(self, home: Optional[Path] = None, cwd: Optional[Path] = None, project: bool = False):
+        self.home = home or Path.home()
+        self.cwd = cwd or Path.cwd()
+        self.project = project
+
+    @property
+    def config_path(self) -> Path:
+        if self.project:
+            return self.cwd / ".cursor" / "mcp.json"
+        return self.home / ".cursor" / "mcp.json"
+
+    def detect(self) -> bool:
+        return (self.home / ".cursor").is_dir()
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        # Project config wins on collisions, so check it first even in global mode.
+        for path in (self.cwd / ".cursor" / "mcp.json", self.home / ".cursor" / "mcp.json"):
+            config = self._read_json(path)
+            if not config:
+                continue
+            entry = (config.get("mcpServers") or {}).get(server_name)
+            if not isinstance(entry, dict):
+                continue
+            url = entry.get("url")
+            if not isinstance(url, str) or not url:
+                continue
+            headers = entry.get("headers")
+            if not isinstance(headers, dict):
+                headers = {}
+            return ExistingEntry(
+                url=url,
+                token=token_from_authorization(headers.get("Authorization")),
+                location=str(path),
+            )
+        return None
+
+    def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
+        path = self.config_path
+        config = self._read_json(path) or {}
+        servers = config.setdefault("mcpServers", {})
+        entry: Dict[str, Any] = {"url": url}
+        if token:
+            entry["headers"] = {"Authorization": bearer_header(token)}
+        servers[server_name] = entry
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        created = not path.exists()
+        path.write_text(json.dumps(config, indent=2) + "\n")
+        if created:
+            path.chmod(0o600)
+        return WriteResult(method="file", location=str(path))
+
+    @staticmethod
+    def _read_json(path: Path) -> Optional[Dict[str, Any]]:
+        if not path.exists():
+            return None
+        try:
+            parsed = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None

--- a/libs/agno_cli/agno_cli/commands/_common.py
+++ b/libs/agno_cli/agno_cli/commands/_common.py
@@ -11,6 +11,18 @@ from agno_cli.errors import CLIError
 ADMIN_TOKEN_ENV = "AGNO_ADMIN_TOKEN"
 SECURITY_KEY_ENV = "OS_SECURITY_KEY"
 
+_SERVER_NAME_ALLOWED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+
+def validate_server_name(server_name: str) -> None:
+    """MCP server entry names must stay flat: a dotted name would create nested TOML
+    tables in Codex's config that later reads could never find."""
+    if not server_name or not set(server_name) <= _SERVER_NAME_ALLOWED:
+        raise CLIError(
+            "Invalid --server-name: " + server_name,
+            hint="Use letters, digits, '-' and '_' only.",
+        )
+
 
 def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
     """Resolve the admin credential used to call the service-accounts API.

--- a/libs/agno_cli/agno_cli/commands/_common.py
+++ b/libs/agno_cli/agno_cli/commands/_common.py
@@ -1,0 +1,66 @@
+"""Helpers shared by CLI commands."""
+
+import os
+import sys
+from typing import Optional, Tuple
+
+import typer
+
+from agno_cli.errors import CLIError
+
+ADMIN_TOKEN_ENV = "AGNO_ADMIN_TOKEN"
+SECURITY_KEY_ENV = "OS_SECURITY_KEY"
+
+
+def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
+    """Resolve the admin credential used to call the service-accounts API.
+
+    Order: AGNO_ADMIN_TOKEN env, OS_SECURITY_KEY env, interactive prompt. Prompting is
+    disabled in --json mode and when stdin is not a TTY, so agent-driven runs fail with
+    a clear instruction instead of hanging.
+    """
+    if auth_mode == "none":
+        return None
+    token = os.environ.get(ADMIN_TOKEN_ENV) or os.environ.get(SECURITY_KEY_ENV)
+    if token:
+        return token
+    if json_mode or not sys.stdin.isatty():
+        raise CLIError(
+            "This AgentOS requires an admin credential to mint tokens (auth mode: " + auth_mode + ").",
+            hint="Set " + ADMIN_TOKEN_ENV + " (or " + SECURITY_KEY_ENV + ") and re-run.",
+        )
+    return typer.prompt("Admin credential for this AgentOS", hide_input=True)
+
+
+def parse_expires(value: str) -> Tuple[Optional[int], bool]:
+    """Parse an --expires value into (expires_in_days, never_expires).
+
+    Accepts a bare number of days ("90"), a d-suffixed form ("90d"), or "never".
+    """
+    cleaned = value.strip().lower()
+    if cleaned == "never":
+        return None, True
+    if cleaned.endswith("d"):
+        cleaned = cleaned[:-1]
+    if not cleaned.isdigit() or int(cleaned) < 1:
+        raise CLIError(
+            "Invalid --expires value: " + value,
+            hint="Use a number of days like '90' or '90d', or 'never'.",
+        )
+    return int(cleaned), False
+
+
+def handle_cli_error(error: CLIError, json_mode: bool) -> "typer.Exit":
+    """Print a CLIError appropriately for the output mode and return the Exit to raise."""
+    from agno_cli.console import emit_json, print_error, print_warning
+
+    if json_mode:
+        payload = {"error": error.message}
+        if error.hint:
+            payload["hint"] = error.hint
+        emit_json(payload)
+    else:
+        print_error(error.message)
+        if error.hint:
+            print_warning(error.hint)
+    return typer.Exit(error.exit_code)

--- a/libs/agno_cli/agno_cli/commands/connect.py
+++ b/libs/agno_cli/agno_cli/commands/connect.py
@@ -1,9 +1,9 @@
 """`agno connect`: wire a running AgentOS into coding agents as an MCP server.
 
 Flow: discover the AgentOS -> resolve admin credential -> mint one service account per
-client -> write each client's MCP config -> verify each connection with a real MCP
-tools/list call -> report. Re-runs are safe: entries that already verify are skipped,
-broken or stale ones are rotated (revoke + re-mint + rewrite).
+client -> write each client's MCP config -> read the config back and verify the entry
+the client will actually use, with a real MCP tools/list call -> report. Re-runs are
+safe: entries that already verify are skipped, broken or stale ones are rotated.
 """
 
 import sys
@@ -13,12 +13,20 @@ import typer
 
 from agno_cli.clients import CLIENT_ALIASES, build_adapters
 from agno_cli.clients.base import ClientAdapter
-from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
+from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token, validate_server_name
 from agno_cli.console import emit_json, print_error, print_info, print_success, print_warning
 from agno_cli.discovery import MCP_ENABLE_INSTRUCTIONS, OSInfo, discover
 from agno_cli.errors import CLIError, ConflictError
 from agno_cli.http import AgentOSAPI, ServiceAccount
 from agno_cli.mcp_client import verify_mcp
+
+# Exit codes: 0 = all connected, 1 = nothing connected, 2 = usage error (click's
+# convention, raised by typer itself), 3 = partial success.
+EXIT_OK = 0
+EXIT_FAILURE = 1
+EXIT_PARTIAL = 3
+
+ROTATE_HINT = "Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched."
 
 
 def _resolve_clients(clients: Optional[str], adapters: Dict[str, ClientAdapter]) -> List[ClientAdapter]:
@@ -48,6 +56,7 @@ def _mint(
     scopes: Optional[List[str]],
     expires_in_days: Optional[int],
     never_expires: bool,
+    privileged: bool,
     rotate: bool,
     skip_existing: bool,
     json_mode: bool,
@@ -62,13 +71,15 @@ def _mint(
             scopes=scopes,
             expires_in_days=expires_in_days,
             never_expires=never_expires,
+            allow_privileged_scopes=privileged,
         )
-    except ConflictError:
+    except ConflictError as e:
         if skip_existing:
             return None
         if not rotate:
             interactive = not json_mode and sys.stdin.isatty()
             if not interactive:
+                e.hint = ROTATE_HINT
                 raise
             if not typer.confirm(
                 "Service account '" + account_name + "' already exists. Revoke and re-mint it?", default=False
@@ -82,6 +93,7 @@ def _mint(
             scopes=scopes,
             expires_in_days=expires_in_days,
             never_expires=never_expires,
+            allow_privileged_scopes=privileged,
         )
 
 
@@ -97,6 +109,9 @@ def connect(
         [], "--scopes", "-s", help="Scope to grant (repeatable). Default: the server's run + read scopes."
     ),
     expires: str = typer.Option("90d", "--expires", help="Token lifetime in days ('90d', '30') or 'never'."),
+    privileged: bool = typer.Option(
+        False, "--privileged", help="Required when --scopes grants write/delete/admin or service_accounts scopes."
+    ),
     server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name written to client configs."),
     project: bool = typer.Option(
         False, "--project", help="Write project-scoped configs (.mcp.json / .cursor/mcp.json) instead of user-level."
@@ -115,6 +130,7 @@ def connect(
             name=name,
             scopes=list(scopes) or None,
             expires=expires,
+            privileged=privileged,
             server_name=server_name,
             project=project,
             rotate=rotate,
@@ -131,12 +147,14 @@ def _connect(
     name: Optional[str],
     scopes: Optional[List[str]],
     expires: str,
+    privileged: bool,
     server_name: str,
     project: bool,
     rotate: bool,
     skip_existing: bool,
     json_mode: bool,
 ) -> None:
+    validate_server_name(server_name)
     expires_in_days, never_expires = parse_expires(expires)
 
     os_info = discover(url)
@@ -175,77 +193,136 @@ def _connect(
 
     shared_account: Optional[ServiceAccount] = None
     results: List[Dict[str, Any]] = []
-    revoke_hints: List[str] = []
 
     try:
         for adapter in selected:
             result: Dict[str, Any] = {"client": adapter.key, "status": "failed", "error": None}
             try:
-                account_name = name or adapter.key
-                existing = adapter.read_existing(server_name)
-
-                # Idempotency: an entry already pointing at this OS that still verifies is left alone.
-                if existing is not None and existing.url == os_info.mcp_url and not rotate:
-                    check = verify_mcp(os_info.mcp_url, token=existing.token)
-                    if check.ok and (existing.token is not None or not minting):
-                        result.update(
-                            status="already-connected",
-                            location=existing.location,
-                            verify=check.public_dict(),
-                        )
-                        results.append(result)
-                        continue
-                    if skip_existing:
-                        result.update(
-                            status="skipped",
-                            error="Existing entry no longer verifies; re-run without --skip-existing to rotate.",
-                        )
-                        results.append(result)
-                        continue
-
-                token: Optional[str] = None
-                account: Optional[ServiceAccount] = None
-                if minting and api is not None:
-                    if name is not None and shared_account is not None:
-                        account = shared_account
-                    else:
-                        account = _mint(
-                            api,
-                            account_name,
-                            scopes,
-                            expires_in_days,
-                            never_expires,
-                            rotate=rotate,
-                            skip_existing=skip_existing,
-                            json_mode=json_mode,
-                        )
-                        if account is None:
-                            result.update(status="skipped", error="Service account exists; kept untouched.")
-                            results.append(result)
-                            continue
-                        if name is not None:
-                            shared_account = account
-                    token = account.token
-
-                write_result = adapter.write(server_name, os_info.mcp_url, token)
-                verify_result = verify_mcp(os_info.mcp_url, token=token)
-
-                result.update(location=write_result.location, verify=verify_result.public_dict())
-                if account is not None:
-                    result["account"] = account.public_dict()
-                    revoke_hints.append(account.name)
-                if verify_result.ok:
-                    result["status"] = "connected"
-                else:
-                    result["error"] = verify_result.error
+                _connect_one(
+                    adapter=adapter,
+                    result=result,
+                    os_info=os_info,
+                    api=api,
+                    server_name=server_name,
+                    name=name,
+                    scopes=scopes,
+                    expires_in_days=expires_in_days,
+                    never_expires=never_expires,
+                    privileged=privileged,
+                    rotate=rotate,
+                    skip_existing=skip_existing,
+                    json_mode=json_mode,
+                    minting=minting,
+                    shared_account=shared_account,
+                )
+                account = result.pop("_account", None)
+                if name is not None and account is not None:
+                    shared_account = account
             except CLIError as e:
-                result["error"] = e.message
+                result["error"] = e.message + ((" " + e.hint) if e.hint else "")
+            except Exception as e:  # one client's failure must never abort the run
+                result["error"] = "Unexpected error (" + type(e).__name__ + "): " + str(e)
+            finally:
+                result.pop("_account", None)
             results.append(result)
     finally:
         if api is not None:
             api.close()
 
     _report(os_info, results, server_name, open_mcp_warning, json_mode)
+
+
+def _connect_one(
+    adapter: ClientAdapter,
+    result: Dict[str, Any],
+    os_info: OSInfo,
+    api: Optional[AgentOSAPI],
+    server_name: str,
+    name: Optional[str],
+    scopes: Optional[List[str]],
+    expires_in_days: Optional[int],
+    never_expires: bool,
+    privileged: bool,
+    rotate: bool,
+    skip_existing: bool,
+    json_mode: bool,
+    minting: bool,
+    shared_account: Optional[ServiceAccount],
+) -> None:
+    account_name = name or adapter.key
+    existing = adapter.read_existing(server_name)
+
+    if existing is not None:
+        if existing.url == os_info.mcp_url and not rotate:
+            # Idempotency: an entry already pointing at this OS that still verifies is left alone.
+            check = verify_mcp(os_info.mcp_url, token=existing.token)
+            if check.ok and (existing.token is not None or not minting):
+                result.update(status="already-connected", location=existing.location, verify=check.public_dict())
+                return
+            if skip_existing:
+                result.update(
+                    status="skipped",
+                    error="Existing entry no longer verifies; re-run without --skip-existing to rotate.",
+                )
+                return
+        elif existing.url != os_info.mcp_url:
+            # The entry points at a different AgentOS; never touch it under --skip-existing.
+            if skip_existing:
+                result.update(
+                    status="skipped",
+                    location=existing.location,
+                    error="Existing entry points at " + existing.url + "; left untouched.",
+                )
+                return
+            result["replaced_url"] = existing.url
+
+    token: Optional[str] = None
+    account: Optional[ServiceAccount] = None
+    if minting and api is not None:
+        if name is not None and shared_account is not None:
+            account = shared_account
+        else:
+            account = _mint(
+                api,
+                account_name,
+                scopes,
+                expires_in_days,
+                never_expires,
+                privileged=privileged,
+                rotate=rotate,
+                skip_existing=skip_existing,
+                json_mode=json_mode,
+            )
+            if account is None:
+                result.update(status="skipped", error="Service account exists; kept untouched.")
+                return
+        token = account.token
+
+    write_result = adapter.write(server_name, os_info.mcp_url, token)
+    result["location"] = write_result.location
+    if write_result.note:
+        result["note"] = write_result.note
+    if account is not None:
+        result["account"] = account.public_dict()
+        result["_account"] = account
+
+    # Verify what the client will actually use, not what we intended to write: the
+    # read-back catches shadowing entries and writes that silently did not take effect.
+    readback = adapter.read_existing(server_name)
+    if readback is None or readback.url != os_info.mcp_url or (token is not None and readback.token != token):
+        found = (readback.location + " -> " + readback.url) if readback is not None else "no entry"
+        result["error"] = (
+            "The config write did not take effect for '" + server_name + "' (found: " + found + "). "
+            "Another entry may shadow it; remove the stale entry and re-run."
+        )
+        return
+
+    verify_result = verify_mcp(os_info.mcp_url, token=readback.token)
+    result["verify"] = verify_result.public_dict()
+    if verify_result.ok:
+        result["status"] = "connected"
+    else:
+        result["error"] = verify_result.error
 
 
 def _report(
@@ -258,11 +335,11 @@ def _report(
     ok_statuses = ("connected", "already-connected")
     ok_count = sum(1 for r in results if r["status"] in ok_statuses)
     if ok_count == len(results):
-        exit_code = 0
+        exit_code = EXIT_OK
     elif ok_count == 0:
-        exit_code = 1
+        exit_code = EXIT_FAILURE
     else:
-        exit_code = 2
+        exit_code = EXIT_PARTIAL
 
     if json_mode:
         emit_json(
@@ -289,6 +366,10 @@ def _report(
             print_warning("  skipped        " + label + "  (" + str(r.get("error") or "") + ")")
         else:
             print_error("  failed         " + label + "  (" + str(r.get("error") or "unknown error") + ")")
+        if r.get("note"):
+            print_warning("                 note: " + str(r["note"]))
+        if r.get("replaced_url"):
+            print_warning("                 replaced an entry that pointed at " + str(r["replaced_url"]))
 
     accounts = sorted({r["account"]["name"] for r in results if r.get("account")})
     if accounts:

--- a/libs/agno_cli/agno_cli/commands/connect.py
+++ b/libs/agno_cli/agno_cli/commands/connect.py
@@ -1,0 +1,301 @@
+"""`agno connect`: wire a running AgentOS into coding agents as an MCP server.
+
+Flow: discover the AgentOS -> resolve admin credential -> mint one service account per
+client -> write each client's MCP config -> verify each connection with a real MCP
+tools/list call -> report. Re-runs are safe: entries that already verify are skipped,
+broken or stale ones are rotated (revoke + re-mint + rewrite).
+"""
+
+import sys
+from typing import Any, Dict, List, Optional
+
+import typer
+
+from agno_cli.clients import CLIENT_ALIASES, build_adapters
+from agno_cli.clients.base import ClientAdapter
+from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
+from agno_cli.console import emit_json, print_error, print_info, print_success, print_warning
+from agno_cli.discovery import MCP_ENABLE_INSTRUCTIONS, OSInfo, discover
+from agno_cli.errors import CLIError, ConflictError
+from agno_cli.http import AgentOSAPI, ServiceAccount
+from agno_cli.mcp_client import verify_mcp
+
+
+def _resolve_clients(clients: Optional[str], adapters: Dict[str, ClientAdapter]) -> List[ClientAdapter]:
+    if clients:
+        selected: List[ClientAdapter] = []
+        for raw in clients.split(","):
+            key = CLIENT_ALIASES.get(raw.strip().lower())
+            if key is None:
+                supported = ", ".join(sorted(set(CLIENT_ALIASES.keys())))
+                raise CLIError("Unknown client: " + raw.strip(), hint="Supported clients: " + supported)
+            adapter = adapters[key]
+            if adapter not in selected:
+                selected.append(adapter)
+        return selected
+    detected = [adapter for adapter in adapters.values() if adapter.detect()]
+    if not detected:
+        raise CLIError(
+            "No supported coding agents detected on this machine.",
+            hint="Install Claude Code, Codex, or Cursor, or pass --clients explicitly.",
+        )
+    return detected
+
+
+def _mint(
+    api: AgentOSAPI,
+    account_name: str,
+    scopes: Optional[List[str]],
+    expires_in_days: Optional[int],
+    never_expires: bool,
+    rotate: bool,
+    skip_existing: bool,
+    json_mode: bool,
+) -> Optional[ServiceAccount]:
+    """Mint a service account, resolving name conflicts per the idempotency policy.
+
+    Returns None when the caller should skip this client (existing account kept).
+    """
+    try:
+        return api.create_service_account(
+            name=account_name,
+            scopes=scopes,
+            expires_in_days=expires_in_days,
+            never_expires=never_expires,
+        )
+    except ConflictError:
+        if skip_existing:
+            return None
+        if not rotate:
+            interactive = not json_mode and sys.stdin.isatty()
+            if not interactive:
+                raise
+            if not typer.confirm(
+                "Service account '" + account_name + "' already exists. Revoke and re-mint it?", default=False
+            ):
+                return None
+        existing = api.find_service_account(account_name)
+        if existing is not None:
+            api.revoke_service_account(existing.id)
+        return api.create_service_account(
+            name=account_name,
+            scopes=scopes,
+            expires_in_days=expires_in_days,
+            never_expires=never_expires,
+        )
+
+
+def connect(
+    url: Optional[str] = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost)."),
+    clients: Optional[str] = typer.Option(
+        None, "--clients", help="Comma-separated clients to configure (claude-code,codex,cursor). Default: detected."
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="Use one shared service account with this name instead of one per client."
+    ),
+    scopes: List[str] = typer.Option(
+        [], "--scopes", "-s", help="Scope to grant (repeatable). Default: the server's run + read scopes."
+    ),
+    expires: str = typer.Option("90d", "--expires", help="Token lifetime in days ('90d', '30') or 'never'."),
+    server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name written to client configs."),
+    project: bool = typer.Option(
+        False, "--project", help="Write project-scoped configs (.mcp.json / .cursor/mcp.json) instead of user-level."
+    ),
+    rotate: bool = typer.Option(False, "--rotate", help="Revoke and re-mint existing accounts without asking."),
+    skip_existing: bool = typer.Option(
+        False, "--skip-existing", help="Never touch existing accounts or config entries."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Connect this machine's coding agents to a running AgentOS over MCP."""
+    try:
+        _connect(
+            url=url,
+            clients=clients,
+            name=name,
+            scopes=list(scopes) or None,
+            expires=expires,
+            server_name=server_name,
+            project=project,
+            rotate=rotate,
+            skip_existing=skip_existing,
+            json_mode=json_output,
+        )
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+
+def _connect(
+    url: Optional[str],
+    clients: Optional[str],
+    name: Optional[str],
+    scopes: Optional[List[str]],
+    expires: str,
+    server_name: str,
+    project: bool,
+    rotate: bool,
+    skip_existing: bool,
+    json_mode: bool,
+) -> None:
+    expires_in_days, never_expires = parse_expires(expires)
+
+    os_info = discover(url)
+    if not os_info.mcp_enabled:
+        raise CLIError(
+            "Found an AgentOS at "
+            + os_info.base_url
+            + ", but its MCP server is not enabled.\n\n"
+            + MCP_ENABLE_INSTRUCTIONS
+        )
+    if not json_mode:
+        version = " (agno " + os_info.version + ")" if os_info.version else ""
+        print_info("AgentOS at " + os_info.base_url + version + ", MCP at " + os_info.mcp_url)
+
+    adapters = build_adapters(project=project)
+    selected = _resolve_clients(clients, adapters)
+
+    minting = os_info.auth_mode not in ("none",)
+    admin_token = resolve_admin_token(os_info.auth_mode, json_mode) if minting else None
+    if not minting and not json_mode:
+        print_info("Authorization is disabled on this AgentOS; connecting without credentials.")
+
+    # Truthful-outcome check: if the OS enforces auth but /mcp answers without a token,
+    # the server predates MCP token enforcement and minted headers are decorative.
+    open_mcp_warning: Optional[str] = None
+    if minting:
+        open_probe = verify_mcp(os_info.mcp_url, token=None)
+        if open_probe.ok:
+            open_mcp_warning = (
+                "This AgentOS accepts unauthenticated MCP requests: its agno version predates "
+                "token enforcement on /mcp. Tokens were still minted and configured; upgrade "
+                "agno to make them meaningful."
+            )
+
+    api = AgentOSAPI(os_info.base_url, admin_token=admin_token) if minting else None
+
+    shared_account: Optional[ServiceAccount] = None
+    results: List[Dict[str, Any]] = []
+    revoke_hints: List[str] = []
+
+    try:
+        for adapter in selected:
+            result: Dict[str, Any] = {"client": adapter.key, "status": "failed", "error": None}
+            try:
+                account_name = name or adapter.key
+                existing = adapter.read_existing(server_name)
+
+                # Idempotency: an entry already pointing at this OS that still verifies is left alone.
+                if existing is not None and existing.url == os_info.mcp_url and not rotate:
+                    check = verify_mcp(os_info.mcp_url, token=existing.token)
+                    if check.ok and (existing.token is not None or not minting):
+                        result.update(
+                            status="already-connected",
+                            location=existing.location,
+                            verify=check.public_dict(),
+                        )
+                        results.append(result)
+                        continue
+                    if skip_existing:
+                        result.update(
+                            status="skipped",
+                            error="Existing entry no longer verifies; re-run without --skip-existing to rotate.",
+                        )
+                        results.append(result)
+                        continue
+
+                token: Optional[str] = None
+                account: Optional[ServiceAccount] = None
+                if minting and api is not None:
+                    if name is not None and shared_account is not None:
+                        account = shared_account
+                    else:
+                        account = _mint(
+                            api,
+                            account_name,
+                            scopes,
+                            expires_in_days,
+                            never_expires,
+                            rotate=rotate,
+                            skip_existing=skip_existing,
+                            json_mode=json_mode,
+                        )
+                        if account is None:
+                            result.update(status="skipped", error="Service account exists; kept untouched.")
+                            results.append(result)
+                            continue
+                        if name is not None:
+                            shared_account = account
+                    token = account.token
+
+                write_result = adapter.write(server_name, os_info.mcp_url, token)
+                verify_result = verify_mcp(os_info.mcp_url, token=token)
+
+                result.update(location=write_result.location, verify=verify_result.public_dict())
+                if account is not None:
+                    result["account"] = account.public_dict()
+                    revoke_hints.append(account.name)
+                if verify_result.ok:
+                    result["status"] = "connected"
+                else:
+                    result["error"] = verify_result.error
+            except CLIError as e:
+                result["error"] = e.message
+            results.append(result)
+    finally:
+        if api is not None:
+            api.close()
+
+    _report(os_info, results, server_name, open_mcp_warning, json_mode)
+
+
+def _report(
+    os_info: OSInfo,
+    results: List[Dict[str, Any]],
+    server_name: str,
+    open_mcp_warning: Optional[str],
+    json_mode: bool,
+) -> None:
+    ok_statuses = ("connected", "already-connected")
+    ok_count = sum(1 for r in results if r["status"] in ok_statuses)
+    if ok_count == len(results):
+        exit_code = 0
+    elif ok_count == 0:
+        exit_code = 1
+    else:
+        exit_code = 2
+
+    if json_mode:
+        emit_json(
+            {
+                "os": os_info.public_dict(),
+                "server_name": server_name,
+                "results": results,
+                "warning": open_mcp_warning,
+                "exit_code": exit_code,
+            }
+        )
+        raise typer.Exit(exit_code)
+
+    print_info("")
+    for r in results:
+        label = r["client"]
+        if r["status"] == "connected":
+            tools = (r.get("verify") or {}).get("tools")
+            suffix = " (" + str(tools) + " tools)" if tools else ""
+            print_success("  connected      " + label + suffix + "  ->  " + str(r.get("location", "")))
+        elif r["status"] == "already-connected":
+            print_success("  already ok     " + label + "  ->  " + str(r.get("location", "")))
+        elif r["status"] == "skipped":
+            print_warning("  skipped        " + label + "  (" + str(r.get("error") or "") + ")")
+        else:
+            print_error("  failed         " + label + "  (" + str(r.get("error") or "unknown error") + ")")
+
+    accounts = sorted({r["account"]["name"] for r in results if r.get("account")})
+    if accounts:
+        print_info("")
+        print_info("Revoke any time with: agno tokens revoke <name>  (accounts: " + ", ".join(accounts) + ")")
+    if open_mcp_warning:
+        print_info("")
+        print_warning(open_mcp_warning)
+
+    raise typer.Exit(exit_code)

--- a/libs/agno_cli/agno_cli/commands/create.py
+++ b/libs/agno_cli/agno_cli/commands/create.py
@@ -1,0 +1,110 @@
+"""`agno create`: scaffold a new AgentOS project from a starter template.
+
+The mechanism is deliberately simple (inherited from `ag infra create`): shallow-clone
+the template repository, strip its git history, and copy example secrets into place.
+No registry file is kept — commands operate on the current directory.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import typer
+
+from agno_cli.commands._common import handle_cli_error
+from agno_cli.console import emit_json, print_info, print_success
+from agno_cli.errors import CLIError
+
+TEMPLATES: Dict[str, str] = {
+    "agentos-docker": "https://github.com/agno-agi/agentos-docker-template",
+    "agentos-aws": "https://github.com/agno-agi/agentos-aws-template",
+    "agentos-railway": "https://github.com/agno-agi/agentos-railway-template",
+}
+
+DEFAULT_TEMPLATE = "agentos-docker"
+
+GIT_TIMEOUT = 300.0
+
+
+def _clone(repo_url: str, target: Path) -> None:
+    if shutil.which("git") is None:
+        raise CLIError("git is required to create a project from a template.", hint="Install git and re-run.")
+    try:
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, str(target)],
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        raise CLIError("git clone timed out after " + str(int(GIT_TIMEOUT)) + "s: " + repo_url)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise CLIError("git clone failed: " + (detail or repo_url))
+    shutil.rmtree(target / ".git", ignore_errors=True)
+
+
+def _copy_example_secrets(project_dir: Path) -> Optional[str]:
+    """Copy infra/example_secrets -> infra/secrets when the template ships one."""
+    example = project_dir / "infra" / "example_secrets"
+    secrets = project_dir / "infra" / "secrets"
+    if example.is_dir() and not secrets.exists():
+        shutil.copytree(example, secrets)
+        return str(secrets)
+    return None
+
+
+def create(
+    name: str = typer.Argument(..., help="Directory name for the new AgentOS project."),
+    template: str = typer.Option(
+        DEFAULT_TEMPLATE, "--template", "-t", help="Starter template: " + ", ".join(sorted(TEMPLATES)) + "."
+    ),
+    template_url: Optional[str] = typer.Option(
+        None, "--url", "-u", help="Clone from a custom template repository URL instead."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Create a new AgentOS project from a starter template."""
+    try:
+        payload = _create(name=name, template=template, template_url=template_url)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        emit_json(payload)
+        return
+    print_success("Created " + str(payload["path"]) + " from " + str(payload["template"]))
+    if payload.get("secrets"):
+        print_info("Example secrets copied to " + str(payload["secrets"]) + " - fill them in before deploying.")
+    print_info("")
+    print_info("Next steps:")
+    print_info("  cd " + name)
+    print_info("  agno infra up      # start it with docker compose")
+    print_info("  agno connect       # make it available in your coding agents")
+
+
+def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, Any]:
+    target = Path.cwd() / name
+    if target.exists():
+        raise CLIError(
+            "The directory " + str(target) + " already exists.",
+            hint="Pick a different name or remove the existing directory.",
+        )
+
+    if template_url:
+        repo_url = template_url
+        template_label = template_url
+    else:
+        repo_url = TEMPLATES.get(template, "")
+        if not repo_url:
+            raise CLIError(
+                "Unknown template: " + template,
+                hint="Available templates: " + ", ".join(sorted(TEMPLATES)) + ", or pass --url for a custom repo.",
+            )
+        template_label = template
+
+    _clone(repo_url, target)
+    secrets = _copy_example_secrets(target)
+    return {"path": str(target), "template": template_label, "secrets": secrets}

--- a/libs/agno_cli/agno_cli/commands/create.py
+++ b/libs/agno_cli/agno_cli/commands/create.py
@@ -81,7 +81,7 @@ def create(
     print_info("")
     print_info("Next steps:")
     print_info("  cd " + name)
-    print_info("  agno infra up      # start it with docker compose")
+    print_info("  agno up            # start it with docker compose")
     print_info("  agno connect       # make it available in your coding agents")
 
 

--- a/libs/agno_cli/agno_cli/commands/infra.py
+++ b/libs/agno_cli/agno_cli/commands/infra.py
@@ -1,0 +1,148 @@
+"""`agno infra`: run the project's infrastructure with docker compose.
+
+This ports the path of the legacy `ag infra` CLI that real projects use: templates ship
+a compose file, and up/down/restart shell out to `docker compose`. The legacy Python
+resource engine (per-resource Docker/AWS orchestration) is intentionally not ported —
+its production path is under redesign (see the agno-infra 2.0 spec); when that lands it
+plugs into this CLI via the agno_cli.plugins entry-point group.
+"""
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import typer
+
+from agno_cli.commands._common import handle_cli_error
+from agno_cli.console import emit_json, print_info, print_success
+from agno_cli.errors import CLIError
+
+infra_app = typer.Typer(name="infra", help="Start and stop the project's infrastructure (docker compose).")
+
+# Same names and order the legacy CLI recognized.
+COMPOSE_FILE_NAMES = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"]
+
+COMPOSE_TIMEOUT = 600.0
+
+JsonOption = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption.")
+FileOption = typer.Option(None, "--file", "-f", help="Compose file to use (default: autodetect in ./ and ./infra).")
+DryRunOption = typer.Option(False, "--dry-run", "-dr", help="Print the docker compose command without running it.")
+
+
+def find_compose_file(explicit: Optional[str] = None, cwd: Optional[Path] = None) -> Path:
+    base = cwd or Path.cwd()
+    if explicit:
+        path = Path(explicit)
+        if not path.is_absolute():
+            path = base / path
+        if not path.exists():
+            raise CLIError("Compose file not found: " + str(path))
+        return path
+    for directory in (base, base / "infra"):
+        for name in COMPOSE_FILE_NAMES:
+            candidate = directory / name
+            if candidate.exists():
+                return candidate
+    raise CLIError(
+        "No compose file found in " + str(base) + " or " + str(base / "infra") + ".",
+        hint="Run from an AgentOS project (agno create <name>) or pass --file.",
+    )
+
+
+def _run_compose(compose_file: Path, args: List[str], dry_run: bool, json_mode: bool) -> Dict[str, Any]:
+    command = ["docker", "compose", "-f", str(compose_file)] + args
+    if dry_run:
+        return {"command": command, "compose_file": str(compose_file), "dry_run": True}
+    if shutil.which("docker") is None:
+        raise CLIError("docker is required.", hint="Install Docker and make sure `docker` is on PATH.")
+    try:
+        result = subprocess.run(
+            command,
+            cwd=str(compose_file.parent),
+            timeout=COMPOSE_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            capture_output=json_mode,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        raise CLIError("docker compose timed out after " + str(int(COMPOSE_TIMEOUT)) + "s.")
+    if result.returncode != 0:
+        detail = ((result.stderr or "") if json_mode else "").strip()
+        raise CLIError(
+            "docker compose exited with code " + str(result.returncode) + ((": " + detail) if detail else "."),
+        )
+    return {"command": command, "compose_file": str(compose_file), "dry_run": False}
+
+
+@infra_app.command("up")
+def up(
+    file: Optional[str] = FileOption,
+    pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images."),
+    dry_run: bool = DryRunOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Start the project's infrastructure: docker compose up -d --build."""
+    try:
+        compose_file = find_compose_file(file)
+        args = ["up", "-d", "--build"]
+        if pull:
+            args += ["--pull", "always"]
+        payload = _run_compose(compose_file, args, dry_run, json_output)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+    _finish(payload, "Infrastructure is up (" + str(payload["compose_file"]) + ").", json_output)
+
+
+@infra_app.command("down")
+def down(
+    file: Optional[str] = FileOption,
+    volumes: bool = typer.Option(False, "--volumes", "-v", help="Also remove named volumes (destroys data)."),
+    dry_run: bool = DryRunOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Stop the project's infrastructure: docker compose down."""
+    try:
+        compose_file = find_compose_file(file)
+        args = ["down"]
+        if volumes:
+            args += ["--volumes"]
+        payload = _run_compose(compose_file, args, dry_run, json_output)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+    _finish(payload, "Infrastructure is down (" + str(payload["compose_file"]) + ").", json_output)
+
+
+@infra_app.command("restart")
+def restart(
+    file: Optional[str] = FileOption,
+    pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images on the way back up."),
+    dry_run: bool = DryRunOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Restart the project's infrastructure: down, then up."""
+    try:
+        compose_file = find_compose_file(file)
+        down_payload = _run_compose(compose_file, ["down"], dry_run, json_output)
+        if not dry_run:
+            time.sleep(2)
+        up_args = ["up", "-d", "--build"]
+        if pull:
+            up_args += ["--pull", "always"]
+        up_payload = _run_compose(compose_file, up_args, dry_run, json_output)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+    payload = {"down": down_payload, "up": up_payload, "compose_file": str(compose_file), "dry_run": dry_run}
+    _finish(payload, "Infrastructure restarted (" + str(compose_file) + ").", json_output)
+
+
+def _finish(payload: Dict[str, Any], message: str, json_mode: bool) -> None:
+    if json_mode:
+        emit_json(payload)
+        return
+    if payload.get("dry_run"):
+        command = payload.get("command") or (payload.get("up") or {}).get("command")
+        print_info("Would run: " + " ".join(command or []))
+        return
+    print_success(message)

--- a/libs/agno_cli/agno_cli/commands/lifecycle.py
+++ b/libs/agno_cli/agno_cli/commands/lifecycle.py
@@ -1,4 +1,4 @@
-"""`agno infra`: run the project's infrastructure with docker compose.
+"""`agno up/down/restart`: run the project with docker compose.
 
 This ports the path of the legacy `ag infra` CLI that real projects use: templates ship
 a compose file, and up/down/restart shell out to `docker compose`. The legacy Python
@@ -18,8 +18,6 @@ import typer
 from agno_cli.commands._common import handle_cli_error
 from agno_cli.console import emit_json, print_info, print_success
 from agno_cli.errors import CLIError
-
-infra_app = typer.Typer(name="infra", help="Start and stop the project's infrastructure (docker compose).")
 
 # Same names and order the legacy CLI recognized.
 COMPOSE_FILE_NAMES = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"]
@@ -76,14 +74,13 @@ def _run_compose(compose_file: Path, args: List[str], dry_run: bool, json_mode: 
     return {"command": command, "compose_file": str(compose_file), "dry_run": False}
 
 
-@infra_app.command("up")
 def up(
     file: Optional[str] = FileOption,
     pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images."),
     dry_run: bool = DryRunOption,
     json_output: bool = JsonOption,
 ) -> None:
-    """Start the project's infrastructure: docker compose up -d --build."""
+    """Start the project: docker compose up -d --build."""
     try:
         compose_file = find_compose_file(file)
         args = ["up", "-d", "--build"]
@@ -92,17 +89,16 @@ def up(
         payload = _run_compose(compose_file, args, dry_run, json_output)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
-    _finish(payload, "Infrastructure is up (" + str(payload["compose_file"]) + ").", json_output)
+    _finish(payload, "Project is up (" + str(payload["compose_file"]) + ").", json_output)
 
 
-@infra_app.command("down")
 def down(
     file: Optional[str] = FileOption,
     volumes: bool = typer.Option(False, "--volumes", "-v", help="Also remove named volumes (destroys data)."),
     dry_run: bool = DryRunOption,
     json_output: bool = JsonOption,
 ) -> None:
-    """Stop the project's infrastructure: docker compose down."""
+    """Stop the project: docker compose down."""
     try:
         compose_file = find_compose_file(file)
         args = ["down"]
@@ -111,17 +107,16 @@ def down(
         payload = _run_compose(compose_file, args, dry_run, json_output)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
-    _finish(payload, "Infrastructure is down (" + str(payload["compose_file"]) + ").", json_output)
+    _finish(payload, "Project is down (" + str(payload["compose_file"]) + ").", json_output)
 
 
-@infra_app.command("restart")
 def restart(
     file: Optional[str] = FileOption,
     pull: bool = typer.Option(False, "--pull", "-p", help="Always pull newer images on the way back up."),
     dry_run: bool = DryRunOption,
     json_output: bool = JsonOption,
 ) -> None:
-    """Restart the project's infrastructure: down, then up."""
+    """Restart the project: down, then up."""
     try:
         compose_file = find_compose_file(file)
         down_payload = _run_compose(compose_file, ["down"], dry_run, json_output)
@@ -134,7 +129,7 @@ def restart(
     except CLIError as e:
         raise handle_cli_error(e, json_output)
     payload = {"down": down_payload, "up": up_payload, "compose_file": str(compose_file), "dry_run": dry_run}
-    _finish(payload, "Infrastructure restarted (" + str(compose_file) + ").", json_output)
+    _finish(payload, "Project restarted (" + str(compose_file) + ").", json_output)
 
 
 def _finish(payload: Dict[str, Any], message: str, json_mode: bool) -> None:

--- a/libs/agno_cli/agno_cli/commands/status.py
+++ b/libs/agno_cli/agno_cli/commands/status.py
@@ -1,0 +1,54 @@
+"""`agno status`: orientation — what OS is running, how it is secured, what is connected."""
+
+from typing import Optional
+
+import typer
+
+from agno_cli.clients import build_adapters
+from agno_cli.commands._common import handle_cli_error
+from agno_cli.console import emit_json, print_info, print_success
+from agno_cli.discovery import discover
+from agno_cli.errors import CLIError
+
+
+def status(
+    url: Optional[str] = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost)."),
+    server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name to look for in clients."),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Show the discovered AgentOS and which coding agents are connected to it."""
+    try:
+        os_info = discover(url)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    adapters = build_adapters()
+    clients = []
+    for adapter in adapters.values():
+        entry = adapter.read_existing(server_name) if adapter.detect() else None
+        clients.append(
+            {
+                "client": adapter.key,
+                "detected": adapter.detect(),
+                "configured": entry is not None,
+                "location": entry.location if entry else None,
+            }
+        )
+
+    if json_output:
+        emit_json({"os": os_info.public_dict(), "clients": clients})
+        return
+
+    version = " (agno " + os_info.version + ")" if os_info.version else ""
+    print_success("AgentOS: " + os_info.base_url + version)
+    mcp = os_info.mcp_url if os_info.mcp_enabled else "disabled"
+    print_info("  MCP: " + mcp)
+    print_info("  Auth mode: " + os_info.auth_mode)
+    print_info("")
+    for c in clients:
+        if not c["detected"]:
+            print_info("  " + str(c["client"]) + ": not detected")
+        elif c["configured"]:
+            print_info("  " + str(c["client"]) + ": configured (" + str(c["location"]) + ")")
+        else:
+            print_info("  " + str(c["client"]) + ": detected, not connected (run: agno connect)")

--- a/libs/agno_cli/agno_cli/commands/tokens.py
+++ b/libs/agno_cli/agno_cli/commands/tokens.py
@@ -1,0 +1,129 @@
+"""`agno tokens`: thin wrappers over the AgentOS service-accounts API."""
+
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import typer
+
+from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
+from agno_cli.console import console, emit_json, print_info, print_success, print_warning
+from agno_cli.discovery import discover
+from agno_cli.errors import CLIError
+from agno_cli.http import AgentOSAPI
+
+tokens_app = typer.Typer(name="tokens", help="Mint, list, and revoke AgentOS service-account tokens.")
+
+UrlOption = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost).")
+JsonOption = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption.")
+
+
+def _timestamp(value: Optional[int]) -> str:
+    if not value:
+        return "-"
+    return datetime.fromtimestamp(value, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _api_for(url: Optional[str], json_mode: bool) -> AgentOSAPI:
+    os_info = discover(url)
+    admin_token = resolve_admin_token(os_info.auth_mode, json_mode)
+    return AgentOSAPI(os_info.base_url, admin_token=admin_token)
+
+
+@tokens_app.command("create")
+def create(
+    name: str = typer.Argument(..., help="Service account name (lowercase slug, e.g. 'ci-runner')."),
+    scopes: List[str] = typer.Option([], "--scopes", "-s", help="Scope to grant (repeatable). Default: run + read."),
+    expires: str = typer.Option("90d", "--expires", help="Days until expiry ('90d', '30') or 'never'."),
+    privileged: bool = typer.Option(
+        False, "--privileged", help="Required to grant write/delete/admin or service_accounts scopes."
+    ),
+    url: Optional[str] = UrlOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Mint a service-account token. The plaintext is shown exactly once."""
+    try:
+        expires_in_days, never_expires = parse_expires(expires)
+        with _api_for(url, json_output) as api:
+            account = api.create_service_account(
+                name=name,
+                scopes=list(scopes) or None,
+                expires_in_days=expires_in_days,
+                never_expires=never_expires,
+                allow_privileged_scopes=privileged,
+            )
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        payload = account.public_dict()
+        payload["token"] = account.token
+        emit_json(payload)
+        return
+
+    print_success("Service account '" + account.name + "' created (principal: " + account.principal + ").")
+    print_info("Scopes: " + ", ".join(account.scopes))
+    print_info("Expires: " + _timestamp(account.expires_at))
+    print_warning("This token is shown once and cannot be retrieved again. Save it now:")
+    console.print()
+    console.print("    " + (account.token or ""), style="bold", highlight=False)
+    console.print()
+
+
+@tokens_app.command("list")
+def list_(
+    url: Optional[str] = UrlOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """List service accounts (metadata and display prefixes only, never tokens)."""
+    try:
+        with _api_for(url, json_output) as api:
+            accounts = api.list_service_accounts()
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        emit_json({"service_accounts": [a.public_dict() for a in accounts]})
+        return
+
+    if not accounts:
+        print_info("No service accounts found.")
+        return
+
+    from rich.table import Table
+
+    table = Table(box=None, header_style="bold")
+    for column in ("Name", "Token", "Scopes", "Expires", "Last used", "Status"):
+        table.add_column(column)
+    for a in accounts:
+        status = "revoked" if a.revoked_at else "active"
+        table.add_row(
+            a.name,
+            a.token_prefix + "…",
+            ", ".join(a.scopes),
+            _timestamp(a.expires_at),
+            _timestamp(a.last_used_at),
+            status,
+        )
+    console.print(table)
+
+
+@tokens_app.command("revoke")
+def revoke(
+    name: str = typer.Argument(..., help="Name of the service account to revoke."),
+    url: Optional[str] = UrlOption,
+    json_output: bool = JsonOption,
+) -> None:
+    """Revoke a service account. Takes effect on the account's next request."""
+    try:
+        with _api_for(url, json_output) as api:
+            account = api.find_service_account(name)
+            if account is None:
+                raise CLIError("No service account named '" + name + "' found.")
+            api.revoke_service_account(account.id)
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+    if json_output:
+        emit_json({"revoked": account.public_dict()})
+        return
+    print_success("Service account '" + name + "' revoked. Existing tokens stop working on their next request.")

--- a/libs/agno_cli/agno_cli/commands/tokens.py
+++ b/libs/agno_cli/agno_cli/commands/tokens.py
@@ -8,7 +8,7 @@ import typer
 from agno_cli.commands._common import handle_cli_error, parse_expires, resolve_admin_token
 from agno_cli.console import console, emit_json, print_info, print_success, print_warning
 from agno_cli.discovery import discover
-from agno_cli.errors import CLIError
+from agno_cli.errors import CLIError, ConflictError
 from agno_cli.http import AgentOSAPI
 
 tokens_app = typer.Typer(name="tokens", help="Mint, list, and revoke AgentOS service-account tokens.")
@@ -44,13 +44,17 @@ def create(
     try:
         expires_in_days, never_expires = parse_expires(expires)
         with _api_for(url, json_output) as api:
-            account = api.create_service_account(
-                name=name,
-                scopes=list(scopes) or None,
-                expires_in_days=expires_in_days,
-                never_expires=never_expires,
-                allow_privileged_scopes=privileged,
-            )
+            try:
+                account = api.create_service_account(
+                    name=name,
+                    scopes=list(scopes) or None,
+                    expires_in_days=expires_in_days,
+                    never_expires=never_expires,
+                    allow_privileged_scopes=privileged,
+                )
+            except ConflictError as e:
+                e.hint = "Revoke it first (agno tokens revoke " + name + ") or pick a different name."
+                raise
     except CLIError as e:
         raise handle_cli_error(e, json_output)
 

--- a/libs/agno_cli/agno_cli/console.py
+++ b/libs/agno_cli/agno_cli/console.py
@@ -1,0 +1,39 @@
+"""Console output helpers.
+
+Two output modes exist for every command: human (rich, colored, informative) and machine
+(--json: a single JSON document on stdout, nothing else). Commands build a payload dict as
+they work; in JSON mode only emit_json touches stdout, so output stays parseable.
+"""
+
+import json
+from typing import Any, Dict
+
+from rich.console import Console
+
+console = Console()
+err_console = Console(stderr=True)
+
+
+def print_heading(msg: str) -> None:
+    console.print(msg, style="green bold")
+
+
+def print_info(msg: str) -> None:
+    console.print(msg)
+
+
+def print_success(msg: str) -> None:
+    console.print(msg, style="chartreuse3")
+
+
+def print_warning(msg: str) -> None:
+    err_console.print(msg, style="magenta")
+
+
+def print_error(msg: str) -> None:
+    err_console.print(msg, style="red")
+
+
+def emit_json(payload: Dict[str, Any]) -> None:
+    """Print the machine-readable result document. The only stdout writer in --json mode."""
+    print(json.dumps(payload, indent=2, sort_keys=False, default=str))

--- a/libs/agno_cli/agno_cli/discovery.py
+++ b/libs/agno_cli/agno_cli/discovery.py
@@ -1,0 +1,119 @@
+"""AgentOS discovery: find a running OS and learn its capabilities before touching it.
+
+Prefers the structured discovery fields on GET /info (agno >= the /info discovery release):
+``mcp: {enabled, path}`` and ``auth_mode``. Falls back to probing for older servers:
+POST to /mcp distinguishes mounted-vs-404, and an unauthenticated GET /config
+distinguishes the auth modes by status code and 401 detail wording.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno_cli.errors import CLIError
+from agno_cli.http import AgentOSAPI, build_client
+
+# AgentOS.serve() defaults to port 7777; 8000 covers bare-uvicorn setups.
+DEFAULT_URLS = ["http://localhost:7777", "http://localhost:8000"]
+
+URL_ENV_VAR = "AGNO_OS_URL"
+
+
+@dataclass
+class OSInfo:
+    base_url: str
+    version: Optional[str]
+    mcp_enabled: bool
+    mcp_path: Optional[str]
+    auth_mode: str  # "none" | "security_key" | "jwt" | "unknown"
+    discovered_via: str  # "info" | "probe"
+
+    @property
+    def mcp_url(self) -> str:
+        path = self.mcp_path or "/mcp"
+        return self.base_url.rstrip("/") + path
+
+    def public_dict(self) -> Dict[str, Any]:
+        return {
+            "url": self.base_url,
+            "version": self.version,
+            "mcp": {"enabled": self.mcp_enabled, "path": self.mcp_path},
+            "auth_mode": self.auth_mode,
+            "discovered_via": self.discovered_via,
+        }
+
+
+def _candidate_urls(url: Optional[str]) -> List[str]:
+    if url:
+        return [url.rstrip("/")]
+    env_url = os.environ.get(URL_ENV_VAR)
+    if env_url:
+        return [env_url.rstrip("/")]
+    return list(DEFAULT_URLS)
+
+
+def _probe_mcp(base_url: str) -> bool:
+    """True when something MCP-shaped is mounted at /mcp.
+
+    A FastAPI app without the MCP mount returns 404 for any method on /mcp; the
+    streamable-HTTP endpoint answers POSTs with anything but 404 (200, 400, 401, 406...).
+    """
+    try:
+        with build_client(base_url=base_url, timeout=5.0) as client:
+            response = client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 0, "method": "ping"},
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+    except httpx.HTTPError:
+        return False
+    return response.status_code != 404
+
+
+def discover(url: Optional[str] = None) -> OSInfo:
+    """Find a running AgentOS and return what the CLI needs to know about it."""
+    candidates = _candidate_urls(url)
+    for candidate in candidates:
+        with AgentOSAPI(candidate) as api:
+            if api.health() is None:
+                continue
+            info = api.info() or {}
+
+            mcp_field = info.get("mcp")
+            auth_mode = info.get("auth_mode")
+            if isinstance(mcp_field, dict) and isinstance(auth_mode, str):
+                return OSInfo(
+                    base_url=candidate,
+                    version=info.get("agno_version"),
+                    mcp_enabled=bool(mcp_field.get("enabled")),
+                    mcp_path=mcp_field.get("path") or ("/mcp" if mcp_field.get("enabled") else None),
+                    auth_mode=auth_mode,
+                    discovered_via="info",
+                )
+
+            mcp_enabled = _probe_mcp(candidate)
+            return OSInfo(
+                base_url=candidate,
+                version=info.get("agno_version"),
+                mcp_enabled=mcp_enabled,
+                mcp_path="/mcp" if mcp_enabled else None,
+                auth_mode=api.probe_auth_mode(),
+                discovered_via="probe",
+            )
+
+    tried = ", ".join(candidates)
+    raise CLIError(
+        "No running AgentOS found (tried: " + tried + ").",
+        hint="Start your AgentOS (agent_os.serve()) or pass --url / set " + URL_ENV_VAR + ".",
+    )
+
+
+MCP_ENABLE_INSTRUCTIONS = """MCP is not enabled on this AgentOS. Enable it and restart:
+
+    agent_os = AgentOS(
+        agents=[...],
+        enable_mcp_server=True,  # add this line
+    )
+"""

--- a/libs/agno_cli/agno_cli/errors.py
+++ b/libs/agno_cli/agno_cli/errors.py
@@ -1,0 +1,28 @@
+"""Error types shared across CLI commands."""
+
+from typing import Optional
+
+
+class CLIError(Exception):
+    """A user-facing failure. Commands catch this, print the message, and exit with exit_code."""
+
+    def __init__(self, message: str, exit_code: int = 1, hint: Optional[str] = None):
+        super().__init__(message)
+        self.message = message
+        self.exit_code = exit_code
+        self.hint = hint
+
+
+class APIError(CLIError):
+    """An AgentOS API call failed."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None, hint: Optional[str] = None):
+        super().__init__(message, exit_code=1, hint=hint)
+        self.status_code = status_code
+
+
+class ConflictError(APIError):
+    """The AgentOS reported a conflict (e.g. a service account with this name already exists)."""
+
+    def __init__(self, message: str, hint: Optional[str] = None):
+        super().__init__(message, status_code=409, hint=hint)

--- a/libs/agno_cli/agno_cli/http.py
+++ b/libs/agno_cli/agno_cli/http.py
@@ -1,0 +1,247 @@
+"""Thin HTTP client for the AgentOS REST API.
+
+This module talks plain HTTP to a running AgentOS. It deliberately does not import the
+agno framework: the CLI must stay installable and fast under `uvx` with nothing but
+httpx, rich, and typer.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno_cli import __version__
+from agno_cli.errors import APIError, ConflictError
+
+# Test hook: tests set this to an httpx.MockTransport so every client in the CLI
+# (API, discovery, MCP verification) talks to an in-memory fake AgentOS.
+_transport_override: Optional[httpx.BaseTransport] = None
+
+DEFAULT_TIMEOUT = 10.0
+
+
+def build_client(base_url: str = "", timeout: float = DEFAULT_TIMEOUT) -> httpx.Client:
+    return httpx.Client(
+        base_url=base_url,
+        timeout=timeout,
+        transport=_transport_override,
+        headers={"user-agent": "agnoctl/" + __version__},
+        follow_redirects=True,
+    )
+
+
+@dataclass
+class ServiceAccount:
+    id: str
+    name: str
+    principal: str
+    token_prefix: str
+    scopes: List[str] = field(default_factory=list)
+    created_at: Optional[int] = None
+    expires_at: Optional[int] = None
+    last_used_at: Optional[int] = None
+    revoked_at: Optional[int] = None
+    created_by: Optional[str] = None
+    # Present only on the create response; never persisted by the CLI.
+    token: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccount":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            principal=data.get("principal") or "sa:" + data["name"],
+            token_prefix=data.get("token_prefix") or "",
+            scopes=data.get("scopes") or [],
+            created_at=data.get("created_at"),
+            expires_at=data.get("expires_at"),
+            last_used_at=data.get("last_used_at"),
+            revoked_at=data.get("revoked_at"),
+            created_by=data.get("created_by"),
+            token=data.get("token"),
+        )
+
+    def public_dict(self) -> Dict[str, Any]:
+        """The account as a JSON-safe dict, always excluding the plaintext token."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "principal": self.principal,
+            "token_prefix": self.token_prefix,
+            "scopes": self.scopes,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "last_used_at": self.last_used_at,
+            "revoked_at": self.revoked_at,
+        }
+
+
+def _error_detail(response: httpx.Response) -> str:
+    try:
+        detail = response.json().get("detail")
+        if isinstance(detail, str) and detail:
+            return detail
+    except Exception:
+        pass
+    return "HTTP " + str(response.status_code)
+
+
+class AgentOSAPI:
+    """Sync client for the AgentOS endpoints the CLI needs.
+
+    The CLI is a short-lived terminal process making a handful of sequential calls, so a
+    sync client is the right shape; programs embedding Agno should use agno.client instead.
+    """
+
+    def __init__(self, base_url: str, admin_token: Optional[str] = None, timeout: float = DEFAULT_TIMEOUT):
+        self.base_url = base_url.rstrip("/")
+        self.admin_token = admin_token
+        self._client = build_client(base_url=self.base_url, timeout=timeout)
+
+    def _headers(self) -> Dict[str, str]:
+        if self.admin_token:
+            return {"Authorization": "Bearer " + self.admin_token}
+        return {}
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "AgentOSAPI":
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.close()
+
+    # -- Probes ------------------------------------------------------------------
+
+    def health(self) -> Optional[Dict[str, Any]]:
+        """GET /health. Returns the payload, or None when unreachable or not an AgentOS."""
+        try:
+            response = self._client.get("/health")
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        try:
+            payload = response.json()
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def info(self) -> Optional[Dict[str, Any]]:
+        """GET /info (unauthenticated). Returns the payload, or None when unavailable."""
+        try:
+            response = self._client.get("/info")
+        except httpx.HTTPError:
+            return None
+        if response.status_code != 200:
+            return None
+        try:
+            payload = response.json()
+        except Exception:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def probe_auth_mode(self) -> str:
+        """Detect the auth mode by probing GET /config without credentials.
+
+        Fallback for servers whose /info predates the mcp/auth_mode discovery fields.
+        The 401 detail strings are the only externally observable distinction between
+        security-key mode and JWT mode on older servers.
+        """
+        try:
+            response = self._client.get("/config")
+        except httpx.HTTPError:
+            return "unknown"
+        if response.status_code == 200:
+            return "none"
+        if response.status_code == 401:
+            detail = _error_detail(response)
+            if "required" in detail.lower():
+                return "security_key"
+            return "jwt"
+        return "unknown"
+
+    # -- Service accounts ----------------------------------------------------------
+
+    def create_service_account(
+        self,
+        name: str,
+        scopes: Optional[List[str]] = None,
+        expires_in_days: Optional[int] = None,
+        never_expires: bool = False,
+        allow_privileged_scopes: bool = False,
+    ) -> ServiceAccount:
+        body: Dict[str, Any] = {"name": name}
+        if scopes:
+            body["scopes"] = scopes
+        if never_expires:
+            body["never_expires"] = True
+        elif expires_in_days is not None:
+            body["expires_in_days"] = expires_in_days
+        if allow_privileged_scopes:
+            body["allow_privileged_scopes"] = True
+
+        response = self._request("POST", "/service-accounts", json=body)
+        if response.status_code == 409:
+            raise ConflictError(
+                "A service account named '" + name + "' already exists.",
+                hint="Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched.",
+            )
+        if response.status_code != 201:
+            raise APIError(
+                "Could not create service account '" + name + "': " + _error_detail(response),
+                status_code=response.status_code,
+            )
+        return ServiceAccount.from_dict(response.json())
+
+    def list_service_accounts(self) -> List[ServiceAccount]:
+        accounts: List[ServiceAccount] = []
+        page = 1
+        while True:
+            response = self._request("GET", "/service-accounts", params={"page": page, "limit": 100})
+            if response.status_code != 200:
+                raise APIError(
+                    "Could not list service accounts: " + _error_detail(response),
+                    status_code=response.status_code,
+                )
+            payload = response.json()
+            data = payload.get("data") if isinstance(payload, dict) else payload
+            if not isinstance(data, list):
+                break
+            accounts.extend(ServiceAccount.from_dict(item) for item in data)
+            meta = payload.get("meta") if isinstance(payload, dict) else None
+            total_pages = (meta or {}).get("total_pages") if isinstance(meta, dict) else None
+            if not total_pages or page >= int(total_pages):
+                break
+            page += 1
+        return accounts
+
+    def find_service_account(self, name: str) -> Optional[ServiceAccount]:
+        for account in self.list_service_accounts():
+            if account.name == name:
+                return account
+        return None
+
+    def revoke_service_account(self, account_id: str) -> None:
+        response = self._request("DELETE", "/service-accounts/" + account_id)
+        if response.status_code not in (200, 204):
+            raise APIError(
+                "Could not revoke service account: " + _error_detail(response),
+                status_code=response.status_code,
+            )
+
+    # -- Internals -----------------------------------------------------------------
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            response = self._client.request(method, path, headers=self._headers(), **kwargs)
+        except httpx.HTTPError as e:
+            raise APIError("Could not reach the AgentOS at " + self.base_url + ": " + str(e)) from e
+        if response.status_code in (401, 403):
+            raise APIError(
+                "The AgentOS rejected the admin credential (" + _error_detail(response) + ").",
+                status_code=response.status_code,
+                hint="Set AGNO_ADMIN_TOKEN (or OS_SECURITY_KEY) to a credential with admin access.",
+            )
+        return response

--- a/libs/agno_cli/agno_cli/http.py
+++ b/libs/agno_cli/agno_cli/http.py
@@ -184,16 +184,13 @@ class AgentOSAPI:
 
         response = self._request("POST", "/service-accounts", json=body)
         if response.status_code == 409:
-            raise ConflictError(
-                "A service account named '" + name + "' already exists.",
-                hint="Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched.",
-            )
+            raise ConflictError("A service account named '" + name + "' already exists.")
         if response.status_code != 201:
             raise APIError(
                 "Could not create service account '" + name + "': " + _error_detail(response),
                 status_code=response.status_code,
             )
-        return ServiceAccount.from_dict(response.json())
+        return self._parse_account(response)
 
     def list_service_accounts(self) -> List[ServiceAccount]:
         accounts: List[ServiceAccount] = []
@@ -205,11 +202,16 @@ class AgentOSAPI:
                     "Could not list service accounts: " + _error_detail(response),
                     status_code=response.status_code,
                 )
-            payload = response.json()
+            payload = self._parse_json(response)
             data = payload.get("data") if isinstance(payload, dict) else payload
             if not isinstance(data, list):
                 break
-            accounts.extend(ServiceAccount.from_dict(item) for item in data)
+            for item in data:
+                if isinstance(item, dict):
+                    try:
+                        accounts.append(ServiceAccount.from_dict(item))
+                    except KeyError as e:
+                        raise APIError("The AgentOS returned a malformed service account (missing " + str(e) + ").")
             meta = payload.get("meta") if isinstance(payload, dict) else None
             total_pages = (meta or {}).get("total_pages") if isinstance(meta, dict) else None
             if not total_pages or page >= int(total_pages):
@@ -232,6 +234,27 @@ class AgentOSAPI:
             )
 
     # -- Internals -----------------------------------------------------------------
+
+    def _parse_json(self, response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except Exception:
+            raise APIError(
+                "The server at "
+                + self.base_url
+                + " returned a non-JSON response (HTTP "
+                + str(response.status_code)
+                + ") - is this really an AgentOS?"
+            )
+
+    def _parse_account(self, response: httpx.Response) -> ServiceAccount:
+        payload = self._parse_json(response)
+        if not isinstance(payload, dict):
+            raise APIError("The AgentOS returned an unexpected service-account payload.")
+        try:
+            return ServiceAccount.from_dict(payload)
+        except KeyError as e:
+            raise APIError("The AgentOS returned a malformed service account (missing " + str(e) + ").")
 
     def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         try:

--- a/libs/agno_cli/agno_cli/main.py
+++ b/libs/agno_cli/agno_cli/main.py
@@ -7,7 +7,7 @@ import typer
 from agno_cli import __version__
 from agno_cli.commands.connect import connect
 from agno_cli.commands.create import create
-from agno_cli.commands.infra import infra_app
+from agno_cli.commands.lifecycle import down, restart, up
 from agno_cli.commands.status import status
 from agno_cli.commands.tokens import tokens_app
 from agno_cli.console import print_info, print_warning
@@ -26,7 +26,9 @@ app.command(name="connect")(connect)
 app.command(name="create")(create)
 app.command(name="status")(status)
 app.add_typer(tokens_app, name="tokens")
-app.add_typer(infra_app, name="infra")
+app.command(name="up")(up)
+app.command(name="down")(down)
+app.command(name="restart")(restart)
 
 
 def _load_plugins() -> None:

--- a/libs/agno_cli/agno_cli/main.py
+++ b/libs/agno_cli/agno_cli/main.py
@@ -1,0 +1,73 @@
+"""The `agno` command: root Typer app and plugin loader."""
+
+from typing import Optional
+
+import typer
+
+from agno_cli import __version__
+from agno_cli.commands.connect import connect
+from agno_cli.commands.status import status
+from agno_cli.commands.tokens import tokens_app
+from agno_cli.console import print_info, print_warning
+
+PLUGIN_GROUP = "agno_cli.plugins"
+
+app = typer.Typer(
+    name="agno",
+    help="The Agno CLI: connect and operate AgentOS, built for humans and coding agents.",
+    no_args_is_help=True,
+    add_completion=False,
+    pretty_exceptions_show_locals=False,
+)
+
+app.command(name="connect")(connect)
+app.command(name="status")(status)
+app.add_typer(tokens_app, name="tokens")
+
+
+def _load_plugins() -> None:
+    """Mount subcommand groups exposed by other installed distributions.
+
+    A plugin is an entry point in the `agno_cli.plugins` group resolving to a
+    typer.Typer; the entry-point name becomes the subcommand name. A broken plugin
+    must never take the core CLI down, so failures are reported and skipped.
+    """
+    from importlib.metadata import entry_points
+
+    try:
+        plugin_entry_points = entry_points(group=PLUGIN_GROUP)
+    except TypeError:  # Python 3.9: entry_points() takes no kwargs and returns a dict
+        plugin_entry_points = entry_points().get(PLUGIN_GROUP, [])  # type: ignore[arg-type,attr-defined]
+
+    for entry_point in plugin_entry_points:
+        try:
+            plugin = entry_point.load()
+        except Exception as e:
+            print_warning("Skipping CLI plugin '" + entry_point.name + "': " + str(e))
+            continue
+        if isinstance(plugin, typer.Typer):
+            app.add_typer(plugin, name=entry_point.name)
+        else:
+            print_warning("Skipping CLI plugin '" + entry_point.name + "': not a typer.Typer")
+
+
+_load_plugins()
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        print_info("agnoctl " + __version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=_version_callback, is_eager=True, help="Print the CLI version and exit."
+    ),
+) -> None:
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/libs/agno_cli/agno_cli/main.py
+++ b/libs/agno_cli/agno_cli/main.py
@@ -6,6 +6,8 @@ import typer
 
 from agno_cli import __version__
 from agno_cli.commands.connect import connect
+from agno_cli.commands.create import create
+from agno_cli.commands.infra import infra_app
 from agno_cli.commands.status import status
 from agno_cli.commands.tokens import tokens_app
 from agno_cli.console import print_info, print_warning
@@ -21,8 +23,10 @@ app = typer.Typer(
 )
 
 app.command(name="connect")(connect)
+app.command(name="create")(create)
 app.command(name="status")(status)
 app.add_typer(tokens_app, name="tokens")
+app.add_typer(infra_app, name="infra")
 
 
 def _load_plugins() -> None:

--- a/libs/agno_cli/agno_cli/mcp_client.py
+++ b/libs/agno_cli/agno_cli/mcp_client.py
@@ -57,9 +57,16 @@ def _parse_jsonrpc_body(response: httpx.Response) -> Optional[Dict[str, Any]]:
 def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0) -> MCPVerifyResult:
     """Handshake with an MCP streamable-HTTP endpoint and list its tools.
 
-    Never raises: connection problems come back as a failed MCPVerifyResult so callers
-    can report per-client outcomes.
+    Never raises: connection problems and malformed payloads come back as a failed
+    MCPVerifyResult so callers can report per-client outcomes.
     """
+    try:
+        return _verify_mcp(mcp_url, token, timeout)
+    except Exception as e:  # never-raises contract
+        return MCPVerifyResult(ok=False, error="MCP verification failed: " + str(e))
+
+
+def _verify_mcp(mcp_url: str, token: Optional[str], timeout: float) -> MCPVerifyResult:
     headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
@@ -131,9 +138,11 @@ def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0)
                     status_code=tools_response.status_code,
                     error="MCP tools/list returned an unexpected payload.",
                 )
-            tools = [
-                tool.get("name", "") for tool in tools_message["result"].get("tools", []) if isinstance(tool, dict)
-            ]
+            result = tools_message["result"]
+            raw_tools = result.get("tools", []) if isinstance(result, dict) else []
+            if not isinstance(raw_tools, list):
+                raw_tools = []
+            tools = [tool.get("name", "") for tool in raw_tools if isinstance(tool, dict)]
             return MCPVerifyResult(ok=True, tools=tools, status_code=tools_response.status_code)
     except httpx.HTTPError as e:
         return MCPVerifyResult(ok=False, error="Could not reach the MCP endpoint: " + str(e))

--- a/libs/agno_cli/agno_cli/mcp_client.py
+++ b/libs/agno_cli/agno_cli/mcp_client.py
@@ -1,0 +1,139 @@
+"""Minimal MCP streamable-HTTP client, used only to verify connections.
+
+Speaks just enough JSON-RPC over streamable HTTP (initialize -> notifications/initialized
+-> tools/list) to prove that a written client config would actually work. Implemented on
+plain httpx so the CLI does not depend on the mcp package.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno_cli import __version__
+from agno_cli.http import build_client
+
+PROTOCOL_VERSION = "2025-03-26"
+
+SESSION_HEADER = "mcp-session-id"
+
+
+@dataclass
+class MCPVerifyResult:
+    ok: bool
+    tools: List[str] = field(default_factory=list)
+    status_code: Optional[int] = None
+    error: Optional[str] = None
+
+    def public_dict(self) -> Dict[str, Any]:
+        return {"ok": self.ok, "tools": len(self.tools), "status_code": self.status_code, "error": self.error}
+
+
+def _parse_jsonrpc_body(response: httpx.Response) -> Optional[Dict[str, Any]]:
+    """Extract the first JSON-RPC message from a JSON or SSE response body."""
+    content_type = response.headers.get("content-type", "")
+    text = response.text
+    if "text/event-stream" in content_type:
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                payload = line[len("data:") :].strip()
+                if payload:
+                    try:
+                        parsed = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(parsed, dict):
+                        return parsed
+        return None
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0) -> MCPVerifyResult:
+    """Handshake with an MCP streamable-HTTP endpoint and list its tools.
+
+    Never raises: connection problems come back as a failed MCPVerifyResult so callers
+    can report per-client outcomes.
+    """
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    if token:
+        headers["Authorization"] = "Bearer " + token
+
+    try:
+        with build_client(timeout=timeout) as client:
+            init_response = client.post(
+                mcp_url,
+                headers=headers,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {"name": "agnoctl", "version": __version__},
+                    },
+                },
+            )
+            if init_response.status_code in (401, 403):
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=init_response.status_code,
+                    error="The MCP endpoint rejected the credential (HTTP " + str(init_response.status_code) + ").",
+                )
+            if init_response.status_code >= 400:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=init_response.status_code,
+                    error="MCP initialize failed with HTTP " + str(init_response.status_code) + ".",
+                )
+            init_message = _parse_jsonrpc_body(init_response)
+            if init_message is None or "result" not in init_message:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=init_response.status_code,
+                    error="MCP initialize returned an unexpected payload.",
+                )
+
+            session_id = init_response.headers.get(SESSION_HEADER)
+            if session_id:
+                headers[SESSION_HEADER] = session_id
+
+            client.post(
+                mcp_url,
+                headers=headers,
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+
+            tools_response = client.post(
+                mcp_url,
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            )
+            if tools_response.status_code >= 400:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=tools_response.status_code,
+                    error="MCP tools/list failed with HTTP " + str(tools_response.status_code) + ".",
+                )
+            tools_message = _parse_jsonrpc_body(tools_response)
+            if tools_message is None or "result" not in tools_message:
+                return MCPVerifyResult(
+                    ok=False,
+                    status_code=tools_response.status_code,
+                    error="MCP tools/list returned an unexpected payload.",
+                )
+            tools = [
+                tool.get("name", "") for tool in tools_message["result"].get("tools", []) if isinstance(tool, dict)
+            ]
+            return MCPVerifyResult(ok=True, tools=tools, status_code=tools_response.status_code)
+    except httpx.HTTPError as e:
+        return MCPVerifyResult(ok=False, error="Could not reach the MCP endpoint: " + str(e))

--- a/libs/agno_cli/pyproject.toml
+++ b/libs/agno_cli/pyproject.toml
@@ -1,0 +1,73 @@
+[project]
+name = "agnoctl"
+version = "0.1.0"
+description = "The Agno CLI: connect and operate AgentOS from the terminal, built for humans and coding agents"
+requires-python = ">=3.9,<4"
+readme = "README.md"
+license = { file = "LICENSE" }
+authors = [
+  {name = "Ashpreet Bedi", email = "ashpreet@agno.com"}
+]
+keywords = ["agno", "agentos", "cli", "mcp", "agents"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Environment :: Console",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+  "httpx",
+  "rich",
+  "typer",
+  "tomli; python_version < '3.11'",
+]
+
+[project.optional-dependencies]
+dev = [
+  "mypy",
+  "pytest",
+  "ruff",
+]
+
+[project.scripts]
+agno = "agno_cli.main:app"
+agnoctl = "agno_cli.main:app"
+
+[project.urls]
+homepage = "https://agno.com"
+documentation = "https://docs.agno.com"
+repository = "https://github.com/agno-agi/agno"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["agno_cli*"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.mypy]
+check_untyped_defs = true
+no_implicit_optional = true
+warn_unused_configs = true
+exclude = ["tests*", "build*"]
+
+[[tool.mypy.overrides]]
+module = ["tomli.*"]
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/libs/agno_cli/scripts/_utils.sh
+++ b/libs/agno_cli/scripts/_utils.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+############################################################################
+# Collection of helper functions to import in other scripts
+############################################################################
+
+space_to_continue() {
+  read -n1 -r -p "Press Enter/Space to continue...  " key
+  if [ "$key" = '' ]; then
+    # Space pressed, pass
+    :
+  else
+    exit 1
+  fi
+  echo ""
+}
+
+print_horizontal_line() {
+  echo "------------------------------------------------------------"
+}
+
+print_heading() {
+  print_horizontal_line
+  echo "-*- $1"
+  print_horizontal_line
+}
+
+print_info() {
+  echo "-*- $1"
+}

--- a/libs/agno_cli/scripts/format.sh
+++ b/libs/agno_cli/scripts/format.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+############################################################################
+# Format the agno_cli library using ruff
+# Usage: ./libs/agno_cli/scripts/format.sh
+############################################################################
+
+CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGNO_CLI_DIR="$(dirname ${CURR_DIR})"
+source ${CURR_DIR}/_utils.sh
+
+print_heading "Formatting agno_cli"
+
+print_heading "Running: ruff format ${AGNO_CLI_DIR}"
+ruff format ${AGNO_CLI_DIR}
+
+print_heading "Running: ruff check --select I --fix ${AGNO_CLI_DIR}"
+ruff check --select I --fix ${AGNO_CLI_DIR}

--- a/libs/agno_cli/scripts/validate.sh
+++ b/libs/agno_cli/scripts/validate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+############################################################################
+# Validate the agno_cli library using ruff and mypy
+# Usage: ./libs/agno_cli/scripts/validate.sh
+############################################################################
+
+CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGNO_CLI_DIR="$(dirname ${CURR_DIR})"
+source ${CURR_DIR}/_utils.sh
+
+print_heading "Validating agno_cli"
+
+print_heading "Running: ruff check ${AGNO_CLI_DIR}"
+ruff check ${AGNO_CLI_DIR}
+
+print_heading "Running: mypy ${AGNO_CLI_DIR}/agno_cli --config-file ${AGNO_CLI_DIR}/pyproject.toml"
+mypy ${AGNO_CLI_DIR}/agno_cli --config-file ${AGNO_CLI_DIR}/pyproject.toml

--- a/libs/agno_cli/tests/conftest.py
+++ b/libs/agno_cli/tests/conftest.py
@@ -1,0 +1,200 @@
+"""Test fixtures: an in-memory fake AgentOS served through httpx.MockTransport."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+
+class FakeAgentOS:
+    """Simulates the AgentOS endpoints the CLI touches.
+
+    auth_mode: "none" | "security_key" | "jwt"
+    info_discovery: serve the mcp/auth_mode fields on /info (newer servers)
+    mcp_requires_token: enforce tokens on /mcp (False models servers predating enforcement)
+    """
+
+    def __init__(
+        self,
+        auth_mode: str = "security_key",
+        security_key: str = "test-admin-key",
+        mcp_enabled: bool = True,
+        info_discovery: bool = True,
+        mcp_requires_token: bool = True,
+        sse_responses: bool = False,
+        agno_version: str = "2.7.0",
+    ):
+        self.auth_mode = auth_mode
+        self.security_key = security_key
+        self.mcp_enabled = mcp_enabled
+        self.info_discovery = info_discovery
+        self.mcp_requires_token = mcp_requires_token
+        self.sse_responses = sse_responses
+        self.agno_version = agno_version
+
+        self.accounts: Dict[str, Dict[str, Any]] = {}  # name -> account dict (with plaintext token)
+        self.create_calls = 0
+        self.mcp_tools = ["run_agent", "run_team", "run_workflow", "get_agentos_config"]
+        self._next_id = 1
+
+    # -- helpers -------------------------------------------------------------------
+
+    def transport(self) -> httpx.MockTransport:
+        return httpx.MockTransport(self.handler)
+
+    def active_tokens(self) -> List[str]:
+        return [a["token"] for a in self.accounts.values() if not a.get("revoked_at")]
+
+    def _bearer(self, request: httpx.Request) -> Optional[str]:
+        value = request.headers.get("Authorization")
+        if value and value.lower().startswith("bearer "):
+            return value[len("bearer ") :]
+        return value
+
+    def _is_admin(self, request: httpx.Request) -> bool:
+        if self.auth_mode == "none":
+            return True
+        return self._bearer(request) == self.security_key
+
+    def _account_response(self, account: Dict[str, Any], include_token: bool = False) -> Dict[str, Any]:
+        payload = {k: v for k, v in account.items() if k != "token"}
+        if include_token:
+            payload["token"] = account["token"]
+        return payload
+
+    def _jsonrpc_response(self, payload: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> httpx.Response:
+        if self.sse_responses:
+            body = "event: message\ndata: " + json.dumps(payload) + "\n\n"
+            return httpx.Response(
+                200, content=body.encode(), headers={"content-type": "text/event-stream", **(headers or {})}
+            )
+        return httpx.Response(200, json=payload, headers=headers or {})
+
+    # -- request handler -----------------------------------------------------------
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+
+        if path == "/health":
+            return httpx.Response(200, json={"status": "ok", "instantiated_at": "2026-07-04T00:00:00Z"})
+
+        if path == "/info":
+            payload: Dict[str, Any] = {"agno_version": self.agno_version, "agents": 1, "teams": 0, "workflows": 0}
+            if self.info_discovery:
+                payload["mcp"] = {"enabled": self.mcp_enabled, "path": "/mcp" if self.mcp_enabled else None}
+                payload["auth_mode"] = self.auth_mode
+            return httpx.Response(200, json=payload)
+
+        if path == "/config":
+            if self.auth_mode == "none":
+                return httpx.Response(200, json={"os_id": "fake"})
+            if self._bearer(request) == self.security_key:
+                return httpx.Response(200, json={"os_id": "fake"})
+            detail = (
+                "Authorization header required" if self.auth_mode == "security_key" else "Authorization header missing"
+            )
+            return httpx.Response(401, json={"detail": detail})
+
+        if path == "/service-accounts" and method == "POST":
+            if not self._is_admin(request):
+                return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            body = json.loads(request.content)
+            name = body["name"]
+            if name in self.accounts and not self.accounts[name].get("revoked_at"):
+                return httpx.Response(409, json={"detail": "Service account '" + name + "' already exists"})
+            self.create_calls += 1
+            # Realistic length: real tokens are agno_pat_ + 43 base62 chars, so the
+            # 16-char display prefix must never contain the whole token.
+            token = "agno_pat_" + (name.replace("-", "") + str(self._next_id) + "x" * 40)[:43]
+            account = {
+                "id": "sa-" + str(self._next_id),
+                "name": name,
+                "principal": "sa:" + name,
+                "token_prefix": token[:16],
+                "scopes": body.get("scopes") or ["agents:run", "teams:run", "workflows:run", "sessions:read"],
+                "created_at": 1780000000,
+                "expires_at": None if body.get("never_expires") else 1790000000,
+                "last_used_at": None,
+                "revoked_at": None,
+                "created_by": None,
+                "token": token,
+            }
+            self._next_id += 1
+            self.accounts[name] = account
+            return httpx.Response(201, json=self._account_response(account, include_token=True))
+
+        if path == "/service-accounts" and method == "GET":
+            if not self._is_admin(request):
+                return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            data = [self._account_response(a) for a in self.accounts.values()]
+            return httpx.Response(
+                200,
+                json={"data": data, "meta": {"page": 1, "limit": 100, "total_pages": 1, "total_count": len(data)}},
+            )
+
+        if path.startswith("/service-accounts/") and method == "DELETE":
+            if not self._is_admin(request):
+                return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            account_id = path.rsplit("/", 1)[1]
+            for account in self.accounts.values():
+                if account["id"] == account_id:
+                    account["revoked_at"] = 1780000001
+                    return httpx.Response(204)
+            return httpx.Response(404, json={"detail": "Service account not found"})
+
+        if path == "/mcp":
+            if not self.mcp_enabled:
+                return httpx.Response(404, json={"detail": "Not Found"})
+            if self.mcp_requires_token and self.auth_mode != "none":
+                token = self._bearer(request)
+                if token != self.security_key and token not in self.active_tokens():
+                    return httpx.Response(401, json={"detail": "Invalid authentication token"})
+            message = json.loads(request.content) if request.content else {}
+            rpc_method = message.get("method")
+            if rpc_method == "initialize":
+                return self._jsonrpc_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "result": {
+                            "protocolVersion": "2025-03-26",
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "FakeAgentOS", "version": self.agno_version},
+                        },
+                    },
+                    headers={"mcp-session-id": "fake-session-1"},
+                )
+            if rpc_method == "notifications/initialized":
+                return httpx.Response(202)
+            if rpc_method == "tools/list":
+                return self._jsonrpc_response(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "result": {"tools": [{"name": name} for name in self.mcp_tools]},
+                    }
+                )
+            return self._jsonrpc_response(
+                {"jsonrpc": "2.0", "id": message.get("id"), "error": {"code": -32601, "message": "Method not found"}}
+            )
+
+        return httpx.Response(404, json={"detail": "Not Found"})
+
+
+@pytest.fixture
+def fake_os(monkeypatch: pytest.MonkeyPatch) -> FakeAgentOS:
+    """A security-key-mode fake AgentOS wired into every CLI HTTP client."""
+    fake = FakeAgentOS()
+    install_fake(monkeypatch, fake)
+    return fake
+
+
+def install_fake(monkeypatch: pytest.MonkeyPatch, fake: FakeAgentOS) -> None:
+    import agno_cli.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", fake.transport())
+    # Keep host-machine credentials and URL overrides out of tests.
+    for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGNO_OS_URL"):
+        monkeypatch.delenv(var, raising=False)

--- a/libs/agno_cli/tests/test_adapters.py
+++ b/libs/agno_cli/tests/test_adapters.py
@@ -1,0 +1,247 @@
+"""Client adapters: config reads/writes for Claude Code, Codex, and Cursor."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+from agno_cli.clients.claude_code import ClaudeCodeAdapter
+from agno_cli.clients.codex import CodexAdapter
+from agno_cli.clients.cursor import CursorAdapter
+
+URL = "http://localhost:7777/mcp"
+TOKEN = "agno_pat_test123"
+
+
+class FakeRunner:
+    """Records subprocess invocations and plays back scripted results."""
+
+    def __init__(self, results: Optional[List[subprocess.CompletedProcess]] = None):
+        self.calls: List[List[str]] = []
+        self.results = results or []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append(list(args))
+        if self.results:
+            return self.results.pop(0)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+
+# -- Claude Code -----------------------------------------------------------------------
+
+
+def test_claude_write_via_cli_flag_order(tmp_path: Path):
+    runner = FakeRunner()
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: "/usr/bin/claude", runner=runner)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "cli"
+    args = runner.calls[0]
+    assert args[:3] == ["claude", "mcp", "add"]
+    # Variadic --header must come after the positional name and URL.
+    assert args.index("--header") > args.index("agno") > args.index("--transport")
+    assert args.index("--header") > args.index(URL)
+    assert "Authorization: Bearer " + TOKEN in args
+
+
+def test_claude_write_cli_retries_on_already_exists(tmp_path: Path):
+    runner = FakeRunner(
+        results=[
+            subprocess.CompletedProcess([], 1, stdout="", stderr="MCP server agno already exists"),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+            subprocess.CompletedProcess([], 0, stdout="", stderr=""),
+        ]
+    )
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: "/usr/bin/claude", runner=runner)
+    adapter.write("agno", URL, TOKEN)
+    assert runner.calls[1][:3] == ["claude", "mcp", "remove"]
+    assert runner.calls[2][:3] == ["claude", "mcp", "add"]
+
+
+def test_claude_write_file_fallback_without_binary(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "file"
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    entry = config["mcpServers"]["agno"]
+    assert entry["url"] == URL
+    assert entry["headers"]["Authorization"] == "Bearer " + TOKEN
+
+
+def test_claude_write_without_token_omits_headers(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    adapter.write("agno", URL, None)
+    entry = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]["agno"]
+    assert "headers" not in entry
+
+
+def test_claude_read_existing_project_file(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    adapter.write("agno", URL, TOKEN)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == URL
+    assert entry.token == TOKEN
+
+
+def test_claude_read_existing_user_scope(tmp_path: Path):
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {"mcpServers": {"agno": {"type": "http", "url": URL, "headers": {"Authorization": "Bearer " + TOKEN}}}}
+        )
+    )
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.token == TOKEN
+
+
+def test_claude_read_existing_local_scope(tmp_path: Path):
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    (tmp_path / ".claude.json").write_text(json.dumps({"projects": {str(cwd): {"mcpServers": {"agno": {"url": URL}}}}}))
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=cwd, which=lambda name: None)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.token is None
+
+
+def test_claude_detect(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    assert adapter.detect() is False
+    (tmp_path / ".claude.json").write_text("{}")
+    assert adapter.detect() is True
+
+
+# -- Codex -----------------------------------------------------------------------------
+
+
+def test_codex_write_creates_config(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "file"
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert parsed["mcp_servers"]["agno"]["http_headers"]["Authorization"] == "Bearer " + TOKEN
+    assert (adapter.config_path.stat().st_mode & 0o777) == 0o600
+
+
+def test_codex_write_preserves_other_content(tmp_path: Path):
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        '# my settings\nmodel = "o5"\n\n[mcp_servers.other]\nurl = "https://example.com/mcp"\n'
+    )
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    text = adapter.config_path.read_text()
+    assert "# my settings" in text
+    parsed = tomllib.loads(text)
+    assert parsed["model"] == "o5"
+    assert parsed["mcp_servers"]["other"]["url"] == "https://example.com/mcp"
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+
+
+def test_codex_write_replaces_existing_entry(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", "http://old:1/mcp", "agno_pat_old")
+    adapter.write("agno", URL, TOKEN)
+
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert parsed["mcp_servers"]["agno"]["http_headers"]["Authorization"] == "Bearer " + TOKEN
+    assert adapter.config_path.read_text().count("[mcp_servers.agno]") == 1
+
+
+def test_codex_replaces_dotted_subtables(tmp_path: Path):
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    (config_dir / "config.toml").write_text(
+        '[mcp_servers.agno]\nurl = "http://old:1/mcp"\n\n[mcp_servers.agno.http_headers]\nAuthorization = "Bearer old"\n\n[mcp_servers.keep]\nurl = "https://keep/mcp"\n'
+    )
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert parsed["mcp_servers"]["keep"]["url"] == "https://keep/mcp"
+    assert "Bearer old" not in adapter.config_path.read_text()
+
+
+def test_codex_read_existing_roundtrip(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == URL
+    assert entry.token == TOKEN
+
+
+def test_codex_read_missing_or_malformed(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    assert adapter.read_existing("agno") is None
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text("this is [not valid toml")
+    assert adapter.read_existing("agno") is None
+
+
+# -- Cursor ----------------------------------------------------------------------------
+
+
+def test_cursor_write_global(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    result = adapter.write("agno", URL, TOKEN)
+
+    assert result.method == "file"
+    config = json.loads((tmp_path / ".cursor" / "mcp.json").read_text())
+    assert config["mcpServers"]["agno"]["url"] == URL
+    assert config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer " + TOKEN
+    assert ((tmp_path / ".cursor" / "mcp.json").stat().st_mode & 0o777) == 0o600
+
+
+def test_cursor_write_project_scope(tmp_path: Path):
+    cwd = tmp_path / "project"
+    cwd.mkdir()
+    adapter = CursorAdapter(home=tmp_path, cwd=cwd, project=True)
+    adapter.write("agno", URL, TOKEN)
+    assert (cwd / ".cursor" / "mcp.json").exists()
+
+
+def test_cursor_write_preserves_other_servers(tmp_path: Path):
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    (config_dir / "mcp.json").write_text(json.dumps({"mcpServers": {"other": {"url": "https://other/mcp"}}}))
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    config = json.loads((config_dir / "mcp.json").read_text())
+    assert config["mcpServers"]["other"]["url"] == "https://other/mcp"
+    assert config["mcpServers"]["agno"]["url"] == URL
+
+
+def test_cursor_read_prefers_project_config(tmp_path: Path):
+    cwd = tmp_path / "project"
+    (cwd / ".cursor").mkdir(parents=True)
+    (tmp_path / ".cursor").mkdir()
+    (cwd / ".cursor" / "mcp.json").write_text(json.dumps({"mcpServers": {"agno": {"url": "http://project/mcp"}}}))
+    (tmp_path / ".cursor" / "mcp.json").write_text(json.dumps({"mcpServers": {"agno": {"url": "http://global/mcp"}}}))
+    adapter = CursorAdapter(home=tmp_path, cwd=cwd)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == "http://project/mcp"
+
+
+def test_cursor_detect(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    assert adapter.detect() is False
+    (tmp_path / ".cursor").mkdir()
+    assert adapter.detect() is True

--- a/libs/agno_cli/tests/test_adapters.py
+++ b/libs/agno_cli/tests/test_adapters.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+import pytest
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -14,6 +16,7 @@ else:
 from agno_cli.clients.claude_code import ClaudeCodeAdapter
 from agno_cli.clients.codex import CodexAdapter
 from agno_cli.clients.cursor import CursorAdapter
+from agno_cli.errors import CLIError
 
 URL = "http://localhost:7777/mcp"
 TOKEN = "agno_pat_test123"
@@ -64,31 +67,77 @@ def test_claude_write_cli_retries_on_already_exists(tmp_path: Path):
     assert runner.calls[2][:3] == ["claude", "mcp", "add"]
 
 
-def test_claude_write_file_fallback_without_binary(tmp_path: Path):
+def test_claude_write_file_fallback_user_scope(tmp_path: Path):
+    """Without the binary, user-scope writes land in ~/.claude.json, never a VCS-shared file."""
     adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
     result = adapter.write("agno", URL, TOKEN)
 
     assert result.method == "file"
-    config = json.loads((tmp_path / ".mcp.json").read_text())
+    config = json.loads((tmp_path / ".claude.json").read_text())
     entry = config["mcpServers"]["agno"]
     assert entry["url"] == URL
     assert entry["headers"]["Authorization"] == "Bearer " + TOKEN
+    assert ((tmp_path / ".claude.json").stat().st_mode & 0o777) == 0o600
+    assert not (tmp_path / ".mcp.json").exists()
+
+
+def test_claude_write_file_fallback_project_scope_warns(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, scope="project", which=lambda name: None)
+    result = adapter.write("agno", URL, TOKEN)
+    config = json.loads((tmp_path / ".mcp.json").read_text())
+    assert config["mcpServers"]["agno"]["url"] == URL
+    assert result.note is not None and "version control" in result.note
+
+
+def test_claude_write_preserves_unrelated_user_config(tmp_path: Path):
+    (tmp_path / ".claude.json").write_text(json.dumps({"onboarding": True, "projects": {"/x": {}}}))
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    adapter.write("agno", URL, TOKEN)
+    config = json.loads((tmp_path / ".claude.json").read_text())
+    assert config["onboarding"] is True
+    assert config["projects"] == {"/x": {}}
+    assert config["mcpServers"]["agno"]["url"] == URL
+
+
+def test_claude_write_refuses_corrupt_config(tmp_path: Path):
+    (tmp_path / ".claude.json").write_text("{not json")
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    with pytest.raises(CLIError) as exc_info:
+        adapter.write("agno", URL, TOKEN)
+    assert "Refusing to modify" in exc_info.value.message
+    assert (tmp_path / ".claude.json").read_text() == "{not json"
 
 
 def test_claude_write_without_token_omits_headers(tmp_path: Path):
     adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
     adapter.write("agno", URL, None)
-    entry = json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]["agno"]
+    entry = json.loads((tmp_path / ".claude.json").read_text())["mcpServers"]["agno"]
     assert "headers" not in entry
 
 
-def test_claude_read_existing_project_file(tmp_path: Path):
+def test_claude_read_existing_roundtrip(tmp_path: Path):
     adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
     adapter.write("agno", URL, TOKEN)
     entry = adapter.read_existing("agno")
     assert entry is not None
     assert entry.url == URL
     assert entry.token == TOKEN
+
+
+def test_claude_local_scope_wins_over_user_scope(tmp_path: Path):
+    """Claude Code resolves local > project > user; read_existing must match."""
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {"agno": {"url": "http://user-scope/mcp"}},
+                "projects": {str(tmp_path): {"mcpServers": {"agno": {"url": "http://local-scope/mcp"}}}},
+            }
+        )
+    )
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    entry = adapter.read_existing("agno")
+    assert entry is not None
+    assert entry.url == "http://local-scope/mcp"
 
 
 def test_claude_read_existing_user_scope(tmp_path: Path):
@@ -194,6 +243,35 @@ def test_codex_read_missing_or_malformed(tmp_path: Path):
     assert adapter.read_existing("agno") is None
 
 
+def test_codex_write_refuses_corrupt_config(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text("this is [not valid toml")
+    with pytest.raises(CLIError) as exc_info:
+        adapter.write("agno", URL, TOKEN)
+    assert "Refusing to modify" in exc_info.value.message
+
+
+def test_codex_preserves_array_of_tables_after_section(tmp_path: Path):
+    """[[array-of-tables]] following the managed section must survive a rewrite."""
+    config_dir = tmp_path / ".codex"
+    config_dir.mkdir()
+    original = (
+        '[mcp_servers.agno]\nurl = "http://old:1/mcp"\n\n'
+        "# profiles below\n"
+        '[[profiles]]\nname = "work"\n\n'
+        '[[profiles]]\nname = "personal"\n'
+    )
+    (config_dir / "config.toml").write_text(original)
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.write("agno", URL, TOKEN)
+
+    parsed = tomllib.loads(adapter.config_path.read_text())
+    assert parsed["mcp_servers"]["agno"]["url"] == URL
+    assert [p["name"] for p in parsed["profiles"]] == ["work", "personal"]
+    assert "# profiles below" in adapter.config_path.read_text()
+
+
 # -- Cursor ----------------------------------------------------------------------------
 
 
@@ -245,3 +323,24 @@ def test_cursor_detect(tmp_path: Path):
     assert adapter.detect() is False
     (tmp_path / ".cursor").mkdir()
     assert adapter.detect() is True
+
+
+def test_cursor_write_refuses_corrupt_config(tmp_path: Path):
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    (config_dir / "mcp.json").write_text("{broken")
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    with pytest.raises(CLIError) as exc_info:
+        adapter.write("agno", URL, TOKEN)
+    assert "Refusing to modify" in exc_info.value.message
+    assert (config_dir / "mcp.json").read_text() == "{broken"
+
+
+def test_cursor_malformed_servers_shape_is_tolerated_on_read(tmp_path: Path):
+    config_dir = tmp_path / ".cursor"
+    config_dir.mkdir()
+    (config_dir / "mcp.json").write_text(json.dumps({"mcpServers": ["not", "a", "dict"]}))
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    assert adapter.read_existing("agno") is None
+    with pytest.raises(CLIError):
+        adapter.write("agno", URL, TOKEN)

--- a/libs/agno_cli/tests/test_connect_cmd.py
+++ b/libs/agno_cli/tests/test_connect_cmd.py
@@ -56,8 +56,8 @@ def test_connect_happy_path(monkeypatch, fake_os, fake_clients):
     for account in fake_os.accounts.values():
         assert account["token"] not in result.output
 
-    # Tokens landed in the client configs.
-    claude_config = json.loads((fake_clients / ".mcp.json").read_text())
+    # Tokens landed in the client configs (Claude user scope = ~/.claude.json).
+    claude_config = json.loads((fake_clients / ".claude.json").read_text())
     assert claude_config["mcpServers"]["agno"]["url"] == MCP_URL
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
     token = cursor_config["mcpServers"]["agno"]["headers"]["Authorization"]
@@ -82,7 +82,7 @@ def test_connect_conflict_without_rotate_fails_noninteractive(monkeypatch, fake_
     assert _connect().exit_code == 0
 
     # Wipe client configs but keep server-side accounts: mint now conflicts.
-    (fake_clients / ".mcp.json").unlink()
+    (fake_clients / ".claude.json").write_text("{}")
     (fake_clients / ".codex" / "config.toml").unlink()
     (fake_clients / ".cursor" / "mcp.json").unlink()
 
@@ -190,4 +190,60 @@ def test_connect_skip_existing_leaves_broken_entry(monkeypatch, fake_os, fake_cl
     result = _connect(["--skip-existing"])
     payload = json.loads(result.output)
     assert all(r["status"] == "skipped" for r in payload["results"])
+    assert result.exit_code == 1
+
+
+def test_connect_skip_existing_never_touches_foreign_entry(monkeypatch, fake_os, fake_clients):
+    """An entry pointing at a DIFFERENT AgentOS is untouchable under --skip-existing."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp", "headers": {"Authorization": "Bearer keep"}}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
+
+    result = _connect(["--clients", "cursor", "--skip-existing"])
+    payload = json.loads(result.output)
+    assert payload["results"][0]["status"] == "skipped"
+    assert "other-os" in payload["results"][0]["error"]
+    config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert config["mcpServers"]["agno"]["url"] == "http://other-os:9999/mcp"
+    assert config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer keep"
+    assert fake_os.create_calls == 0
+
+
+def test_connect_replacing_foreign_entry_is_reported(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp"}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
+
+    result = _connect(["--clients", "cursor"])
+    payload = json.loads(result.output)
+    assert payload["results"][0]["status"] == "connected"
+    assert payload["results"][0]["replaced_url"] == "http://other-os:9999/mcp"
+
+
+def test_connect_partial_failure_keeps_json_contract(monkeypatch, fake_os, fake_clients):
+    """One corrupt client config fails that client only; output stays one JSON document, exit 3."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".cursor" / "mcp.json").write_text("{corrupt")
+
+    result = _connect()
+    payload = json.loads(result.output)
+    by_client = {r["client"]: r for r in payload["results"]}
+    assert by_client["cursor"]["status"] == "failed"
+    assert "Refusing to modify" in by_client["cursor"]["error"]
+    assert by_client["claude-code"]["status"] == "connected"
+    assert by_client["codex"]["status"] == "connected"
+    assert result.exit_code == 3
+
+
+def test_connect_detects_shadowing_claude_local_entry(monkeypatch, fake_os, fake_clients):
+    """A stale local-scope entry shadows the user-scope write; connect must fail loudly, not lie."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".claude.json").write_text(
+        json.dumps({"projects": {str(fake_clients): {"mcpServers": {"agno": {"url": "http://stale:1/mcp"}}}}})
+    )
+
+    result = _connect(["--clients", "claude-code", "--rotate"])
+    payload = json.loads(result.output)
+    assert payload["results"][0]["status"] == "failed"
+    assert "shadow" in payload["results"][0]["error"]
     assert result.exit_code == 1

--- a/libs/agno_cli/tests/test_connect_cmd.py
+++ b/libs/agno_cli/tests/test_connect_cmd.py
@@ -1,0 +1,193 @@
+"""`agno connect` end-to-end flows against the fake AgentOS and tmp client configs."""
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import agno_cli.commands.connect as connect_module
+from agno_cli.clients.claude_code import ClaudeCodeAdapter
+from agno_cli.clients.codex import CodexAdapter
+from agno_cli.clients.cursor import CursorAdapter
+from agno_cli.main import app
+from tests.conftest import FakeAgentOS, install_fake
+
+runner = CliRunner()
+
+URL_ARGS = ["--url", "http://localhost:7777"]
+MCP_URL = "http://localhost:7777/mcp"
+
+
+@pytest.fixture
+def fake_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """All three clients 'installed' under a tmp home, wired into the connect command."""
+    (tmp_path / ".claude.json").write_text("{}")
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".cursor").mkdir()
+
+    def build(home=None, cwd=None, project=False):
+        return {
+            "claude-code": ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None),
+            "codex": CodexAdapter(home=tmp_path),
+            "cursor": CursorAdapter(home=tmp_path, cwd=tmp_path, project=project),
+        }
+
+    monkeypatch.setattr(connect_module, "build_adapters", build)
+    return tmp_path
+
+
+def _connect(args=(), **kwargs):
+    return runner.invoke(app, ["connect", "--json"] + URL_ARGS + list(args), **kwargs)
+
+
+def test_connect_happy_path(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    assert {r["client"] for r in payload["results"]} == {"claude-code", "codex", "cursor"}
+    assert all(r["status"] == "connected" for r in payload["results"])
+    assert all(r["verify"]["ok"] for r in payload["results"])
+    assert sorted(fake_os.accounts.keys()) == ["claude-code", "codex", "cursor"]
+
+    # No plaintext token anywhere in the report.
+    for account in fake_os.accounts.values():
+        assert account["token"] not in result.output
+
+    # Tokens landed in the client configs.
+    claude_config = json.loads((fake_clients / ".mcp.json").read_text())
+    assert claude_config["mcpServers"]["agno"]["url"] == MCP_URL
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    token = cursor_config["mcpServers"]["agno"]["headers"]["Authorization"]
+    assert token == "Bearer " + fake_os.accounts["cursor"]["token"]
+
+
+def test_connect_rerun_is_idempotent(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    first = _connect()
+    assert first.exit_code == 0, first.output
+    creates_after_first = fake_os.create_calls
+
+    second = _connect()
+    assert second.exit_code == 0, second.output
+    payload = json.loads(second.output)
+    assert all(r["status"] == "already-connected" for r in payload["results"])
+    assert fake_os.create_calls == creates_after_first
+
+
+def test_connect_conflict_without_rotate_fails_noninteractive(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+
+    # Wipe client configs but keep server-side accounts: mint now conflicts.
+    (fake_clients / ".mcp.json").unlink()
+    (fake_clients / ".codex" / "config.toml").unlink()
+    (fake_clients / ".cursor" / "mcp.json").unlink()
+
+    result = _connect()
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert all("already exists" in (r["error"] or "") for r in payload["results"])
+
+
+def test_connect_rotate_replaces_accounts(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    old_token = fake_os.accounts["cursor"]["token"]
+
+    result = _connect(["--rotate"])
+    assert result.exit_code == 0, result.output
+    new_token = fake_os.accounts["cursor"]["token"]
+    assert new_token != old_token
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer " + new_token
+
+
+def test_connect_rotates_stale_entry(monkeypatch, fake_os, fake_clients):
+    """A config entry whose token was revoked server-side gets rotated on re-run."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    for account in list(fake_os.accounts.values()):
+        account["revoked_at"] = 1780000001
+
+    result = _connect(["--rotate"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "connected" for r in payload["results"])
+
+
+def test_connect_no_auth_mode(monkeypatch, fake_clients):
+    fake = FakeAgentOS(auth_mode="none")
+    install_fake(monkeypatch, fake)
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "connected" for r in payload["results"])
+    assert fake.create_calls == 0
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "headers" not in cursor_config["mcpServers"]["agno"]
+
+
+def test_connect_mcp_disabled(monkeypatch, fake_clients):
+    fake = FakeAgentOS(mcp_enabled=False)
+    install_fake(monkeypatch, fake)
+    result = _connect()
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "enable_mcp_server=True" in payload["error"]
+
+
+def test_connect_warns_when_mcp_unauthenticated(monkeypatch, fake_clients):
+    fake = FakeAgentOS(mcp_requires_token=False)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["warning"] is not None
+    assert "unauthenticated" in payload["warning"]
+
+
+def test_connect_shared_account_with_name(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _connect(["--name", "my-machine"])
+    assert result.exit_code == 0, result.output
+    assert list(fake_os.accounts.keys()) == ["my-machine"]
+    assert fake_os.create_calls == 1
+
+
+def test_connect_explicit_client_selection(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [r["client"] for r in payload["results"]] == ["cursor"]
+    assert list(fake_os.accounts.keys()) == ["cursor"]
+
+
+def test_connect_unknown_client(monkeypatch, fake_os, fake_clients):
+    result = _connect(["--clients", "emacs"])
+    assert result.exit_code == 1
+    assert "Unknown client" in json.loads(result.output)["error"]
+
+
+def test_connect_missing_admin_credential(monkeypatch, fake_os, fake_clients):
+    result = _connect()
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "AGNO_ADMIN_TOKEN" in payload["hint"]
+
+
+def test_connect_skip_existing_leaves_broken_entry(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    for account in list(fake_os.accounts.values()):
+        account["revoked_at"] = 1780000001
+
+    result = _connect(["--skip-existing"])
+    payload = json.loads(result.output)
+    assert all(r["status"] == "skipped" for r in payload["results"])
+    assert result.exit_code == 1

--- a/libs/agno_cli/tests/test_create_infra.py
+++ b/libs/agno_cli/tests/test_create_infra.py
@@ -1,0 +1,168 @@
+"""`agno create` and `agno infra` behavior (git and docker are faked)."""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import agno_cli.commands.create as create_module
+import agno_cli.commands.infra as infra_module
+from agno_cli.commands.infra import find_compose_file
+from agno_cli.errors import CLIError
+from agno_cli.main import app
+
+runner = CliRunner()
+
+
+class FakeGit:
+    """Simulates `git clone` by scaffolding a template directory."""
+
+    def __init__(self, with_secrets: bool = True, returncode: int = 0):
+        self.with_secrets = with_secrets
+        self.returncode = returncode
+        self.calls = []
+
+    def __call__(self, args, **kwargs):
+        self.calls.append(list(args))
+        if self.returncode == 0 and args[:2] == ["git", "clone"]:
+            target = Path(args[-1])
+            (target / ".git").mkdir(parents=True)
+            (target / "docker-compose.yml").write_text("services: {}\n")
+            if self.with_secrets:
+                (target / "infra" / "example_secrets").mkdir(parents=True)
+                (target / "infra" / "example_secrets" / "example.env").write_text("KEY=value\n")
+        return subprocess.CompletedProcess(args, self.returncode, stdout="", stderr="boom" if self.returncode else "")
+
+
+@pytest.fixture
+def fake_git(monkeypatch, tmp_path):
+    fake = FakeGit()
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+    return fake
+
+
+def test_create_scaffolds_project(fake_git, tmp_path):
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    assert payload["template"] == "agentos-docker"
+    project = tmp_path / "my-os"
+    assert (project / "docker-compose.yml").exists()
+    assert not (project / ".git").exists()
+    assert (project / "infra" / "secrets" / "example.env").exists()
+    clone_args = fake_git.calls[0]
+    assert "https://github.com/agno-agi/agentos-docker-template" in clone_args
+
+
+def test_create_refuses_existing_directory(fake_git, tmp_path):
+    (tmp_path / "my-os").mkdir()
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+    assert result.exit_code == 1
+    assert "already exists" in json.loads(result.output)["error"]
+
+
+def test_create_unknown_template(fake_git):
+    result = runner.invoke(app, ["create", "my-os", "-t", "nope", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "Unknown template" in payload["error"]
+    assert "agentos-docker" in payload["hint"]
+
+
+def test_create_custom_url(fake_git):
+    result = runner.invoke(app, ["create", "my-os", "-u", "https://example.com/custom.git", "--json"])
+    assert result.exit_code == 0, result.output
+    assert "https://example.com/custom.git" in fake_git.calls[0]
+
+
+def test_create_clone_failure(monkeypatch, tmp_path):
+    fake = FakeGit(returncode=128)
+    monkeypatch.setattr(create_module.subprocess, "run", fake)
+    monkeypatch.setattr(create_module.shutil, "which", lambda name: "/usr/bin/git")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["create", "my-os", "--json"])
+    assert result.exit_code == 1
+    assert "git clone failed" in json.loads(result.output)["error"]
+
+
+# -- infra -----------------------------------------------------------------------------
+
+
+def test_find_compose_file_autodetect(tmp_path):
+    (tmp_path / "infra").mkdir()
+    (tmp_path / "infra" / "compose.yaml").write_text("services: {}\n")
+    assert find_compose_file(cwd=tmp_path) == tmp_path / "infra" / "compose.yaml"
+    # Root-level files win over infra/ ones.
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    assert find_compose_file(cwd=tmp_path) == tmp_path / "docker-compose.yml"
+
+
+def test_find_compose_file_missing(tmp_path):
+    with pytest.raises(CLIError) as exc_info:
+        find_compose_file(cwd=tmp_path)
+    assert "No compose file" in exc_info.value.message
+
+
+def test_infra_up_dry_run_command(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["infra", "up", "--pull", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["command"] == [
+        "docker",
+        "compose",
+        "-f",
+        str(tmp_path / "docker-compose.yml"),
+        "up",
+        "-d",
+        "--build",
+        "--pull",
+        "always",
+    ]
+    assert payload["dry_run"] is True
+
+
+def test_infra_down_dry_run_volumes(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["infra", "down", "-v", "--dry-run", "--json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["command"][-2:] == ["down", "--volumes"]
+
+
+def test_infra_up_runs_compose(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(args, **kwargs):
+        calls.append((list(args), kwargs.get("cwd")))
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(infra_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["infra", "up", "--json"])
+    assert result.exit_code == 0, result.output
+    args, cwd = calls[0]
+    assert args[:4] == ["docker", "compose", "-f", str(tmp_path / "docker-compose.yml")]
+    assert cwd == str(tmp_path)
+
+
+def test_infra_compose_failure_maps_to_exit_1(monkeypatch, tmp_path):
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        infra_module.subprocess,
+        "run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 17, stdout="", stderr="broken"),
+    )
+    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["infra", "up", "--json"])
+    assert result.exit_code == 1
+    assert "exited with code 17" in json.loads(result.output)["error"]

--- a/libs/agno_cli/tests/test_create_lifecycle.py
+++ b/libs/agno_cli/tests/test_create_lifecycle.py
@@ -1,4 +1,4 @@
-"""`agno create` and `agno infra` behavior (git and docker are faked)."""
+"""`agno create` and `agno up/down/restart` behavior (git and docker are faked)."""
 
 import json
 import subprocess
@@ -8,8 +8,8 @@ import pytest
 from typer.testing import CliRunner
 
 import agno_cli.commands.create as create_module
-import agno_cli.commands.infra as infra_module
-from agno_cli.commands.infra import find_compose_file
+import agno_cli.commands.lifecycle as lifecycle_module
+from agno_cli.commands.lifecycle import find_compose_file
 from agno_cli.errors import CLIError
 from agno_cli.main import app
 
@@ -111,7 +111,7 @@ def test_find_compose_file_missing(tmp_path):
 def test_infra_up_dry_run_command(monkeypatch, tmp_path):
     (tmp_path / "docker-compose.yml").write_text("services: {}\n")
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["infra", "up", "--pull", "--dry-run", "--json"])
+    result = runner.invoke(app, ["up", "--pull", "--dry-run", "--json"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["command"] == [
@@ -131,7 +131,7 @@ def test_infra_up_dry_run_command(monkeypatch, tmp_path):
 def test_infra_down_dry_run_volumes(monkeypatch, tmp_path):
     (tmp_path / "docker-compose.yml").write_text("services: {}\n")
     monkeypatch.chdir(tmp_path)
-    result = runner.invoke(app, ["infra", "down", "-v", "--dry-run", "--json"])
+    result = runner.invoke(app, ["down", "-v", "--dry-run", "--json"])
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["command"][-2:] == ["down", "--volumes"]
 
@@ -145,9 +145,9 @@ def test_infra_up_runs_compose(monkeypatch, tmp_path):
         calls.append((list(args), kwargs.get("cwd")))
         return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
 
-    monkeypatch.setattr(infra_module.subprocess, "run", fake_run)
-    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
-    result = runner.invoke(app, ["infra", "up", "--json"])
+    monkeypatch.setattr(lifecycle_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(lifecycle_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["up", "--json"])
     assert result.exit_code == 0, result.output
     args, cwd = calls[0]
     assert args[:4] == ["docker", "compose", "-f", str(tmp_path / "docker-compose.yml")]
@@ -158,11 +158,11 @@ def test_infra_compose_failure_maps_to_exit_1(monkeypatch, tmp_path):
     (tmp_path / "docker-compose.yml").write_text("services: {}\n")
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
-        infra_module.subprocess,
+        lifecycle_module.subprocess,
         "run",
         lambda args, **kwargs: subprocess.CompletedProcess(args, 17, stdout="", stderr="broken"),
     )
-    monkeypatch.setattr(infra_module.shutil, "which", lambda name: "/usr/bin/docker")
-    result = runner.invoke(app, ["infra", "up", "--json"])
+    monkeypatch.setattr(lifecycle_module.shutil, "which", lambda name: "/usr/bin/docker")
+    result = runner.invoke(app, ["up", "--json"])
     assert result.exit_code == 1
     assert "exited with code 17" in json.loads(result.output)["error"]

--- a/libs/agno_cli/tests/test_discovery.py
+++ b/libs/agno_cli/tests/test_discovery.py
@@ -1,0 +1,67 @@
+"""Discovery: structured /info fields, probe fallbacks, and failure modes."""
+
+import httpx
+import pytest
+
+from agno_cli.discovery import discover
+from agno_cli.errors import CLIError
+from tests.conftest import FakeAgentOS, install_fake
+
+
+def test_discover_via_info_fields(fake_os):
+    info = discover("http://localhost:7777")
+    assert info.discovered_via == "info"
+    assert info.mcp_enabled is True
+    assert info.mcp_url == "http://localhost:7777/mcp"
+    assert info.auth_mode == "security_key"
+    assert info.version == "2.7.0"
+
+
+def test_discover_probe_fallback_security_key(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False)
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.discovered_via == "probe"
+    assert info.mcp_enabled is True
+    assert info.auth_mode == "security_key"
+
+
+def test_discover_probe_fallback_jwt(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False, auth_mode="jwt")
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.auth_mode == "jwt"
+
+
+def test_discover_probe_fallback_none_auth(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False, auth_mode="none")
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.auth_mode == "none"
+
+
+def test_discover_probe_detects_mcp_disabled(monkeypatch):
+    fake = FakeAgentOS(info_discovery=False, mcp_enabled=False)
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.mcp_enabled is False
+    assert info.mcp_path is None
+
+
+def test_discover_unreachable_raises(monkeypatch):
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    import agno_cli.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(refuse))
+    monkeypatch.delenv("AGNO_OS_URL", raising=False)
+    with pytest.raises(CLIError) as exc_info:
+        discover(None)
+    assert "No running AgentOS" in exc_info.value.message
+
+
+def test_discover_env_var_url(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_OS_URL", "http://envhost:9000")
+    info = discover(None)
+    assert info.base_url == "http://envhost:9000"

--- a/libs/agno_cli/tests/test_mcp_client.py
+++ b/libs/agno_cli/tests/test_mcp_client.py
@@ -45,3 +45,25 @@ def test_verify_404_when_mcp_disabled(monkeypatch):
     result = verify_mcp(MCP_URL, token=fake.security_key)
     assert result.ok is False
     assert result.status_code == 404
+
+
+def test_verify_never_raises_on_malformed_result(monkeypatch):
+    """A server returning a garbage tools/list result must yield a failed result, not a traceback."""
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        import json as json_module
+
+        message = json_module.loads(request.content) if request.content else {}
+        if message.get("method") == "initialize":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": {}})
+        if message.get("method") == "tools/list":
+            return httpx.Response(200, json={"jsonrpc": "2.0", "id": 2, "result": "not-a-dict"})
+        return httpx.Response(202)
+
+    import agno_cli.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
+    result = verify_mcp(MCP_URL, token="anything")
+    assert result.ok is True
+    assert result.tools == []

--- a/libs/agno_cli/tests/test_mcp_client.py
+++ b/libs/agno_cli/tests/test_mcp_client.py
@@ -1,0 +1,47 @@
+"""MCP verification client: JSON and SSE payloads, auth failures."""
+
+from agno_cli.mcp_client import verify_mcp
+from tests.conftest import FakeAgentOS, install_fake
+
+MCP_URL = "http://localhost:7777/mcp"
+
+
+def test_verify_ok_with_valid_token(monkeypatch, fake_os):
+    result = verify_mcp(MCP_URL, token=fake_os.security_key)
+    assert result.ok is True
+    assert "run_agent" in result.tools
+
+
+def test_verify_rejected_without_token(monkeypatch, fake_os):
+    result = verify_mcp(MCP_URL, token=None)
+    assert result.ok is False
+    assert result.status_code == 401
+
+
+def test_verify_rejected_with_bad_token(monkeypatch, fake_os):
+    result = verify_mcp(MCP_URL, token="agno_pat_wrong")
+    assert result.ok is False
+    assert result.status_code == 401
+
+
+def test_verify_parses_sse_responses(monkeypatch):
+    fake = FakeAgentOS(sse_responses=True)
+    install_fake(monkeypatch, fake)
+    result = verify_mcp(MCP_URL, token=fake.security_key)
+    assert result.ok is True
+    assert result.tools == fake.mcp_tools
+
+
+def test_verify_open_server_no_token(monkeypatch):
+    fake = FakeAgentOS(auth_mode="none")
+    install_fake(monkeypatch, fake)
+    result = verify_mcp(MCP_URL, token=None)
+    assert result.ok is True
+
+
+def test_verify_404_when_mcp_disabled(monkeypatch):
+    fake = FakeAgentOS(mcp_enabled=False)
+    install_fake(monkeypatch, fake)
+    result = verify_mcp(MCP_URL, token=fake.security_key)
+    assert result.ok is False
+    assert result.status_code == 404

--- a/libs/agno_cli/tests/test_tokens_cmd.py
+++ b/libs/agno_cli/tests/test_tokens_cmd.py
@@ -34,13 +34,16 @@ def test_create_human_output_prints_token(monkeypatch, fake_os):
     assert "shown once" in result.output
 
 
-def test_create_conflict_errors(monkeypatch, fake_os):
+def test_create_conflict_errors_with_tokens_hint(monkeypatch, fake_os):
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
     _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
     result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
     assert result.exit_code == 1
     payload = json.loads(result.output)
     assert "already exists" in payload["error"]
+    # The hint must reference flags this command actually has.
+    assert "agno tokens revoke ci-runner" in payload["hint"]
+    assert "--rotate" not in payload["hint"]
 
 
 def test_list_never_exposes_tokens(monkeypatch, fake_os):

--- a/libs/agno_cli/tests/test_tokens_cmd.py
+++ b/libs/agno_cli/tests/test_tokens_cmd.py
@@ -1,0 +1,90 @@
+"""`agno tokens` command behavior."""
+
+import json
+
+from typer.testing import CliRunner
+
+from agno_cli.main import app
+
+runner = CliRunner()
+
+URL_ARGS = ["--url", "http://localhost:7777"]
+
+
+def _run(args, **kwargs):
+    return runner.invoke(app, args, **kwargs)
+
+
+def test_create_json_includes_token_once(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["name"] == "ci-runner"
+    assert payload["token"].startswith("agno_pat_")
+    assert payload["principal"] == "sa:ci-runner"
+
+
+def test_create_human_output_prints_token(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner"] + URL_ARGS)
+    assert result.exit_code == 0, result.output
+    token = fake_os.accounts["ci-runner"]["token"]
+    assert token in result.output
+    assert "shown once" in result.output
+
+
+def test_create_conflict_errors(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "already exists" in payload["error"]
+
+
+def test_list_never_exposes_tokens(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "list", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload["service_accounts"]) == 1
+    assert "token" not in payload["service_accounts"][0]
+    assert payload["service_accounts"][0]["token_prefix"]
+
+
+def test_revoke_by_name(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "revoke", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    assert fake_os.accounts["ci-runner"]["revoked_at"] is not None
+
+
+def test_revoke_unknown_name(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "revoke", "ghost", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    assert "No service account named" in json.loads(result.output)["error"]
+
+
+def test_missing_admin_credential_fails_with_hint(monkeypatch, fake_os):
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "AGNO_ADMIN_TOKEN" in payload["hint"]
+
+
+def test_expires_never(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner", "--expires", "never", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    assert json.loads(result.output)["expires_at"] is None
+
+
+def test_expires_invalid(monkeypatch, fake_os):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _run(["tokens", "create", "ci-runner", "--expires", "soon", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    assert "Invalid --expires" in json.loads(result.output)["error"]

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -8,11 +8,13 @@
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${CURR_DIR}")"
 AGNO_DIR="${REPO_ROOT}/libs/agno"
+AGNO_CLI_DIR="${REPO_ROOT}/libs/agno_cli"
 AGNO_INFRA_DIR="${REPO_ROOT}/libs/agno_infra"
 COOKBOOK_DIR="${REPO_ROOT}/cookbook"
 source ${CURR_DIR}/_utils.sh
 
 print_heading "Formatting all libraries"
 source ${AGNO_DIR}/scripts/format.sh
+source ${AGNO_CLI_DIR}/scripts/format.sh
 source ${AGNO_INFRA_DIR}/scripts/format.sh
 source ${COOKBOOK_DIR}/scripts/format.sh

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -8,11 +8,13 @@
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${CURR_DIR}")"
 AGNO_DIR="${REPO_ROOT}/libs/agno"
+AGNO_CLI_DIR="${REPO_ROOT}/libs/agno_cli"
 AGNO_INFRA_DIR="${REPO_ROOT}/libs/agno_infra"
 COOKBOOK_DIR="${REPO_ROOT}/cookbook"
 source ${CURR_DIR}/_utils.sh
 
 print_heading "Validating all libraries"
 source ${AGNO_DIR}/scripts/validate.sh
+source ${AGNO_CLI_DIR}/scripts/validate.sh
 source ${AGNO_INFRA_DIR}/scripts/validate.sh
 source ${COOKBOOK_DIR}/scripts/validate.sh


### PR DESCRIPTION
# fix: /info auth_mode detection + agno tokens revoke response body

Follow-up to #8742 and #8743. Two bugs uncovered while testing `agno connect` end-to-end against the service-accounts cookbook shipped by #8742.

Both are small, but bug 1 causes `agno connect` to silently produce broken configs (headers missing, verification 401s) against the exact cookbook the PR ships as its reference example — so the fix is needed for the golden path to actually work.

---

## Summary

**Bug 1 (high).** `GET /info` reports `auth_mode: "none"` when JWT enforcement is wired via `app.add_middleware(JWTMiddleware, ...)` instead of `AgentOS(authorization=True)`. Because `agno connect` reads `auth_mode` from `/info` and gates the whole mint-token-and-inject-header path on it, a lying `"none"` makes the CLI skip minting entirely. It writes MCP client configs with no `Authorization` header, then verification fails with 401. The server-side setup is exactly the pattern the shipped cookbook demonstrates.

**Bug 2 (medium).** `agno tokens revoke --json` returns `{"revoked": {..., "revoked_at": null}}` for accounts that were just revoked. The DELETE endpoint responds 204 (no body), and the CLI wraps the *pre-revoke* snapshot as the JSON response. The server state is correct — only the response body misleads machine-driven callers.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Root cause

### Bug 1

`libs/agno/agno/os/auth.py::get_effective_auth_mode()` recognises three JWT-enforcement paths:

1. `AgentOS(authorization=True)` constructor arg
2. `settings.authorization_enabled = True`
3. `JWT_VERIFICATION_KEY` / `JWT_JWKS_FILE` env vars

It does **not** detect the fourth, equally-valid path: calling `app.add_middleware(JWTMiddleware, ...)` after `agent_os.get_app()`. This is the pattern the SA cookbook itself uses:

```python
agent_os = AgentOS(agents=[...], db=db, enable_mcp_server=True)
app = agent_os.get_app()
app.add_middleware(JWTMiddleware, verification_keys=[JWT_SECRET], authorization=True)
