### PR TITLE
fix: dedup MCP AgentOS config databases and guard get_db against no database

### DIFF
--- a/cookbook/05_agent_os/mcp_demo/custom_mcp_tool_example.py
+++ b/cookbook/05_agent_os/mcp_demo/custom_mcp_tool_example.py
@@ -2,7 +2,7 @@
 AgentOS app that exposes ONE custom MCP tool routed through an agent, with the
 built-in MCP tools disabled and the server gated to its owner.
 
-This is the "one tool" shape: instead of the ~19 built-in AgentOS tools, the MCP
+This is the "one tool" shape: instead of the 8 built-in AgentOS tools, the MCP
 server at /mcp exposes a single purpose-built tool that routes the caller's
 question through a dedicated agent. Useful when you want to expose an AgentOS
 agent as a single, well-scoped, owner-only MCP tool for another product to call.
@@ -73,7 +73,7 @@ agent_os = AgentOS(
     enable_mcp_server=True,
     mcp_config=MCPServerConfig(
         tools=[ask_workspace],  # register our custom tool
-        enable_builtin_tools=False,  # ship ONLY our tool (disable the ~19 built-ins)
+        enable_builtin_tools=False,  # ship ONLY our tool (disable the 8 built-ins)
         # owner-only: 401 before the model runs
         authorize=lambda user_id: user_id in OWNER_IDS,
         # DNS-rebinding protection; localhost is allowed out of the box, add your deploy host

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -53,8 +53,8 @@ class MCPServerConfig(BaseModel):
     # When ``include_tags`` is set, only built-ins carrying one of those tags are registered.
     # ``exclude_tags`` is then subtracted. Both are ignored when ``enable_builtin_tools`` is False.
     # Typed as ``MCPBuiltinTag`` (a ``Literal``) so the IDE autocompletes the values and pydantic
-    # rejects typos at construction with a message like "Input should be 'core', 'session' or
-    # 'memory'" -- otherwise an unknown tag would silently produce an empty server.
+    # rejects typos at construction with a message like "Input should be 'core' or 'session'"
+    # -- otherwise an unknown tag would silently produce an empty server.
     include_tags: Optional[Set[MCPBuiltinTag]] = None
     exclude_tags: Optional[Set[MCPBuiltinTag]] = None
 

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -11,7 +11,7 @@ from fastmcp import Context, FastMCP
 from fastmcp.server.http import (
     StarletteWithLifespan,
 )
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 
 from agno.db.base import SessionType
 from agno.os.mcp_results import build_run_tool_result, trim_session_run
@@ -735,7 +735,9 @@ def build_mcp_server(
         return {
             "os_id": os.id or "AgentOS",
             "description": os.description,
-            "databases": [db.id for db_list in os.dbs.values() for db in db_list],
+            # A db shared by several components is registered once per component in os.dbs,
+            # so collect the ids into a set to list each database once -- matching the REST /config route.
+            "databases": list({db.id for db_id, dbs in os.dbs.items() for db in dbs}),
             "agents": agents_out,
             "teams": teams_out,
             "workflows": workflows_out,

--- a/libs/agno/agno/os/mcp_results.py
+++ b/libs/agno/agno/os/mcp_results.py
@@ -121,7 +121,7 @@ def build_run_tool_result(run_output: AnyRunOutput, result_mode: str = "trimmed"
     ``to_dict()`` (media base64-encoded there — no separate media blocks, so large
     payloads are not shipped twice).
     """
-    from fastmcp.tools.tool import ToolResult
+    from fastmcp.tools import ToolResult
 
     text = _content_text(run_output)
     if not text and getattr(run_output, "is_paused", False):

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -311,8 +311,13 @@ async def get_db(
             status_code=400, detail="The db_id query parameter is required when using multiple databases"
         )
 
+    # Raise if no database is registered (an empty dict, or ids mapped to empty lists)
+    all_dbs = [db for db_list in dbs.values() for db in db_list]
+    if not all_dbs:
+        raise HTTPException(status_code=400, detail="No database is configured on this AgentOS")
+
     # Return the first (and only) database
-    return next(db for dbs in dbs.values() for db in dbs)
+    return all_dbs[0]
 
 
 def _generate_knowledge_id(name: str, db_id: str, table_name: str) -> str:


### PR DESCRIPTION
## Summary

Small correctness fixes to the AgentOS MCP interface (v2) and the shared `get_db` helper it relies on. The happy path is unchanged; this covers two edge cases plus three doc/cleanup items.

- **`get_agentos_config` lists each database once.** A database shared by several components is registered once per component in `os.dbs`, so the tool returned duplicate ids (e.g. `["pg", "pg", "pg"]`). It now collects the ids into a set — the same expression the REST `/config` route already uses in `os/router.py` — so the MCP config tool and the REST route agree.
- **`get_db` returns a clear `400` when no database is configured.** With no database, `os.dbs` is empty and the old `next(...)` raised a bare `StopIteration`, which inside an `async` function surfaces as the opaque `RuntimeError: coroutine raised StopIteration`. It now raises `HTTPException(400, "No database is configured on this AgentOS")`. This also covers an id mapped to an empty list, and drops a loop variable that shadowed the `dbs` parameter.
- **Import `ToolResult` from the stable `fastmcp.tools` path** instead of the `fastmcp.tools.tool` compatibility shim (which fastmcp plans to remove), matching the existing `from fastmcp.tools import Tool` import in the same module.
- **Docs:** correct a stale `MCPBuiltinTag` comment that still listed the removed `memory` tag, and update the custom-MCP-tool cookbook's built-in count (~19 to 8).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verified against a real FastMCP client (in-memory and over HTTP) with a real Postgres:

- No database configured -> the MCP session tools and the REST session/memory routes return a clear `400` instead of the opaque `coroutine raised StopIteration`.
- One database shared by three components -> `get_agentos_config` returns `["pg"]`, matching REST `/config`.

The full MCP test surface was run for regressions (12 files, 402 tests) with no failures, and `./scripts/validate.sh` (ruff + whole-repo mypy) passes. No new unit test was added for the two edge cases; they are exercised by the existing MCP suite plus the manual real-client verification above.
