### PR TITLE
fix(reader): JSONReader chunk=False default is not applied

### DIFF
--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -21,6 +21,7 @@ class JSONReader(Reader):
         if chunking_strategy is None:
             chunk_size = kwargs.get("chunk_size", 5000)
             chunking_strategy = FixedSizeChunking(chunk_size=chunk_size)
+        kwargs.setdefault("chunk", False)
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -72,6 +72,28 @@ def test_chunking():
     assert all("chunk" in doc.meta_data for doc in documents)
 
 
+def test_default_chunk_is_false():
+    # JSONReader declares chunk: bool = False, so a plain instance should not chunk
+    reader = JSONReader()
+    assert reader.chunk is False
+
+
+def test_default_does_not_split_large_object(tmp_path):
+    # Large top-level objects should stay intact as valid JSON, not be chunked into fragments
+    json_path = tmp_path / "large.json"
+    test_data = [
+        {"id": 1, "text": "alpha " * 1200},
+        {"id": 2, "text": "beta " * 1200},
+    ]
+    json_path.write_text(json.dumps(test_data))
+
+    reader = JSONReader()
+    documents = reader.read(json_path)
+
+    assert len(documents) == 2
+    assert [json.loads(doc.content) for doc in documents] == test_data
+
+
 def test_file_not_found():
     reader = JSONReader()
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
## Problem
`JSONReader` declares `chunk: bool = False` as its default, but a plain `JSONReader()` instance actually chunks (`reader.chunk` is `True`). For large top-level JSON objects, this splits them into multiple text chunks whose content is no longer valid JSON, breaking any downstream code that expects `json.loads(doc.content)` to succeed. This also affects `Knowledge.insert(path="...json")`, which picks `JSONReader` by file suffix and calls `reader.read(path)` with default settings.

## Root cause
`JSONReader.__init__` (`libs/agno/agno/knowledge/reader/json_reader.py`) builds a `chunking_strategy` when none is given, then calls `super().__init__(chunking_strategy=chunking_strategy, **kwargs)` — but never passes `chunk=False`. The base `Reader.__init__` defaults `chunk=True`, so that default silently wins over the subclass's declared `chunk: bool = False`.

## Fix
`kwargs.setdefault("chunk", False)` before calling `super().__init__()`, so the reader's own default is honored while still letting callers pass `chunk=True` explicitly if they want chunking.

Added regression tests: `test_default_chunk_is_false` (asserts `JSONReader().chunk is False`) and `test_default_does_not_split_large_object` (asserts a large multi-object JSON file round-trips as valid JSON per document, not fragmented text).

Fixes #8679