### PR TITLE
fix(os): enforce per-resource RBAC on AgentOS built-in MCP tools (privilege escalation via /mcp)

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -16,6 +16,7 @@ from agno.db.schemas import UserMemory
 from agno.os.routers.memory.schemas import (
     UserMemorySchema,
 )
+from agno.os.mcp_auth import require_mcp_scope
 from agno.os.schema import (
     AgentSessionDetailSchema,
     AgentSummaryResponse,
@@ -199,6 +200,7 @@ def build_mcp_server(
         output_schema=ConfigResponse.model_json_schema(),
     )  # type: ignore
     async def config() -> ConfigResponse:
+        require_mcp_scope(["config:read"])
         return ConfigResponse(
             os_id=os.id or "AgentOS",
             description=os.description,
@@ -231,6 +233,7 @@ def build_mcp_server(
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> RunOutput:
+        require_mcp_scope(["agents:run"], resource_type="agents", resource_id=agent_id)
         agent = get_agent_by_id(agent_id, os.agents)
         if agent is None:
             raise Exception(f"Agent {agent_id} not found")
@@ -244,6 +247,7 @@ def build_mcp_server(
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> TeamRunOutput:
+        require_mcp_scope(["teams:run"], resource_type="teams", resource_id=team_id)
         team = get_team_by_id(team_id, os.teams)
         if team is None:
             raise Exception(f"Team {team_id} not found")
@@ -257,6 +261,7 @@ def build_mcp_server(
         user_id: Optional[str] = None,
         session_id: Optional[str] = None,
     ) -> WorkflowRunOutput:
+        require_mcp_scope(["workflows:run"], resource_type="workflows", resource_id=workflow_id)
         workflow = get_workflow_by_id(workflow_id, os.workflows)
         if workflow is None:
             raise Exception(f"Workflow {workflow_id} not found")
@@ -281,6 +286,7 @@ def build_mcp_server(
         sort_by: str = "created_at",
         sort_order: str = "desc",
     ) -> Dict[str, Any]:
+        require_mcp_scope(["sessions:read"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -345,6 +351,7 @@ def build_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        require_mcp_scope(["sessions:read"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -394,6 +401,7 @@ def build_mcp_server(
     ) -> Dict[str, Any]:
         import time
 
+        require_mcp_scope(["sessions:write"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -485,6 +493,7 @@ def build_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
+        require_mcp_scope(["sessions:read"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -546,6 +555,7 @@ def build_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        require_mcp_scope(["sessions:read"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -605,6 +615,7 @@ def build_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        require_mcp_scope(["sessions:write"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -654,6 +665,7 @@ def build_mcp_server(
         summary: Optional[Dict[str, Any]] = None,
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        require_mcp_scope(["sessions:write"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
@@ -730,6 +742,7 @@ def build_mcp_server(
         db_id: str,
         user_id: Optional[str] = None,
     ) -> str:
+        require_mcp_scope(["sessions:delete"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
@@ -757,6 +770,7 @@ def build_mcp_server(
         session_types: Optional[List[str]] = None,
         user_id: Optional[str] = None,
     ) -> str:
+        require_mcp_scope(["sessions:delete"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
@@ -784,6 +798,7 @@ def build_mcp_server(
         user_id: str,
         topics: Optional[List[str]] = None,
     ) -> UserMemorySchema:
+        require_mcp_scope(["memories:write"])
         user_id = _resolve_user_id(user_id) or user_id
         db = await get_db(os.dbs, db_id)
 
@@ -833,6 +848,7 @@ def build_mcp_server(
         db_id: str,
         user_id: Optional[str] = None,
     ) -> UserMemorySchema:
+        require_mcp_scope(["memories:read"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
@@ -868,6 +884,7 @@ def build_mcp_server(
         sort_by: str = "updated_at",
         sort_order: str = "desc",
     ) -> Dict[str, Any]:
+        require_mcp_scope(["memories:read"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
@@ -934,6 +951,7 @@ def build_mcp_server(
         user_id: str,
         topics: Optional[List[str]] = None,
     ) -> UserMemorySchema:
+        require_mcp_scope(["memories:write"])
         user_id = _resolve_user_id(user_id) or user_id
         db = await get_db(os.dbs, db_id)
 
@@ -980,6 +998,7 @@ def build_mcp_server(
         memory_id: str,
         user_id: Optional[str] = None,
     ) -> str:
+        require_mcp_scope(["memories:delete"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
@@ -1006,6 +1025,7 @@ def build_mcp_server(
         db_id: str,
         user_id: Optional[str] = None,
     ) -> str:
+        require_mcp_scope(["memories:delete"])
         user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 

--- a/libs/agno/agno/os/mcp_auth.py
+++ b/libs/agno/agno/os/mcp_auth.py
@@ -1,0 +1,65 @@
+"""Authorization helpers for AgentOS MCP tools."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from starlette.requests import Request
+
+from agno.os.auth import build_insufficient_permissions_detail
+from agno.os.scopes import has_required_scopes
+
+
+def _get_fastmcp_request() -> Optional[Request]:
+    """Return the in-flight FastMCP HTTP request, when there is one."""
+    try:
+        from fastmcp.server.dependencies import get_http_request
+    except ImportError:
+        return None
+
+    try:
+        return get_http_request()
+    except RuntimeError:
+        return None
+
+
+def require_mcp_scope(
+    required_scopes: List[str],
+    *,
+    resource_type: Optional[str] = None,
+    resource_id: Optional[str] = None,
+    request: Optional[Request] = None,
+) -> None:
+    """Enforce AgentOS RBAC for an MCP tool call.
+
+    FastMCP tools are invoked through a single HTTP route (``/mcp``), so the
+    REST middleware cannot infer a per-tool scope from the URL. This helper
+    applies the same scope matcher inside each built-in tool when an HTTP/JWT
+    request context exists. Direct in-memory MCP tests and local programmatic
+    calls keep the previous behavior because no request context is available.
+    """
+    request = request or _get_fastmcp_request()
+    if request is None:
+        return
+
+    state = getattr(request, "state", None)
+    if not getattr(state, "authorization_enabled", False):
+        return
+
+    scopes = getattr(state, "scopes", []) or []
+    if isinstance(scopes, str):
+        scopes = [scopes]
+
+    admin_scope_raw = getattr(state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+
+    if has_required_scopes(
+        scopes,
+        required_scopes,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        admin_scope=admin_scope,
+    ):
+        return
+
+    raise PermissionError(build_insufficient_permissions_detail(required_scopes))

--- a/libs/agno/tests/unit/os/test_mcp_auth.py
+++ b/libs/agno/tests/unit/os/test_mcp_auth.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agno.os.mcp_auth import require_mcp_scope
+
+
+def _request(scopes, *, authorization_enabled=True, admin_scope=None):
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            authorization_enabled=authorization_enabled,
+            scopes=scopes,
+            admin_scope=admin_scope,
+        )
+    )
+
+
+def test_require_mcp_scope_allows_without_http_request_context():
+    require_mcp_scope(["agents:run"], resource_type="agents", resource_id="demo-agent", request=None)
+
+
+def test_require_mcp_scope_allows_when_authorization_disabled():
+    request = _request([], authorization_enabled=False)
+
+    require_mcp_scope(["agents:run"], resource_type="agents", resource_id="demo-agent", request=request)
+
+
+def test_require_mcp_scope_allows_matching_global_scope():
+    request = _request(["sessions:read"])
+
+    require_mcp_scope(["sessions:read"], request=request)
+
+
+def test_require_mcp_scope_allows_matching_resource_scope():
+    request = _request(["agents:demo-agent:run"])
+
+    require_mcp_scope(["agents:run"], resource_type="agents", resource_id="demo-agent", request=request)
+
+
+def test_require_mcp_scope_rejects_unrelated_scope():
+    request = _request(["sessions:read"])
+
+    with pytest.raises(PermissionError, match="agents:run"):
+        require_mcp_scope(["agents:run"], resource_type="agents", resource_id="demo-agent", request=request)
+
+
+def test_require_mcp_scope_rejects_wrong_resource_scope():
+    request = _request(["agents:other-agent:run"])
+
+    with pytest.raises(PermissionError, match="agents:run"):
+        require_mcp_scope(["agents:run"], resource_type="agents", resource_id="demo-agent", request=request)
+
+
+def test_require_mcp_scope_accepts_custom_admin_scope():
+    request = _request(["root"], admin_scope="root")
+
+    require_mcp_scope(["memories:delete"], request=request)


### PR DESCRIPTION
## Summary
Fixes #8705.

The AgentOS built-in MCP tools at `/mcp` (`run_agent`/`run_team`/`run_workflow` and session/memory CRUD) performed **no per-resource authorization**. With `AgentOS(authorization=True, enable_mcp_server=True)`, any authenticated JWT — including a read-only or narrowly-scoped token — could run any agent/team/workflow and read/write/delete any session or memory via `/mcp`, bypassing the per-resource RBAC the REST routes enforce (vertical privilege escalation).

## Fix
- New `agno/os/mcp_auth.py::require_mcp_scope(...)` applies the **same** `has_required_scopes(...)` matcher the REST middleware uses, reading the caller's scopes / `admin_scope` from `request.state` (already populated by the JWT middleware — no middleware change needed).
- Each built-in MCP tool now enforces the scope its REST equivalent requires; `run_agent`/`run_team`/`run_workflow` check per-resource (`resource_type`/`resource_id`); session/memory read/write/delete check the matching scope.
- Secure-by-default (no opt-in flag): MCP now matches REST exactly, which was the intent that diverged.
- No behavior change for in-memory / programmatic calls (no HTTP request context → no-op), so existing in-process usage keeps working.

## Tests
`tests/unit/os/test_mcp_auth.py` — 7 cases, all passing locally:
- low-priv `sessions:read` token → `PermissionError` on `run_agent(...)` (the privesc);
- cross-resource: `agents:other-agent:run` → denied on `demo-agent`;
- matching global / per-resource scope allowed; custom admin scope allowed; auth-disabled and no-request-context are no-ops.
