### PR TITLE
[fix] Serialize remote agent media content safely

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -91,6 +91,10 @@ class AgentOSClient:
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
 
+    @staticmethod
+    def _json_dumps_media(media: Sequence[Any]) -> str:
+        return json.dumps([item.to_dict() if hasattr(item, "to_dict") else item.model_dump() for item in media])
+
     def _request(
         self,
         method: str,
@@ -576,13 +580,13 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.model_dump() for img in images])
+            data["images"] = self._json_dumps_media(images)
         if audio:
-            data["audio"] = json.dumps([a.model_dump() for a in audio])
+            data["audio"] = self._json_dumps_media(audio)
         if videos:
-            data["videos"] = json.dumps([v.model_dump() for v in videos])
+            data["videos"] = self._json_dumps_media(videos)
         if files:
-            data["files"] = json.dumps([f.model_dump() for f in files])
+            data["files"] = self._json_dumps_media(files)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
@@ -636,13 +640,13 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.model_dump() for img in images])
+            data["images"] = self._json_dumps_media(images)
         if audio:
-            data["audio"] = json.dumps([a.model_dump() for a in audio])
+            data["audio"] = self._json_dumps_media(audio)
         if videos:
-            data["videos"] = json.dumps([v.model_dump() for v in videos])
+            data["videos"] = self._json_dumps_media(videos)
         if files:
-            data["files"] = json.dumps([f.model_dump() for f in files])
+            data["files"] = self._json_dumps_media(files)
 
         for key, value in kwargs.items():
             if isinstance(value, dict):

--- a/libs/agno/tests/unit/os/test_client.py
+++ b/libs/agno/tests/unit/os/test_client.py
@@ -12,11 +12,13 @@ Tests cover:
 8. Run operations
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agno.client import AgentOSClient
+from agno.media import Image
 
 
 def test_init_with_base_url():
@@ -549,6 +551,35 @@ async def test_run_agent():
 
 
 @pytest.mark.asyncio
+async def test_run_agent_serializes_image_content_as_base64():
+    """Verify run_agent can send Image content bytes as JSON form data."""
+    client = AgentOSClient(base_url="http://localhost:7777")
+    mock_data = {
+        "run_id": "run-123",
+        "agent_id": "agent-1",
+        "content": "ok",
+        "created_at": 1234567890,
+    }
+
+    with patch.object(client, "_apost", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_data
+        await client.run_agent(
+            agent_id="agent-1",
+            message="Describe this image",
+            images=[Image(id="img-1", content=b"image-bytes", mime_type="image/png")],
+        )
+
+        data = mock_post.call_args.args[1]
+        assert json.loads(data["images"]) == [
+            {
+                "id": "img-1",
+                "mime_type": "image/png",
+                "content": "aW1hZ2UtYnl0ZXM=",
+            }
+        ]
+
+
+@pytest.mark.asyncio
 async def test_run_team():
     """Verify run_team executes a team run."""
     client = AgentOSClient(base_url="http://localhost:7777")
@@ -657,6 +688,37 @@ async def test_run_agent_stream_returns_typed_events():
         assert isinstance(events[1], RunContentEvent)
         assert events[1].content == "Hello"
         assert isinstance(events[2], RunCompletedEvent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_stream_serializes_image_content_as_base64():
+    """Verify run_agent_stream can send Image content bytes as JSON form data."""
+    client = AgentOSClient(base_url="http://localhost:7777")
+
+    async def async_generator():
+        if False:
+            yield ""
+
+    with patch.object(client, "_astream_post_form_data") as mock_stream:
+        mock_stream.return_value = async_generator()
+
+        events = []
+        async for event in client.run_agent_stream(
+            "agent-123",
+            "Describe this image",
+            images=[Image(id="img-1", content=b"image-bytes", mime_type="image/png")],
+        ):
+            events.append(event)
+
+        assert events == []
+        data = mock_stream.call_args.args[1]
+        assert json.loads(data["images"]) == [
+            {
+                "id": "img-1",
+                "mime_type": "image/png",
+                "content": "aW1hZ2UtYnl0ZXM=",
+            }
+        ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Serialize AgentOS run media through each media type’s existing `to_dict()` representation.
- Preserve byte-backed image, audio, video, and file content as JSON-safe base64 for both regular and streaming remote agent runs.
- Add regression coverage for byte-backed images in both request paths.

The AgentOS client previously called `model_dump()` and then `json.dumps()` directly. Media objects containing raw bytes therefore raised `TypeError: Object of type bytes is not JSON serializable` before the request could be sent.

Fixes #8789.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This change was implemented with AI assistance and reviewed against the issue, existing media serialization behavior, and repository contribution guidelines.

Validation:

- `.venv/bin/pytest libs/agno/tests/unit/os/test_client.py -q` (42 passed)
- `./scripts/format.sh`
- `./scripts/validate.sh`
