### PR TITLE
feat: add team subjects and numeric judge scoring to the eval suite

### DIFF
--- a/cookbook/09_evals/suite/README.md
+++ b/cookbook/09_evals/suite/README.md
@@ -5,6 +5,7 @@ Suite examples run multiple eval cases as one aggregated suite with tag selectio
 ## Files
 
 - `suite_basic.py` - Two cases (judge + reliability checks) run through the built-in `cli()`.
+- `suite_team_scoring.py` - A Team run through the suite (the leader delegates to a calculator member and a writer member); reliability sees the members' tool calls, and every answer is graded by a numeric 1-10 judge.
 
 ## Usage
 

--- a/cookbook/09_evals/suite/TEST_LOG.md
+++ b/cookbook/09_evals/suite/TEST_LOG.md
@@ -11,3 +11,13 @@
 **Re-test (2026-07-05, after the external-review fix round):** full run with `--json-output` passed 2/2 with exit code 0 and the expected payload (`tools_called: ["factorial"]`, `status: "PASS"`); the falsy-check guard rejects `expected_tool_calls=()` at construction; the `python -m agno.eval` module entry is removed.
 
 ---
+
+### suite_team_scoring.py
+
+**Status:** PASS
+
+**Description:** Runs two cases against one Team whose leader delegates to a calculator member and a writer member. The first case grades a numeric-scored arithmetic answer and checks the member's `multiply` tool; the second grades a numeric-scored explanation the leader delegates to the writer member. Exercised `--list`, `--list --json-output`, `--tag smoke`, `--name`, and a full run with `--json-output`, plus the programmatic `run_cases` and `arun_cases` entry points.
+
+**Result:** 2/2 cases passed with exit code 0. Both cases carry `team_id: "assistant-team"` and `agent_id: null`. The arithmetic case's reliability saw the member's real tool (`tools_called: ["delegate_task_to_member", "multiply"]`) via `team_response=`, and both cases reported `judge_score: 10` in the payload.
+
+---

--- a/cookbook/09_evals/suite/suite_team_scoring.py
+++ b/cookbook/09_evals/suite/suite_team_scoring.py
@@ -14,7 +14,7 @@ python cookbook/09_evals/suite/suite_team_scoring.py --json-output tmp/evals.jso
 import sys
 
 from agno.agent import Agent
-from agno.eval import Case, cli
+from agno.eval import Case, JudgeMode, cli
 from agno.models.openai import OpenAIResponses
 from agno.team.team import Team
 from agno.tools.calculator import CalculatorTools
@@ -50,7 +50,7 @@ CASES = (
         input="What is 4891 multiplied by 7238?",
         tags=("smoke",),
         criteria="States that the product is 35,401,058.",
-        judge_mode="numeric",
+        judge_mode=JudgeMode.NUMERIC,
         judge_threshold=7,
         expected_tool_calls=("multiply",),
     ),
@@ -59,7 +59,7 @@ CASES = (
         team=assistant_team,
         input="Explain compound interest in one paragraph.",
         criteria="Explains that interest is earned on both the principal and previously earned interest.",
-        judge_mode="numeric",
+        judge_mode=JudgeMode.NUMERIC,
         judge_threshold=7,
     ),
 )

--- a/cookbook/09_evals/suite/suite_team_scoring.py
+++ b/cookbook/09_evals/suite/suite_team_scoring.py
@@ -50,7 +50,7 @@ CASES = (
         input="What is 4891 multiplied by 7238?",
         tags=("smoke",),
         criteria="States that the product is 35,401,058.",
-        judge_scoring="numeric",
+        judge_mode="numeric",
         judge_threshold=7,
         expected_tool_calls=("multiply",),
     ),
@@ -59,7 +59,7 @@ CASES = (
         team=assistant_team,
         input="Explain compound interest in one paragraph.",
         criteria="Explains that interest is earned on both the principal and previously earned interest.",
-        judge_scoring="numeric",
+        judge_mode="numeric",
         judge_threshold=7,
     ),
 )

--- a/cookbook/09_evals/suite/suite_team_scoring.py
+++ b/cookbook/09_evals/suite/suite_team_scoring.py
@@ -1,0 +1,71 @@
+"""
+Eval Suite: Team with Numeric Judge Scoring
+===========================================
+
+Run a Team through the suite - the leader delegates to its members - and grade every
+answer with a numeric 1-10 judge.
+
+python cookbook/09_evals/suite/suite_team_scoring.py                 # run all cases
+python cookbook/09_evals/suite/suite_team_scoring.py --list          # list cases
+python cookbook/09_evals/suite/suite_team_scoring.py --tag smoke     # run a tagged subset
+python cookbook/09_evals/suite/suite_team_scoring.py --json-output tmp/evals.json
+"""
+
+import sys
+
+from agno.agent import Agent
+from agno.eval import Case, cli
+from agno.models.openai import OpenAIResponses
+from agno.team.team import Team
+from agno.tools.calculator import CalculatorTools
+
+# ---------------------------------------------------------------------------
+# Create the Team and its members
+# ---------------------------------------------------------------------------
+calculator = Agent(
+    id="calculator",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[CalculatorTools()],
+    instructions="Use the calculator tools for every arithmetic operation. Never compute arithmetic yourself.",
+)
+writer = Agent(
+    id="writer",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions="Answer in one clear paragraph.",
+)
+assistant_team = Team(
+    id="assistant-team",
+    model=OpenAIResponses(id="gpt-5.5"),
+    members=[calculator, writer],
+    instructions="Delegate arithmetic to the calculator member and writing to the writer member, then report the member's result.",
+)
+
+# ---------------------------------------------------------------------------
+# Declare Cases - both run against the Team
+# ---------------------------------------------------------------------------
+CASES = (
+    Case(
+        name="team_uses_calculator",
+        team=assistant_team,
+        input="What is 4891 multiplied by 7238?",
+        tags=("smoke",),
+        criteria="States that the product is 35,401,058.",
+        judge_scoring="numeric",
+        judge_threshold=7,
+        expected_tool_calls=("multiply",),
+    ),
+    Case(
+        name="team_explains_clearly",
+        team=assistant_team,
+        input="Explain compound interest in one paragraph.",
+        criteria="Explains that interest is earned on both the principal and previously earned interest.",
+        judge_scoring="numeric",
+        judge_threshold=7,
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Run Suite
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    sys.exit(cli(CASES))

--- a/libs/agno/agno/eval/__init__.py
+++ b/libs/agno/agno/eval/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "BaseEval",
     "Case",
     "CaseResult",
+    "JudgeMode",
     "PerformanceEval",
     "PerformanceResult",
     "ReliabilityEval",
@@ -41,7 +42,7 @@ def __getattr__(name: str):
         from agno.eval import reliability
 
         return getattr(reliability, name)
-    elif name in ("Case", "CaseResult", "SuiteResult", "arun_cases", "run_cases", "cli", "acli"):
+    elif name in ("Case", "CaseResult", "JudgeMode", "SuiteResult", "arun_cases", "run_cases", "cli", "acli"):
         from agno.eval import suite
 
         return getattr(suite, name)

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -49,8 +49,8 @@ __all__ = [
 
 
 class JudgeMode(str, Enum):
-    """How the judge grades a Case's answer. A str-enum, so `judge_mode="numeric"` still works,
-    and the values are exactly AgentAsJudgeEval's scoring_strategy= (the suite forwards them)."""
+    """How the judge grades a Case's answer. A str-enum whose values match AgentAsJudgeEval's
+    scoring_strategy; the equal string (e.g. "numeric") is accepted too."""
 
     BINARY = "binary"  # a pass/fail verdict
     NUMERIC = "numeric"  # a 1-10 score, passes when it meets judge_threshold
@@ -72,18 +72,15 @@ class Case:
     timeout_seconds: Optional[int] = None
 
     # Judge check - set `criteria` to enable AgentAsJudgeEval. Verdict is binary pass/fail by
-    # default; set judge_mode="numeric" for a 1-10 score gated on judge_threshold.
+    # default; set judge_mode=JudgeMode.NUMERIC for a 1-10 score gated on judge_threshold.
     criteria: Optional[str] = None
     # Per-case judge model override; falls back to the runner's judge_model=,
     # then AgentAsJudgeEval's default
     judge_model: Optional[Model] = None
-    # Judge scoring mode (JudgeMode.BINARY / JudgeMode.NUMERIC). "binary" is a pass/fail verdict;
-    # "numeric" grades 1-10 and passes when the score meets judge_threshold (the judge computes both,
-    # so results still gate cleanly). Named judge_mode, not judge_scoring, to stay distinct from the
-    # judge_score it produces.
+    # Judge scoring mode. BINARY is a pass/fail verdict; NUMERIC grades 1-10 and passes when the
+    # score meets judge_threshold.
     judge_mode: JudgeMode = JudgeMode.BINARY
-    # Pass bar for numeric scoring (1-10); read only when judge_mode is "numeric". Kept beside
-    # judge_mode (rather than folded into a single Optional) so a case documents its bar inline.
+    # Pass bar for numeric scoring (1-10); read only when judge_mode is NUMERIC.
     judge_threshold: int = 7
 
     # Reliability check - set `expected_tool_calls` to enable ReliabilityEval.
@@ -109,11 +106,8 @@ class Case:
         # that verified nothing.
         if not self.criteria and not self.expected_tool_calls:
             raise ValueError(f"case {self.name!r} has no checks: set criteria and/or expected_tool_calls")
-        # Validate the judge config here, not at run time: the enum is not enforced against a raw
-        # string passed positionally, so a typo'd mode ("Numeric") or an out-of-range threshold
-        # would otherwise sail through construction and only surface as a judge error - after a full
-        # model run is already spent. `in (BINARY, NUMERIC)` accepts the enum members and their
-        # equal strings (str-enum), so judge_mode="numeric" is fine but "Numeric" is rejected.
+        # A raw string bypasses the JudgeMode type, so reject an unknown mode and, for NUMERIC, a
+        # judge_threshold outside 1-10. Membership accepts the enum members and their equal strings.
         if self.judge_mode not in (JudgeMode.BINARY, JudgeMode.NUMERIC):
             raise ValueError(f"case {self.name!r}: judge_mode must be a JudgeMode, got {self.judge_mode!r}")
         if self.judge_mode == JudgeMode.NUMERIC and not 1 <= self.judge_threshold <= 10:
@@ -388,8 +382,7 @@ async def _run_case_body(
                 criteria=case.criteria,
                 # Numeric mode grades 1-10 and derives passed = score >= threshold itself, so the
                 # verdict still gates cleanly; binary mode ignores threshold.
-                # judge_mode is a str-enum whose values ARE scoring_strategy's; cast bridges the
-                # enum to the Literal the eval declares (the value passes through unchanged).
+                # cast the str-enum to the Literal scoring_strategy declares; the value is unchanged.
                 scoring_strategy=cast(Literal["binary", "numeric"], case.judge_mode),
                 threshold=case.judge_threshold,
                 model=case.judge_model or judge_model,

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -61,15 +61,18 @@ class Case:
     # Per-case timeout in seconds; falls back to the runner's default_timeout
     timeout_seconds: Optional[int] = None
 
-    # Judge check - set `criteria` to enable AgentAsJudgeEval (binary pass/fail).
+    # Judge check - set `criteria` to enable AgentAsJudgeEval. Verdict is binary pass/fail by
+    # default; set judge_mode="numeric" for a 1-10 score gated on judge_threshold.
     criteria: Optional[str] = None
     # Per-case judge model override; falls back to the runner's judge_model=,
     # then AgentAsJudgeEval's default
     judge_model: Optional[Model] = None
-    # Judge scoring: "binary" is a pass/fail verdict; "numeric" grades 1-10 and passes when
+    # Judge scoring mode. "binary" is a pass/fail verdict; "numeric" grades 1-10 and passes when
     # the score meets judge_threshold (the judge computes both, so results still gate cleanly).
-    judge_scoring: Literal["binary", "numeric"] = "binary"
-    # Pass bar for numeric scoring (1-10); ignored when judge_scoring is "binary".
+    # Named judge_mode, not judge_scoring, to stay distinct from the judge_score it produces.
+    judge_mode: Literal["binary", "numeric"] = "binary"
+    # Pass bar for numeric scoring (1-10); read only when judge_mode is "numeric". Kept beside
+    # judge_mode (rather than folded into a single Optional) so a case documents its bar inline.
     judge_threshold: int = 7
 
     # Reliability check - set `expected_tool_calls` to enable ReliabilityEval.
@@ -95,6 +98,13 @@ class Case:
         # that verified nothing.
         if not self.criteria and not self.expected_tool_calls:
             raise ValueError(f"case {self.name!r} has no checks: set criteria and/or expected_tool_calls")
+        # Validate the judge config here, not at run time: Literal is not enforced at runtime, so a
+        # typo'd mode ("Numeric") or an out-of-range threshold would otherwise sail through
+        # construction and only surface as a judge error - after a full model run is already spent.
+        if self.judge_mode not in ("binary", "numeric"):
+            raise ValueError(f"case {self.name!r}: judge_mode must be 'binary' or 'numeric', got {self.judge_mode!r}")
+        if self.judge_mode == "numeric" and not 1 <= self.judge_threshold <= 10:
+            raise ValueError(f"case {self.name!r}: judge_threshold must be 1-10, got {self.judge_threshold}")
 
 
 @dataclass
@@ -365,7 +375,7 @@ async def _run_case_body(
                 criteria=case.criteria,
                 # Numeric mode grades 1-10 and derives passed = score >= threshold itself, so the
                 # verdict still gates cleanly; binary mode ignores threshold.
-                scoring_strategy=case.judge_scoring,
+                scoring_strategy=case.judge_mode,
                 threshold=case.judge_threshold,
                 model=case.judge_model or judge_model,
                 db=db,

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -14,9 +14,10 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from inspect import isawaitable, iscoroutine, iscoroutinefunction
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union, cast
 from uuid import uuid4
 
 from agno.agent import Agent
@@ -38,12 +39,21 @@ if TYPE_CHECKING:
 __all__ = [
     "Case",
     "CaseResult",
+    "JudgeMode",
     "SuiteResult",
     "acli",
     "arun_cases",
     "cli",
     "run_cases",
 ]
+
+
+class JudgeMode(str, Enum):
+    """How the judge grades a Case's answer. A str-enum, so `judge_mode="numeric"` still works,
+    and the values are exactly AgentAsJudgeEval's scoring_strategy= (the suite forwards them)."""
+
+    BINARY = "binary"  # a pass/fail verdict
+    NUMERIC = "numeric"  # a 1-10 score, passes when it meets judge_threshold
 
 
 @dataclass(frozen=True)
@@ -67,10 +77,11 @@ class Case:
     # Per-case judge model override; falls back to the runner's judge_model=,
     # then AgentAsJudgeEval's default
     judge_model: Optional[Model] = None
-    # Judge scoring mode. "binary" is a pass/fail verdict; "numeric" grades 1-10 and passes when
-    # the score meets judge_threshold (the judge computes both, so results still gate cleanly).
-    # Named judge_mode, not judge_scoring, to stay distinct from the judge_score it produces.
-    judge_mode: Literal["binary", "numeric"] = "binary"
+    # Judge scoring mode (JudgeMode.BINARY / JudgeMode.NUMERIC). "binary" is a pass/fail verdict;
+    # "numeric" grades 1-10 and passes when the score meets judge_threshold (the judge computes both,
+    # so results still gate cleanly). Named judge_mode, not judge_scoring, to stay distinct from the
+    # judge_score it produces.
+    judge_mode: JudgeMode = JudgeMode.BINARY
     # Pass bar for numeric scoring (1-10); read only when judge_mode is "numeric". Kept beside
     # judge_mode (rather than folded into a single Optional) so a case documents its bar inline.
     judge_threshold: int = 7
@@ -98,12 +109,14 @@ class Case:
         # that verified nothing.
         if not self.criteria and not self.expected_tool_calls:
             raise ValueError(f"case {self.name!r} has no checks: set criteria and/or expected_tool_calls")
-        # Validate the judge config here, not at run time: Literal is not enforced at runtime, so a
-        # typo'd mode ("Numeric") or an out-of-range threshold would otherwise sail through
-        # construction and only surface as a judge error - after a full model run is already spent.
-        if self.judge_mode not in ("binary", "numeric"):
-            raise ValueError(f"case {self.name!r}: judge_mode must be 'binary' or 'numeric', got {self.judge_mode!r}")
-        if self.judge_mode == "numeric" and not 1 <= self.judge_threshold <= 10:
+        # Validate the judge config here, not at run time: the enum is not enforced against a raw
+        # string passed positionally, so a typo'd mode ("Numeric") or an out-of-range threshold
+        # would otherwise sail through construction and only surface as a judge error - after a full
+        # model run is already spent. `in (BINARY, NUMERIC)` accepts the enum members and their
+        # equal strings (str-enum), so judge_mode="numeric" is fine but "Numeric" is rejected.
+        if self.judge_mode not in (JudgeMode.BINARY, JudgeMode.NUMERIC):
+            raise ValueError(f"case {self.name!r}: judge_mode must be a JudgeMode, got {self.judge_mode!r}")
+        if self.judge_mode == JudgeMode.NUMERIC and not 1 <= self.judge_threshold <= 10:
             raise ValueError(f"case {self.name!r}: judge_threshold must be 1-10, got {self.judge_threshold}")
 
 
@@ -375,7 +388,9 @@ async def _run_case_body(
                 criteria=case.criteria,
                 # Numeric mode grades 1-10 and derives passed = score >= threshold itself, so the
                 # verdict still gates cleanly; binary mode ignores threshold.
-                scoring_strategy=case.judge_mode,
+                # judge_mode is a str-enum whose values ARE scoring_strategy's; cast bridges the
+                # enum to the Literal the eval declares (the value passes through unchanged).
+                scoring_strategy=cast(Literal["binary", "numeric"], case.judge_mode),
                 threshold=case.judge_threshold,
                 model=case.judge_model or judge_model,
                 db=db,

--- a/libs/agno/agno/eval/suite.py
+++ b/libs/agno/agno/eval/suite.py
@@ -1,6 +1,6 @@
 """Eval suite runner: declare `Case`s, run them with `run_cases`/`arun_cases`, ship a CLI with `cli`.
 
-A `Case` is one input to one agent plus optional checks (`AgentAsJudgeEval` via
+A `Case` is one input to one agent or team plus optional checks (`AgentAsJudgeEval` via
 `criteria`, `ReliabilityEval` via `expected_tool_calls`). The runner executes the
 selected cases sequentially on a single event loop and returns a `SuiteResult`
 whose `to_dict()` payload is a stable contract for CI consumers.
@@ -16,7 +16,7 @@ import time
 from dataclasses import dataclass, field
 from inspect import isawaitable, iscoroutine, iscoroutinefunction
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple, Union
 from uuid import uuid4
 
 from agno.agent import Agent
@@ -27,7 +27,9 @@ from agno.models.base import Model
 from agno.run.agent import RunErrorEvent, RunOutput, RunOutputEvent
 from agno.run.base import RunStatus
 from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+from agno.run.team import TeamRunOutput
 from agno.run.workflow import WorkflowErrorEvent
+from agno.team.team import Team
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -46,13 +48,15 @@ __all__ = [
 
 @dataclass(frozen=True)
 class Case:
-    """One eval case: an input to one agent, plus optional judge/reliability checks."""
+    """One eval case: an input to one agent or team, plus optional judge/reliability checks."""
 
     name: str
     input: str
-    # agent is the last required field so it can gain a default later (team/workflow
-    # alternatives per the spec's fast-follow) without a non-default-after-default error.
-    agent: Agent
+    # The agent or team under test: pass exactly one of agent= or team= (separate fields,
+    # mirroring AccuracyEval, so a Team never rides in a param named 'agent'). A Team routes
+    # reliability through team_response=.
+    agent: Optional[Agent] = None
+    team: Optional[Team] = None
     tags: Tuple[str, ...] = ()
     # Per-case timeout in seconds; falls back to the runner's default_timeout
     timeout_seconds: Optional[int] = None
@@ -62,12 +66,17 @@ class Case:
     # Per-case judge model override; falls back to the runner's judge_model=,
     # then AgentAsJudgeEval's default
     judge_model: Optional[Model] = None
+    # Judge scoring: "binary" is a pass/fail verdict; "numeric" grades 1-10 and passes when
+    # the score meets judge_threshold (the judge computes both, so results still gate cleanly).
+    judge_scoring: Literal["binary", "numeric"] = "binary"
+    # Pass bar for numeric scoring (1-10); ignored when judge_scoring is "binary".
+    judge_threshold: int = 7
 
     # Reliability check - set `expected_tool_calls` to enable ReliabilityEval.
     expected_tool_calls: Optional[Tuple[str, ...]] = None
     allow_additional_tool_calls: bool = True
 
-    # Lifecycle hooks. setup runs before the agent (outside the timeout); its return
+    # Lifecycle hooks. setup runs before the run (outside the timeout); its return
     # value ("context") is passed to teardown. teardown always runs once setup has
     # completed (pass, fail, error, timeout) and receives (context, result) so it can
     # inspect result.error / result.timed_out. Sync callables run via
@@ -76,6 +85,11 @@ class Case:
     teardown: Optional[Callable[[Any, "CaseResult"], Any]] = None
 
     def __post_init__(self) -> None:
+        # Exactly one of agent/team: neither has anything to run, both is ambiguous.
+        if self.agent is None and self.team is None:
+            raise ValueError(f"case {self.name!r}: provide one of 'agent' or 'team'")
+        if self.agent is not None and self.team is not None:
+            raise ValueError(f"case {self.name!r}: provide only one of 'agent' or 'team'")
         # Truthiness, not `is None`: criteria="" or expected_tool_calls=() would
         # otherwise construct a case whose checks pass vacuously - a green CI gate
         # that verified nothing.
@@ -88,25 +102,29 @@ class CaseResult:
     """Outcome of one case, with enough evidence to debug a failure from the payload alone."""
 
     name: str
-    agent_id: str
     tags: Tuple[str, ...]
+    # Split like AccuracyEval: agent_id for an agent case, team_id for a team; the other
+    # stays None.
+    agent_id: Optional[str] = None
+    team_id: Optional[str] = None
     # The generated eval session id - links the case to its stored session/trace when
     # db= is set. Empty for skipped cases: no session was created.
     session_id: str = ""
     duration_seconds: float = 0.0
     judge_passed: Optional[bool] = None  # None = check not configured
     judge_reason: Optional[str] = None  # the judge's stated reason, when available
+    judge_score: Optional[int] = None  # numeric-mode score (1-10); None in binary mode
     reliability_passed: Optional[bool] = None  # None = check not configured
     output: Optional[str] = None  # response text - what the judge graded
     tools_called: Tuple[str, ...] = ()  # tool names fired during the run, in order
     timed_out: bool = False
     # True for cases the suite never ran (appended after a cancelled-run abort)
     skipped: bool = False
-    # Agent error, judge/reliability error, teardown error - "; "-joined
+    # Run error, judge/reliability error, teardown error - "; "-joined
     error: Optional[str] = None
     # Raw run output - full programmatic access to content, tool calls, metrics.
-    # Excluded from to_dict().
-    response: Optional[RunOutput] = None
+    # Excluded from to_dict(). A team case stores its TeamRunOutput.
+    response: Optional[Union[RunOutput, TeamRunOutput]] = None
 
     @property
     def passed(self) -> bool:
@@ -155,11 +173,13 @@ class SuiteResult:
                 {
                     "name": result.name,
                     "agent_id": result.agent_id,
+                    "team_id": result.team_id,
                     "tags": list(result.tags),
                     "session_id": result.session_id,
                     "duration_seconds": result.duration_seconds,
                     "judge_passed": result.judge_passed,
                     "judge_reason": result.judge_reason,
+                    "judge_score": result.judge_score,
                     "reliability_passed": result.reliability_passed,
                     "output": result.output,
                     "tools_called": list(result.tools_called),
@@ -179,15 +199,21 @@ class SuiteResult:
 # an is_error property (mirroring is_cancelled), switch to that.
 _RUN_ERROR_EVENTS = (RunErrorEvent, TeamRunErrorEvent, WorkflowErrorEvent)
 
+# Keyed by non-completed status; the "agent"/"team" label is prefixed at use.
 _STATUS_ERRORS = {
-    RunStatus.paused: "agent: run paused awaiting user input",
-    RunStatus.cancelled: "agent: run cancelled",
-    RunStatus.error: "agent: run ended in error status",
+    RunStatus.paused: "run paused awaiting user input",
+    RunStatus.cancelled: "run cancelled",
+    RunStatus.error: "run ended in error status",
 }
 
 
-def _agent_id(case: Case) -> str:
-    return case.agent.id or case.name
+def _component_id(case: Case) -> str:
+    # Exactly one of agent/team is set (enforced at construction); fall back to the case name.
+    if case.agent is not None:
+        return case.agent.id or case.name
+    if case.team is not None:
+        return case.team.id or case.name
+    return case.name
 
 
 def _case_matches(case: Case, *, tag: Optional[str], name: Optional[str]) -> bool:
@@ -202,7 +228,17 @@ def _append_error(result: CaseResult, message: str) -> None:
     result.error = "; ".join(part for part in (result.error, message) if part)
 
 
-def _extract_evidence(result: CaseResult, response: RunOutput) -> None:
+def _tool_names(response: Union[RunOutput, TeamRunOutput]) -> Tuple[str, ...]:
+    """Tool names fired during the run, in order. A team's members keep their calls in
+    member_responses, so collect one level down - otherwise only the leader's
+    delegate_task_to_member shows, not the member's real tool."""
+    names = [tool.tool_name or "?" for tool in (response.tools or [])]
+    for member in getattr(response, "member_responses", None) or []:
+        names.extend(tool.tool_name or "?" for tool in (member.tools or []))
+    return tuple(names)
+
+
+def _extract_evidence(result: CaseResult, response: Union[RunOutput, TeamRunOutput]) -> None:
     """Copy the payload evidence fields (output, tools_called) off the run output."""
     try:
         result.output = response.get_content_as_string() if response.content is not None else ""
@@ -211,7 +247,7 @@ def _extract_evidence(result: CaseResult, response: RunOutput) -> None:
         # values json can't handle (datetime, bytes, ...) - fall back to repr
         # rather than failing the case on evidence extraction.
         result.output = str(response.content)
-    result.tools_called = tuple(tool.tool_name or "?" for tool in (response.tools or []))
+    result.tools_called = _tool_names(response)
 
 
 async def _call_hook(hook: Callable[..., Any], *args: Any) -> Any:
@@ -247,19 +283,26 @@ async def _run_case_body(
     db: Optional[Union[BaseDb, AsyncBaseDb]],
     on_run_event: Optional[Callable[[Case, RunOutputEvent], None]],
 ) -> None:
-    """Agent run + judge + reliability checks. Runs inside the case timeout; mutates result."""
-    response: Optional[RunOutput] = None
-    agent_errored = False
+    """Run the agent or team, then judge + reliability checks. Runs inside the case timeout; mutates result."""
+    response: Optional[Union[RunOutput, TeamRunOutput]] = None
+    component_errored = False
+    # Pick the agent or team under test (exactly one is set) and label it for error messages.
+    if case.agent is not None:
+        runner: Union[Agent, Team] = case.agent
+        component_label = "agent"
+    else:
+        runner = case.team  # type: ignore[assignment]
+        component_label = "team"
     forward_events = on_run_event is not None
     try:
-        async for event in case.agent.arun(
+        async for event in runner.arun(
             input=case.input,
             stream=True,
             stream_events=True,
             yield_run_output=True,
             session_id=result.session_id,
         ):
-            if isinstance(event, RunOutput):
+            if isinstance(event, (RunOutput, TeamRunOutput)):
                 # The final run output arrives in-stream (yield_run_output=True). It is
                 # captured, not forwarded to on_run_event - on_case_end delivers it.
                 # Response AND evidence fields are committed immediately: the stream can
@@ -273,42 +316,45 @@ async def _run_case_body(
                 # The streaming path does not raise on in-run model/API failures: it
                 # yields an error event and ends without the final RunOutput. Recorded
                 # at capture time so a later timeout cannot discard it.
-                agent_errored = True
+                component_errored = True
                 # Agent/team error events carry the message in .content, the
                 # workflow's in .error
                 error_text = getattr(event, "content", None) or getattr(event, "error", None) or "unknown error"
                 error_type = getattr(event, "error_type", None)
                 if error_type:
                     error_text = f"{error_type}: {error_text}"
-                _append_error(result, f"agent: {error_text}")
+                _append_error(result, f"{component_label}: {error_text}")
             if forward_events and on_run_event is not None:
                 try:
                     _call_presentation_hook(on_run_event, case, event)
                 except Exception as exc:
-                    # A presentation-hook bug must not read as an agent failure: record
+                    # A presentation-hook bug must not read as a run failure: record
                     # it once and stop forwarding for the rest of this case.
                     forward_events = False
                     _append_error(result, f"hook: on_run_event {type(exc).__name__}: {exc}")
     except Exception as exc:
         # Only pre-stream failures (e.g. input validation) raise out of arun.
-        _append_error(result, f"agent: {type(exc).__name__}: {exc}")
+        _append_error(result, f"{component_label}: {type(exc).__name__}: {exc}")
         return
 
     # Only a completed run is gradeable: paused/cancelled runs carry placeholder
     # content (e.g. HITL boilerplate), and any other status (pending, running,
     # regenerated, ...) is not a real answer either.
-    gradeable = not agent_errored and response is not None and response.status == RunStatus.completed
+    gradeable = not component_errored and response is not None and response.status == RunStatus.completed
     if not gradeable:
-        if not agent_errored:
+        if not component_errored:
             if response is None:
-                _append_error(result, "agent: no run output recorded")
+                _append_error(result, f"{component_label}: no run output recorded")
             else:
                 _append_error(
                     result,
                     # `or` instead of a .get() default: the default is evaluated eagerly,
-                    # and a duck-typed agent may yield status=None (no .value).
-                    _STATUS_ERRORS.get(response.status)
-                    or f"agent: run ended with status {getattr(response.status, 'value', response.status)}",
+                    # and a duck-typed agent or team may yield status=None (no .value).
+                    f"{component_label}: "
+                    + (
+                        _STATUS_ERRORS.get(response.status)
+                        or f"run ended with status {getattr(response.status, 'value', response.status)}"
+                    ),
                 )
         return
 
@@ -317,7 +363,10 @@ async def _run_case_body(
             judge = await AgentAsJudgeEval(
                 name=case.name,
                 criteria=case.criteria,
-                scoring_strategy="binary",
+                # Numeric mode grades 1-10 and derives passed = score >= threshold itself, so the
+                # verdict still gates cleanly; binary mode ignores threshold.
+                scoring_strategy=case.judge_scoring,
+                threshold=case.judge_threshold,
                 model=case.judge_model or judge_model,
                 db=db,
                 show_spinner=False,
@@ -331,14 +380,21 @@ async def _run_case_body(
             if judge is not None and judge.results:
                 result.judge_passed = judge.results[0].passed
                 result.judge_reason = judge.results[0].reason or None
+                # None in binary mode; the 1-10 number in numeric mode, kept so a payload can
+                # track quality drift a bare pass/fail would hide.
+                result.judge_score = getattr(judge.results[0], "score", None)
             else:
                 _append_error(result, "judge: returned no result")
 
     if case.expected_tool_calls:
+        # A team's real tool calls live in nested member runs; ReliabilityEval merges those via
+        # team_response= (agent_response= sees only the top-level messages - a team leader's
+        # delegation).
         try:
             reliability = await ReliabilityEval(
                 name=case.name,
-                agent_response=response,
+                agent_response=response if isinstance(response, RunOutput) else None,
+                team_response=response if isinstance(response, TeamRunOutput) else None,
                 expected_tool_calls=list(case.expected_tool_calls),
                 allow_additional_tool_calls=case.allow_additional_tool_calls,
                 db=db,
@@ -365,9 +421,10 @@ async def _arun_case(
     start = time.perf_counter()
     result = CaseResult(
         name=case.name,
-        agent_id=_agent_id(case),
         tags=case.tags,
-        # Dedicated session per case so eval traffic doesn't pollute agent history
+        agent_id=_component_id(case) if case.agent is not None else None,
+        team_id=_component_id(case) if case.team is not None else None,
+        # Dedicated session per case so eval traffic doesn't pollute the agent or team's history
         session_id=f"eval-{case.name}-{uuid4().hex[:8]}",
     )
     timeout = case.timeout_seconds if case.timeout_seconds is not None else default_timeout
@@ -437,9 +494,10 @@ async def arun_cases(
     raises (or an async hook, which is rejected) is recorded on the case
     ("hook: ..." error) without aborting the suite.
 
-    A cancelled run (Ctrl-C, or a server-side cancel_run) aborts the suite; the
-    unrun cases are recorded as failed with a "skipped: ..." error so the payload
-    still accounts for every selected case.
+    A cancelled run aborts the suite: the unrun cases are recorded as failed with a
+    "skipped: ..." error so the payload still accounts for every selected case. This
+    fires on a cancelled RunOutput - a server-side cancel_run, or a KeyboardInterrupt
+    agno converts into one.
     """
     selected = [case for case in cases if _case_matches(case, tag=tag, name=name)]
 
@@ -467,9 +525,10 @@ async def arun_cases(
             except Exception as exc:
                 _append_error(result, f"hook: on_case_end {type(exc).__name__}: {exc}")
         if result.response is not None and result.response.status == RunStatus.cancelled:
-            # agno converts Ctrl-C during a run into a cancelled RunOutput instead of
-            # re-raising (a server-side cancel_run produces the same status) - stop
-            # the suite here rather than marching through the remaining cases.
+            # A server-side cancel_run (and a KeyboardInterrupt agno converts into a cancelled
+            # RunOutput) surfaces as status=cancelled - stop here rather than marching through
+            # the remaining cases. A terminal Ctrl-C under asyncio.run instead propagates
+            # CancelledError, which unwinds the suite before reaching this branch.
             break
 
     # The unrun remainder (non-empty only after a cancelled-run abort; the cancelled
@@ -479,8 +538,9 @@ async def arun_cases(
     for case in selected[len(results) :]:
         result = CaseResult(
             name=case.name,
-            agent_id=_agent_id(case),
             tags=case.tags,
+            agent_id=_component_id(case) if case.agent is not None else None,
+            team_id=_component_id(case) if case.team is not None else None,
             skipped=True,
             error="skipped: suite aborted after cancelled run",
         )
@@ -547,9 +607,9 @@ class _CliRenderer:
 
         self._index += 1
         self._console.rule(
-            f"[bold]{escape(case.name)}[/bold]  [dim]{escape(_agent_id(case))} · {self._index}/{self._total}[/dim]"
+            f"[bold]{escape(case.name)}[/bold]  [dim]{escape(_component_id(case))} · {self._index}/{self._total}[/dim]"
         )
-        self._base_label = f"[bold]running[/bold] {escape(_agent_id(case))}…"
+        self._base_label = f"[bold]running[/bold] {escape(_component_id(case))}…"
         self._status = Status(self._base_label, console=self._console, spinner="dots")
         self._status.start()
 
@@ -564,7 +624,7 @@ class _CliRenderer:
             tool_name = getattr(tool, "tool_name", None)
             if tool_name:
                 self._status.update(
-                    f"[bold]running[/bold] {escape(_agent_id(case))} → [cyan]{escape(tool_name)}[/cyan]…"
+                    f"[bold]running[/bold] {escape(_component_id(case))} → [cyan]{escape(tool_name)}[/cyan]…"
                 )
         elif event_type == "ToolCallCompleted":
             self._status.update(self._base_label)
@@ -641,12 +701,12 @@ def _print_case_list(console: "Console", cases: Sequence[Case], *, default_timeo
 
     table = Table(title="Eval Cases", title_style="bold sky_blue1", show_header=True, header_style="bold")
     table.add_column("Case", overflow="fold")
-    table.add_column("Agent")
+    table.add_column("Component")
     table.add_column("Tags")
     table.add_column("Timeout")
     for case in cases:
         timeout = case.timeout_seconds if case.timeout_seconds is not None else default_timeout
-        table.add_row(escape(case.name), escape(_agent_id(case)), escape(", ".join(case.tags)), str(timeout))
+        table.add_row(escape(case.name), escape(_component_id(case)), escape(", ".join(case.tags)), str(timeout))
     console.print(table)
 
 
@@ -745,7 +805,8 @@ async def acli(
                 "cases": [
                     {
                         "name": case.name,
-                        "agent_id": _agent_id(case),
+                        "agent_id": _component_id(case) if case.agent is not None else None,
+                        "team_id": _component_id(case) if case.team is not None else None,
                         "tags": list(case.tags),
                         "timeout_seconds": case.timeout_seconds if case.timeout_seconds is not None else args.timeout,
                     }

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -180,8 +180,8 @@ def test_judge_mode_is_a_binary_numeric_enum():
 
 
 def test_judge_mode_accepts_enum_member_and_equal_string():
-    # Passing the enum is the blessed path; the equal raw string still constructs (str-enum), so
-    # judge_mode="numeric" keeps working alongside JudgeMode.NUMERIC.
+    # The enum and its equal string both construct (str-enum): JudgeMode.NUMERIC and
+    # judge_mode="numeric" are interchangeable.
     _make_case(judge_mode=JudgeMode.NUMERIC, judge_threshold=8)
     _make_case(judge_mode="numeric", judge_threshold=8)
 

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from agno.eval import suite
-from agno.eval.suite import Case, SuiteResult, acli, arun_cases, cli, run_cases
+from agno.eval.suite import Case, JudgeMode, SuiteResult, acli, arun_cases, cli, run_cases
 from agno.models.response import ToolExecution
 from agno.run.agent import RunErrorEvent, RunOutput, ToolCallCompletedEvent, ToolCallStartedEvent
 from agno.run.base import RunStatus
@@ -169,10 +169,27 @@ def test_case_with_either_check_constructs():
     _make_case(criteria=None, expected_tool_calls=("search_web",))
 
 
+def test_judge_mode_is_a_binary_numeric_enum():
+    # JudgeMode is the public, importable type; it defaults to BINARY and is a str-enum whose values
+    # are AgentAsJudgeEval's scoring_strategy vocabulary.
+    from agno.eval import JudgeMode as ExportedJudgeMode
+
+    assert ExportedJudgeMode is JudgeMode
+    assert (JudgeMode.BINARY, JudgeMode.NUMERIC) == ("binary", "numeric")
+    assert Case(name="d", agent=StubAgent(), input="q", criteria="c").judge_mode is JudgeMode.BINARY
+
+
+def test_judge_mode_accepts_enum_member_and_equal_string():
+    # Passing the enum is the blessed path; the equal raw string still constructs (str-enum), so
+    # judge_mode="numeric" keeps working alongside JudgeMode.NUMERIC.
+    _make_case(judge_mode=JudgeMode.NUMERIC, judge_threshold=8)
+    _make_case(judge_mode="numeric", judge_threshold=8)
+
+
 def test_invalid_judge_mode_is_rejected_at_construction():
-    # judge_mode is a Literal, not enforced at runtime by the dataclass - guard it explicitly so a
-    # typo fails fast here, not silently as a degraded binary run after a model call is spent.
-    with pytest.raises(ValueError, match="judge_mode must be 'binary' or 'numeric'"):
+    # A raw string bypasses the enum type, so guard it explicitly: a typo fails fast here, not
+    # silently as a degraded binary run after a model call is spent.
+    with pytest.raises(ValueError, match="judge_mode must be a JudgeMode"):
         _make_case(judge_mode="Numeric")
 
 
@@ -180,11 +197,11 @@ def test_numeric_threshold_out_of_range_is_rejected_at_construction():
     # A numeric judge_threshold outside 1-10 fails fast (mirroring AgentAsJudgeEval's own bound),
     # so a bad bar is caught before the run rather than surfacing as a post-run judge error.
     with pytest.raises(ValueError, match="judge_threshold must be 1-10"):
-        _make_case(judge_mode="numeric", judge_threshold=0)
+        _make_case(judge_mode=JudgeMode.NUMERIC, judge_threshold=0)
     with pytest.raises(ValueError, match="judge_threshold must be 1-10"):
-        _make_case(judge_mode="numeric", judge_threshold=11)
+        _make_case(judge_mode=JudgeMode.NUMERIC, judge_threshold=11)
     # Out of range is fine in binary mode - the threshold is never read.
-    _make_case(judge_mode="binary", judge_threshold=99)
+    _make_case(judge_mode=JudgeMode.BINARY, judge_threshold=99)
 
 
 def test_exactly_one_of_agent_or_team_required():
@@ -664,7 +681,7 @@ def test_numeric_scoring_forwards_mode_and_threshold_and_captures_score(monkeypa
     # judge_mode="numeric" forwards the mode + per-case threshold to the judge (which derives
     # passed = score >= threshold itself), and the 1-10 score lands on the result and the payload.
     judge_instances, _ = _install_fake_evals(monkeypatch, judge_passed=True, judge_score=8)
-    case = _make_case(judge_mode="numeric", judge_threshold=8)
+    case = _make_case(judge_mode=JudgeMode.NUMERIC, judge_threshold=8)
 
     suite_result = run_cases([case])
     result = suite_result.results[0]
@@ -680,7 +697,7 @@ def test_numeric_scoring_forwards_mode_and_threshold_and_captures_score(monkeypa
 def test_numeric_score_below_threshold_fails_the_case(monkeypatch):
     # The judge computes passed=False when score < threshold; the suite reflects it faithfully.
     _install_fake_evals(monkeypatch, judge_passed=False, judge_score=5)
-    case = _make_case(judge_mode="numeric", judge_threshold=7)
+    case = _make_case(judge_mode=JudgeMode.NUMERIC, judge_threshold=7)
 
     result = run_cases([case]).results[0]
 

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-from dataclasses import fields
 from types import SimpleNamespace
 
 import pytest
@@ -77,6 +76,7 @@ def _install_fake_evals(
     *,
     judge_passed=True,
     judge_reason="meets the criteria",
+    judge_score=None,
     judge_error=None,
     judge_delay=0.0,
     reliability_status="PASSED",
@@ -101,7 +101,9 @@ def _install_fake_evals(
                 await asyncio.sleep(judge_delay)
             if judge_error is not None:
                 raise judge_error
-            return SimpleNamespace(results=[SimpleNamespace(passed=judge_passed, reason=judge_reason)])
+            return SimpleNamespace(
+                results=[SimpleNamespace(passed=judge_passed, reason=judge_reason, score=judge_score)]
+            )
 
     class FakeReliabilityEval:
         def __init__(self, **kwargs):
@@ -167,10 +169,36 @@ def test_case_with_either_check_constructs():
     _make_case(criteria=None, expected_tool_calls=("search_web",))
 
 
-def test_agent_is_the_last_required_field():
-    # agent must stay last of the required fields so it can gain a default later
-    # (team/workflow alternatives) without a non-default-after-default TypeError.
-    assert [f.name for f in fields(Case)[:3]] == ["name", "input", "agent"]
+def test_exactly_one_of_agent_or_team_required():
+    # A case takes exactly one of agent/team: neither leaves nothing to run, both is ambiguous.
+    from agno.agent import Agent
+    from agno.team.team import Team
+
+    with pytest.raises(ValueError, match="provide one of 'agent' or 'team'"):
+        Case(name="neither", input="q", criteria="c")
+    with pytest.raises(ValueError, match="provide only one of 'agent' or 'team'"):
+        Case(name="both", input="q", criteria="c", agent=Agent(id="a"), team=Team(members=[Agent(id="m")]))
+
+
+def test_agent_and_team_both_construct():
+    # Agent and Team are both supported via their own fields; a Team routes reliability
+    # through team_response=.
+    from agno.agent import Agent
+    from agno.team.team import Team
+
+    Case(name="agent", agent=Agent(id="a"), input="q", criteria="c")
+    Case(name="team", team=Team(members=[Agent(id="m")]), input="q", criteria="c")
+
+
+def test_team_case_populates_team_id_not_agent_id(monkeypatch):
+    # A team's id lands in team_id; agent_id stays None (mirrors AccuracyEval's split).
+    _install_fake_evals(monkeypatch)
+    case = Case(name="t", team=StubAgent(id="research-team"), input="q", criteria="c")
+
+    result = run_cases([case]).results[0]
+
+    assert result.team_id == "research-team"
+    assert result.agent_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -292,6 +320,38 @@ def test_cancelled_run_is_not_judged(monkeypatch):
     assert result.reliability_passed is None
     assert judge_instances == []
     assert reliability_instances == []
+
+
+def test_team_labels_errors_as_team(monkeypatch):
+    # A team reports failures as 'team:', not 'agent:' - the label follows team=.
+    _install_fake_evals(monkeypatch)
+    cancelled_output = _output(content="Run cancelled by user.", status=RunStatus.cancelled)
+    case = Case(name="team_cancel", team=StubAgent(output=cancelled_output), input="q", criteria="c")
+
+    result = run_cases([case]).results[0]
+
+    assert result.error == "team: run cancelled"
+    assert result.passed is False
+
+
+def test_team_label_follows_every_error_route(monkeypatch):
+    # The 'team:' label must follow team= on EVERY failure route (not just the cancelled one
+    # the test above covers): a pre-stream raise, a mid-stream error event, a run that yields
+    # nothing, and a non-completed final status. None may regress to 'agent:'.
+    from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+
+    _install_fake_evals(monkeypatch)
+    routes = {
+        "team: RuntimeError: boom": StubAgent(error=RuntimeError("boom")),
+        "team: member failed": StubAgent(events=[TeamRunErrorEvent(content="member failed")], emit_output=False),
+        "team: no run output recorded": StubAgent(emit_output=False),
+        "team: run paused awaiting user input": StubAgent(output=_output(status=RunStatus.paused)),
+        "team: run ended with status RUNNING": StubAgent(output=_output(content="x", status=RunStatus.running)),
+    }
+    for expected, stub in routes.items():
+        result = run_cases([Case(name="t", team=stub, input="q", criteria="c")]).results[0]
+        assert result.error == expected, f"route {expected!r} produced {result.error!r}"
+        assert result.passed is False
 
 
 def test_cancelled_run_aborts_the_suite_and_records_skipped_cases(monkeypatch):
@@ -571,6 +631,46 @@ def test_judge_only_case(monkeypatch):
     assert result.passed is True
 
 
+def test_binary_scoring_is_the_default(monkeypatch):
+    # Default judge_scoring forwards "binary" and the default threshold; no score captured.
+    judge_instances, _ = _install_fake_evals(monkeypatch)
+
+    result = run_cases([_make_case()]).results[0]
+
+    assert judge_instances[0].kwargs["scoring_strategy"] == "binary"
+    assert judge_instances[0].kwargs["threshold"] == 7
+    assert result.judge_score is None
+
+
+def test_numeric_scoring_forwards_mode_and_threshold_and_captures_score(monkeypatch):
+    # judge_scoring="numeric" forwards the mode + per-case threshold to the judge (which derives
+    # passed = score >= threshold itself), and the 1-10 score lands on the result and the payload.
+    judge_instances, _ = _install_fake_evals(monkeypatch, judge_passed=True, judge_score=8)
+    case = _make_case(judge_scoring="numeric", judge_threshold=8)
+
+    suite_result = run_cases([case])
+    result = suite_result.results[0]
+
+    assert judge_instances[0].kwargs["scoring_strategy"] == "numeric"
+    assert judge_instances[0].kwargs["threshold"] == 8
+    assert result.judge_passed is True
+    assert result.judge_score == 8
+    assert result.passed is True
+    assert suite_result.to_dict()["cases"][0]["judge_score"] == 8
+
+
+def test_numeric_score_below_threshold_fails_the_case(monkeypatch):
+    # The judge computes passed=False when score < threshold; the suite reflects it faithfully.
+    _install_fake_evals(monkeypatch, judge_passed=False, judge_score=5)
+    case = _make_case(judge_scoring="numeric", judge_threshold=7)
+
+    result = run_cases([case]).results[0]
+
+    assert result.judge_passed is False
+    assert result.judge_score == 5
+    assert result.passed is False
+
+
 def test_reliability_only_case(monkeypatch):
     _install_fake_evals(monkeypatch)
     case = _make_case(criteria=None, expected_tool_calls=("search_web",))
@@ -682,6 +782,32 @@ def test_reliability_kwargs_forwarded(monkeypatch):
     assert kwargs["allow_additional_tool_calls"] is False
 
 
+def test_team_output_routes_reliability_to_team_response_and_flattens_tools(monkeypatch):
+    # A team's members' tool calls live in member_responses; ReliabilityEval merges them only
+    # via team_response= (agent_response= sees just the leader's delegation). The runner routes
+    # by the captured output type, and the evidence surfaces the member's real tool.
+    from agno.run.team import TeamRunOutput
+
+    _, reliability_instances = _install_fake_evals(monkeypatch)
+    member = _output(content="42", tools=[ToolExecution(tool_name="multiply")])
+    team_output = TeamRunOutput(
+        content="42",
+        status=RunStatus.completed,
+        tools=[ToolExecution(tool_name="delegate_task_to_member")],
+        member_responses=[member],
+    )
+    case = _make_case(agent=StubAgent(output=team_output), criteria=None, expected_tool_calls=("multiply",))
+
+    result = run_cases([case]).results[0]
+
+    kwargs = reliability_instances[0].kwargs
+    assert kwargs["team_response"] is team_output
+    assert kwargs["agent_response"] is None
+    # evidence surfaces the member's real tool, not only the leader's delegation
+    assert result.tools_called == ("delegate_task_to_member", "multiply")
+    assert result.reliability_passed is True
+
+
 # ---------------------------------------------------------------------------
 # JSON payload contract (check 9)
 # ---------------------------------------------------------------------------
@@ -704,11 +830,13 @@ def test_to_dict_matches_contract(monkeypatch):
     assert list(case_payload.keys()) == [
         "name",
         "agent_id",
+        "team_id",
         "tags",
         "session_id",
         "duration_seconds",
         "judge_passed",
         "judge_reason",
+        "judge_score",
         "reliability_passed",
         "output",
         "tools_called",
@@ -719,11 +847,13 @@ def test_to_dict_matches_contract(monkeypatch):
     ]
     assert case_payload["name"] == "capital_of_france"
     assert case_payload["agent_id"] == "geo-agent"
+    assert case_payload["team_id"] is None
     assert case_payload["tags"] == ["smoke", "release"]
     assert case_payload["session_id"].startswith("eval-capital_of_france-")
     assert isinstance(case_payload["duration_seconds"], float)
     assert case_payload["judge_passed"] is True
     assert case_payload["judge_reason"] == "meets the criteria"
+    assert case_payload["judge_score"] is None  # binary mode carries no score
     assert case_payload["reliability_passed"] is True
     assert case_payload["output"] == "Paris."
     assert case_payload["tools_called"] == ["search_web"]
@@ -1058,7 +1188,9 @@ def test_cli_list_with_json_output_writes_case_list(monkeypatch, tmp_path):
     assert exit_code == 0
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert payload == {
-        "cases": [{"name": "listed", "agent_id": "stub-agent", "tags": ["smoke"], "timeout_seconds": 30}]
+        "cases": [
+            {"name": "listed", "agent_id": "stub-agent", "team_id": None, "tags": ["smoke"], "timeout_seconds": 30}
+        ]
     }
     assert agent.run_count == 0
 

--- a/libs/agno/tests/unit/eval/test_suite.py
+++ b/libs/agno/tests/unit/eval/test_suite.py
@@ -169,6 +169,24 @@ def test_case_with_either_check_constructs():
     _make_case(criteria=None, expected_tool_calls=("search_web",))
 
 
+def test_invalid_judge_mode_is_rejected_at_construction():
+    # judge_mode is a Literal, not enforced at runtime by the dataclass - guard it explicitly so a
+    # typo fails fast here, not silently as a degraded binary run after a model call is spent.
+    with pytest.raises(ValueError, match="judge_mode must be 'binary' or 'numeric'"):
+        _make_case(judge_mode="Numeric")
+
+
+def test_numeric_threshold_out_of_range_is_rejected_at_construction():
+    # A numeric judge_threshold outside 1-10 fails fast (mirroring AgentAsJudgeEval's own bound),
+    # so a bad bar is caught before the run rather than surfacing as a post-run judge error.
+    with pytest.raises(ValueError, match="judge_threshold must be 1-10"):
+        _make_case(judge_mode="numeric", judge_threshold=0)
+    with pytest.raises(ValueError, match="judge_threshold must be 1-10"):
+        _make_case(judge_mode="numeric", judge_threshold=11)
+    # Out of range is fine in binary mode - the threshold is never read.
+    _make_case(judge_mode="binary", judge_threshold=99)
+
+
 def test_exactly_one_of_agent_or_team_required():
     # A case takes exactly one of agent/team: neither leaves nothing to run, both is ambiguous.
     from agno.agent import Agent
@@ -632,7 +650,7 @@ def test_judge_only_case(monkeypatch):
 
 
 def test_binary_scoring_is_the_default(monkeypatch):
-    # Default judge_scoring forwards "binary" and the default threshold; no score captured.
+    # Default judge_mode forwards "binary" and the default threshold; no score captured.
     judge_instances, _ = _install_fake_evals(monkeypatch)
 
     result = run_cases([_make_case()]).results[0]
@@ -643,10 +661,10 @@ def test_binary_scoring_is_the_default(monkeypatch):
 
 
 def test_numeric_scoring_forwards_mode_and_threshold_and_captures_score(monkeypatch):
-    # judge_scoring="numeric" forwards the mode + per-case threshold to the judge (which derives
+    # judge_mode="numeric" forwards the mode + per-case threshold to the judge (which derives
     # passed = score >= threshold itself), and the 1-10 score lands on the result and the payload.
     judge_instances, _ = _install_fake_evals(monkeypatch, judge_passed=True, judge_score=8)
-    case = _make_case(judge_scoring="numeric", judge_threshold=8)
+    case = _make_case(judge_mode="numeric", judge_threshold=8)
 
     suite_result = run_cases([case])
     result = suite_result.results[0]
@@ -662,7 +680,7 @@ def test_numeric_scoring_forwards_mode_and_threshold_and_captures_score(monkeypa
 def test_numeric_score_below_threshold_fails_the_case(monkeypatch):
     # The judge computes passed=False when score < threshold; the suite reflects it faithfully.
     _install_fake_evals(monkeypatch, judge_passed=False, judge_score=5)
-    case = _make_case(judge_scoring="numeric", judge_threshold=7)
+    case = _make_case(judge_mode="numeric", judge_threshold=7)
 
     result = run_cases([case]).results[0]
 


### PR DESCRIPTION
## Summary

The eval suite (`agno.eval.suite`) accepted only a single `Agent` as a `Case` subject and graded answers with a binary pass/fail judge. This adds two capabilities, both lifted from framework features that already exist:

- **Team subjects** — a `Case` takes `agent=` or `team=`. A team routes its reliability check through `ReliabilityEval`'s `team_response=`, so a member's real tool call is counted rather than only the leader's `delegate_task_to_member`. The evidence list (`tools_called`) collects member tool calls one level down.
- **Numeric judge scoring** — `judge_mode=JudgeMode.NUMERIC` grades 1-10 and passes when the score meets `judge_threshold` (default 7); `JudgeMode.BINARY` stays the default. `AgentAsJudgeEval` derives the pass/fail from the score, so a case still gates on a clean verdict. `JudgeMode` is a `str`-enum exported from `agno.eval` (so `from agno.eval import JudgeMode`, and the equal string `judge_mode="numeric"` still works); it is named `judge_mode`, not `judge_scoring`, to stay distinct from the `judge_score` it produces. `Case.__post_init__` validates the judge config at construction — an unknown `judge_mode` or an out-of-range numeric `judge_threshold` fails fast rather than surfacing as a post-run judge error.

Supporting changes: `CaseResult` splits `agent_id`/`team_id` (mirroring `AccuracyEval`), the `to_dict()` payload and `--list` output gain `team_id` and `judge_score`, run errors are prefixed with the subject that failed (`team:` / `agent:`), and the `--list` table column reads `Component`.

`reliability.py` is unchanged — both features reuse `team_response=` and `scoring_strategy="numeric"`, which were already present.

The cookbook `cookbook/09_evals/suite/suite_team_scoring.py` runs a team whose leader delegates to a calculator member and a writer member, with every answer graded by a numeric judge.

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Future work (not in this PR)

**Workflow subjects.** The suite takes an `Agent` or a `Team`; a `Workflow` is the natural third subject. Adding it is additive and non-breaking — a `workflow=` field beside `agent=`/`team=`, a `workflow_id` payload key, and reliability routed through a `workflow_response=`. It is held back because it needs new framework wiring (a workflow-response tool merge), while this PR only lifts capabilities that already exist. The one-level team-member tool merge is generalised to recurse at the same time, which also covers teams nested more than one level deep.

**AccuracyEval as a check.** Each case here gates on a binary PASS/FAIL from the judge and reliability checks. `AccuracyEval` is a different eval: it reports a graded accuracy score and carries no native pass/fail. Exposing it as a suite check is future work, because its numeric accuracy has to be mapped onto the suite's pass/fail gate (for example, a threshold) — there is no pass/fail on it to read directly.