### PR TITLE
feat: add user_id ownership column to service accounts

### DIFF
--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -325,6 +325,9 @@ AUTH_TOKEN_TABLE_SCHEMA = {
 SERVICE_ACCOUNT_TABLE_SCHEMA = {
     "id": {"type": String, "primary_key": True, "nullable": False},
     "name": {"type": String, "nullable": False},
+    # Ownership: the user this account belongs to (created_by is audit: who minted it).
+    # NULL means a workspace-level machine account with no owning user.
+    "user_id": {"type": String, "nullable": True},
     "token_hash": {"type": String, "nullable": False, "unique": True, "index": True},
     "token_prefix": {"type": String, "nullable": False},
     "scopes": {"type": JSONB, "nullable": False},

--- a/libs/agno/agno/db/schemas/service_accounts.py
+++ b/libs/agno/agno/db/schemas/service_accounts.py
@@ -29,6 +29,10 @@ class ServiceAccount:
     token_hash: str
     token_prefix: str
     scopes: List[str] = field(default_factory=list)
+    # The user this account belongs to. Distinct from created_by (audit: who minted
+    # the token); user_id is ownership. None means a workspace-level machine account
+    # with no owning user.
+    user_id: Optional[str] = None
     created_at: Optional[int] = None
     expires_at: Optional[int] = None
     last_used_at: Optional[int] = None
@@ -62,6 +66,7 @@ class ServiceAccount:
         return {
             "id": self.id,
             "name": self.name,
+            "user_id": self.user_id,
             "token_hash": self.token_hash,
             "token_prefix": self.token_prefix,
             "scopes": self.scopes,
@@ -78,6 +83,7 @@ class ServiceAccount:
         valid_keys = {
             "id",
             "name",
+            "user_id",
             "token_hash",
             "token_prefix",
             "scopes",

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -287,6 +287,9 @@ AUTH_TOKEN_TABLE_SCHEMA = {
 SERVICE_ACCOUNT_TABLE_SCHEMA = {
     "id": {"type": String, "primary_key": True, "nullable": False},
     "name": {"type": String, "nullable": False},
+    # Ownership: the user this account belongs to (created_by is audit: who minted it).
+    # NULL means a workspace-level machine account with no owning user.
+    "user_id": {"type": String, "nullable": True},
     "token_hash": {"type": String, "nullable": False, "unique": True, "index": True},
     "token_prefix": {"type": String, "nullable": False},
     "scopes": {"type": JSON, "nullable": False},

--- a/libs/agno/agno/os/routers/service_accounts/router.py
+++ b/libs/agno/agno/os/routers/service_accounts/router.py
@@ -184,6 +184,7 @@ def get_service_accounts_router(os_db: Any, settings: Any) -> APIRouter:
             created_at=now,
             expires_at=expires_at,
             created_by=getattr(request.state, "user_id", None),
+            user_id=getattr(request.state, "user_id", None),
         )
 
         try:

--- a/libs/agno/agno/os/routers/service_accounts/schema.py
+++ b/libs/agno/agno/os/routers/service_accounts/schema.py
@@ -78,6 +78,11 @@ class ServiceAccountResponse(BaseModel):
     id: str
     name: str
     principal: str = Field(..., description="The user_id attached to runs made with this token, e.g. 'sa:claude-code'")
+    user_id: Optional[str] = Field(
+        default=None,
+        description="The user this account belongs to; None for workspace-level accounts. "
+        "Distinct from created_by, which records who minted the token.",
+    )
     token_prefix: str = Field(..., description="First characters of the token, for display only")
     scopes: List[ScopeSchema] = Field(
         default_factory=list, description="Scopes granted to the token, in the shared RBAC read shape"
@@ -101,6 +106,7 @@ class ServiceAccountResponse(BaseModel):
             last_used_at=data.get("last_used_at"),
             revoked_at=data.get("revoked_at"),
             created_by=data.get("created_by"),
+            user_id=data.get("user_id"),
         )
 
 

--- a/libs/agno/tests/integration/db/postgres/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/postgres/test_service_accounts.py
@@ -47,12 +47,13 @@ class TestServiceAccountsTable:
         assert "revoked_at IS NULL" in indexes[partial_index_name]
 
     def test_crud_roundtrip(self, postgres_db_real):
-        created = postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        created = postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1", user_id="alice"))
         assert created["name"] == "claude-code"
 
         fetched = postgres_db_real.get_service_account("sa-1")
         assert fetched is not None
         assert fetched["scopes"] == ["agents:run", "sessions:read"]
+        assert fetched["user_id"] == "alice"
 
         by_hash = postgres_db_real.get_service_account_by_token_hash("hash-1")
         assert by_hash is not None and by_hash["id"] == "sa-1"

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -40,12 +40,13 @@ class TestServiceAccountsTable:
         assert "revoked_at IS NULL" in indexes[partial_index_name]
 
     def test_crud_roundtrip(self, sqlite_db_real):
-        created = sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+        created = sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1", user_id="alice"))
         assert created["name"] == "claude-code"
 
         fetched = sqlite_db_real.get_service_account("sa-1")
         assert fetched is not None
         assert fetched["scopes"] == ["agents:run", "sessions:read"]
+        assert fetched["user_id"] == "alice"
 
         by_hash = sqlite_db_real.get_service_account_by_token_hash("hash-1")
         assert by_hash is not None and by_hash["id"] == "sa-1"

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -91,6 +91,7 @@ class TestServiceAccountLifecycleWithJWT:
         assert pat.startswith("agno_pat_")
         assert body["principal"] == "sa:claude-code"
         assert body["created_by"] == "human-admin"
+        assert body["user_id"] == "human-admin"
 
         with patch.object(test_agent, "arun", new_callable=AsyncMock) as mock_arun:
             mock_arun.return_value = _mock_run_output()
@@ -255,9 +256,7 @@ class TestServiceAccountLifecycleWithJWT:
         minted_id = minted.json()["id"]
 
         # The admin PAT can revoke without needing service_accounts:delete.
-        revoke = jwt_client.delete(
-            f"/service-accounts/{minted_id}", headers={"Authorization": f"Bearer {admin_pat}"}
-        )
+        revoke = jwt_client.delete(f"/service-accounts/{minted_id}", headers={"Authorization": f"Bearer {admin_pat}"})
         assert revoke.status_code == 204, revoke.text
 
 

--- a/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
+++ b/libs/agno/tests/unit/os/routers/test_service_accounts_router.py
@@ -22,6 +22,7 @@ def _make_account_dict(**overrides):
     d = {
         "id": "sa-1",
         "name": "claude-code",
+        "user_id": "admin-user",
         "token_hash": "a" * 64,
         "token_prefix": "agno_pat_abc1234",
         "scopes": list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
@@ -107,6 +108,34 @@ class TestCreateServiceAccount:
         stored = mock_db.create_service_account.call_args.args[0]
         assert body["token"] not in str(stored)
         assert stored["token_hash"] != body["token"]
+
+    def test_mint_records_owner_and_creator(self, mock_db, settings):
+        """A JWT-authenticated mint stamps both user_id (ownership) and created_by (audit)."""
+        app = FastAPI()
+
+        @app.middleware("http")
+        async def set_authenticated_user(request, call_next):
+            request.state.authenticated = True
+            request.state.user_id = "alice"
+            return await call_next(request)
+
+        app.include_router(get_service_accounts_router(os_db=mock_db, settings=settings))
+        response = TestClient(app).post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["user_id"] == "alice"
+        assert body["created_by"] == "alice"
+        stored = mock_db.create_service_account.call_args.args[0]
+        assert stored["user_id"] == "alice"
+        assert stored["created_by"] == "alice"
+
+    def test_mint_without_user_context_leaves_owner_unset(self, client, mock_db):
+        """A root minted without a user context (os_security_key) has no owning user."""
+        response = client.post("/service-accounts", json={"name": "claude-code"})
+        assert response.status_code == 201
+        assert response.json()["user_id"] is None
+        stored = mock_db.create_service_account.call_args.args[0]
+        assert stored["user_id"] is None
 
     def test_custom_expiry(self, client):
         response = client.post("/service-accounts", json={"name": "cursor", "expires_in_days": 7})

--- a/libs/agno/tests/unit/os/test_service_accounts.py
+++ b/libs/agno/tests/unit/os/test_service_accounts.py
@@ -42,6 +42,7 @@ def _account_row(
     return {
         "id": "sa-id-1",
         "name": name,
+        "user_id": "admin-user",
         "token_hash": token_hash,
         "token_prefix": "agno_pat_abc1234",
         "scopes": list(DEFAULT_SERVICE_ACCOUNT_SCOPES),


### PR DESCRIPTION
## Summary

Adds a nullable `user_id` ownership column to the service-account schema, stamped at mint time from the authenticated principal. Follow-up to the Slack discussion on user isolation: the DB adapters fail closed on missing columns (`is_valid_table` -> `ValueError`, no auto-ALTER path), so adding this after 2.7 GA would force a real migration on every deployment. Adding it now, while service accounts are still pre-release, makes it free for the GA audience.

**Semantics**
- `user_id` = ownership: the user the account belongs to. This is what the 3.0 user-isolation work will key on (e.g. Bob cannot see Alice's tokens or their sessions).
- `created_by` = audit: who minted the token. Today the two carry the same value; they diverge once admins can mint for other users.
- `NULL` = workspace-level machine account with no owning user (e.g. minted via `OS_SECURITY_KEY` with no user context).

No read-path or enforcement behavior yet - that lands with the 3.0 user-management pack. Runs made with a PAT keep the `sa:<name>` principal.

**Changes**
- `db/schemas/service_accounts.py`: `user_id` on the `ServiceAccount` dataclass, `to_dict`, `from_dict`.
- `db/postgres/schemas.py`, `db/sqlite/schemas.py`: `user_id` column, placed in the identity block right after `name` (matching the `sessions`/`memories` convention; column order is frozen per-table at creation, so position had to be picked now).
- `os/routers/service_accounts/router.py`: mint stamps `user_id` from `request.state.user_id`, alongside `created_by`.
- `os/routers/service_accounts/schema.py`: `user_id` exposed on `ServiceAccountResponse` with a description distinguishing it from `created_by`.
- No adapter changes needed: all four adapters insert the full `to_dict()` dict.
- agnoctl untouched: its client picks response fields explicitly, so the new field is additive.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests:** new unit tests cover both mint paths (JWT mint stamps owner + creator; security-key mint with no user context leaves owner `NULL`), plus round-trip assertions in the sqlite/postgres DB integration tests and the JWT lifecycle integration test. Full `unit/os` suite green (1532 passed), postgres integration 4/4 against pgvector.

**Alpha heads-up:** anyone on the 2.7 alphas with an existing `agno_service_accounts` table will hit the fail-closed schema check on upgrade and needs to drop the table. Fine at alpha - exactly the pain this PR spares GA users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
