### PR TITLE
fix: default-on MCP rebinding protection for open servers

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1115,20 +1115,27 @@ def _add_transport_security_middleware(
 
 
 def _mcp_server_is_open(os: "AgentOS") -> bool:
-    """True when /mcp serves anonymous callers: no JWT source and no security key.
+    """True when /mcp serves anonymous callers: no auth is effectively enforced.
 
-    Mirrors ``AuthMiddleware.dispatch``: with neither a JWT source nor a security key, a
-    request carrying no bearer token passes through unauthenticated. A service-account
-    verifier alone does NOT close this -- PATs are only checked when actually presented, so
-    a caller that sends none is still served. This is the one configuration a rebound web
-    page could drive, so it is the case that needs default transport security.
+    Delegates to :func:`get_effective_auth_mode` -- the same detection the auth layer and
+    ``/info`` use -- so this agrees with them on every mode: ``AgentOS(authorization=True)``,
+    JWT env vars, a manually installed ``JWTMiddleware`` on a ``base_app``, and the security
+    key all count as authenticated. Only when it returns "none" does /mcp answer requests
+    carrying no bearer token (a service-account verifier alone does NOT close that path --
+    PATs are checked only when presented). That anonymous case is the one a rebound web page
+    could drive, so it is the case that needs default transport security. Authenticated
+    deployments rely on the bearer token instead, so their deployed hostname is not gated.
     """
-    from os import getenv
+    from agno.os.auth import get_effective_auth_mode
 
-    settings = getattr(os, "settings", None)
-    security_key = bool(getattr(settings, "os_security_key", None)) if settings is not None else False
-    jwt_env = bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
-    return not (bool(getattr(os, "authorization", False)) or jwt_env or security_key)
+    return (
+        get_effective_auth_mode(
+            getattr(os, "settings", None),
+            bool(getattr(os, "authorization", False)),
+            getattr(os, "base_app", None),
+        )
+        == "none"
+    )
 
 
 def get_mcp_server(

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1112,6 +1112,23 @@ def _add_transport_security_middleware(
     mcp_app.add_middleware(_MCPTransportSecurityMiddleware)
 
 
+def _mcp_server_is_open(os: "AgentOS") -> bool:
+    """True when /mcp serves anonymous callers: no JWT source and no security key.
+
+    Mirrors ``AuthMiddleware.dispatch``: with neither a JWT source nor a security key, a
+    request carrying no bearer token passes through unauthenticated. A service-account
+    verifier alone does NOT close this -- PATs are only checked when actually presented, so
+    a caller that sends none is still served. This is the one configuration a rebound web
+    page could drive, so it is the case that needs default transport security.
+    """
+    from os import getenv
+
+    settings = getattr(os, "settings", None)
+    security_key = bool(getattr(settings, "os_security_key", None)) if settings is not None else False
+    jwt_env = bool(getenv("JWT_VERIFICATION_KEY") or getenv("JWT_JWKS_FILE"))
+    return not (bool(getattr(os, "authorization", False)) or jwt_env or security_key)
+
+
 def get_mcp_server(
     os: "AgentOS",
 ) -> StarletteWithLifespan:
@@ -1131,10 +1148,11 @@ def get_mcp_server(
     mcp_config: "Optional[MCPServerConfig]" = getattr(os, "mcp_config", None)
 
     # Use http_app for Streamable HTTP transport (modern MCP standard).
-    # fastmcp >= 3.4.3 adds a Host/Origin guard with localhost-only defaults,
-    # which 421s deployed hosts. Transport security on /mcp is opt-in via
-    # MCPServerConfig.allowed_hosts (middleware below), so disable the built-in
-    # guard where the parameter exists.
+    # fastmcp >= 3.4.3 adds a Host/Origin guard with localhost-only defaults, which 421s
+    # deployed hosts before our own middleware runs. Disable it where the parameter exists
+    # and run AgentOS's single validation engine instead (the transport-security middleware
+    # below), which protects open servers by default and lets deployed hosts opt in via
+    # MCPServerConfig.allowed_hosts.
     http_app_kwargs: Dict[str, Any] = {"path": "/mcp"}
     if "host_origin_protection" in inspect.signature(mcp.http_app).parameters:
         http_app_kwargs["host_origin_protection"] = False
@@ -1168,7 +1186,20 @@ def get_mcp_server(
             mcp_app.add_middleware(cls, *args, **kwargs)
 
     # Outermost: built-in DNS-rebinding protection (runs first, before auth and tools).
-    if mcp_config is not None and mcp_config.allowed_hosts is not None:
-        _add_transport_security_middleware(mcp_app, mcp_config.allowed_hosts, mcp_config.allowed_origins)
+    #
+    # A configured ``allowed_hosts`` always applies. On top of that, when the server is OPEN
+    # (no JWT and no security key, so /mcp answers anonymous callers) we default to
+    # localhost-only protection even without ``allowed_hosts`` -- this is the one config a
+    # rebound web page could drive, and it restores the safe default fastmcp's own guard gave
+    # before we disabled it. Authenticated deployments rely on the bearer token, which a
+    # rebinding attacker cannot supply, so protection there stays opt-in: their real hostname
+    # is not gated (the 421/400 regression the built-in guard caused) unless they set
+    # ``allowed_hosts`` themselves.
+    allowed_hosts = mcp_config.allowed_hosts if mcp_config is not None else None
+    allowed_origins = mcp_config.allowed_origins if mcp_config is not None else None
+    if allowed_hosts is None and _mcp_server_is_open(os):
+        allowed_hosts = []
+    if allowed_hosts is not None:
+        _add_transport_security_middleware(mcp_app, allowed_hosts, allowed_origins)
 
     return mcp_app

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -885,6 +885,28 @@ async def test_authenticated_server_does_not_gate_hosts_by_default():
     assert response.status_code == 200
 
 
+def test_manual_jwt_middleware_on_base_app_is_not_open():
+    """A base_app carrying a manually installed JWTMiddleware is authenticated, so /mcp must not
+    be treated as open: no default localhost host gate is added (its deployed hostname would
+    otherwise be 400'd). Mirrors get_effective_auth_mode / the /info auth-mode detection, which
+    both recognize the manual-middleware path."""
+    from fastapi import FastAPI
+
+    from agno.os.middleware.jwt import JWTMiddleware
+
+    base = FastAPI()
+    base.add_middleware(JWTMiddleware, validate=False)  # validate=False counts as a JWT key source
+    os = AgentOS(
+        agents=[_agent()],
+        base_app=base,
+        enable_mcp_server=True,
+        mcp_config=MCPServerConfig(tools=[_ok_tool], enable_builtin_tools=False),
+    )
+    assert mcp_mod._mcp_server_is_open(os) is False
+    names = [m.cls.__name__ for m in get_mcp_server(os).user_middleware]
+    assert "_MCPTransportSecurityMiddleware" not in names
+
+
 # ==================== Security key + service account auth (non-JWT modes) ====================
 
 # Router dependencies never run for mounted sub-apps, so in non-JWT modes /mcp gets its own

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -644,7 +644,10 @@ async def _mcp_http_client(os: AgentOS):
     app = os.get_app()
     async with app.router.lifespan_context(app):
         transport = httpx.ASGITransport(app=app)
-        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        # base_url sets the default Host header. Use localhost so the default-on
+        # rebinding protection for open servers allows it; host-gating tests override
+        # the Host explicitly to exercise the reject path.
+        async with httpx.AsyncClient(transport=transport, base_url="http://localhost") as client:
             yield client
 
 
@@ -859,10 +862,26 @@ async def test_transport_security_rejects_unknown_origin():
     assert "invalid_origin" in response.text
 
 
-async def test_no_transport_security_when_unset():
-    """Without allowed_hosts, no host validation is added (unchanged behavior)."""
+async def test_open_server_gets_default_rebinding_protection():
+    """An OPEN server (no JWT, no security key) with no allowed_hosts still gets localhost-only
+    protection by default: a rebound / non-localhost Host is rejected. This is the one config a
+    malicious web page could drive, so it must not serve anonymous cross-host requests."""
     async with _mcp_http_client(_security_os()) as client:
-        response = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_headers(host="anything.example.com"))
+        rejected = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_headers(host="evil.example.com"))
+        allowed = await client.post("/mcp", json=_MCP_INIT_BODY, headers=_headers(host="localhost:7777"))
+    assert rejected.status_code == 400
+    assert "invalid_host" in rejected.text
+    assert allowed.status_code == 200
+
+
+async def test_authenticated_server_does_not_gate_hosts_by_default():
+    """A server with auth configured relies on the bearer token to defeat rebinding, so its real
+    deployed hostname is not gated without allowed_hosts (no 421/400 regression). The security key
+    still guards the request; the Host itself passes."""
+    async with _mcp_http_client(_auth_os(security_key="test-key")) as client:
+        response = await client.post(
+            "/mcp", json=_MCP_INIT_BODY, headers={**_bearer("test-key"), "Host": "myapp.example.com"}
+        )
     assert response.status_code == 200
 
 


### PR DESCRIPTION
## Summary

Closes a DNS-rebinding gap in the MCP transport introduced on `feat/v2.7`.

Commit 22fc6000 ("disable fastmcp's built-in Host/Origin guard on /mcp") turned off fastmcp >= 3.4.3's always-on Host/Origin guard because its localhost-only defaults `421`ed deployed hosts (`agno connect verify` included). The intent was to route all host validation through AgentOS's own transport-security middleware. But that middleware only mounts when `MCPServerConfig.allowed_hosts` is set, and the default is `None`.

Net effect: an **open** MCP server — `AgentOS(enable_mcp_server=True)` with no `authorization`, no `OS_SECURITY_KEY`, and no `allowed_hosts` — lost all rebinding protection, where fastmcp previously defended it. On an open server, `/mcp` answers anonymous callers (`AuthMiddleware.dispatch` lets a tokenless request through when there is no JWT source and no security key; a service-account verifier alone does not close that path). So a malicious web page can rebind a hostname to `127.0.0.1` and drive the local server's tools.

### The fix

Re-enable localhost-only protection **by default for the open case only**, keyed on the same "no JWT and no security key" condition `AuthMiddleware` uses to admit anonymous requests:

- **Open server, no `allowed_hosts`** → localhost-only Host/Origin validation is applied automatically (a rebound / non-localhost Host is rejected with `400`). This restores fastmcp's safe default.
- **Authenticated server** (JWT or `OS_SECURITY_KEY`) → the bearer token already defeats rebinding, so the real deployed hostname stays **ungated** unless the operator opts in via `allowed_hosts`. This preserves the ergonomics 22fc6000 restored — no return of the `421`/`400` on deployed hosts.
- **Explicit `allowed_hosts`** → unchanged; always applied.

The change is contained to `get_mcp_server` plus a small `_mcp_server_is_open` helper; fastmcp's built-in guard stays disabled so there is still a single validation engine.

## Type of change

- [x] Bug fix
- [x] Breaking change (only for **open** servers: an open `/mcp` with no `allowed_hosts` now rejects non-localhost Hosts by default — see Additional Notes)

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — see note on pre-existing mypy errors below
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated — this PR was written with Claude Code assistance

---

## Additional Notes

**Base branch:** targets `feat/v2.7` (the change lives entirely on that feature branch).

**Security considerations:** this is a defense-in-depth fix for the local-dev-no-auth scenario. Production deployments with auth were never exposed (the token defeats rebinding), and they are unaffected by this change.

**Behavior change to be aware of:** an open server (no auth) that relied on serving arbitrary Hosts on `/mcp` will now get `400 invalid_host` for non-localhost Hosts. The intended posture for a non-localhost open deployment is to declare its host via `MCPServerConfig(allowed_hosts=[...])`. If you want to keep an open server reachable on a custom host without auth, set `allowed_hosts`.

**Tests:**
- `test_open_server_gets_default_rebinding_protection` — open server, no `allowed_hosts`: non-localhost Host → `400`, localhost → `200`.
- `test_authenticated_server_does_not_gate_hosts_by_default` — authed server: real deployed hostname passes (no gating).
- The shared `/mcp` test client now defaults its `Host` to `localhost`; host-gating tests override it explicitly. Full `test_mcp_server.py` suite green (57 passed).

**Follow-up (not in this PR):** `fastmcp` is unpinned, and the guard is disabled via `inspect.signature` sniffing for the `host_origin_protection` kwarg. If fastmcp renames that kwarg the sniff silently misses — failure mode is fail-*safe* (fastmcp's guard re-enables → `421` on deployed hosts, an availability not a security regression), but pinning `fastmcp` to a compatible range is worth a separate change.

**CI note:** `./scripts/validate.sh` reports 11 pre-existing mypy errors in unrelated Google/Anthropic/AWS model files (`gemini_interactions.py`, `gemini.py`, `claude.py`, `aws/claude.py`); these exist on `feat/v2.7` independent of this PR (verified by stashing this change). `os/mcp.py` type-checks clean and `ruff` passes.
