### PR TITLE
feat(tools): add BoxLite sandbox toolkit

### DIFF
--- a/cookbook/91_tools/boxlite_tools.py
+++ b/cookbook/91_tools/boxlite_tools.py
@@ -1,0 +1,47 @@
+"""🧰 Agent with BoxLite tools
+
+This example shows how to use Agno's BoxLite integration to run Agent-generated code
+in a fast, local micro-VM sandbox. BoxLite boots an isolated VM from an OCI image in
+sub-second time — no API key or cloud account required.
+
+1. Install the dependencies:
+    uv pip install agno anthropic boxlite
+2. Run:
+    python cookbook/91_tools/boxlite_tools.py
+"""
+
+from agno.agent import Agent
+from agno.tools.boxlite import BoxLiteTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    name="Coding Agent with BoxLite tools",
+    tools=[BoxLiteTools()],
+    markdown=True,
+    instructions=[
+        "You are an expert at writing and executing code. You have access to a local, isolated BoxLite sandbox.",
+        "Your primary purpose is to:",
+        "1. Write clear, efficient code based on user requests",
+        "2. ALWAYS execute the code in the BoxLite sandbox using run_code",
+        "3. Show the actual execution results to the user",
+        "4. Provide explanations of how the code works and what the output means",
+        "Guidelines:",
+        "- NEVER just provide code without executing it",
+        "- Execute all code using the run_code tool to show real results",
+        "- Use file operations (create_file, read_file) when working with scripts",
+        "- Install missing packages when needed using run_shell_command",
+        "- Always show both the code AND the execution output",
+        "- Handle errors gracefully and explain any issues encountered",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Write Python code to generate 10 random numbers between 1 and 100, sort them in ascending order, and print each number"
+    )

--- a/libs/agno/agno/tools/boxlite.py
+++ b/libs/agno/agno/tools/boxlite.py
@@ -1,0 +1,334 @@
+import asyncio
+import atexit
+import base64
+import json
+import posixpath
+import shlex
+import threading
+from pathlib import PurePosixPath
+from textwrap import dedent
+from typing import Any, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.code_execution import prepare_python_code
+from agno.utils.log import log_debug, log_error, log_info
+
+try:
+    from boxlite import SimpleBox
+except ImportError:
+    raise ImportError("`boxlite` not installed. Please install using `pip install boxlite`")
+
+DEFAULT_INSTRUCTIONS = dedent(
+    """\
+    You have access to a persistent BoxLite micro-VM sandbox for code execution. The sandbox
+    maintains state (files, installed packages, working directory) across interactions.
+    Available tools:
+    - `run_code`: Execute Python code in the sandbox
+    - `run_shell_command`: Execute shell commands (bash)
+    - `create_file`: Create or update files
+    - `read_file`: Read file contents
+    - `list_files`: List directory contents
+    - `delete_file`: Delete files or directories
+    - `change_directory`: Change the working directory
+    MANDATORY: When users ask for code, you MUST:
+    1. Write the code
+    2. Execute it using run_code (or run_shell_command)
+    3. Show the actual output/results
+    4. Never just provide code without executing it
+    CRITICAL WORKFLOW:
+    1. Before running scripts, install any required packages with: run_shell_command("pip install <packages>")
+    2. When running scripts, capture both output AND errors
+    3. If a script produces no output, check for errors or add print statements
+
+    Remember: Your job is to provide working, executed code, not just code snippets!
+    """
+)
+
+
+class BoxLiteTools(Toolkit):
+    """Run agent-generated code and shell commands inside a BoxLite micro-VM sandbox.
+
+    BoxLite (https://github.com/boxlite-ai/boxlite) boots a lightweight, isolated micro-VM
+    from an OCI image locally in sub-second time, so untrusted code never touches the host.
+    One box is created when the toolkit is constructed and reused across tool calls; call
+    ``shutdown_sandbox`` (or let ``atexit`` fire) to tear it down.
+    """
+
+    def __init__(
+        self,
+        image: str = "python:slim",
+        cpus: Optional[int] = None,
+        memory_mib: Optional[int] = None,
+        working_directory: str = "/root",
+        timeout: int = 300,
+        instructions: Optional[str] = None,
+        add_instructions: bool = False,
+        **kwargs,
+    ):
+        """Initialize the BoxLite toolkit and boot a sandbox.
+
+        Args:
+            image: OCI image the sandbox boots from (default: ``"python:slim"``).
+            cpus: Number of vCPUs for the sandbox (default: BoxLite runtime default).
+            memory_mib: Memory limit in MiB (default: BoxLite runtime default).
+            working_directory: Directory commands and relative file paths resolve against.
+            timeout: Seconds to allow each command to run before it is killed.
+            instructions: Override the default agent instructions.
+            add_instructions: Whether to add the instructions to the agent's system message.
+        """
+        self.image = image
+        self.cpus = cpus
+        self.memory_mib = memory_mib
+        self.working_directory = working_directory
+        self.timeout = timeout
+        self._cwd = working_directory
+
+        # BoxLite's synchronous API refuses to run inside an already-running asyncio loop,
+        # and Agno invokes sync tool callables inline on the agent's loop during `arun()`.
+        # So we drive the async SimpleBox on a private event loop in its own thread; bridging
+        # via run_coroutine_threadsafe is safe from both sync and async agent runs.
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever, name="boxlite-tools-loop", daemon=True
+        )
+        self._loop_thread.start()
+
+        self._box: Optional[SimpleBox] = None
+        try:
+            self._box = SimpleBox(image=self.image, cpus=self.cpus, memory_mib=self.memory_mib)
+            self._await(self._box.start(), timeout=max(self.timeout, 600))
+            # The image's WORKDIR is not guaranteed to exist; bootstrap it before use.
+            self._exec_shell(f"mkdir -p {_q(self.working_directory)}")
+            log_info(f"Started BoxLite sandbox from image '{self.image}'")
+        except Exception as e:
+            self._teardown()
+            log_error(f"Could not start BoxLite sandbox: {e}")
+            raise
+
+        atexit.register(self.shutdown_sandbox)
+
+        tools: List[Any] = [
+            self.run_code,
+            self.run_shell_command,
+            self.create_file,
+            self.read_file,
+            self.list_files,
+            self.delete_file,
+            self.change_directory,
+            self.shutdown_sandbox,
+        ]
+        super().__init__(
+            name="boxlite_tools",
+            tools=tools,
+            instructions=instructions or DEFAULT_INSTRUCTIONS,
+            add_instructions=add_instructions,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+    def _await(self, coro, timeout: Optional[float] = None):
+        """Run a SimpleBox coroutine on the private loop and block for its result."""
+        return asyncio.run_coroutine_threadsafe(coro, self._loop).result(timeout=timeout)
+
+    def _exec_shell(self, command: str, cwd: Optional[str] = None):
+        """Run a shell command string in the sandbox and return its ExecResult."""
+        if self._box is None:
+            raise RuntimeError("BoxLite sandbox has been shut down.")
+        return self._await(
+            self._box.exec("sh", "-c", command, cwd=cwd, timeout=self.timeout),
+            timeout=self.timeout + 30,
+        )
+
+    @staticmethod
+    def _combine(result) -> str:
+        """Merge stdout and stderr so the agent sees tracebacks and diagnostics."""
+        parts = [part for part in (result.stdout, result.stderr) if part]
+        output = "".join(parts)
+        if output:
+            return output
+        return f"(no output, exit code {result.exit_code})"
+
+    def _teardown(self) -> None:
+        """Stop the private event loop and join its thread. Idempotent."""
+        if self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._loop_thread.is_alive():
+            self._loop_thread.join(timeout=10)
+        if not self._loop.is_closed():
+            self._loop.close()
+
+    # ── Tools ─────────────────────────────────────────────────────────────────
+    def run_code(self, code: str) -> str:
+        """Execute Python code in the sandbox.
+
+        Args:
+            code: Python code to execute.
+
+        Returns:
+            Combined stdout/stderr of the execution.
+        """
+        try:
+            result = self._await(
+                self._box.exec(
+                    "python", "-c", prepare_python_code(code), cwd=self._cwd, timeout=self.timeout
+                ),
+                timeout=self.timeout + 30,
+            )
+            return self._combine(result)
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error executing code: {str(e)}"})
+
+    def run_shell_command(self, command: str) -> str:
+        """Execute a shell command in the sandbox.
+
+        Args:
+            command: Shell command to execute.
+
+        Returns:
+            Combined stdout/stderr of the command.
+        """
+        try:
+            stripped = command.strip()
+            if stripped.startswith("cd ") and "&&" not in stripped and ";" not in stripped:
+                return self.change_directory(stripped[3:].strip())
+            return self._combine(self._exec_shell(command, cwd=self._cwd))
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error executing command: {str(e)}"})
+
+    def create_file(self, file_path: str, content: str) -> str:
+        """Create or overwrite a file in the sandbox.
+
+        Args:
+            file_path: File path, relative to the working directory or absolute.
+            content: Content to write to the file.
+
+        Returns:
+            Success message or JSON error.
+        """
+        try:
+            path = self._resolve(file_path)
+            parent = posixpath.dirname(path)
+            # base64 round-trip writes any content verbatim (quotes, newlines, the EOF
+            # sentinel, binary) — avoiding the escaping pitfalls of a shell heredoc.
+            encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+            command = f"mkdir -p {_q(parent)} && printf %s {_q(encoded)} | base64 -d > {_q(path)}"
+            result = self._exec_shell(command)
+            if result.exit_code != 0:
+                return json.dumps(
+                    {"status": "error", "message": f"Failed to create file: {self._combine(result)}"}
+                )
+            return f"File created/updated: {path}"
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error creating file: {str(e)}"})
+
+    def read_file(self, file_path: str) -> str:
+        """Read a file from the sandbox.
+
+        Args:
+            file_path: File path, relative to the working directory or absolute.
+
+        Returns:
+            File contents or JSON error.
+        """
+        try:
+            path = self._resolve(file_path)
+            result = self._exec_shell(f"cat {_q(path)}")
+            if result.exit_code != 0:
+                return json.dumps(
+                    {"status": "error", "message": f"Error reading file: {self._combine(result)}"}
+                )
+            return result.stdout
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error reading file: {str(e)}"})
+
+    def list_files(self, directory: Optional[str] = None) -> str:
+        """List files in a directory.
+
+        Args:
+            directory: Directory to list (defaults to the current working directory).
+
+        Returns:
+            Directory listing or JSON error.
+        """
+        try:
+            path = self._resolve(directory) if directory is not None else self._cwd
+            result = self._exec_shell(f"ls -la {_q(path)}")
+            if result.exit_code != 0:
+                return json.dumps(
+                    {"status": "error", "message": f"Error listing directory: {self._combine(result)}"}
+                )
+            return f"Contents of {path}:\n{result.stdout}"
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error listing files: {str(e)}"})
+
+    def delete_file(self, file_path: str) -> str:
+        """Delete a file or directory from the sandbox.
+
+        Args:
+            file_path: File or directory path, relative to the working directory or absolute.
+
+        Returns:
+            Success message or JSON error.
+        """
+        try:
+            path = self._resolve(file_path)
+            check = self._exec_shell(f"test -d {_q(path)} && echo directory || echo file")
+            flags = "-rf" if "directory" in check.stdout else "-f"
+            result = self._exec_shell(f"rm {flags} {_q(path)}")
+            if result.exit_code != 0:
+                return json.dumps(
+                    {"status": "error", "message": f"Failed to delete: {self._combine(result)}"}
+                )
+            return f"Deleted: {path}"
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error deleting file: {str(e)}"})
+
+    def change_directory(self, directory: str) -> str:
+        """Change the current working directory used by subsequent commands.
+
+        Args:
+            directory: Directory to change to, relative to the working directory or absolute.
+
+        Returns:
+            Success message or error.
+        """
+        try:
+            path = self._resolve(directory)
+            result = self._exec_shell(f"test -d {_q(path)} && echo exists || echo missing")
+            if "exists" in result.stdout:
+                self._cwd = path
+                log_debug(f"Working directory changed to: {path}")
+                return f"Changed directory to: {path}"
+            return f"Error: Directory {path} not found"
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error changing directory: {str(e)}"})
+
+    def shutdown_sandbox(self) -> str:
+        """Stop and remove the sandbox and release its resources. Idempotent.
+
+        Returns:
+            Success message or JSON error.
+        """
+        try:
+            if self._box is not None:
+                try:
+                    self._await(self._box.stop(), timeout=self.timeout)
+                finally:
+                    self._box = None
+            self._teardown()
+            return "BoxLite sandbox shut down."
+        except Exception as e:
+            return json.dumps({"status": "error", "message": f"Error shutting down sandbox: {str(e)}"})
+
+    def _resolve(self, file_path: str) -> str:
+        """Resolve a path against the working directory and normalize it (POSIX)."""
+        path = PurePosixPath(file_path)
+        if not path.is_absolute():
+            path = PurePosixPath(self._cwd) / path
+        return posixpath.normpath(str(path))
+
+
+def _q(value: str) -> str:
+    """Quote a string for safe interpolation into a /bin/sh command."""
+    return shlex.quote(value)

--- a/libs/agno/tests/unit/tools/test_boxlite.py
+++ b/libs/agno/tests/unit/tools/test_boxlite.py
@@ -1,0 +1,220 @@
+"""Test BoxLiteTools functionality."""
+
+import base64
+import re
+import shlex
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock the boxlite module before importing BoxLiteTools so the import guard passes
+# without the native runtime being installed.
+sys.modules["boxlite"] = MagicMock()
+
+from agno.tools.boxlite import BoxLiteTools  # noqa: E402
+
+
+def _exec_result(stdout: str = "", stderr: str = "", exit_code: int = 0) -> MagicMock:
+    """Build a mock that quacks like boxlite.ExecResult."""
+    result = MagicMock()
+    result.stdout = stdout
+    result.stderr = stderr
+    result.exit_code = exit_code
+    return result
+
+
+@pytest.fixture
+def mock_box() -> MagicMock:
+    """A mock SimpleBox whose async methods resolve on the toolkit's private loop."""
+    box = MagicMock()
+    box.start = AsyncMock(return_value=None)
+    box.stop = AsyncMock(return_value=None)
+    box.exec = AsyncMock(return_value=_exec_result())
+    return box
+
+
+@pytest.fixture
+def tools(mock_box):
+    """Construct BoxLiteTools with a mocked box, then hand back a clean exec mock."""
+    with patch("agno.tools.boxlite.SimpleBox") as sync_box_cls:
+        sync_box_cls.return_value = mock_box
+        toolkit = BoxLiteTools()
+        # __init__ boots the box and bootstraps the working dir; drop those calls so
+        # each test asserts only against the exec calls it triggers.
+        mock_box.exec.reset_mock()
+        mock_box.exec.return_value = _exec_result()
+        mock_box.exec.side_effect = None
+        try:
+            yield toolkit, mock_box
+        finally:
+            toolkit.shutdown_sandbox()
+
+
+def _last_shell_command(mock_box: MagicMock) -> str:
+    """Return the `sh -c <command>` string from the most recent exec call."""
+    args = mock_box.exec.call_args.args
+    assert args[0] == "sh" and args[1] == "-c"
+    return args[2]
+
+
+class TestBoxLiteTools:
+    def test_initialization_boots_box(self, mock_box):
+        """The box is created from the given image and started during __init__."""
+        with patch("agno.tools.boxlite.SimpleBox") as sync_box_cls:
+            sync_box_cls.return_value = mock_box
+            toolkit = BoxLiteTools(image="alpine:latest")
+            try:
+                sync_box_cls.assert_called_once()
+                assert sync_box_cls.call_args.kwargs["image"] == "alpine:latest"
+                mock_box.start.assert_awaited_once()
+                # __init__ bootstraps the working directory via mkdir -p.
+                assert "mkdir -p" in _last_shell_command(mock_box)
+            finally:
+                toolkit.shutdown_sandbox()
+
+    def test_run_code(self, tools):
+        """run_code executes `python -c <code>` and returns combined output."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stdout="Hello, World!\n")
+
+        result = toolkit.run_code("print('Hello, World!')")
+
+        assert result == "Hello, World!\n"
+        call = mock_box.exec.call_args
+        assert call.args[0] == "python" and call.args[1] == "-c"
+        assert call.kwargs["cwd"] == "/root"
+
+    def test_run_code_surfaces_stderr(self, tools):
+        """A failing script returns its traceback (stderr) to the agent."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stderr="Traceback: boom\n", exit_code=1)
+
+        result = toolkit.run_code("raise SystemExit(1)")
+
+        assert "Traceback: boom" in result
+
+    def test_run_shell_command(self, tools):
+        """run_shell_command wraps the command in `sh -c` at the working directory."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stdout="file1.txt\nfile2.txt")
+
+        result = toolkit.run_shell_command("ls -la")
+
+        assert "file1.txt" in result
+        assert _last_shell_command(mock_box) == "ls -la"
+        assert mock_box.exec.call_args.kwargs["cwd"] == "/root"
+
+    def test_run_shell_command_cd_updates_working_directory(self, tools):
+        """A bare `cd` is intercepted and updates the tracked working directory."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stdout="exists\n")
+
+        result = toolkit.run_shell_command("cd /workspace")
+
+        assert "Changed directory to: /workspace" in result
+        assert toolkit._cwd == "/workspace"
+        assert _last_shell_command(mock_box) == "test -d /workspace && echo exists || echo missing"
+
+    def test_create_file_roundtrips_content(self, tools):
+        """create_file base64-encodes content so it survives the shell verbatim."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(exit_code=0)
+
+        content = "line1\n'quotes' and $VARS and \"double\"\nEOF\n"
+        result = toolkit.create_file("out.txt", content)
+
+        assert result == "File created/updated: /root/out.txt"
+        command = _last_shell_command(mock_box)
+        # The path is shell-quoted, and the emitted base64 decodes back to the content.
+        assert shlex.quote("/root/out.txt") in command
+        token = re.search(r"printf %s (\S+) \| base64 -d", command).group(1)
+        emitted_b64 = shlex.split(token)[0]
+        assert base64.b64decode(emitted_b64).decode("utf-8") == content
+
+    def test_create_file_quotes_injected_path(self, tools):
+        """A path with shell metacharacters is quoted, not executed."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(exit_code=0)
+
+        toolkit.create_file("evil; id;.txt", "data")
+
+        command = _last_shell_command(mock_box)
+        assert shlex.quote("/root/evil; id;.txt") in command
+        assert "; id;" not in command.replace(shlex.quote("/root/evil; id;.txt"), "")
+
+    def test_read_file(self, tools):
+        """read_file cats the resolved, quoted path and returns stdout."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stdout="file contents")
+
+        result = toolkit.read_file("notes.txt")
+
+        assert result == "file contents"
+        assert _last_shell_command(mock_box) == f"cat {shlex.quote('/root/notes.txt')}"
+
+    def test_read_file_error(self, tools):
+        """A non-zero exit is reported as a JSON error, not returned as content."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stderr="No such file", exit_code=1)
+
+        result = toolkit.read_file("missing.txt")
+
+        assert '"status": "error"' in result
+        assert "No such file" in result
+
+    def test_list_files(self, tools):
+        """list_files runs `ls -la` against the quoted path."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stdout="total 0\nfile1.txt")
+
+        result = toolkit.list_files("subdir")
+
+        assert "file1.txt" in result
+        assert _last_shell_command(mock_box) == f"ls -la {shlex.quote('/root/subdir')}"
+
+    def test_delete_file(self, tools):
+        """delete_file checks the type then removes with the right flags."""
+        toolkit, mock_box = tools
+        mock_box.exec.side_effect = [
+            _exec_result(stdout="file\n"),  # test -d ... -> "file"
+            _exec_result(exit_code=0),  # rm -f ...
+        ]
+
+        result = toolkit.delete_file("stale.txt")
+
+        assert result == "Deleted: /root/stale.txt"
+        assert mock_box.exec.call_args_list[1].args[2] == f"rm -f {shlex.quote('/root/stale.txt')}"
+
+    def test_change_directory_missing(self, tools):
+        """Changing to a non-existent directory leaves the working directory unchanged."""
+        toolkit, mock_box = tools
+        mock_box.exec.return_value = _exec_result(stdout="missing\n")
+
+        result = toolkit.change_directory("/does/not/exist")
+
+        assert "not found" in result
+        assert toolkit._cwd == "/root"
+
+    def test_error_handling(self, tools):
+        """Exceptions from the SDK are caught and returned as JSON errors."""
+        toolkit, mock_box = tools
+        mock_box.exec.side_effect = RuntimeError("boom")
+
+        result = toolkit.run_shell_command("ls")
+
+        assert '"status": "error"' in result
+        assert "boom" in result
+
+    def test_shutdown_is_idempotent(self, mock_box):
+        """shutdown_sandbox stops the box once and is safe to call repeatedly."""
+        with patch("agno.tools.boxlite.SimpleBox") as sync_box_cls:
+            sync_box_cls.return_value = mock_box
+            toolkit = BoxLiteTools()
+
+            first = toolkit.shutdown_sandbox()
+            second = toolkit.shutdown_sandbox()
+
+            assert "shut down" in first
+            assert "shut down" in second
+            mock_box.stop.assert_awaited_once()


### PR DESCRIPTION
Closes #8803

## Description

Adds `BoxLiteTools`, a toolkit that runs agent-generated code and shell commands inside a
[BoxLite](https://github.com/boxlite-ai/boxlite) micro-VM — a lightweight, isolated sandbox
that boots locally from an OCI image in sub-second time. It sits alongside the existing
`E2BTools` and `DaytonaTools`, but is **local / embeddable**: no API key, no cloud account,
no per-sandbox network round-trip.

### Tools

Mirrors the `DaytonaTools` surface so it's a drop-in alternative:

- `run_code` — execute Python code
- `run_shell_command` — execute shell commands
- `create_file` / `read_file` / `list_files` / `delete_file`
- `change_directory`
- `shutdown_sandbox`

```python
from agno.agent import Agent
from agno.tools.boxlite import BoxLiteTools

agent = Agent(tools=[BoxLiteTools()])  # boots a python:slim micro-VM locally
agent.print_response("Compute the 20th Fibonacci number and print it")
```

### Notes for reviewers

- **Async safety.** BoxLite's synchronous API cannot run inside an already-running asyncio
  loop, and Agno invokes sync tool callables inline on the agent loop during `arun()`. So the
  toolkit drives BoxLite's async `SimpleBox` on a private event loop in a dedicated thread and
  bridges via `run_coroutine_threadsafe`. This keeps the tools safe from both `run()` and
  `arun()` / AgentOS.
- **File writes** go through a base64 round-trip (`printf %s <b64> | base64 -d > path`) so
  arbitrary content (quotes, newlines, heredoc sentinels) is written verbatim, and all derived
  shell paths are `shlex.quote`-d.
- One box is created per toolkit and reused across calls; `shutdown_sandbox` (and an `atexit`
  hook) tears it down.

### Testing

- `libs/agno/tests/unit/tools/test_boxlite.py` — unit tests covering execution, file ops,
  working-directory tracking, shell-injection quoting, error handling, and idempotent shutdown
  (SDK mocked, matching the `test_daytona.py` / `test_e2b.py` style).
- `cookbook/91_tools/boxlite_tools.py` — runnable example.

Requires `pip install boxlite`.
