### PR TITLE
fix: keep tool defaults for omitted params on HITL continue

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -544,6 +544,15 @@ def handle_external_execution_update(agent: Agent, run_messages: RunMessages, to
 
 def handle_user_input_update(agent: Agent, tool: ToolExecution):
     for field in tool.user_input_schema or []:
+        # A None value means the agent omitted this parameter and the user did
+        # not supply it (user_input_schema contains every non-framework param,
+        # not just user_input_fields). Writing None here would override the
+        # function's own default (e.g. priority="normal" -> None) and raise
+        # validation errors when the tool is executed on continue. Explicit
+        # None values the agent actually passed already live in tool_args (they
+        # come from fc.arguments), so skipping preserves them.
+        if field.value is None:
+            continue
         if not tool.tool_args:
             tool.tool_args = {}
         tool.tool_args[field.name] = field.value

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -298,6 +298,131 @@ def test_user_input_with_run_context_execution():
     assert run_context.session_state["sent"] == 1
 
 
+def _build_paused_tool_execution(func: Function, agent_args: Dict[str, Any], user_values: Dict[str, Any]):
+    """Reproduce the paused ToolExecution the model layer builds for a HITL tool.
+
+    Mirrors agno.models.base: user_input_schema is the function's full schema and
+    each field value is populated from the arguments the agent actually passed;
+    user_values are then applied as if provided on continue.
+    """
+    from agno.models.response import ToolExecution
+
+    schema = func.user_input_schema or []
+    for field in schema:
+        if field.name in agent_args:
+            field.value = agent_args[field.name]
+    for field in schema:
+        if field.name in user_values:
+            field.value = user_values[field.name]
+    return ToolExecution(
+        tool_call_id="call_1",
+        tool_name=func.name,
+        tool_args=dict(agent_args),
+        user_input_schema=schema,
+    )
+
+
+def test_handle_user_input_update_skips_omitted_defaulted_params():
+    """Omitted defaulted params must not be forced to None on continue (issue #6870)."""
+    from agno.agent._tools import handle_user_input_update
+
+    @tool(requires_user_input=True, user_input_fields=["to_address"])
+    def send_email(subject: str, body: str, to_address: str, priority: str = "normal", cc: Optional[str] = None) -> str:
+        """Send an email.
+
+        Args:
+            subject (str): The subject.
+            body (str): The body.
+            to_address (str): The recipient.
+            priority (str): Delivery priority.
+            cc (str): Optional CC address.
+        """
+        return f"to={to_address} priority={priority} cc={cc}"
+
+    send_email.process_entrypoint()
+
+    # Agent provided subject/body only; user supplies the single user_input_field.
+    tool_execution = _build_paused_tool_execution(
+        send_email,
+        agent_args={"subject": "Hi", "body": "Hello"},
+        user_values={"to_address": "a@b.com"},
+    )
+
+    handle_user_input_update(None, tool_execution)  # type: ignore[arg-type]  # agent is unused
+
+    # Agent-provided and user-filled values are written back.
+    assert tool_execution.tool_args["subject"] == "Hi"
+    assert tool_execution.tool_args["body"] == "Hello"
+    assert tool_execution.tool_args["to_address"] == "a@b.com"
+    # Omitted defaulted params are left out so the function defaults apply.
+    assert "priority" not in tool_execution.tool_args
+    assert "cc" not in tool_execution.tool_args
+
+
+def test_handle_user_input_update_continue_executes_with_defaults():
+    """After continue, executing the tool uses the function default for omitted params (issue #6870)."""
+    from agno.agent._tools import handle_user_input_update
+
+    @tool(requires_user_input=True, user_input_fields=["to_address"])
+    def send_email(subject: str, body: str, to_address: str, priority: str = "normal") -> str:
+        """Send an email.
+
+        Args:
+            subject (str): The subject.
+            body (str): The body.
+            to_address (str): The recipient.
+            priority (str): Delivery priority.
+        """
+        # priority.upper() would raise AttributeError if it were forced to None.
+        return f"to={to_address} priority={priority.upper()}"
+
+    send_email.process_entrypoint()
+
+    tool_execution = _build_paused_tool_execution(
+        send_email,
+        agent_args={"subject": "Hi", "body": "Hello"},
+        user_values={"to_address": "a@b.com"},
+    )
+
+    handle_user_input_update(None, tool_execution)  # type: ignore[arg-type]
+
+    fc = FunctionCall(function=send_email, arguments=tool_execution.tool_args)
+    result = fc.execute()
+    assert result.status == "success"
+    assert result.result == "to=a@b.com priority=NORMAL"
+
+
+def test_handle_user_input_update_preserves_explicit_agent_none():
+    """An explicit None the agent passed for a defaulted param is preserved (issue #6870)."""
+    from agno.agent._tools import handle_user_input_update
+
+    @tool(requires_user_input=True, user_input_fields=["to_address"])
+    def send_email(subject: str, to_address: str, cc: Optional[str] = None) -> str:
+        """Send an email.
+
+        Args:
+            subject (str): The subject.
+            to_address (str): The recipient.
+            cc (str): Optional CC address.
+        """
+        return f"to={to_address} cc={cc}"
+
+    send_email.process_entrypoint()
+
+    # Agent explicitly passed cc=None (a valid value); it already lives in tool_args.
+    tool_execution = _build_paused_tool_execution(
+        send_email,
+        agent_args={"subject": "Hi", "cc": None},
+        user_values={"to_address": "a@b.com"},
+    )
+
+    handle_user_input_update(None, tool_execution)  # type: ignore[arg-type]
+
+    assert tool_execution.tool_args["to_address"] == "a@b.com"
+    assert "cc" in tool_execution.tool_args
+    assert tool_execution.tool_args["cc"] is None
+
+
 def test_function_process_entrypoint_skip_processing():
     """Test that entrypoint processing is skipped when skip_entrypoint_processing is True."""
 


### PR DESCRIPTION
## Summary

Fixes #6870.

For a HITL tool declared with `requires_user_input=True` and a subset of
`user_input_fields`, defaulted parameters that the agent omits from its tool
call (e.g. `priority: str = "normal"`, `cc: str | None = None`) were being
forced to `None` when the run was continued, overriding the function's own
defaults and raising a validation error on execution
("Could not run function ... validation errors").

Root cause: `user_input_schema` is built from *every* non-framework parameter,
not just the ones in `user_input_fields`. A parameter the agent omits keeps its
schema field at `value=None`. `handle_user_input_update` (the helper shared by
the agent and team continue paths) then copied *every* field — including those
`None`s — back into `tool_args`, clobbering the defaults.

Fix: skip schema fields whose `value is None` so omitted defaulted params fall
back to the function's own default. Explicit `None` values the agent actually
passed are already present in `tool_args` (they come from `fc.arguments`), so
they are preserved unchanged. Because the helper is shared, this fixes both the
agent and team continue paths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Added three offline unit tests in `libs/agno/tests/unit/tools/test_functions.py`:

- `test_handle_user_input_update_skips_omitted_defaulted_params` — omitted
  defaulted params are not written to `tool_args`; agent-provided and
  user-filled values are.
- `test_handle_user_input_update_continue_executes_with_defaults` — executing
  the tool after continue succeeds using the function default. Reproduces the
  reported failure: without the fix this raises
  `pydantic ... ValidationError: priority - Input should be a valid string
  [input_value=None]`.
- `test_handle_user_input_update_preserves_explicit_agent_none` — an explicit
  `None` the agent passed for a defaulted param is preserved (no regression).

Validation (from a clean `.venv`): `ruff format --check` and `ruff check` clean
on the changed files, `mypy libs/agno` clean (894 files), and the new tests plus
the surrounding `tools`/`agent`/`team` unit suites pass.