### PR TITLE
[fix] Avoid duplicate multimodal kwargs in RemoteAgent runs

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -696,6 +696,14 @@ def get_agent_router(
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
 
+        # Media params are always passed explicitly below (from the processed uploads).
+        # Remote callers -- e.g. a RemoteAgent used as a team member -- serialize
+        # images/audio/videos/files into JSON form fields, which get_request_kwargs then
+        # surfaces in kwargs. Drop them here so they are not also forwarded via **kwargs,
+        # which would raise "got multiple values for keyword argument 'images'". (#8771)
+        for media_key in ("images", "audio", "videos", "files"):
+            kwargs.pop(media_key, None)
+
         # Extract auth token for remote agents
         auth_token = get_auth_token_from_request(request)
 

--- a/libs/agno/tests/integration/os/test_agent_runs.py
+++ b/libs/agno/tests/integration/os/test_agent_runs.py
@@ -111,6 +111,100 @@ def test_create_agent_run_with_kwargs(test_os_client, test_agent: Agent):
         assert call_args.kwargs["extra_field_two"] == "bar"
 
 
+def test_create_agent_run_with_media_kwargs_no_duplicate(test_os_client, test_agent: Agent):
+    """Regression for #8771: media fields arriving as request kwargs must not collide
+    with the explicit ``images=``/``audio=``/``videos=``/``files=`` params of ``arun``.
+
+    A RemoteAgent (e.g. a remote team member) serializes ``images``/``audio``/``videos``
+    into JSON form fields. On the server these are not declared parameters of
+    ``create_agent_run``, so they fall through into ``kwargs``. Passing both
+    ``images=...`` explicitly and ``**kwargs`` (which also holds ``images``) previously
+    raised ``TypeError: arun() got multiple values for keyword argument 'images'``.
+    """
+
+    class MockRunOutput:
+        def to_dict(self):
+            return {}
+
+    # Mimic what the AgentOS client sends for a remote agent run.
+    images_payload = json.dumps([{"content": None, "url": "https://example.com/a.png"}])
+    audio_payload = json.dumps([{"content": None, "url": "https://example.com/a.mp3"}])
+    videos_payload = json.dumps([{"content": None, "url": "https://example.com/a.mp4"}])
+
+    with (
+        patch.object(test_agent, "deep_copy", return_value=test_agent),
+        patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun,
+    ):
+        mock_arun.return_value = MockRunOutput()
+
+        response = test_os_client.post(
+            f"/agents/{test_agent.id}/runs",
+            data={
+                "message": "Describe this",
+                "stream": "false",
+                "images": images_payload,
+                "audio": audio_payload,
+                "videos": videos_payload,
+                # A normal non-media kwarg must still be forwarded.
+                "extra_field": "foo",
+            },
+        )
+
+        # Without the fix this raises TypeError inside the handler -> HTTP 500.
+        assert response.status_code == 200
+
+        # arun must have been called exactly once, with each media kwarg present once.
+        assert mock_arun.call_count == 1
+        call_kwargs = mock_arun.call_args.kwargs
+        assert "images" in call_kwargs
+        assert "audio" in call_kwargs
+        assert "videos" in call_kwargs
+        # The explicit media params win; the raw JSON strings from kwargs are not
+        # forwarded (no UploadFile was sent, so they resolve to None).
+        assert call_kwargs["images"] != images_payload
+        assert call_kwargs["audio"] != audio_payload
+        assert call_kwargs["videos"] != videos_payload
+        # Non-media kwargs are still forwarded untouched.
+        assert call_kwargs["extra_field"] == "foo"
+
+
+def test_create_agent_run_streaming_with_media_kwargs_no_duplicate(test_os_client, test_agent: Agent):
+    """Streaming variant of the #8771 regression.
+
+    The streaming path forwards the same explicit media params plus ``**kwargs`` into
+    ``agent_response_streamer``, which also binds them to named params, so the duplicate
+    ``images`` kwarg must be stripped before the call too.
+    """
+
+    async def _fake_arun(*args, **kwargs):
+        from agno.run.agent import RunContentEvent
+
+        yield RunContentEvent(run_id="run-1", content="hello")
+
+    images_payload = json.dumps([{"content": None, "url": "https://example.com/a.png"}])
+
+    with (
+        patch.object(test_agent, "deep_copy", return_value=test_agent),
+        patch.object(test_agent, "arun", side_effect=_fake_arun) as mock_arun,
+    ):
+        with test_os_client.stream(
+            "POST",
+            f"/agents/{test_agent.id}/runs",
+            data={
+                "message": "Describe this",
+                "stream": "true",
+                "images": images_payload,
+            },
+        ) as response:
+            assert response.status_code == 200
+            body = "".join(response.iter_text())
+
+        # A duplicate-kwarg TypeError would surface as a RunError event, not content.
+        assert "hello" in body
+        assert mock_arun.call_count == 1
+        assert mock_arun.call_args.kwargs["images"] != images_payload
+
+
 def test_kwargs_propagate_to_run_context(test_os_client, test_agent: Agent):
     """Test passing kwargs to an agent run."""
 


### PR DESCRIPTION
## Summary

Fixes duplicate multimodal kwargs in the AgentOS agent run endpoint when a `RemoteAgent` receives media input through team delegation.

Remote callers can send media values such as `
## Summary

Fixes duplicate multimodal kwargs in the AgentOS agent run endpoint when a `RemoteAgent` receives media input through team delegation.

Remote callersimages`, `audio`, `videos`, and `files` through request kwargs. The endpoint also passes processed media values explicitly to `agent.arun` and the streaming response path. When a duplicated key such as `images` remains in `kwargs`, Python raises:

```text
TypeError: Agent.arun() got multiple values for keyword argument 'images'
```

This PR removes media keys from `kwargs` after media processing and before forwarding `**kwargs`, so media parameters are passed exactly once while non-media kwargs continue to propagate.

Fixes #8771.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tested with:

```bash
python -m pytest libs/agno/tests/integration/os/test_agent_runs.py -q
python -m pytest libs/agno/tests/integration/os/test_utils.py libs/agno/tests/integration/os/test_client.py -q
python -m ruff check libs/agno/agno/os/routers/agents/router.py libs/agno/tests/integration/os/test_agent_runs.py
python -m ruff format --check libs/agno/agno/os/routers/agents/router.py libs/agno/tests/integration/os/test_agent_runs.py
python -m mypy libs/agno/agno/os/routers/agents/router.py --config-file libs/agno/pyproject.toml
git diff --check
```

Targeted integration tests were run for the affected AgentOS run path. The new regression tests use mocked agent execution and do not require external API calls.