### PR TITLE
feat: resolve AGENTOS_URL from .env.production / .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # Ignore .env files
 .env
+.env.production
 
 # Ignore .envrc files (used by direnv: https://direnv.net/)
 .envrc

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -73,6 +73,39 @@ def require_secure_url(url: str, *, allow_http: bool, what: str = "a credential"
     )
 
 
+def ensure_env_file_url_trusted(
+    base_url: str,
+    url_source: str,
+    url_source_file: Optional[str],
+    *,
+    assume_yes: bool,
+    json_mode: bool,
+) -> None:
+    """Guard the ambient-env-file redirect before a credential or config write.
+
+    An AGENTOS_URL read from a .env / .env.production in the current directory is trusted
+    automatically only when it points at a loopback host. A non-loopback env-file URL could
+    have been planted by an untrusted directory to redirect the admin credential or rewrite
+    MCP client configs, so require an explicit go-ahead: prompt interactively (default no),
+    and refuse outright in automation (--json or no TTY) unless --yes was passed. An explicit
+    --url or an exported AGENTOS_URL env var is not an ambient file and is trusted as before.
+    """
+    if url_source != "env-file":
+        return
+    if _is_loopback_host(urlsplit(base_url).hostname):
+        return
+    if assume_yes:
+        return
+    source = url_source_file or "an env file"
+    if json_mode or not stdin_is_interactive():
+        raise CLIError(
+            "AGENTOS_URL in " + source + " points at a non-local host (" + base_url + ").",
+            hint="Pass --url to target it explicitly, or --yes to trust the env file.",
+        )
+    if not typer.confirm("Trust AGENTOS_URL=" + base_url + " (from " + source + ")?", default=False):
+        raise CLIError("Aborted: did not trust the env-file URL " + base_url + ".")
+
+
 def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
     """Resolve the admin credential used to call the service-accounts API.
 

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -84,11 +84,12 @@ def ensure_env_file_url_trusted(
     """Guard the ambient-env-file redirect before a credential or config write.
 
     An AGENTOS_URL read from a .env / .env.production in the current directory is trusted
-    automatically only when it points at a loopback host. A non-loopback env-file URL could
-    have been planted by an untrusted directory to redirect the admin credential or rewrite
-    MCP client configs, so require an explicit go-ahead: prompt interactively (default no),
-    and refuse outright in automation (--json or no TTY) unless --yes was passed. An explicit
-    --url or an exported AGENTOS_URL env var is not an ambient file and is trusted as before.
+    automatically only when it points at this machine (localhost / 127.x / ::1). A URL that
+    points at a remote host could have been planted by an untrusted directory to redirect the
+    admin credential or rewrite MCP client configs, so require an explicit go-ahead: prompt
+    interactively (default no), and refuse outright in automation (--json or no TTY) unless
+    --yes was passed. An explicit --url or an exported AGENTOS_URL env var is not an ambient
+    file and is trusted as before.
     """
     if url_source != "env-file":
         return
@@ -99,7 +100,7 @@ def ensure_env_file_url_trusted(
     source = url_source_file or "an env file"
     if json_mode or not stdin_is_interactive():
         raise CLIError(
-            "AGENTOS_URL in " + source + " points at a non-local host (" + base_url + ").",
+            "AGENTOS_URL in " + source + " points to a remote host (" + base_url + ").",
             hint="Pass --url to target it explicitly, or --yes to trust the env file.",
         )
     if not typer.confirm("Trust AGENTOS_URL=" + base_url + " (from " + source + ")?", default=False):

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -232,10 +232,10 @@ def connect(
         False, "--skip-existing", help="Never touch existing accounts or config entries."
     ),
     allow_http: bool = typer.Option(
-        False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a non-loopback host."
+        False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a remote host."
     ),
     yes: bool = typer.Option(
-        False, "--yes", "-y", help="Trust a non-loopback AGENTOS_URL read from a .env file without prompting."
+        False, "--yes", "-y", help="Trust a remote AGENTOS_URL from a .env file without prompting."
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
 ) -> None:

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -280,7 +280,12 @@ def _connect(
         )
     if not json_mode:
         version = " (agno " + os_info.version + ")" if os_info.version else ""
-        source = " (from AGENTOS_URL)" if os_info.url_source == "env" else ""
+        if os_info.url_source == "env":
+            source = " (from AGENTOS_URL)"
+        elif os_info.url_source == "env-file":
+            source = " (from AGENTOS_URL in " + (os_info.url_source_file or "env file") + ")"
+        else:
+            source = ""
         print_info("AgentOS at " + os_info.base_url + version + source + ", MCP at " + os_info.mcp_url)
 
     adapters = build_adapters(project=project)

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -17,6 +17,7 @@ from agnoctl.clients import CLIENT_ALIASES, build_adapters
 from agnoctl.clients.base import ClientAdapter
 from agnoctl.commands._common import (
     _is_loopback_host,
+    ensure_env_file_url_trusted,
     handle_cli_error,
     parse_expires,
     require_secure_url,
@@ -200,7 +201,9 @@ def _mint(
 
 
 def connect(
-    url: Optional[str] = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost)."),
+    url: Optional[str] = typer.Option(
+        None, "--url", help="AgentOS base URL. Default: AGENTOS_URL, then .env.production/.env, then localhost."
+    ),
     clients: Optional[str] = typer.Option(
         None,
         "--clients",
@@ -231,6 +234,9 @@ def connect(
     allow_http: bool = typer.Option(
         False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a non-loopback host."
     ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Trust a non-loopback AGENTOS_URL read from a .env file without prompting."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
 ) -> None:
     """Connect this machine's coding agents to a running AgentOS over MCP."""
@@ -247,6 +253,7 @@ def connect(
             rotate=rotate,
             skip_existing=skip_existing,
             allow_http=allow_http,
+            assume_yes=yes,
             json_mode=json_output,
         )
     except CLIError as e:
@@ -265,12 +272,18 @@ def _connect(
     rotate: bool,
     skip_existing: bool,
     allow_http: bool,
+    assume_yes: bool,
     json_mode: bool,
 ) -> None:
     validate_server_name(server_name)
     expires_in_days, never_expires = parse_expires(expires)
 
     os_info = discover(url)
+    # Before anything sensitive (minting, config writes), confirm an off-machine URL that
+    # came from an ambient .env file -- it could be redirecting us from an untrusted dir.
+    ensure_env_file_url_trusted(
+        os_info.base_url, os_info.url_source, os_info.url_source_file, assume_yes=assume_yes, json_mode=json_mode
+    )
     if not os_info.mcp_enabled:
         raise CLIError(
             "Found an AgentOS at "
@@ -280,12 +293,7 @@ def _connect(
         )
     if not json_mode:
         version = " (agno " + os_info.version + ")" if os_info.version else ""
-        if os_info.url_source == "env":
-            source = " (from AGENTOS_URL)"
-        elif os_info.url_source == "env-file":
-            source = " (from AGENTOS_URL in " + (os_info.url_source_file or "env file") + ")"
-        else:
-            source = ""
+        source = os_info.source_note()
         print_info("AgentOS at " + os_info.base_url + version + source + ", MCP at " + os_info.mcp_url)
 
     adapters = build_adapters(project=project)

--- a/libs/agnoctl/agnoctl/commands/status.py
+++ b/libs/agnoctl/agnoctl/commands/status.py
@@ -12,7 +12,9 @@ from agnoctl.errors import CLIError
 
 
 def status(
-    url: Optional[str] = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost)."),
+    url: Optional[str] = typer.Option(
+        None, "--url", help="AgentOS base URL. Default: AGENTOS_URL, then .env.production/.env, then localhost."
+    ),
     server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name to look for in clients."),
     json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
 ) -> None:
@@ -40,7 +42,7 @@ def status(
         return
 
     version = " (agno " + os_info.version + ")" if os_info.version else ""
-    print_success("AgentOS: " + os_info.base_url + version)
+    print_success("AgentOS: " + os_info.base_url + os_info.source_note() + version)
     mcp = os_info.mcp_url if os_info.mcp_enabled else "disabled"
     print_info("  MCP: " + mcp)
     print_info("  Auth mode: " + os_info.auth_mode)

--- a/libs/agnoctl/agnoctl/commands/tokens.py
+++ b/libs/agnoctl/agnoctl/commands/tokens.py
@@ -26,10 +26,10 @@ UrlOption = typer.Option(
 )
 JsonOption = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption.")
 AllowHttpOption = typer.Option(
-    False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a non-loopback host."
+    False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a remote host."
 )
 TrustEnvFileOption = typer.Option(
-    False, "--yes", "-y", help="Trust a non-loopback AGENTOS_URL read from a .env file without prompting."
+    False, "--yes", "-y", help="Trust a remote AGENTOS_URL from a .env file without prompting."
 )
 
 
@@ -43,7 +43,7 @@ def _api_for(
     url: Optional[str], json_mode: bool, allow_http: bool, sensitive: bool = False, assume_yes: bool = False
 ) -> AgentOSAPI:
     os_info = discover(url)
-    # A non-loopback URL pulled from an ambient .env file could be redirecting this
+    # A remote URL pulled from an ambient .env file could be redirecting this
     # credential-bearing call; confirm it (or refuse in automation) before going further.
     ensure_env_file_url_trusted(
         os_info.base_url, os_info.url_source, os_info.url_source_file, assume_yes=assume_yes, json_mode=json_mode
@@ -159,7 +159,7 @@ def revoke(
     json_output: bool = JsonOption,
     allow_http: bool = AllowHttpOption,
     yes: bool = typer.Option(
-        False, "--yes", "-y", help="Skip confirmation prompts (revoking, and trusting a non-loopback .env-file URL)."
+        False, "--yes", "-y", help="Skip confirmation prompts (revoking, and trusting a remote .env-file URL)."
     ),
 ) -> None:
     """Revoke a service account. Takes effect on the account's next request."""

--- a/libs/agnoctl/agnoctl/commands/tokens.py
+++ b/libs/agnoctl/agnoctl/commands/tokens.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 import typer
 
 from agnoctl.commands._common import (
+    ensure_env_file_url_trusted,
     handle_cli_error,
     parse_expires,
     require_secure_url,
@@ -20,10 +21,15 @@ from agnoctl.http import AgentOSAPI
 
 tokens_app = typer.Typer(name="tokens", help="Mint, list, and revoke AgentOS service-account tokens.")
 
-UrlOption = typer.Option(None, "--url", help="AgentOS base URL (default: autodiscover on localhost).")
+UrlOption = typer.Option(
+    None, "--url", help="AgentOS base URL. Default: AGENTOS_URL, then .env.production/.env, then localhost."
+)
 JsonOption = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption.")
 AllowHttpOption = typer.Option(
     False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a non-loopback host."
+)
+TrustEnvFileOption = typer.Option(
+    False, "--yes", "-y", help="Trust a non-loopback AGENTOS_URL read from a .env file without prompting."
 )
 
 
@@ -33,12 +39,19 @@ def _timestamp(value: Optional[int]) -> str:
     return datetime.fromtimestamp(value, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
 
-def _api_for(url: Optional[str], json_mode: bool, allow_http: bool, sensitive: bool = False) -> AgentOSAPI:
+def _api_for(
+    url: Optional[str], json_mode: bool, allow_http: bool, sensitive: bool = False, assume_yes: bool = False
+) -> AgentOSAPI:
     os_info = discover(url)
+    # A non-loopback URL pulled from an ambient .env file could be redirecting this
+    # credential-bearing call; confirm it (or refuse in automation) before going further.
+    ensure_env_file_url_trusted(
+        os_info.base_url, os_info.url_source, os_info.url_source_file, assume_yes=assume_yes, json_mode=json_mode
+    )
     # Surface which OS we resolved before we mint or attach a credential: on a shared host
     # autodiscovery could land on a port-squatter, and the operator should see the target.
     if url is None and not json_mode:
-        print_info("Using AgentOS at " + os_info.base_url)
+        print_info("Using AgentOS at " + os_info.base_url + os_info.source_note())
     admin_token = resolve_admin_token(os_info.auth_mode, json_mode)
     # Refuse to put a bearer credential (admin token) or receive a freshly minted PAT over
     # plaintext HTTP unless the target is loopback or the operator opted in with --allow-http.
@@ -62,13 +75,14 @@ def create(
     url: Optional[str] = UrlOption,
     json_output: bool = JsonOption,
     allow_http: bool = AllowHttpOption,
+    yes: bool = TrustEnvFileOption,
 ) -> None:
     """Mint a service-account token. The plaintext is shown exactly once."""
     try:
         expires_in_days, never_expires = parse_expires(expires)
         # The plaintext PAT rides back in the create response, so this call is sensitive
         # even when the OS itself requires no admin credential to reach it.
-        with _api_for(url, json_output, allow_http, sensitive=True) as api:
+        with _api_for(url, json_output, allow_http, sensitive=True, assume_yes=yes) as api:
             try:
                 account = api.create_service_account(
                     name=name,
@@ -103,10 +117,11 @@ def list_(
     url: Optional[str] = UrlOption,
     json_output: bool = JsonOption,
     allow_http: bool = AllowHttpOption,
+    yes: bool = TrustEnvFileOption,
 ) -> None:
     """List service accounts (metadata and display prefixes only, never tokens)."""
     try:
-        with _api_for(url, json_output, allow_http) as api:
+        with _api_for(url, json_output, allow_http, assume_yes=yes) as api:
             accounts = api.list_service_accounts()
     except CLIError as e:
         raise handle_cli_error(e, json_output)
@@ -143,11 +158,13 @@ def revoke(
     url: Optional[str] = UrlOption,
     json_output: bool = JsonOption,
     allow_http: bool = AllowHttpOption,
-    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the interactive confirmation prompt."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip confirmation prompts (revoking, and trusting a non-loopback .env-file URL)."
+    ),
 ) -> None:
     """Revoke a service account. Takes effect on the account's next request."""
     try:
-        with _api_for(url, json_output, allow_http) as api:
+        with _api_for(url, json_output, allow_http, assume_yes=yes) as api:
             account = api.find_service_account(name)
             if account is None:
                 raise CLIError("No service account named '" + name + "' found.")

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -8,6 +8,7 @@ distinguishes the auth modes by status code and 401 detail wording.
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -28,6 +29,11 @@ DEFAULT_URLS = [
 
 URL_ENV_VAR = "AGENTOS_URL"
 
+# Project env files scanned for AGENTOS_URL when it is not already in the process
+# environment, so `agno connect` targets a deployed OS whose URL the deploy scripts
+# persisted (to .env.production) without needing --url. Preferred order: production first.
+ENV_FILES = (".env.production", ".env")
+
 
 @dataclass
 class OSInfo:
@@ -37,7 +43,8 @@ class OSInfo:
     mcp_path: Optional[str]
     auth_mode: str  # "none" | "security_key" | "jwt" | "unknown"
     discovered_via: str  # "info" | "probe"
-    url_source: str = "default"  # "flag" | "env" | "default"
+    url_source: str = "default"  # "flag" | "env" | "env-file" | "default"
+    url_source_file: Optional[str] = None  # env file AGENTOS_URL came from, when url_source == "env-file"
 
     @property
     def mcp_url(self) -> str:
@@ -56,16 +63,57 @@ class OSInfo:
             "auth_mode": self.auth_mode,
             "discovered_via": self.discovered_via,
             "url_source": self.url_source,
+            "url_source_file": self.url_source_file,
         }
 
 
-def _candidate_urls(url: Optional[str]) -> "tuple[List[str], str]":
+def _read_env_value(path: Path, key: str) -> Optional[str]:
+    """Read a single ``KEY=value`` from a .env-style file. No dotenv dependency: agnoctl
+    parses only what it needs and never loads the file into the process environment.
+    Tolerates an ``export `` prefix, surrounding quotes, blank lines, and ``#`` comments;
+    the last uncommented assignment wins. Returns None if absent or unreadable."""
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    found: Optional[str] = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        name, sep, value = line.partition("=")
+        if not sep or name.strip() != key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        if value:
+            found = value  # keep scanning: a later assignment overrides an earlier one
+    return found
+
+
+def _agentos_url_from_env_files() -> "tuple[Optional[str], Optional[str]]":
+    """AGENTOS_URL from a project env file (.env.production preferred, then .env), read
+    from the current working directory. Returns (url, filename) or (None, None)."""
+    for name in ENV_FILES:
+        value = _read_env_value(Path.cwd() / name, URL_ENV_VAR)
+        if value:
+            return value.rstrip("/"), name
+    return None, None
+
+
+def _candidate_urls(url: Optional[str]) -> "tuple[List[str], str, Optional[str]]":
     if url:
-        return [url.rstrip("/")], "flag"
+        return [url.rstrip("/")], "flag", None
     env_url = os.environ.get(URL_ENV_VAR)
     if env_url:
-        return [env_url.rstrip("/")], "env"
-    return list(DEFAULT_URLS), "default"
+        return [env_url.rstrip("/")], "env", None
+    file_url, file_name = _agentos_url_from_env_files()
+    if file_url:
+        return [file_url], "env-file", file_name
+    return list(DEFAULT_URLS), "default", None
 
 
 def _probe_mcp(base_url: str) -> bool:
@@ -88,7 +136,7 @@ def _probe_mcp(base_url: str) -> bool:
 
 def discover(url: Optional[str] = None) -> OSInfo:
     """Find a running AgentOS and return what the CLI needs to know about it."""
-    candidates, url_source = _candidate_urls(url)
+    candidates, url_source, url_source_file = _candidate_urls(url)
     for candidate in candidates:
         with AgentOSAPI(candidate) as api:
             if api.health() is None:
@@ -106,6 +154,7 @@ def discover(url: Optional[str] = None) -> OSInfo:
                     auth_mode=auth_mode,
                     discovered_via="info",
                     url_source=url_source,
+                    url_source_file=url_source_file,
                 )
 
             mcp_enabled = _probe_mcp(candidate)
@@ -117,12 +166,15 @@ def discover(url: Optional[str] = None) -> OSInfo:
                 auth_mode=api.probe_auth_mode(),
                 discovered_via="probe",
                 url_source=url_source,
+                url_source_file=url_source_file,
             )
 
     tried = ", ".join(candidates)
     raise CLIError(
         "No running AgentOS found (tried: " + tried + ").",
-        hint="Start your AgentOS (agent_os.serve()) or pass --url / set " + URL_ENV_VAR + ".",
+        hint="Start your AgentOS (agent_os.serve()), pass --url, or set "
+        + URL_ENV_VAR
+        + " (in your shell or a .env.production / .env file).",
     )
 
 

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -66,6 +66,10 @@ class OSInfo:
             "url_source_file": self.url_source_file,
         }
 
+    def source_note(self) -> str:
+        """Provenance suffix like ' (from AGENTOS_URL in .env.production)' for messages."""
+        return _source_note(self.url_source, self.url_source_file)
+
 
 def _read_env_value(path: Path, key: str) -> Optional[str]:
     """Read a single ``KEY=value`` from a .env-style file. No dotenv dependency: agnoctl
@@ -73,34 +77,55 @@ def _read_env_value(path: Path, key: str) -> Optional[str]:
     Tolerates an ``export `` prefix, surrounding quotes, blank lines, and ``#`` comments;
     the last uncommented assignment wins. Returns None if absent or unreadable."""
     try:
-        text = path.read_text()
-    except OSError:
+        # utf-8-sig transparently drops a UTF-8 BOM (some Windows editors add one); catching
+        # UnicodeDecodeError keeps a binary/other-encoding file from crashing discovery.
+        text = path.read_text(encoding="utf-8-sig")
+    except (OSError, UnicodeDecodeError):
         return None
     found: Optional[str] = None
     for raw in text.splitlines():
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        if line.startswith("export "):
-            line = line[len("export ") :].lstrip()
+        if line.startswith("export ") or line.startswith("export\t"):
+            line = line[len("export") :].lstrip()
         name, sep, value = line.partition("=")
         if not sep or name.strip() != key:
             continue
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-            value = value[1:-1]
-        if value:
-            found = value  # keep scanning: a later assignment overrides an earlier one
+        if value[:1] in ("'", '"'):
+            # Quoted value: take what's inside the matching quote and ignore any trailing
+            # inline comment. An unterminated quote is left as-is (a malformed line).
+            end = value.find(value[0], 1)
+            if end != -1:
+                value = value[1:end]
+        else:
+            # Unquoted value: an inline comment starts at the first '#' preceded by
+            # whitespace ("host  # note"); a '#' with no leading space is a literal (a URL
+            # fragment) and is kept.
+            for i in range(1, len(value)):
+                if value[i] == "#" and value[i - 1] in " \t":
+                    value = value[:i].rstrip()
+                    break
+        # The last assignment wins, including an empty one that clears an earlier value.
+        found = value or None
     return found
 
 
 def _agentos_url_from_env_files() -> "tuple[Optional[str], Optional[str]]":
     """AGENTOS_URL from a project env file (.env.production preferred, then .env), read
     from the current working directory. Returns (url, filename) or (None, None)."""
+    try:
+        cwd = Path.cwd()
+    except OSError:
+        # The working directory was deleted out from under us; treat as "no env file".
+        return None, None
     for name in ENV_FILES:
-        value = _read_env_value(Path.cwd() / name, URL_ENV_VAR)
+        value = _read_env_value(cwd / name, URL_ENV_VAR)
         if value:
-            return value.rstrip("/"), name
+            url = value.rstrip("/")
+            if url:  # a slash-only value ("/") normalizes to "" -- skip it and try the next file
+                return url, name
     return None, None
 
 
@@ -114,6 +139,15 @@ def _candidate_urls(url: Optional[str]) -> "tuple[List[str], str, Optional[str]]
     if file_url:
         return [file_url], "env-file", file_name
     return list(DEFAULT_URLS), "default", None
+
+
+def _source_note(url_source: str, url_source_file: Optional[str]) -> str:
+    """A short '(from AGENTOS_URL ...)' provenance suffix for user-facing messages."""
+    if url_source == "env-file" and url_source_file:
+        return " (from AGENTOS_URL in " + url_source_file + ")"
+    if url_source == "env":
+        return " (from AGENTOS_URL)"
+    return ""
 
 
 def _probe_mcp(base_url: str) -> bool:
@@ -137,8 +171,18 @@ def _probe_mcp(base_url: str) -> bool:
 def discover(url: Optional[str] = None) -> OSInfo:
     """Find a running AgentOS and return what the CLI needs to know about it."""
     candidates, url_source, url_source_file = _candidate_urls(url)
+    source_note = _source_note(url_source, url_source_file)
     for candidate in candidates:
-        with AgentOSAPI(candidate) as api:
+        try:
+            api = AgentOSAPI(candidate)
+        except httpx.InvalidURL as e:
+            # A user-supplied URL (flag/env/env-file) that httpx cannot parse -- e.g. an
+            # un-expanded "${PORT}" or a typo'd port. Fail clearly, not with a traceback.
+            raise CLIError(
+                "Invalid AgentOS URL: " + candidate + source_note + ".",
+                hint="Fix the URL" + (" in " + url_source_file if url_source_file else "") + " or pass --url.",
+            ) from e
+        with api:
             if api.health() is None:
                 continue
             info = api.info() or {}
@@ -170,11 +214,21 @@ def discover(url: Optional[str] = None) -> OSInfo:
             )
 
     tried = ", ".join(candidates)
+    if url_source == "env-file":
+        hint = (
+            "The URL came from AGENTOS_URL in "
+            + (url_source_file or "an env file")
+            + " in this directory -- fix or remove it, pass --url, or start your AgentOS (agent_os.serve())."
+        )
+    else:
+        hint = (
+            "Start your AgentOS (agent_os.serve()), pass --url, or set "
+            + URL_ENV_VAR
+            + " (in your shell or a .env.production / .env file)."
+        )
     raise CLIError(
-        "No running AgentOS found (tried: " + tried + ").",
-        hint="Start your AgentOS (agent_os.serve()), pass --url, or set "
-        + URL_ENV_VAR
-        + " (in your shell or a .env.production / .env file).",
+        "No running AgentOS found (tried: " + tried + source_note + ").",
+        hint=hint,
     )
 
 

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -1,6 +1,7 @@
 """Test fixtures: an in-memory fake AgentOS served through httpx.MockTransport."""
 
 import json
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import httpx
@@ -204,10 +205,15 @@ class FakeAgentOS:
 
 
 @pytest.fixture
-def fake_os(monkeypatch: pytest.MonkeyPatch) -> FakeAgentOS:
-    """A security-key-mode fake AgentOS wired into every CLI HTTP client."""
+def fake_os(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> FakeAgentOS:
+    """A security-key-mode fake AgentOS wired into every CLI HTTP client.
+
+    Also chdir into an empty tmp dir so discovery never resolves a stray project
+    .env / .env.production from the developer's checkout; a test exercising env-file
+    resolution writes the file into this directory (its cwd)."""
     fake = FakeAgentOS()
     install_fake(monkeypatch, fake)
+    monkeypatch.chdir(tmp_path)
     return fake
 
 
@@ -215,6 +221,8 @@ def install_fake(monkeypatch: pytest.MonkeyPatch, fake: FakeAgentOS) -> None:
     import agnoctl.http as http_module
 
     monkeypatch.setattr(http_module, "_transport_override", fake.transport())
-    # Keep host-machine credentials and URL overrides out of tests.
+    # Keep host-machine credentials and URL overrides out of tests. Discovery also reads a
+    # cwd .env / .env.production; the fake_os fixture chdirs to an isolated dir, and direct
+    # install_fake callers pass --url or set AGENTOS_URL / chdir themselves.
     for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGENTOS_URL"):
         monkeypatch.delenv(var, raising=False)

--- a/libs/agnoctl/tests/test_discovery.py
+++ b/libs/agnoctl/tests/test_discovery.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 
-from agnoctl.discovery import discover
+from agnoctl.discovery import _read_env_value, discover
 from agnoctl.errors import CLIError
 from tests.conftest import FakeAgentOS, install_fake
 
@@ -48,7 +48,7 @@ def test_discover_probe_detects_mcp_disabled(monkeypatch):
     assert info.mcp_path is None
 
 
-def test_discover_unreachable_raises(monkeypatch):
+def test_discover_unreachable_raises(monkeypatch, tmp_path):
     def refuse(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("connection refused", request=request)
 
@@ -56,6 +56,7 @@ def test_discover_unreachable_raises(monkeypatch):
 
     monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(refuse))
     monkeypatch.delenv("AGENTOS_URL", raising=False)
+    monkeypatch.chdir(tmp_path)  # no AGENTOS_URL in a .env file to pick up
     with pytest.raises(CLIError) as exc_info:
         discover(None)
     assert "No running AgentOS" in exc_info.value.message
@@ -75,7 +76,7 @@ def test_default_urls_probe_bumped_ports():
     assert "http://localhost:7779" in DEFAULT_URLS
 
 
-def test_discover_finds_os_on_bumped_port_when_7777_is_taken(monkeypatch):
+def test_discover_finds_os_on_bumped_port_when_7777_is_taken(monkeypatch, tmp_path):
     """An AgentOS on 7778 (7777 occupied) must be found by autodiscovery, not missed."""
     fake = FakeAgentOS()
 
@@ -88,7 +89,53 @@ def test_discover_finds_os_on_bumped_port_when_7777_is_taken(monkeypatch):
 
     monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
     monkeypatch.delenv("AGENTOS_URL", raising=False)
+    monkeypatch.chdir(tmp_path)  # exercise the localhost-defaults path, not a .env file
 
     info = discover(None)
     assert info.base_url == "http://localhost:7778"
     assert info.mcp_url == "http://localhost:7778/mcp"
+
+
+def test_discover_env_file_url(monkeypatch, tmp_path, fake_os):
+    """AGENTOS_URL in .env.production is picked up when neither --url nor the env var is set."""
+    (tmp_path / ".env.production").write_text('AGENTOS_URL="http://filehost:9000"\n')
+    monkeypatch.chdir(tmp_path)
+    info = discover(None)
+    assert info.base_url == "http://filehost:9000"
+    assert info.url_source == "env-file"
+    assert info.url_source_file == ".env.production"
+
+
+def test_discover_env_var_beats_env_file(monkeypatch, tmp_path, fake_os):
+    """The process environment takes precedence over a value sitting in a .env file."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://filehost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("AGENTOS_URL", "http://envhost:9000")
+    info = discover(None)
+    assert info.base_url == "http://envhost:9000"
+    assert info.url_source == "env"
+
+
+def test_discover_env_production_beats_env(monkeypatch, tmp_path, fake_os):
+    """.env.production is preferred over .env when both define AGENTOS_URL."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    (tmp_path / ".env").write_text("AGENTOS_URL=http://localhost:7777\n")
+    monkeypatch.chdir(tmp_path)
+    info = discover(None)
+    assert info.base_url == "http://prodhost:9000"
+    assert info.url_source_file == ".env.production"
+
+
+def test_read_env_value_parsing(tmp_path):
+    """export prefix and surrounding quotes are stripped; the last uncommented value wins."""
+    path = tmp_path / ".env.production"
+    path.write_text("# comment\nexport AGENTOS_URL='http://first'\nAGENTOS_URL=\"http://second\"\n")
+    assert _read_env_value(path, "AGENTOS_URL") == "http://second"
+
+
+def test_read_env_value_ignores_comments_and_missing(tmp_path):
+    """A commented-out assignment (as `down.sh` leaves on teardown) is not read; absent → None."""
+    path = tmp_path / ".env.production"
+    path.write_text("# AGENTOS_URL=http://commented\nOTHER=x\n")
+    assert _read_env_value(path, "AGENTOS_URL") is None
+    assert _read_env_value(tmp_path / "does-not-exist", "AGENTOS_URL") is None

--- a/libs/agnoctl/tests/test_discovery.py
+++ b/libs/agnoctl/tests/test_discovery.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 
-from agnoctl.discovery import _read_env_value, discover
+from agnoctl.discovery import _agentos_url_from_env_files, _read_env_value, discover
 from agnoctl.errors import CLIError
 from tests.conftest import FakeAgentOS, install_fake
 
@@ -139,3 +139,63 @@ def test_read_env_value_ignores_comments_and_missing(tmp_path):
     path.write_text("# AGENTOS_URL=http://commented\nOTHER=x\n")
     assert _read_env_value(path, "AGENTOS_URL") is None
     assert _read_env_value(tmp_path / "does-not-exist", "AGENTOS_URL") is None
+
+
+def test_read_env_value_strips_inline_comment(tmp_path):
+    """An unquoted value ends at a whitespace-preceded '#' (as a deploy note might append)."""
+    path = tmp_path / ".env.production"
+    path.write_text("AGENTOS_URL=http://host:9000  # deployed by up.sh\n")
+    assert _read_env_value(path, "AGENTOS_URL") == "http://host:9000"
+
+
+def test_read_env_value_keeps_url_fragment(tmp_path):
+    """A '#' with no leading whitespace is a literal (URL fragment), not a comment."""
+    path = tmp_path / ".env"
+    path.write_text("AGENTOS_URL=http://host:9000/path#frag\n")
+    assert _read_env_value(path, "AGENTOS_URL") == "http://host:9000/path#frag"
+
+
+def test_read_env_value_quoted_value_ignores_trailing_comment(tmp_path):
+    """A quoted value keeps only its inner text; a trailing inline comment is dropped."""
+    path = tmp_path / ".env"
+    path.write_text('AGENTOS_URL="http://host:9000"  # prod\n')
+    assert _read_env_value(path, "AGENTOS_URL") == "http://host:9000"
+
+
+def test_read_env_value_handles_utf8_bom(tmp_path):
+    """A BOM-prefixed file (some Windows editors add one) still resolves the key."""
+    path = tmp_path / ".env.production"
+    path.write_text("AGENTOS_URL=http://host:9000\n", encoding="utf-8-sig")
+    assert _read_env_value(path, "AGENTOS_URL") == "http://host:9000"
+
+
+def test_read_env_value_non_utf8_returns_none(tmp_path):
+    """A non-UTF-8 file is skipped (None), not a crash."""
+    path = tmp_path / ".env.production"
+    path.write_bytes(b"AGENTOS_URL=http://host\xff\xfe\n")
+    assert _read_env_value(path, "AGENTOS_URL") is None
+
+
+def test_read_env_value_empty_assignment_clears_earlier(tmp_path):
+    """The last assignment wins, so a trailing empty AGENTOS_URL= clears an earlier value."""
+    path = tmp_path / ".env.production"
+    path.write_text("AGENTOS_URL=http://old:9000\nAGENTOS_URL=\n")
+    assert _read_env_value(path, "AGENTOS_URL") is None
+
+
+def test_env_file_slash_only_value_falls_through(monkeypatch, tmp_path):
+    """A slash-only .env.production value normalizes to empty, so .env is still consulted."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=/\n")
+    (tmp_path / ".env").write_text("AGENTOS_URL=http://realhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    assert _agentos_url_from_env_files() == ("http://realhost:9000", ".env")
+
+
+def test_discover_invalid_env_file_url_raises_clean_error(monkeypatch, tmp_path):
+    """A malformed env-file URL (e.g. an un-expanded ${PORT}) fails as a CLIError, not a traceback."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://host:${PORT}\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AGENTOS_URL", raising=False)
+    with pytest.raises(CLIError) as exc_info:
+        discover(None)
+    assert "Invalid AgentOS URL" in exc_info.value.message

--- a/libs/agnoctl/tests/test_security.py
+++ b/libs/agnoctl/tests/test_security.py
@@ -66,7 +66,7 @@ def test_env_file_gate_refuses_remote_in_automation():
         ensure_env_file_url_trusted(
             "https://prod.example.com", "env-file", ".env.production", assume_yes=False, json_mode=True
         )
-    assert "non-local host" in exc.value.message
+    assert "remote host" in exc.value.message
     assert "--url" in (exc.value.hint or "") and "--yes" in (exc.value.hint or "")
 
 

--- a/libs/agnoctl/tests/test_security.py
+++ b/libs/agnoctl/tests/test_security.py
@@ -2,7 +2,12 @@
 
 import pytest
 
-from agnoctl.commands._common import _is_loopback_host, require_secure_url, validate_project_name
+from agnoctl.commands._common import (
+    _is_loopback_host,
+    ensure_env_file_url_trusted,
+    require_secure_url,
+    validate_project_name,
+)
 from agnoctl.errors import CLIError
 
 # -- require_secure_url ----------------------------------------------------------------
@@ -50,6 +55,56 @@ def test_is_loopback_host():
     assert not _is_loopback_host("example.com")
     assert not _is_loopback_host("10.0.0.1")
     assert not _is_loopback_host(None)
+
+
+# -- ensure_env_file_url_trusted -------------------------------------------------------
+
+
+def test_env_file_gate_refuses_remote_in_automation():
+    """A non-loopback env-file URL is refused in --json/non-TTY runs unless opted in."""
+    with pytest.raises(CLIError) as exc:
+        ensure_env_file_url_trusted(
+            "https://prod.example.com", "env-file", ".env.production", assume_yes=False, json_mode=True
+        )
+    assert "non-local host" in exc.value.message
+    assert "--url" in (exc.value.hint or "") and "--yes" in (exc.value.hint or "")
+
+
+def test_env_file_gate_allows_remote_with_assume_yes():
+    ensure_env_file_url_trusted(
+        "https://prod.example.com", "env-file", ".env.production", assume_yes=True, json_mode=True
+    )  # must not raise
+
+
+def test_env_file_gate_allows_loopback_env_file():
+    ensure_env_file_url_trusted(
+        "http://localhost:7777", "env-file", ".env", assume_yes=False, json_mode=True
+    )  # must not raise
+
+
+@pytest.mark.parametrize("source", ["env", "flag", "default"])
+def test_env_file_gate_ignores_non_file_sources(source):
+    # An exported AGENTOS_URL or an explicit --url is not an ambient file; never gated.
+    ensure_env_file_url_trusted(
+        "https://prod.example.com", source, None, assume_yes=False, json_mode=True
+    )  # must not raise
+
+
+def test_env_file_gate_prompts_interactively(monkeypatch):
+    import agnoctl.commands._common as common
+
+    monkeypatch.setattr(common, "stdin_is_interactive", lambda: True)
+    monkeypatch.setattr(common.typer, "confirm", lambda *a, **k: False)
+    with pytest.raises(CLIError) as exc:
+        ensure_env_file_url_trusted(
+            "https://prod.example.com", "env-file", ".env.production", assume_yes=False, json_mode=False
+        )
+    assert "Aborted" in exc.value.message
+
+    monkeypatch.setattr(common.typer, "confirm", lambda *a, **k: True)
+    ensure_env_file_url_trusted(
+        "https://prod.example.com", "env-file", ".env.production", assume_yes=False, json_mode=False
+    )  # must not raise
 
 
 # -- validate_project_name -------------------------------------------------------------

--- a/libs/agnoctl/tests/test_tokens_cmd.py
+++ b/libs/agnoctl/tests/test_tokens_cmd.py
@@ -64,7 +64,7 @@ def test_list_refuses_remote_env_file_url_in_json(monkeypatch, tmp_path, fake_os
     result = _run(["tokens", "list", "--json"])  # no --url: resolve from the env file
     assert result.exit_code == 1, result.output
     payload = json.loads(result.output)
-    assert "non-local host" in payload["error"]
+    assert "remote host" in payload["error"]
     assert "--url" in payload["hint"] and "--yes" in payload["hint"]
 
 

--- a/libs/agnoctl/tests/test_tokens_cmd.py
+++ b/libs/agnoctl/tests/test_tokens_cmd.py
@@ -57,6 +57,27 @@ def test_list_never_exposes_tokens(monkeypatch, fake_os):
     assert payload["service_accounts"][0]["token_prefix"]
 
 
+def test_list_refuses_remote_env_file_url_in_json(monkeypatch, tmp_path, fake_os):
+    """A reachable but non-loopback AGENTOS_URL from a cwd .env file is refused in --json runs."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=https://evil.example\n")
+    result = _run(["tokens", "list", "--json"])  # no --url: resolve from the env file
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert "non-local host" in payload["error"]
+    assert "--url" in payload["hint"] and "--yes" in payload["hint"]
+
+
+def test_list_trusts_remote_env_file_url_with_yes(monkeypatch, tmp_path, fake_os):
+    """--yes opts into a non-loopback env-file URL; the call then proceeds against it."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=https://evil.example\n")
+    result = _run(["tokens", "list", "--json", "--yes"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert "service_accounts" in payload
+
+
 def test_revoke_by_name(monkeypatch, fake_os):
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
     _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)


### PR DESCRIPTION
## Summary

Teaches `agnoctl` discovery to resolve `AGENTOS_URL` from a project env file when neither `--url` nor the `AGENTOS_URL` process env var is set. `discover()` reads `AGENTOS_URL` from `./.env.production` (preferred) then `./.env` in the current working directory, so `agno connect` can target a deployed OS whose URL the deploy scripts persisted — without needing `--url`.

Resolution order: `--url` flag → `AGENTOS_URL` env var → `.env.production` → `.env` → localhost defaults.

**Feature (commit 1)**
- `discovery.py`: `_read_env_value()` + `_agentos_url_from_env_files()`; `_candidate_urls()` now returns the source; `OSInfo` gains `url_source="env-file"` and a `url_source_file` field.
- `connect.py`: the success line discloses env-file provenance.

**Hardening (commit 2, addressing review)**
- **Parser robustness**: read as `utf-8-sig` (BOM), skip non-UTF-8 files instead of crashing, strip inline comments from unquoted values, treat a trailing empty `AGENTOS_URL=` as clearing, and stop shadowing `.env` when `.env.production` holds a slash-only value.
- **Clean errors, not tracebacks**: catch `httpx.InvalidURL` (malformed URL, e.g. an un-expanded `${PORT}`) and `OSError` (deleted CWD); the "No running AgentOS" error/hint now names the env-file source.
- **Security gate** (`ensure_env_file_url_trusted`): a non-loopback `AGENTOS_URL` read from an ambient `.env` file is confirmed interactively — and refused in `--json`/non-TTY unless `--yes`/`--url` — before any credential is attached or client config written. Loopback stays frictionless.
- Source disclosure in `tokens`/`status`, corrected `--url` help text, and `.env.production` added to `.gitignore`.

## Type of change

- [x] New feature
- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Security consideration (addressed in commit 2).** Because discovery reads `AGENTOS_URL` from a file in the current directory, an untrusted directory could otherwise silently redirect the CLI — and the global `AGNO_ADMIN_TOKEN`/`OS_SECURITY_KEY` credential — to an attacker host (`require_secure_url` only checks the scheme, so any https host passed), or with `auth_mode: none` rewrite local coding-agent MCP configs. This is now gated: a non-loopback env-file URL requires interactive confirmation and is refused in automation without an explicit `--yes`/`--url`, and `.env.production` is gitignored. Thanks @ysolanky for the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)