### PR TITLE
fix: decouple SA verifier from db presence

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1123,12 +1123,6 @@ class AgentOS:
         if self._internal_service_token:
             fastapi_app.state.internal_service_token = self._internal_service_token
 
-        # Expose the service account verifier for the auth dependency and any
-        # manually added JWTMiddleware.
-        service_account_verifier = self._get_service_account_verifier()
-        if service_account_verifier is not None:
-            fastapi_app.state.service_account_verifier = service_account_verifier
-
         # Install the single auth layer whenever any credential is configured. It
         # covers the REST routes and the mounted /mcp app together (one middleware on
         # the parent app), so the mounted sub-app carries no auth code of its own.
@@ -1143,7 +1137,17 @@ class AgentOS:
                     "With authorization=True, only JWT authorization will be used. "
                     "Consider removing OS_SECURITY_KEY from your environment."
                 )
-        if self.authorization or jwt_env_configured or security_key or service_account_verifier is not None:
+
+        # SAs ride on top of a base auth mechanism -- only provision the verifier when JWT
+        # or a security key is configured. PATs cannot be minted without JWT anyway, so
+        # provisioning it on a db-only instance is dead weight AND traps stale ``agno_pat_``
+        # tokens in clients into 401s on an otherwise-open server.
+        auth_configured = bool(self.authorization or jwt_env_configured or security_key)
+        service_account_verifier = self._get_service_account_verifier() if auth_configured else None
+        if service_account_verifier is not None:
+            fastapi_app.state.service_account_verifier = service_account_verifier
+
+        if auth_configured:
             # In JWT mode the security key is ignored (JWT takes precedence), matching
             # get_effective_auth_mode; pass None so the middleware doesn't fall back to it.
             effective_key = None if (self.authorization or jwt_env_configured) else security_key

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -977,18 +977,25 @@ async def test_pat_without_db_gets_service_accounts_disabled_401():
     assert response.json()["detail"] == "Service accounts are not enabled on this AgentOS instance"
 
 
-async def test_open_mode_with_db_stays_open_but_verifies_pats(tmp_path):
-    """No security key: requests without a PAT pass through (open, matching REST), but a
-    presented PAT is still verified and rejected when invalid."""
+async def test_open_mode_with_db_stays_open_and_ignores_stale_pats(tmp_path):
+    """A db-only AgentOS (no security key, no JWT) does NOT provision the SA verifier:
+    the operator did not configure auth, so no auth layer runs.
+
+    Regression: before this behaviour changed, ``AgentOS(db=db)`` silently attached the
+    verifier and installed the AuthMiddleware; a stale ``agno_pat_...`` in a client would
+    then 401 an instance the operator meant to be open. Now stale PATs are ignored --
+    same as any other bearer on an open instance.
+    """
     db = _sqlite_db(tmp_path)
     async with _mcp_http_client(_auth_os(security_key=None, db=db)) as client:
         open_response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_MCP_HEADERS)
-        bad_pat_response = await client.post(
+        stale_pat_response = await client.post(
             "/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_invalid00000000000")
         )
     assert open_response.status_code == 200
-    assert bad_pat_response.status_code == 401
-    assert bad_pat_response.json()["detail"] == "Invalid or expired service account token"
+    # Stale PAT passes through anonymously on an open instance -- the verifier was never
+    # provisioned (no base auth mechanism configured), so nothing is looking at the token.
+    assert stale_pat_response.status_code == 200
 
 
 def test_no_auth_mode_installs_no_auth_layer():

--- a/libs/agno/tests/unit/os/test_service_account_verifier_provisioning.py
+++ b/libs/agno/tests/unit/os/test_service_account_verifier_provisioning.py
@@ -1,0 +1,97 @@
+"""Provisioning of the service-account verifier is decoupled from db presence.
+
+Previously the verifier was created whenever an AgentOS had a db, which meant a
+stale ``agno_pat_...`` in a browser could 401 an otherwise-open instance because
+"I have a db" was silently being read as "I want PAT auth". The verifier is now
+only provisioned when the operator actually configured a base auth mechanism
+(JWT or security key).
+"""
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+from agno.os.config import AuthorizationConfig
+from agno.os.settings import AgnoAPISettings
+
+
+JWT_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture(autouse=True)
+def clean_auth_env(monkeypatch):
+    monkeypatch.delenv("OS_SECURITY_KEY", raising=False)
+    monkeypatch.delenv("JWT_VERIFICATION_KEY", raising=False)
+    monkeypatch.delenv("JWT_JWKS_FILE", raising=False)
+
+
+@pytest.fixture
+def sqlite_db(tmp_path):
+    return SqliteDb(db_file=str(tmp_path / "provisioning.db"))
+
+
+def _agent():
+    return Agent(id="a", name="a", telemetry=False)
+
+
+class TestSAVerifierProvisioning:
+    def test_db_alone_does_not_install_verifier(self, sqlite_db):
+        """Regression: db + no auth = no verifier on app.state, no auth middleware.
+
+        Before this fix, AgentOS(agents=[...], db=db) would silently attach a
+        service-account verifier to app.state and install the AuthMiddleware to
+        run it -- meaning a stale ``agno_pat_...`` in a client would 401 even
+        though the operator never configured auth.
+        """
+        os_instance = AgentOS(agents=[_agent()], db=sqlite_db, telemetry=False)
+        app = os_instance.get_app()
+        assert getattr(app.state, "service_account_verifier", None) is None
+
+    def test_authorization_true_installs_verifier(self, sqlite_db):
+        os_instance = AgentOS(
+            agents=[_agent()],
+            db=sqlite_db,
+            telemetry=False,
+            authorization=True,
+            authorization_config=AuthorizationConfig(verification_keys=[JWT_SECRET], algorithm="HS256"),
+        )
+        app = os_instance.get_app()
+        assert getattr(app.state, "service_account_verifier", None) is not None
+
+    def test_security_key_installs_verifier(self, sqlite_db):
+        os_instance = AgentOS(
+            agents=[_agent()],
+            db=sqlite_db,
+            telemetry=False,
+            settings=AgnoAPISettings(os_security_key="root-key"),
+        )
+        app = os_instance.get_app()
+        assert getattr(app.state, "service_account_verifier", None) is not None
+
+    def test_jwt_env_var_installs_verifier(self, sqlite_db, monkeypatch):
+        """Env-var-configured JWT (manual middleware path) auto-enables the verifier."""
+        monkeypatch.setenv("JWT_VERIFICATION_KEY", JWT_SECRET)
+        os_instance = AgentOS(agents=[_agent()], db=sqlite_db, telemetry=False)
+        app = os_instance.get_app()
+        assert getattr(app.state, "service_account_verifier", None) is not None
+
+
+class TestOpenInstanceStaysOpen:
+    def test_no_auth_middleware_on_db_only_instance(self, sqlite_db):
+        """The AuthMiddleware itself must not install when only a db is present.
+
+        Ayush's symptom: stale ``agno_pat_...`` in browser -> 401 -> confused user.
+        Root cause: AuthMiddleware installed to run the verifier. Fix: don't install
+        the middleware at all when the operator did not opt into auth.
+        """
+        from agno.os.middleware.jwt import AuthMiddleware
+
+        os_instance = AgentOS(agents=[_agent()], db=sqlite_db, telemetry=False)
+        app = os_instance.get_app()
+
+        auth_middleware_present = any(
+            isinstance(getattr(mw, "cls", None), type) and issubclass(mw.cls, AuthMiddleware)
+            for mw in app.user_middleware
+        )
+        assert not auth_middleware_present


### PR DESCRIPTION
## Summary

`AgentOS(agents=[...], db=db)` — with no `authorization=True`, no `os_security_key`, and no JWT env vars — was silently installing the AuthMiddleware and provisioning a service-account verifier. That produced surprising, hard-to-diagnose behavior: an otherwise-open instance would 401 any client that happened to send a stale `agno_pat_...` bearer token from a previous session.

Reported when a frontend that had been talking to a JWT-enabled dev instance kept its `agno_pat_...` in localStorage, then reconnected to the same OS after auth was removed. Every request 401'd because the verifier was still on `app.state` and rejected the (now-unknown) PAT.

## Root cause

Two spots in `AgentOS._prepare_app` had the wrong trigger condition. Both keyed off "does a service-account verifier exist" rather than "did the operator configure a base auth mechanism":

```python
# Before
service_account_verifier = self._get_service_account_verifier()   # runs whenever db is set
if self.authorization or jwt_env_configured or security_key or service_account_verifier is not None:
    self._add_auth_middleware(...)
```

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
