### PR TITLE
release: v2.7.1

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1082,7 +1082,8 @@ jobs:
         run: |
           VIRTUAL_ENV=.venv uv venv --python 3.12
           VIRTUAL_ENV=.venv uv pip install -r ./libs/agno/requirements.txt
-          VIRTUAL_ENV=.venv uv pip install -e ./libs/agno[dev,os,integration-tests,openai]
+          # One resolve for both editables: the local agnoctl satisfies agno's floor
+          VIRTUAL_ENV=.venv uv pip install -e ./libs/agnoctl -e ./libs/agno[dev,os,integration-tests,openai]
           # TODO: a2a-sdk v1.0+ has breaking changes, update agno for it
           VIRTUAL_ENV=.venv uv pip install "a2a-sdk>=0.3.0,<1.0"
       - name: Run A2A integration tests

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1187,7 +1187,7 @@ jobs:
           VIRTUAL_ENV=.venv uv venv --python 3.12
           VIRTUAL_ENV=.venv uv pip install agno
           VIRTUAL_ENV=.venv uv pip install -r ./libs/agno/requirements.txt
-          VIRTUAL_ENV=.venv uv pip install openai chromadb sqlalchemy fastapi pytest pytest-asyncio pytest-cov pytest-mock pytest-rerunfailures pytest-timeout
+          VIRTUAL_ENV=.venv uv pip install openai chromadb sqlalchemy fastapi python-multipart pytest pytest-asyncio pytest-cov pytest-mock pytest-rerunfailures pytest-timeout
       - name: Run Basic Clean Test
         working-directory: .
         env:

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -24,10 +24,8 @@ classifiers = [
 ]
 
 dependencies = [
-  # Floor at the latest *published* agnoctl: resolvers install the newest
-  # anyway, and a floor referencing an unpublished version breaks every
-  # from-source install in the merge-to-publish window of a release.
-  "agnoctl>=0.1.0a5",
+  # Lockstep floor: the agnoctl version released alongside this agno version.
+  "agnoctl>=0.1.1",
   "docstring-parser",
   # Prevent the request-smuggling CVE in h11 < 0.16
   "h11>=0.16.0",

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.7.0"
+version = "2.7.1"
 description = "The programming language for agentic software."
 requires-python = ">=3.9,<4"
 readme = "README.md"

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 ]
 
 dependencies = [
-  # Lockstep floor: the agnoctl version released alongside this agno version.
   "agnoctl>=0.1.1",
   "docstring-parser",
   # Prevent the request-smuggling CVE in h11 < 0.16

--- a/libs/agno/tests/integration/tools/test_custom_api.py
+++ b/libs/agno/tests/integration/tools/test_custom_api.py
@@ -9,13 +9,18 @@ from agno.tools.api import CustomApiTools
 
 def _skip_if_upstream_down(data: dict) -> None:
     # dog.ceo is a live third-party service; a 5xx from it (Cloudflare 520s are
-    # common) or a transport-level failure (SSL/connection errors yield an
-    # "error" dict with no status_code) says nothing about our code, so it
-    # must not red the build.
+    # common), a transport-level failure (SSL/connection errors yield an
+    # "error" dict with no status_code), or a non-JSON error page (outages
+    # serve an HTML 404 in place of the API's JSON envelope) says nothing
+    # about our code, so it must not red the build. A non-200 with the JSON
+    # envelope still fails: that is dog.ceo answering that we asked for a
+    # route it does not have.
     if "status_code" not in data:
         pytest.skip(f"dog.ceo unreachable: {data.get('error', 'no response')}")
     if data["status_code"] >= 500:
         pytest.skip(f"dog.ceo unavailable (HTTP {data['status_code']})")
+    if data["status_code"] != 200 and "text" in data["data"]:
+        pytest.skip(f"dog.ceo unavailable (HTTP {data['status_code']}, non-JSON body)")
 
 
 def test_integration_dog_api():

--- a/libs/agno/tests/system/Dockerfile.agno_a2a
+++ b/libs/agno/tests/system/Dockerfile.agno_a2a
@@ -10,12 +10,14 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the entire agno library
-COPY . /app/agno
+# Copy the agno and agnoctl libraries (build context is libs/)
+COPY agnoctl /app/agnoctl
+COPY agno /app/agno
 
-# Install agno from local source
+# Install agno from local source; the local agnoctl in the same resolve
+# satisfies agno's agnoctl floor without touching PyPI
 WORKDIR /app/agno
-RUN pip install --no-cache-dir ".[os]"
+RUN pip install --no-cache-dir /app/agnoctl ".[os]"
 
 # Install additional dependencies for the server
 RUN pip install --no-cache-dir \
@@ -34,7 +36,7 @@ RUN pip install --no-cache-dir \
 
 # Copy the remote server script
 WORKDIR /app
-COPY tests/system/agno_a2a_server.py /app/agno_a2a_server.py
+COPY agno/tests/system/agno_a2a_server.py /app/agno_a2a_server.py
 
 # Expose the remote server port
 EXPOSE 7004

--- a/libs/agno/tests/system/Dockerfile.gateway
+++ b/libs/agno/tests/system/Dockerfile.gateway
@@ -10,12 +10,14 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the entire agno library
-COPY . /app/agno
+# Copy the agno and agnoctl libraries (build context is libs/)
+COPY agnoctl /app/agnoctl
+COPY agno /app/agno
 
-# Install agno from local source
+# Install agno from local source; the local agnoctl in the same resolve
+# satisfies agno's agnoctl floor without touching PyPI
 WORKDIR /app/agno
-RUN pip install --no-cache-dir ".[os]"
+RUN pip install --no-cache-dir /app/agnoctl ".[os]"
 
 # Install additional dependencies for the server
 RUN pip install --no-cache-dir \
@@ -43,7 +45,7 @@ RUN pip install --no-cache-dir \
 
 # Copy the gateway server script
 WORKDIR /app
-COPY tests/system/gateway_server.py /app/gateway_server.py
+COPY agno/tests/system/gateway_server.py /app/gateway_server.py
 
 # Expose the gateway port
 EXPOSE 7001

--- a/libs/agno/tests/system/Dockerfile.remote
+++ b/libs/agno/tests/system/Dockerfile.remote
@@ -10,12 +10,14 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy the entire agno library
-COPY . /app/agno
+# Copy the agno and agnoctl libraries (build context is libs/)
+COPY agnoctl /app/agnoctl
+COPY agno /app/agno
 
-# Install agno from local source
+# Install agno from local source; the local agnoctl in the same resolve
+# satisfies agno's agnoctl floor without touching PyPI
 WORKDIR /app/agno
-RUN pip install --no-cache-dir ".[os]"
+RUN pip install --no-cache-dir /app/agnoctl ".[os]"
 
 # Install additional dependencies for the server
 RUN pip install --no-cache-dir \
@@ -41,7 +43,7 @@ RUN pip install --no-cache-dir \
 
 # Copy the remote server script
 WORKDIR /app
-COPY tests/system/remote_server.py /app/remote_server.py
+COPY agno/tests/system/remote_server.py /app/remote_server.py
 
 # Expose the remote server port
 EXPOSE 7002

--- a/libs/agno/tests/system/docker-compose.yaml
+++ b/libs/agno/tests/system/docker-compose.yaml
@@ -22,8 +22,8 @@ services:
   # Remote AgentOS Server (hosts actual agents, teams, workflows)
   remote-server:
     build:
-      context: ../..
-      dockerfile: tests/system/Dockerfile.remote
+      context: ../../..
+      dockerfile: agno/tests/system/Dockerfile.remote
     container_name: system-test-remote
     environment:
       DATABASE_URL: postgresql+psycopg://ai:ai@postgres:5432/ai
@@ -75,8 +75,8 @@ services:
   # A2A AgentOS Server (hosts actual agents, teams, workflows)
   agno-a2a-server:
     build:
-      context: ../..
-      dockerfile: tests/system/Dockerfile.agno_a2a
+      context: ../../..
+      dockerfile: agno/tests/system/Dockerfile.agno_a2a
     container_name: system-test-agno-a2a
     environment:
       DATABASE_URL: postgresql+psycopg://ai:ai@postgres:5432/ai
@@ -103,8 +103,8 @@ services:
   # Gateway AgentOS Server (consumes remote agents via RemoteAgent, RemoteTeam, RemoteWorkflow)
   gateway-server:
     build:
-      context: ../..
-      dockerfile: tests/system/Dockerfile.gateway
+      context: ../../..
+      dockerfile: agno/tests/system/Dockerfile.gateway
     container_name: system-test-gateway
     environment:
       DATABASE_URL: postgresql+psycopg://ai:ai@postgres:5432/ai

--- a/libs/agnoctl/pyproject.toml
+++ b/libs/agnoctl/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnoctl"
-version = "0.1.0"
+version = "0.1.1"
 description = "The Agno CLI: connect and operate AgentOS from the terminal, built for humans and coding agents"
 requires-python = ">=3.9,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

Lockstep patch release: `agno` 2.7.1 + `agnoctl` 0.1.1. agno now floors agnoctl at the lockstep version (`agnoctl>=0.1.1`).

## New Features:

- **agnoctl: resolve `AGENTOS_URL` from `.env.production` / `.env` (#8791)**: When neither `--url` nor the `AGENTOS_URL` process env var is set, discovery reads `AGENTOS_URL` from `./.env.production` (preferred) then `./.env` in the current working directory — so `agno connect` can target a deployed AgentOS whose URL the deploy scripts persisted. Resolution order: `--url` flag → `AGENTOS_URL` env var → `.env.production` → `.env` → localhost defaults. `connect`, `tokens`, and `status` output discloses the env-file source.

## Security:

- **Env-file URL trust gate**: A non-loopback `AGENTOS_URL` read from an ambient env file is confirmed interactively before any credential is attached or client config is written — and refused in `--json`/non-TTY mode unless `--yes` or `--url` is passed. Loopback URLs stay frictionless. `.env.production` is now gitignored.

## Improvements:

- **Robust env-file parsing**: reads `utf-8-sig` (BOM), skips non-UTF-8 files instead of crashing, strips inline comments from unquoted values, treats a trailing empty `AGENTOS_URL=` as clearing the value.
- **Clean errors instead of tracebacks**: malformed URLs (e.g. an un-expanded `${PORT}`) and a deleted CWD now produce clear CLI errors; the "No running AgentOS" hint names the env-file source.

## Testing:

- SQLite scheduler integration tests unpack the `(rows, count)` tuple returned by `get_schedules` (#8749).

## CI fixes (release-window breakage):

- **test-clean-os**: installs `python-multipart` explicitly. The job tests the *published* agno package; it previously got python-multipart transitively from agno 2.6.x base deps, which broke the moment 2.7.0 (where fastapi/python-multipart live in the `[os]` extra) landed on PyPI.
- **From-source jobs resolve agnoctl from the workspace**: with the floor at the unpublished lockstep version, `test-a2a` installs `libs/agnoctl` editable in the same resolve as `libs/agno` (mirroring `test_setup.sh`), and the system-test Docker images (remote, agno_a2a, gateway) widen their build context from `libs/agno` to `libs/` and install `/app/agnoctl` together with `.[os]`.

---

## Type of change

- [x] Release

## Checklist

- [x] Version bumps: `agno` 2.7.0 → 2.7.1, `agnoctl` 0.1.0 → 0.1.1; agnoctl floor → `>=0.1.1`
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh` — both pass
- [x] Workspace-agnoctl resolve verified locally (`pip install --dry-run libs/agnoctl "libs/agno[os]"` → agno 2.7.1 + agnoctl 0.1.1) and `docker compose config` valid

**Publish order**: agno 2.7.1 hard-requires `agnoctl>=0.1.1`, so agnoctl must publish before agno (the release workflow's existing agnoctl → agno order covers this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
