### PR TITLE
chore: tidy pyproject extras — alphabetize, close aggregate gaps, fix agno[embedders]

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -70,7 +70,8 @@ dev = [
   "agno[a2a]",
 ]
 
-os = ["fastapi", "python-multipart>=0.0.18", "uvicorn", "websockets", "sqlalchemy", "PyJWT", "opentelemetry-sdk", "openinference-instrumentation-agno", "croniter>=1.3", "pytz>=2023.3"]
+# AgentOS server bundle
+os = ["fastapi", "python-multipart>=0.0.18", "uvicorn", "websockets", "sqlalchemy", "PyJWT", "opentelemetry-sdk", "openinference-instrumentation-agno", "agno[scheduler]"]
 mcp = ["mcp>=1.9.2", "fastmcp"]
 scheduler = ["croniter>=1.3", "pytz>=2023.3"]
 
@@ -82,15 +83,15 @@ arize = ["arize-phoenix", "agno[opentelemetry]", "opentelemetry-exporter-otlp-pr
 langfuse = ["langfuse"]
 
 # Dependencies for Models
-aws-bedrock = ["boto3", "aioboto3"]
 anthropic = ["anthropic"]
+aws-bedrock = ["boto3", "aioboto3"]
 azure = ["azure-ai-inference", "aiohttp"]
 cerebras = ["cerebras-cloud-sdk"]
 cohere = ["cohere"]
-infinity = ["infinity_client"]
 google = ["google-genai>=1.52.0", "pydantic>=2.12.5"]
 groq = ["groq"]
 ibm = ["ibm-watsonx-ai"]
+infinity = ["infinity_client"]
 litellm = ["litellm<=1.82.6"]
 lmstudio = ["lmstudio"]
 meta = ["llama-api-client"]
@@ -113,90 +114,90 @@ brave = ["brave-search"]
 browserbase = ["browserbase", "playwright"]
 cartesia = ["cartesia"]
 confluence = ["atlassian-python-api"]
-docling = ["docling"]
+crawl4ai = ["crawl4ai>=0.6.3"]
+daytona = ["daytona"]
 ddg = ["ddgs"]
+docling = ["docling"]
 duckdb = ["duckdb"]
 elevenlabs = ["elevenlabs"]
 evm = ["web3"]
 exa = ["exa_py>=2.0.0"]
-you-com = []
-seltz = ["seltz>=0.2.0"]
 fal = ["fal_client"]
 firecrawl = ["firecrawl-py==3.4.0"]
-tavily = ["tavily-python"]
-scavio = ["scavio"]
-crawl4ai = ["crawl4ai>=0.6.3"]
 github = ["PyGithub"]
 gitlab = ["python-gitlab", "httpx"]
 gmail = ["google-api-python-client", "google-auth-httplib2", "google-auth-oauthlib"]
-google_bigquery = ["google-cloud-bigquery"]
-google_slides = ["google-api-python-client", "google-auth-httplib2", "google-auth-oauthlib"]
+google-bigquery = ["google-cloud-bigquery"]
+google-slides = ["google-api-python-client", "google-auth-httplib2", "google-auth-oauthlib"]
 googlemaps = ["googlemaps", "google-maps-places"]
 matplotlib = ["matplotlib"]
 mem0 = ["mem0ai"]
 memori = ["memori>=3.0.5"]
+neo4j = ["neo4j"]
 newspaper = ["newspaper4k", "lxml_html_clean"]
 notion = ["notion-client"]
 opencv = ["opencv-python"]
+oxylabs = ["oxylabs"]
 parallel = ["parallel-web>=1.0"]
 psycopg = ["psycopg-binary", "psycopg"]
 redshift = ["redshift-connector"]
 reportlab = ["reportlab"]
 salesforce = ["simple-salesforce"]
+scavio = ["scavio"]
 scrapegraph = ["scrapegraph-py>=2.0.0"]
+seltz = ["seltz>=0.2.0"]
+tavily = ["tavily-python"]
+telegram = ["pyTelegramBotAPI>=4.32.0", "aiohttp"]
 todoist = ["todoist-api-python"]
+trafilatura = ["trafilatura"]
+twelvelabs = ["twelvelabs>=1.2.8"]
 valyu = ["valyu"]
 webex = ["webexpythonsdk"]
+whatsapp-crypto = ["cryptography>=41.0"]
 yfinance = ["yfinance"]
+you-com = []
 youtube = ["youtube_transcript_api"]
 zep = ["zep-cloud"]
-daytona = ["daytona"]
-oxylabs = ["oxylabs"]
-trafilatura = ["trafilatura"]
-neo4j = ["neo4j"]
-telegram = ["pyTelegramBotAPI>=4.32.0", "aiohttp"]
-twelvelabs = ["twelvelabs>=1.2.8"]
-whatsapp-crypto = ["cryptography>=41.0"]
 
 # Dependencies for Storage
-sql = ["sqlalchemy"]
-postgres = ["psycopg-binary"]
-async_postgres = ["asyncpg"]
-async_mongo = ["pymongo>=4.9", "motor"]
-sqlite = ["sqlalchemy", "aiosqlite"]
-gcs = ["google-cloud-storage"]
+async-mongo = ["pymongo>=4.9", "motor"]
+async-postgres = ["asyncpg"]
 firestore = ["google-cloud-firestore"]
-redis = ["redis", "redisvl>=0.12.1"]
+gcs = ["google-cloud-storage"]
 mysql = ["pymysql", "asyncmy"]
+postgres = ["psycopg-binary"]
+redis = ["redis", "redisvl>=0.12.1"]
+sql = ["sqlalchemy"]
+sqlite = ["sqlalchemy", "aiosqlite"]
 
 # Dependencies for Vector databases
-pgvector = ["pgvector"]
+cassandra = ["cassio"]
 chromadb = ["chromadb"]
+clickhouse = ["clickhouse-connect"]
+couchbase = ["couchbase"]
 lancedb = ["lancedb>=0.26.0"]
+milvusdb = ["pymilvus>=2.5.10"]
+mongodb = ["pymongo[srv]"]
+pgvector = ["pgvector"]
+pinecone = ["pinecone==5.4.2"]
 pylance = ["pylance"]
 qdrant = ["qdrant-client"]
-couchbase = ["couchbase"]
-cassandra = ["cassio"]
-mongodb = ["pymongo[srv]"]
 singlestore = ["sqlalchemy"]
-weaviate = ["weaviate-client"]
-milvusdb = ["pymilvus>=2.5.10"]
-clickhouse = ["clickhouse-connect"]
-pinecone = ["pinecone==5.4.2"]
 surrealdb = ["surrealdb>=1.0.4"]
 upstash = ["upstash-vector"]
+weaviate = ["weaviate-client"]
 
 # Dependencies for Knowledge
-pdf = ["pypdf", "rapidocr_onnxruntime"]
-docx = ["python-docx"]
-pptx = ["python-pptx"]
-text = ["aiofiles"]
-csv = ["aiofiles"]
-excel = ["openpyxl", "xlrd"]
-markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
 chonkie = [
     "chonkie[semantic,code]>=1.6.7",
 ]
+csv = ["aiofiles"]
+docx = ["python-docx"]
+excel = ["openpyxl", "xlrd"]
+markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
+pdf = ["pypdf", "rapidocr_onnxruntime"]
+pptx = ["python-pptx"]
+text = ["aiofiles"]
 
 # Dependencies for AG-UI integration
 agui = ["ag-ui-protocol>=0.1.15", "jsonpatch>=1.33"]
@@ -211,11 +212,12 @@ slack = ["slack_sdk>=3.40.0", "aiohttp>=3.7.3,<4"]
 huggingface = [
     "huggingface-hub",
 ]
+vllm = ["vllm"]
 
 # Dependencies for Performance
 performance = ["memory_profiler"]
 
-# Dependencies for Running cookbook
+# Dependencies for running cookbooks
 cookbooks = ["inquirer", "email_validator"]
 
 # Dependencies for Docker
@@ -228,122 +230,130 @@ infra = ["agno-infra"]
 
 # All models
 models = [
-  "agno[aws-bedrock]",
   "agno[anthropic]",
+  "agno[aws-bedrock]",
   "agno[azure]",
   "agno[cerebras]",
   "agno[cohere]",
   "agno[google]",
   "agno[groq]",
   "agno[ibm]",
+  "agno[infinity]",
   # "agno[litellm]",  # Temporarily disabled - litellm compromised on PyPI (March 24, 2026)
+  "agno[lmstudio]",
   "agno[meta]",
   # "agno[mistral]",  # Temporarily disabled - mistralai quarantined on PyPI (May 12, 2026)
   "agno[ollama]",
   "agno[openai]",
-  "agno[portkey]"
+  "agno[portkey]",
 ]
 
 # All tools
 tools = [
+  "agno[agentql]",
   "agno[apify]",
   "agno[arxiv]",
-  "agno[exa]",
-  "agno[seltz]",
+  "agno[brave]",
+  "agno[browserbase]",
   "agno[cartesia]",
-  "agno[ddg]",
-  "agno[duckdb]",
-  "agno[newspaper]",
-  "agno[youtube]",
-  "agno[firecrawl]",
-  "agno[tavily]",
-  "agno[scavio]",
+  "agno[confluence]",
   # "agno[crawl4ai]",  # Excluded: depends on litellm, which was compromised on PyPI (March 24, 2026)
+  "agno[daytona]",
+  "agno[ddg]",
+  "agno[docling]",
+  "agno[duckdb]",
+  "agno[elevenlabs]",
+  "agno[evm]",
+  "agno[exa]",
+  "agno[fal]",
+  "agno[firecrawl]",
   "agno[github]",
   "agno[gitlab]",
   "agno[gmail]",
-  "agno[google_slides]",
+  "agno[google-bigquery]",
+  "agno[google-slides]",
   "agno[googlemaps]",
-  "agno[todoist]",
   "agno[matplotlib]",
-  "agno[elevenlabs]",
-  "agno[evm]",
-  "agno[fal]",
-  "agno[webex]",
   "agno[mcp]",
-  "agno[browserbase]",
-  "agno[agentql]",
-  "agno[opencv]",
-  "agno[parallel]",
-  "agno[salesforce]",
-  "agno[scrapegraph]",
-  "agno[valyu]",
-  "agno[yfinance]",
-  "agno[confluence]",
-  "agno[docling]",
-  "agno[notion]",
-  "agno[oxylabs]",
-  "agno[zep]",
   "agno[mem0]",
   "agno[memori]",
-  "agno[google_bigquery]",
+  "agno[neo4j]",
+  "agno[newspaper]",
+  "agno[notion]",
+  "agno[opencv]",
+  "agno[oxylabs]",
+  "agno[parallel]",
   "agno[psycopg]",
   "agno[redshift]",
   "agno[reportlab]",
+  "agno[salesforce]",
+  "agno[scavio]",
+  "agno[scrapegraph]",
+  "agno[seltz]",
+  "agno[tavily]",
+  "agno[telegram]",
+  "agno[todoist]",
   "agno[trafilatura]",
-  "agno[neo4j]",
   "agno[twelvelabs]",
+  "agno[valyu]",
+  "agno[webex]",
+  "agno[whatsapp-crypto]",
+  "agno[yfinance]",
+  "agno[you-com]",
+  "agno[youtube]",
+  "agno[zep]",
 ]
 
 # All storage
 storage = [
-  "agno[sql]",
-  "agno[postgres]",
-  "agno[async_postgres]",
-  "agno[async_mongo]",
-  "agno[sqlite]",
-  "agno[gcs]",
+  "agno[async-mongo]",
+  "agno[async-postgres]",
   "agno[firestore]",
-  "agno[redis]",
+  "agno[gcs]",
+  "agno[mysql]",
+  "agno[postgres]",
+  "agno[redis]",  # also listed under vectordbs (redis serves both roles)
+  "agno[sql]",
+  "agno[sqlite]",
 ]
 
 # All vector databases
 vectordbs = [
-  "agno[pgvector]",
-  "agno[chromadb]",
-  "agno[lancedb]",
-  "agno[qdrant]",
-  "agno[couchbase]",
   "agno[cassandra]",
-  "agno[mongodb]",
-  "agno[singlestore]",
-  "agno[weaviate]",
-  "agno[milvusdb]",
+  "agno[chromadb]",
   "agno[clickhouse]",
+  "agno[couchbase]",
+  "agno[lancedb]",
+  "agno[milvusdb]",
+  "agno[mongodb]",
+  "agno[pgvector]",
   "agno[pinecone]",
+  "agno[pylance]",
+  "agno[qdrant]",
+  "agno[redis]",  # also listed under storage (redis serves both roles)
+  "agno[singlestore]",
   "agno[surrealdb]",
   "agno[upstash]",
-  "agno[pylance]",
-  "agno[redis]",
+  "agno[weaviate]",
 ]
 
 # All knowledge
 knowledge = [
-  "agno[pdf]",
-  "agno[docx]",
-  "agno[pptx]",
-  "agno[text]",
+  "agno[chonkie]",
   "agno[csv]",
+  "agno[docling]",  # also a tool; parses docs for knowledge
+  "agno[docx]",
   "agno[excel]",
   "agno[markdown]",
-  "agno[docling]",
-  "agno[chonkie]"
+  "agno[pdf]",
+  "agno[pptx]",
+  "agno[text]",
 ]
 
 # All embedders
 embedders = [
   "agno[huggingface]",
-  "agno[vllm]"
+  "agno[vllm]",
 ]
 
 # All libraries for testing


### PR DESCRIPTION
## Summary

A readability/organization pass over `libs/agno/pyproject.toml`'s `[project.optional-dependencies]` (128 → 129 extras), plus one real bugfix. 2.7 felt like the right window to tidy this up.

**Every change is zero-breakage for existing `pip install "agno[...]"` users.** Verified by diffing the fully-resolved dependency closure of all 129 extras before vs after: **zero removals**, only the intended additions. Reorders never affect resolution; aggregate additions only grow a set; the underscore→hyphen key renames are free PEP 503 name-normalization aliases (`agno[async_postgres]` still resolves to `agno[async-postgres]`).

What changed:

- **fix:** define `vllm = ["vllm"]`. The `embedders` aggregate referenced `agno[vllm]`, but no `vllm` extra existed — making `agno[embedders]` (and transitively `agno[tests]`) unresolvable under uv. There's a real vLLM embedder (`knowledge/embedder/vllm.py`) whose local path does `from vllm import LLM`, so the extra is legitimate.
- **os cluster:** added an `# AgentOS server bundle` header (it was the one unlabeled group) and pointed `os` at `agno[scheduler]` instead of duplicating `croniter`/`pytz` (identical closure). `mcp` stays an independent toggle.
- **ordering:** one law — alphabetical within Models, Tools, Storage, Vector databases, Knowledge, and the aggregate lists. This is the main readability win and gives new entries an obvious home.
- **aggregate coverage:** closed silent gaps so "all X" means all X — `models` += `infinity`, `lmstudio`; `storage` += `mysql`; `tools` += `brave`, `daytona`, `telegram`, `whatsapp-crypto`, `you-com`. Intentional exclusions (`litellm`/`mistral`/`crawl4ai`) remain commented; `agno[mcp]` kept in `tools`.
- **naming:** normalized the four underscore extra keys to hyphen (`async_postgres`, `async_mongo`, `google_bigquery`, `google_slides`).
- **docs:** inline comments on the intentional `redis` (storage↔vectordbs) and `docling` (tool→knowledge) cross-listings so they don't read as bugs; aligned the cookbook header.

Deliberately **not** in scope: no PEP 735 `[dependency-groups]` move for dev/test (that one *is* a soft break), no category-prefix renames, no codegen/pre-commit machinery — kept it to the low-maintenance, no-churn wins.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — n/a: `pyproject.toml` metadata is not covered by ruff/mypy. Instead validated the TOML parses, that no extra has a dangling self-reference, and that no extra's resolved closure lost a dependency.
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a
- [x] Tested in clean environment — before/after closure diff over all 129 extras
- [ ] Tests added/updated (if applicable) — optional guardrail test (assert groups sorted + aggregates complete) available on request; not included to keep the change minimal

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The `vllm` fix is the only functional change — everything else is organizational. Reviewers can trust the "zero-breakage" claim mechanically: the resolved-closure diff over all 129 extras shows only these additions and no removals — `embedders`:+vllm, `models`:+infinity/lmstudio, `storage`:+mysql, `tools`:+brave/daytona/telegram/whatsapp-crypto, `tests`:+(union, incl. vllm so it now resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
