### PR TITLE
fix: attribute MCP-initiated runs by detaching their trace from the tool-call span

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -3,7 +3,8 @@
 import functools
 import inspect
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Literal, Optional, Union
 from uuid import uuid4
 
 from fastmcp import Context, FastMCP
@@ -365,6 +366,33 @@ async def _consume_agentic_stream(ctx: Context, stream: Any, label: str) -> Unio
     return final
 
 
+@contextmanager
+def _detached_trace_context() -> Iterator[None]:
+    """Run a component in a fresh OTel root trace, detached from FastMCP's tool-call span.
+
+    FastMCP wraps every tool call in an identity-less ``tools/call ...`` SERVER span. Left
+    attached, the agno run span nests under it, and the trace layer -- which reads a trace's
+    identity (run_id / session_id / user_id / agent_id) from its root span -- takes it from
+    that context-less protocol span instead of the run, so runs invoked over MCP land with a
+    NULL, mislabeled trace. Detaching to an invalid parent makes the run span its own root,
+    so the run is attributed exactly like the REST run routes (which have no wrapping span).
+
+    No-op when OpenTelemetry is not installed.
+    """
+    try:
+        from opentelemetry import context as otel_context
+        from opentelemetry import trace as otel_trace
+    except ImportError:
+        yield
+        return
+
+    token = otel_context.attach(otel_trace.set_span_in_context(otel_trace.INVALID_SPAN))
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
+
+
 async def _run_agentic_component(
     ctx: Context, component: Any, message: str, user_id: Optional[str], session_id: Optional[str], label: str
 ) -> Union[RunOutput, TeamRunOutput]:
@@ -380,18 +408,19 @@ async def _run_agentic_component(
     from agno.agent.agent import Agent
     from agno.team.team import Team
 
-    if not isinstance(component, (Agent, Team)):
-        return await component.arun(message, user_id=user_id, session_id=session_id)
+    with _detached_trace_context():
+        if not isinstance(component, (Agent, Team)):
+            return await component.arun(message, user_id=user_id, session_id=session_id)
 
-    stream = component.arun(
-        message,
-        user_id=user_id,
-        session_id=session_id,
-        stream=True,
-        stream_events=True,
-        yield_run_output=True,
-    )
-    return await _consume_agentic_stream(ctx, stream, label=label)
+        stream = component.arun(
+            message,
+            user_id=user_id,
+            session_id=session_id,
+            stream=True,
+            stream_events=True,
+            yield_run_output=True,
+        )
+        return await _consume_agentic_stream(ctx, stream, label=label)
 
 
 def _describe_step_event(event: Any, total_steps: Optional[float]) -> str:
@@ -783,19 +812,21 @@ def build_mcp_server(
         workflow = await _resolve_run_component(os, "workflows", workflow_id, user_id=user_id, session_id=session_id)
         # Mint a fresh session per call when omitted (matches REST), never the sticky default.
         session_id = _session_id_or_new(session_id)
-        if isinstance(workflow, RemoteWorkflow):
-            run_output = await workflow.arun(message, user_id=user_id, session_id=session_id)
-            return build_run_tool_result(run_output, result_mode)
-        steps = getattr(workflow, "steps", None)
-        total_steps = float(len(steps)) if isinstance(steps, (list, tuple)) and steps else None
-        stream = workflow.arun(
-            message,
-            user_id=user_id,
-            session_id=session_id,
-            stream=True,
-            stream_events=True,
-        )
-        run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, user_id)
+        # Detach from FastMCP's tool-call span so the workflow run is its own root trace.
+        with _detached_trace_context():
+            if isinstance(workflow, RemoteWorkflow):
+                run_output = await workflow.arun(message, user_id=user_id, session_id=session_id)
+                return build_run_tool_result(run_output, result_mode)
+            steps = getattr(workflow, "steps", None)
+            total_steps = float(len(steps)) if isinstance(steps, (list, tuple)) and steps else None
+            stream = workflow.arun(
+                message,
+                user_id=user_id,
+                session_id=session_id,
+                stream=True,
+                stream_events=True,
+            )
+            run_output = await _consume_workflow_stream(ctx, workflow, stream, total_steps, user_id)
         return build_run_tool_result(run_output, result_mode)
 
     # ==================== Run Lifecycle Tools ====================
@@ -834,13 +865,15 @@ def build_mcp_server(
         await _enforce_run_continuation_allowed(os.db, run_id)
         await _report_progress(ctx, 0.0, f"Continuing run {run_id}")
         try:
-            run_output = await run_service.continue_paused_run(
-                component,
-                run_id=run_id,
-                session_id=session_id,
-                user_id=user_id,
-                requirements=requirements,
-            )
+            # Detach from FastMCP's tool-call span so the resumed run is its own root trace.
+            with _detached_trace_context():
+                run_output = await run_service.continue_paused_run(
+                    component,
+                    run_id=run_id,
+                    session_id=session_id,
+                    user_id=user_id,
+                    requirements=requirements,
+                )
         except run_service.RemoteContinuationUnsupported as e:
             raise Exception(str(e))
         return build_run_tool_result(run_output, result_mode)

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -297,6 +297,34 @@ async def test_run_workflow_threads_resolved_identity(monkeypatch):
     assert captured["session_id"] == "s-3"
 
 
+def test_detached_trace_context_starts_a_new_root_trace():
+    """The MCP tracing fix: `_detached_trace_context` makes a span started inside it the
+    ROOT of a new trace. FastMCP wraps every tool call in an identity-less `tools/call ...`
+    span; without detaching, the agno run span nests under it and the trace layer (which
+    reads a trace's identity from its root span) attributes the run to that protocol span,
+    producing a NULL/mislabeled trace. Detaching makes the run its own root, attributed like
+    a REST run."""
+    pytest.importorskip("opentelemetry")
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    tracer = TracerProvider().get_tracer("test")
+    with tracer.start_as_current_span("tools/call run_agent") as protocol_span:
+        protocol_ctx = protocol_span.get_span_context()
+        assert protocol_ctx.is_valid
+
+        with mcp_mod._detached_trace_context():
+            # No current recording span inside the detach -> the run span cannot inherit
+            # FastMCP's protocol span.
+            assert not otel_trace.get_current_span().get_span_context().is_valid
+            with tracer.start_as_current_span("Demo.arun") as run_span:
+                assert run_span.parent is None, "run span must be a root, not nested"
+                assert run_span.get_span_context().trace_id != protocol_ctx.trace_id
+
+        # The FastMCP span is current again once the run completes.
+        assert otel_trace.get_current_span().get_span_context().trace_id == protocol_ctx.trace_id
+
+
 # ==================== Session minting (omitted session_id -> fresh session per call) ====================
 #
 # The run tools must mint a fresh session_id when the caller omits one, exactly like the


### PR DESCRIPTION
## Summary

Runs invoked over the AgentOS **MCP server** were written to `agno_traces` with **NULL `run_id` / `session_id` / `user_id` / `agent_id`** and a **mislabeled name** (e.g. `OpenAIResponses.ainvoke_stream`). Because the Studio **Traces → SESSIONS** view groups by `session_id`, it showed almost nothing — even though the runs were visible under **RUNS**.

### Root cause

FastMCP instruments every tool call with an OTel `tools/call ...` SERVER span (via the same global tracer provider agno installs). The agno run span is therefore a **child** of that identity-less span, and the trace layer reads a trace's identity from its **root span** — which is the context-less protocol span, not the run. The run span *does* carry `run_id`/`session_id`/`user_id`; it was simply never the root. REST runs are unaffected: there is no wrapping span, so their run span is the root and is attributed correctly.

Verified against a live deployment (86/86 nested `*.arun` spans carried `run_id`, 84/86 carried `session_id`, but their trace rows were NULL) and reproduced end-to-end through the real FastMCP server.

### Fix — MCP layer only

Run the component inside a **detached OTel context** (`_detached_trace_context`) in the `run_agent` / `run_team` / `run_workflow` / `continue_run` tools, so the agno run span starts its **own root trace** and is attributed exactly like a REST run.

Chosen deliberately over reworking the trace-aggregation layer: `create_trace_from_spans` is shared by **all 13 DB adapters**, and each non-relational adapter (redis, surrealdb, mongo, json, gcs, firestore, dynamo, clickhouse) reimplements the upsert merge. A change there would have to be mirrored into every adapter or it would regress the existing post-hook / team-nesting attribution. This fix touches **neither `create_trace_from_spans` nor any adapter**, so it is backend-agnostic and cannot regress that logic.

Before → after (real `run_agent` via FastMCP):

```
BEFORE  row.name=tools/list        run_id=None  session=None   user=None   (true root: tools/call run_agent)   ← run buried, NULL
AFTER   row.name=Demo_Agent.arun   run_id=6c65…  session=3e11…  user=alice@example.com                          ← run is its own root, attributed
```

### Trade-off

An MCP call now produces **two** traces — the run's (attributed) and the `tools/call ...` protocol span's (NULL, like the existing `tools/list` rows) — rather than one nested trace. The run is fully attributable and groups into the SESSIONS view; the protocol row is harmless noise.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation (`ruff format`, `ruff check`, `mypy` on changed files — all clean)
- [x] Self-review completed
- [x] Documentation updated (docstring on `_detached_trace_context`)
- [ ] Examples and guides: N/A (internal tracing fix)
- [x] Tested in clean environment
- [x] Tests added — `test_detached_trace_context_starts_a_new_root_trace`; full MCP server suite (56 tests) passes

### Duplicate and AI-Generated PR Check

- [x] Searched existing open PRs; none address this
- [x] Assisted by Claude Code

---

## Additional Notes

Follow-ups filed separately: SDK-536 (bind caller `user_id` on MCP/builtin run tools + reject client-supplied `user_id` — the observed `user_id="hello"` leak) and SDK-537 (FastMCP `trace_id` bleed where a `tools/list` handshake shares a run's trace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)