### PR TITLE
[fix] Respect model strict tool support in learning stores

### DIFF
--- a/libs/agno/agno/learn/stores/entity_memory.py
+++ b/libs/agno/agno/learn/stores/entity_memory.py
@@ -44,6 +44,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 from agno.learn.config import EntityMemoryConfig, LearningMode
 from agno.learn.schemas import EntityMemory
 from agno.learn.stores.protocol import LearningStore
+from agno.learn.stores.utils import build_functions_for_model
 from agno.learn.utils import build_learning_id
 from agno.utils.log import (
     log_debug,
@@ -3065,25 +3066,7 @@ class EntityMemoryStore(LearningStore):
 
     def _build_functions_for_model(self, tools: List[Callable]) -> List[Any]:
         """Convert callables to Functions for model."""
-        from agno.tools.function import Function
-
-        functions = []
-        seen_names = set()
-
-        for tool in tools:
-            try:
-                name = tool.__name__
-                if name in seen_names:
-                    continue
-                seen_names.add(name)
-
-                func = Function.from_callable(tool, strict=True)
-                func.strict = True
-                functions.append(func)
-            except Exception as e:
-                log_warning(f"Could not add function {tool}: {str(e)}")
-
-        return functions
+        return build_functions_for_model(tools, self.model)
 
     # =========================================================================
     # Private Helpers

--- a/libs/agno/agno/learn/stores/learned_knowledge.py
+++ b/libs/agno/agno/learn/stores/learned_knowledge.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional
 from agno.learn.config import LearnedKnowledgeConfig, LearningMode
 from agno.learn.schemas import LearnedKnowledge
 from agno.learn.stores.protocol import LearningStore
+from agno.learn.stores.utils import build_functions_for_model
 from agno.learn.utils import to_dict_safe
 from agno.utils.log import (
     log_debug,
@@ -1355,25 +1356,7 @@ These insights are already in the knowledge base. Do not save variations of thes
 
     def _build_functions_for_model(self, tools: List[Callable]) -> List[Any]:
         """Convert callables to Functions for model."""
-        from agno.tools.function import Function
-
-        functions = []
-        seen_names = set()
-
-        for tool in tools:
-            try:
-                name = tool.__name__
-                if name in seen_names:
-                    continue
-                seen_names.add(name)
-
-                func = Function.from_callable(tool, strict=True)
-                func.strict = True
-                functions.append(func)
-            except Exception as e:
-                log_warning(f"Could not add function {tool}: {str(e)}")
-
-        return functions
+        return build_functions_for_model(tools, self.model)
 
     def _summarize_existing(self, learnings: List[Any]) -> str:
         """Summarize existing learnings to help avoid duplicates."""

--- a/libs/agno/agno/learn/stores/session_context.py
+++ b/libs/agno/agno/learn/stores/session_context.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 from agno.learn.config import LearningMode, SessionContextConfig
 from agno.learn.schemas import SessionContext
 from agno.learn.stores.protocol import LearningStore
+from agno.learn.stores.utils import build_functions_for_model
 from agno.learn.utils import build_learning_id, from_dict_safe, to_dict_safe
 from agno.utils.log import (
     log_debug,
@@ -858,26 +859,7 @@ class SessionContextStore(LearningStore):
 
     def _build_functions_for_model(self, tools: List[Callable]) -> List["Function"]:
         """Convert callables to Functions for model."""
-        from agno.tools.function import Function
-
-        functions = []
-        seen_names = set()
-
-        for tool in tools:
-            try:
-                name = tool.__name__
-                if name in seen_names:
-                    continue
-                seen_names.add(name)
-
-                func = Function.from_callable(tool, strict=True)
-                func.strict = True
-                functions.append(func)
-                log_debug(f"Added function {func.name}")
-            except Exception as e:
-                log_warning(f"Could not add function {tool}: {str(e)}")
-
-        return functions
+        return build_functions_for_model(tools, self.model, log_added=True)
 
     def _get_extraction_tools(
         self,

--- a/libs/agno/agno/learn/stores/user_memory.py
+++ b/libs/agno/agno/learn/stores/user_memory.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 from agno.learn.config import LearningMode, UserMemoryConfig
 from agno.learn.schemas import Memories
 from agno.learn.stores.protocol import LearningStore
+from agno.learn.stores.utils import build_functions_for_model
 from agno.learn.utils import build_learning_id, from_dict_safe, to_dict_safe
 from agno.utils.log import (
     log_debug,
@@ -955,26 +956,7 @@ class UserMemoryStore(LearningStore):
 
     def _build_functions_for_model(self, tools: List[Callable]) -> List["Function"]:
         """Convert callables to Functions for model."""
-        from agno.tools.function import Function
-
-        functions = []
-        seen_names = set()
-
-        for tool in tools:
-            try:
-                name = tool.__name__
-                if name in seen_names:
-                    continue
-                seen_names.add(name)
-
-                func = Function.from_callable(tool, strict=True)
-                func.strict = True
-                functions.append(func)
-                log_debug(f"Added function {func.name}")
-            except Exception as e:
-                log_warning(f"Could not add function {tool}: {str(e)}")
-
-        return functions
+        return build_functions_for_model(tools, self.model, log_added=True)
 
     def _get_system_message(
         self,

--- a/libs/agno/agno/learn/stores/user_profile.py
+++ b/libs/agno/agno/learn/stores/user_profile.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 from agno.learn.config import LearningMode, UserProfileConfig
 from agno.learn.schemas import UserProfile
 from agno.learn.stores.protocol import LearningStore
+from agno.learn.stores.utils import build_functions_for_model
 from agno.learn.utils import build_learning_id, from_dict_safe, to_dict_safe
 from agno.utils.log import (
     log_debug,
@@ -1022,26 +1023,7 @@ class UserProfileStore(LearningStore):
 
     def _build_functions_for_model(self, tools: List[Callable]) -> List["Function"]:
         """Convert callables to Functions for model."""
-        from agno.tools.function import Function
-
-        functions = []
-        seen_names = set()
-
-        for tool in tools:
-            try:
-                name = tool.__name__
-                if name in seen_names:
-                    continue
-                seen_names.add(name)
-
-                func = Function.from_callable(tool, strict=True)
-                func.strict = True
-                functions.append(func)
-                log_debug(f"Added function {func.name}")
-            except Exception as e:
-                log_warning(f"Could not add function {tool}: {str(e)}")
-
-        return functions
+        return build_functions_for_model(tools, self.model, log_added=True)
 
     def _get_system_message(
         self,

--- a/libs/agno/agno/learn/stores/utils.py
+++ b/libs/agno/agno/learn/stores/utils.py
@@ -1,0 +1,29 @@
+from typing import Any, Callable, List
+
+from agno.tools.function import Function
+from agno.utils.log import log_debug, log_warning
+
+
+def build_functions_for_model(tools: List[Callable], model: Any, *, log_added: bool = False) -> List[Function]:
+    """Convert learning store callables to Functions for the configured model."""
+    functions: List[Function] = []
+    seen_names = set()
+    use_strict_tools = bool(getattr(model, "supports_native_structured_outputs", False))
+
+    for tool in tools:
+        try:
+            name = tool.__name__
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+
+            func = Function.from_callable(tool, strict=use_strict_tools)
+            if use_strict_tools:
+                func.strict = True
+            functions.append(func)
+            if log_added:
+                log_debug(f"Added function {func.name}")
+        except Exception as e:
+            log_warning(f"Could not add function {tool}: {str(e)}")
+
+    return functions

--- a/libs/agno/tests/unit/learn/test_strict_function_building.py
+++ b/libs/agno/tests/unit/learn/test_strict_function_building.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+
+from agno.learn.config import (
+    EntityMemoryConfig,
+    LearnedKnowledgeConfig,
+    SessionContextConfig,
+    UserMemoryConfig,
+    UserProfileConfig,
+)
+from agno.learn.stores.entity_memory import EntityMemoryStore
+from agno.learn.stores.learned_knowledge import LearnedKnowledgeStore
+from agno.learn.stores.session_context import SessionContextStore
+from agno.learn.stores.user_memory import UserMemoryStore
+from agno.learn.stores.user_profile import UserProfileStore
+
+
+def sample_learning_tool(required_value: str, optional_value: Optional[str] = None) -> str:
+    """Sample learning tool."""
+    return required_value if optional_value is None else optional_value
+
+
+@pytest.mark.parametrize(
+    ("store_cls", "config_cls"),
+    [
+        (UserProfileStore, UserProfileConfig),
+        (UserMemoryStore, UserMemoryConfig),
+        (SessionContextStore, SessionContextConfig),
+        (LearnedKnowledgeStore, LearnedKnowledgeConfig),
+        (EntityMemoryStore, EntityMemoryConfig),
+    ],
+)
+def test_learning_store_functions_omit_strict_for_models_without_native_structured_outputs(store_cls, config_cls):
+    model = SimpleNamespace(supports_native_structured_outputs=False)
+    store = store_cls(config=config_cls(model=model))
+
+    functions = store._build_functions_for_model([sample_learning_tool])
+
+    assert len(functions) == 1
+    assert functions[0].strict is None
+    assert "strict" not in functions[0].to_dict()
+    assert "required_value" in functions[0].parameters["required"]
+    assert "optional_value" not in functions[0].parameters["required"]
+
+
+@pytest.mark.parametrize(
+    ("store_cls", "config_cls"),
+    [
+        (UserProfileStore, UserProfileConfig),
+        (UserMemoryStore, UserMemoryConfig),
+        (SessionContextStore, SessionContextConfig),
+        (LearnedKnowledgeStore, LearnedKnowledgeConfig),
+        (EntityMemoryStore, EntityMemoryConfig),
+    ],
+)
+def test_learning_store_functions_keep_strict_for_native_structured_output_models(store_cls, config_cls):
+    model = SimpleNamespace(supports_native_structured_outputs=True)
+    store = store_cls(config=config_cls(model=model))
+
+    functions = store._build_functions_for_model([sample_learning_tool])
+
+    assert len(functions) == 1
+    assert functions[0].strict is True
+    assert functions[0].to_dict()["strict"] is True
+    assert "required_value" in functions[0].parameters["required"]
+    assert "optional_value" in functions[0].parameters["required"]


### PR DESCRIPTION
## Summary
- add a shared learning-store function builder that only enables strict tool schemas when the configured model supports native structured outputs
- update user profile, user memory, session context, learned knowledge, and entity memory stores to use that builder
- add regression tests covering strict and non-strict model capability paths across all five stores

## Root cause
The learning stores always built internal extraction tools with `strict=True`. Anthropic-compatible providers that set `supports_native_structured_outputs=False`, such as VertexAI Claude, can reject that `strict` field even though regular tool calling is supported.

Fixes #6599

## Validation
- `/tmp/agno-semantic-scholar-venv/bin/python -m pytest libs/agno/tests/unit/learn/test_strict_function_building.py -q`
- `/tmp/agno-semantic-scholar-venv/bin/python -m pytest libs/agno/tests/unit/test_learning_machine.py libs/agno/tests/unit/test_learning_message_filtering.py libs/agno/tests/unit/team/test_team_learning.py libs/agno/tests/unit/learn/test_strict_function_building.py -q`
- `/tmp/agno-semantic-scholar-venv/bin/python -m ruff check libs/agno/agno/learn/stores/utils.py libs/agno/agno/learn/stores/session_context.py libs/agno/agno/learn/stores/user_memory.py libs/agno/agno/learn/stores/user_profile.py libs/agno/agno/learn/stores/learned_knowledge.py libs/agno/agno/learn/stores/entity_memory.py libs/agno/tests/unit/learn/test_strict_function_building.py`
- `/tmp/agno-semantic-scholar-venv/bin/python -m ruff format --check libs/agno/agno/learn/stores/utils.py libs/agno/agno/learn/stores/session_context.py libs/agno/agno/learn/stores/user_memory.py libs/agno/agno/learn/stores/user_profile.py libs/agno/agno/learn/stores/learned_knowledge.py libs/agno/agno/learn/stores/entity_memory.py libs/agno/tests/unit/learn/test_strict_function_building.py`
- `/tmp/agno-semantic-scholar-venv/bin/python -m mypy libs/agno/agno/learn/stores/utils.py libs/agno/agno/learn/stores/session_context.py libs/agno/agno/learn/stores/user_memory.py libs/agno/agno/learn/stores/user_profile.py libs/agno/agno/learn/stores/learned_knowledge.py libs/agno/agno/learn/stores/entity_memory.py libs/agno/tests/unit/learn/test_strict_function_building.py --follow-imports=skip --ignore-missing-imports`