### PR TITLE
ci: bound every Main Validation job with timeout-minutes

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -24,6 +24,11 @@ concurrency:
 # provider-side tool_use_failed) while anything deterministically broken
 # still fails twice and stays red. Requires pytest-rerunfailures in every
 # job env that runs pytest.
+#
+# Every job also carries timeout-minutes so a hung provider stream fails the
+# job instead of wedging it until GitHub's 6-hour default. The ceiling is
+# 20 min, except the three jobs whose green runs are measured above that
+# (test-google, test-teams-3, test-knowledge-1: 30 min).
 env:
   PYTEST_ADDOPTS: "--reruns 1"
 
@@ -31,6 +36,7 @@ jobs:
   # Run tests for OpenAI
   test-openai:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -56,6 +62,7 @@ jobs:
   # Run tests for Google
   test-google:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # Green runs regularly reach ~22 min
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -82,6 +89,7 @@ jobs:
   # Run tests for Anthropic
   test-anthropic:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -138,6 +146,7 @@ jobs:
   test-cohere:
     if: false # Disable cohere tests until we get a production account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -164,6 +173,7 @@ jobs:
   test-deepseek:
     if: false # Disable deepseek tests until we get a production account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -189,6 +199,7 @@ jobs:
   test-fireworks:
     if: false # Disable fireworks tests until we get a production account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -219,6 +230,7 @@ jobs:
   # Run tests for Groq
   test-groq:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -245,6 +257,7 @@ jobs:
   test-mistral:
     if: false # Disable mistral tests until we get a production account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -271,6 +284,7 @@ jobs:
   test-nvidia:
     if: false # Disable nvidia tests until we get a test account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -296,6 +310,7 @@ jobs:
   test-openrouter:
     if: false # Disable openrouter tests until we get a test account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -322,6 +337,7 @@ jobs:
   test-perplexity:
     if: false # Disable perplexity tests until we get a production account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -347,6 +363,7 @@ jobs:
   test-sambanova:
     if: false # Temporarily disabled
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -372,6 +389,7 @@ jobs:
   test-together:
     if: false # The tests take too long to run
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -397,6 +415,7 @@ jobs:
   # Run tests for xAI
   test-xai:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: false # Disable xAI tests until we get a test account
     strategy:
       matrix:
@@ -424,6 +443,7 @@ jobs:
   test-v0:
     if: false # We don't have credits
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -449,6 +469,7 @@ jobs:
   test-ibm-watsonx:
     if: false # Our account is not working
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -477,6 +498,7 @@ jobs:
   test-cerebras:
     if: false
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -500,6 +522,7 @@ jobs:
 
   test-deepinfra:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -526,6 +549,7 @@ jobs:
   test-aimlapi:
     if: false # We need more credits
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -557,6 +581,7 @@ jobs:
   test-dashscope:
     if: false # We need more credits
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -588,6 +613,7 @@ jobs:
   test-langdb:
     if: false # We do not have a company account
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -618,6 +644,7 @@ jobs:
 
   test-agents:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -662,6 +689,7 @@ jobs:
 
   test-agents-2:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -704,6 +732,7 @@ jobs:
 
   test-teams-1:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -744,6 +773,7 @@ jobs:
 
   test-teams-2:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -784,6 +814,7 @@ jobs:
 
   test-teams-3:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # Green runs take 24-26 min; split the job to get under 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -824,6 +855,7 @@ jobs:
 
   test-teams-4:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -869,6 +901,7 @@ jobs:
 
   verify-split-test-coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - name: Verify all split integration tests are assigned to CI jobs
@@ -889,6 +922,7 @@ jobs:
 
   test-workflows:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -919,6 +953,7 @@ jobs:
 
   test-embedder:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -950,6 +985,7 @@ jobs:
 
   test-knowledge-1:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # Green runs regularly reach ~21 min
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -989,6 +1025,7 @@ jobs:
 
   test-knowledge-2:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1025,6 +1062,7 @@ jobs:
   # Run A2A tests (isolated due to dependency conflicts)
   test-a2a:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1059,6 +1097,7 @@ jobs:
 
   test-clean:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1092,6 +1131,7 @@ jobs:
 
   test-agent-os:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1124,6 +1164,7 @@ jobs:
 
   test-clean-os:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1158,6 +1199,7 @@ jobs:
   # Run remaining integration tests
   test-remaining:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1189,6 +1231,7 @@ jobs:
 
   test-dev-setup:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -1232,6 +1275,7 @@ jobs:
   # Run AgentOS System Tests (multi-container Docker setup)
   test-agentos-system:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         python-version: ["3.12"]


### PR DESCRIPTION
## Summary

Workflow-file-only change, split out of #8784 for independent review — no source or test changes.

Every Main Validation job now carries `timeout-minutes` so a hung provider stream (or the WS test hang fixed in #8784) fails the job instead of wedging it until GitHub's 6-hour default — which is exactly what happened on every `feat/v2.7` push on Jul 6, with `test-agent-os` blocking 50+ minutes until the next push cancelled it.

The ceiling is **20 minutes**, except the three jobs whose *green* runs measure above that across the last six runs:

| Job | Green-run duration | Timeout |
|---|---|---|
| `test-teams-3` | 24–26 min (every run) | 30 |
| `test-knowledge-1` | 16–21 min | 30 |
| `test-google` | 13–22 min | 30 |

The full-matrix dispatch on the combined branch (https://github.com/agno-agi/agno/actions/runs/28812027683, 23/23 green) validated the split in the same run: `test-teams-3` passed at 24.3 min and `test-knowledge-1` at 19.6 min — a blanket 20 would have killed both mid-pass.

Note: this PR alone does not turn `test-agent-os` green — the auth regression it fails on is fixed in #8784. With only this PR merged, that job fails bounded (~20 min) instead of wedging for hours. Merge order between the two doesn't matter.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Timeout numbers are from measured job durations across the six most recent completed Main Validation runs (Jul 6). If `test-teams-3` is ever split like teams-1/2/4, its exception can drop to the 20-minute default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)