### PR TITLE
fix(models): stop when tool call limit blocks progress

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -832,6 +832,9 @@ class Model(ABC):
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True, use_compressed_content=_compress_tool_results)
 
+                if self._all_tool_calls_blocked_by_limit(function_call_results):
+                    break
+
                 # Check if we should stop after tool calls
                 if any(m.stop_after_tool_call for m in function_call_results):
                     break
@@ -1052,6 +1055,9 @@ class Model(ABC):
 
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True, use_compressed_content=_compress_tool_results)
+
+                if self._all_tool_calls_blocked_by_limit(function_call_results):
+                    break
 
                 # Check if we should stop after tool calls
                 if any(m.stop_after_tool_call for m in function_call_results):
@@ -1559,6 +1565,9 @@ class Model(ABC):
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True, use_compressed_content=_compress_tool_results)
 
+                if self._all_tool_calls_blocked_by_limit(function_call_results):
+                    break
+
                 # Check if we should stop after tool calls
                 if any(m.stop_after_tool_call for m in function_call_results):
                     break
@@ -1837,6 +1846,9 @@ class Model(ABC):
 
                 for function_call_result in function_call_results:
                     function_call_result.log(metrics=True, use_compressed_content=_compress_tool_results)
+
+                if self._all_tool_calls_blocked_by_limit(function_call_results):
+                    break
 
                 # Check if we should stop after tool calls
                 if any(m.stop_after_tool_call for m in function_call_results):
@@ -2128,7 +2140,12 @@ class Model(ABC):
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,
             tool_call_error=True,
+            tool_call_limit_reached=True,
         )
+
+    @staticmethod
+    def _all_tool_calls_blocked_by_limit(function_call_results: List[Message]) -> bool:
+        return bool(function_call_results) and all(m.tool_call_limit_reached for m in function_call_results)
 
     def run_function_call(
         self,

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -103,6 +103,8 @@ class Message(BaseModel):
     tool_args: Optional[Any] = None
     # The error of the tool call
     tool_call_error: Optional[bool] = None
+    # True only when the tool call was blocked by tool_call_limit.
+    tool_call_limit_reached: bool = False
     # If True, the agent will stop executing after this tool call.
     stop_after_tool_call: bool = False
     # When True, the message will be added to the agent's memory.

--- a/libs/agno/tests/unit/models/test_tool_call_limit_loop.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit_loop.py
@@ -1,0 +1,104 @@
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+from agno.tools.function import Function, FunctionCall
+
+
+class _TestModel(Model):
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return ModelResponse()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        return iter(())
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        if False:
+            yield ModelResponse()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response if isinstance(response, ModelResponse) else ModelResponse()
+
+
+def _function_call(name: str, executed: list[str] | None = None) -> FunctionCall:
+    def tool() -> str:
+        if executed is not None:
+            executed.append(name)
+        return f"{name}-ok"
+
+    function = Function.from_callable(tool, name=name)
+    function.process_entrypoint()
+    return FunctionCall(function=function, call_id=f"{name}-call", arguments={})
+
+
+def test_tool_call_limit_results_are_marked_with_specific_flag() -> None:
+    model = _TestModel(id="test-model", name="Test model")
+    executed: list[str] = []
+    results: list[Message] = []
+
+    list(
+        model.run_function_calls(
+            function_calls=[
+                _function_call("first", executed),
+                _function_call("second", executed),
+            ],
+            function_call_results=results,
+            function_call_limit=1,
+        )
+    )
+
+    assert executed == ["first"]
+    assert len(results) == 2
+    assert results[0].tool_call_error is False
+    assert results[0].tool_call_limit_reached is False
+    assert results[1].tool_call_error is True
+    assert results[1].tool_call_limit_reached is True
+
+
+def test_limit_stop_guard_only_fires_when_all_results_are_limit_blocked() -> None:
+    model = _TestModel(id="test-model", name="Test model")
+    blocked_results: list[Message] = []
+
+    list(
+        model.run_function_calls(
+            function_calls=[
+                _function_call("first"),
+                _function_call("second"),
+            ],
+            function_call_results=blocked_results,
+            function_call_limit=0,
+        )
+    )
+
+    assert model._all_tool_calls_blocked_by_limit(blocked_results) is True
+
+
+def test_limit_stop_guard_does_not_fire_for_runtime_tool_errors() -> None:
+    runtime_error_result = Message(
+        role="tool",
+        content="tool failed",
+        tool_call_error=True,
+        tool_call_limit_reached=False,
+    )
+
+    assert _TestModel._all_tool_calls_blocked_by_limit([runtime_error_result]) is False
+
+
+def test_limit_stop_guard_does_not_fire_for_mixed_batches() -> None:
+    successful_result = Message(role="tool", content="ok", tool_call_error=False)
+    blocked_result = Message(
+        role="tool",
+        content="Tool call limit reached.",
+        tool_call_error=True,
+        tool_call_limit_reached=True,
+    )
+
+    assert _TestModel._all_tool_calls_blocked_by_limit([successful_result, blocked_result]) is False


### PR DESCRIPTION
## Summary
- add a limit-specific `tool_call_limit_reached` marker for tool calls blocked by `tool_call_limit`
- stop the model loop only when every result in the current batch was blocked by the tool-call limit
- apply the guard across sync, async, streaming, and async streaming response paths
- add focused unit coverage for limit-blocked batches, runtime tool errors, and mixed batches

Fixes #8304
Related: #8324, #6993

## Why this shape
#8324 checks `tool_call_error`, but that flag is also used for ordinary runtime tool failures. This PR keeps recoverable tool-error behavior intact and stops only the hard no-progress condition where all requested tool calls were blocked by the configured limit.

## Testing
- `/tmp/agno-pr-test-venv/bin/python -m pytest libs/agno/tests/unit/models/test_tool_call_limit_loop.py -q` (`4 passed`)
- `uvx ruff check libs/agno/agno/models/base.py libs/agno/agno/models/message.py libs/agno/tests/unit/models/test_tool_call_limit_loop.py`
- `uvx ruff format --check libs/agno/agno/models/base.py libs/agno/agno/models/message.py libs/agno/tests/unit/models/test_tool_call_limit_loop.py`
