### PR TITLE
fix: verify service-account PATs wherever a db exists, ignore unverifiable PATs on open instances

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1138,15 +1138,18 @@ class AgentOS:
                     "Consider removing OS_SECURITY_KEY from your environment."
                 )
 
-        # SAs ride on top of a base auth mechanism -- only provision the verifier when JWT
-        # or a security key is configured. PATs cannot be minted without JWT anyway, so
-        # provisioning it on a db-only instance is dead weight AND traps stale ``agno_pat_``
-        # tokens in clients into 401s on an otherwise-open server.
-        auth_configured = bool(self.authorization or jwt_env_configured or security_key)
-        service_account_verifier = self._get_service_account_verifier() if auth_configured else None
+        # The verifier is the *capability* to check ``agno_pat_`` tokens and exists
+        # whenever there is a db to verify against. It must be on app.state even when
+        # no auth is configured here: the WS authenticate action, the REST dependency,
+        # and any manually added JWTMiddleware all resolve it at request time. Whether
+        # a request is *required* to authenticate is a separate policy decision -- the
+        # middleware below only installs when the operator configured a base auth
+        # mechanism, so a db alone never locks an instance down.
+        service_account_verifier = self._get_service_account_verifier()
         if service_account_verifier is not None:
             fastapi_app.state.service_account_verifier = service_account_verifier
 
+        auth_configured = bool(self.authorization or jwt_env_configured or security_key)
         if auth_configured:
             # In JWT mode the security key is ignored (JWT takes precedence), matching
             # get_effective_auth_mode; pass None so the middleware doesn't fall back to it.

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -67,19 +67,34 @@ def get_auth_token_from_request(request: Request) -> Optional[str]:
     return None
 
 
-async def _authenticate_service_account(request: Request, token: str) -> bool:
-    """
-    Authenticate a service account token (agno_pat_...) outside the JWT middleware,
-    i.e. in os_security_key or open deployments.
+async def _authenticate_service_account(
+    request: Request, token: str, treat_unverifiable_as_anonymous: bool = False
+) -> bool:
+    """Verify a service account token (agno_pat_...) and attach its identity to the request.
 
-    Attaches the account identity to request.state exactly like the JWT middleware
-    does (user_id = the sa:<name> principal, scopes = the account's scopes) and
-    enforces the account's scopes against the default scope mappings. Service account
-    scopes are ACL data owned by this AgentOS instance, so - unlike JWT scopes - they
-    are enforced in every deployment mode.
+    Runs for requests that carry an ``agno_pat_`` bearer but were not already
+    authenticated by the auth middleware. On success, request.state gets the same
+    identity the middleware would attach (user_id = the ``sa:<name>`` principal,
+    the account's scopes) and the scopes are enforced against the route. Scope
+    enforcement is never skipped: service account scopes are ACL data owned by
+    this AgentOS instance, unlike JWT claims.
+
+    ``treat_unverifiable_as_anonymous`` selects what happens when the token can
+    NOT be verified (unknown, expired, revoked, or verification unavailable):
+
+    - ``False`` (instances with auth configured): the request is rejected.
+    - ``True`` (open instances -- no security key, no JWT): the token is ignored
+      and the request proceeds anonymously, the same as any other unrecognized
+      header on a server without auth. This keeps a stale token left behind in a
+      client from locking out an instance that has no auth on it.
+
+    A token that DOES verify is never ignored: it attributes the request and its
+    scopes apply, in both modes.
     """
     verifier = getattr(request.app.state, "service_account_verifier", None)
     if verifier is None:
+        if treat_unverifiable_as_anonymous:
+            return True
         raise HTTPException(status_code=401, detail="Service accounts are not enabled on this AgentOS instance")
 
     admin_scope_raw = getattr(request.app.state, "admin_scope", None)
@@ -95,7 +110,11 @@ async def _authenticate_service_account(request: Request, token: str) -> bool:
     if error is not None:
         status_code, detail, required_scopes = error
         if status_code == 403:
+            # The token verified, so the account's ACL applies: insufficient scopes
+            # reject the request even on an otherwise-open instance.
             raise HTTPException(status_code=403, detail=build_insufficient_permissions_detail(required_scopes))
+        if treat_unverifiable_as_anonymous:
+            return True
         raise HTTPException(status_code=status_code, detail=detail)
 
     return True
@@ -194,12 +213,18 @@ def get_authentication_dependency(settings: AgnoAPISettings):
         if getattr(request.state, "authenticated", False):
             return True
 
-        # Service account tokens (agno_pat_...) are verified and scope-checked in
-        # every deployment mode - including os_security_key mode and open dev
-        # instances, where they also provide run attribution.
+        # Service account tokens (agno_pat_...) are dispatched by prefix: they never
+        # reach the JWT validator or the security-key comparison below. With auth
+        # configured (security key or JWT), a PAT must verify or the request is
+        # rejected. On an open instance a PAT that verifies still provides
+        # attribution and scope enforcement, while one that cannot be verified is
+        # ignored like any other unrecognized header on a server without auth.
         token = credentials.credentials if credentials else None
         if token and token.startswith(SERVICE_ACCOUNT_TOKEN_PREFIX):
-            return await _authenticate_service_account(request, token)
+            instance_has_auth = bool(settings and settings.os_security_key) or _is_jwt_configured()
+            return await _authenticate_service_account(
+                request, token, treat_unverifiable_as_anonymous=not instance_has_auth
+            )
 
         # Also skip if JWT is configured via environment variables
         if _is_jwt_configured():

--- a/libs/agno/tests/integration/os/test_service_accounts.py
+++ b/libs/agno/tests/integration/os/test_service_accounts.py
@@ -166,11 +166,27 @@ class TestServiceAccountLifecycleWithJWT:
         assert response.json()["detail"] == UNIFORM_401_DETAIL
 
     def test_expired_pat_gets_same_uniform_401(self, jwt_client, sqlite_db):
-        admin_jwt = _make_jwt(["agent_os:admin"])
-        minted = _mint(jwt_client, admin_jwt).json()
-        sqlite_db.update_service_account(minted["id"], expires_at=int(time.time()) - 10)
+        # expires_at is immutable after mint (update_service_account whitelists only
+        # last_used_at/revoked_at), so simulate expiry by inserting an account that
+        # is already past its expiry, exactly as a real token ages out.
+        import uuid
 
-        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {minted['token']}"})
+        from agno.db.schemas.service_accounts import ServiceAccount
+        from agno.os.service_accounts import DEFAULT_SERVICE_ACCOUNT_SCOPES, generate_token
+
+        plaintext, token_hash, token_prefix = generate_token()
+        account = ServiceAccount(
+            id=str(uuid.uuid4()),
+            name="expired-sa",
+            token_hash=token_hash,
+            token_prefix=token_prefix,
+            scopes=list(DEFAULT_SERVICE_ACCOUNT_SCOPES),
+            created_at=int(time.time()) - 100,
+            expires_at=int(time.time()) - 10,
+        )
+        sqlite_db.create_service_account(account.to_dict())
+
+        response = jwt_client.get("/sessions", headers={"Authorization": f"Bearer {plaintext}"})
         assert response.status_code == 401
         assert response.json()["detail"] == UNIFORM_401_DETAIL
 
@@ -340,7 +356,9 @@ class TestServiceAccountsInSecurityKeyMode:
 
 
 class TestServiceAccountsOnOpenInstance:
-    """On an open dev instance PATs still verify and provide attribution."""
+    """On an open dev instance a PAT that verifies still attributes the request;
+    one that cannot be verified falls through to anonymous access (a stale token
+    in a client must never lock out an instance the operator never put auth on)."""
 
     @pytest.fixture
     def open_client(self, test_agent, sqlite_db):
@@ -380,9 +398,13 @@ class TestServiceAccountsOnOpenInstance:
         assert run_response.status_code == 200
         assert mock_arun.call_args.kwargs["user_id"] == "sa:claude-code"
 
-    def test_invalid_pat_rejected_even_on_open_instance(self, open_client):
+    def test_stale_pat_falls_through_anonymous_on_open_instance(self, open_client):
+        # A PAT that cannot be verified is ignored on an open instance: the request
+        # proceeds anonymously, exactly as if no token had been sent. This is what
+        # keeps a stale token left in a client (e.g. browser localStorage from a
+        # previously auth-enabled deployment) from locking out a server without auth.
         response = open_client.get("/sessions", headers={"Authorization": "Bearer agno_pat_invalid000000000000000000"})
-        assert response.status_code == 401
+        assert response.status_code == 200
 
 
 # A minimal MCP initialize request - enough to reach (or be blocked before) the MCP machinery.
@@ -466,10 +488,12 @@ class TestServiceAccountsOverMCP:
     def test_mcp_stays_open_without_security_key(self, mcp_open_client):
         assert self._mcp_post(mcp_open_client).status_code == 200
 
-    def test_mcp_rejects_invalid_pat_even_on_open_instance(self, mcp_open_client):
+    def test_mcp_ignores_pat_on_open_instance(self, mcp_open_client):
+        # No auth middleware installs on an open instance, and mounted sub-apps never
+        # run route dependencies, so /mcp sees the token but nothing inspects it: the
+        # request passes through anonymously (same stale-PAT tolerance as REST).
         response = self._mcp_post(mcp_open_client, token="agno_pat_invalid000000000000000000")
-        assert response.status_code == 401
-        assert response.json()["detail"] == UNIFORM_401_DETAIL
+        assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -553,7 +577,10 @@ class TestServiceAccountsOverWebSocket:
             patch("agno.os.router.handle_workflow_via_websocket", new_callable=AsyncMock) as handler,
             security_key_client.websocket_connect("/workflows/ws") as ws,
         ):
-            _ws_authenticate(ws, minted["token"])
+            # Assert the auth frame: on auth failure no identity frame ever arrives
+            # and the next receive_text() blocks the suite forever.
+            auth_frame = _ws_authenticate(ws, minted["token"])
+            assert auth_frame["event"] == "authenticated", auth_frame
             ws.receive_text()  # identity frame
             ws.send_text(json.dumps({"action": "start-workflow", "workflow_id": "wf", "message": "go"}))
             frame = json.loads(ws.receive_text())
@@ -568,7 +595,8 @@ class TestServiceAccountsOverWebSocket:
             patch("agno.os.router.handle_workflow_via_websocket", new_callable=AsyncMock) as handler,
             security_key_client.websocket_connect("/workflows/ws") as ws,
         ):
-            _ws_authenticate(ws, minted["token"])
+            auth_frame = _ws_authenticate(ws, minted["token"])
+            assert auth_frame["event"] == "authenticated", auth_frame
             ws.receive_text()  # identity frame
             ws.send_text(
                 json.dumps({"action": "start-workflow", "workflow_id": "wf", "message": "go", "user_id": "mallory"})
@@ -596,7 +624,8 @@ class TestServiceAccountsOverWebSocket:
         admin_jwt = _make_jwt(["agent_os:admin"])
         minted = _mint(jwt_client, admin_jwt, name="ws-jwt-limited", scopes=["sessions:read"]).json()
         with jwt_client.websocket_connect("/workflows/ws") as ws:
-            _ws_authenticate(ws, minted["token"])
+            auth_frame = _ws_authenticate(ws, minted["token"])
+            assert auth_frame["event"] == "authenticated", auth_frame
             ws.receive_text()  # identity frame
             ws.send_text(json.dumps({"action": "start-workflow", "workflow_id": "wf", "message": "go"}))
             frame = json.loads(ws.receive_text())

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -978,13 +978,12 @@ async def test_pat_without_db_gets_service_accounts_disabled_401():
 
 
 async def test_open_mode_with_db_stays_open_and_ignores_stale_pats(tmp_path):
-    """A db-only AgentOS (no security key, no JWT) does NOT provision the SA verifier:
-    the operator did not configure auth, so no auth layer runs.
+    """A db-only AgentOS (no security key, no JWT) installs no auth layer on /mcp.
 
-    Regression: before this behaviour changed, ``AgentOS(db=db)`` silently attached the
-    verifier and installed the AuthMiddleware; a stale ``agno_pat_...`` in a client would
-    then 401 an instance the operator meant to be open. Now stale PATs are ignored --
-    same as any other bearer on an open instance.
+    The verifier still lives on app.state (the WS authenticate action and manually
+    added JWTMiddleware resolve it at request time), but no middleware runs for the
+    mounted app, so a stale ``agno_pat_...`` in a client is ignored -- same as any
+    other bearer on an open instance.
     """
     db = _sqlite_db(tmp_path)
     async with _mcp_http_client(_auth_os(security_key=None, db=db)) as client:
@@ -993,8 +992,8 @@ async def test_open_mode_with_db_stays_open_and_ignores_stale_pats(tmp_path):
             "/mcp", json=_MCP_INIT_BODY, headers=_bearer("agno_pat_invalid00000000000")
         )
     assert open_response.status_code == 200
-    # Stale PAT passes through anonymously on an open instance -- the verifier was never
-    # provisioned (no base auth mechanism configured), so nothing is looking at the token.
+    # Stale PAT passes through anonymously: no auth middleware is installed on an
+    # open instance, so nothing is looking at the token.
     assert stale_pat_response.status_code == 200
 
 

--- a/libs/agno/tests/unit/os/test_service_account_verifier_provisioning.py
+++ b/libs/agno/tests/unit/os/test_service_account_verifier_provisioning.py
@@ -1,13 +1,16 @@
-"""Provisioning of the service-account verifier is decoupled from db presence.
+"""Service-account verifier capability vs auth-enforcement policy.
 
-Previously the verifier was created whenever an AgentOS had a db, which meant a
-stale ``agno_pat_...`` in a browser could 401 an otherwise-open instance because
-"I have a db" was silently being read as "I want PAT auth". The verifier is now
-only provisioned when the operator actually configured a base auth mechanism
-(JWT or security key).
+The verifier (the *capability* to check ``agno_pat_`` tokens) lives on app.state
+whenever the AgentOS has a db: the WS authenticate action, the REST dependency,
+and manually added JWTMiddleware all resolve it at request time. Enforcement is
+a separate decision: the auth middleware only installs when the operator
+configured a base auth mechanism (JWT or security key), and on an open instance
+an unverifiable PAT falls through to anonymous access. A stale ``agno_pat_...``
+in a browser must never 401 an instance the operator meant to be open.
 """
 
 import pytest
+from starlette.testclient import TestClient
 
 from agno.agent.agent import Agent
 from agno.db.sqlite import SqliteDb
@@ -35,17 +38,15 @@ def _agent():
 
 
 class TestSAVerifierProvisioning:
-    def test_db_alone_does_not_install_verifier(self, sqlite_db):
-        """Regression: db + no auth = no verifier on app.state, no auth middleware.
-
-        Before this fix, AgentOS(agents=[...], db=db) would silently attach a
-        service-account verifier to app.state and install the AuthMiddleware to
-        run it -- meaning a stale ``agno_pat_...`` in a client would 401 even
-        though the operator never configured auth.
+    def test_db_alone_exposes_verifier_without_enforcement(self, sqlite_db):
+        """A db is enough to *have* the verifier -- request-time consumers (the WS
+        authenticate action, manually added JWTMiddleware) need it even when
+        AgentOS itself installs no auth. Enforcement stays off: see
+        TestOpenInstanceStaysOpen for the no-middleware / stale-PAT-ignored pins.
         """
         os_instance = AgentOS(agents=[_agent()], db=sqlite_db, telemetry=False)
         app = os_instance.get_app()
-        assert getattr(app.state, "service_account_verifier", None) is None
+        assert getattr(app.state, "service_account_verifier", None) is not None
 
     def test_authorization_true_installs_verifier(self, sqlite_db):
         os_instance = AgentOS(
@@ -78,11 +79,9 @@ class TestSAVerifierProvisioning:
 
 class TestOpenInstanceStaysOpen:
     def test_no_auth_middleware_on_db_only_instance(self, sqlite_db):
-        """The AuthMiddleware itself must not install when only a db is present.
-
-        Ayush's symptom: stale ``agno_pat_...`` in browser -> 401 -> confused user.
-        Root cause: AuthMiddleware installed to run the verifier. Fix: don't install
-        the middleware at all when the operator did not opt into auth.
+        """The AuthMiddleware must not install when only a db is present: having
+        the means to verify tokens is not the same as requiring them. An instance
+        with no security key and no JWT stays open, db or not.
         """
         from agno.os.middleware.jwt import AuthMiddleware
 
@@ -94,3 +93,16 @@ class TestOpenInstanceStaysOpen:
             for mw in app.user_middleware
         )
         assert not auth_middleware_present
+
+    def test_stale_pat_ignored_on_open_rest_route(self, sqlite_db):
+        """End-to-end pin of the open-instance rule: a stale ``agno_pat_`` bearer
+        on a db-only (open) instance is ignored and the request proceeds
+        anonymously, exactly as if no token had been sent.
+        """
+        os_instance = AgentOS(agents=[_agent()], db=sqlite_db, telemetry=False)
+        client = TestClient(os_instance.get_app())
+
+        no_token = client.get("/agents")
+        stale_pat = client.get("/agents", headers={"Authorization": "Bearer agno_pat_stale00000000000000000000"})
+        assert no_token.status_code == 200
+        assert stale_pat.status_code == 200


### PR DESCRIPTION
## Summary

Service-account (PAT) authentication follows two rules that were previously conflated behind one gate. This PR separates them.

### Change 1 — the verifier is on `app.state` whenever the instance has a db (`os/app.py`)

The verifier answers one question: *is this `agno_pat_` token real?* The only thing it needs is a db to check against. Three consumers resolve it from `app.state` at request time:

- the WS `authenticate` action (`/workflows/ws`),
- the REST auth dependency,
- `JWTMiddleware` added manually via `app.add_middleware(...)` (the deployment style used when you want JWT config that `AgentOS(authorization=True)` doesn't express).

**When you hit this:** you run `AgentOS(agents=[...], db=db)` and wire JWT by adding the middleware yourself, or a WS client authenticates with a PAT in jwt mode. Without this change the verifier isn't on `app.state` in those setups, so every PAT — including freshly minted ones — is rejected as invalid.

Requiring auth remains a separate decision: the auth middleware still only installs when a security key or JWT is configured. A db alone never locks an instance down.

### Change 2 — open instances ignore PATs they cannot verify (`os/auth.py`)

With auth configured (security key or JWT), nothing changes: a PAT must verify or the request is rejected, fail-closed.

On an **open** instance (no security key, no JWT), the REST dependency's PAT branch now works like this:

- PAT **verifies** → request is attributed (`user_id = sa:<name>`) and the account's scopes are enforced. Presenting a live credential opts you into its ACL.
- PAT **cannot be verified** (unknown / expired / revoked / no db) → the token is ignored and the request proceeds anonymously, the same as any other unrecognized header on a server without auth.

**When you hit this:** a client holds a leftover token — typically a browser that last talked to a JWT-enabled dev instance and kept `agno_pat_...` in localStorage — and reconnects after auth was removed. Previously every request 401'd; now the instance behaves as what it is: open. (The flag implementing this is `treat_unverifiable_as_anonymous` on `_authenticate_service_account`.)

### Resulting semantics

| Surface | Open instance + unverifiable PAT | Open instance + valid PAT |
|---|---|---|
| REST | anonymous pass-through | authenticates + attributes, scopes enforced |
| MCP (mounted app, no middleware) | anonymous pass-through | anonymous pass-through |
| WS `authenticate` action | rejected (`auth_error`) | authenticates + attributes |

The WS row differs on purpose: `authenticate` is an explicit request to be authenticated, and answering "authenticated" without verifying — or silently ignoring the action — would let a client believe an identity it doesn't have. All three rows are pinned by tests.

### Test changes

- WS tests assert the `authenticated` frame before waiting for further frames. The identity frame is only sent after successful auth, so a test that skips the assert and calls `receive_text()` blocks forever when auth breaks — this is what wedged `test-agent-os` runs for hours. Now it fails in a second.
- The expired-PAT test inserts an account already past its expiry instead of mutating `expires_at` post-mint, which `update_service_account` correctly rejects (only `last_used_at`/`revoked_at` are mutable).
- Open-instance pins updated to the semantics above; provisioning unit tests pin verifier exposure, middleware absence, and the end-to-end stale-PAT behavior.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Context: #8778 introduced the conflation (verifier exposure gated on auth config), which broke the manual-middleware and WS PAT paths and left the stale-PAT lockout it targeted unfixed on REST (the dependency fail-closed with a different 401). This PR is the follow-up; the two code changes ship together because restoring the verifier without the anonymous fall-through would bring the lockout back.

Verified locally: service-accounts integration + provisioning + MCP unit files (99 passed), full `tests/unit/os` (1555 passed), auth-adjacent integration files (241 passed). Full-matrix Main Validation on this fix (pre-split branch, combined with the #8785 timeouts): 23/23 green, `test-agent-os` at 8.3 min — https://github.com/agno-agi/agno/actions/runs/28812027683

🤖 Generated with [Claude Code](https://claude.com/claude-code)