### PR TITLE
[feat] Add Semantic Scholar tools

### DIFF
--- a/cookbook/91_tools/semantic_scholar_tools.py
+++ b/cookbook/91_tools/semantic_scholar_tools.py
@@ -1,0 +1,49 @@
+"""
+Semantic Scholar Tools
+======================
+
+Demonstrates SemanticScholarTools for academic paper search and paper metadata lookup.
+
+Most Semantic Scholar endpoints work without an API key, but setting
+SEMANTIC_SCHOLAR_API_KEY gives more stable rate limits.
+"""
+
+from agno.agent import Agent
+from agno.tools.semantic_scholar import SemanticScholarTools
+
+# ---------------------------------------------------------------------------
+# Create Agents
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    tools=[SemanticScholarTools()],
+    instructions=[
+        "Use Semantic Scholar to find relevant academic papers.",
+        "Prefer papers with DOI, open access PDFs, citation counts, and concise TLDRs when available.",
+    ],
+    markdown=True,
+)
+
+research_agent = Agent(
+    tools=[SemanticScholarTools(all=True, max_results=3)],
+    instructions=[
+        "Help users compare papers and authors from Semantic Scholar metadata.",
+        "Mention publication year, venue, citation count, DOI, and open access PDF links when available.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agents
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Search for recent papers about retrieval augmented generation evaluation.",
+        stream=True,
+    )
+
+    research_agent.print_response(
+        "Find papers by Semantic Scholar author id 1741101 and summarize their RAG relevance.",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/semantic_scholar.py
+++ b/libs/agno/agno/tools/semantic_scholar.py
@@ -1,0 +1,210 @@
+import json
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error
+
+
+DEFAULT_PAPER_FIELDS = (
+    "paperId,title,abstract,authors,year,venue,publicationDate,url,externalIds,"
+    "citationCount,referenceCount,isOpenAccess,openAccessPdf,fieldsOfStudy,tldr"
+)
+
+
+class SemanticScholarTools(Toolkit):
+    """
+    SemanticScholarTools is a toolkit for searching academic papers with the
+    Semantic Scholar Academic Graph API.
+
+    Args:
+        api_key (Optional[str]): Semantic Scholar API key. If not provided,
+            uses SEMANTIC_SCHOLAR_API_KEY from the environment. Most endpoints
+            can be used without a key, but a key gives more stable rate limits.
+        max_results (int): Default number of papers to return. Default is 5.
+        timeout (int): Request timeout in seconds. Default is 30.
+        enable_search_papers (bool): Enable paper search. Default is True.
+        enable_get_paper (bool): Enable fetching paper details. Default is True.
+        enable_get_author_papers (bool): Enable fetching papers by author. Default is False.
+        all (bool): If True, enable every Semantic Scholar tool.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        max_results: int = 5,
+        timeout: int = 30,
+        enable_search_papers: bool = True,
+        enable_get_paper: bool = True,
+        enable_get_author_papers: bool = False,
+        all: bool = False,
+        **kwargs,
+    ):
+        self.api_key = api_key or getenv("SEMANTIC_SCHOLAR_API_KEY")
+        self.max_results = max_results
+        self.timeout = timeout
+        self.base_url = "https://api.semanticscholar.org/graph/v1"
+
+        tools: List[Any] = []
+        if all or enable_search_papers:
+            tools.append(self.search_papers)
+        if all or enable_get_paper:
+            tools.append(self.get_paper)
+        if all or enable_get_author_papers:
+            tools.append(self.get_author_papers)
+
+        super().__init__(name="semantic_scholar_tools", tools=tools, **kwargs)
+
+    def _headers(self) -> Dict[str, str]:
+        return {"x-api-key": self.api_key} if self.api_key else {}
+
+    def _get(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Make a GET request to the Semantic Scholar API."""
+        try:
+            url = f"{self.base_url}/{path.lstrip('/')}"
+            log_debug(f"Requesting Semantic Scholar path={path}")
+            response = httpx.get(url, params=params, headers=self._headers(), timeout=self.timeout)
+            response.raise_for_status()
+            return response.json()  # type: ignore[no-any-return]
+        except httpx.HTTPStatusError as e:
+            log_error(f"Semantic Scholar HTTP error: {e}")
+            return {"error": f"HTTP {e.response.status_code}: {e.response.text}"}
+        except httpx.RequestError as e:
+            log_error(f"Semantic Scholar request error: {e}")
+            return {"error": str(e)}
+        except ValueError as e:
+            log_error(f"Semantic Scholar JSON decode error: {e}")
+            return {"error": f"Invalid JSON response: {e}"}
+
+    @staticmethod
+    def _compact_paper(paper: Dict[str, Any]) -> Dict[str, Any]:
+        external_ids = paper.get("externalIds") or {}
+        open_access_pdf = paper.get("openAccessPdf") or {}
+        tldr = paper.get("tldr") or {}
+
+        authors = [
+            {
+                "author_id": author.get("authorId"),
+                "name": author.get("name"),
+            }
+            for author in paper.get("authors", [])
+        ]
+
+        return {
+            "paper_id": paper.get("paperId"),
+            "title": paper.get("title"),
+            "abstract": paper.get("abstract"),
+            "year": paper.get("year"),
+            "publication_date": paper.get("publicationDate"),
+            "venue": paper.get("venue"),
+            "url": paper.get("url"),
+            "doi": external_ids.get("DOI"),
+            "arxiv_id": external_ids.get("ArXiv"),
+            "pubmed_id": external_ids.get("PubMed"),
+            "authors": authors,
+            "citation_count": paper.get("citationCount"),
+            "reference_count": paper.get("referenceCount"),
+            "fields_of_study": paper.get("fieldsOfStudy"),
+            "is_open_access": paper.get("isOpenAccess"),
+            "open_access_pdf_url": open_access_pdf.get("url"),
+            "tldr": tldr.get("text"),
+        }
+
+    def search_papers(
+        self,
+        query: str,
+        max_results: Optional[int] = None,
+        fields: Optional[str] = None,
+    ) -> str:
+        """Search Semantic Scholar for academic papers.
+
+        Args:
+            query (str): Search query, such as "retrieval augmented generation".
+            max_results (Optional[int]): Number of results to return. Defaults to the instance setting.
+            fields (Optional[str]): Comma-separated Semantic Scholar paper fields to request.
+
+        Returns:
+            str: JSON string containing matching papers and metadata.
+        """
+        if not query:
+            return json.dumps({"error": "Please provide a query to search for"})
+
+        limit = max_results if max_results is not None else self.max_results
+        if limit < 1:
+            return json.dumps({"error": "max_results must be greater than 0"})
+
+        params = {
+            "query": query,
+            "limit": min(limit, 100),
+            "fields": fields or DEFAULT_PAPER_FIELDS,
+        }
+
+        data = self._get("paper/search", params)
+        if "error" in data:
+            return json.dumps({"error": data["error"]})
+
+        result = {
+            "total": data.get("total"),
+            "offset": data.get("offset"),
+            "papers": [self._compact_paper(paper) for paper in data.get("data", [])],
+        }
+        return json.dumps(result, indent=2)
+
+    def get_paper(self, paper_id: str, fields: Optional[str] = None) -> str:
+        """Fetch details for a Semantic Scholar paper.
+
+        Args:
+            paper_id (str): Semantic Scholar paper ID, Corpus ID, DOI:<doi>, ARXIV:<id>, or PMID:<id>.
+            fields (Optional[str]): Comma-separated Semantic Scholar paper fields to request.
+
+        Returns:
+            str: JSON string containing paper metadata.
+        """
+        if not paper_id:
+            return json.dumps({"error": "Please provide a paper_id"})
+
+        data = self._get(f"paper/{paper_id}", {"fields": fields or DEFAULT_PAPER_FIELDS})
+        if "error" in data:
+            return json.dumps({"error": data["error"]})
+
+        return json.dumps(self._compact_paper(data), indent=2)
+
+    def get_author_papers(
+        self,
+        author_id: str,
+        max_results: Optional[int] = None,
+        fields: Optional[str] = None,
+    ) -> str:
+        """Fetch papers written by a Semantic Scholar author.
+
+        Args:
+            author_id (str): Semantic Scholar author ID.
+            max_results (Optional[int]): Number of papers to return. Defaults to the instance setting.
+            fields (Optional[str]): Comma-separated paper fields to request.
+
+        Returns:
+            str: JSON string containing the author's papers.
+        """
+        if not author_id:
+            return json.dumps({"error": "Please provide an author_id"})
+
+        limit = max_results if max_results is not None else self.max_results
+        if limit < 1:
+            return json.dumps({"error": "max_results must be greater than 0"})
+
+        params = {
+            "limit": min(limit, 100),
+            "fields": fields or DEFAULT_PAPER_FIELDS,
+        }
+
+        data = self._get(f"author/{author_id}/papers", params)
+        if "error" in data:
+            return json.dumps({"error": data["error"]})
+
+        result = {
+            "author_id": author_id,
+            "papers": [self._compact_paper(paper) for paper in data.get("data", [])],
+        }
+        return json.dumps(result, indent=2)

--- a/libs/agno/tests/unit/tools/test_semantic_scholar.py
+++ b/libs/agno/tests/unit/tools/test_semantic_scholar.py
@@ -1,0 +1,208 @@
+import json
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from agno.tools.semantic_scholar import SemanticScholarTools
+
+
+@pytest.fixture(autouse=True)
+def clear_env(monkeypatch):
+    monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+
+
+@pytest.fixture
+def semantic_scholar_tools():
+    return SemanticScholarTools(api_key="test_key", max_results=5)
+
+
+@pytest.fixture
+def sample_paper():
+    return {
+        "paperId": "abc123",
+        "title": "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks",
+        "abstract": "A paper about retrieval augmented generation.",
+        "year": 2020,
+        "publicationDate": "2020-05-01",
+        "venue": "NeurIPS",
+        "url": "https://www.semanticscholar.org/paper/abc123",
+        "externalIds": {"DOI": "10.0000/test", "ArXiv": "2005.11401", "PubMed": "12345"},
+        "authors": [{"authorId": "1741101", "name": "Patrick Lewis"}],
+        "citationCount": 1234,
+        "referenceCount": 42,
+        "fieldsOfStudy": ["Computer Science"],
+        "isOpenAccess": True,
+        "openAccessPdf": {"url": "https://example.com/paper.pdf"},
+        "tldr": {"text": "Retrieval improves generation."},
+    }
+
+
+def mock_response(json_data):
+    response = Mock(spec=httpx.Response)
+    response.json.return_value = json_data
+    response.raise_for_status.return_value = None
+    return response
+
+
+def test_init_with_api_key():
+    tools = SemanticScholarTools(api_key="direct_key")
+    assert tools.api_key == "direct_key"
+
+
+def test_init_with_env_api_key(monkeypatch):
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "env_key")
+    tools = SemanticScholarTools()
+    assert tools.api_key == "env_key"
+
+
+def test_init_constructor_key_overrides_env(monkeypatch):
+    monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "env_key")
+    tools = SemanticScholarTools(api_key="direct_key")
+    assert tools.api_key == "direct_key"
+
+
+def test_init_default_tools():
+    tools = SemanticScholarTools(api_key="test_key")
+    tool_names = [tool.name for tool in tools.functions.values()]
+    assert "search_papers" in tool_names
+    assert "get_paper" in tool_names
+    assert "get_author_papers" not in tool_names
+
+
+def test_init_all_tools():
+    tools = SemanticScholarTools(api_key="test_key", all=True)
+    tool_names = [tool.name for tool in tools.functions.values()]
+    assert "search_papers" in tool_names
+    assert "get_paper" in tool_names
+    assert "get_author_papers" in tool_names
+
+
+def test_headers_with_api_key(semantic_scholar_tools):
+    assert semantic_scholar_tools._headers() == {"x-api-key": "test_key"}
+
+
+def test_headers_without_api_key():
+    tools = SemanticScholarTools()
+    assert tools._headers() == {}
+
+
+def test_get_uses_timeout_headers_and_params(semantic_scholar_tools):
+    with patch("httpx.get", return_value=mock_response({"data": []})) as mock_get:
+        semantic_scholar_tools._get("paper/search", {"query": "rag"})
+
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.semanticscholar.org/graph/v1/paper/search"
+    assert kwargs["params"] == {"query": "rag"}
+    assert kwargs["headers"] == {"x-api-key": "test_key"}
+    assert kwargs["timeout"] == 30
+
+
+def test_get_http_error(semantic_scholar_tools):
+    request = httpx.Request("GET", "https://api.semanticscholar.org/graph/v1/paper/search")
+    response = httpx.Response(429, request=request, text="rate limited")
+    error = httpx.HTTPStatusError("too many requests", request=request, response=response)
+    mocked_response = Mock(spec=httpx.Response)
+    mocked_response.raise_for_status.side_effect = error
+
+    with patch("httpx.get", return_value=mocked_response):
+        result = semantic_scholar_tools._get("paper/search", {"query": "rag"})
+
+    assert "error" in result
+    assert "HTTP 429" in result["error"]
+
+
+def test_get_request_error(semantic_scholar_tools):
+    request = httpx.Request("GET", "https://api.semanticscholar.org/graph/v1/paper/search")
+    with patch("httpx.get", side_effect=httpx.RequestError("network down", request=request)):
+        result = semantic_scholar_tools._get("paper/search", {"query": "rag"})
+
+    assert result["error"] == "network down"
+
+
+def test_get_invalid_json(semantic_scholar_tools):
+    response = Mock(spec=httpx.Response)
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("No JSON object")
+
+    with patch("httpx.get", return_value=response):
+        result = semantic_scholar_tools._get("paper/search", {"query": "rag"})
+
+    assert "Invalid JSON response" in result["error"]
+
+
+def test_search_papers_success(semantic_scholar_tools, sample_paper):
+    with patch.object(
+        semantic_scholar_tools,
+        "_get",
+        return_value={"total": 1, "offset": 0, "data": [sample_paper]},
+    ) as mock_get:
+        result = json.loads(semantic_scholar_tools.search_papers("retrieval augmented generation"))
+
+    mock_get.assert_called_once()
+    path, params = mock_get.call_args.args
+    assert path == "paper/search"
+    assert params["query"] == "retrieval augmented generation"
+    assert params["limit"] == 5
+    assert result["total"] == 1
+    assert result["papers"][0]["paper_id"] == "abc123"
+    assert result["papers"][0]["doi"] == "10.0000/test"
+    assert result["papers"][0]["authors"] == [{"author_id": "1741101", "name": "Patrick Lewis"}]
+
+
+def test_search_papers_validates_query(semantic_scholar_tools):
+    result = json.loads(semantic_scholar_tools.search_papers(""))
+    assert "error" in result
+
+
+def test_search_papers_validates_max_results(semantic_scholar_tools):
+    result = json.loads(semantic_scholar_tools.search_papers("rag", max_results=0))
+    assert result["error"] == "max_results must be greater than 0"
+
+
+def test_search_papers_caps_limit_at_100(semantic_scholar_tools):
+    with patch.object(semantic_scholar_tools, "_get", return_value={"data": []}) as mock_get:
+        semantic_scholar_tools.search_papers("rag", max_results=500)
+
+    _, params = mock_get.call_args.args
+    assert params["limit"] == 100
+
+
+def test_search_papers_returns_error(semantic_scholar_tools):
+    with patch.object(semantic_scholar_tools, "_get", return_value={"error": "rate limited"}):
+        result = json.loads(semantic_scholar_tools.search_papers("rag"))
+
+    assert result["error"] == "rate limited"
+
+
+def test_get_paper_success(semantic_scholar_tools, sample_paper):
+    with patch.object(semantic_scholar_tools, "_get", return_value=sample_paper) as mock_get:
+        result = json.loads(semantic_scholar_tools.get_paper("ARXIV:2005.11401"))
+
+    mock_get.assert_called_once()
+    path, params = mock_get.call_args.args
+    assert path == "paper/ARXIV:2005.11401"
+    assert "fields" in params
+    assert result["title"] == sample_paper["title"]
+    assert result["open_access_pdf_url"] == "https://example.com/paper.pdf"
+
+
+def test_get_paper_validates_paper_id(semantic_scholar_tools):
+    result = json.loads(semantic_scholar_tools.get_paper(""))
+    assert result["error"] == "Please provide a paper_id"
+
+
+def test_get_author_papers_success(semantic_scholar_tools, sample_paper):
+    with patch.object(semantic_scholar_tools, "_get", return_value={"data": [sample_paper]}) as mock_get:
+        result = json.loads(semantic_scholar_tools.get_author_papers("1741101", max_results=3))
+
+    path, params = mock_get.call_args.args
+    assert path == "author/1741101/papers"
+    assert params["limit"] == 3
+    assert result["author_id"] == "1741101"
+    assert result["papers"][0]["title"] == sample_paper["title"]
+
+
+def test_get_author_papers_validates_author_id(semantic_scholar_tools):
+    result = json.loads(semantic_scholar_tools.get_author_papers(""))
+    assert result["error"] == "Please provide an author_id"


### PR DESCRIPTION
## Summary

Closes #8750.

Adds SemanticScholarTools, a research toolkit backed by the Semantic Scholar Academic Graph API. It gives Agno agents paper search, paper metadata lookup, and optional author-paper lookup without adding a new package dependency.

## Changes

- Add SemanticScholarTools under libs/agno/agno/tools/
- Support search_papers, get_paper, and get_author_papers
- Use existing httpx dependency and optional SEMANTIC_SCHOLAR_API_KEY header support
- Add mock-based unit tests for initialization, request handling, formatting, validation, and error paths
- Add a cookbook example under cookbook/91_tools/

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts or focused equivalents
- [x] Self-review completed
- [x] Documentation updated through a cookbook example
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## How Has This Been Tested?

- /tmp/agno-semantic-scholar-venv/bin/python -m pytest libs/agno/tests/unit/tools/test_semantic_scholar.py -q
- /tmp/agno-semantic-scholar-venv/bin/python -m ruff check libs/agno/agno/tools/semantic_scholar.py libs/agno/tests/unit/tools/test_semantic_scholar.py cookbook/91_tools/semantic_scholar_tools.py
- /tmp/agno-semantic-scholar-venv/bin/python -m ruff format --check libs/agno/agno/tools/semantic_scholar.py libs/agno/tests/unit/tools/test_semantic_scholar.py cookbook/91_tools/semantic_scholar_tools.py
- /tmp/agno-semantic-scholar-venv/bin/python -m mypy libs/agno/agno/tools/semantic_scholar.py --config-file libs/agno/pyproject.toml --follow-imports=skip

## Additional Notes

Unauthenticated live smoke testing hit Semantic Scholar shared public rate limiting with HTTP 429, so the PR relies on mock-based unit coverage and supports SEMANTIC_SCHOLAR_API_KEY for stable usage.

AI assistance disclosure: This PR was generated with Codex. I reviewed the implementation scope and ran the checks listed above.