### PR TITLE
fix: correct auth_mode detection and revoke response body in service-accounts flow

### DIFF
--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -120,24 +120,54 @@ def _is_jwt_configured() -> bool:
     return bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
 
 
+def _has_jwt_middleware(app: Any) -> bool:
+    """Check whether the app has JWTMiddleware installed via ``add_middleware``.
+
+    Covers deployments that wire JWT auth by calling ``app.add_middleware(JWTMiddleware, ...)``
+    directly instead of via ``AgentOS(authorization=True)`` or JWT env vars.
+    """
+    if app is None:
+        return False
+    try:
+        from agno.os.middleware.jwt import JWTMiddleware
+    except ImportError:
+        return False
+    user_middleware = getattr(app, "user_middleware", None) or []
+    for mw in user_middleware:
+        cls = getattr(mw, "cls", None)
+        if cls is JWTMiddleware:
+            return True
+    return False
+
+
 def get_effective_auth_mode(
-    settings: Optional[AgnoAPISettings], authorization: bool = False
+    settings: Optional[AgnoAPISettings],
+    authorization: bool = False,
+    app: Any = None,
 ) -> Literal["none", "security_key", "jwt"]:
     """Return the authentication mode effectively enforced by the OS.
 
     Mirrors the precedence used by ``get_authentication_dependency``:
-    JWT (via authorization=True on AgentOS or JWT environment variables) takes
-    precedence over the security key, which takes precedence over no auth.
+    JWT (via authorization=True on AgentOS, JWT environment variables, or a manually
+    installed ``JWTMiddleware``) takes precedence over the security key, which takes
+    precedence over no auth.
 
     Args:
         settings: The API settings containing the security key and authorization flag
         authorization: The AgentOS authorization flag (JWT middleware enabled)
+        app: The Starlette/FastAPI app instance; when provided, its middleware stack
+            is inspected so a manually-installed ``JWTMiddleware`` is detected.
 
     Returns:
         "jwt" when JWT authorization is effectively active, "security_key" when
         only the OS security key is enforced, "none" when authentication is disabled.
     """
-    if authorization or (settings is not None and settings.authorization_enabled) or _is_jwt_configured():
+    if (
+        authorization
+        or (settings is not None and settings.authorization_enabled)
+        or _is_jwt_configured()
+        or _has_jwt_middleware(app)
+    ):
         return "jwt"
     if settings is not None and settings.os_security_key:
         return "security_key"

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -5,6 +5,7 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Request,
     WebSocket,
 )
 
@@ -265,7 +266,7 @@ def get_info_router(os: "AgentOS") -> APIRouter:
         description="Return lightweight, unauthenticated metadata about this AgentOS instance.",
         response_model=InfoResponse,
     )
-    async def get_info() -> InfoResponse:
+    async def get_info(request: Request) -> InfoResponse:
         mcp_enabled = bool(os.enable_mcp_server)
         return InfoResponse(
             agno_version=agno_version,
@@ -273,7 +274,7 @@ def get_info_router(os: "AgentOS") -> APIRouter:
             team_count=len(os.teams or []),
             workflow_count=len(os.workflows or []),
             mcp=McpInfo(enabled=mcp_enabled, path="/mcp" if mcp_enabled else None),
-            auth_mode=get_effective_auth_mode(settings=os.settings, authorization=os.authorization),
+            auth_mode=get_effective_auth_mode(settings=os.settings, authorization=os.authorization, app=request.app),
         )
 
     return router

--- a/libs/agno/tests/unit/os/test_info_endpoint.py
+++ b/libs/agno/tests/unit/os/test_info_endpoint.py
@@ -86,6 +86,29 @@ class TestInfoEndpointAuthMode:
         # JWT configured via env vars is effectively enforced, even without authorization=True
         assert body["auth_mode"] == "jwt"
 
+    def test_auth_mode_jwt_via_manually_added_middleware(self):
+        """Regression: JWTMiddleware installed via ``app.add_middleware`` must be detected.
+
+        Some deployments configure JWT auth by calling ``app.add_middleware(JWTMiddleware, ...)``
+        instead of using ``AgentOS(authorization=True)``. Before the fix, ``/info`` reported
+        ``auth_mode: "none"`` for these deployments, and ``agno connect`` skipped the mint
+        step and produced configs without a bearer token.
+        """
+        from agno.os.middleware import JWTMiddleware
+
+        agent = Agent(name="Info Agent", id="info-agent", telemetry=False)
+        os_instance = AgentOS(agents=[agent], telemetry=False)
+        app = os_instance.get_app()
+        app.add_middleware(
+            JWTMiddleware,
+            verification_keys=[JWT_SECRET],
+            algorithm="HS256",
+            authorization=True,
+        )
+        client = TestClient(app)
+        body = client.get("/info").json()
+        assert body["auth_mode"] == "jwt"
+
 
 class TestGetEffectiveAuthMode:
     def test_none_when_settings_missing(self):

--- a/libs/agno_cli/agno_cli/commands/tokens.py
+++ b/libs/agno_cli/agno_cli/commands/tokens.py
@@ -1,5 +1,6 @@
 """`agno tokens`: thin wrappers over the AgentOS service-accounts API."""
 
+import time
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -126,6 +127,11 @@ def revoke(
             api.revoke_service_account(account.id)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
+
+    # The DELETE endpoint returns 204, so the account object above is the pre-revoke
+    # snapshot. Stamp revoked_at locally to reflect what the API state now is.
+    if account.revoked_at is None:
+        account.revoked_at = int(time.time())
 
     if json_output:
         emit_json({"revoked": account.public_dict()})

--- a/libs/agno_cli/tests/test_tokens_cmd.py
+++ b/libs/agno_cli/tests/test_tokens_cmd.py
@@ -65,6 +65,21 @@ def test_revoke_by_name(monkeypatch, fake_os):
     assert fake_os.accounts["ci-runner"]["revoked_at"] is not None
 
 
+def test_revoke_json_body_shows_revoked_at(monkeypatch, fake_os):
+    """Regression: the revoke response body must reflect the post-revoke state.
+
+    Before the fix, the CLI emitted the pre-revoke snapshot (fetched before the
+    DELETE call), so ``revoked.revoked_at`` was ``None`` in the JSON body even
+    though the account was in fact revoked on the server.
+    """
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    result = _run(["tokens", "revoke", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["revoked"]["revoked_at"] is not None
+
+
 def test_revoke_unknown_name(monkeypatch, fake_os):
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
     result = _run(["tokens", "revoke", "ghost", "--json"] + URL_ARGS)


### PR DESCRIPTION
# fix: /info auth_mode detection + agno tokens revoke response body

Follow-up to #8742 and #8743. Two bugs uncovered while testing `agno connect` end-to-end against the service-accounts cookbook shipped by #8742.

Both are small, but bug 1 causes `agno connect` to silently produce broken configs (headers missing, verification 401s) against the exact cookbook the PR ships as its reference example — so the fix is needed for the golden path to actually work.

---

## Summary

**Bug 1 (high).** `GET /info` reports `auth_mode: "none"` when JWT enforcement is wired via `app.add_middleware(JWTMiddleware, ...)` instead of `AgentOS(authorization=True)`. Because `agno connect` reads `auth_mode` from `/info` and gates the whole mint-token-and-inject-header path on it, a lying `"none"` makes the CLI skip minting entirely. It writes MCP client configs with no `Authorization` header, then verification fails with 401. The server-side setup is exactly the pattern the shipped cookbook demonstrates.

**Bug 2 (medium).** `agno tokens revoke --json` returns `{"revoked": {..., "revoked_at": null}}` for accounts that were just revoked. The DELETE endpoint responds 204 (no body), and the CLI wraps the *pre-revoke* snapshot as the JSON response. The server state is correct — only the response body misleads machine-driven callers.

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Root cause

### Bug 1

`libs/agno/agno/os/auth.py::get_effective_auth_mode()` recognises three JWT-enforcement paths:

1. `AgentOS(authorization=True)` constructor arg
2. `settings.authorization_enabled = True`
3. `JWT_VERIFICATION_KEY` / `JWT_JWKS_FILE` env vars

It does **not** detect the fourth, equally-valid path: calling `app.add_middleware(JWTMiddleware, ...)` after `agent_os.get_app()`. This is the pattern the SA cookbook itself uses:

```python
agent_os = AgentOS(agents=[...], db=db, enable_mcp_server=True)
app = agent_os.get_app()
app.add_middleware(JWTMiddleware, verification_keys=[JWT_SECRET], authorization=True)
