### PR TITLE
fix: whitelist mutable columns in update_service_account

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -1271,6 +1271,9 @@ class BaseDb(ABC):
     ) -> Optional[Dict[str, Any]]:
         """Update a service account by ID (e.g. set revoked_at or last_used_at).
 
+        Only SERVICE_ACCOUNT_MUTABLE_COLUMNS may be updated; any other column, an
+        empty update, or resetting revoked_at to None raises ValueError.
+
         With return_record=False the post-update re-fetch is skipped and None is
         returned on success too — for callers that discard the row (last_used touches).
         """
@@ -2160,7 +2163,11 @@ class AsyncBaseDb(ABC):
     async def update_service_account(
         self, service_account_id: str, return_record: bool = True, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
-        """Update a service account by ID (e.g. set revoked_at or last_used_at)."""
+        """Update a service account by ID (e.g. set revoked_at or last_used_at).
+
+        Only SERVICE_ACCOUNT_MUTABLE_COLUMNS may be updated; any other column, an
+        empty update, or resetting revoked_at to None raises ValueError.
+        """
         raise NotImplementedError
 
     async def delete_service_account(self, service_account_id: str) -> bool:

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -25,7 +25,10 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.service_accounts import resolve_service_account_sort_column
+from agno.db.schemas.service_accounts import (
+    resolve_service_account_sort_column,
+    validate_service_account_update,
+)
 from agno.db.utils import deserialize_session, deserialize_sessions, json_serializer
 from agno.run.base import RunStatus
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
@@ -3998,6 +4001,7 @@ class AsyncPostgresDb(AsyncBaseDb):
     async def update_service_account(
         self, service_account_id: str, return_record: bool = True, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
+        validate_service_account_update(kwargs)
         try:
             table = await self._get_table(table_type="service_accounts")
             if table is None:

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -25,7 +25,10 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.service_accounts import resolve_service_account_sort_column
+from agno.db.schemas.service_accounts import (
+    resolve_service_account_sort_column,
+    validate_service_account_update,
+)
 from agno.db.utils import deserialize_session, deserialize_sessions, json_serializer
 from agno.run.base import RunStatus
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
@@ -5352,6 +5355,7 @@ class PostgresDb(BaseDb):
     def update_service_account(
         self, service_account_id: str, return_record: bool = True, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
+        validate_service_account_update(kwargs)
         try:
             table = self._get_table(table_type="service_accounts")
             if table is None:

--- a/libs/agno/agno/db/schemas/service_accounts.py
+++ b/libs/agno/agno/db/schemas/service_accounts.py
@@ -20,6 +20,33 @@ def resolve_service_account_sort_column(sort_by: str) -> str:
     return sort_by if sort_by in SERVICE_ACCOUNT_SORTABLE_COLUMNS else "created_at"
 
 
+# Columns update_service_account may modify. Everything else is immutable after creation:
+# identity (id, name), credentials (token_hash, token_prefix), authorization (scopes,
+# user_id) and audit fields (created_at, created_by) — changing any of them would rebind
+# or rescope an already-minted token. Shared by every DB backend's update_service_account
+# so the guardrail cannot drift between them.
+SERVICE_ACCOUNT_MUTABLE_COLUMNS = frozenset({"last_used_at", "revoked_at"})
+
+
+def validate_service_account_update(updates: Dict[str, Any]) -> None:
+    """Reject an update payload that is empty, touches an immutable column, or un-revokes.
+
+    Raises ValueError so misuse fails loudly at the call site instead of reaching the
+    database (or being swallowed by an adapter's catch-all error handling).
+    """
+    if not updates:
+        raise ValueError("update_service_account requires at least one column to update")
+    disallowed = set(updates) - SERVICE_ACCOUNT_MUTABLE_COLUMNS
+    if disallowed:
+        raise ValueError(
+            f"update_service_account cannot modify {sorted(disallowed)}: "
+            f"only {sorted(SERVICE_ACCOUNT_MUTABLE_COLUMNS)} are mutable; "
+            "revoke the account and mint a new token instead"
+        )
+    if updates.get("revoked_at", ...) is None:
+        raise ValueError("revocation is one-way: revoked_at cannot be reset to None")
+
+
 @dataclass
 class ServiceAccount:
     """Model for a service account: a machine identity authenticated by an opaque token."""

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -16,7 +16,10 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.service_accounts import resolve_service_account_sort_column
+from agno.db.schemas.service_accounts import (
+    resolve_service_account_sort_column,
+    validate_service_account_update,
+)
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.db.sqlite.utils import (
     abulk_upsert_metrics,
@@ -4185,6 +4188,7 @@ class AsyncSqliteDb(AsyncBaseDb):
     async def update_service_account(
         self, service_account_id: str, return_record: bool = True, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
+        validate_service_account_update(kwargs)
         try:
             table = await self._get_table(table_type="service_accounts")
             if table is None:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -14,7 +14,10 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
-from agno.db.schemas.service_accounts import resolve_service_account_sort_column
+from agno.db.schemas.service_accounts import (
+    resolve_service_account_sort_column,
+    validate_service_account_update,
+)
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.db.sqlite.utils import (
     apply_sorting,
@@ -5203,6 +5206,7 @@ class SqliteDb(BaseDb):
     def update_service_account(
         self, service_account_id: str, return_record: bool = True, **kwargs: Any
     ) -> Optional[Dict[str, Any]]:
+        validate_service_account_update(kwargs)
         try:
             table = self._get_table(table_type="service_accounts")
             if table is None:

--- a/libs/agno/tests/integration/db/postgres/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/postgres/test_service_accounts.py
@@ -97,3 +97,28 @@ class TestServiceAccountsTable:
 
         accounts, _ = postgres_db_real.get_service_accounts(sort_by="name", sort_order="asc")
         assert [account["name"] for account in accounts] == ["account-0", "account-1", "account-2"]
+
+    def test_update_guardrails(self, postgres_db_real):
+        postgres_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+
+        # Immutable columns are rejected before reaching the database
+        with pytest.raises(ValueError, match="cannot modify"):
+            postgres_db_real.update_service_account("sa-1", token_hash="attacker-hash")
+        with pytest.raises(ValueError, match="cannot modify"):
+            postgres_db_real.update_service_account("sa-1", name="other", last_used_at=int(time.time()))
+
+        # Empty updates are rejected
+        with pytest.raises(ValueError, match="at least one column"):
+            postgres_db_real.update_service_account("sa-1")
+
+        # Revocation is one-way
+        postgres_db_real.update_service_account("sa-1", revoked_at=int(time.time()))
+        with pytest.raises(ValueError, match="one-way"):
+            postgres_db_real.update_service_account("sa-1", revoked_at=None)
+
+        # The record survived every rejected update untouched
+        account = postgres_db_real.get_service_account("sa-1")
+        assert account is not None
+        assert account["token_hash"] == "hash-1"
+        assert account["name"] == "claude-code"
+        assert account["revoked_at"] is not None

--- a/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
+++ b/libs/agno/tests/integration/db/sqlite/test_service_accounts.py
@@ -108,3 +108,28 @@ class TestServiceAccountsTable:
 
         accounts, _ = sqlite_db_real.get_service_accounts(sort_by="name", sort_order="asc")
         assert [account["name"] for account in accounts] == ["account-0", "account-1", "account-2"]
+
+    def test_update_guardrails(self, sqlite_db_real):
+        sqlite_db_real.create_service_account(_account("sa-1", "claude-code", "hash-1"))
+
+        # Immutable columns are rejected before reaching the database
+        with pytest.raises(ValueError, match="cannot modify"):
+            sqlite_db_real.update_service_account("sa-1", token_hash="attacker-hash")
+        with pytest.raises(ValueError, match="cannot modify"):
+            sqlite_db_real.update_service_account("sa-1", name="other", last_used_at=int(time.time()))
+
+        # Empty updates are rejected
+        with pytest.raises(ValueError, match="at least one column"):
+            sqlite_db_real.update_service_account("sa-1")
+
+        # Revocation is one-way
+        sqlite_db_real.update_service_account("sa-1", revoked_at=int(time.time()))
+        with pytest.raises(ValueError, match="one-way"):
+            sqlite_db_real.update_service_account("sa-1", revoked_at=None)
+
+        # The record survived every rejected update untouched
+        account = sqlite_db_real.get_service_account("sa-1")
+        assert account is not None
+        assert account["token_hash"] == "hash-1"
+        assert account["name"] == "claude-code"
+        assert account["revoked_at"] is not None

--- a/libs/agno/tests/unit/db/test_service_accounts_schema.py
+++ b/libs/agno/tests/unit/db/test_service_accounts_schema.py
@@ -1,0 +1,52 @@
+"""Unit tests for the shared service-account schema helpers."""
+
+import pytest
+
+from agno.db.schemas.service_accounts import (
+    SERVICE_ACCOUNT_MUTABLE_COLUMNS,
+    resolve_service_account_sort_column,
+    validate_service_account_update,
+)
+
+
+class TestValidateServiceAccountUpdate:
+    def test_mutable_columns_pass(self):
+        validate_service_account_update({"last_used_at": 1751000000})
+        validate_service_account_update({"revoked_at": 1751000000})
+        validate_service_account_update({"last_used_at": 1751000000, "revoked_at": 1751000000})
+
+    def test_empty_update_rejected(self):
+        with pytest.raises(ValueError, match="at least one column"):
+            validate_service_account_update({})
+
+    @pytest.mark.parametrize(
+        "column", ["id", "name", "user_id", "token_hash", "token_prefix", "scopes", "created_at", "created_by"]
+    )
+    def test_immutable_columns_rejected(self, column):
+        with pytest.raises(ValueError, match="cannot modify"):
+            validate_service_account_update({column: "new-value"})
+
+    def test_immutable_column_rejected_even_alongside_mutable_one(self):
+        with pytest.raises(ValueError, match="cannot modify"):
+            validate_service_account_update({"last_used_at": 1751000000, "token_hash": "attacker-hash"})
+
+    def test_unknown_column_rejected(self):
+        with pytest.raises(ValueError, match="cannot modify"):
+            validate_service_account_update({"no_such_column": 1})
+
+    def test_unrevoke_rejected(self):
+        with pytest.raises(ValueError, match="one-way"):
+            validate_service_account_update({"revoked_at": None})
+
+    def test_mutable_whitelist_is_minimal(self):
+        # The whitelist should only ever grow deliberately: it is exactly what
+        # the routers and the token verifier need today.
+        assert SERVICE_ACCOUNT_MUTABLE_COLUMNS == frozenset({"last_used_at", "revoked_at"})
+
+
+class TestResolveServiceAccountSortColumn:
+    def test_known_column_passes_through(self):
+        assert resolve_service_account_sort_column("name") == "name"
+
+    def test_unknown_column_clamped_to_default(self):
+        assert resolve_service_account_sort_column("token_hash") == "created_at"

--- a/libs/agno/tests/unit/os/test_service_account_verifier_provisioning.py
+++ b/libs/agno/tests/unit/os/test_service_account_verifier_provisioning.py
@@ -15,7 +15,6 @@ from agno.os import AgentOS
 from agno.os.config import AuthorizationConfig
 from agno.os.settings import AgnoAPISettings
 
-
 JWT_SECRET = "test-jwt-secret"
 
 


### PR DESCRIPTION
## Summary

Adds guardrails to `update_service_account`, addressing @ysolanky's review comment on #8747 (https://github.com/agno-agi/agno/pull/8747#discussion_r3529846190).

The function passed `**kwargs` verbatim into `table.update().values(**kwargs)`, so any column could be rewritten after a token was minted:

- `token_hash` / `token_prefix` — rebind the account to a different secret
- `revoked_at=None` — un-revoke a killed token
- `name`, `scopes`, `user_id` — change identity, authorization, or ownership
- `id`, `created_at`, `created_by` — rewrite audit fields

The only mutations any caller actually performs are the `last_used_at` touch (token verifier) and setting `revoked_at` (revoke endpoint), so the update surface is now clamped to exactly that.

**Changes:**

- `db/schemas/service_accounts.py`: new `SERVICE_ACCOUNT_MUTABLE_COLUMNS = {last_used_at, revoked_at}` whitelist and `validate_service_account_update()` helper — same shared-module pattern as the existing `SERVICE_ACCOUNT_SORTABLE_COLUMNS` sort whitelist, so the guardrail cannot drift between backends.
- All four adapters (`postgres`, `async_postgres`, `sqlite`, `async_sqlite`): call the validator **before** the catch-all `try`, so misuse raises `ValueError` loudly instead of being swallowed into a silent `return None`.
- Rejected outright: immutable columns, empty updates, and `revoked_at=None` (revocation is one-way at the DB layer — mint a new token instead).
- `db/base.py`: sync and async contract docstrings document the new behavior.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests** (all passing):

- New `tests/unit/db/test_service_accounts_schema.py` — 12 unit tests for the validator (immutable columns rejected, empty update rejected, un-revoke rejected, whitelist stays minimal).
- New `test_update_guardrails` in both `tests/integration/db/sqlite/test_service_accounts.py` and `tests/integration/db/postgres/test_service_accounts.py` — verifies the adapter wiring end-to-end and that a rejected update leaves the row untouched.
- Existing service-account suites: sqlite/postgres DB integration, unit OS verifier and router tests all pass.

**Pre-existing failure, not from this PR:** `tests/integration/os/test_service_accounts.py` fails 13/37 on a clean `feat/v2.7` checkout (b73b1736e) with `"Service accounts are not enabled on this AgentOS instance"` — identical failure count with and without this change. Looks introduced by #8778 (decouple SA verifier from db presence); flagging separately.

**Behavior note:** valid callers are unaffected. A `ValueError` can only be triggered by new code passing a disallowed column — it propagates instead of the old silent `return None`, which is the point of the guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
