### PR TITLE
fix: sandbox CsvTools.query_csv_file to block DuckDB file access outside csvs

### DIFF
--- a/libs/agno/agno/tools/csv_toolkit.py
+++ b/libs/agno/agno/tools/csv_toolkit.py
@@ -116,6 +116,30 @@ class CsvTools(Toolkit):
             logger.exception("Error getting columns")
             return f"Error getting columns: {e}"
 
+    @staticmethod
+    def _lock_down_connection(con: Any) -> None:
+        """Sandbox a DuckDB connection before running caller-controlled SQL.
+
+        The allowlisted CSV is already materialized into a table before this is
+        called, so the query itself needs neither filesystem nor network access.
+        Disabling external access blocks DuckDB's file-I/O primitives
+        (``read_text``, ``read_blob``, ``read_csv``, ``COPY ... TO``, ``ATTACH``,
+        ``INSTALL``/``LOAD`` extensions, ...) that would otherwise let a query
+        read or write local files outside the configured ``csvs`` allowlist.
+
+        ``enable_external_access`` cannot be re-enabled while the database is
+        running, so a query cannot turn it back on.
+        """
+        # Essential protection — must succeed; if it raises, the caller's outer
+        # try/except returns an error and the untrusted SQL is never executed.
+        con.execute("SET enable_external_access=false")
+        try:
+            # Defense in depth: freeze configuration so the query cannot use SET
+            # to weaken the sandbox. Not supported on very old DuckDB builds.
+            con.execute("SET lock_configuration=true")
+        except Exception as e:
+            log_debug(f"Could not lock DuckDB configuration: {e}")
+
     def query_csv_file(self, csv_name: str, sql_query: str) -> str:
         """Use this function to run a SQL query on csv file `csv_name` without the extension.
         The Table name is the name of the csv file without the extension.
@@ -123,6 +147,13 @@ class CsvTools(Toolkit):
         Always wrap column names with double quotes if they contain spaces or special characters
         Remember to escape the quotes in th e JSON string (use \")
         Use single quotes for string values
+
+        For safety this runs against the selected CSV only: DuckDB external
+        filesystem/network access is disabled before the query executes, so
+        file-I/O primitives (read_text, COPY ... TO, ATTACH, ...) cannot reach
+        paths outside the configured ``csvs`` allowlist. If you pass your own
+        ``duckdb_connection``, external access is disabled on it for the query;
+        use a dedicated connection if it also serves other external-access work.
 
         Args:
             csv_name (str): The name of the csv file to query
@@ -157,6 +188,12 @@ class CsvTools(Toolkit):
                 f'CREATE TABLE "{table_name}" AS SELECT * FROM read_csv(?, ignore_errors=false, auto_detect=true)',
                 [str(file_path)],
             )
+
+            # -*- Lock the connection down before running caller-controlled SQL.
+            # The allowlisted CSV is now materialized into the table above, so the
+            # query needs no filesystem/network access. This prevents DuckDB file-I/O
+            # primitives (read_text/COPY/ATTACH/...) from reaching paths outside `csvs`.
+            self._lock_down_connection(con)
 
             # -*- Format the SQL Query
             # Remove backticks

--- a/libs/agno/tests/unit/tools/test_csv_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_csv_toolkit.py
@@ -66,3 +66,55 @@ def test_query_csv_file_path_injection_is_neutralized(tmp_path):
 
     # The path is bound as a parameter, so the injected statement never runs
     assert connection.execute("SELECT COUNT(*) FROM inventory").fetchone()[0] == 1
+
+
+def test_query_csv_file_blocks_reading_files_outside_allowlist(tmp_path):
+    pytest.importorskip("duckdb")
+    allowed = tmp_path / "allowed.csv"
+    secret = tmp_path / "secret.txt"
+    allowed.write_text("id,name\n1,alice\n", encoding="utf-8")
+    secret.write_text("POC_SECRET_MARKER\n", encoding="utf-8")
+
+    tools = CsvTools(
+        csvs=[allowed],
+        enable_read_csv_file=False,
+        enable_list_csv_files=False,
+        enable_get_columns=False,
+        enable_query_csv_file=True,
+    )
+
+    result = tools.query_csv_file("allowed", f"SELECT content FROM read_text('{secret}')")
+
+    # DuckDB file I/O is disabled, so the secret file cannot be read
+    assert "POC_SECRET_MARKER" not in result
+    assert "Error" in result
+
+
+def test_query_csv_file_blocks_writing_files_outside_allowlist(tmp_path):
+    pytest.importorskip("duckdb")
+    allowed = tmp_path / "allowed.csv"
+    out = tmp_path / "written.csv"
+    allowed.write_text("id,name\n1,alice\n", encoding="utf-8")
+
+    tools = CsvTools(csvs=[allowed])
+
+    tools.query_csv_file(
+        "allowed",
+        f"COPY (SELECT 'CSVTOOLS_WRITE_BYPASS' AS marker) TO '{out}' (HEADER, DELIMITER ',')",
+    )
+
+    # COPY ... TO is blocked, so no file is written outside the allowlist
+    assert not out.exists()
+
+
+def test_query_csv_file_allows_legit_query_after_lockdown(tmp_path):
+    pytest.importorskip("duckdb")
+    csv_path = tmp_path / "sales.csv"
+    csv_path.write_text("region,total\nEU,10\nUS,20\n", encoding="utf-8")
+    tools = CsvTools(csvs=[csv_path])
+
+    # A normal aggregate over the allowlisted CSV still works after the lockdown,
+    # including DuckDB type auto-detection (SUM over a numeric column).
+    result = tools.query_csv_file("sales", 'SELECT SUM(total) FROM "sales"')
+
+    assert "30" in result


### PR DESCRIPTION
## Summary

`CsvTools.query_csv_file()` validates `csv_name` against the configured `csvs`
allowlist, but then executes fully caller-controlled DuckDB SQL. DuckDB's
default connection permits filesystem/network primitives, so a caller granted
only the `query_csv_file` function can read and write local files **outside**
the allowlist — bypassing the documented read-only CSV-analysis contract
(`cookbook/91_tools/csv_tools.py`: "Analyze existing CSV files without
modifications").

For example, with only `enable_query_csv_file=True`:

```python
tools.query_csv_file("allowed", "SELECT content FROM read_text('/etc/passwd')")
tools.query_csv_file("allowed", "COPY (SELECT 'x') TO '/tmp/out.csv'")
```

both succeed today (issue #8643).

### Fix

After the allowlisted CSV is materialized into a DuckDB table, disable external
filesystem/network access on the connection **before** running the caller's
SQL (`SET enable_external_access=false`, plus `SET lock_configuration=true` as
defense in depth). The CSV is already loaded, so legitimate analytical queries
still work — including type auto-detection — while `read_text`, `read_csv`,
`COPY ... TO`, `ATTACH`, and `INSTALL`/`LOAD` are rejected. `enable_external_access`
cannot be re-enabled while the database is running, so a query cannot turn it
back on.

Issue number: #8643

## Type of change

- [x] Bug fix (security)
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Security considerations:

- The allowlisted CSV is loaded via a parameter-bound `read_csv(?)` (unchanged),
  then external access is disabled for the caller-controlled query. The lockdown
  is fail-closed: if the `SET` cannot be applied, the query is not executed.
- If you pass your own `duckdb_connection`, external access is disabled on it
  for the duration of the query (documented in the docstring); use a dedicated
  connection if it also serves other external-access work. The default path
  creates a fresh per-call connection, so cookbook/common usage is unaffected.

New regression tests (`libs/agno/tests/unit/tools/test_csv_toolkit.py`) cover:
reading a file outside the allowlist is blocked, `COPY ... TO` writes are
blocked, and a legitimate aggregate `SELECT` still returns after the lockdown.

submission; it is held to the same tests/CI/review quality bar per
`CONTRIBUTING.md`.

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.