### PR TITLE
[fix] Gate OpenAI strict schema normalization on strict_output

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -229,7 +229,13 @@ class OpenAIChat(Model):
                 # Convert Pydantic to JSON schema for regular endpoint
                 from agno.utils.models.schema_utils import get_response_schema_for_provider
 
-                schema = get_response_schema_for_provider(response_format, "openai")
+                # `additionalProperties: false` is an OpenAI strict-mode requirement. It is only
+                # needed when strict output is on, and OpenAI-compatible providers reached through
+                # subclasses (e.g. OpenRouter routing to xAI/Grok) reject it. Only apply the
+                # OpenAI-specific normalization when strict output is requested; otherwise normalize
+                # generically so provider-incompatible constraints are not injected.
+                schema_provider = "openai" if self.strict_output else "generic"
+                schema = get_response_schema_for_provider(response_format, schema_provider)
                 base_params["response_format"] = {
                     "type": "json_schema",
                     "json_schema": {

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -297,7 +297,13 @@ class OpenAIResponses(Model):
         # Set the response format
         if response_format is not None:
             if isinstance(response_format, type) and issubclass(response_format, BaseModel):
-                schema = get_response_schema_for_provider(response_format, "openai")
+                # `additionalProperties: false` is an OpenAI strict-mode requirement. It is only
+                # needed when strict output is on, and OpenAI-compatible providers reached through
+                # subclasses (e.g. OpenRouter routing to xAI/Grok) reject it. Only apply the
+                # OpenAI-specific normalization when strict output is requested; otherwise normalize
+                # generically so provider-incompatible constraints are not injected.
+                schema_provider = "openai" if self.strict_output else "generic"
+                schema = get_response_schema_for_provider(response_format, schema_provider)
                 text_params["format"] = {
                     "type": "json_schema",
                     "name": response_format.__name__,

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
@@ -1,9 +1,26 @@
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel, Field
 
 from agno.exceptions import ModelAuthenticationError
 from agno.models.openrouter import OpenRouterResponses
+
+
+class _Decision(BaseModel):
+    action: str = Field(..., min_length=1)
+    reason: str = Field(..., min_length=1)
+
+
+def _contains_additional_properties_false(node) -> bool:
+    """Recursively check whether any object node sets `additionalProperties: false`."""
+    if isinstance(node, dict):
+        if node.get("additionalProperties") is False:
+            return True
+        return any(_contains_additional_properties_false(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_contains_additional_properties_false(item) for item in node)
+    return False
 
 
 def test_openrouter_responses_default_config():
@@ -91,3 +108,28 @@ def test_openrouter_responses_client_params():
     assert params["base_url"] == "https://openrouter.ai/api/v1"
     assert params["timeout"] == 30.0
     assert params["max_retries"] == 3
+
+
+def test_openrouter_responses_non_strict_schema_omits_additional_properties_false():
+    """With strict_output=False, the response schema must not carry OpenAI's
+    `additionalProperties: false`, which non-OpenAI providers (e.g. xAI/Grok via
+    OpenRouter) reject with HTTP 400. Regression guard for issue #7455."""
+    model = OpenRouterResponses(id="x-ai/grok-4.20", api_key="test-key", strict_output=False)
+
+    request_params = model.get_request_params(response_format=_Decision)
+    schema = request_params["text"]["format"]["schema"]
+
+    assert request_params["text"]["format"]["strict"] is False
+    assert not _contains_additional_properties_false(schema)
+
+
+def test_openrouter_responses_strict_schema_keeps_additional_properties_false():
+    """With strict_output=True (the default), the OpenAI strict-mode schema
+    normalization is preserved, so `additionalProperties: false` is injected."""
+    model = OpenRouterResponses(id="openai/gpt-oss-20b", api_key="test-key", strict_output=True)
+
+    request_params = model.get_request_params(response_format=_Decision)
+    schema = request_params["text"]["format"]["schema"]
+
+    assert request_params["text"]["format"]["strict"] is True
+    assert schema.get("additionalProperties") is False

--- a/libs/agno/tests/unit/utils/test_schema_utils.py
+++ b/libs/agno/tests/unit/utils/test_schema_utils.py
@@ -214,3 +214,17 @@ def test_multiple_dict_types():
     assert "rating" not in required_fields
     assert "scores" not in required_fields
     assert "metadata" not in required_fields
+
+
+def test_generic_provider_omits_additional_properties_false():
+    """Generic normalization must not inject the OpenAI-only `additionalProperties: false`.
+
+    OpenAI-compatible providers (e.g. OpenRouter routing to xAI/Grok) reject that
+    constraint, so the non-"openai" normalization path must leave it out while the
+    "openai" path still sets it. Regression guard for issue #7455.
+    """
+    openai_schema = get_response_schema_for_provider(SimpleModel, "openai")
+    generic_schema = get_response_schema_for_provider(SimpleModel, "generic")
+
+    assert openai_schema.get("additionalProperties") is False
+    assert "additionalProperties" not in generic_schema


### PR DESCRIPTION
## Summary

`OpenRouterResponses` (and any OpenAI-compatible model built on `OpenAIChat` /
`OpenAIResponses`) unconditionally normalized a Pydantic `output_schema` with
OpenAI's strict-structured-output rules, injecting `additionalProperties: false`
into every object node. Both request builders hardcoded the schema provider to
`"openai"`:

- `libs/agno/agno/models/openai/responses.py` (`get_request_params`)
- `libs/agno/agno/models/openai/chat.py` (`get_request_params`)

Non-OpenAI backends reached through OpenRouter reject that property. Confirmed
with `x-ai/grok-4.20`:

```
Schema validation failed: [standard_violation]
/properties/properties/additionalProperties: property schema 'false' is not supported
```

`additionalProperties: false` is an OpenAI **strict-mode** requirement — it is
only needed when strict output is on, and is unnecessary for OpenAI itself
outside strict mode. This change selects the schema-normalization provider from
`strict_output`:

- `strict_output=True` (the default) → keep the OpenAI normalization; existing
  behavior is unchanged.
- `strict_output=False` → normalize generically so provider-incompatible
  constraints are not injected.

`normalize_schema_for_provider` already routes any non-`openai`/`gemini` key
through generic normalization, so no change to the schema utilities was needed.

Fixes #7455

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines (`ruff format`, `ruff check`)
- [x] Ran format/validation scripts (`ruff check .` and `mypy . --config-file pyproject.toml` from `libs/agno`, both clean)
- [x] Self-review completed
- [x] Documentation updated (comments explaining the strict-mode gating at both call sites)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tests (all offline, no API key or network required):

- `libs/agno/tests/unit/utils/test_schema_utils.py::test_generic_provider_omits_additional_properties_false`
  pins the normalization contract: the `"openai"` path sets
  `additionalProperties: false`, the generic path does not.
- `libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py`
  adds two `get_request_params` regression tests: with `strict_output=False` the
  built schema contains no `additionalProperties: false` at any node; with
  `strict_output=True` it is preserved (guards the default OpenAI path from
  regressing).

Disclosure: this PR was AI-generated and has been reviewed to meet the project's
quality bar — it includes tests and passes `ruff` + `mypy` locally.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.
