### PR TITLE
feat: add user_id ownership column to service accounts

### DIFF
--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -333,6 +333,9 @@ SERVICE_ACCOUNT_TABLE_SCHEMA = {
     "last_used_at": {"type": BigInteger, "nullable": True},
     "revoked_at": {"type": BigInteger, "nullable": True},
     "created_by": {"type": String, "nullable": True},
+    # Ownership (nullable): the human principal the account belongs to; NULL is a
+    # workspace/machine-level account. Distinct from created_by, which is audit-only.
+    "user_id": {"type": String, "nullable": True},
     # Names are reusable after revocation (rotation keeps the same identity),
     # so uniqueness only applies to active accounts.
     "_partial_unique_indexes": [{"name": "uq_active_name", "columns": ["name"], "where": "revoked_at IS NULL"}],

--- a/libs/agno/agno/db/schemas/service_accounts.py
+++ b/libs/agno/agno/db/schemas/service_accounts.py
@@ -34,6 +34,10 @@ class ServiceAccount:
     last_used_at: Optional[int] = None
     revoked_at: Optional[int] = None
     created_by: Optional[str] = None
+    # Ownership, not audit: the human principal this account belongs to (drives
+    # per-user isolation when user management lands). created_by stays audit-only
+    # (who minted the token). NULL means a workspace/machine-level account.
+    user_id: Optional[str] = None
 
     def __post_init__(self) -> None:
         self.created_at = now_epoch_s() if self.created_at is None else to_epoch_s(self.created_at)
@@ -70,6 +74,7 @@ class ServiceAccount:
             "last_used_at": self.last_used_at,
             "revoked_at": self.revoked_at,
             "created_by": self.created_by,
+            "user_id": self.user_id,
         }
 
     @classmethod
@@ -86,6 +91,7 @@ class ServiceAccount:
             "last_used_at",
             "revoked_at",
             "created_by",
+            "user_id",
         }
         filtered = {k: v for k, v in data.items() if k in valid_keys}
         if filtered.get("scopes") is None:

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -295,6 +295,9 @@ SERVICE_ACCOUNT_TABLE_SCHEMA = {
     "last_used_at": {"type": BigInteger, "nullable": True},
     "revoked_at": {"type": BigInteger, "nullable": True},
     "created_by": {"type": String, "nullable": True},
+    # Ownership (nullable): the human principal the account belongs to; NULL is a
+    # workspace/machine-level account. Distinct from created_by, which is audit-only.
+    "user_id": {"type": String, "nullable": True},
     # Names are reusable after revocation (rotation keeps the same identity),
     # so uniqueness only applies to active accounts.
     "_partial_unique_indexes": [{"name": "uq_active_name", "columns": ["name"], "where": "revoked_at IS NULL"}],

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -184,6 +184,9 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
             created_at=now,
             expires_at=expires_at,
             created_by=getattr(request.state, "user_id", None),
+            # Ownership starts as the minting principal; enforcement semantics
+            # arrive with the user-management work (nothing reads this yet).
+            user_id=getattr(request.state, "user_id", None),
         )
 
         try:

--- a/libs/agno/agno/os/routers/service_accounts/schema.py
+++ b/libs/agno/agno/os/routers/service_accounts/schema.py
@@ -86,7 +86,10 @@ class ServiceAccountResponse(BaseModel):
     expires_at: Optional[int] = None
     last_used_at: Optional[int] = None
     revoked_at: Optional[int] = None
-    created_by: Optional[str] = None
+    created_by: Optional[str] = Field(None, description="Audit: who minted the token")
+    user_id: Optional[str] = Field(
+        None, description="Ownership: the human principal this account belongs to; null for workspace-level accounts"
+    )
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ServiceAccountResponse":
@@ -101,6 +104,7 @@ class ServiceAccountResponse(BaseModel):
             last_used_at=data.get("last_used_at"),
             revoked_at=data.get("revoked_at"),
             created_by=data.get("created_by"),
+            user_id=data.get("user_id"),
         )
 
 

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -91,6 +91,9 @@ class TestServiceAccountLifecycleWithJWT:
         assert pat.startswith("agno_pat_")
         assert body["principal"] == "sa:claude-code"
         assert body["created_by"] == "human-admin"
+        # Ownership is populated at mint from the authenticated principal;
+        # created_by stays audit-only (who minted)
+        assert body["user_id"] == "human-admin"
 
         with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
             mock_arun.return_value = _mock_run_output()
@@ -255,9 +258,7 @@ class TestServiceAccountLifecycleWithJWT:
         minted_id = minted.json()["id"]
 
         # The admin PAT can revoke without needing service_accounts:delete.
-        revoke = jwt_client.delete(
-            f"/service-accounts/{minted_id}", headers={"Authorization": f"Bearer {admin_pat}"}
-        )
+        revoke = jwt_client.delete(f"/service-accounts/{minted_id}", headers={"Authorization": f"Bearer {admin_pat}"})
         assert revoke.status_code == 204, revoke.text
 
 

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -30,6 +30,7 @@ def _make_account_dict(**overrides):
         "last_used_at": None,
         "revoked_at": None,
         "created_by": "admin-user",
+        "user_id": "admin-user",
     }
     d.update(overrides)
     return d
@@ -107,6 +108,10 @@ class TestCreateServiceAccount:
         stored = mock_db.create_service_account.call_args.args[0]
         assert body["token"] not in str(stored)
         assert stored["token_hash"] != body["token"]
+        # Ownership starts as the minting principal (both None here: security-key
+        # auth carries no user identity), and the response exposes it
+        assert stored.get("user_id") == stored.get("created_by")
+        assert body["user_id"] == body["created_by"]
 
     def test_custom_expiry(self, client):
         response = client.post("/service-accounts", json={"name": "cursor", "expires_in_days": 7})

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -106,6 +106,17 @@ class TestPrincipal:
         assert account.principal == "sa:cursor"
 
 
+class TestOwnership:
+    def test_user_id_roundtrips_and_defaults_to_none(self):
+        row = _account_row(name="owned")
+        # Absent key means a workspace-level account with no owning user
+        assert ServiceAccount.from_dict(row).user_id is None
+        row["user_id"] = "alice"
+        account = ServiceAccount.from_dict(row)
+        assert account.user_id == "alice"
+        assert account.to_dict()["user_id"] == "alice"
+
+
 class TestScopeHelpers:
     def test_invalid_scopes_detected(self):
         assert get_invalid_scopes(["agents:run", "bogus"]) == ["bogus"]


### PR DESCRIPTION
## Summary

Adds a nullable `user_id` column to the service-accounts schema now, while the feature is still in alpha, so the 2.7 GA audience never needs a migration. The adapters fail closed on missing columns — `is_valid_table` compares against the expected schema and `_get_or_create_table` raises on mismatch, with no auto-ALTER — and the MigrationManager's table-type map doesn't cover `service_accounts`, so adding this after GA means writing both a v3 migration and the plumbing to run it. Right now it's free.

**Semantics (deliberately narrow):**
- `user_id` — **ownership**: the human principal this account belongs to; `NULL` means a workspace/machine-level account with no owning user. This is the field the 3.0 user-management isolation work will read (Bob can't see Alice's SAs or their sessions). **Nothing reads it yet** — no enforcement or read-path behavior in 2.7.
- `created_by` — **audit**, unchanged: who minted the token (could be an admin minting for someone else, someday).
- Populated at mint from the authenticated principal (same value as `created_by` today), so tokens minted during 2.7's lifetime already carry ownership when 3.0 lands, and the field has an immediate writer. Runs keep the `sa:<name>` principal for attribution — this doesn't force the machine-identity-vs-delegated-identity decision; 3.0 can resolve ownership through the SA record either way.

**Footprint:** dataclass + to_dict/from_dict (`db/schemas/service_accounts.py`), the shared postgres/sqlite table schemas (async backends use the same modules), the router response schema, and the mint route. 40 insertions.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts — ruff format/check clean, mypy clean on changed files
- [x] Self-review completed
- [x] Documentation updated (field comments encode the ownership-vs-audit distinction)
- [ ] Examples and guides — n/a (no behavior change; nothing reads the field yet)
- [x] Tested in clean environment
- [x] Tests added/updated — full service-account suites green (109 tests): dataclass roundtrip + absent-key default, mint stores ownership mirroring the minting principal, JWT-authenticated mint carries `user_id == sub` end-to-end through a real table

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — built with Claude Code, human-directed

---

## Additional Notes

**Alpha-only impact:** a deployment that created `agno_service_accounts` on a1–a5 will fail the fail-closed schema check on upgrade and must drop the table. Nothing has shipped stable; this is exactly the window that makes the change free.

This is the last item gating the v2.7.0a5 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)