### PR TITLE
fix(reader): CSVReader treats str paths as file-like objects

### DIFF
--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -62,12 +62,16 @@ class CSVReader(Reader):
         return [ContentType.CSV]
 
     def read(
-        self, file: Union[Path, IO[Any]], delimiter: str = ",", quotechar: str = '"', name: Optional[str] = None
+        self,
+        file: Union[Path, str, IO[Any]],
+        delimiter: str = ",",
+        quotechar: str = '"',
+        name: Optional[str] = None,
     ) -> List[Document]:
         """Read a CSV file and return a list of documents.
 
         Args:
-            file: Path to CSV file or file-like object.
+            file: Path (or path string) to CSV file, or file-like object.
             delimiter: CSV field delimiter. Default is comma.
             quotechar: CSV quote character. Default is double quote.
             name: Optional name override for the document.
@@ -79,7 +83,8 @@ class CSVReader(Reader):
             FileNotFoundError: If the file path doesn't exist.
         """
         try:
-            if isinstance(file, Path):
+            if isinstance(file, (Path, str)):
+                file = Path(file)
                 if not file.exists():
                     raise FileNotFoundError(f"Could not find file: {file}")
                 log_debug(f"Reading: {file}")
@@ -126,7 +131,7 @@ class CSVReader(Reader):
 
     async def async_read(
         self,
-        file: Union[Path, IO[Any]],
+        file: Union[Path, str, IO[Any]],
         delimiter: str = ",",
         quotechar: str = '"',
         page_size: int = 1000,
@@ -135,7 +140,7 @@ class CSVReader(Reader):
         """Read a CSV file asynchronously, processing batches of rows concurrently.
 
         Args:
-            file: Path to CSV file or file-like object.
+            file: Path (or path string) to CSV file, or file-like object.
             delimiter: CSV field delimiter. Default is comma.
             quotechar: CSV quote character. Default is double quote.
             page_size: Number of rows per page for large files.
@@ -148,7 +153,8 @@ class CSVReader(Reader):
             FileNotFoundError: If the file path doesn't exist.
         """
         try:
-            if isinstance(file, Path):
+            if isinstance(file, (Path, str)):
+                file = Path(file)
                 if not file.exists():
                     raise FileNotFoundError(f"Could not find file: {file}")
                 log_debug(f"Reading async: {file}")

--- a/libs/agno/tests/unit/reader/test_csv_reader.py
+++ b/libs/agno/tests/unit/reader/test_csv_reader.py
@@ -67,6 +67,16 @@ def test_read_path(csv_reader, csv_file):
     assert documents[3].content == expected_content_4
 
 
+def test_read_str_path(csv_reader, csv_file):
+    documents = csv_reader.read(str(csv_file))
+
+    assert len(documents) == 4
+    assert documents[0].name == "test"
+
+    expected_content_1 = "name, age, city"
+    assert documents[0].content == expected_content_1
+
+
 def test_read_file_object(csv_reader):
     file_obj = io.BytesIO(SAMPLE_CSV.encode("utf-8"))
     file_obj.name = "memory.csv"
@@ -144,6 +154,15 @@ async def test_async_read_path(csv_reader, csv_file):
     assert documents[1].content == "John, 30, New York"
     assert documents[2].content == "Jane, 25, San Francisco"
     assert documents[3].content == "Bob, 40, Chicago"
+
+
+@pytest.mark.asyncio
+async def test_async_read_str_path(csv_reader, csv_file):
+    documents = await csv_reader.async_read(str(csv_file))
+
+    assert len(documents) == 4
+    assert documents[0].name == "test"
+    assert documents[0].content == "name, age, city"
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem
`CSVReader.read()` and `CSVReader.async_read()` silently return no documents when given a CSV path as a plain `str`, even though the reader's own docstring documents `reader.read("data.csv")` as valid usage. Instead of loading the file, it logs `Error reading <path>: 'str' object has no attribute 'seek'`.

## Root cause
Both methods only special-case `Path` instances for local files (`libs/agno/agno/knowledge/reader/csv_reader.py`). A `str` path falls through to the file-like-object branch, which calls `file.seek(0)` — `str` has no `seek` method, so the read raises internally, gets caught by the generic `except Exception`, and returns `[]`.

This also affects `Knowledge` ingestion: `Knowledge._select_reader_by_uri()` picks `CSVReader` for `.csv` strings and `Knowledge._read()` forwards the `str` source straight to `reader.read()`, so a local `.csv` path/URI given as a string silently produces no documents.

## Fix
Normalize `str` the same way as `Path` in both `read()` and `async_read()`: `isinstance(file, (Path, str))` → wrap in `Path(file)` before the existing existence check and file-open logic. The file-like/`BytesIO` branch is untouched.

Added regression tests (`test_read_str_path`, `test_async_read_str_path`) asserting a string path reads the same documents as a `Path`.

Fixes #8673