### PR TITLE
feat: align service-account scope payloads with the RBAC governance shape

### DIFF
--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -160,7 +160,8 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
         _: bool = Depends(auth_dependency),
     ) -> ServiceAccountCreateResponse:
         """Mint a service account token. The plaintext token is returned exactly once."""
-        scopes = list(body.scopes) if body.scopes is not None else list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
+        requested_scopes = body.scope_strings()
+        scopes = requested_scopes if requested_scopes is not None else list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
         _validate_requested_scopes(request, body, scopes)
 
         existing = await _db_call("get_service_account_by_name", body.name)

--- a/libs/agno/agno/os/routers/service_accounts/schema.py
+++ b/libs/agno/agno/os/routers/service_accounts/schema.py
@@ -1,9 +1,15 @@
-"""Pydantic request/response models for the service accounts API."""
+"""Pydantic request/response models for the service accounts API.
 
-from typing import Any, Dict, List, Optional
+Scopes ride the shared RBAC payload shapes (:class:`~agno.os.schema.ScopeItem` for
+writes, :class:`~agno.os.schema.ScopeSchema` for reads) so this API and the RBAC
+governance APIs present one payload structure to frontends.
+"""
+
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
+from agno.os.schema import ScopeItem, ScopeSchema
 from agno.os.service_accounts import (
     DEFAULT_EXPIRY_DAYS,
     get_principal,
@@ -17,10 +23,11 @@ class ServiceAccountCreate(BaseModel):
         max_length=63,
         description="Machine identity name (lowercase slug), e.g. 'claude-code' or 'github-actions'",
     )
-    scopes: Optional[List[str]] = Field(
+    scopes: Optional[List[Union[str, ScopeItem]]] = Field(
         default=None,
-        description="Scopes granted to the token. Defaults to run and read scopes: "
-        "agents:run, teams:run, workflows:run, sessions:read",
+        description="Scopes granted to the token, as plain strings or {scope, effect} objects "
+        "(the shared RBAC write shape; token scopes are grants, so only effect='allow' is accepted). "
+        "Defaults to run and read scopes: agents:run, teams:run, workflows:run, sessions:read",
     )
     expires_in_days: Optional[int] = Field(
         default=DEFAULT_EXPIRY_DAYS,
@@ -48,6 +55,22 @@ class ServiceAccountCreate(BaseModel):
             )
         return v
 
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes(cls, v: Optional[List[Union[str, ScopeItem]]]) -> Optional[List[Union[str, ScopeItem]]]:
+        for item in v or []:
+            if isinstance(item, ScopeItem) and item.effect != "allow":
+                raise ValueError(
+                    f"Token scopes are grants: effect must be 'allow' (got {item.effect!r} for {item.scope!r})"
+                )
+        return v
+
+    def scope_strings(self) -> Optional[List[str]]:
+        """The requested scopes as raw strings, whichever write shape the client used."""
+        if self.scopes is None:
+            return None
+        return [item if isinstance(item, str) else item.scope for item in self.scopes]
+
 
 class ServiceAccountResponse(BaseModel):
     """Service account metadata. Never includes the token hash or plaintext."""
@@ -56,7 +79,9 @@ class ServiceAccountResponse(BaseModel):
     name: str
     principal: str = Field(..., description="The user_id attached to runs made with this token, e.g. 'sa:claude-code'")
     token_prefix: str = Field(..., description="First characters of the token, for display only")
-    scopes: List[str]
+    scopes: List[ScopeSchema] = Field(
+        default_factory=list, description="Scopes granted to the token, in the shared RBAC read shape"
+    )
     created_at: int
     expires_at: Optional[int] = None
     last_used_at: Optional[int] = None
@@ -70,7 +95,7 @@ class ServiceAccountResponse(BaseModel):
             name=data["name"],
             principal=get_principal(data["name"]),
             token_prefix=data["token_prefix"],
-            scopes=data.get("scopes") or [],
+            scopes=[ScopeSchema.from_raw(scope) for scope in data.get("scopes") or []],
             created_at=data["created_at"],
             expires_at=data.get("expires_at"),
             last_used_at=data.get("last_used_at"),

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -21,6 +21,7 @@ from agno.os.config import (
     SessionConfig,
     TracesConfig,
 )
+from agno.os.scopes import split_scope
 from agno.os.utils import extract_input_media, get_run_input, get_session_name, to_utc_datetime
 from agno.session import AgentSession, TeamSession, WorkflowSession
 from agno.team.factory import TeamFactory
@@ -79,6 +80,36 @@ class InternalServerErrorResponse(BaseModel):
 
     detail: str = Field(..., description="Error detail message")
     error_code: Optional[str] = Field(None, description="Error code for categorization")
+
+
+class ScopeItem(BaseModel):
+    """Write shape for one scope grant — the RBAC payload shared by every scope-bearing API.
+
+    Endpoints that take scopes accept plain strings or these objects interchangeably.
+    """
+
+    scope: str = Field(..., description="Scope string, e.g. 'agents:*:run'")
+    effect: str = Field("allow", description="'allow' or 'deny'")
+
+
+class ScopeSchema(BaseModel):
+    """Read shape for one scope — the parsed RBAC payload shared by every scope-bearing API.
+
+    Mirrors the cloud RBAC scope shape ({raw, namespace, sub_namespace, permission, value})
+    so a frontend renders scopes from any AgentOS API with one integration.
+    """
+
+    id: Optional[str] = Field(None, description="Scope id (null — scopes aren't individually addressable)")
+    raw: str = Field(..., description="Original scope string, e.g. 'agents:*:run'")
+    namespace: str = Field(..., description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Specific resource id or wildcard '*'")
+    permission: str = Field(..., description="Action, e.g. 'read' / 'run' / 'write'")
+    value: str = Field("allow", description="'allow' or 'deny'")
+
+    @classmethod
+    def from_raw(cls, raw: str, value: str = "allow") -> "ScopeSchema":
+        namespace, sub_namespace, permission = split_scope(raw)
+        return cls(raw=raw, namespace=namespace, sub_namespace=sub_namespace, permission=permission, value=value)
 
 
 class HealthResponse(BaseModel):

--- a/libs/agno/agno/os/scopes.py
+++ b/libs/agno/agno/os/scopes.py
@@ -171,6 +171,25 @@ def parse_scope(scope: str, admin_scope: Optional[str] = None) -> ParsedScope:
     return ParsedScope(raw=scope, scope_type="unknown")
 
 
+def split_scope(raw: str) -> Tuple[str, Optional[str], str]:
+    """Split a scope string into its wire-format parts: (namespace, sub_namespace, permission).
+
+    This is the parse behind the ``{raw, namespace, sub_namespace, permission}`` payload
+    shape shared by every scope-bearing management API (service accounts, RBAC governance),
+    so all surfaces render a scope identically for UIs:
+
+        ``agents:read``    -> ("agents", None, "read")
+        ``agents:*:run``   -> ("agents", "*", "run")
+        ``agent_os:admin`` -> ("agent_os", None, "admin")
+    """
+    parts = raw.split(":")
+    if len(parts) == 2:
+        return parts[0], None, parts[1]
+    if len(parts) >= 3:
+        return parts[0], ":".join(parts[1:-1]), parts[-1]
+    return (parts[0] if parts else "unknown"), None, "unknown"
+
+
 def matches_scope(
     user_scope: ParsedScope,
     required_scope: ParsedScope,

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -87,7 +87,16 @@ class TestCreateServiceAccount:
         body = response.json()
         assert body["name"] == "claude-code"
         assert body["principal"] == "sa:claude-code"
-        assert body["scopes"] == DEFAULT_SERVICE_ACCOUNT_SCOPES
+        assert [s["raw"] for s in body["scopes"]] == list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
+        # Scopes ride the shared RBAC read shape so governance and token UIs render alike
+        assert body["scopes"][0] == {
+            "id": None,
+            "raw": "agents:run",
+            "namespace": "agents",
+            "sub_namespace": None,
+            "permission": "run",
+            "value": "allow",
+        }
         assert body["token"].startswith(TOKEN_PREFIX)
         assert body["token_prefix"] == body["token"][:16]
         # Default expiry ~90 days out
@@ -152,7 +161,37 @@ class TestCreateServiceAccount:
             json={"name": "ci", "scopes": ["sessions:write"], "allow_privileged_scopes": True},
         )
         assert response.status_code == 201
-        assert response.json()["scopes"] == ["sessions:write"]
+        assert [s["raw"] for s in response.json()["scopes"]] == ["sessions:write"]
+
+    def test_mint_accepts_scope_objects(self, client):
+        # The shared RBAC write shape ({scope, effect}) is accepted alongside plain strings
+        response = client.post(
+            "/service-accounts",
+            json={"name": "ci", "scopes": [{"scope": "agents:run", "effect": "allow"}, "sessions:read"]},
+        )
+        assert response.status_code == 201
+        assert [s["raw"] for s in response.json()["scopes"]] == ["agents:run", "sessions:read"]
+
+    def test_mint_rejects_deny_effect(self, client):
+        # Token scopes are pure grants; a deny rule belongs on a role, not a token
+        response = client.post(
+            "/service-accounts",
+            json={"name": "ci", "scopes": [{"scope": "agents:run", "effect": "deny"}]},
+        )
+        assert response.status_code == 422
+        assert "allow" in response.text
+
+    def test_per_resource_scope_parses_into_sub_namespace(self, client):
+        response = client.post("/service-accounts", json={"name": "ci", "scopes": ["agents:my-agent:run"]})
+        assert response.status_code == 201
+        assert response.json()["scopes"][0] == {
+            "id": None,
+            "raw": "agents:my-agent:run",
+            "namespace": "agents",
+            "sub_namespace": "my-agent",
+            "permission": "run",
+            "value": "allow",
+        }
 
     def test_duplicate_active_name_conflicts(self, client, mock_db):
         mock_db.get_service_account_by_name = MagicMock(return_value=_make_account_dict())
@@ -308,7 +347,7 @@ class TestCreateServiceAccountSecurityKeyRoot:
             json={"name": "ci", "scopes": ["agent_os:admin"], "allow_privileged_scopes": True},
         )
         assert response.status_code == 201, response.text
-        assert response.json()["scopes"] == ["agent_os:admin"]
+        assert [s["raw"] for s in response.json()["scopes"]] == ["agent_os:admin"]
 
     def test_invalid_security_key_is_rejected(self, mock_db):
         settings = AgnoAPISettings(os_security_key="root-key-123")
@@ -344,6 +383,10 @@ class TestListServiceAccounts:
         entry = body["data"][0]
         assert entry["token_prefix"] == "agno_pat_abc1234"
         assert entry["principal"] == "sa:claude-code"
+        # List responses carry the same parsed scope shape as the create response
+        assert [s["raw"] for s in entry["scopes"]] == list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
+        assert entry["scopes"][0]["namespace"] == "agents"
+        assert entry["scopes"][0]["value"] == "allow"
         assert "token" not in entry
         assert "token_hash" not in entry
         assert "a" * 64 not in response.text

--- a/libs/agno/tests/unit/os/test_scopes.py
+++ b/libs/agno/tests/unit/os/test_scopes.py
@@ -8,6 +8,7 @@ from agno.os.scopes import (
     get_resource_context_from_path,
     has_required_scopes,
     parse_scope,
+    split_scope,
 )
 
 
@@ -75,6 +76,29 @@ class TestParseScope:
     def test_unknown_scope(self):
         parsed = parse_scope("malformed:scope:with:too:many:parts")
         assert parsed.scope_type == "unknown"
+
+
+class TestSplitScope:
+    """The wire-format split behind the {raw, namespace, sub_namespace, permission} payloads."""
+
+    def test_global_scope(self):
+        assert split_scope("agents:read") == ("agents", None, "read")
+
+    def test_per_resource_scope(self):
+        assert split_scope("agents:my-agent:run") == ("agents", "my-agent", "run")
+
+    def test_wildcard_scope(self):
+        assert split_scope("agents:*:run") == ("agents", "*", "run")
+
+    def test_admin_scope_splits_literally(self):
+        # No admin special-casing on the wire: UIs see the literal parts
+        assert split_scope("agent_os:admin") == ("agent_os", None, "admin")
+
+    def test_extra_segments_fold_into_sub_namespace(self):
+        assert split_scope("agents:a:b:run") == ("agents", "a:b", "run")
+
+    def test_malformed_scope(self):
+        assert split_scope("justoneword") == ("justoneword", None, "unknown")
 
 
 class TestHasRequiredScopes:

--- a/libs/agnoctl/agnoctl/http.py
+++ b/libs/agnoctl/agnoctl/http.py
@@ -47,12 +47,14 @@ class ServiceAccount:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccount":
+        # Servers send scopes as parsed RBAC objects ({raw, namespace, ...}) or as
+        # plain strings; keep the raw string either way.
         return cls(
             id=data["id"],
             name=data["name"],
             principal=data.get("principal") or "sa:" + data["name"],
             token_prefix=data.get("token_prefix") or "",
-            scopes=data.get("scopes") or [],
+            scopes=[s if isinstance(s, str) else s.get("raw", "") for s in data.get("scopes") or []],
             created_at=data.get("created_at"),
             expires_at=data.get("expires_at"),
             last_used_at=data.get("last_used_at"),

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -59,9 +59,22 @@ class FakeAgentOS:
 
     def _account_response(self, account: Dict[str, Any], include_token: bool = False) -> Dict[str, Any]:
         payload = {k: v for k, v in account.items() if k != "token"}
+        # Render scopes in the parsed RBAC shape the server returns; the store keeps raw strings.
+        payload["scopes"] = [self._scope_object(s) for s in account.get("scopes") or []]
         if include_token:
             payload["token"] = account["token"]
         return payload
+
+    def _scope_object(self, raw: str) -> Dict[str, Any]:
+        parts = raw.split(":")
+        return {
+            "id": None,
+            "raw": raw,
+            "namespace": parts[0],
+            "sub_namespace": ":".join(parts[1:-1]) if len(parts) > 2 else None,
+            "permission": parts[-1],
+            "value": "allow",
+        }
 
     def _jsonrpc_response(self, payload: Dict[str, Any], headers: Optional[Dict[str, str]] = None) -> httpx.Response:
         if self.sse_responses:


### PR DESCRIPTION
## Summary

The Service Tokens GET/POST APIs returned `scopes` as bare strings, while the RBAC Governance APIs (#8322) present scopes parsed — `{raw, namespace, sub_namespace, permission, value}` — and accept writes as plain strings or `{scope, effect}` objects. Once Governance lands, we'd ship two inconsistent payload structures for the same concept, and the UI would need two integrations.

This PR moves the service-account APIs onto the shared shape before the 2.7 release:

- **`agno.os.scopes.split_scope`** — the wire-format split (`agents:*:run` → `("agents", "*", "run")`), byte-compatible with the governance parser so both surfaces render scopes identically.
- **`agno.os.schema.ScopeSchema` / `ScopeItem`** — the shared read/write payload models, placed in the common OS schema module so the governance router can adopt them on rebase.
- **Responses** (`GET /service-accounts`, `POST /service-accounts`) now return parsed scope objects: `{"id": null, "raw": "agents:run", "namespace": "agents", "sub_namespace": null, "permission": "run", "value": "allow"}`. Tokens are pure grants, so `value` is always `"allow"`.
- **Create requests** accept plain strings or `{scope, effect}` objects interchangeably (the governance write shape). `effect="deny"` is rejected with a 422 — a deny rule belongs on a role, not a token.
- **Storage is unchanged** — the DB keeps raw scope strings; only the API payload shape changes.
- **agnoctl** parses both response shapes (objects from current servers, strings from earlier alphas) and keeps displaying raw scope strings.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — generated with Claude Code, reviewed by @ashpreetbedi

---

## Additional Notes

- Tests: 105 unit (service-accounts router + scopes) and 36 integration (service accounts) pass; 153 agnoctl tests pass against the updated fake server, which now returns the parsed shape.
- Mint requests sent as plain strings (cookbooks, agnoctl, integration tests) keep working unchanged — only the response shape is new, and service accounts are unreleased so there is no compatibility surface to preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)