### PR TITLE
fix: v2.7 review nits — workflow_id in MCP history, remote ownership gate, silent registry dedup

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -723,8 +723,6 @@ class AgentOS:
         """
         if self.registry is None:
             self.registry = Registry()
-            # Auto-created purely to wire up primitives; suppress duplicate chatter.
-            self.registry._emit_dedup_logs = False
 
         if self._agents:
             existing_agents = {aid: a for a in self.registry.agents if (aid := getattr(a, "id", None)) is not None}
@@ -772,8 +770,6 @@ class AgentOS:
         """
         if self.registry is None:
             self.registry = Registry()
-            # Auto-created purely to wire up primitives; suppress duplicate chatter.
-            self.registry._emit_dedup_logs = False
 
         if self.knowledge_instances:
             existing_knowledge = {
@@ -802,8 +798,6 @@ class AgentOS:
         """
         if self.registry is None:
             self.registry = Registry()
-            # Auto-created purely to wire up primitives; suppress duplicate chatter.
-            self.registry._emit_dedup_logs = False
 
         registry = self.registry
         memory_by_id = {mid: m for m in registry.memory_managers if (mid := getattr(m, "id", None)) is not None}
@@ -872,8 +866,6 @@ class AgentOS:
         """
         if self.registry is None:
             self.registry = Registry()
-            # Auto-created purely to wire up primitives; suppress duplicate chatter.
-            self.registry._emit_dedup_logs = False
 
         try:
             collect_components_from_os(self._agents, self._teams, self._workflows, self.registry)

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -31,7 +31,7 @@ from agno.os.utils import (
     resolve_team,
     resolve_workflow,
 )
-from agno.remote.base import RemoteDb
+from agno.remote.base import BaseRemote, RemoteDb
 from agno.run.agent import RunEvent, RunOutput
 from agno.run.team import TeamRunEvent, TeamRunOutput
 from agno.run.workflow import WorkflowRunEvent, WorkflowRunOutput
@@ -614,6 +614,12 @@ def _make_run_ownership_verifier(os: "AgentOS"):
     ):
         if component is None:
             raise Exception(f"Component {component_id} not found")
+        if isinstance(component, BaseRemote):
+            # Remote components keep their sessions on the remote OS -- there is no
+            # local session to prove ownership against (BaseRemote has no aget_session).
+            # Defer to the downstream helpers, mirroring the REST surface: continue
+            # raises RemoteContinuationUnsupported, cancel forwards to the remote.
+            return
         scoped_user_id = _scoped_caller_user_id()
         if scoped_user_id is None:
             return

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -144,7 +144,16 @@ def build_run_tool_result(run_output: AnyRunOutput, result_mode: str = "trimmed"
 # tools, the history tool ships only what a frontend model needs, not the raw internals.
 # Lives here so the two "what MCP clients see of a run" policies (fresh results above,
 # history reads) stay in one file.
-SESSION_RUN_HISTORY_FIELDS = ("run_id", "run_input", "content", "status", "created_at", "agent_id", "team_id")
+SESSION_RUN_HISTORY_FIELDS = (
+    "run_id",
+    "run_input",
+    "content",
+    "status",
+    "created_at",
+    "agent_id",
+    "team_id",
+    "workflow_id",
+)
 
 
 def trim_session_run(run: Any) -> Dict[str, Any]:

--- a/libs/agno/agno/registry/registry.py
+++ b/libs/agno/agno/registry/registry.py
@@ -11,7 +11,7 @@ from agno.db.base import BaseDb
 from agno.models.base import Model
 from agno.tools.function import Function
 from agno.tools.toolkit import Toolkit
-from agno.utils.log import log_debug, log_warning
+from agno.utils.log import log_warning
 from agno.vectordb.base import VectorDb
 
 if TYPE_CHECKING:
@@ -52,13 +52,6 @@ class Registry:
     # Code-defined agents and teams (for workflow rehydration)
     agents: List[Agent] = field(default_factory=list)
     teams: List[Team] = field(default_factory=list)
-    # Internal: whether add_* should log when a duplicate component is skipped.
-    # AgentOS turns this off for registries it auto-creates while wiring up
-    # components from primitives -- there, dedup is an internal step the user did
-    # not ask for, so duplicate chatter would be noise. A user-constructed
-    # Registry keeps it on, so clashes against explicitly declared components are
-    # surfaced.
-    _emit_dedup_logs: bool = field(default=True, repr=False, compare=False)
 
     @cached_property
     def _entrypoint_lookup(self) -> Dict[str, Any]:
@@ -137,11 +130,6 @@ class Registry:
             if existing is model:
                 return
             if _model_identity(existing) == key:
-                if self._emit_dedup_logs:
-                    log_debug(
-                        f"Registry: skipped a duplicate model "
-                        f"'{getattr(model, 'provider', None)}/{getattr(model, 'id', None)}'; keeping the registered instance."
-                    )
                 return
         self.models.append(model)
 
@@ -157,11 +145,8 @@ class Registry:
           instance wins deterministically: user-declared registry tools are added
           before primitives are walked, and primitives are walked in order, so a
           later matching instance is skipped. This is expected (re-instantiating a
-          default toolkit in two places is common), so the skip is logged at debug
-          rather than warned -- and only when ``_emit_dedup_logs`` is set (i.e. the
-          user explicitly defined this registry); for registries AgentOS
-          auto-creates to wire up primitives the skip is silent. The trade-off is
-          accepted: rehydration resolves
+          default toolkit in two places is common), so the skip is silent. The
+          trade-off is accepted: rehydration resolves
           entrypoints by function name globally (see ``_entrypoint_lookup``), so
           only one instance can ever back a given name regardless of dedup -- two
           toolkits that differ only in non-functional config (api keys, timeouts,
@@ -189,10 +174,6 @@ class Registry:
                     isinstance(existing, Toolkit)
                     and (type(existing), existing.name, frozenset(existing.functions)) == key
                 ):
-                    if self._emit_dedup_logs:
-                        log_debug(
-                            f"Registry: skipped a duplicate '{tool.name}' toolkit; keeping the registered instance."
-                        )
                     return
         else:
             for existing in self.tools:

--- a/libs/agno/tests/unit/os/test_mcp_surface_v2.py
+++ b/libs/agno/tests/unit/os/test_mcp_surface_v2.py
@@ -241,9 +241,55 @@ async def test_get_session_runs_history_is_trimmed():
     trimmed = trim_session_run(RunSchema.from_dict(session["runs"][0]))
     assert trimmed["content"] == "hi there"
     assert trimmed["status"] == "COMPLETED"
+    assert trimmed["agent_id"] == "a-1"
     assert "messages" not in trimmed
     assert "events" not in trimmed
     assert "SECRET_PROMPT" not in str(trimmed)
+
+
+def test_trim_session_run_keeps_workflow_id():
+    """Workflow runs keep the id of the workflow that produced them, exactly like
+    agent and team runs keep agent_id/team_id in trimmed history."""
+    from agno.os.mcp_results import trim_session_run
+    from agno.os.schema import WorkflowRunSchema
+
+    run = WorkflowRunSchema.from_dict(
+        {"run_id": "wr-1", "workflow_id": "wf-1", "content": "wf result", "status": "COMPLETED"}
+    )
+    trimmed = trim_session_run(run)
+    assert trimmed["workflow_id"] == "wf-1"
+    assert trimmed["run_id"] == "wr-1"
+    assert "step_results" not in trimmed
+
+
+# ==================== Run-lifecycle ownership gate ====================
+
+
+async def test_run_ownership_gate_skips_remote_components(monkeypatch):
+    """A scoped caller acting on a remote component must not hit the local session
+    lookup -- BaseRemote has no aget_session, so the old path raised AttributeError.
+    The downstream helpers own the outcome (RemoteContinuationUnsupported for
+    continue, acancel_run forwarding for cancel), mirroring REST."""
+    from agno.agent.remote import RemoteAgent
+
+    monkeypatch.setattr(mcp_mod, "_scoped_caller_user_id", lambda: "user-1")
+    verify = mcp_mod._make_run_ownership_verifier(None)  # type: ignore[arg-type]
+    remote = RemoteAgent(base_url="http://remote.invalid:1", agent_id="remote-agent")
+
+    # Must not raise and must not attempt any network call.
+    await verify(remote, "agents", "remote-agent", "session-1", "run-1")
+
+
+async def test_run_ownership_gate_still_blocks_unowned_local_runs(monkeypatch):
+    monkeypatch.setattr(mcp_mod, "_scoped_caller_user_id", lambda: "user-1")
+    verify = mcp_mod._make_run_ownership_verifier(None)  # type: ignore[arg-type]
+
+    class _LocalAgent:
+        async def aget_session(self, session_id, user_id):
+            return None
+
+    with pytest.raises(Exception, match="Run not found"):
+        await verify(_LocalAgent(), "agents", "demo-agent", "session-1", "run-1")
 
 
 # ==================== Session service ====================

--- a/libs/agno/tests/unit/os/test_registry_population.py
+++ b/libs/agno/tests/unit/os/test_registry_population.py
@@ -526,42 +526,28 @@ class TestPopulateRegistryComponentsCacheInvalidation:
 
 
 class TestPopulateRegistryDedupLogging:
-    """Dedup chatter is suppressed for registries AgentOS auto-creates."""
+    """Dedup is an expected wiring step and must never log -- duplicate-skip chatter
+    on startup reads like a problem to users when nothing is wrong."""
 
-    def test_auto_created_registry_is_silent_on_duplicate(self, monkeypatch):
+    def test_dedup_is_silent_even_for_user_declared_registry(self, monkeypatch):
         import agno.registry.registry as registry_module
 
-        debugs = []
-        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: debugs.append(msg))
+        logged = []
+        monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: logged.append(msg))
+        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: logged.append(msg), raising=False)
 
         class _NamedToolkit(Toolkit):
             def __init__(self):
                 super().__init__(name="shared_name", tools=[])
 
-        # No registry provided -> AgentOS auto-creates one; duplicates across the
-        # two agents are an internal wiring detail and must not be logged.
-        a = Agent(name="A1", id="a1", tools=[_NamedToolkit()], telemetry=False)
-        b = Agent(name="A2", id="a2", tools=[_NamedToolkit()], telemetry=False)
-        os = AgentOS(agents=[a, b], telemetry=False)
-
-        assert os.registry._emit_dedup_logs is False
-        assert not any("shared_name" in m for m in debugs)
-
-    def test_user_registry_logs_on_clash_with_primitive(self, monkeypatch):
-        import agno.registry.registry as registry_module
-
-        debugs = []
-        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: debugs.append(msg))
-
-        class _NamedToolkit(Toolkit):
-            def __init__(self):
-                super().__init__(name="shared_name", tools=[])
-
-        # User explicitly declares a registry; a primitive carrying a matching
-        # toolkit clashes with it, which is worth surfacing.
+        # A user-declared registry clashing with a primitive's toolkit, and an
+        # auto-created registry deduping across agents: both stay silent.
         registry = Registry(tools=[_NamedToolkit()])
         agent = Agent(name="A1", id="a1", tools=[_NamedToolkit()], telemetry=False)
-        os = AgentOS(agents=[agent], registry=registry, telemetry=False)
+        AgentOS(agents=[agent], registry=registry, telemetry=False)
 
-        assert os.registry._emit_dedup_logs is True
-        assert any("shared_name" in m for m in debugs)
+        a = Agent(name="A2", id="a2", tools=[_NamedToolkit()], telemetry=False)
+        b = Agent(name="A3", id="a3", tools=[_NamedToolkit()], telemetry=False)
+        AgentOS(agents=[a, b], telemetry=False)
+
+        assert not any("shared_name" in m for m in logged)

--- a/libs/agno/tests/unit/registry/test_registry.py
+++ b/libs/agno/tests/unit/registry/test_registry.py
@@ -1198,13 +1198,15 @@ class TestAddModel:
         reg.add_model(OpenAIResponses(id="gpt-5.4"))  # genuine duplicate
         assert len(reg.models) == 1
 
-    def test_logs_debug_when_dropping_matching_model(self, monkeypatch):
-        # A re-instantiated model (catalog id reused) is benign, so the skip is
-        # logged at debug rather than warned.
+    def test_dropping_matching_model_is_silent(self, monkeypatch):
+        # A re-instantiated model (catalog id reused) is benign and expected, so
+        # the skip must not log at all -- duplicate-skip chatter on startup reads
+        # like a problem to users when nothing is wrong.
         import agno.registry.registry as registry_module
 
-        debugs = []
-        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: debugs.append(msg))
+        logs = []
+        monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: logs.append(msg))
+        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: logs.append(msg), raising=False)
 
         m1 = _model("gpt-5.4")
         m2 = _model("gpt-5.4")  # same provider+id, distinct instance
@@ -1212,14 +1214,14 @@ class TestAddModel:
         reg.add_model(m1)
         reg.add_model(m2)
         assert len(reg.models) == 1 and reg.models[0] is m1
-        assert debugs and "gpt-5.4" in debugs[0]
+        assert logs == []
 
     def test_no_log_when_same_model_instance_repeats(self, monkeypatch):
         import agno.registry.registry as registry_module
 
         logs = []
         monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: logs.append(msg))
-        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: logs.append(msg))
+        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: logs.append(msg), raising=False)
 
         m = _model("gpt-5.4")
         reg = Registry()
@@ -1263,18 +1265,20 @@ class TestAddTool:
         reg.add_tool(tk2)
         assert reg.tools == [tk1]
 
-    def test_logs_debug_when_dropping_matching_toolkit(self, monkeypatch):
+    def test_dropping_matching_toolkit_is_silent(self, monkeypatch):
         # Re-instantiating a default toolkit in two places is common and benign,
-        # so the skip is logged at debug rather than warned.
+        # so the skip must not log at all.
         import agno.registry.registry as registry_module
 
-        debugs = []
-        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: debugs.append(msg))
+        logs = []
+        monkeypatch.setattr(registry_module, "log_warning", lambda msg, *a, **k: logs.append(msg))
+        monkeypatch.setattr(registry_module, "log_debug", lambda msg, *a, **k: logs.append(msg), raising=False)
 
         reg = Registry()
         reg.add_tool(Toolkit(name="same", tools=[]))
         reg.add_tool(Toolkit(name="same", tools=[]))
-        assert debugs and "same" in debugs[0]
+        assert len(reg.tools) == 1
+        assert logs == []
 
     def test_keeps_toolkits_with_different_function_sets(self):
         # Same type and name but different functions are genuinely different


### PR DESCRIPTION
## Summary

Three small pre-release cleanups for 2.7: the two verified findings from the ultra review of #8747, plus removal of the registry duplicate-skip debug chatter reported from the new AgentOS templates.

**1. Workflow runs lose their `workflow_id` in MCP history** (`libs/agno/agno/os/mcp_results.py`)
`SESSION_RUN_HISTORY_FIELDS` whitelisted `agent_id` and `team_id` but not `workflow_id` — `WorkflowRunSchema` carries only `workflow_id`, so trimmed history for a workflow session came back with no identifier for the workflow that produced each run. Added `workflow_id` to the tuple.

**2. `continue_run`/`cancel_run` crash for scoped callers on remote components** (`libs/agno/agno/os/mcp.py`)
`verify_run_ownership` calls `component.aget_session(...)`, which `BaseRemote` doesn't implement, and the tool wrapper only catches `RunOwnershipError` — so a scoped caller (service-account PAT, or a JWT user under user isolation) hit a raw `AttributeError`. It failed closed, but for `cancel_run` it blocked an operation that works for admins on the same target. The gate now skips remote components — their sessions live on the remote OS, so there is no local session to check — and defers to the downstream helpers, mirroring REST: continue raises `RemoteContinuationUnsupported`, cancel forwards via `acancel_run`.

**3. Registry duplicate-skip logs removed** (`libs/agno/agno/registry/registry.py`, `app.py`)
User-declared registries logged `Registry: skipped a duplicate model/toolkit; keeping the registered instance.` on every dedup, spamming template startup output with lines that read like problems. Dedup is expected wiring (toolkits and models are legitimately re-instantiated at call sites), so the skip is now silent everywhere and the `_emit_dedup_logs` flag is gone. The genuinely actionable warning — distinct tools sharing a name at rehydration — still logs.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — generated with Claude Code, reviewed by @ashpreetbedi

---

## Additional Notes

- New tests: trimmed history keeps `workflow_id` (and still strips transcripts); the ownership gate skips `RemoteAgent` without touching the network while still blocking unowned local runs; registry dedup is asserted silent for both user-declared and auto-created registries.
- 129 MCP/registry-population tests and 147 registry tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)