### PR TITLE
fix: harden AgentOS auth surface (A2A auth, trace IDOR, PAT mint, validate=False)

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1246,16 +1246,19 @@ class AgentOS:
         # added by the user-scoped-DB work stay dormant.
         fastapi_app.state.user_isolation_enabled = user_isolation
 
-        # Interfaces authenticate themselves (Slack HMAC, Telegram webhook verification),
-        # so their route prefixes are excluded from the auth layer alongside the public
-        # routes. Passing excluded_route_paths replaces the middleware defaults, so the
+        # Only interfaces that verify the authenticity of their own inbound requests
+        # (Slack HMAC, Telegram/WhatsApp webhook secrets -- see
+        # BaseInterface.authenticates_own_requests) are excluded from the central auth
+        # layer alongside the public routes. Interfaces that do NOT self-authenticate
+        # (e.g. A2A) stay behind AuthMiddleware, so enabling authentication protects them
+        # too. Passing excluded_route_paths replaces the middleware defaults, so the
         # defaults are repeated here.
         excluded_route_paths: Optional[List[str]] = None
         if self.interfaces:
             interface_prefixes = [
                 f"{interface.prefix}/*"
                 for interface in self.interfaces
-                if hasattr(interface, "prefix") and interface.prefix
+                if getattr(interface, "authenticates_own_requests", False) and getattr(interface, "prefix", None)
             ]
             if interface_prefixes:
                 excluded_route_paths = [

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -226,6 +226,11 @@ def get_authentication_dependency(settings: AgnoAPISettings):
         if token != settings.os_security_key:
             raise HTTPException(status_code=401, detail="Invalid authentication token")
 
+        # A valid security key is a trusted, unscoped root. Mark it authenticated like the
+        # internal-token path above, so downstream gates that distinguish an authenticated
+        # root from an anonymous open-mode caller (e.g. service-account minting) treat it as
+        # a real credential rather than falling through to the fail-closed anonymous branch.
+        request.state.authenticated = True
         return True
 
     return auth_dependency

--- a/libs/agno/agno/os/interfaces/base.py
+++ b/libs/agno/agno/os/interfaces/base.py
@@ -18,6 +18,15 @@ class BaseInterface(ABC):
     prefix: str
     tags: List[str]
 
+    # Whether this interface verifies the authenticity of its own inbound requests
+    # (e.g. Slack/Telegram/WhatsApp verify a signing secret in their routers). When
+    # True, AgentOS excludes the interface's route prefix from the central auth layer,
+    # since the interface authenticates callers itself. Interfaces that do NOT
+    # self-authenticate (the default) stay behind AuthMiddleware and require a valid
+    # AgentOS credential once authentication is enabled -- see
+    # AgentOS._add_auth_middleware.
+    authenticates_own_requests: bool = False
+
     router: APIRouter
 
     @abstractmethod

--- a/libs/agno/agno/os/interfaces/slack/slack.py
+++ b/libs/agno/agno/os/interfaces/slack/slack.py
@@ -13,6 +13,10 @@ from agno.workflow import RemoteWorkflow, Workflow
 class Slack(BaseInterface):
     type = "slack"
 
+    # Verifies the Slack request signature (X-Slack-Signature) in its router, so it is
+    # excluded from the central auth layer.
+    authenticates_own_requests = True
+
     router: APIRouter
 
     def __init__(

--- a/libs/agno/agno/os/interfaces/telegram/telegram.py
+++ b/libs/agno/agno/os/interfaces/telegram/telegram.py
@@ -24,6 +24,10 @@ DEFAULT_BOT_COMMANDS: List[Dict[str, str]] = [
 class Telegram(BaseInterface):
     type = "telegram"
 
+    # Verifies the Telegram webhook secret token in its router, so it is excluded from
+    # the central auth layer.
+    authenticates_own_requests = True
+
     router: APIRouter
 
     def __init__(

--- a/libs/agno/agno/os/interfaces/whatsapp/whatsapp.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/whatsapp.py
@@ -13,6 +13,10 @@ from agno.workflow import RemoteWorkflow, Workflow
 class Whatsapp(BaseInterface):
     type = "whatsapp"
 
+    # Verifies the WhatsApp webhook signature (X-Hub-Signature-256) in its router, so it
+    # is excluded from the central auth layer.
+    authenticates_own_requests = True
+
     router: APIRouter
 
     def __init__(

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -1081,6 +1081,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return self._create_error_response(401, "Token has expired", origin, cors_allowed_origins)
             request.state.authenticated = False
             request.state.token = token
+            # Fail closed: a token was presented but could not be decoded. Do not leave RBAC
+            # dormant on this validate=False fall-through — mark authorization enabled with an
+            # empty scope set so route/tool gates deny protected routes exactly as they would
+            # for a valid zero-scope token. Otherwise a garbage token gets MORE access than a
+            # well-formed one, because downstream gates read authorization_enabled (default
+            # False) and skip enforcement entirely.
+            request.state.authorization_enabled = self.authorization or False
+            request.state.scopes = []
+            request.state.admin_scope = self.admin_scope
+            request.state.user_isolation_enabled = self.user_isolation
 
         except jwt.InvalidTokenError as e:
             if self.validate:
@@ -1088,12 +1098,32 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return self._create_error_response(401, f"Invalid token: {str(e)}", origin, cors_allowed_origins)
             request.state.authenticated = False
             request.state.token = token
+            # Fail closed: a token was presented but could not be decoded. Do not leave RBAC
+            # dormant on this validate=False fall-through — mark authorization enabled with an
+            # empty scope set so route/tool gates deny protected routes exactly as they would
+            # for a valid zero-scope token. Otherwise a garbage token gets MORE access than a
+            # well-formed one, because downstream gates read authorization_enabled (default
+            # False) and skip enforcement entirely.
+            request.state.authorization_enabled = self.authorization or False
+            request.state.scopes = []
+            request.state.admin_scope = self.admin_scope
+            request.state.user_isolation_enabled = self.user_isolation
         except Exception as e:
             if self.validate:
                 log_warning(f"Error decoding token: {str(e)}")
                 return self._create_error_response(401, f"Error decoding token: {str(e)}", origin, cors_allowed_origins)
             request.state.authenticated = False
             request.state.token = token
+            # Fail closed: a token was presented but could not be decoded. Do not leave RBAC
+            # dormant on this validate=False fall-through — mark authorization enabled with an
+            # empty scope set so route/tool gates deny protected routes exactly as they would
+            # for a valid zero-scope token. Otherwise a garbage token gets MORE access than a
+            # well-formed one, because downstream gates read authorization_enabled (default
+            # False) and skip enforcement entirely.
+            request.state.authorization_enabled = self.authorization or False
+            request.state.scopes = []
+            request.state.admin_scope = self.admin_scope
+            request.state.user_isolation_enabled = self.user_isolation
 
         return await call_next(request)
 

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -1081,16 +1081,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return self._create_error_response(401, "Token has expired", origin, cors_allowed_origins)
             request.state.authenticated = False
             request.state.token = token
-            # Fail closed: a token was presented but could not be decoded. Do not leave RBAC
-            # dormant on this validate=False fall-through — mark authorization enabled with an
-            # empty scope set so route/tool gates deny protected routes exactly as they would
-            # for a valid zero-scope token. Otherwise a garbage token gets MORE access than a
-            # well-formed one, because downstream gates read authorization_enabled (default
-            # False) and skip enforcement entirely.
-            request.state.authorization_enabled = self.authorization or False
-            request.state.scopes = []
-            request.state.admin_scope = self.admin_scope
-            request.state.user_isolation_enabled = self.user_isolation
 
         except jwt.InvalidTokenError as e:
             if self.validate:
@@ -1098,32 +1088,31 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 return self._create_error_response(401, f"Invalid token: {str(e)}", origin, cors_allowed_origins)
             request.state.authenticated = False
             request.state.token = token
-            # Fail closed: a token was presented but could not be decoded. Do not leave RBAC
-            # dormant on this validate=False fall-through — mark authorization enabled with an
-            # empty scope set so route/tool gates deny protected routes exactly as they would
-            # for a valid zero-scope token. Otherwise a garbage token gets MORE access than a
-            # well-formed one, because downstream gates read authorization_enabled (default
-            # False) and skip enforcement entirely.
-            request.state.authorization_enabled = self.authorization or False
-            request.state.scopes = []
-            request.state.admin_scope = self.admin_scope
-            request.state.user_isolation_enabled = self.user_isolation
         except Exception as e:
             if self.validate:
                 log_warning(f"Error decoding token: {str(e)}")
                 return self._create_error_response(401, f"Error decoding token: {str(e)}", origin, cors_allowed_origins)
             request.state.authenticated = False
             request.state.token = token
-            # Fail closed: a token was presented but could not be decoded. Do not leave RBAC
-            # dormant on this validate=False fall-through — mark authorization enabled with an
-            # empty scope set so route/tool gates deny protected routes exactly as they would
-            # for a valid zero-scope token. Otherwise a garbage token gets MORE access than a
-            # well-formed one, because downstream gates read authorization_enabled (default
-            # False) and skip enforcement entirely.
+
+        # validate=False decode-failure fall-through: a token was present but could not be
+        # decoded (this mode skips signature verification, so only a structurally-malformed
+        # token lands here). The success path sets the completion marker and runs _check_scopes;
+        # its ABSENCE identifies this fall-through. Treat the caller as authenticated-but-empty
+        # (no claims, no scopes) and -- when RBAC is on -- run the SAME scope gate the success
+        # path runs, so a malformed token is never more permissive than a valid zero-scope one.
+        # Without this, routes gated only by the middleware's own _check_scopes (memory,
+        # knowledge, sessions, metrics, ...) would skip enforcement, while the state below only
+        # covers the downstream route/tool gates (runs, MCP).
+        if not getattr(request.state, _AUTH_COMPLETE_ATTR, False):
             request.state.authorization_enabled = self.authorization or False
             request.state.scopes = []
             request.state.admin_scope = self.admin_scope
             request.state.user_isolation_enabled = self.user_isolation
+            if self.authorization:
+                error_response = self._check_scopes(request, method, path, [], origin, cors_allowed_origins)
+                if error_response is not None:
+                    return error_response
 
         return await call_next(request)
 

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -1099,14 +1099,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # decoded (this mode skips signature verification, so only a structurally-malformed
         # token lands here). The success path sets the completion marker and runs _check_scopes;
         # its ABSENCE identifies this fall-through. Treat the caller as authenticated-but-empty
-        # (no claims, no scopes) and -- when RBAC is on -- run the SAME scope gate the success
-        # path runs, so a malformed token is never more permissive than a valid zero-scope one.
-        # Without this, routes gated only by the middleware's own _check_scopes (memory,
-        # knowledge, sessions, metrics, ...) would skip enforcement, while the state below only
-        # covers the downstream route/tool gates (runs, MCP).
+        # -- no identity, no claims, no scopes -- identical to a valid token carrying no ``sub``
+        # and no scopes, so a malformed token is never more permissive than such a token. When
+        # RBAC is on, run the SAME scope gate the success path runs; without it, routes gated
+        # only by the middleware's own _check_scopes (memory, knowledge, sessions, metrics, ...)
+        # would skip enforcement, while the state below only covers the downstream route/tool
+        # gates (runs, MCP). ``user_id`` is pinned to None (matching the no-``sub`` success path)
+        # so the user-isolation layer scopes queries by owner rather than reading a stale id.
         if not getattr(request.state, _AUTH_COMPLETE_ATTR, False):
             request.state.authorization_enabled = self.authorization or False
             request.state.scopes = []
+            request.state.user_id = None
             request.state.admin_scope = self.admin_scope
             request.state.user_isolation_enabled = self.user_isolation
             if self.authorization:

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -119,15 +119,18 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
         # powerful than itself.
         caller_scopes = getattr(request.state, "scopes", None)
         if caller_scopes is None:
-            # No scope context. Two very different callers land here:
-            #   - a trusted root (os_security_key / internal service token): the auth
-            #     layer set request.state.authenticated = True. It is unscoped by
-            #     definition and may mint anything.
+            # No scope context (request.state.scopes is None). Two very different callers
+            # can land here:
+            #   - a trusted root authenticated by the OS security key: the auth layer set
+            #     request.state.authenticated = True but attached no scopes. It is unscoped
+            #     by definition and may mint anything. (The internal service token carries
+            #     INTERNAL_SERVICE_SCOPES, so it is NOT None here and takes the subset-rule
+            #     path below instead.)
             #   - an anonymous caller on an OPEN instance (no security key, no JWT):
-            #     authenticated is falsy. It must NOT be able to mint a privileged
-            #     token, which would persist as a durable admin credential even after
-            #     the operator later switches authentication on (PAT scopes are enforced
-            #     independently of the authorization flag).
+            #     authenticated is falsy. It must NOT be able to mint a privileged token,
+            #     which would persist as a durable admin credential even after the operator
+            #     later switches authentication on (PAT scopes are enforced independently of
+            #     the authorization flag).
             if getattr(request.state, "authenticated", False):
                 return
             unauth_privileged = get_privileged_scopes(scopes, admin_scope=admin_scope)

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -127,23 +127,22 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
             #     INTERNAL_SERVICE_SCOPES, so it is NOT None here and takes the subset-rule
             #     path below instead.)
             #   - an anonymous caller on an OPEN instance (no security key, no JWT):
-            #     authenticated is falsy. It must NOT be able to mint a privileged token,
-            #     which would persist as a durable admin credential even after the operator
-            #     later switches authentication on (PAT scopes are enforced independently of
-            #     the authorization flag).
+            #     authenticated is falsy. It must NOT be able to mint ANY token. A minted PAT
+            #     persists as a durable credential even after the operator later switches
+            #     authentication on (PAT scopes are enforced independently of the authorization
+            #     flag), so a briefly-exposed open instance would leak a permanent credential.
+            #     Even a non-privileged run/read token grants durable compute and cross-user
+            #     reads, so anonymous minting is refused outright -- not just for privileged
+            #     scopes. Minting requires a real credential (OS_SECURITY_KEY or JWT).
             if getattr(request.state, "authenticated", False):
                 return
-            unauth_privileged = get_privileged_scopes(scopes, admin_scope=admin_scope)
-            if unauth_privileged:
-                raise HTTPException(
-                    status_code=401,
-                    detail=(
-                        "Authentication is required to mint a service account with privileged "
-                        f"scope(s): {', '.join(unauth_privileged)}. Configure OS_SECURITY_KEY or JWT "
-                        "authentication before creating privileged tokens."
-                    ),
-                )
-            return
+            raise HTTPException(
+                status_code=401,
+                detail=(
+                    "Authentication is required to mint a service account. Configure "
+                    "OS_SECURITY_KEY or JWT authentication before creating tokens."
+                ),
+            )
         effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
         if effective_admin_scope in caller_scopes:
             return

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -116,10 +116,30 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
 
         # Subset rule: minted scopes must be held by the creator, so a caller with
         # only service_accounts:write can never escalate by minting a token more
-        # powerful than itself. Callers without scope context (root os_security_key
-        # or open dev instances) are exempt - they are unscoped by definition.
+        # powerful than itself.
         caller_scopes = getattr(request.state, "scopes", None)
         if caller_scopes is None:
+            # No scope context. Two very different callers land here:
+            #   - a trusted root (os_security_key / internal service token): the auth
+            #     layer set request.state.authenticated = True. It is unscoped by
+            #     definition and may mint anything.
+            #   - an anonymous caller on an OPEN instance (no security key, no JWT):
+            #     authenticated is falsy. It must NOT be able to mint a privileged
+            #     token, which would persist as a durable admin credential even after
+            #     the operator later switches authentication on (PAT scopes are enforced
+            #     independently of the authorization flag).
+            if getattr(request.state, "authenticated", False):
+                return
+            unauth_privileged = get_privileged_scopes(scopes, admin_scope=admin_scope)
+            if unauth_privileged:
+                raise HTTPException(
+                    status_code=401,
+                    detail=(
+                        "Authentication is required to mint a service account with privileged "
+                        f"scope(s): {', '.join(unauth_privileged)}. Configure OS_SECURITY_KEY or JWT "
+                        "authentication before creating privileged tokens."
+                    ),
+                )
             return
         effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
         if effective_admin_scope in caller_scopes:

--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -401,16 +401,21 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(request)
             headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
-            # Thread the scoped ``user_id`` to the remote so ownership is enforced there,
-            # exactly as the list endpoint (``GET /traces``) does. Without it the single-trace
-            # detail endpoint would be strictly weaker than the list it mirrors: a scoped
-            # caller could read another user's trace by id. ``effective_user_id`` is None for
-            # admins / unscoped callers, which the remote treats as unrestricted.
+            # Enforce ownership locally for a scoped caller, not only via the forwarded bearer.
+            # The remote also scopes by the bearer, but a remote that predates this fix (or
+            # trusts an upstream gateway) would otherwise leak. The full-trace result carries
+            # user_id; for a single span we fetch the parent trace first (a span has no
+            # user_id) and check it, mirroring the local branch below. Admin / unscoped callers
+            # (effective_user_id is None) keep the single-call fast path.
+            if effective_user_id is not None:
+                parent_trace = await db.get_trace(trace_id=trace_id, run_id=run_id, db_id=db_id, headers=headers)
+                _require_trace_owner(parent_trace, effective_user_id)
+                if span_id is None:
+                    return parent_trace
             return await db.get_trace(
                 trace_id=trace_id,
                 span_id=span_id,
                 run_id=run_id,
-                user_id=effective_user_id,
                 db_id=db_id,
                 headers=headers,
             )

--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from fastapi import Depends, HTTPException, Query, Request
 from fastapi.routing import APIRouter
@@ -51,6 +51,20 @@ def _apply_user_scope_to_filter(filter_expr_dict: Optional[dict], effective_user
     if filter_expr_dict is None:
         return user_clause
     return {"op": "AND", "conditions": [user_clause, filter_expr_dict]}
+
+
+def _require_trace_owner(trace: Any, effective_user_id: Optional[str]) -> None:
+    """Enforce single-trace ownership for non-admin scoped callers.
+
+    ``get_trace`` looks a trace up by its unique ``trace_id`` / ``run_id`` with no
+    user filter (the DB contract delegates the ownership check to the route layer),
+    so a scoped caller must be shown only their own trace. A ``trace_id`` / ``run_id``
+    is not a capability — both leak through run/session APIs, SSE streams and logs —
+    so a mismatch is masked as a 404 rather than a 403. Admins / unscoped callers
+    (``effective_user_id is None``) are unaffected.
+    """
+    if effective_user_id is not None and getattr(trace, "user_id", None) != effective_user_id:
+        raise HTTPException(status_code=404, detail="Trace not found")
 
 
 def get_traces_router(
@@ -375,14 +389,12 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         db_id: Optional[str] = Query(default=None, description="Database ID to query trace from"),
     ):
         """Get detailed trace with hierarchical span tree, or a specific span within the trace"""
-        # ``trace_id`` is a unique key — there's nothing to narrow further at
-        # the DB layer, so ``get_trace`` only takes ``trace_id`` / ``run_id``.
-        # Authorization for this endpoint is upheld by the list endpoint
-        # (``GET /traces``), which is the only way for a non-admin caller to
-        # discover trace_ids in the first place; that listing is scoped to
-        # the caller's ``user_id``, so by the time a request lands here the
-        # caller necessarily owns the trace they're asking about.
-        db, _ = await resolve_db_and_scope(request, dbs, db_id)
+        # ``trace_id`` / ``run_id`` are unique keys, so ``get_trace`` takes no user
+        # filter at the DB layer; ownership is enforced here at the route layer (see
+        # ``_require_trace_owner``) after the trace is fetched. Both ids leak through
+        # run/session APIs, SSE and logs, so a non-admin caller reaching this route
+        # does NOT necessarily own the trace and must be checked.
+        db, effective_user_id = await resolve_db_and_scope(request, dbs, db_id)
 
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(request)
@@ -407,6 +419,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
                 if parent_trace is None:
                     raise HTTPException(status_code=404, detail="Trace not found")
+                _require_trace_owner(parent_trace, effective_user_id)
 
                 if isinstance(db, AsyncBaseDb):
                     span = await db.get_span(span_id)
@@ -431,6 +444,7 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
 
             if trace is None:
                 raise HTTPException(status_code=404, detail="Trace not found")
+            _require_trace_owner(trace, effective_user_id)
 
             # Get all spans for this trace
             if isinstance(db, AsyncBaseDb):

--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -61,7 +61,9 @@ def _require_trace_owner(trace: Any, effective_user_id: Optional[str]) -> None:
     so a scoped caller must be shown only their own trace. A ``trace_id`` / ``run_id``
     is not a capability — both leak through run/session APIs, SSE streams and logs —
     so a mismatch is masked as a 404 rather than a 403. Admins / unscoped callers
-    (``effective_user_id is None``) are unaffected.
+    (``effective_user_id is None``) are unaffected. A trace with no ``user_id`` is
+    treated as not-owned for a scoped caller (fail-closed), consistent with the list
+    endpoint, which also excludes NULL-user rows from a scoped caller's results.
     """
     if effective_user_id is not None and getattr(trace, "user_id", None) != effective_user_id:
         raise HTTPException(status_code=404, detail="Trace not found")

--- a/libs/agno/agno/os/routers/traces/traces.py
+++ b/libs/agno/agno/os/routers/traces/traces.py
@@ -401,10 +401,16 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(request)
             headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
+            # Thread the scoped ``user_id`` to the remote so ownership is enforced there,
+            # exactly as the list endpoint (``GET /traces``) does. Without it the single-trace
+            # detail endpoint would be strictly weaker than the list it mirrors: a scoped
+            # caller could read another user's trace by id. ``effective_user_id`` is None for
+            # admins / unscoped callers, which the remote treats as unrestricted.
             return await db.get_trace(
                 trace_id=trace_id,
                 span_id=span_id,
                 run_id=run_id,
+                user_id=effective_user_id,
                 db_id=db_id,
                 headers=headers,
             )

--- a/libs/agno/tests/integration/os/test_a2a_auth.py
+++ b/libs/agno/tests/integration/os/test_a2a_auth.py
@@ -1,0 +1,80 @@
+"""S1: the A2A interface does not authenticate its own requests, so it must sit
+behind the central AuthMiddleware. Enabling ``authorization`` therefore protects the
+A2A execution/discovery endpoints too, instead of leaving them anonymous.
+
+Self-authenticating interfaces (Slack/Telegram/WhatsApp verify a signing secret in
+their own routers) keep their ``authenticates_own_requests = True`` marker and stay
+excluded from the central layer.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
+from agno.os.interfaces.a2a import A2A
+
+JWT_SECRET = "test-secret-for-a2a-auth"
+TEST_OS_ID = "a2a-auth-os"
+AGENT_ID = "a2a-agent"
+
+CARD_PATH = f"/a2a/agents/{AGENT_ID}/.well-known/agent-card.json"
+
+
+def _token(scopes=None):
+    payload = {
+        "sub": "user-1",
+        "scopes": scopes if scopes is not None else ["agents:read", "agents:run"],
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm="HS256")
+
+
+@pytest.fixture
+def a2a_client():
+    agent = Agent(id=AGENT_ID, name="A2A Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=TEST_OS_ID,
+        agents=[agent],
+        a2a_interface=True,
+        authorization=True,
+        authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+    )
+    return TestClient(agent_os.get_app())
+
+
+class TestA2ARequiresAuth:
+    def test_a2a_card_rejects_anonymous_request(self, a2a_client):
+        # Previously reachable with no credential; now behind the auth layer.
+        resp = a2a_client.get(CARD_PATH)
+        assert resp.status_code == 401, resp.text
+
+    def test_a2a_card_allows_authenticated_request(self, a2a_client):
+        resp = a2a_client.get(CARD_PATH, headers={"Authorization": f"Bearer {_token()}"})
+        assert resp.status_code == 200, resp.text
+
+    def test_a2a_message_send_rejects_anonymous_request(self, a2a_client):
+        # 401 fires in the middleware, before the route parses the body.
+        resp = a2a_client.post(f"/a2a/agents/{AGENT_ID}/v1/message:send", json={})
+        assert resp.status_code == 401, resp.text
+
+
+class TestInterfaceSelfAuthMarkers:
+    """The marker that decides whether an interface is excluded from the central
+    auth layer. A2A must NOT self-authenticate (Slack/Telegram/WhatsApp set the
+    marker True in their own modules; asserting those here would require their
+    optional SDKs)."""
+
+    def test_a2a_does_not_self_authenticate(self):
+        assert A2A.authenticates_own_requests is False
+
+    def test_base_interface_defaults_to_not_self_authenticating(self):
+        from agno.os.interfaces.base import BaseInterface
+
+        assert BaseInterface.authenticates_own_requests is False

--- a/libs/agno/tests/integration/os/test_jwt_validate_false_failclosed.py
+++ b/libs/agno/tests/integration/os/test_jwt_validate_false_failclosed.py
@@ -1,0 +1,62 @@
+"""S3: with ``validate=False`` (unverified dev mode) and ``authorization=True``, a
+token that cannot be decoded must NOT leave RBAC dormant. The decode-failure
+fall-through has to mark ``authorization_enabled`` and an empty scope set so a garbage
+token is treated exactly like a valid zero-scope token -- otherwise malformed input
+gets MORE access than well-formed input, because every RBAC gate reads
+``request.state.authorization_enabled`` (default False) and skips enforcement.
+"""
+
+import jwt
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from agno.os.middleware import JWTMiddleware
+
+
+@pytest.fixture
+def state_client():
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request):
+        return {
+            "authenticated": getattr(request.state, "authenticated", None),
+            "authorization_enabled": getattr(request.state, "authorization_enabled", None),
+            "scopes": getattr(request.state, "scopes", None),
+        }
+
+    # Unverified dev mode with RBAC requested. No verification key needed (validate=False).
+    app.add_middleware(JWTMiddleware, validate=False, authorization=True)
+    return TestClient(app)
+
+
+def _unsigned_token(scopes):
+    # validate=False decodes without verifying the signature, so any secret works.
+    return jwt.encode({"sub": "u", "scopes": scopes}, "unused", algorithm="HS256")
+
+
+class TestValidateFalseFailsClosed:
+    def test_garbage_token_enables_rbac_with_empty_scopes(self, state_client):
+        resp = state_client.get("/whoami", headers={"Authorization": "Bearer not-a-jwt"})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # The fix: RBAC is active (not dormant) and the caller carries no scopes.
+        assert body["authorization_enabled"] is True
+        assert body["scopes"] == []
+        assert body["authenticated"] is False
+
+    def test_garbage_token_matches_valid_empty_scope_token(self, state_client):
+        garbage = state_client.get("/whoami", headers={"Authorization": "Bearer not-a-jwt"}).json()
+        valid_empty = state_client.get("/whoami", headers={"Authorization": f"Bearer {_unsigned_token([])}"}).json()
+        # Garbage input must not be more permissive than a valid zero-scope token.
+        assert garbage["authorization_enabled"] == valid_empty["authorization_enabled"]
+        assert garbage["scopes"] == valid_empty["scopes"] == []
+
+    def test_valid_scoped_token_still_carries_its_scopes(self, state_client):
+        body = state_client.get(
+            "/whoami", headers={"Authorization": f"Bearer {_unsigned_token(['agents:read'])}"}
+        ).json()
+        assert body["authenticated"] is True
+        assert body["authorization_enabled"] is True
+        assert body["scopes"] == ["agents:read"]

--- a/libs/agno/tests/integration/os/test_jwt_validate_false_failclosed.py
+++ b/libs/agno/tests/integration/os/test_jwt_validate_false_failclosed.py
@@ -60,3 +60,28 @@ class TestValidateFalseFailsClosed:
         assert body["authenticated"] is True
         assert body["authorization_enabled"] is True
         assert body["scopes"] == ["agents:read"]
+
+
+class TestValidateFalseEnforcesScopesOnFallThrough:
+    """The fall-through must run the SAME scope gate as the success path, so a malformed
+    token is denied on scope-protected routes -- including routes gated only by the
+    middleware's _check_scopes (memory/knowledge/sessions/metrics), which have no
+    downstream dependency to catch them."""
+
+    def test_garbage_token_denied_on_scope_gated_route(self, state_client):
+        # /memories requires memories:read in the default scope map; a garbage token holds
+        # no scopes, so the middleware denies it (403) before the request is routed.
+        resp = state_client.get("/memories", headers={"Authorization": "Bearer not-a-jwt"})
+        assert resp.status_code == 403, resp.text
+
+    def test_garbage_matches_valid_empty_scope_token_on_scope_gated_route(self, state_client):
+        garbage = state_client.get("/memories", headers={"Authorization": "Bearer not-a-jwt"})
+        valid_empty = state_client.get("/memories", headers={"Authorization": f"Bearer {_unsigned_token([])}"})
+        # Malformed input must be no more permissive than a valid zero-scope token.
+        assert garbage.status_code == valid_empty.status_code == 403
+
+    def test_garbage_token_allowed_on_unmapped_route(self, state_client):
+        # An un-mapped path requires no scope, so it stays reachable -- matching a valid
+        # zero-scope token (no over-denial).
+        resp = state_client.get("/whoami", headers={"Authorization": "Bearer not-a-jwt"})
+        assert resp.status_code == 200

--- a/libs/agno/tests/integration/os/test_jwt_validate_false_failclosed.py
+++ b/libs/agno/tests/integration/os/test_jwt_validate_false_failclosed.py
@@ -20,10 +20,12 @@ def state_client():
 
     @app.get("/whoami")
     async def whoami(request: Request):
+        # "UNSET" distinguishes "attribute never set" from an explicit None identity.
         return {
             "authenticated": getattr(request.state, "authenticated", None),
             "authorization_enabled": getattr(request.state, "authorization_enabled", None),
             "scopes": getattr(request.state, "scopes", None),
+            "user_id": getattr(request.state, "user_id", "UNSET"),
         }
 
     # Unverified dev mode with RBAC requested. No verification key needed (validate=False).
@@ -45,6 +47,8 @@ class TestValidateFalseFailsClosed:
         assert body["authorization_enabled"] is True
         assert body["scopes"] == []
         assert body["authenticated"] is False
+        # Identity is pinned to None (no stale id leaks in), so user-isolation scopes by owner.
+        assert body["user_id"] is None
 
     def test_garbage_token_matches_valid_empty_scope_token(self, state_client):
         garbage = state_client.get("/whoami", headers={"Authorization": "Bearer not-a-jwt"}).json()

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -306,8 +306,28 @@ class TestServiceAccountsOnOpenInstance:
         agent_os = AgentOS(agents=[test_agent], db=sqlite_db)
         return TestClient(agent_os.get_app())
 
-    def test_pat_authenticates_and_attributes_on_open_instance(self, open_client, test_agent):
-        pat = _mint(open_client, "anything-goes").json()["token"]
+    def test_pat_authenticates_and_attributes_on_open_instance(self, open_client, test_agent, sqlite_db):
+        # Anonymous mint is refused on an open instance (S4: a token minted with no auth would
+        # be a durable credential surviving a later lockdown). A PAT reaches an open instance
+        # only if it was minted earlier under a security key / JWT -- simulate that by inserting
+        # the account directly. The point here is that the PAT AUTHENTICATES and attributes
+        # correctly on an open box.
+        import uuid
+
+        from agno.db.schemas.service_accounts import ServiceAccount
+        from agno.os.service_accounts import DEFAULT_SERVICE_ACCOUNT_SCOPES, generate_token
+
+        plaintext, token_hash, token_prefix = generate_token()
+        account = ServiceAccount(
+            id=str(uuid.uuid4()),
+            name="claude-code",
+            token_hash=token_hash,
+            token_prefix=token_prefix,
+            scopes=list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
+            created_at=int(time.time()),
+        )
+        sqlite_db.create_service_account(account.to_dict())
+        pat = plaintext
 
         with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
             mock_arun.return_value = _mock_run_output()

--- a/libs/agno/tests/integration/os/test_user_isolation_02.py
+++ b/libs/agno/tests/integration/os/test_user_isolation_02.py
@@ -130,13 +130,10 @@ def custom_admin_client(test_agent):
 class TestTraceListScoping:
     """``GET /traces`` must only return traces owned by the caller.
 
-    The single-trace detail endpoint (``GET /traces/{trace_id}``) does NOT
-    enforce row-level ownership: a unique ``trace_id`` is sufficient — see
-    the design notes at the top of this file. The list endpoint is where
-    isolation actually matters, because that's how non-admin callers
-    discover which trace_ids exist at all. If the list endpoint leaked
-    other users' rows, every downstream "knew the trace_id" assumption
-    falls apart.
+    The list endpoint is how a non-admin caller discovers which trace_ids
+    exist; ``TestTraceDetailScoping`` covers the single-trace detail endpoint,
+    which enforces row-level ownership after fetching (a trace_id / run_id is
+    not a secret, so it cannot be relied on as an implicit authorization).
     """
 
     def _insert_trace(self, db, *, trace_id: str, user_id: str):
@@ -205,6 +202,68 @@ class TestTraceListScoping:
         assert {"trace-admin-a", "trace-admin-b"}.issubset(returned_ids), (
             f"admin should see all traces; got {returned_ids}"
         )
+
+
+class TestTraceDetailScoping:
+    """``GET /traces/{trace_id}`` must enforce row-level ownership for non-admin
+    callers (S2). A trace_id / run_id is not a capability -- both leak through
+    run/session APIs, SSE and logs -- so a scoped caller asking for another
+    user's trace (by trace_id or run_id, full trace or a single span) gets a
+    masking 404, while the owner and admins still get 200.
+    """
+
+    def _insert_trace(self, db, *, trace_id: str, user_id: str):
+        from agno.tracing.schemas import Trace
+
+        now = datetime.now(UTC)
+        db.upsert_trace(
+            Trace(
+                trace_id=trace_id,
+                name="root",
+                status="OK",
+                start_time=now,
+                end_time=now,
+                duration_ms=0,
+                total_spans=0,
+                error_count=0,
+                run_id=f"run-{trace_id}",
+                session_id=f"session-{trace_id}",
+                user_id=user_id,
+                agent_id="test-agent",
+                team_id=None,
+                workflow_id=None,
+                created_at=now,
+            )
+        )
+
+    def test_owner_can_read_own_trace(self, client, shared_db):
+        self._insert_trace(shared_db, trace_id="trace-own-1", user_id="user-a")
+        resp = client.get("/traces/trace-own-1", headers=auth_header(make_token("user-a")))
+        assert resp.status_code == 200, resp.text
+
+    def test_non_owner_cannot_read_trace_by_id(self, client, shared_db):
+        self._insert_trace(shared_db, trace_id="trace-priv-1", user_id="user-a")
+        resp = client.get("/traces/trace-priv-1", headers=auth_header(make_token("user-b")))
+        assert resp.status_code == 404, resp.text
+
+    def test_non_owner_cannot_read_trace_by_run_id(self, client, shared_db):
+        # The run_id fallback lookup must not become an ownership bypass.
+        self._insert_trace(shared_db, trace_id="trace-priv-2", user_id="user-a")
+        resp = client.get("/traces/unknown?run_id=run-trace-priv-2", headers=auth_header(make_token("user-b")))
+        assert resp.status_code == 404, resp.text
+
+    def test_non_owner_cannot_read_span_of_foreign_trace(self, client, shared_db):
+        # Parent-trace ownership is checked before the span is fetched, so a
+        # non-owner is masked with 404 even with a guessed span_id.
+        self._insert_trace(shared_db, trace_id="trace-priv-3", user_id="user-a")
+        resp = client.get("/traces/trace-priv-3?span_id=any-span", headers=auth_header(make_token("user-b")))
+        assert resp.status_code == 404, resp.text
+
+    def test_admin_can_read_any_trace(self, client, shared_db):
+        self._insert_trace(shared_db, trace_id="trace-admin-x", user_id="user-a")
+        admin_token = make_token("admin-1", scopes=["agent_os:admin"])
+        resp = client.get("/traces/trace-admin-x", headers=auth_header(admin_token))
+        assert resp.status_code == 200, resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/integration/os/test_user_isolation_02.py
+++ b/libs/agno/tests/integration/os/test_user_isolation_02.py
@@ -206,10 +206,10 @@ class TestTraceListScoping:
 
 class TestTraceDetailScoping:
     """``GET /traces/{trace_id}`` must enforce row-level ownership for non-admin
-    callers (S2). A trace_id / run_id is not a capability -- both leak through
-    run/session APIs, SSE and logs -- so a scoped caller asking for another
-    user's trace (by trace_id or run_id, full trace or a single span) gets a
-    masking 404, while the owner and admins still get 200.
+    callers (S2). A trace_id is not a capability -- it leaks through run/session
+    APIs, SSE and logs -- so a scoped caller asking for another user's trace (the
+    full trace or a single span within it) gets a masking 404, while the owner and
+    admins still get 200.
     """
 
     def _insert_trace(self, db, *, trace_id: str, user_id: str):
@@ -236,6 +236,27 @@ class TestTraceDetailScoping:
             )
         )
 
+    def _insert_span(self, db, *, span_id: str, trace_id: str):
+        from agno.tracing.schemas import Span
+
+        now = datetime.now(UTC)
+        db.create_span(
+            Span(
+                span_id=span_id,
+                trace_id=trace_id,
+                parent_span_id=None,
+                name="root",
+                span_kind="AGENT",
+                status_code="OK",
+                status_message=None,
+                start_time=now,
+                end_time=now,
+                duration_ms=0,
+                attributes={},
+                created_at=now,
+            )
+        )
+
     def test_owner_can_read_own_trace(self, client, shared_db):
         self._insert_trace(shared_db, trace_id="trace-own-1", user_id="user-a")
         resp = client.get("/traces/trace-own-1", headers=auth_header(make_token("user-a")))
@@ -246,17 +267,21 @@ class TestTraceDetailScoping:
         resp = client.get("/traces/trace-priv-1", headers=auth_header(make_token("user-b")))
         assert resp.status_code == 404, resp.text
 
-    def test_non_owner_cannot_read_trace_by_run_id(self, client, shared_db):
-        # The run_id fallback lookup must not become an ownership bypass.
-        self._insert_trace(shared_db, trace_id="trace-priv-2", user_id="user-a")
-        resp = client.get("/traces/unknown?run_id=run-trace-priv-2", headers=auth_header(make_token("user-b")))
-        assert resp.status_code == 404, resp.text
+    def test_owner_can_read_span_of_own_trace(self, client, shared_db):
+        # Proves the span exists and is returnable, so the non-owner 404 below is the
+        # ownership gate rejecting the caller, not a missing span.
+        self._insert_trace(shared_db, trace_id="trace-span-own", user_id="user-a")
+        self._insert_span(shared_db, span_id="span-own", trace_id="trace-span-own")
+        resp = client.get("/traces/trace-span-own?span_id=span-own", headers=auth_header(make_token("user-a")))
+        assert resp.status_code == 200, resp.text
 
     def test_non_owner_cannot_read_span_of_foreign_trace(self, client, shared_db):
-        # Parent-trace ownership is checked before the span is fetched, so a
-        # non-owner is masked with 404 even with a guessed span_id.
+        # A REAL span is inserted, so without the parent-trace ownership gate the request
+        # would return the span (200). The gate must 404 a non-owner *before* the span is
+        # fetched -- so this test fails if the ownership check is removed (not a tautology).
         self._insert_trace(shared_db, trace_id="trace-priv-3", user_id="user-a")
-        resp = client.get("/traces/trace-priv-3?span_id=any-span", headers=auth_header(make_token("user-b")))
+        self._insert_span(shared_db, span_id="span-priv-3", trace_id="trace-priv-3")
+        resp = client.get("/traces/trace-priv-3?span_id=span-priv-3", headers=auth_header(make_token("user-b")))
         assert resp.status_code == 404, resp.text
 
     def test_admin_can_read_any_trace(self, client, shared_db):

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -117,8 +117,21 @@ class TestCreateServiceAccount:
         response = client.post("/service-accounts", json={"name": "ci", "scopes": ["service_accounts:write"]})
         assert response.status_code == 400
 
-    def test_privileged_scope_allowed_with_flag(self, client):
-        response = client.post(
+    def test_privileged_scope_allowed_with_flag_for_authenticated_root(self, mock_db, settings):
+        # A trusted root (os_security_key / internal token sets request.state.authenticated)
+        # may mint a privileged token when the explicit flag is set. An UNauthenticated
+        # (open-mode) caller may not -- see TestCreateServiceAccountUnauthenticatedOpenMode.
+        from fastapi import Request
+
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def set_authenticated(request: Request, call_next):
+            request.state.authenticated = True
+            return await call_next(request)
+
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        response = TestClient(app).post(
             "/service-accounts",
             json={"name": "ci", "scopes": ["sessions:write"], "allow_privileged_scopes": True},
         )
@@ -199,12 +212,59 @@ class TestCreateServiceAccountSubsetRule:
         response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:other-agent:run"]})
         assert response.status_code == 403
 
-    def test_unscoped_root_caller_is_exempt(self, mock_db, settings):
-        # No request.state.scopes (os_security_key or open dev instance)
+    def test_unscoped_caller_can_mint_non_privileged(self, mock_db, settings):
+        # No request.state.scopes and not authenticated (an open dev instance): a plain
+        # non-privileged token is still allowed so open-mode ergonomics are preserved.
+        # Privileged/admin tokens are blocked for this caller -- see
+        # TestCreateServiceAccountUnauthenticatedOpenMode.
         app = FastAPI()
         app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
         response = TestClient(app).post("/service-accounts", json={"name": "ci", "scopes": ["teams:run"]})
         assert response.status_code == 201
+
+
+class TestCreateServiceAccountUnauthenticatedOpenMode:
+    """S4: on an OPEN instance (no security key, no JWT) request.state.authenticated is
+    falsy and scopes is unset. Such an anonymous caller may mint a plain non-privileged
+    token, but must NOT be able to mint a privileged/admin token -- which would otherwise
+    persist as a durable admin credential even after the operator later enables auth."""
+
+    @pytest.fixture
+    def anon_client(self, mock_db, settings):
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        return TestClient(app)
+
+    def test_anonymous_can_mint_default_non_privileged_token(self, anon_client):
+        response = anon_client.post("/service-accounts", json={"name": "ci"})
+        assert response.status_code == 201
+
+    def test_anonymous_cannot_mint_admin_even_with_flag(self, anon_client):
+        response = anon_client.post(
+            "/service-accounts",
+            json={
+                "name": "backdoor",
+                "scopes": ["agent_os:admin"],
+                "allow_privileged_scopes": True,
+                "never_expires": True,
+            },
+        )
+        assert response.status_code == 401
+        assert "Authentication is required" in response.json()["detail"]
+
+    def test_anonymous_cannot_mint_write_scope_even_with_flag(self, anon_client):
+        response = anon_client.post(
+            "/service-accounts",
+            json={"name": "w", "scopes": ["sessions:write"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 401
+
+    def test_anonymous_cannot_mint_service_accounts_scope_even_with_flag(self, anon_client):
+        response = anon_client.post(
+            "/service-accounts",
+            json={"name": "minter", "scopes": ["service_accounts:write"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 401
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -51,12 +51,28 @@ def settings():
     return AgnoAPISettings()
 
 
+def _authenticated_app(mock_db, settings):
+    """An app whose caller is an authenticated, unscoped root (os_security_key / JWT).
+
+    Minting requires authentication, so the happy-path fixture authenticates. A middleware
+    marks request.state.authenticated = True, standing in for the auth layer that would set
+    it in production. Anonymous open-mode behaviour is covered separately by
+    TestCreateServiceAccountUnauthenticatedOpenMode.
+    """
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def set_authenticated(request, call_next):
+        request.state.authenticated = True
+        return await call_next(request)
+
+    app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+    return app
+
+
 @pytest.fixture
 def client(mock_db, settings):
-    app = FastAPI()
-    router = get_service_accounts_router(os_db=mock_db, settings=settings)
-    app.include_router(router)
-    return TestClient(app)
+    return TestClient(_authenticated_app(mock_db, settings))
 
 
 # =============================================================================
@@ -153,9 +169,7 @@ class TestCreateServiceAccount:
     def test_db_without_support_returns_503(self, settings):
         db = MagicMock()
         db.get_service_account_by_name = MagicMock(side_effect=NotImplementedError)
-        app = FastAPI()
-        app.include_router(get_service_accounts_router(os_db=db, settings=settings))
-        response = TestClient(app).post("/service-accounts", json={"name": "ci"})
+        response = TestClient(_authenticated_app(db, settings)).post("/service-accounts", json={"name": "ci"})
         assert response.status_code == 503
 
 
@@ -212,22 +226,23 @@ class TestCreateServiceAccountSubsetRule:
         response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:other-agent:run"]})
         assert response.status_code == 403
 
-    def test_unscoped_caller_can_mint_non_privileged(self, mock_db, settings):
-        # No request.state.scopes and not authenticated (an open dev instance): a plain
-        # non-privileged token is still allowed so open-mode ergonomics are preserved.
-        # Privileged/admin tokens are blocked for this caller -- see
+    def test_unscoped_unauthenticated_caller_cannot_mint(self, mock_db, settings):
+        # No request.state.scopes and not authenticated (an open dev instance). Even a plain
+        # non-privileged token is refused: an anonymously-minted PAT persists as a durable
+        # credential after the operator later enables auth. See
         # TestCreateServiceAccountUnauthenticatedOpenMode.
         app = FastAPI()
         app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
         response = TestClient(app).post("/service-accounts", json={"name": "ci", "scopes": ["teams:run"]})
-        assert response.status_code == 201
+        assert response.status_code == 401
 
 
 class TestCreateServiceAccountUnauthenticatedOpenMode:
     """S4: on an OPEN instance (no security key, no JWT) request.state.authenticated is
-    falsy and scopes is unset. Such an anonymous caller may mint a plain non-privileged
-    token, but must NOT be able to mint a privileged/admin token -- which would otherwise
-    persist as a durable admin credential even after the operator later enables auth."""
+    falsy and scopes is unset. Such an anonymous caller must NOT be able to mint ANY token
+    -- privileged or not -- because a minted PAT persists as a durable credential even after
+    the operator later enables auth (PAT scopes are enforced independently of the
+    authorization flag). Minting requires a real credential (OS_SECURITY_KEY or JWT)."""
 
     @pytest.fixture
     def anon_client(self, mock_db, settings):
@@ -235,9 +250,19 @@ class TestCreateServiceAccountUnauthenticatedOpenMode:
         app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
         return TestClient(app)
 
-    def test_anonymous_can_mint_default_non_privileged_token(self, anon_client):
+    def test_anonymous_cannot_mint_default_token(self, anon_client):
         response = anon_client.post("/service-accounts", json={"name": "ci"})
-        assert response.status_code == 201
+        assert response.status_code == 401
+        assert "Authentication is required" in response.json()["detail"]
+
+    def test_anonymous_cannot_mint_never_expiring_run_token(self, anon_client):
+        # The durable-credential case: a never-expiring run/read token would survive the
+        # operator later enabling auth. Refused even though its scopes are non-privileged.
+        response = anon_client.post(
+            "/service-accounts",
+            json={"name": "backdoor", "scopes": ["agents:run", "sessions:read"], "never_expires": True},
+        )
+        assert response.status_code == 401
 
     def test_anonymous_cannot_mint_admin_even_with_flag(self, anon_client):
         response = anon_client.post(
@@ -263,6 +288,36 @@ class TestCreateServiceAccountUnauthenticatedOpenMode:
         response = anon_client.post(
             "/service-accounts",
             json={"name": "minter", "scopes": ["service_accounts:write"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 401
+
+
+class TestCreateServiceAccountSecurityKeyRoot:
+    """A caller validated by the OS security key is a trusted, unscoped root: the auth
+    dependency marks it authenticated, so it may mint privileged tokens. Regression test for
+    the security-key path failing to set request.state.authenticated (which would falsely
+    route a legitimate root through the fail-closed anonymous branch)."""
+
+    def test_security_key_root_can_mint_privileged(self, mock_db):
+        settings = AgnoAPISettings(os_security_key="root-key-123")
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        response = TestClient(app).post(
+            "/service-accounts",
+            headers={"Authorization": "Bearer root-key-123"},
+            json={"name": "ci", "scopes": ["agent_os:admin"], "allow_privileged_scopes": True},
+        )
+        assert response.status_code == 201, response.text
+        assert response.json()["scopes"] == ["agent_os:admin"]
+
+    def test_invalid_security_key_is_rejected(self, mock_db):
+        settings = AgnoAPISettings(os_security_key="root-key-123")
+        app = FastAPI()
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        response = TestClient(app).post(
+            "/service-accounts",
+            headers={"Authorization": "Bearer wrong-key"},
+            json={"name": "ci"},
         )
         assert response.status_code == 401
 

--- a/libs/agno/tests/unit/os/test_router_user_id_threading.py
+++ b/libs/agno/tests/unit/os/test_router_user_id_threading.py
@@ -191,11 +191,12 @@ class TestTraceRouterUserIdThreading:
 
     def test_get_trace_does_not_pass_user_id(self, trace_db, no_security_key):
         """``trace_id`` is a unique key — a trace already belongs to one
-        owner, so ``get_trace`` doesn't accept ``user_id`` / ``session_id`` /
-        ``agent_id`` filters. Authorization for the detail endpoint is
-        carried by the list endpoint (which scopes trace_id discovery to
-        the caller). The router must not pass extra kwargs that don't exist
-        in ``BaseDb.get_trace`` — otherwise non-sqlite backends TypeError."""
+        owner, so the LOCAL-DB ``get_trace`` doesn't accept ``user_id`` /
+        ``session_id`` / ``agent_id`` filters; ownership is enforced at the
+        route layer by ``_require_trace_owner`` after fetch. The router must
+        not pass extra kwargs that don't exist in ``BaseDb.get_trace`` —
+        otherwise non-sqlite backends TypeError. (RemoteDb is different — see
+        ``test_get_trace_remote_db_threads_jwt_sub``.)"""
         app = _build_trace_app(trace_db, isolation=True)
         TestClient(app).get("/traces/trace-1")
         kwargs = trace_db.get_trace.call_args.kwargs
@@ -203,6 +204,28 @@ class TestTraceRouterUserIdThreading:
         assert "session_id" not in kwargs
         assert "agent_id" not in kwargs
         assert kwargs["trace_id"] == "trace-1"
+
+    def test_get_trace_remote_db_threads_jwt_sub(self, no_security_key):
+        """RemoteDb single-trace detail (S2): the scoped ``user_id`` must be forwarded to the
+        remote so ownership is enforced there, matching the list endpoint. Unlike a local DB
+        (whose ``_require_trace_owner`` check runs in-process), a RemoteDb call leaves the
+        process, so without forwarding the scope the detail endpoint would be strictly weaker
+        than the list it mirrors — a scoped caller could read another user's trace by id."""
+        from unittest.mock import AsyncMock
+
+        from agno.os.routers.traces.traces import get_traces_router
+        from agno.remote.base import RemoteDb
+
+        remote = MagicMock(spec=RemoteDb)
+        remote.get_trace = AsyncMock(return_value={"trace_id": "t1"})
+        app = FastAPI()
+        app.include_router(get_traces_router({"default": [remote]}, AgnoAPISettings()))
+        app.add_middleware(_make_jwt_middleware(user_isolation_enabled=True))
+        # The remote's response shape is validated by FastAPI's response_model and isn't what
+        # this test exercises; we assert only that the scoped user_id was forwarded (not the
+        # ?user_id=attacker query param).
+        TestClient(app, raise_server_exceptions=False).get("/traces/t1?user_id=attacker")
+        assert remote.get_trace.call_args.kwargs["user_id"] == "jwt_alice"
 
     def test_trace_stats_isolation_on_forces_jwt_sub(self, trace_db, no_security_key):
         app = _build_trace_app(trace_db, isolation=True)

--- a/libs/agno/tests/unit/os/test_router_user_id_threading.py
+++ b/libs/agno/tests/unit/os/test_router_user_id_threading.py
@@ -195,8 +195,8 @@ class TestTraceRouterUserIdThreading:
         ``session_id`` / ``agent_id`` filters; ownership is enforced at the
         route layer by ``_require_trace_owner`` after fetch. The router must
         not pass extra kwargs that don't exist in ``BaseDb.get_trace`` —
-        otherwise non-sqlite backends TypeError. (RemoteDb is different — see
-        ``test_get_trace_remote_db_threads_jwt_sub``.)"""
+        otherwise non-sqlite backends TypeError. (RemoteDb is the same — see
+        ``test_get_trace_remote_db_enforces_ownership_locally``.)"""
         app = _build_trace_app(trace_db, isolation=True)
         TestClient(app).get("/traces/trace-1")
         kwargs = trace_db.get_trace.call_args.kwargs
@@ -205,27 +205,30 @@ class TestTraceRouterUserIdThreading:
         assert "agent_id" not in kwargs
         assert kwargs["trace_id"] == "trace-1"
 
-    def test_get_trace_remote_db_threads_jwt_sub(self, no_security_key):
-        """RemoteDb single-trace detail (S2): the scoped ``user_id`` must be forwarded to the
-        remote so ownership is enforced there, matching the list endpoint. Unlike a local DB
-        (whose ``_require_trace_owner`` check runs in-process), a RemoteDb call leaves the
-        process, so without forwarding the scope the detail endpoint would be strictly weaker
-        than the list it mirrors — a scoped caller could read another user's trace by id."""
+    def test_get_trace_remote_db_enforces_ownership_locally(self, no_security_key):
+        """RemoteDb single-trace detail (S2): ``AgentOSClient.get_trace`` has NO ``user_id``
+        parameter (and no ``**kwargs``), so the scoped id cannot be forwarded to the remote --
+        doing so raises ``TypeError``. Ownership is instead enforced LOCALLY on the fetched
+        trace via ``_require_trace_owner`` (version-independent of the remote), so a scoped
+        caller cannot read another user's trace by id, and ``user_id`` is never threaded into
+        the remote call."""
+        from types import SimpleNamespace
         from unittest.mock import AsyncMock
 
         from agno.os.routers.traces.traces import get_traces_router
         from agno.remote.base import RemoteDb
 
         remote = MagicMock(spec=RemoteDb)
-        remote.get_trace = AsyncMock(return_value={"trace_id": "t1"})
+        # The remote returns user-a's trace; the scoped caller is jwt_alice.
+        remote.get_trace = AsyncMock(return_value=SimpleNamespace(user_id="user-a", trace_id="t1"))
         app = FastAPI()
         app.include_router(get_traces_router({"default": [remote]}, AgnoAPISettings()))
         app.add_middleware(_make_jwt_middleware(user_isolation_enabled=True))
-        # The remote's response shape is validated by FastAPI's response_model and isn't what
-        # this test exercises; we assert only that the scoped user_id was forwarded (not the
-        # ?user_id=attacker query param).
-        TestClient(app, raise_server_exceptions=False).get("/traces/t1?user_id=attacker")
-        assert remote.get_trace.call_args.kwargs["user_id"] == "jwt_alice"
+        resp = TestClient(app, raise_server_exceptions=False).get("/traces/t1?user_id=attacker")
+        # Local ownership gate -> 404 (would be 200 if the fetched foreign trace were returned).
+        assert resp.status_code == 404
+        # user_id must NOT be forwarded to the remote (client.get_trace would TypeError on it).
+        assert "user_id" not in remote.get_trace.call_args.kwargs
 
     def test_trace_stats_isolation_on_forces_jwt_sub(self, trace_db, no_security_key):
         app = _build_trace_app(trace_db, isolation=True)

--- a/libs/agno/tests/unit/os/test_traces_remote_ownership.py
+++ b/libs/agno/tests/unit/os/test_traces_remote_ownership.py
@@ -1,0 +1,72 @@
+"""S2 / finding #2: the RemoteDb branch of GET /traces/{trace_id} must ALSO enforce
+ownership locally for a scoped caller -- not rely solely on the remote enforcing it via
+the forwarded bearer. A remote that predates the ownership fix (or trusts an upstream
+gateway) would otherwise leak another user's trace back through the gateway.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from agno.os.routers.traces.schemas import TraceDetail
+from agno.os.routers.traces.traces import get_traces_router
+from agno.os.settings import AgnoAPISettings
+from agno.remote.base import RemoteDb
+
+
+def _build(remote_trace_user_id: str, *, scoped: bool):
+    now = datetime.now(UTC)
+    trace = TraceDetail(
+        trace_id="t1",
+        name="root",
+        status="OK",
+        duration="0ms",
+        start_time=now,
+        end_time=now,
+        total_spans=0,
+        error_count=0,
+        user_id=remote_trace_user_id,
+        created_at=now,
+        tree=[],
+    )
+    remote = MagicMock(spec=RemoteDb)
+    remote.get_trace = AsyncMock(return_value=trace)
+
+    class _State(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            request.state.user_id = "user-b"
+            request.state.scopes = ["traces:read"]
+            # scoped=True -> non-admin isolated caller (effective_user_id == "user-b");
+            # scoped=False -> isolation off (effective_user_id is None, admin-like).
+            request.state.user_isolation_enabled = scoped
+            return await call_next(request)
+
+    app = FastAPI()
+    app.include_router(get_traces_router({"remote": [remote]}, AgnoAPISettings()))
+    app.add_middleware(_State)
+    return TestClient(app), remote
+
+
+class TestRemoteDbTraceOwnership:
+    def test_scoped_non_owner_gets_404(self):
+        # The remote returns user-a's trace; without the local ownership check the gateway
+        # would forward it (200) -- a leak. With the fix, the gateway 404s.
+        client, remote = _build("user-a", scoped=True)
+        resp = client.get("/traces/t1")
+        assert resp.status_code == 404, resp.text
+        remote.get_trace.assert_awaited()
+
+    def test_scoped_owner_gets_200(self):
+        client, _ = _build("user-b", scoped=True)
+        resp = client.get("/traces/t1")
+        assert resp.status_code == 200, resp.text
+
+    def test_unscoped_caller_skips_local_check(self):
+        # isolation off -> effective_user_id is None -> single call, no local ownership gate
+        # (admins/operators keep the unscoped view).
+        client, _ = _build("user-a", scoped=False)
+        resp = client.get("/traces/t1")
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Closes four authentication/authorization issues on the AgentOS server surface (`libs/agno/agno/os/`), surfaced by an adversarial review of the v2.7 auth changes. **Three pre-date this branch** (verified against `main`); **one — the service-account mint (S4) — is new in v2.7.** Scoped deliberately to files **not** owned by the parallel v2.7 auth workstream, so it can land independently.

**S1 (HIGH) — A2A interface bypassed authentication.** `_add_auth_middleware` excluded *every* interface's route prefix from the single auth layer. Slack/Telegram/WhatsApp verify their own signing secret, but the A2A router authenticates nothing — so `authorization=True` + A2A left `/a2a/*` (agent/team/workflow execution, task read/cancel) reachable with no credential. Adds `BaseInterface.authenticates_own_requests` (default `False`; `True` on the three messaging interfaces) and excludes only self-authenticating interfaces. A2A now sits behind `AuthMiddleware`.

**S2 (HIGH) — `GET /traces/{trace_id}` ignored `user_isolation`.** The endpoint discarded the scoped `user_id` and fetched purely by `trace_id`/`run_id` with no ownership check, letting a non-admin read another user's prompts and model responses by an id that is not secret (it leaks via run/session APIs, SSE, logs). Enforces ownership after fetch — the DB contract (`get_trace` docstring) already delegates this to the route — masking a mismatch as 404. Covers the `run_id` and `span_id` paths.

**S3 (MEDIUM) — `validate=False` + `authorization=True` failed open.** In unverified dev mode a token that couldn't be decoded fell through without ever setting `authorization_enabled`, so every RBAC gate went dormant and a *garbage* token got more access than a valid zero-scope one. The fall-through now sets `authorization_enabled` + empty scopes so it is denied identically. (Reachable only via manual `add_middleware` wiring, not the `AgentOS(authorization=...)` API.)

**S4 (MEDIUM — the only issue new in v2.7) — anonymous admin-PAT mint in open mode.** An open instance (db present, no `OS_SECURITY_KEY`, no JWT) let an anonymous caller mint a never-expiring `agent_os:admin` PAT that kept working after the operator later enabled auth (PAT scopes are enforced independently of the `authorization` flag). The mint subset-rule exemption now keys off `request.state.authenticated` (set by the trusted security-key / internal-token roots) instead of "no scopes", so an unauthenticated caller cannot mint privileged tokens; plain non-privileged mint still works.

## Type of change

- [x] Bug fix
- [x] Breaking change (see Additional Notes: S1)
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — ruff + mypy clean (903 files)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a
- [x] Tested in clean environment
- [x] Tests added/updated — full `os` suite + new integration tests green (**1545 passed**)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this
- [x] If a similar PR exists, I have explained below why this PR is a better approach — companion to the parallel v2.7 fix PR; non-overlapping files
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Security considerations / behaviour change (S1):** enabling `authorization=True` now protects `/a2a/*`. A deployment that ran `A2A + authorization=True` and relied (knowingly or not) on A2A being open will now require a valid credential on A2A calls. That is the fix, but it is a breaking change for those deployments. Custom third-party `BaseInterface` subclasses default to `authenticates_own_requests=False` (fail-closed) and must opt in if they verify their own requests.

**Follow-up (not in this PR):** A2A paths (`/a2a/agents/...`) don't classify in the RBAC scope map, so S1 enforces *authentication* but not per-resource `agents:run` *scope* on A2A. Worth a separate change (add A2A routes to the scope map or per-route deps).

**Deferred (S6):** WebSocket workflow `reconnect` replays another user's buffered run events when `user_isolation=False` — this is the documented single-tenant contract of that mode, and a clean fix needs owner-tagging plumbed through the run/streaming pipeline (or overlaps the parallel session's `router.py` WS work). Left for its own change.

**Handoff to the parallel v2.7 session** (their files, intentionally untouched here): keep `get_session_runs(run_id=...)` full-detail scoped to `_scoped_caller_user_id()`; thread `request.state.admin_scope` into `run_continuation_blocked_reason` so a custom admin scope can bypass the approval gate.

**Provenance:** S1/S2/S3 exist identically on `main` (not v2.7 regressions); only S4 is introduced by the v2.7 service-accounts work. v2.7 does not widen the blast radius of the pre-existing three (default PAT scopes don't include `traces:read`, there's no MCP traces tool, and the A2A exclusion is unchanged).

---

## Post-review follow-up (commit `ac43a804f`)

A second adversarial review of this branch surfaced residual gaps in the fixes above. Addressed here:

- **S4 tightened — refuse *all* anonymous mints, not just privileged.** The original S4 fix still let an anonymous caller on an open instance mint a **never-expiring non-privileged** PAT (`agents:run`, `teams:run`, `workflows:run`, `sessions:read`, …). That token persists as a durable credential after the operator later enables auth — the same "durable credential" threat S4 cites for privileged scopes — and grants indefinite compute + cross-user reads. Minting now requires a real credential (`OS_SECURITY_KEY` or JWT); open-mode anonymous mint returns `401`. `agno connect` is unaffected (it never mints against an open instance); `agno tokens create` against an open box now needs a security key.

- **S2 extended to RemoteDb (enforced locally).** The `GET /traces/{trace_id}` ownership fix skipped the `RemoteDb` branch. `AgentOSClient.get_trace` has no `user_id` parameter (and no `**kwargs`), so forwarding the scoped id would raise `TypeError`; instead the gateway now enforces ownership **locally** on the fetched trace (for a scoped caller: fetch the parent trace, check `trace.user_id`, then return/fetch the span) — version-independent of whether the remote is patched. Covered by a RemoteDb ownership unit test that uses the real client signature.

- **Security-key root no longer false-closed.** The tightened S4 gate keys off `request.state.authenticated`, but the REST security-key dependency validated the key without setting that flag (unlike the internal-token path), so a legitimate root minting through the dependency path was wrongly `401`'d. `get_authentication_dependency` now sets `request.state.authenticated = True` on a valid security-key match.

- **`validate=False` identity pinned.** The decode-failure fall-through now sets `request.state.user_id = None` (matching the no-`sub` success path), so under `user_isolation` a malformed token is scoped by owner rather than reading a stale id.

**Breaking change / migration (S1, restated for release notes):** enabling `authorization=True` now protects `/a2a/*` and any interface that does not self-authenticate. **Custom third-party `BaseInterface` subclasses that verify their own inbound requests (their own webhook signature) must set `authenticates_own_requests = True`** — otherwise their webhook routes fall behind `AuthMiddleware` and the external provider's unauthenticated callbacks will receive `401` after upgrading to v2.7 with auth enabled. The default is fail-closed (`False`).

**Deferred (tracked separately):** an operator escape hatch to keep A2A agent-card discovery (`/.well-known/agent-card.json`) anonymous while protecting execution — currently `authorization=True` gates the card too, with no per-route knob on `AuthorizationConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)