### PR TITLE
chore: rate limit PAT mint for members

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1093,9 +1093,13 @@ class AgentOS:
             @fastapi_app.exception_handler(HTTPException)
             async def http_exception_handler(_, exc: HTTPException) -> JSONResponse:
                 log_error(f"HTTP exception: {exc.status_code} {exc.detail}")
+                # Preserve caller-set headers (Retry-After on 429, WWW-Authenticate on 401,
+                # Location on 3xx redirects, etc.). Discarding them silently broke every
+                # endpoint that raises HTTPException(headers=...) previously.
                 return JSONResponse(
                     status_code=exc.status_code,
                     content={"detail": str(exc.detail)},
+                    headers=exc.headers,
                 )
 
             @fastapi_app.exception_handler(HTTPStatusError)
@@ -1136,6 +1140,17 @@ class AgentOS:
         service_account_verifier = self._get_service_account_verifier()
         if service_account_verifier is not None:
             fastapi_app.state.service_account_verifier = service_account_verifier
+
+        # Per-user mint rate limiter, shared across mint requests. Only installed when the
+        # configured max is positive; setting service_account_mint_max=0 disables it.
+        mint_max = getattr(self.settings, "service_account_mint_max", 0) if self.settings else 0
+        if mint_max > 0:
+            from agno.os.service_accounts import MintRateLimiter
+
+            fastapi_app.state.service_account_mint_limiter = MintRateLimiter(
+                max_mints=mint_max,
+                window_seconds=getattr(self.settings, "service_account_mint_window_seconds", 3600),
+            )
 
         # Install the single auth layer whenever any credential is configured. It
         # covers the REST routes and the mounted /mcp app together (one middleware on

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -163,6 +163,31 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
         scopes = list(body.scopes) if body.scopes is not None else list(DEFAULT_SERVICE_ACCOUNT_SCOPES)
         _validate_requested_scopes(request, body, scopes)
 
+        # Per-user mint rate limit: guards against a scoped member (or a buggy script)
+        # generating unbounded tokens. Admin callers bypass -- an operator may need to
+        # bulk-provision. The limiter is opt-in via AgnoAPISettings.service_account_mint_max
+        # and lives on app.state (may be None if disabled or not yet installed). We check
+        # here and record after the DB write succeeds, so failed/duplicate mints do not
+        # consume the caller's budget.
+        mint_limiter = getattr(request.app.state, "service_account_mint_limiter", None)
+        mint_key: Optional[str] = None
+        if mint_limiter is not None:
+            admin_scope = _get_admin_scope(request)
+            caller_scopes = getattr(request.state, "scopes", None) or []
+            effective_admin_scope = admin_scope or AgentOSScope.ADMIN.value
+            is_admin = effective_admin_scope in caller_scopes
+            if not is_admin:
+                mint_key = getattr(request.state, "user_id", None) or (
+                    request.client.host if request.client else "unknown"
+                )
+                if mint_limiter.is_limited(mint_key):
+                    retry_after = mint_limiter.seconds_until_available(mint_key)
+                    raise HTTPException(
+                        status_code=429,
+                        detail="Service-account mint rate limit exceeded. Wait and retry.",
+                        headers={"Retry-After": str(retry_after)},
+                    )
+
         existing = await _db_call("get_service_account_by_name", body.name)
         if existing is not None:
             raise HTTPException(
@@ -200,6 +225,10 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
                 )
             log_error(f"Could not create service account: {exc}")
             raise HTTPException(status_code=500, detail="Could not create service account")
+
+        # Only meter successful mints -- a 409/500 does not consume the caller's budget.
+        if mint_limiter is not None and mint_key is not None:
+            mint_limiter.record_mint(mint_key)
 
         metadata = ServiceAccountResponse.from_dict(account.to_dict())
         return ServiceAccountCreateResponse(**metadata.model_dump(), token=plaintext_token)

--- a/libs/agno/agno/os/service_accounts.py
+++ b/libs/agno/agno/os/service_accounts.py
@@ -183,6 +183,56 @@ class _FailedLookupLimiter:
             self._failures.popitem(last=False)
 
 
+class MintRateLimiter:
+    """Sliding-window limiter for service-account MINT requests, keyed by minter identity.
+
+    Guards against a member with ``service_accounts:write`` scope generating an unbounded
+    number of tokens (accidentally through a script bug, or deliberately). Admin callers
+    bypass; every other caller is metered per-user against ``max_mints`` in ``window_seconds``.
+
+    In-process and per-worker: with N uvicorn workers the effective budget is N times
+    larger. That is fine for the intended use case — legit devs need a handful of tokens
+    per hour, malicious spam still runs into the cap on any single worker before it
+    materially fills the DB.
+    """
+
+    def __init__(self, max_mints: int = 10, window_seconds: int = 3600, max_entries: int = 1024):
+        self.max_mints = max_mints
+        self.window_seconds = window_seconds
+        self.max_entries = max_entries
+        self._mints: "OrderedDict[str, List[float]]" = OrderedDict()
+
+    def _prune(self, key: str) -> List[float]:
+        timestamps = self._mints.get(key) or []
+        cutoff = time.monotonic() - self.window_seconds
+        fresh = [t for t in timestamps if t > cutoff]
+        if fresh:
+            self._mints[key] = fresh
+        else:
+            self._mints.pop(key, None)
+        return fresh
+
+    def is_limited(self, key: str) -> bool:
+        return len(self._prune(key)) >= self.max_mints
+
+    def record_mint(self, key: str) -> None:
+        fresh = self._prune(key)
+        fresh.append(time.monotonic())
+        self._mints[key] = fresh
+        self._mints.move_to_end(key)
+        while len(self._mints) > self.max_entries:
+            self._mints.popitem(last=False)
+
+    def seconds_until_available(self, key: str) -> int:
+        """Suggest a Retry-After value: seconds until the oldest fresh mint ages out."""
+        fresh = self._prune(key)
+        if len(fresh) < self.max_mints:
+            return 0
+        oldest = min(fresh)
+        remaining = self.window_seconds - (time.monotonic() - oldest)
+        return max(1, int(remaining))
+
+
 class _VerificationCache:
     """Bounded, TTL'd LRU of successful verifications, keyed by token hash.
 

--- a/libs/agno/agno/os/settings.py
+++ b/libs/agno/agno/os/settings.py
@@ -31,6 +31,17 @@ class AgnoAPISettings(BaseSettings):
         default=30, description="TTL (seconds) for the in-process service-account verification cache; 0 disables it"
     )
 
+    # Per-user cap on service-account MINT requests. Guards against a scoped member
+    # generating unbounded tokens; admin callers bypass. In-process and per-worker,
+    # so with N workers the effective budget is N times larger. Set max_mints to 0
+    # to disable the mint limiter entirely.
+    service_account_mint_max: int = Field(
+        default=10, description="Max service-account mints per user per window; 0 disables the mint limiter"
+    )
+    service_account_mint_window_seconds: int = Field(
+        default=3600, description="Rolling window (seconds) over which service_account_mint_max applies"
+    )
+
     # Cors origin list to allow requests from.
     # This list is set using the set_cors_origin_list validator
     cors_origin_list: Optional[List[str]] = Field(default=None, validate_default=True)

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -218,6 +218,93 @@ class TestServiceAccountLifecycleWithJWT:
         response = jwt_client.get("/service-accounts", headers={"Authorization": f"Bearer {plain_jwt}"})
         assert response.status_code == 403
 
+    def test_mint_rate_limiter_caps_non_admin_members(self, test_agent, sqlite_db):
+        """A scoped member with service_accounts:write cannot mint unbounded tokens.
+
+        Guards against a member (or a buggy script) spamming the mint endpoint. The
+        limit applies per-user, admin callers bypass, and failed mints (e.g. 409 on a
+        duplicate name) do NOT consume the caller's budget.
+        """
+        settings = AgnoAPISettings(service_account_mint_max=3, service_account_mint_window_seconds=3600)
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db, settings=settings)
+        app = agent_os.get_app()
+        app.add_middleware(
+            JWTMiddleware, verification_keys=[JWT_SECRET], algorithm="HS256", authorization=True
+        )
+        client = TestClient(app)
+
+        member_jwt = _make_jwt(
+            ["agents:run", "service_accounts:write", "service_accounts:read"], sub="bob"
+        )
+
+        # First three mints succeed. Only request agents:run (the one scope Bob holds
+        # from his JWT) so the subset rule is satisfied.
+        for i in range(3):
+            r = client.post(
+                "/service-accounts",
+                headers={"Authorization": f"Bearer {member_jwt}"},
+                json={"name": f"bob-pat-{i}", "scopes": ["agents:run"]},
+            )
+            assert r.status_code == 201, r.text
+
+        # Fourth mint is rate-limited with a Retry-After header.
+        rate_limited = client.post(
+            "/service-accounts",
+            headers={"Authorization": f"Bearer {member_jwt}"},
+            json={"name": "bob-pat-3", "scopes": ["agents:run"]},
+        )
+        assert rate_limited.status_code == 429
+        assert "Retry-After" in rate_limited.headers
+        assert int(rate_limited.headers["Retry-After"]) > 0
+
+        # Admin scope bypasses the limiter entirely.
+        admin_jwt = _make_jwt(["agent_os:admin"], sub="alice")
+        for i in range(5):
+            r = client.post(
+                "/service-accounts",
+                headers={"Authorization": f"Bearer {admin_jwt}"},
+                json={"name": f"alice-pat-{i}"},
+            )
+            assert r.status_code == 201, r.text
+
+    def test_mint_rate_limiter_does_not_bill_failed_mints(self, test_agent, sqlite_db):
+        """A duplicate-name 409 must not consume the caller's mint budget."""
+        settings = AgnoAPISettings(service_account_mint_max=2, service_account_mint_window_seconds=3600)
+        agent_os = AgentOS(agents=[test_agent], db=sqlite_db, settings=settings)
+        app = agent_os.get_app()
+        app.add_middleware(
+            JWTMiddleware, verification_keys=[JWT_SECRET], algorithm="HS256", authorization=True
+        )
+        client = TestClient(app)
+
+        member_jwt = _make_jwt(
+            ["agents:run", "service_accounts:write", "service_accounts:read"], sub="bob"
+        )
+
+        # First mint succeeds.
+        first = client.post(
+            "/service-accounts",
+            headers={"Authorization": f"Bearer {member_jwt}"},
+            json={"name": "dup", "scopes": ["agents:run"]},
+        )
+        assert first.status_code == 201
+
+        # Duplicate name -> 409, budget unchanged.
+        dup = client.post(
+            "/service-accounts",
+            headers={"Authorization": f"Bearer {member_jwt}"},
+            json={"name": "dup", "scopes": ["agents:run"]},
+        )
+        assert dup.status_code == 409
+
+        # Still under the cap: one more successful mint is allowed.
+        second = client.post(
+            "/service-accounts",
+            headers={"Authorization": f"Bearer {member_jwt}"},
+            json={"name": "other", "scopes": ["agents:run"]},
+        )
+        assert second.status_code == 201, second.text
+
     def test_admin_pat_can_manage_service_accounts_end_to_end(self, jwt_client):
         """A PAT minted with agent_os:admin scope must be able to mint, list, and revoke.
 


### PR DESCRIPTION
## Summary

Rate-limits `POST /service-accounts` mint requests per user, addressing feedback from Monalisha:

> okay makes sense, but i was just worried that member will generate a lot of tokens and the OS api will be hit numerous times

A scoped member with `service_accounts:write` can now be capped at N mints per rolling window without needing to restructure the scope model.

## What changed

### `MintRateLimiter`

New class in [libs/agno/agno/os/service_accounts.py](libs/agno/agno/os/service_accounts.py), following the same sliding-window pattern as the existing `_FailedLookupLimiter`. Keyed on `request.state.user_id` (the minter's JWT sub or SA principal), bounded LRU by max entries so a worker seeing many distinct users doesn't leak memory.

Exposes `is_limited(key)`, `record_mint(key)`, and `seconds_until_available(key)` for the router.

### Wiring

- **`AgnoAPISettings`** ([settings.py](libs/agno/agno/os/settings.py)) gains two configurable knobs:
  - `service_account_mint_max` (default: **10**) — max mints per user per window; **`0` disables the limiter entirely**
  - `service_account_mint_window_seconds` (default: **3600** = 1 hour)
- **AgentOS** ([app.py](libs/agno/agno/os/app.py)) constructs the limiter at `_add_auth_middleware` time and attaches it to `app.state.service_account_mint_limiter`. In-process and per-worker, so with N uvicorn workers the effective budget is N times larger.
- **Router** ([routers/service_accounts/router.py](libs/agno/agno/os/routers/service_accounts/router.py)) checks the limiter in `POST /service-accounts` before the DB insert.

### Behavior

- **Admin callers bypass** — an operator may need to bulk-provision for a team; the point of the limiter is to cap scoped members, not restrict admins.
- **Failed mints (409 on duplicate name, 500 on DB error) do not consume budget** — the `record_mint` call happens only after the successful DB insert.
- On limit exceeded: **429 with a `Retry-After` header** so `agno tokens create` (or any client) can back off cleanly.
- Anonymous callers can't reach this path at all (already blocked upstream by `_validate_requested_scopes`).

### Small collateral fix

The custom `HTTPException` handler at [app.py:1093](libs/agno/agno/os/app.py) was discarding `exc.headers`. That silently broke any endpoint raising `HTTPException(headers=...)` — including my `Retry-After`, but also any future `WWW-Authenticate` on 401 or `Location` on 3xx redirects. Now passes `headers=exc.headers` through. Verified with a reproducer against a plain FastAPI app (headers propagate correctly) vs the AgentOS app (they were being stripped before this fix).

## Tests

Two integration tests in [test_service_accounts.py](libs/agno/tests/integration/os/test_service_accounts.py):

- **`test_mint_rate_limiter_caps_non_admin_members`** — Bob with `service_accounts:write` gets 3 successful mints then a 429 with `Retry-After`; Alice with `agent_os:admin` mints 5 without any limiting
- **`test_mint_rate_limiter_does_not_bill_failed_mints`** — a duplicate-name 409 doesn't consume Bob's budget; a subsequent mint under the cap still succeeds

Full SA suite (39 tests) green, broader OS unit suite (1081 tests) green.

## Type of change

- [x] New feature (opt-out by default; setting `service_account_mint_max=0` disables entirely)
- [x] Bug fix (`HTTPException(headers=...)` no longer silently dropped by the AgentOS exception handler)

## Design notes

**Why per-user, not per-IP:** matches the exact concern ("member will generate a lot of tokens"). Multiple members legitimately behind the same NAT/proxy each get their own budget. Since anonymous mints are already blocked at [router.py:139-145](libs/agno/agno/os/routers/service_accounts/router.py#L139-L145), we're guaranteed to have a real caller identity to key on.

**Why 10/hour default:** legit developers need a handful of tokens per hour at most — `agno connect --rotate` on 3–5 machines twice over comfortably fits. A malicious script hits the cap on the first worker before it materially fills the DB. Operators who want a different budget (higher for CI-heavy workspaces, lower for stricter governance) can tune `service_account_mint_max`.

**Why bypass admin:** admin scope is already the "trusted operator" grant. Rate-limiting admin would break legitimate bulk-provisioning use cases (setting up a whole team's PATs at once). The rate limit is a member-governance tool, not a system-wide throttle.

**Why record after success:** billing failed mints would let a caller intentionally exhaust another user's budget by hammering the endpoint with duplicate names — or let a caller find themselves throttled after a series of 500s they can't debug. The successful-DB-insert boundary is the natural point to "charge" the budget.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (docstrings on `MintRateLimiter`, settings fields, and design notes in the mint handler)
- [x] Tested in clean environment
- [x] Tests added — 2 new integration tests covering the cap, admin bypass, and failure-doesn't-bill behavior
