### PR TITLE
feat: agno connect multi-target select, disconnect, restart hints, identity-named entries

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -281,6 +281,8 @@ def get_info_router(os: "AgentOS") -> APIRouter:
     async def get_info(request: Request) -> InfoResponse:
         mcp_enabled = bool(os.enable_mcp_server)
         return InfoResponse(
+            os_id=os.id or "Unnamed OS",
+            name=os.name,
             agno_version=agno_version,
             agent_count=len(os.agents or []),
             team_count=len(os.teams or []),

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -273,6 +273,8 @@ class McpInfo(BaseModel):
 class InfoResponse(BaseModel):
     """Response schema for the /info endpoint returning lightweight OS metadata."""
 
+    os_id: str = Field(..., description="Unique identifier for the OS instance")
+    name: Optional[str] = Field(None, description="Name of the OS instance")
     agno_version: str = Field(..., description="Version of the agno framework")
     agent_count: int = Field(0, description="Number of agents registered in the OS")
     team_count: int = Field(0, description="Number of teams registered in the OS")

--- a/libs/agno/tests/unit/os/test_info_endpoint.py
+++ b/libs/agno/tests/unit/os/test_info_endpoint.py
@@ -42,6 +42,19 @@ class TestInfoEndpointBasics:
         assert body["team_count"] == 0
         assert body["workflow_count"] == 0
 
+    def test_returns_name_and_os_id(self):
+        client = _build_client(name="Customer Support", id="os-123")
+        body = client.get("/info").json()
+        assert body["name"] == "Customer Support"
+        assert body["os_id"] == "os-123"
+
+    def test_name_omitted_and_os_id_generated(self):
+        client = _build_client()
+        body = client.get("/info").json()
+        assert body["name"] is None
+        # AgentOS auto-generates an id when none is passed, so os_id is always present.
+        assert body["os_id"]
+
 
 class TestInfoEndpointMcpDiscovery:
     def test_mcp_disabled_by_default(self):

--- a/libs/agnoctl/agnoctl/clients/__init__.py
+++ b/libs/agnoctl/agnoctl/clients/__init__.py
@@ -20,6 +20,18 @@ CLIENT_ALIASES = {
     "cursor": "cursor",
 }
 
+# Human-facing names for report lines and restart hints; JSON output keeps the raw keys.
+CLIENT_DISPLAY_NAMES = {
+    "claude-code": "Claude Code",
+    "claude-desktop": "Claude Desktop",
+    "codex": "Codex",
+    "cursor": "Cursor",
+}
+
+
+def display_name(client_key: str) -> str:
+    return CLIENT_DISPLAY_NAMES.get(client_key, client_key)
+
 
 def build_adapters(
     home: Optional[Path] = None,

--- a/libs/agnoctl/agnoctl/clients/__init__.py
+++ b/libs/agnoctl/agnoctl/clients/__init__.py
@@ -1,7 +1,8 @@
 """Client adapters: how each coding agent stores MCP server configuration."""
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urlsplit, urlunsplit
 
 from agnoctl.clients.base import ClientAdapter, ExistingEntry, WriteResult
 from agnoctl.clients.claude_code import ClaudeCodeAdapter
@@ -46,3 +47,43 @@ def build_adapters(
         "codex": CodexAdapter(home=home),
         "cursor": CursorAdapter(home=home, cwd=cwd, project=project),
     }
+
+
+def _base_url_of_entry(entry_url: str) -> Optional[str]:
+    """The AgentOS base URL behind an MCP entry, or None when it cannot be derived.
+
+    connect always writes ``<base>/mcp`` (including path-routed deployments like
+    ``https://host/team1/mcp``), so stripping the final ``/mcp`` segment recovers the
+    base. Entries with any other path shape are not ours to reinterpret.
+    """
+    parts = urlsplit(entry_url)
+    if parts.scheme.lower() not in ("http", "https") or not parts.netloc:
+        return None
+    path = parts.path.rstrip("/")
+    if not path.endswith("/mcp"):
+        return None
+    return urlunsplit((parts.scheme, parts.netloc, path[: -len("/mcp")], "", "")).rstrip("/")
+
+
+def configured_sources(adapters: Dict[str, ClientAdapter]) -> List[Tuple[str, str, Optional[str]]]:
+    """Discovery candidates for every AgentOS the local client configs already point at.
+
+    The client configs are the one durable record of previously connected OSes (there
+    is no other memory), so the interactive picker offers them alongside the ambient
+    env-file URL and the localhost defaults. Returns (base_url, "client-config",
+    "<display names>") tuples; a corrupt config never breaks discovery.
+    """
+    found: Dict[str, List[str]] = {}
+    for adapter in adapters.values():
+        try:
+            entries = adapter.list_entries()
+        except Exception:
+            continue
+        for entry in entries.values():
+            base = _base_url_of_entry(entry.url)
+            if base is None:
+                continue
+            names = found.setdefault(base, [])
+            if display_name(adapter.key) not in names:
+                names.append(display_name(adapter.key))
+    return [(base, "client-config", ", ".join(names)) for base, names in found.items()]

--- a/libs/agnoctl/agnoctl/clients/base.py
+++ b/libs/agnoctl/agnoctl/clients/base.py
@@ -13,9 +13,13 @@ import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from agnoctl.errors import CLIError
+
+# Predicate over an entry's URL: remove()/pop_server_entry() only touch entries whose
+# URL satisfies it, so a same-named entry pointing at a different AgentOS is never lost.
+UrlMatcher = Callable[[str], bool]
 
 
 @dataclass
@@ -34,6 +38,14 @@ class WriteResult:
     method: str  # "cli" (client's own CLI did the write) | "file" (we edited the config file)
     location: str
     note: Optional[str] = None  # caveat worth surfacing to the user (e.g. VCS-shared file)
+
+
+@dataclass
+class RemoveResult:
+    """Whether (and where) a config entry was removed."""
+
+    removed: bool
+    location: Optional[str] = None  # where the entry was found; None when it was not
 
 
 def servers_table(config: object) -> dict:
@@ -151,6 +163,42 @@ def write_servers_entry(
     atomic_write_text(path, json.dumps(config, indent=2) + "\n", secure=secure)
 
 
+def pop_server_entry(config: Dict[str, Any], server_name: str, matches: Optional[UrlMatcher] = None) -> bool:
+    """Delete one entry from a parsed config's ``mcpServers`` table; True when deleted.
+
+    With ``matches``, the entry is only deleted when its URL satisfies the predicate --
+    the guard that keeps a same-named entry pointing at a different AgentOS intact.
+    """
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict) or server_name not in servers:
+        return False
+    if matches is not None:
+        entry = servers[server_name]
+        url = entry.get("url") if isinstance(entry, dict) else None
+        if not isinstance(url, str) or not matches(url):
+            return False
+    del servers[server_name]
+    return True
+
+
+def remove_servers_entry(path: Path, server_name: str, matches: Optional[UrlMatcher] = None) -> bool:
+    """Delete one ``mcpServers`` entry from a JSON config file; True when it was there.
+
+    Mirror of write_servers_entry: same strict parse and atomic replace, and a missing
+    file or absent key means no write at all. The rewrite keeps the file's other content
+    untouched, and never at looser permissions than it already had (mode is preserved
+    by atomic_write_text's non-secure path; remaining entries may still carry tokens,
+    but a file that holds them was already written 0600 by the write path).
+    """
+    if not path.exists():
+        return False
+    config = read_json_strict(path)
+    if not pop_server_entry(config, server_name, matches):
+        return False
+    atomic_write_text(path, json.dumps(config, indent=2) + "\n", secure=False)
+    return True
+
+
 class ClientAdapter(ABC):
     key: str
 
@@ -161,6 +209,22 @@ class ClientAdapter(ABC):
     @abstractmethod
     def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
         """Return the existing MCP entry for server_name, if any."""
+
+    @abstractmethod
+    def list_entries(self) -> Dict[str, ExistingEntry]:
+        """Every MCP entry this client resolves, keyed by name (resolution precedence
+        applied on name collisions). Lets a caller find entries by URL when the name
+        is not known -- e.g. disconnect locating what connect wrote for a given OS."""
+
+    @abstractmethod
+    def remove(self, server_name: str, matches: Optional[UrlMatcher] = None) -> RemoveResult:
+        """Delete the MCP entry for server_name from every scope this adapter manages,
+        so no shadowed entry in a lower-precedence scope takes over after a restart.
+
+        Offline by design: config edits only, no OS or credentials involved. With
+        ``matches``, each scope's entry is deleted only when its URL satisfies the
+        predicate. A missing entry is a clean no-op (removed=False), never an error.
+        """
 
     @abstractmethod
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:

--- a/libs/agnoctl/agnoctl/clients/claude_code.py
+++ b/libs/agnoctl/agnoctl/clients/claude_code.py
@@ -17,6 +17,7 @@ After the write, connect reads the entry back and re-verifies it, so a write tha
 take effect (or a shadowing entry) is reported, never assumed.
 """
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -25,9 +26,15 @@ from typing import Any, Callable, Dict, List, Optional
 from agnoctl.clients.base import (
     ClientAdapter,
     ExistingEntry,
+    RemoveResult,
+    UrlMatcher,
     WriteResult,
+    atomic_write_text,
     bearer_header,
+    pop_server_entry,
     read_json_lenient,
+    read_json_strict,
+    remove_servers_entry,
     servers_table,
     token_from_authorization,
     write_servers_entry,
@@ -78,34 +85,72 @@ class ClaudeCodeAdapter(ClientAdapter):
     def detect(self) -> bool:
         return self._which("claude") is not None or self._user_config_path.exists()
 
-    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
-        """Return the entry Claude Code would resolve: local > project > user scope."""
+    def _scoped_servers(self) -> "List[tuple[Dict[str, Any], str]]":
+        """(servers table, location label) per scope, in Claude Code's resolution
+        precedence: local (~/.claude.json projects.<cwd>) > project (.mcp.json) > user
+        (~/.claude.json mcpServers)."""
+        scopes: "List[tuple[Dict[str, Any], str]]" = []
         user_config = read_json_lenient(self._user_config_path)
-
         if user_config:
             projects = user_config.get("projects")
             if isinstance(projects, dict):
                 project = projects.get(str(self.cwd))
                 if isinstance(project, dict):
-                    entry = _entry_from_servers(
-                        servers_table(project), server_name, str(self._user_config_path) + " (local scope)"
-                    )
-                    if entry:
-                        return entry
-
+                    scopes.append((servers_table(project), str(self._user_config_path) + " (local scope)"))
         project_config = read_json_lenient(self._project_config_path)
         if project_config:
-            entry = _entry_from_servers(servers_table(project_config), server_name, str(self._project_config_path))
-            if entry:
-                return entry
-
+            scopes.append((servers_table(project_config), str(self._project_config_path)))
         if user_config:
-            entry = _entry_from_servers(
-                servers_table(user_config), server_name, str(self._user_config_path) + " (user scope)"
-            )
+            scopes.append((servers_table(user_config), str(self._user_config_path) + " (user scope)"))
+        return scopes
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        """Return the entry Claude Code would resolve: local > project > user scope."""
+        for servers, location in self._scoped_servers():
+            entry = _entry_from_servers(servers, server_name, location)
             if entry:
                 return entry
         return None
+
+    def list_entries(self) -> Dict[str, ExistingEntry]:
+        entries: Dict[str, ExistingEntry] = {}
+        for servers, location in self._scoped_servers():
+            for name in servers:
+                if name not in entries:
+                    entry = _entry_from_servers(servers, name, location)
+                    if entry:
+                        entries[name] = entry
+        return entries
+
+    def remove(self, server_name: str, matches: Optional[UrlMatcher] = None) -> RemoveResult:
+        """Delete the entry from every scope it lives in: local (~/.claude.json
+        projects.<cwd>), project (.mcp.json), and user (~/.claude.json mcpServers).
+        Both ~/.claude.json scopes are handled in one strict read + one atomic write."""
+        removed_local = removed_user = False
+        if self._user_config_path.exists():
+            config = read_json_strict(self._user_config_path)
+            projects = config.get("projects")
+            if isinstance(projects, dict):
+                project = projects.get(str(self.cwd))
+                if isinstance(project, dict):
+                    removed_local = pop_server_entry(project, server_name, matches)
+            removed_user = pop_server_entry(config, server_name, matches)
+            if removed_local or removed_user:
+                atomic_write_text(self._user_config_path, json.dumps(config, indent=2) + "\n", secure=False)
+
+        removed_project = remove_servers_entry(self._project_config_path, server_name, matches)
+
+        # Report in Claude Code's resolution precedence: local > project > user.
+        locations: List[str] = []
+        if removed_local:
+            locations.append(str(self._user_config_path) + " (local scope)")
+        if removed_project:
+            locations.append(str(self._project_config_path))
+        if removed_user:
+            locations.append(str(self._user_config_path) + " (user scope)")
+        if not locations:
+            return RemoveResult(removed=False)
+        return RemoveResult(removed=True, location=", ".join(locations))
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         # A token on `claude mcp add`'s argv would be exposed to `ps`/proc and execve audit

--- a/libs/agnoctl/agnoctl/clients/claude_desktop.py
+++ b/libs/agnoctl/agnoctl/clients/claude_desktop.py
@@ -19,6 +19,7 @@ verifies the AgentOS endpoint itself, not that Claude can spawn npx, so a missin
 surfaced as a note rather than a failure.
 """
 
+import json
 import os
 import re
 import shutil
@@ -29,9 +30,13 @@ from typing import Any, Callable, Dict, List, Optional
 from agnoctl.clients.base import (
     ClientAdapter,
     ExistingEntry,
+    RemoveResult,
+    UrlMatcher,
     WriteResult,
+    atomic_write_text,
     bearer_header,
     read_json_lenient,
+    read_json_strict,
     servers_table,
     token_from_authorization,
     write_servers_entry,
@@ -124,6 +129,34 @@ class ClaudeDesktopAdapter(ClientAdapter):
         if config is None:
             return None
         return _entry_from_config(servers_table(config).get(server_name), str(self.config_path))
+
+    def list_entries(self) -> Dict[str, ExistingEntry]:
+        config = read_json_lenient(self.config_path)
+        if config is None:
+            return {}
+        entries: Dict[str, ExistingEntry] = {}
+        for name, raw in servers_table(config).items():
+            entry = _entry_from_config(raw, str(self.config_path))
+            if entry:
+                entries[name] = entry
+        return entries
+
+    def remove(self, server_name: str, matches: Optional[UrlMatcher] = None) -> RemoveResult:
+        # Not remove_servers_entry: a Claude Desktop entry is an mcp-remote bridge whose
+        # URL lives inside args, so the URL guard needs _entry_from_config to extract it.
+        if not self.config_path.exists():
+            return RemoveResult(removed=False)
+        config = read_json_strict(self.config_path)
+        servers = config.get("mcpServers")
+        if not isinstance(servers, dict) or server_name not in servers:
+            return RemoveResult(removed=False)
+        if matches is not None:
+            entry = _entry_from_config(servers.get(server_name), str(self.config_path))
+            if entry is None or not matches(entry.url):
+                return RemoveResult(removed=False)
+        del servers[server_name]
+        atomic_write_text(self.config_path, json.dumps(config, indent=2) + "\n", secure=False)
+        return RemoveResult(removed=True, location=str(self.config_path))
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         args: List[str] = ["-y", "mcp-remote", url]

--- a/libs/agnoctl/agnoctl/clients/codex.py
+++ b/libs/agnoctl/agnoctl/clients/codex.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List, Optional
 from agnoctl.clients.base import (
     ClientAdapter,
     ExistingEntry,
+    RemoveResult,
+    UrlMatcher,
     WriteResult,
     atomic_write_text,
     bearer_header,
@@ -90,24 +92,30 @@ class CodexAdapter(ClientAdapter):
     def detect(self) -> bool:
         return (self.home / ".codex").is_dir()
 
-    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+    def list_entries(self) -> Dict[str, ExistingEntry]:
         parsed = self._parse_config()
-        if parsed is None:
-            return None
-        entry = (parsed.get("mcp_servers") or {}).get(server_name)
-        if not isinstance(entry, dict):
-            return None
-        url = entry.get("url")
-        if not isinstance(url, str) or not url:
-            return None
-        headers = entry.get("http_headers")
-        if not isinstance(headers, dict):
-            headers = {}
-        return ExistingEntry(
-            url=url,
-            token=token_from_authorization(_ci_get(headers, "Authorization")),
-            location=str(self.config_path),
-        )
+        servers = (parsed or {}).get("mcp_servers")
+        if not isinstance(servers, dict):
+            return {}
+        entries: Dict[str, ExistingEntry] = {}
+        for name, entry in servers.items():
+            if not isinstance(entry, dict):
+                continue
+            url = entry.get("url")
+            if not isinstance(url, str) or not url:
+                continue
+            headers = entry.get("http_headers")
+            if not isinstance(headers, dict):
+                headers = {}
+            entries[name] = ExistingEntry(
+                url=url,
+                token=token_from_authorization(_ci_get(headers, "Authorization")),
+                location=str(self.config_path),
+            )
+        return entries
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        return self.list_entries().get(server_name)
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         block_lines = ["[mcp_servers." + server_name + "]", "url = " + _toml_string(url)]
@@ -117,33 +125,64 @@ class CodexAdapter(ClientAdapter):
             )
         block = "\n".join(block_lines) + "\n"
 
-        existing_text = self.config_path.read_text() if self.config_path.exists() else ""
-        if existing_text:
-            try:
-                tomllib.loads(existing_text)
-            except tomllib.TOMLDecodeError as e:
-                raise CLIError(
-                    "Refusing to modify "
-                    + str(self.config_path)
-                    + ": the existing TOML does not parse ("
-                    + str(e)
-                    + ").",
-                    hint="Fix or move the file, then re-run.",
-                )
+        existing_text, _ = self._read_strict()
         new_text = self._replace_section(existing_text, server_name, block)
-
-        try:
-            tomllib.loads(new_text)
-        except tomllib.TOMLDecodeError as e:
-            raise CLIError(
-                "Refusing to write " + str(self.config_path) + ": the resulting TOML would be invalid (" + str(e) + ")."
-            )
+        self._validate_result(new_text)
 
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
         atomic_write_text(self.config_path, new_text, secure=bool(token))
         return WriteResult(method="file", location=str(self.config_path))
 
+    def remove(self, server_name: str, matches: Optional[UrlMatcher] = None) -> RemoveResult:
+        """Drop the [mcp_servers.<name>] table via the same section-replace the write
+        path uses (with an empty block). _replace_section does not report whether it
+        found anything, so existence is checked on the parsed config first."""
+        text, parsed = self._read_strict()
+        servers = parsed.get("mcp_servers")
+        if not isinstance(servers, dict) or server_name not in servers:
+            return RemoveResult(removed=False)
+        if matches is not None:
+            entry = servers.get(server_name)
+            url = entry.get("url") if isinstance(entry, dict) else None
+            if not isinstance(url, str) or not matches(url):
+                return RemoveResult(removed=False)
+
+        new_text = self._replace_section(text, server_name, "")
+        remaining = self._validate_result(new_text)
+        # The line scanner only handles the layouts write() produces ([mcp_servers.<name>]
+        # tables and inline entries). A hand-written dotted-key spelling parses to the same
+        # entry but survives the scan; reporting "removed" for it would be a lie.
+        if server_name in (remaining.get("mcp_servers") or {}):
+            raise CLIError(
+                "Could not remove '" + server_name + "' from " + str(self.config_path) + ": unsupported TOML layout.",
+                hint="Remove the entry from the file manually.",
+            )
+        atomic_write_text(self.config_path, new_text, secure=False)
+        return RemoveResult(removed=True, location=str(self.config_path))
+
     # -- Internals -----------------------------------------------------------------
+
+    def _read_strict(self) -> "tuple[str, Dict[str, Any]]":
+        """The config file's text and parse; a file that does not parse refuses loudly
+        (shared by the write and remove paths so their refusal behavior cannot drift)."""
+        if not self.config_path.exists():
+            return "", {}
+        text = self.config_path.read_text()
+        try:
+            return text, tomllib.loads(text)
+        except tomllib.TOMLDecodeError as e:
+            raise CLIError(
+                "Refusing to modify " + str(self.config_path) + ": the existing TOML does not parse (" + str(e) + ").",
+                hint="Fix or move the file, then re-run.",
+            )
+
+    def _validate_result(self, new_text: str) -> Dict[str, Any]:
+        try:
+            return tomllib.loads(new_text)
+        except tomllib.TOMLDecodeError as e:
+            raise CLIError(
+                "Refusing to write " + str(self.config_path) + ": the resulting TOML would be invalid (" + str(e) + ")."
+            )
 
     def _parse_config(self) -> Optional[Dict[str, Any]]:
         if not self.config_path.exists():

--- a/libs/agnoctl/agnoctl/clients/cursor.py
+++ b/libs/agnoctl/agnoctl/clients/cursor.py
@@ -12,9 +12,12 @@ from typing import Any, Dict, Optional
 from agnoctl.clients.base import (
     ClientAdapter,
     ExistingEntry,
+    RemoveResult,
+    UrlMatcher,
     WriteResult,
     bearer_header,
     read_json_lenient,
+    remove_servers_entry,
     servers_table,
     token_from_authorization,
     write_servers_entry,
@@ -38,27 +41,42 @@ class CursorAdapter(ClientAdapter):
     def detect(self) -> bool:
         return (self.home / ".cursor").is_dir()
 
-    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
-        # Project config wins on collisions, so check it first even in global mode.
+    def list_entries(self) -> Dict[str, ExistingEntry]:
+        entries: Dict[str, ExistingEntry] = {}
+        # Project config wins on collisions, so it is read first and never overwritten.
         for path in (self.cwd / ".cursor" / "mcp.json", self.home / ".cursor" / "mcp.json"):
             config = read_json_lenient(path)
             if config is None:
                 continue
-            entry = servers_table(config).get(server_name)
-            if not isinstance(entry, dict):
-                continue
-            url = entry.get("url")
-            if not isinstance(url, str) or not url:
-                continue
-            headers = entry.get("headers")
-            if not isinstance(headers, dict):
-                headers = {}
-            return ExistingEntry(
-                url=url,
-                token=token_from_authorization(headers.get("Authorization")),
-                location=str(path),
-            )
-        return None
+            for name, entry in servers_table(config).items():
+                if name in entries or not isinstance(entry, dict):
+                    continue
+                url = entry.get("url")
+                if not isinstance(url, str) or not url:
+                    continue
+                headers = entry.get("headers")
+                if not isinstance(headers, dict):
+                    headers = {}
+                entries[name] = ExistingEntry(
+                    url=url,
+                    token=token_from_authorization(headers.get("Authorization")),
+                    location=str(path),
+                )
+        return entries
+
+    def read_existing(self, server_name: str) -> Optional[ExistingEntry]:
+        return self.list_entries().get(server_name)
+
+    def remove(self, server_name: str, matches: Optional[UrlMatcher] = None) -> RemoveResult:
+        # Both scopes, project first: a shadowed entry in the other file must not
+        # silently take over after the client restarts.
+        locations = []
+        for path in (self.cwd / ".cursor" / "mcp.json", self.home / ".cursor" / "mcp.json"):
+            if remove_servers_entry(path, server_name, matches):
+                locations.append(str(path))
+        if not locations:
+            return RemoveResult(removed=False)
+        return RemoveResult(removed=True, location=", ".join(locations))
 
     def write(self, server_name: str, url: str, token: Optional[str]) -> WriteResult:
         path = self.config_path

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -13,6 +13,17 @@ from agnoctl.errors import CLIError
 ADMIN_TOKEN_ENV = "AGNO_ADMIN_TOKEN"
 SECURITY_KEY_ENV = "OS_SECURITY_KEY"
 
+# Service-account tokens are dispatched by this prefix on the server, in every auth
+# mode -- including an OS with no REST authentication at all, where a verified PAT is
+# the ONLY credential that can authenticate (and mint, when its scopes allow).
+PAT_PREFIX = "agno_pat_"
+
+
+def env_admin_credential() -> Optional[str]:
+    """The admin credential from the environment, if the operator exported one."""
+    return os.environ.get(ADMIN_TOKEN_ENV) or os.environ.get(SECURITY_KEY_ENV)
+
+
 _SERVER_NAME_ALLOWED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
 
 # MCP entry name when the AgentOS serves no usable name (servers predating the /info
@@ -134,28 +145,41 @@ ADMIN_TOKEN_SOURCES = (
 
 
 def require_mint_capable(base_url: str, auth_mode: str, or_else: Optional[str] = None) -> None:
-    """Fail fast when this AgentOS cannot mint tokens for anyone.
+    """Fail fast when this AgentOS cannot mint tokens for THIS run.
 
-    auth_mode describes the REST plane; "none" means it is open, and an open server
-    refuses every mint (anonymous callers must never create durable credentials) while
-    accepting any credential on reads -- so resolving a credential would prompt for,
-    and appear to accept, a value the mint then rejects. The unauthenticated probe
-    confirms the service-accounts API really is open before failing (a proxy or a
-    manually installed auth layer that /info knows nothing about may guard it), and
-    stays the disambiguator for any server whose /info cannot be taken at its word.
+    auth_mode describes the REST plane; "none" means the server itself has no key, no
+    JWT config -- nothing that could authenticate a caller except a service-account
+    bearer, which it dispatches by prefix in every mode. So on "none":
+
+    - an exported ``agno_pat_`` credential may mint (the server scope-checks it);
+    - any other exported credential can never authenticate a mint -- say so instead of
+      letting the open plane "accept" it on reads and reject it at the mint;
+    - with no credential at all, an open service-accounts API means the anonymous mint
+      is refused outright. The unauthenticated probe confirms the plane really is open
+      before failing; when it is guarded (a proxy or a manually installed auth layer
+      that /info knows nothing about), fall through to the caller's flow instead.
     """
     if auth_mode not in ("none",):
         return
-    from agnoctl.http import service_accounts_open
-
-    if not service_accounts_open(base_url):
+    token = env_admin_credential()
+    if token and token.startswith(PAT_PREFIX):
         return
     hint = "Set " + SECURITY_KEY_ENV + " (or configure JWT auth) on the server to enable minting."
     if or_else:
         hint += " " + or_else
+    if token:
+        raise CLIError(
+            "This AgentOS has no REST authentication configured, so only a service-account token "
+            "(" + PAT_PREFIX + "...) can authenticate a mint -- the exported admin credential cannot.",
+            hint="Export a previously minted token via " + ADMIN_TOKEN_ENV + ". " + hint,
+        )
+    from agnoctl.http import service_accounts_open
+
+    if not service_accounts_open(base_url):
+        return
     raise CLIError(
         "This AgentOS cannot mint tokens: its REST API has no authentication configured, "
-        "and the server refuses to mint without an authenticated caller.",
+        "and the server refuses anonymous minting.",
         hint=hint,
     )
 
@@ -165,11 +189,14 @@ def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
 
     Order: AGNO_ADMIN_TOKEN env, OS_SECURITY_KEY env, interactive prompt. Prompting is
     disabled in --json mode and when stdin is not a TTY, so agent-driven runs fail with
-    a clear instruction instead of hanging.
+    a clear instruction instead of hanging. On auth_mode "none" an EXPORTED credential
+    is still honored -- a service-account bearer authenticates by prefix even on an
+    open REST plane, and a guard /info cannot see (proxy, custom middleware) may want
+    it -- but nothing is ever prompted for on a server that claims to need nothing.
     """
     if auth_mode == "none":
-        return None
-    token = os.environ.get(ADMIN_TOKEN_ENV) or os.environ.get(SECURITY_KEY_ENV)
+        return env_admin_credential()
+    token = env_admin_credential()
     if token:
         return token
     if json_mode or not sys.stdin.isatty():

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -1,6 +1,5 @@
 """Helpers shared by CLI commands."""
 
-import ipaddress
 import os
 import sys
 from typing import Optional, Tuple
@@ -8,12 +7,41 @@ from urllib.parse import urlsplit
 
 import typer
 
+from agnoctl.discovery import _is_loopback_host
 from agnoctl.errors import CLIError
 
 ADMIN_TOKEN_ENV = "AGNO_ADMIN_TOKEN"
 SECURITY_KEY_ENV = "OS_SECURITY_KEY"
 
 _SERVER_NAME_ALLOWED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+# MCP entry name when the AgentOS serves no usable name (servers predating the /info
+# name field, or a name that slugs to nothing). agnoctl 0.1.x named every entry
+# LEGACY_SERVER_NAME; connect recognizes those entries and renames them in place.
+DEFAULT_SERVER_NAME = "agentos"
+LEGACY_SERVER_NAME = "agno"
+
+
+def derive_server_name(os_name: Optional[str]) -> str:
+    """The MCP entry name derived from an AgentOS instance name.
+
+    Client configs should read "customer-support" (the OS's identity), not a framework
+    constant. Slugified to the validate_server_name charset: lowercased, spaces and dots
+    become "-", anything else outside the charset is dropped, runs collapse.
+    """
+    if not os_name:
+        return DEFAULT_SERVER_NAME
+    chars = []
+    for ch in os_name.lower():
+        if ch in " .":
+            chars.append("-")
+        elif ch in _SERVER_NAME_ALLOWED:
+            chars.append(ch)
+    slug = "".join(chars)
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    slug = slug.strip("-")
+    return slug or DEFAULT_SERVER_NAME
 
 
 def validate_server_name(server_name: str) -> None:
@@ -36,20 +64,6 @@ def validate_project_name(name: str) -> None:
             "Invalid project name: " + name,
             hint="Use a single directory name of letters, digits, '-' and '_' only (no '/', '..' or absolute paths).",
         )
-
-
-def _is_loopback_host(host: Optional[str]) -> bool:
-    """True for hosts that never leave the machine: localhost, 127.0.0.0/8, ::1, and the
-    unspecified addresses (0.0.0.0, ::) that dev servers bind to."""
-    if not host:
-        return False
-    if host.lower() == "localhost":
-        return True
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        return False
-    return ip.is_loopback or ip.is_unspecified
 
 
 def require_secure_url(url: str, *, allow_http: bool, what: str = "a credential") -> None:
@@ -87,9 +101,10 @@ def ensure_env_file_url_trusted(
     automatically only when it points at this machine (localhost / 127.x / ::1). A URL that
     points at a remote host could have been planted by an untrusted directory to redirect the
     admin credential or rewrite MCP client configs, so require an explicit go-ahead: prompt
-    interactively (default no), and refuse outright in automation (--json or no TTY) unless
-    --yes was passed. An explicit --url or an exported AGENTOS_URL env var is not an ambient
-    file and is trusted as before.
+    interactively (default yes -- the operator eyeballs the URL, and it is almost always the
+    one their own deploy just wrote), and refuse outright in automation (--json or no TTY)
+    unless --yes was passed, since a headless run has no one looking at the URL. An explicit
+    --url or an exported AGENTOS_URL env var is not an ambient file and is trusted as before.
     """
     if url_source != "env-file":
         return
@@ -103,8 +118,19 @@ def ensure_env_file_url_trusted(
             "AGENTOS_URL in " + source + " points to a remote host (" + base_url + ").",
             hint="Pass --url to target it explicitly, or --yes to trust the env file.",
         )
-    if not typer.confirm("Trust AGENTOS_URL=" + base_url + " (from " + source + ")?", default=False):
+    if not typer.confirm("Trust AGENTOS_URL=" + base_url + " (from " + source + ")?", default=True):
         raise CLIError("Aborted: did not trust the env-file URL " + base_url + ".")
+
+
+# Where a human gets an admin credential when none is in the environment. The UI path
+# ships with the AgentOS control plane; on a JWT-mode OS it is the only sanctioned source.
+ADMIN_TOKEN_SOURCES = (
+    "Generate a short-lived admin token in the AgentOS UI (Settings -> OS & Security), or set "
+    + ADMIN_TOKEN_ENV
+    + " (or "
+    + SECURITY_KEY_ENV
+    + ")."
+)
 
 
 def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
@@ -122,8 +148,11 @@ def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
     if json_mode or not sys.stdin.isatty():
         raise CLIError(
             "This AgentOS requires an admin credential to mint tokens (auth mode: " + auth_mode + ").",
-            hint="Set " + ADMIN_TOKEN_ENV + " (or " + SECURITY_KEY_ENV + ") and re-run.",
+            hint=ADMIN_TOKEN_SOURCES,
         )
+    from agnoctl.console import print_info
+
+    print_info(ADMIN_TOKEN_SOURCES)
     return typer.prompt("Admin credential for this AgentOS", hide_input=True)
 
 

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -133,6 +133,32 @@ ADMIN_TOKEN_SOURCES = (
 )
 
 
+def require_mint_capable(base_url: str, auth_mode: str, or_else: Optional[str] = None) -> None:
+    """Fail fast when this AgentOS cannot mint tokens for anyone.
+
+    auth_mode "oauth" covers two very different deployments: OAuth composed with a REST
+    credential (OS_SECURITY_KEY / JWT -- minting works), and OAuth as the only auth,
+    leaving the REST plane open. The open one refuses every mint while accepting any
+    credential on reads, so resolving a credential would prompt for -- and appear to
+    accept -- a value the mint then rejects. Detect the open plane up front and name
+    the real problem: the server, not the credential.
+    """
+    if auth_mode != "oauth":
+        return
+    from agnoctl.http import service_accounts_open
+
+    if not service_accounts_open(base_url):
+        return
+    hint = "Set " + SECURITY_KEY_ENV + " (or configure JWT auth) on the server to enable minting."
+    if or_else:
+        hint += " " + or_else
+    raise CLIError(
+        "This AgentOS cannot mint tokens: OAuth protects its MCP endpoint, but its REST API has "
+        "no authentication configured, and the server refuses to mint without an authenticated caller.",
+        hint=hint,
+    )
+
+
 def resolve_admin_token(auth_mode: str, json_mode: bool) -> Optional[str]:
     """Resolve the admin credential used to call the service-accounts API.
 

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -136,14 +136,15 @@ ADMIN_TOKEN_SOURCES = (
 def require_mint_capable(base_url: str, auth_mode: str, or_else: Optional[str] = None) -> None:
     """Fail fast when this AgentOS cannot mint tokens for anyone.
 
-    auth_mode "oauth" covers two very different deployments: OAuth composed with a REST
-    credential (OS_SECURITY_KEY / JWT -- minting works), and OAuth as the only auth,
-    leaving the REST plane open. The open one refuses every mint while accepting any
-    credential on reads, so resolving a credential would prompt for -- and appear to
-    accept -- a value the mint then rejects. Detect the open plane up front and name
-    the real problem: the server, not the credential.
+    auth_mode describes the REST plane; "none" means it is open, and an open server
+    refuses every mint (anonymous callers must never create durable credentials) while
+    accepting any credential on reads -- so resolving a credential would prompt for,
+    and appear to accept, a value the mint then rejects. The unauthenticated probe
+    confirms the service-accounts API really is open before failing (a proxy or a
+    manually installed auth layer that /info knows nothing about may guard it), and
+    stays the disambiguator for any server whose /info cannot be taken at its word.
     """
-    if auth_mode != "oauth":
+    if auth_mode not in ("none",):
         return
     from agnoctl.http import service_accounts_open
 
@@ -153,8 +154,8 @@ def require_mint_capable(base_url: str, auth_mode: str, or_else: Optional[str] =
     if or_else:
         hint += " " + or_else
     raise CLIError(
-        "This AgentOS cannot mint tokens: OAuth protects its MCP endpoint, but its REST API has "
-        "no authentication configured, and the server refuses to mint without an authenticated caller.",
+        "This AgentOS cannot mint tokens: its REST API has no authentication configured, "
+        "and the server refuses to mint without an authenticated caller.",
         hint=hint,
     )
 

--- a/libs/agnoctl/agnoctl/commands/_common.py
+++ b/libs/agnoctl/agnoctl/commands/_common.py
@@ -106,31 +106,38 @@ def ensure_env_file_url_trusted(
     assume_yes: bool,
     json_mode: bool,
 ) -> None:
-    """Guard the ambient-env-file redirect before a credential or config write.
+    """Guard the ambient-URL redirect before a credential or config write.
 
-    An AGENTOS_URL read from a .env / .env.production in the current directory is trusted
-    automatically only when it points at this machine (localhost / 127.x / ::1). A URL that
-    points at a remote host could have been planted by an untrusted directory to redirect the
-    admin credential or rewrite MCP client configs, so require an explicit go-ahead: prompt
-    interactively (default yes -- the operator eyeballs the URL, and it is almost always the
-    one their own deploy just wrote), and refuse outright in automation (--json or no TTY)
-    unless --yes was passed, since a headless run has no one looking at the URL. An explicit
-    --url or an exported AGENTOS_URL env var is not an ambient file and is trusted as before.
+    An AGENTOS_URL read from a .env / .env.production in the current directory -- or an
+    MCP entry harvested from a client config -- is trusted automatically only when it
+    points at this machine (localhost / 127.x / ::1). A URL that points at a remote
+    host could have been planted (an untrusted directory's env file or project-scoped
+    MCP config) to redirect the admin credential or rewrite MCP client configs, so
+    require an explicit go-ahead: prompt interactively (default yes -- the operator
+    eyeballs the URL, and it is almost always one their own deploy or an earlier
+    connect wrote), and refuse outright in automation (--json or no TTY) unless --yes
+    was passed, since a headless run has no one looking at the URL. An explicit --url
+    or an exported AGENTOS_URL env var is deliberate and trusted as before.
     """
-    if url_source != "env-file":
+    if url_source not in ("env-file", "client-config"):
         return
     if _is_loopback_host(urlsplit(base_url).hostname):
         return
     if assume_yes:
         return
-    source = url_source_file or "an env file"
+    if url_source == "client-config":
+        source = "your " + (url_source_file or "client") + " MCP config"
+        described = base_url + " (from " + source + ")"
+    else:
+        source = url_source_file or "an env file"
+        described = "AGENTOS_URL=" + base_url + " (from " + source + ")"
     if json_mode or not stdin_is_interactive():
         raise CLIError(
-            "AGENTOS_URL in " + source + " points to a remote host (" + base_url + ").",
-            hint="Pass --url to target it explicitly, or --yes to trust the env file.",
+            "The URL in " + source + " points to a remote host (" + base_url + ").",
+            hint="Pass --url to target it explicitly, or --yes to trust it.",
         )
-    if not typer.confirm("Trust AGENTOS_URL=" + base_url + " (from " + source + ")?", default=True):
-        raise CLIError("Aborted: did not trust the env-file URL " + base_url + ".")
+    if not typer.confirm("Trust " + described + "?", default=True):
+        raise CLIError("Aborted: did not trust the URL " + base_url + ".")
 
 
 # Where a human gets an admin credential when none is in the environment. The UI path

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -17,10 +17,13 @@ from rich.status import Status
 from agnoctl.clients import CLIENT_ALIASES, build_adapters, display_name
 from agnoctl.clients.base import ClientAdapter
 from agnoctl.commands._common import (
+    ADMIN_TOKEN_ENV,
     LEGACY_SERVER_NAME,
+    PAT_PREFIX,
     _is_loopback_host,
     derive_server_name,
     ensure_env_file_url_trusted,
+    env_admin_credential,
     handle_cli_error,
     parse_expires,
     require_mint_capable,
@@ -422,7 +425,14 @@ def _connect(
         os_label = '"' + os_info.name + '" ' if os_info.name else ""
         print_info("AgentOS " + os_label + "at " + os_info.base_url + version + source + ", MCP at " + os_info.mcp_url)
         if oauth_mode:
-            servers = os_info.oauth.authorization_servers if os_info.oauth is not None else []
+            # Name the authorization server only when it is a separate system (an
+            # external IdP); the builtin AS is the OS itself, and repeating its URL
+            # with a trailing slash reads like a mystery third party.
+            servers = [
+                s.rstrip("/")
+                for s in (os_info.oauth.authorization_servers if os_info.oauth is not None else [])
+                if s.rstrip("/") != os_info.base_url.rstrip("/")
+            ]
             issuer = (" via " + ", ".join(servers)) if servers else ""
             print_info("The MCP endpoint is OAuth-protected: apps complete a one-time sign-in" + issuer + ".")
 
@@ -443,26 +453,49 @@ def _connect(
         else []
     )
 
-    # Minting needs a REST plane that can authenticate the caller: auth_mode is that
-    # plane (the MCP OAuth posture lives in os_info.oauth and never enables minting).
-    minting = os_info.auth_mode not in ("none",) and bool(selected) and not oauth_mode
-    # --pat explicitly asks for minted bearers; against an open REST plane ("none") the
-    # server refuses every mint, so silently writing the tokenless entries the operator
-    # opted out of would be a lie. Fail up front naming the server-side gap.
-    if pat and os_info.oauth_enabled and not minting and selected:
-        require_mint_capable(
-            os_info.base_url, os_info.auth_mode, or_else="Or drop --pat to use the OAuth sign-in flow."
+    # Minting needs a credential the server can authenticate: a protected REST plane
+    # (auth_mode is that plane; the MCP OAuth posture lives in os_info.oauth and never
+    # enables minting), or -- on an open plane -- an exported service-account token,
+    # which the server dispatches by prefix and scope-checks in every auth mode.
+    env_credential = env_admin_credential()
+    minting = (
+        bool(selected)
+        and not oauth_mode
+        and (
+            os_info.auth_mode not in ("none",)
+            or (pat and env_credential is not None and env_credential.startswith(PAT_PREFIX))
         )
+    )
+    # Dead end: minted tokens are wanted (--pat) or required (/mcp is token-protected
+    # with no authorization server to sign in through), but nothing can mint here.
+    # Fail before any credential prompt or config write.
+    if selected and not oauth_mode and not minting and (pat or os_info.oauth is not None):
+        if pat and os_info.oauth_enabled:
+            or_else = "Or drop --pat to use the OAuth sign-in flow."
+        elif os_info.oauth is not None:
+            or_else = "Or export a previously minted token via " + ADMIN_TOKEN_ENV + " and re-run with --pat."
+        else:
+            or_else = "Or drop --pat to connect without a token (this MCP endpoint is unauthenticated)."
+        require_mint_capable(os_info.base_url, os_info.auth_mode, or_else=or_else)
         raise CLIError(
-            "--pat needs an admin credential to mint tokens, but this AgentOS reports no REST "
-            "authentication (auth mode: " + os_info.auth_mode + ").",
-            hint="Set OS_SECURITY_KEY (or configure JWT auth) on the server, or drop --pat.",
+            "This AgentOS reports no REST authentication (auth mode: "
+            + os_info.auth_mode
+            + ") and no admin credential is exported, so nothing can mint the tokens "
+            + ("--pat asks for." if pat else "its token-protected MCP endpoint needs."),
+            hint="Set OS_SECURITY_KEY (or configure JWT auth) on the server, or export "
+            + ADMIN_TOKEN_ENV
+            + " if minting worked before. "
+            + or_else,
         )
     # When we mint, the admin token is attached to base_url and the minted PATs are written
     # into client configs and sent to the (same-origin) MCP URL. Refuse to do any of that
     # over plaintext HTTP to a non-loopback host unless the operator opted in.
     if minting:
         require_secure_url(os_info.base_url, allow_http=allow_http, what="the admin credential and minted tokens")
+    elif selected and _stored_token_exists(selected, (server_name, legacy_name), os_info.mcp_url):
+        # Not minting, but re-verification re-sends any token already stored in a
+        # matching entry: the same plaintext rule applies to credentials we merely relay.
+        require_secure_url(os_info.base_url, allow_http=allow_http, what="a token stored in a client config")
     admin_token = resolve_admin_token(os_info.auth_mode, json_mode) if minting else None
     # "Authorization is disabled" is a statement about the whole server; stay quiet when
     # an mcp.oauth block says /mcp has its own auth the REST plane knows nothing about.
@@ -560,11 +593,17 @@ def _connect(
 
     # Spot a deployed AgentOS: when discovery lands on a public, token-free URL (typically
     # AGENTOS_URL set to the production domain), the hosted chat apps can use it too --
-    # surface their setup steps without requiring --clients.
+    # surface their setup steps without requiring --clients. Auto-surfaced apps are
+    # marked so the report can render them as one compact aside instead of two full
+    # instruction blocks nobody asked for; explicitly requested apps keep the detail.
+    explicit_apps = set(wanted_apps)
     if auto_surface_apps:
         wanted_apps = list(CHAT_APPS)
     for app in wanted_apps:
-        results.append(_chat_app_instructions(app, os_info))
+        entry = _chat_app_instructions(app, os_info)
+        if app not in explicit_apps:
+            entry["auto"] = True
+        results.append(entry)
 
     _report(os_info, results, server_name, open_mcp_warning, json_mode)
 
@@ -638,6 +677,18 @@ def _select_os(candidates: List[OSInfo], verb: str) -> OSInfo:
         if raw.isdigit() and 1 <= int(raw) <= len(candidates):
             return candidates[int(raw) - 1]
         print_warning("Enter a number between 1 and " + str(len(candidates)) + ".")
+
+
+def _stored_token_exists(adapters: List[ClientAdapter], names: "tuple[Optional[str], ...]", mcp_url: str) -> bool:
+    """Whether any selected client already holds a token-carrying entry for this OS."""
+    for adapter in adapters:
+        for name in names:
+            if name is None:
+                continue
+            entry = adapter.read_existing(name)
+            if entry is not None and entry.token is not None and entry.url == mcp_url:
+                return True
+    return False
 
 
 def _remove_legacy_entry(adapter: ClientAdapter, os_info: OSInfo, legacy_name: str, result: Dict[str, Any]) -> None:
@@ -833,16 +884,21 @@ def _report(
         raise typer.Exit(exit_code)
 
     print_info("")
+    # Auto-surfaced chat apps render as one compact aside at the end; only explicitly
+    # requested ones get their full instruction blocks in the result list.
+    auto_apps = [r for r in results if r["status"] == "manual" and r.get("auto")]
     for r in results:
+        if r["status"] == "manual" and r.get("auto"):
+            continue
         label = display_name(r["client"])
         if r["status"] == "connected":
             tools = (r.get("verify") or {}).get("tools")
             suffix = " (" + str(tools) + " tools)" if tools else ""
             print_success("  connected      " + label + suffix + "  ->  " + str(r.get("location", "")))
         elif r["status"] == "needs-login":
+            # The sign-in step lives in the "To finish" section below, next to the
+            # restart step, so the row stays a one-line statement of what happened.
             print_warning("  sign in        " + label + "  ->  " + str(r.get("location", "")))
-            for step in r.get("instructions", []):
-                print_info("                 - " + step)
         elif r["status"] == "already-connected":
             print_success("  already ok     " + label + "  ->  " + str(r.get("location", "")))
         elif r["status"] == "skipped":
@@ -858,37 +914,54 @@ def _report(
             print_error("  failed         " + label + "  (" + str(r.get("error") or "unknown error") + ")")
         if r.get("note"):
             print_warning("                 note: " + str(r["note"]))
-        if r.get("replaced_url"):
-            print_warning("                 replaced an entry that pointed at " + str(r["replaced_url"]))
         if r.get("replaced_legacy"):
             print_warning("                 renamed the legacy '" + str(r["replaced_legacy"]) + "' entry")
 
-    # One summary + restart section: freshly wired clients hold no live MCP session yet,
-    # and rotated ones keep using the previous (now revoked) token until they restart.
+    # Entries replaced across clients are almost always the same other OS (same entry
+    # name, e.g. local vs deployed instances both named "AgentOS"): say it once, with
+    # the way to keep both, instead of a cryptic per-row echo.
+    replaced_urls: Dict[str, List[str]] = {}
+    for r in results:
+        if r.get("replaced_url"):
+            replaced_urls.setdefault(str(r["replaced_url"]), []).append(display_name(r["client"]))
+    for url, labels in replaced_urls.items():
+        print_info("")
+        print_warning(
+            "This replaced " + (", ".join(sorted(set(labels)))) + "'s existing '" + server_name + "' entry, "
+            "which pointed at " + url + " -- those apps now connect to this OS instead."
+        )
+        print_info(
+            "To use both, reconnect the other OS under its own entry name: "
+            "agno connect --url <other-os> --server-name <name>"
+        )
+
+    # One summary + next-steps section: freshly wired clients hold no live MCP session
+    # yet, and rotated ones keep using the previous (now revoked) token until they
+    # restart. The sign-in steps sit HERE, numbered after the restart they depend on.
     fresh = sorted({display_name(r["client"]) for r in results if r["status"] in ("connected", "needs-login")})
     if fresh:
-        signin_pending = any(r["status"] == "needs-login" for r in results)
+        signin_steps = [
+            (display_name(r["client"]), r["instructions"][0])
+            for r in results
+            if r["status"] == "needs-login" and r.get("instructions")
+        ]
         os_label = ('"' + os_info.name + '"') if os_info.name else os_info.base_url
         count = str(len(fresh)) + (" app" if len(fresh) == 1 else " apps")
         loads = "so it loads" if len(fresh) == 1 else "so they load"
         print_info("")
-        verb = "Configured" if signin_pending else "Connected"
+        verb = "Configured" if signin_steps else "Connected"
         print_success(
-            verb
-            + " "
-            + count
-            + " "
-            + ("for" if signin_pending else "to")
-            + " "
-            + os_label
-            + " as '"
-            + server_name
-            + "'."
+            verb + " " + count + " " + ("for" if signin_steps else "to") + " " + os_label + " as '" + server_name + "'."
         )
-        restart = "Restart " + ", ".join(fresh) + " " + loads + " the new MCP server."
-        if signin_pending:
-            restart += " Then complete the one-time sign-in above."
-        print_warning(restart)
+        if signin_steps:
+            width = max(len(name) for name, _ in signin_steps)
+            print_warning("To finish:")
+            print_info("  1. Restart " + ", ".join(fresh) + " " + loads + " the new MCP server.")
+            print_info("  2. Complete the one-time sign-in in each app:")
+            for name, step in signin_steps:
+                print_info("       " + name.ljust(width + 2) + step)
+        else:
+            print_warning("Restart " + ", ".join(fresh) + " " + loads + " the new MCP server.")
         if any(r.get("rotated") for r in results):
             print_warning("A rotated client keeps using its previous (now revoked) token until it restarts.")
 
@@ -914,6 +987,15 @@ def _report(
             + " carried tokens; the service accounts behind them stay valid until they expire."
         )
         print_info("Revoke them with: agno tokens revoke <name> --url " + os_info.base_url)
+
+    if auto_apps:
+        print_info("")
+        print_info("Also reachable from the hosted chat apps (claude.ai, ChatGPT):")
+        print_info("  Settings -> Connectors -> Add custom connector -> " + os_info.mcp_url)
+        if os_info.oauth_enabled:
+            print_info("  Both authenticate with the same one-time sign-in when you add the connector.")
+        print_info("  Custom connectors need a paid plan; ChatGPT needs Developer Mode for full tool access.")
+
     if open_mcp_warning:
         print_info("")
         print_warning(open_mcp_warning)

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -23,6 +23,7 @@ from agnoctl.commands._common import (
     ensure_env_file_url_trusted,
     handle_cli_error,
     parse_expires,
+    require_mint_capable,
     require_secure_url,
     resolve_admin_token,
     stdin_is_interactive,
@@ -290,7 +291,14 @@ def connect(
     project: bool = typer.Option(
         False, "--project", help="Write project-scoped configs (.mcp.json / .cursor/mcp.json) instead of user-level."
     ),
-    rotate: bool = typer.Option(False, "--rotate", help="Revoke and re-mint existing accounts without asking."),
+    rotate: bool = typer.Option(
+        False,
+        "--rotate",
+        help=(
+            "Rewrite existing entries without asking: revoke and re-mint their accounts, "
+            "or convert them to OAuth sign-in on an OAuth-protected OS."
+        ),
+    ),
     skip_existing: bool = typer.Option(
         False, "--skip-existing", help="Never touch existing accounts or config entries."
     ),
@@ -385,6 +393,29 @@ def _connect(
     # --pat opts back into minted bearers (the server accepts both) for headless clients.
     oauth_mode = os_info.oauth_enabled and not pat
 
+    # Mint-shaping flags describe a token an OAuth run never mints; erroring beats
+    # silently writing tokenless entries whose effective access comes from the
+    # authorization server's grant instead of the flags.
+    if oauth_mode:
+        shaping = [
+            flag
+            for flag, used in (
+                ("--name", name is not None),
+                ("--scopes", scopes is not None),
+                ("--expires", expires != DEFAULT_EXPIRES),
+                ("--privileged", privileged),
+            )
+            if used
+        ]
+        if shaping:
+            raise CLIError(
+                ", ".join(shaping) + " only shape minted tokens, but this AgentOS's MCP endpoint is "
+                "OAuth-protected: apps sign in through the authorization server and nothing is minted.",
+                hint="Add --pat to mint service-account tokens anyway (for headless clients), or drop "
+                + ", ".join(shaping)
+                + ".",
+            )
+
     if not json_mode:
         version = " (agno " + os_info.version + ")" if os_info.version else ""
         source = os_info.source_note()
@@ -418,6 +449,13 @@ def _connect(
     # over plaintext HTTP to a non-loopback host unless the operator opted in.
     if minting:
         require_secure_url(os_info.base_url, allow_http=allow_http, what="the admin credential and minted tokens")
+        # Before any credential is resolved (or prompted for): an OS whose only auth is
+        # the OAuth provider on /mcp refuses every mint, so no credential can help.
+        require_mint_capable(
+            os_info.base_url,
+            os_info.auth_mode,
+            or_else="Or drop --pat to use the OAuth sign-in flow." if pat else None,
+        )
     admin_token = resolve_admin_token(os_info.auth_mode, json_mode) if minting else None
     if not minting and selected and not json_mode and os_info.auth_mode == "none":
         print_info("Authorization is disabled on this AgentOS; connecting without credentials.")
@@ -751,6 +789,15 @@ def _connect_one(
         # token until it is restarted. Flag it so the report can say so.
         if existing is not None and existing.token is not None and token is not None and existing.token != token:
             result["rotated"] = True
+        # A tokenless write that replaced a token-carrying entry (OAuth conversion via
+        # --rotate, or a legacy-entry rename) erases the bearer from disk but not the
+        # service account behind it: nothing here holds a credential to revoke with.
+        # Flag it so the report can point at `agno tokens revoke`.
+        if token is None and (
+            (existing is not None and existing.token is not None)
+            or (result.get("replaced_legacy") and legacy is not None and legacy.token is not None)
+        ):
+            result["replaced_token_entry"] = True
     else:
         result["error"] = verify_result.error
 
@@ -848,6 +895,16 @@ def _report(
             + ", ".join(accounts)
             + ")"
         )
+
+    replaced_tokens = sorted({display_name(r["client"]) for r in results if r.get("replaced_token_entry")})
+    if replaced_tokens:
+        print_info("")
+        print_warning(
+            "The replaced entries for "
+            + ", ".join(replaced_tokens)
+            + " carried tokens; the service accounts behind them stay valid until they expire."
+        )
+        print_info("Revoke them with: agno tokens revoke <name> --url " + os_info.base_url)
     if open_mcp_warning:
         print_info("")
         print_warning(open_mcp_warning)

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -95,6 +95,15 @@ CHAT_APPS_SPEC = {
 }
 CHAT_APPS = tuple(CHAT_APPS_SPEC)
 
+# The one-time sign-in each client runs after a tokenless entry is written for an
+# OAuth-protected MCP endpoint. {server} is the entry name.
+OAUTH_SIGNIN_STEPS = {
+    "claude-code": "Run: claude mcp login {server}  (or /mcp -> Authenticate inside a session)",
+    "claude-desktop": "Restart Claude Desktop; mcp-remote opens the browser sign-in automatically",
+    "codex": "Run: codex mcp login {server}",
+    "cursor": "Open Cursor Settings -> MCP and click Connect on '{server}'",
+}
+
 
 def _split_chat_apps(clients: Optional[str]) -> "tuple[Optional[str], List[str]]":
     """Peel chat-app requests out of --clients; returns (remaining clients, wanted apps)."""
@@ -140,6 +149,17 @@ def _chat_app_instructions(app: str, os_info: OSInfo) -> Dict[str, Any]:
             + os_info.base_url
             + "; deploy it behind a public HTTPS URL (or a tunnel) before adding it."
         )
+    if os_info.oauth_enabled:
+        auth_line = (
+            "This AgentOS's MCP endpoint supports OAuth sign-in, which is exactly how "
+            + ui_name
+            + "'s Connectors UI authenticates: you will be asked to authorize when adding the connector."
+        )
+    else:
+        auth_line = (
+            ui_name + "'s Connectors UI authenticates with OAuth, not bearer tokens, so a token-protected "
+            "AgentOS cannot be added from the UI yet; use a public or OAuth-enabled AgentOS."
+        )
     return {
         "client": app,
         "status": "manual",
@@ -147,8 +167,7 @@ def _chat_app_instructions(app: str, os_info: OSInfo) -> Dict[str, Any]:
         "url": os_info.mcp_url,
         "instructions": [
             ui_name + " reaches MCP servers from its cloud, so the AgentOS must be on a public HTTPS URL.",
-            ui_name + "'s Connectors UI authenticates with OAuth, not bearer tokens, so a token-protected "
-            "AgentOS cannot be added from the UI yet; use a public or OAuth-enabled AgentOS.",
+            auth_line,
             where,
         ],
         "note": note,
@@ -258,6 +277,11 @@ def connect(
     privileged: bool = typer.Option(
         False, "--privileged", help="Required when --scopes grants write/delete/admin or service_accounts scopes."
     ),
+    pat: bool = typer.Option(
+        False,
+        "--pat",
+        help="Mint service-account tokens even when the MCP endpoint is OAuth-protected (for headless clients).",
+    ),
     server_name: Optional[str] = typer.Option(
         None,
         "--server-name",
@@ -287,6 +311,7 @@ def connect(
             scopes=list(scopes) or None,
             expires=expires,
             privileged=privileged,
+            pat=pat,
             server_name=server_name,
             project=project,
             rotate=rotate,
@@ -306,6 +331,7 @@ def _connect(
     scopes: Optional[List[str]],
     expires: str,
     privileged: bool,
+    pat: bool,
     server_name: Optional[str],
     project: bool,
     rotate: bool,
@@ -353,19 +379,32 @@ def _connect(
         if server_name != LEGACY_SERVER_NAME and not skip_existing:
             legacy_name = LEGACY_SERVER_NAME
     legacy_token_reuse = scopes is None and expires == DEFAULT_EXPIRES
+
+    # OAuth-first: when /mcp is OAuth-protected, apps sign in through the authorization
+    # server themselves -- entries are written without tokens and nothing is minted.
+    # --pat opts back into minted bearers (the server accepts both) for headless clients.
+    oauth_mode = os_info.oauth_enabled and not pat
+
     if not json_mode:
         version = " (agno " + os_info.version + ")" if os_info.version else ""
         source = os_info.source_note()
         os_label = '"' + os_info.name + '" ' if os_info.name else ""
         print_info("AgentOS " + os_label + "at " + os_info.base_url + version + source + ", MCP at " + os_info.mcp_url)
+        if oauth_mode:
+            servers = os_info.oauth.authorization_servers if os_info.oauth is not None else []
+            issuer = (" via " + ", ".join(servers)) if servers else ""
+            print_info("The MCP endpoint is OAuth-protected: apps complete a one-time sign-in" + issuer + ".")
 
     adapters = build_adapters(project=project)
     clients_remaining, wanted_apps = _split_chat_apps(clients)
     # Auto-surface the hosted chat apps only when the run wasn't scoped by --clients AND
-    # the deployed OS is one they can actually add: public HTTPS and no token gate (their
-    # Connectors UIs authenticate with OAuth, not bearer tokens). Explicitly requested
-    # chat apps are honored regardless -- their instructions carry the caveats.
-    auto_surface_apps = clients is None and os_info.auth_mode == "none" and _reachable_from_cloud(os_info)
+    # the deployed OS is one they can actually add: public HTTPS, and either no token
+    # gate or an OAuth-protected /mcp (their Connectors UIs authenticate with OAuth).
+    # Explicitly requested chat apps are honored regardless -- their instructions carry
+    # the caveats.
+    auto_surface_apps = (
+        clients is None and (os_info.auth_mode == "none" or os_info.oauth_enabled) and _reachable_from_cloud(os_info)
+    )
     # Auto-detect only when no --clients was given; a chat-app-only request selects no adapters.
     selected = (
         _resolve_clients(clients_remaining, adapters, required=not auto_surface_apps)
@@ -373,14 +412,14 @@ def _connect(
         else []
     )
 
-    minting = os_info.auth_mode not in ("none",) and bool(selected)
+    minting = os_info.auth_mode not in ("none",) and bool(selected) and not oauth_mode
     # When we mint, the admin token is attached to base_url and the minted PATs are written
     # into client configs and sent to the (same-origin) MCP URL. Refuse to do any of that
     # over plaintext HTTP to a non-loopback host unless the operator opted in.
     if minting:
         require_secure_url(os_info.base_url, allow_http=allow_http, what="the admin credential and minted tokens")
     admin_token = resolve_admin_token(os_info.auth_mode, json_mode) if minting else None
-    if not minting and selected and not json_mode:
+    if not minting and selected and not json_mode and os_info.auth_mode == "none":
         print_info("Authorization is disabled on this AgentOS; connecting without credentials.")
 
     # Truthful-outcome check: if the OS enforces auth but /mcp answers without a token,
@@ -457,6 +496,7 @@ def _connect(
                     shared_token=shared_token,
                     legacy_name=legacy_name,
                     legacy_token_reuse=legacy_token_reuse,
+                    oauth_mode=oauth_mode,
                     status=status,
                 )
             except CLIError as e:
@@ -585,6 +625,7 @@ def _connect_one(
     shared_token: Optional[str],
     legacy_name: Optional[str] = None,
     legacy_token_reuse: bool = True,
+    oauth_mode: bool = False,
     status: Optional[Status] = None,
 ) -> None:
     account_name = name or adapter.key
@@ -593,8 +634,14 @@ def _connect_one(
 
     if existing is not None:
         if existing.url == os_info.mcp_url and not rotate:
-            # Idempotency: an entry already pointing at this OS that still verifies is left alone.
-            check = verify_mcp(os_info.mcp_url, token=existing.token)
+            # Idempotency: an entry already pointing at this OS that still verifies is left
+            # alone. A tokenless entry on an OAuth-protected endpoint verifies via the
+            # challenge (the client holds the sign-in state, not the config).
+            check = verify_mcp(
+                os_info.mcp_url,
+                token=existing.token,
+                expect_oauth_challenge=oauth_mode and existing.token is None,
+            )
             if check.ok and (existing.token is not None or not minting):
                 result.update(status="already-connected", location=existing.location, verify=check.public_dict())
                 if legacy_name is not None and legacy is not None:
@@ -683,10 +730,20 @@ def _connect_one(
         )
         return
 
-    verify_result = verify_mcp(os_info.mcp_url, token=readback.token)
+    verify_result = verify_mcp(
+        os_info.mcp_url, token=readback.token, expect_oauth_challenge=oauth_mode and readback.token is None
+    )
     result["verify"] = verify_result.public_dict()
     if verify_result.ok:
-        result["status"] = "connected"
+        if verify_result.oauth_challenge:
+            # The entry is in place and the endpoint answers with an OAuth challenge:
+            # the last step -- the sign-in -- happens inside the client itself.
+            result["status"] = "needs-login"
+            step = OAUTH_SIGNIN_STEPS.get(adapter.key)
+            if step:
+                result["instructions"] = [step.replace("{server}", server_name)]
+        else:
+            result["status"] = "connected"
         if legacy_name is not None and legacy is not None:
             _remove_legacy_entry(adapter, os_info, legacy_name, result)
         # A client that was already configured with a *different* token still holds the
@@ -705,7 +762,7 @@ def _report(
     open_mcp_warning: Optional[str],
     json_mode: bool,
 ) -> None:
-    exit_code = exit_code_for(results, ("connected", "already-connected", "manual"))
+    exit_code = exit_code_for(results, ("connected", "already-connected", "needs-login", "manual"))
 
     if json_mode:
         emit_json(
@@ -726,6 +783,10 @@ def _report(
             tools = (r.get("verify") or {}).get("tools")
             suffix = " (" + str(tools) + " tools)" if tools else ""
             print_success("  connected      " + label + suffix + "  ->  " + str(r.get("location", "")))
+        elif r["status"] == "needs-login":
+            print_warning("  sign in        " + label + "  ->  " + str(r.get("location", "")))
+            for step in r.get("instructions", []):
+                print_info("                 - " + step)
         elif r["status"] == "already-connected":
             print_success("  already ok     " + label + "  ->  " + str(r.get("location", "")))
         elif r["status"] == "skipped":
@@ -748,14 +809,30 @@ def _report(
 
     # One summary + restart section: freshly wired clients hold no live MCP session yet,
     # and rotated ones keep using the previous (now revoked) token until they restart.
-    fresh = sorted({display_name(r["client"]) for r in results if r["status"] == "connected"})
+    fresh = sorted({display_name(r["client"]) for r in results if r["status"] in ("connected", "needs-login")})
     if fresh:
+        signin_pending = any(r["status"] == "needs-login" for r in results)
         os_label = ('"' + os_info.name + '"') if os_info.name else os_info.base_url
         count = str(len(fresh)) + (" app" if len(fresh) == 1 else " apps")
         loads = "so it loads" if len(fresh) == 1 else "so they load"
         print_info("")
-        print_success("Connected " + count + " to " + os_label + " as '" + server_name + "'.")
-        print_warning("Restart " + ", ".join(fresh) + " " + loads + " the new MCP server.")
+        verb = "Configured" if signin_pending else "Connected"
+        print_success(
+            verb
+            + " "
+            + count
+            + " "
+            + ("for" if signin_pending else "to")
+            + " "
+            + os_label
+            + " as '"
+            + server_name
+            + "'."
+        )
+        restart = "Restart " + ", ".join(fresh) + " " + loads + " the new MCP server."
+        if signin_pending:
+            restart += " Then complete the one-time sign-in above."
+        print_warning(restart)
         if any(r.get("rotated") for r in results):
             print_warning("A rotated client keeps using its previous (now revoked) token until it restarts.")
 

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -12,21 +12,31 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
 
 import typer
+from rich.status import Status
 
-from agnoctl.clients import CLIENT_ALIASES, build_adapters
+from agnoctl.clients import CLIENT_ALIASES, build_adapters, display_name
 from agnoctl.clients.base import ClientAdapter
 from agnoctl.commands._common import (
+    LEGACY_SERVER_NAME,
     _is_loopback_host,
+    derive_server_name,
     ensure_env_file_url_trusted,
     handle_cli_error,
     parse_expires,
     require_secure_url,
     resolve_admin_token,
+    stdin_is_interactive,
     validate_server_name,
 )
-from agnoctl.console import emit_json, print_error, print_info, print_success, print_warning
-from agnoctl.discovery import MCP_ENABLE_INSTRUCTIONS, OSInfo, discover
-from agnoctl.errors import CLIError, ConflictError
+from agnoctl.console import console, emit_json, print_error, print_info, print_success, print_warning
+from agnoctl.discovery import (
+    MCP_ENABLE_INSTRUCTIONS,
+    OSInfo,
+    _agentos_url_from_env_files,
+    discover,
+    discover_all,
+)
+from agnoctl.errors import APIError, CLIError, ConflictError
 from agnoctl.http import AgentOSAPI, ServiceAccount
 from agnoctl.mcp_client import verify_mcp
 
@@ -35,6 +45,24 @@ from agnoctl.mcp_client import verify_mcp
 EXIT_OK = 0
 EXIT_FAILURE = 1
 EXIT_PARTIAL = 3
+
+DEFAULT_EXPIRES = "90d"
+
+
+def exit_code_for(results: List[Dict[str, Any]], ok_statuses: "tuple[str, ...]") -> int:
+    """0 = every result ok, 1 = every real result failed, 3 = mixed. "manual" rows
+    (chat-app instructions) count as ok but can neither rescue nor mask the real
+    adapters' outcomes: when every real adapter failed, appended manual entries must
+    not soften total failure into partial."""
+    ok_count = sum(1 for r in results if r["status"] in ok_statuses)
+    real_results = [r for r in results if r["status"] != "manual"]
+    real_ok = sum(1 for r in real_results if r["status"] in ok_statuses)
+    if ok_count == len(results):
+        return EXIT_OK
+    if real_results and real_ok == 0:
+        return EXIT_FAILURE
+    return EXIT_PARTIAL
+
 
 ROTATE_HINT = "Re-run with --rotate to revoke and re-mint it, or --skip-existing to leave it untouched."
 
@@ -163,10 +191,12 @@ def _mint(
     rotate: bool,
     skip_existing: bool,
     json_mode: bool,
+    status: Optional["Status"] = None,
 ) -> Optional[ServiceAccount]:
     """Mint a service account, resolving name conflicts per the idempotency policy.
 
     Returns None when the caller should skip this client (existing account kept).
+    A live progress spinner is paused around the conflict prompt so it can be read.
     """
     try:
         return api.create_service_account(
@@ -184,9 +214,14 @@ def _mint(
             if not interactive:
                 e.hint = ROTATE_HINT
                 raise
-            if not typer.confirm(
+            if status is not None:
+                status.stop()
+            confirmed = typer.confirm(
                 "Service account '" + account_name + "' already exists. Revoke and re-mint it?", default=False
-            ):
+            )
+            if status is not None:
+                status.start()
+            if not confirmed:
                 return None
         existing = api.find_service_account(account_name)
         if existing is not None:
@@ -219,11 +254,15 @@ def connect(
     scopes: List[str] = typer.Option(
         [], "--scopes", "-s", help="Scope to grant (repeatable). Default: the server's run + read scopes."
     ),
-    expires: str = typer.Option("90d", "--expires", help="Token lifetime in days ('90d', '30') or 'never'."),
+    expires: str = typer.Option(DEFAULT_EXPIRES, "--expires", help="Token lifetime in days ('90d', '30') or 'never'."),
     privileged: bool = typer.Option(
         False, "--privileged", help="Required when --scopes grants write/delete/admin or service_accounts scopes."
     ),
-    server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name written to client configs."),
+    server_name: Optional[str] = typer.Option(
+        None,
+        "--server-name",
+        help="MCP server entry name written to client configs. Default: derived from the AgentOS name.",
+    ),
     project: bool = typer.Option(
         False, "--project", help="Write project-scoped configs (.mcp.json / .cursor/mcp.json) instead of user-level."
     ),
@@ -267,7 +306,7 @@ def _connect(
     scopes: Optional[List[str]],
     expires: str,
     privileged: bool,
-    server_name: str,
+    server_name: Optional[str],
     project: bool,
     rotate: bool,
     skip_existing: bool,
@@ -275,10 +314,23 @@ def _connect(
     assume_yes: bool,
     json_mode: bool,
 ) -> None:
-    validate_server_name(server_name)
+    if server_name is not None:
+        validate_server_name(server_name)
     expires_in_days, never_expires = parse_expires(expires)
 
-    os_info = discover(url)
+    # Interactive runs may choose among every live AgentOS; non-interactive runs
+    # (--json / no TTY) resolve the single highest-priority target, so automation is
+    # deterministic and a dead env-file OS is a hard failure, never a silent retarget.
+    interactive = not json_mode and stdin_is_interactive()
+    if interactive:
+        candidates = discover_all(url)
+        os_info = _select_os(candidates, verb="connect")
+        if url is None and not any(c.url_source == "env-file" for c in candidates):
+            file_url, file_name = _agentos_url_from_env_files()
+            if file_url:
+                print_warning("Note: AGENTOS_URL in " + str(file_name) + " (" + file_url + ") did not answer.")
+    else:
+        os_info = discover(url)
     # Before anything sensitive (minting, config writes), confirm an off-machine URL that
     # came from an ambient .env file -- it could be redirecting us from an untrusted dir.
     ensure_env_file_url_trusted(
@@ -291,10 +343,21 @@ def _connect(
             + ", but its MCP server is not enabled.\n\n"
             + MCP_ENABLE_INSTRUCTIONS
         )
+    # The entry name carries the OS's identity (its /info name) unless the operator chose
+    # one. legacy_name marks runs where entries named "agno" (agnoctl 0.1.x) that point at
+    # this OS get renamed in place; their token is reused only for a default mint (custom
+    # --scopes/--expires means the operator wants a freshly provisioned account).
+    legacy_name: Optional[str] = None
+    if server_name is None:
+        server_name = derive_server_name(os_info.name)
+        if server_name != LEGACY_SERVER_NAME and not skip_existing:
+            legacy_name = LEGACY_SERVER_NAME
+    legacy_token_reuse = scopes is None and expires == DEFAULT_EXPIRES
     if not json_mode:
         version = " (agno " + os_info.version + ")" if os_info.version else ""
         source = os_info.source_note()
-        print_info("AgentOS at " + os_info.base_url + version + source + ", MCP at " + os_info.mcp_url)
+        os_label = '"' + os_info.name + '" ' if os_info.name else ""
+        print_info("AgentOS " + os_label + "at " + os_info.base_url + version + source + ", MCP at " + os_info.mcp_url)
 
     adapters = build_adapters(project=project)
     clients_remaining, wanted_apps = _split_chat_apps(clients)
@@ -337,6 +400,20 @@ def _connect(
     results: List[Dict[str, Any]] = []
 
     try:
+        # Fail a bad credential fast: one cheap authed call before any minting or config
+        # writes, so a rejected paste surfaces immediately instead of reading like a
+        # hang. Human path only -- in --json the per-client results carry the failure.
+        if api is not None and not json_mode:
+            try:
+                with console.status("Checking the admin credential..."):
+                    api.check_admin_credential()
+                print_success("Credential accepted.")
+            except APIError as e:
+                # 403 means authenticated but not granted service_accounts:read; the
+                # mint itself needs only service_accounts:write, so keep going.
+                if e.status_code != 403:
+                    raise
+
         # Shared-account mode: resolve the token once, before any config is touched --
         # clients then only write configs, and none of them can hit a name conflict
         # that would re-mint (and revoke) the shared token mid-run.
@@ -358,7 +435,10 @@ def _connect(
             )
         for adapter in selected:
             result: Dict[str, Any] = {"client": adapter.key, "status": "failed", "error": None}
+            status = None if json_mode else console.status("Connecting " + display_name(adapter.key) + "...")
             try:
+                if status is not None:
+                    status.start()
                 _connect_one(
                     adapter=adapter,
                     result=result,
@@ -375,11 +455,17 @@ def _connect(
                     json_mode=json_mode,
                     minting=minting,
                     shared_token=shared_token,
+                    legacy_name=legacy_name,
+                    legacy_token_reuse=legacy_token_reuse,
+                    status=status,
                 )
             except CLIError as e:
-                result["error"] = e.message + ((" " + e.hint) if e.hint else "")
+                result["error"] = e.full_message
             except Exception as e:  # one client's failure must never abort the run
                 result["error"] = "Unexpected error (" + type(e).__name__ + "): " + str(e)
+            finally:
+                if status is not None:
+                    status.stop()
             results.append(result)
     finally:
         if api is not None:
@@ -439,6 +525,48 @@ def _resolve_shared_token(
     return account.token if account is not None else None
 
 
+def _select_os(candidates: List[OSInfo], verb: str) -> OSInfo:
+    """Pick the target when discovery finds more than one running AgentOS.
+
+    A numbered menu; Enter takes the first candidate, which _candidate_sources orders
+    as the env-file/env URL -- the target single-source discovery resolves. Trust is
+    not decided here: the chosen URL still flows through the env-file trust gate, so
+    picking a remote env-file URL prompts while picking local stays silent.
+    """
+    if len(candidates) == 1:
+        return candidates[0]
+    print_info("Found multiple running AgentOS. Which one do you want to " + verb + "?")
+    print_info("")
+    width = max(len(c.base_url) for c in candidates)
+    for index, candidate in enumerate(candidates, start=1):
+        tag = "local " if _is_loopback_host(urlsplit(candidate.base_url).hostname) else "remote"
+        os_label = ' "' + candidate.name + '"' if candidate.name else ""
+        print_info(
+            "  " + str(index) + "  " + candidate.base_url.ljust(width) + "  " + tag + os_label + candidate.source_note()
+        )
+    print_info("")
+    prompt_label = {"connect": "Connect to", "disconnect": "Disconnect from"}.get(verb, "Select")
+    while True:
+        raw = str(typer.prompt(prompt_label, default="1")).strip()
+        if raw.isdigit() and 1 <= int(raw) <= len(candidates):
+            return candidates[int(raw) - 1]
+        print_warning("Enter a number between 1 and " + str(len(candidates)) + ".")
+
+
+def _remove_legacy_entry(adapter: ClientAdapter, os_info: OSInfo, legacy_name: str, result: Dict[str, Any]) -> None:
+    """Drop the stale duplicate left by an entry rename: the "agno" entry (agnoctl
+    0.1.x naming) is removed from every scope where it points at this OS -- the URL
+    guard keeps a same-named entry for a different OS intact, in every scope. Cleanup
+    must never fail an otherwise successful connect: an error becomes a note."""
+    try:
+        removal = adapter.remove(legacy_name, matches=lambda entry_url: entry_url == os_info.mcp_url)
+        if removal.removed:
+            result["replaced_legacy"] = legacy_name
+    except Exception as e:
+        note = "Could not remove the legacy '" + legacy_name + "' entry: " + str(e)
+        result["note"] = (str(result["note"]) + " " + note) if result.get("note") else note
+
+
 def _connect_one(
     adapter: ClientAdapter,
     result: Dict[str, Any],
@@ -455,9 +583,13 @@ def _connect_one(
     json_mode: bool,
     minting: bool,
     shared_token: Optional[str],
+    legacy_name: Optional[str] = None,
+    legacy_token_reuse: bool = True,
+    status: Optional[Status] = None,
 ) -> None:
     account_name = name or adapter.key
     existing = adapter.read_existing(server_name)
+    legacy = adapter.read_existing(legacy_name) if legacy_name is not None else None
 
     if existing is not None:
         if existing.url == os_info.mcp_url and not rotate:
@@ -465,6 +597,8 @@ def _connect_one(
             check = verify_mcp(os_info.mcp_url, token=existing.token)
             if check.ok and (existing.token is not None or not minting):
                 result.update(status="already-connected", location=existing.location, verify=check.public_dict())
+                if legacy_name is not None and legacy is not None:
+                    _remove_legacy_entry(adapter, os_info, legacy_name, result)
                 return
             if skip_existing:
                 result.update(
@@ -486,28 +620,49 @@ def _connect_one(
     token: Optional[str] = None
     account: Optional[ServiceAccount] = None
     if minting and api is not None:
-        if name is not None:
-            if shared_token is None:
-                result.update(status="skipped", error="Service account exists; kept untouched.")
-                return
-            token = shared_token
-        else:
-            account = _mint(
-                api,
-                account_name,
-                scopes,
-                expires_in_days,
-                never_expires,
-                privileged=privileged,
-                rotate=rotate,
-                skip_existing=skip_existing,
-                json_mode=json_mode,
-            )
-            if account is None:
-                result.update(status="skipped", error="Service account exists; kept untouched.")
-                return
-            token = account.token
+        # Entry rename: a legacy "agno" entry pointing at this OS whose token verifies
+        # hands its token to the identity-named entry, keeping the account that backs it.
+        if (
+            legacy is not None
+            and legacy.url == os_info.mcp_url
+            and legacy.token is not None
+            and legacy_token_reuse
+            and existing is None
+            and name is None
+            and not rotate
+        ):
+            if status is not None:
+                status.update("Verifying the existing '" + str(legacy_name) + "' token...")
+            if verify_mcp(os_info.mcp_url, token=legacy.token).ok:
+                token = legacy.token
+        if token is None:
+            if name is not None:
+                if shared_token is None:
+                    result.update(status="skipped", error="Service account exists; kept untouched.")
+                    return
+                token = shared_token
+            else:
+                if status is not None:
+                    status.update("Minting token for " + display_name(adapter.key) + "...")
+                account = _mint(
+                    api,
+                    account_name,
+                    scopes,
+                    expires_in_days,
+                    never_expires,
+                    privileged=privileged,
+                    rotate=rotate,
+                    skip_existing=skip_existing,
+                    json_mode=json_mode,
+                    status=status,
+                )
+                if account is None:
+                    result.update(status="skipped", error="Service account exists; kept untouched.")
+                    return
+                token = account.token
 
+    if status is not None:
+        status.update("Writing config for " + display_name(adapter.key) + "...")
     write_result = adapter.write(server_name, os_info.mcp_url, token)
     result["location"] = write_result.location
     if write_result.note:
@@ -515,6 +670,8 @@ def _connect_one(
     if account is not None:
         result["account"] = account.public_dict()
 
+    if status is not None:
+        status.update("Verifying " + os_info.mcp_url + "...")
     # Verify what the client will actually use, not what we intended to write: the
     # read-back catches shadowing entries and writes that silently did not take effect.
     readback = adapter.read_existing(server_name)
@@ -530,6 +687,8 @@ def _connect_one(
     result["verify"] = verify_result.public_dict()
     if verify_result.ok:
         result["status"] = "connected"
+        if legacy_name is not None and legacy is not None:
+            _remove_legacy_entry(adapter, os_info, legacy_name, result)
         # A client that was already configured with a *different* token still holds the
         # old one in its live, in-process MCP connection: it keeps using the now-revoked
         # token until it is restarted. Flag it so the report can say so.
@@ -546,19 +705,7 @@ def _report(
     open_mcp_warning: Optional[str],
     json_mode: bool,
 ) -> None:
-    # "manual" (chat-app instructions) is not a failure: agnoctl did all it can. But it
-    # must not mask one either -- when every real adapter failed, appended manual
-    # entries cannot soften total failure into "partial".
-    ok_statuses = ("connected", "already-connected", "manual")
-    ok_count = sum(1 for r in results if r["status"] in ok_statuses)
-    real_results = [r for r in results if r["status"] != "manual"]
-    real_ok = sum(1 for r in real_results if r["status"] in ok_statuses)
-    if ok_count == len(results):
-        exit_code = EXIT_OK
-    elif real_results and real_ok == 0:
-        exit_code = EXIT_FAILURE
-    else:
-        exit_code = EXIT_PARTIAL
+    exit_code = exit_code_for(results, ("connected", "already-connected", "manual"))
 
     if json_mode:
         emit_json(
@@ -574,7 +721,7 @@ def _report(
 
     print_info("")
     for r in results:
-        label = r["client"]
+        label = display_name(r["client"])
         if r["status"] == "connected":
             tools = (r.get("verify") or {}).get("tools")
             suffix = " (" + str(tools) + " tools)" if tools else ""
@@ -584,7 +731,7 @@ def _report(
         elif r["status"] == "skipped":
             print_warning("  skipped        " + label + "  (" + str(r.get("error") or "") + ")")
         elif r["status"] == "manual":
-            ui_name = CHAT_APPS_SPEC[label][0] if label in CHAT_APPS_SPEC else label
+            ui_name = CHAT_APPS_SPEC[r["client"]][0] if r["client"] in CHAT_APPS_SPEC else label
             print_warning("  action needed  " + label + "  (set up in the " + ui_name + " UI)")
             for step in r.get("instructions", []):
                 print_info("                 - " + step)
@@ -596,18 +743,34 @@ def _report(
             print_warning("                 note: " + str(r["note"]))
         if r.get("replaced_url"):
             print_warning("                 replaced an entry that pointed at " + str(r["replaced_url"]))
+        if r.get("replaced_legacy"):
+            print_warning("                 renamed the legacy '" + str(r["replaced_legacy"]) + "' entry")
 
-    if any(r.get("rotated") for r in results):
+    # One summary + restart section: freshly wired clients hold no live MCP session yet,
+    # and rotated ones keep using the previous (now revoked) token until they restart.
+    fresh = sorted({display_name(r["client"]) for r in results if r["status"] == "connected"})
+    if fresh:
+        os_label = ('"' + os_info.name + '"') if os_info.name else os_info.base_url
+        count = str(len(fresh)) + (" app" if len(fresh) == 1 else " apps")
+        loads = "so it loads" if len(fresh) == 1 else "so they load"
         print_info("")
-        print_warning(
-            "A token was rotated. Restart the affected coding agent(s) so they reconnect with the "
-            "new token — a running client keeps using the previous (now revoked) token until it does."
-        )
+        print_success("Connected " + count + " to " + os_label + " as '" + server_name + "'.")
+        print_warning("Restart " + ", ".join(fresh) + " " + loads + " the new MCP server.")
+        if any(r.get("rotated") for r in results):
+            print_warning("A rotated client keeps using its previous (now revoked) token until it restarts.")
 
     accounts = sorted({r["account"]["name"] for r in results if r.get("account")})
     if accounts:
         print_info("")
-        print_info("Revoke any time with: agno tokens revoke <name>  (accounts: " + ", ".join(accounts) + ")")
+        # The --url pin matters: tokens resolves its own target, which may differ from
+        # the OS this run connected (e.g. after picking the local OS off the menu).
+        print_info(
+            "Revoke any time with: agno tokens revoke <name> --url "
+            + os_info.base_url
+            + "  (accounts: "
+            + ", ".join(accounts)
+            + ")"
+        )
     if open_mcp_warning:
         print_info("")
         print_warning(open_mcp_warning)

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -443,21 +443,30 @@ def _connect(
         else []
     )
 
+    # Minting needs a REST plane that can authenticate the caller: auth_mode is that
+    # plane (the MCP OAuth posture lives in os_info.oauth and never enables minting).
     minting = os_info.auth_mode not in ("none",) and bool(selected) and not oauth_mode
+    # --pat explicitly asks for minted bearers; against an open REST plane ("none") the
+    # server refuses every mint, so silently writing the tokenless entries the operator
+    # opted out of would be a lie. Fail up front naming the server-side gap.
+    if pat and os_info.oauth_enabled and not minting and selected:
+        require_mint_capable(
+            os_info.base_url, os_info.auth_mode, or_else="Or drop --pat to use the OAuth sign-in flow."
+        )
+        raise CLIError(
+            "--pat needs an admin credential to mint tokens, but this AgentOS reports no REST "
+            "authentication (auth mode: " + os_info.auth_mode + ").",
+            hint="Set OS_SECURITY_KEY (or configure JWT auth) on the server, or drop --pat.",
+        )
     # When we mint, the admin token is attached to base_url and the minted PATs are written
     # into client configs and sent to the (same-origin) MCP URL. Refuse to do any of that
     # over plaintext HTTP to a non-loopback host unless the operator opted in.
     if minting:
         require_secure_url(os_info.base_url, allow_http=allow_http, what="the admin credential and minted tokens")
-        # Before any credential is resolved (or prompted for): an OS whose only auth is
-        # the OAuth provider on /mcp refuses every mint, so no credential can help.
-        require_mint_capable(
-            os_info.base_url,
-            os_info.auth_mode,
-            or_else="Or drop --pat to use the OAuth sign-in flow." if pat else None,
-        )
     admin_token = resolve_admin_token(os_info.auth_mode, json_mode) if minting else None
-    if not minting and selected and not json_mode and os_info.auth_mode == "none":
+    # "Authorization is disabled" is a statement about the whole server; stay quiet when
+    # an mcp.oauth block says /mcp has its own auth the REST plane knows nothing about.
+    if not minting and selected and not json_mode and os_info.auth_mode == "none" and os_info.oauth is None:
         print_info("Authorization is disabled on this AgentOS; connecting without credentials.")
 
     # Truthful-outcome check: if the OS enforces auth but /mcp answers without a token,

--- a/libs/agnoctl/agnoctl/commands/connect.py
+++ b/libs/agnoctl/agnoctl/commands/connect.py
@@ -14,7 +14,7 @@ from urllib.parse import urlsplit
 import typer
 from rich.status import Status
 
-from agnoctl.clients import CLIENT_ALIASES, build_adapters, display_name
+from agnoctl.clients import CLIENT_ALIASES, build_adapters, configured_sources, display_name
 from agnoctl.clients.base import ClientAdapter
 from agnoctl.commands._common import (
     ADMIN_TOKEN_ENV,
@@ -32,7 +32,7 @@ from agnoctl.commands._common import (
     stdin_is_interactive,
     validate_server_name,
 )
-from agnoctl.console import console, emit_json, print_error, print_info, print_success, print_warning
+from agnoctl.console import console, emit_json, print_error, print_info, print_success, print_warning, shorten_home
 from agnoctl.discovery import (
     MCP_ENABLE_INSTRUCTIONS,
     OSInfo,
@@ -360,7 +360,10 @@ def _connect(
     # deterministic and a dead env-file OS is a hard failure, never a silent retarget.
     interactive = not json_mode and stdin_is_interactive()
     if interactive:
-        candidates = discover_all(url)
+        # The client configs are the durable record of previously connected OSes, so
+        # the picker offers those too (e.g. a deployed OS connected last week vs the
+        # local one running now). Non-interactive runs never see these candidates.
+        candidates = discover_all(url, extra_sources=configured_sources(build_adapters(project=project)))
         os_info = _select_os(candidates, verb="connect")
         if url is None and not any(c.url_source == "env-file" for c in candidates):
             file_url, file_name = _agentos_url_from_env_files()
@@ -894,13 +897,13 @@ def _report(
         if r["status"] == "connected":
             tools = (r.get("verify") or {}).get("tools")
             suffix = " (" + str(tools) + " tools)" if tools else ""
-            print_success("  connected      " + label + suffix + "  ->  " + str(r.get("location", "")))
+            print_success("  connected      " + label + suffix + "  ->  " + shorten_home(str(r.get("location", ""))))
         elif r["status"] == "needs-login":
             # The sign-in step lives in the "To finish" section below, next to the
             # restart step, so the row stays a one-line statement of what happened.
-            print_warning("  sign in        " + label + "  ->  " + str(r.get("location", "")))
+            print_warning("  sign in        " + label + "  ->  " + shorten_home(str(r.get("location", ""))))
         elif r["status"] == "already-connected":
-            print_success("  already ok     " + label + "  ->  " + str(r.get("location", "")))
+            print_success("  already ok     " + label + "  ->  " + shorten_home(str(r.get("location", ""))))
         elif r["status"] == "skipped":
             print_warning("  skipped        " + label + "  (" + str(r.get("error") or "") + ")")
         elif r["status"] == "manual":

--- a/libs/agnoctl/agnoctl/commands/disconnect.py
+++ b/libs/agnoctl/agnoctl/commands/disconnect.py
@@ -282,8 +282,9 @@ def _report(
     if cleared:
         print_info("")
         print_warning("Restart " + ", ".join(cleared) + " to drop the connection.")
-        # On an auth-less OS connect minted nothing, so there is nothing to revoke.
-        if not revoke and (os_info is None or os_info.auth_mode != "none"):
+        # On an auth-less or OAuth-protected OS connect minted nothing (OAuth sign-in
+        # state lives inside the clients), so there is nothing to revoke.
+        if not revoke and (os_info is None or os_info.auth_mode not in ("none", "oauth")):
             url_hint = (" --url " + os_info.base_url) if os_info is not None else ""
             print_info(
                 "Tokens minted for these apps stay valid. Revoke them with: agno tokens revoke <name>" + url_hint

--- a/libs/agnoctl/agnoctl/commands/disconnect.py
+++ b/libs/agnoctl/agnoctl/commands/disconnect.py
@@ -166,9 +166,14 @@ def _disconnect(
     )
 
     results: List[Dict[str, Any]] = []
+    removed_token_entry = False
     for adapter in selected:
         result: Dict[str, Any] = {"client": adapter.key, "status": "not-found", "error": None}
         try:
+            # The resolving entries, read before removal: whether a removed entry carried
+            # a token decides the revoke reminder below (an OAuth OS holds sign-in state
+            # in the client, but a --pat run minted a real account there too).
+            entries = adapter.list_entries()
             if server_name is not None:
                 names = [server_name]
             elif matcher is not None:
@@ -176,7 +181,7 @@ def _disconnect(
                 # RESOLVING entry matches: precedence can hide the target's entry behind
                 # a same-named one for another OS in a higher-precedence scope. remove()
                 # applies the URL guard per scope, so non-matching names are no-ops.
-                names = list(adapter.list_entries())
+                names = list(entries)
             else:
                 names = []
             removed_names: List[str] = []
@@ -185,6 +190,9 @@ def _disconnect(
                 removal = adapter.remove(candidate, matches=matcher)
                 if removal.removed:
                     removed_names.append(candidate)
+                    entry = entries.get(candidate)
+                    if entry is not None and entry.token is not None:
+                        removed_token_entry = True
                     if removal.location and removal.location not in locations:
                         locations.append(removal.location)
             if removed_names:
@@ -229,7 +237,7 @@ def _disconnect(
                     revocation.update(status="failed", error="Unexpected error (" + type(e).__name__ + "): " + str(e))
                 revocations.append(revocation)
 
-    _report(os_info, server_name, target_urls, results, revocations, revoke, json_mode)
+    _report(os_info, server_name, target_urls, results, revocations, revoke, removed_token_entry, json_mode)
 
 
 def _report(
@@ -239,6 +247,7 @@ def _report(
     results: List[Dict[str, Any]],
     revocations: List[Dict[str, Any]],
     revoke: bool,
+    removed_token_entry: bool,
     json_mode: bool,
 ) -> None:
     # not-found is a clean outcome: nothing to undo.
@@ -294,9 +303,11 @@ def _report(
     if cleared:
         print_info("")
         print_warning("Restart " + ", ".join(cleared) + " to drop the connection.")
-        # On an auth-less or OAuth-protected OS connect minted nothing (OAuth sign-in
-        # state lives inside the clients), so there is nothing to revoke.
-        if not revoke and (os_info is None or os_info.auth_mode not in ("none", "oauth")):
+        # The reminder keys on what was actually removed, not the server's auth mode:
+        # tokenless entries (OAuth sign-in, auth-less OS) have nothing to revoke, while
+        # a token-carrying entry backs a still-valid account even on an OAuth OS
+        # (connect --pat mints there too).
+        if not revoke and removed_token_entry:
             url_hint = (" --url " + os_info.base_url) if os_info is not None else ""
             print_info(
                 "Tokens minted for these apps stay valid. Revoke them with: agno tokens revoke <name>" + url_hint

--- a/libs/agnoctl/agnoctl/commands/disconnect.py
+++ b/libs/agnoctl/agnoctl/commands/disconnect.py
@@ -85,14 +85,22 @@ def disconnect(
 
 
 def _matches_targets(entry_url: str, targets: List[str]) -> bool:
-    """Whether an entry's MCP URL points at one of the target base URLs (scheme+host+port)."""
+    """Whether an entry's MCP URL points at one of the target base URLs.
+
+    Same scheme+host+port AND the entry's path lives under the target's base path, so
+    two AgentOS path-routed on one host (/customer-a, /customer-b) never match each
+    other. A target with no path (the usual base URL) matches any path on that host.
+    """
     entry = urlsplit(entry_url)
     for target in targets:
         parts = urlsplit(target)
-        if (
-            entry.scheme.lower() == parts.scheme.lower()
-            and (entry.netloc or "").lower() == (parts.netloc or "").lower()
-        ):
+        if entry.scheme.lower() != parts.scheme.lower():
+            continue
+        if (entry.netloc or "").lower() != (parts.netloc or "").lower():
+            continue
+        base_path = parts.path.rstrip("/")
+        entry_path = entry.path or "/"
+        if not base_path or entry_path == base_path or entry_path.startswith(base_path + "/"):
             return True
     return False
 
@@ -164,7 +172,11 @@ def _disconnect(
             if server_name is not None:
                 names = [server_name]
             elif matcher is not None:
-                names = [entry_name for entry_name, entry in adapter.list_entries().items() if matcher(entry.url)]
+                # Every known name is a removal candidate, not just those whose
+                # RESOLVING entry matches: precedence can hide the target's entry behind
+                # a same-named one for another OS in a higher-precedence scope. remove()
+                # applies the URL guard per scope, so non-matching names are no-ops.
+                names = list(adapter.list_entries())
             else:
                 names = []
             removed_names: List[str] = []

--- a/libs/agnoctl/agnoctl/commands/disconnect.py
+++ b/libs/agnoctl/agnoctl/commands/disconnect.py
@@ -1,0 +1,292 @@
+"""`agno disconnect`: remove the AgentOS MCP entry from coding-agent configs.
+
+The inverse of connect, offline by default: config edits only, no OS and no admin
+credential required. Entries are located by where they point, not by guessing names:
+with `--server-name` exactly that entry is removed; otherwise every entry pointing at
+the target AgentOS goes -- its live address when the OS answers, else every address
+discovery would have tried (the env-file URL and the localhost defaults), so tearing
+down a deployed OS never blocks disconnect. Entries pointing at any other server are
+never touched. Opt-in --revoke also revokes the service accounts connect minted; only
+that path needs the OS and an admin credential.
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlsplit
+
+import typer
+
+from agnoctl.clients import build_adapters, display_name
+from agnoctl.commands._common import (
+    ensure_env_file_url_trusted,
+    handle_cli_error,
+    require_secure_url,
+    resolve_admin_token,
+    stdin_is_interactive,
+    validate_server_name,
+)
+from agnoctl.commands.connect import (
+    CHAT_APPS_SPEC,
+    _resolve_clients,
+    _select_os,
+    _split_chat_apps,
+    exit_code_for,
+)
+from agnoctl.console import emit_json, print_error, print_info, print_success, print_warning
+from agnoctl.discovery import OSInfo, _candidate_sources, discover, discover_all
+from agnoctl.errors import CLIError
+from agnoctl.http import AgentOSAPI
+
+
+def disconnect(
+    url: Optional[str] = typer.Option(
+        None, "--url", help="AgentOS base URL. Default: AGENTOS_URL, then .env.production/.env, then localhost."
+    ),
+    clients: Optional[str] = typer.Option(
+        None,
+        "--clients",
+        help=(
+            "Comma-separated clients (claude-code,claude-desktop,codex,cursor; claude-ai and chatgpt "
+            "print manual removal steps). Default: detected."
+        ),
+    ),
+    server_name: Optional[str] = typer.Option(
+        None,
+        "--server-name",
+        help="Remove exactly this entry name. Default: every entry pointing at the target AgentOS.",
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", help="With --revoke: the shared service-account name used at connect time."
+    ),
+    revoke: bool = typer.Option(
+        False, "--revoke", help="Also revoke the matching service accounts (needs the OS and an admin credential)."
+    ),
+    allow_http: bool = typer.Option(
+        False, "--allow-http", help="Permit sending credentials over plaintext HTTP to a remote host."
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Trust a remote AGENTOS_URL from a .env file without prompting."
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
+) -> None:
+    """Disconnect this machine's coding agents from your AgentOS."""
+    try:
+        _disconnect(
+            url=url,
+            clients=clients,
+            server_name=server_name,
+            name=name,
+            revoke=revoke,
+            allow_http=allow_http,
+            assume_yes=yes,
+            json_mode=json_output,
+        )
+    except CLIError as e:
+        raise handle_cli_error(e, json_output)
+
+
+def _matches_targets(entry_url: str, targets: List[str]) -> bool:
+    """Whether an entry's MCP URL points at one of the target base URLs (scheme+host+port)."""
+    entry = urlsplit(entry_url)
+    for target in targets:
+        parts = urlsplit(target)
+        if (
+            entry.scheme.lower() == parts.scheme.lower()
+            and (entry.netloc or "").lower() == (parts.netloc or "").lower()
+        ):
+            return True
+    return False
+
+
+def _disconnect(
+    url: Optional[str],
+    clients: Optional[str],
+    server_name: Optional[str],
+    name: Optional[str],
+    revoke: bool,
+    allow_http: bool,
+    assume_yes: bool,
+    json_mode: bool,
+) -> None:
+    if server_name is not None:
+        validate_server_name(server_name)
+
+    # Discovery locates the OS whose entries should go; it is best-effort because the
+    # most common reason to disconnect is that the OS is already gone. Only --revoke,
+    # which must talk to the OS, treats "no running AgentOS" as fatal. Non-interactive
+    # runs use single-target discover() so automation stays deterministic.
+    os_info: Optional[OSInfo] = None
+    if revoke or server_name is None:
+        interactive = not json_mode and stdin_is_interactive()
+        try:
+            os_info = _select_os(discover_all(url), verb="disconnect") if interactive else discover(url)
+        except CLIError:
+            if revoke:
+                raise
+            os_info = None
+
+    # The removal targets: entries pointing at the live OS's address, or -- when
+    # nothing answers -- at any address discovery would have tried for this directory.
+    matcher: Optional[Callable[[str], bool]] = None
+    target_urls: List[str] = []
+    if server_name is None:
+        target_urls = [os_info.base_url] if os_info is not None else [s[0] for s in _candidate_sources(url)]
+
+        def _match(entry_url: str) -> bool:
+            return _matches_targets(entry_url, target_urls)
+
+        matcher = _match
+        if os_info is None and not json_mode:
+            print_info("No running AgentOS found; removing entries pointing at: " + ", ".join(target_urls))
+
+    api: Optional[AgentOSAPI] = None
+    if revoke and os_info is not None:
+        # The admin credential is about to ride on this URL: same gates as connect.
+        ensure_env_file_url_trusted(
+            os_info.base_url, os_info.url_source, os_info.url_source_file, assume_yes=assume_yes, json_mode=json_mode
+        )
+        if os_info.auth_mode not in ("none",):
+            require_secure_url(os_info.base_url, allow_http=allow_http, what="the admin credential")
+        admin_token = resolve_admin_token(os_info.auth_mode, json_mode)
+        api = AgentOSAPI(os_info.base_url, admin_token=admin_token)
+
+    adapters = build_adapters()
+    clients_remaining, wanted_apps = _split_chat_apps(clients)
+    selected = (
+        _resolve_clients(clients_remaining, adapters, required=not wanted_apps)
+        if clients is None or clients_remaining
+        else []
+    )
+
+    results: List[Dict[str, Any]] = []
+    for adapter in selected:
+        result: Dict[str, Any] = {"client": adapter.key, "status": "not-found", "error": None}
+        try:
+            if server_name is not None:
+                names = [server_name]
+            elif matcher is not None:
+                names = [entry_name for entry_name, entry in adapter.list_entries().items() if matcher(entry.url)]
+            else:
+                names = []
+            removed_names: List[str] = []
+            locations: List[str] = []
+            for candidate in names:
+                removal = adapter.remove(candidate, matches=matcher)
+                if removal.removed:
+                    removed_names.append(candidate)
+                    if removal.location and removal.location not in locations:
+                        locations.append(removal.location)
+            if removed_names:
+                result["status"] = "removed"
+                result["removed"] = removed_names
+                result["location"] = ", ".join(locations)
+        except CLIError as e:
+            result.update(status="failed", error=e.full_message)
+        except Exception as e:  # one client's failure must never abort the run
+            result.update(status="failed", error="Unexpected error (" + type(e).__name__ + "): " + str(e))
+        results.append(result)
+
+    # Hosted chat apps have no local config to edit; say where the human removes them.
+    for app in wanted_apps:
+        ui_name = CHAT_APPS_SPEC[app][0] if app in CHAT_APPS_SPEC else app
+        results.append(
+            {
+                "client": app,
+                "status": "manual",
+                "error": None,
+                "instructions": ["Remove the connector in the " + ui_name + " UI: Settings -> Connectors."],
+            }
+        )
+
+    # --revoke: best-effort, after the config removals, one account per selected client
+    # (or the one shared --name account) -- mirroring how connect named them at mint time.
+    revocations: List[Dict[str, Any]] = []
+    if api is not None:
+        account_names = [name] if name else sorted(adapter.key for adapter in selected)
+        with api:
+            for account_name in account_names:
+                revocation: Dict[str, Any] = {"account": account_name, "status": "revoked", "error": None}
+                try:
+                    account = api.find_service_account(account_name)
+                    if account is None:
+                        revocation["status"] = "not-found"
+                    else:
+                        api.revoke_service_account(account.id)
+                except CLIError as e:
+                    revocation.update(status="failed", error=e.full_message)
+                except Exception as e:
+                    revocation.update(status="failed", error="Unexpected error (" + type(e).__name__ + "): " + str(e))
+                revocations.append(revocation)
+
+    _report(os_info, server_name, target_urls, results, revocations, revoke, json_mode)
+
+
+def _report(
+    os_info: Optional[OSInfo],
+    server_name: Optional[str],
+    target_urls: List[str],
+    results: List[Dict[str, Any]],
+    revocations: List[Dict[str, Any]],
+    revoke: bool,
+    json_mode: bool,
+) -> None:
+    # not-found is a clean outcome: nothing to undo.
+    exit_code = exit_code_for(results, ("removed", "not-found", "manual"))
+    if exit_code == 0 and any(r["status"] == "failed" for r in revocations):
+        exit_code = 3
+
+    if json_mode:
+        emit_json(
+            {
+                "os": os_info.public_dict() if os_info is not None else None,
+                "server_name": server_name,
+                "target_urls": target_urls or None,
+                "results": results,
+                "revocations": revocations,
+                "exit_code": exit_code,
+            }
+        )
+        raise typer.Exit(exit_code)
+
+    print_info("")
+    for r in results:
+        label = display_name(r["client"])
+        if r["status"] == "removed":
+            names = ", ".join(r.get("removed") or [])
+            print_success("  removed        " + label + " ('" + names + "')  ->  " + str(r.get("location", "")))
+        elif r["status"] == "not-found":
+            print_info("  not found      " + label + "  (no matching entry)")
+        elif r["status"] == "manual":
+            print_warning("  action needed  " + label)
+            for step in r.get("instructions", []):
+                print_info("                 - " + step)
+        else:
+            print_error("  failed         " + label + "  (" + str(r.get("error") or "unknown error") + ")")
+
+    for revocation in revocations:
+        if revocation["status"] == "revoked":
+            print_success("  revoked        service account '" + str(revocation["account"]) + "'")
+        elif revocation["status"] == "not-found":
+            print_info("  no account     '" + str(revocation["account"]) + "' (already revoked or never minted)")
+        else:
+            print_error(
+                "  revoke failed  '"
+                + str(revocation["account"])
+                + "'  ("
+                + str(revocation.get("error") or "unknown error")
+                + ")"
+            )
+
+    # A running client holds its MCP connection in-process; the entry's removal only
+    # takes effect when the client restarts.
+    cleared = sorted({display_name(r["client"]) for r in results if r["status"] == "removed"})
+    if cleared:
+        print_info("")
+        print_warning("Restart " + ", ".join(cleared) + " to drop the connection.")
+        # On an auth-less OS connect minted nothing, so there is nothing to revoke.
+        if not revoke and (os_info is None or os_info.auth_mode != "none"):
+            url_hint = (" --url " + os_info.base_url) if os_info is not None else ""
+            print_info(
+                "Tokens minted for these apps stay valid. Revoke them with: agno tokens revoke <name>" + url_hint
+            )
+
+    raise typer.Exit(exit_code)

--- a/libs/agnoctl/agnoctl/commands/disconnect.py
+++ b/libs/agnoctl/agnoctl/commands/disconnect.py
@@ -15,7 +15,7 @@ from urllib.parse import urlsplit
 
 import typer
 
-from agnoctl.clients import build_adapters, display_name
+from agnoctl.clients import build_adapters, configured_sources, display_name
 from agnoctl.commands._common import (
     ensure_env_file_url_trusted,
     handle_cli_error,
@@ -31,7 +31,7 @@ from agnoctl.commands.connect import (
     _split_chat_apps,
     exit_code_for,
 )
-from agnoctl.console import emit_json, print_error, print_info, print_success, print_warning
+from agnoctl.console import emit_json, print_error, print_info, print_success, print_warning, shorten_home
 from agnoctl.discovery import OSInfo, _candidate_sources, discover, discover_all
 from agnoctl.errors import CLIError
 from agnoctl.http import AgentOSAPI
@@ -126,7 +126,11 @@ def _disconnect(
     if revoke or server_name is None:
         interactive = not json_mode and stdin_is_interactive()
         try:
-            os_info = _select_os(discover_all(url), verb="disconnect") if interactive else discover(url)
+            os_info = (
+                _select_os(discover_all(url, extra_sources=configured_sources(build_adapters())), verb="disconnect")
+                if interactive
+                else discover(url)
+            )
         except CLIError:
             if revoke:
                 raise
@@ -273,7 +277,9 @@ def _report(
         label = display_name(r["client"])
         if r["status"] == "removed":
             names = ", ".join(r.get("removed") or [])
-            print_success("  removed        " + label + " ('" + names + "')  ->  " + str(r.get("location", "")))
+            print_success(
+                "  removed        " + label + " ('" + names + "')  ->  " + shorten_home(str(r.get("location", "")))
+            )
         elif r["status"] == "not-found":
             print_info("  not found      " + label + "  (no matching entry)")
         elif r["status"] == "manual":

--- a/libs/agnoctl/agnoctl/commands/status.py
+++ b/libs/agnoctl/agnoctl/commands/status.py
@@ -5,7 +5,7 @@ from typing import Optional
 import typer
 
 from agnoctl.clients import build_adapters
-from agnoctl.commands._common import handle_cli_error
+from agnoctl.commands._common import derive_server_name, handle_cli_error
 from agnoctl.console import emit_json, print_info, print_success
 from agnoctl.discovery import discover
 from agnoctl.errors import CLIError
@@ -15,7 +15,9 @@ def status(
     url: Optional[str] = typer.Option(
         None, "--url", help="AgentOS base URL. Default: AGENTOS_URL, then .env.production/.env, then localhost."
     ),
-    server_name: str = typer.Option("agno", "--server-name", help="MCP server entry name to look for in clients."),
+    server_name: Optional[str] = typer.Option(
+        None, "--server-name", help="MCP server entry name to look for. Default: derived from the AgentOS name."
+    ),
     json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
 ) -> None:
     """Show the discovered AgentOS and which coding agents are connected to it."""
@@ -23,6 +25,10 @@ def status(
         os_info = discover(url)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
+
+    # Look for what connect would write today: the OS-name-derived entry.
+    if server_name is None:
+        server_name = derive_server_name(os_info.name)
 
     adapters = build_adapters()
     clients = []
@@ -46,6 +52,12 @@ def status(
     mcp = os_info.mcp_url if os_info.mcp_enabled else "disabled"
     print_info("  MCP: " + mcp)
     print_info("  Auth mode: " + os_info.auth_mode)
+    # auth_mode is the REST plane only; without this line an OAuth-protected /mcp
+    # would read as an unsecured deployment ("Auth mode: none").
+    if os_info.oauth is not None:
+        servers = os_info.oauth.authorization_servers
+        mcp_auth = ("OAuth via " + ", ".join(servers)) if servers else "token-protected (no authorization server)"
+        print_info("  MCP auth: " + mcp_auth)
     print_info("")
     for c in clients:
         if not c["detected"]:

--- a/libs/agnoctl/agnoctl/commands/tokens.py
+++ b/libs/agnoctl/agnoctl/commands/tokens.py
@@ -10,6 +10,7 @@ from agnoctl.commands._common import (
     ensure_env_file_url_trusted,
     handle_cli_error,
     parse_expires,
+    require_mint_capable,
     require_secure_url,
     resolve_admin_token,
     stdin_is_interactive,
@@ -40,7 +41,12 @@ def _timestamp(value: Optional[int]) -> str:
 
 
 def _api_for(
-    url: Optional[str], json_mode: bool, allow_http: bool, sensitive: bool = False, assume_yes: bool = False
+    url: Optional[str],
+    json_mode: bool,
+    allow_http: bool,
+    sensitive: bool = False,
+    assume_yes: bool = False,
+    mint: bool = False,
 ) -> AgentOSAPI:
     os_info = discover(url)
     # A remote URL pulled from an ambient .env file could be redirecting this
@@ -52,6 +58,10 @@ def _api_for(
     # autodiscovery could land on a port-squatter, and the operator should see the target.
     if url is None and not json_mode:
         print_info("Using AgentOS at " + os_info.base_url + os_info.source_note())
+    # Before any credential is resolved (or prompted for): an OS whose only auth is the
+    # OAuth provider on /mcp refuses every mint, so no credential can help.
+    if mint:
+        require_mint_capable(os_info.base_url, os_info.auth_mode)
     admin_token = resolve_admin_token(os_info.auth_mode, json_mode)
     # Refuse to put a bearer credential (admin token) or receive a freshly minted PAT over
     # plaintext HTTP unless the target is loopback or the operator opted in with --allow-http.
@@ -82,7 +92,7 @@ def create(
         expires_in_days, never_expires = parse_expires(expires)
         # The plaintext PAT rides back in the create response, so this call is sensitive
         # even when the OS itself requires no admin credential to reach it.
-        with _api_for(url, json_output, allow_http, sensitive=True, assume_yes=yes) as api:
+        with _api_for(url, json_output, allow_http, sensitive=True, assume_yes=yes, mint=True) as api:
             try:
                 account = api.create_service_account(
                     name=name,

--- a/libs/agnoctl/agnoctl/console.py
+++ b/libs/agnoctl/agnoctl/console.py
@@ -6,12 +6,21 @@ they work; in JSON mode only emit_json touches stdout, so output stays parseable
 """
 
 import json
+from pathlib import Path
 from typing import Any, Dict
 
 from rich.console import Console
 
 console = Console()
 err_console = Console(stderr=True)
+
+
+def shorten_home(text: str) -> str:
+    """Display-only: the home-directory prefix reads better as ~. Never used in JSON."""
+    home = str(Path.home())
+    if home and home != "/" and home in text:
+        return text.replace(home, "~")
+    return text
 
 
 def print_heading(msg: str) -> None:

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -8,7 +8,7 @@ distinguishes the auth modes by status code and 401 detail wording.
 
 import ipaddress
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
@@ -57,17 +57,35 @@ ENV_FILES = (".env.production", ".env")
 
 
 @dataclass
+class McpOAuth:
+    """OAuth discovery details served on /info when AgentOS(mcp_auth=...) protects /mcp."""
+
+    authorization_servers: List[str] = field(default_factory=list)
+    resource: Optional[str] = None
+
+    def public_dict(self) -> Dict[str, Any]:
+        return {"authorization_servers": self.authorization_servers, "resource": self.resource}
+
+
+@dataclass
 class OSInfo:
     base_url: str
     version: Optional[str]
     mcp_enabled: bool
     mcp_path: Optional[str]
-    auth_mode: str  # "none" | "security_key" | "jwt" | "unknown"
+    auth_mode: str  # "none" | "security_key" | "jwt" | "oauth" | "unknown"
     discovered_via: str  # "info" | "probe"
     url_source: str = "default"  # "flag" | "env" | "env-file" | "default"
     url_source_file: Optional[str] = None  # env file AGENTOS_URL came from, when url_source == "env-file"
     name: Optional[str] = None  # AgentOS(name=...), served on /info by agno >= 2.8; None on older servers
     os_id: Optional[str] = None
+    oauth: Optional[McpOAuth] = None  # set when the MCP endpoint is OAuth-protected
+
+    @property
+    def oauth_enabled(self) -> bool:
+        """Whether /mcp is OAuth-protected: clients sign in through the authorization
+        server instead of carrying a minted bearer token."""
+        return self.oauth is not None or self.auth_mode == "oauth"
 
     @property
     def mcp_url(self) -> str:
@@ -84,7 +102,11 @@ class OSInfo:
             "name": self.name,
             "os_id": self.os_id,
             "version": self.version,
-            "mcp": {"enabled": self.mcp_enabled, "path": self.mcp_path},
+            "mcp": {
+                "enabled": self.mcp_enabled,
+                "path": self.mcp_path,
+                "oauth": self.oauth.public_dict() if self.oauth is not None else None,
+            },
             "auth_mode": self.auth_mode,
             "discovered_via": self.discovered_via,
             "url_source": self.url_source,
@@ -237,6 +259,18 @@ def _str_or_none(value: Any) -> Optional[str]:
     return value if isinstance(value, str) and value else None
 
 
+def _parse_mcp_oauth(mcp_field: Dict[str, Any]) -> Optional[McpOAuth]:
+    """The /info mcp.oauth object, when the server advertises OAuth on /mcp."""
+    raw = mcp_field.get("oauth")
+    if not isinstance(raw, dict):
+        return None
+    servers = raw.get("authorization_servers")
+    return McpOAuth(
+        authorization_servers=[s for s in servers if isinstance(s, str)] if isinstance(servers, list) else [],
+        resource=_str_or_none(raw.get("resource")),
+    )
+
+
 def _probe_candidate(candidate: str, url_source: str, url_source_file: Optional[str]) -> Optional[OSInfo]:
     """Probe one candidate URL; an OSInfo when a live AgentOS answers, else None."""
     try:
@@ -267,6 +301,7 @@ def _probe_candidate(candidate: str, url_source: str, url_source_file: Optional[
                 url_source_file=url_source_file,
                 name=_str_or_none(info.get("name")),
                 os_id=_str_or_none(info.get("os_id")),
+                oauth=_parse_mcp_oauth(mcp_field),
             )
 
         mcp_enabled = _probe_mcp(candidate)

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -6,15 +6,21 @@ POST to /mcp distinguishes mounted-vs-404, and an unauthenticated GET /config
 distinguishes the auth modes by status code and 401 detail wording.
 """
 
+import ipaddress
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit
 
 import httpx
 
 from agnoctl.errors import CLIError
 from agnoctl.http import AgentOSAPI, build_client
+
+# Discovery probes short-circuit on dead hosts; a stale remote AGENTOS_URL should cost
+# seconds, not the full API timeout, on every invocation.
+DISCOVERY_TIMEOUT = 5.0
 
 # AgentOS.serve() defaults to port 7777; when that is taken, users commonly bump to
 # 7778/7779, and 8000 covers a bare-uvicorn setup. All are probed on localhost when no
@@ -28,6 +34,21 @@ DEFAULT_URLS = [
 ]
 
 URL_ENV_VAR = "AGENTOS_URL"
+
+
+def _is_loopback_host(host: Optional[str]) -> bool:
+    """True for hosts that never leave the machine: localhost, 127.0.0.0/8, ::1, and the
+    unspecified addresses (0.0.0.0, ::) that dev servers bind to."""
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return ip.is_loopback or ip.is_unspecified
+
 
 # Project env files scanned for AGENTOS_URL when it is not already in the process
 # environment, so `agno connect` targets a deployed OS whose URL the deploy scripts
@@ -45,6 +66,8 @@ class OSInfo:
     discovered_via: str  # "info" | "probe"
     url_source: str = "default"  # "flag" | "env" | "env-file" | "default"
     url_source_file: Optional[str] = None  # env file AGENTOS_URL came from, when url_source == "env-file"
+    name: Optional[str] = None  # AgentOS(name=...), served on /info by agno >= 2.8; None on older servers
+    os_id: Optional[str] = None
 
     @property
     def mcp_url(self) -> str:
@@ -58,6 +81,8 @@ class OSInfo:
     def public_dict(self) -> Dict[str, Any]:
         return {
             "url": self.base_url,
+            "name": self.name,
+            "os_id": self.os_id,
             "version": self.version,
             "mcp": {"enabled": self.mcp_enabled, "path": self.mcp_path},
             "auth_mode": self.auth_mode,
@@ -129,16 +154,56 @@ def _agentos_url_from_env_files() -> "tuple[Optional[str], Optional[str]]":
     return None, None
 
 
-def _candidate_urls(url: Optional[str]) -> "tuple[List[str], str, Optional[str]]":
+def _dedup_key(url: str) -> "tuple[str, str, Optional[str]]":
+    """Key under which two candidate URLs mean the same server. Loopback aliases
+    (localhost vs 127.0.0.1) collapse, so an env-file URL for a local server does not
+    make the same OS show up twice."""
+    try:
+        parts = urlsplit(url)
+        host = "loopback" if _is_loopback_host(parts.hostname) else (parts.hostname or url)
+        port = str(parts.port) if parts.port is not None else ""
+    except ValueError:
+        return "", url, None
+    return parts.scheme.lower(), host, port
+
+
+def _candidate_sources(url: Optional[str]) -> "List[tuple[str, str, Optional[str]]]":
+    """Every (url, source, source_file) discovery should consider, in priority order.
+
+    An explicit --url or an exported AGENTOS_URL is a deliberate, single target. An
+    AGENTOS_URL read from an ambient env file is different: a deploy script persisting
+    the production URL to .env.production must not make a locally running AgentOS
+    undiscoverable, so the env-file URL and the localhost defaults coexist.
+    """
     if url:
-        return [url.rstrip("/")], "flag", None
+        return [(url.rstrip("/"), "flag", None)]
     env_url = os.environ.get(URL_ENV_VAR)
     if env_url:
-        return [env_url.rstrip("/")], "env", None
+        return [(env_url.rstrip("/"), "env", None)]
+    sources: "List[tuple[str, str, Optional[str]]]" = []
+    seen = set()
     file_url, file_name = _agentos_url_from_env_files()
     if file_url:
-        return [file_url], "env-file", file_name
-    return list(DEFAULT_URLS), "default", None
+        sources.append((file_url, "env-file", file_name))
+        seen.add(_dedup_key(file_url))
+    for default_url in DEFAULT_URLS:
+        if _dedup_key(default_url) not in seen:
+            sources.append((default_url, "default", None))
+    return sources
+
+
+def _primary_sources(url: Optional[str]) -> "List[tuple[str, str, Optional[str]]]":
+    """The highest-priority source's candidates only: the single-target view used by
+    discover(). An ambient env-file URL is authoritative here -- localhost is not
+    probed behind it -- which keeps tokens/status pinned to one deterministic target."""
+    sources = _candidate_sources(url)
+    primary = sources[0][1]
+    return [s for s in sources if s[1] == primary]
+
+
+def _candidate_urls(url: Optional[str]) -> "tuple[List[str], str, Optional[str]]":
+    sources = _primary_sources(url)
+    return [s[0] for s in sources], sources[0][1], sources[0][2]
 
 
 def _source_note(url_source: str, url_source_file: Optional[str]) -> str:
@@ -168,56 +233,63 @@ def _probe_mcp(base_url: str) -> bool:
     return response.status_code != 404
 
 
-def discover(url: Optional[str] = None) -> OSInfo:
-    """Find a running AgentOS and return what the CLI needs to know about it."""
-    candidates, url_source, url_source_file = _candidate_urls(url)
-    source_note = _source_note(url_source, url_source_file)
-    for candidate in candidates:
-        try:
-            api = AgentOSAPI(candidate)
-        except httpx.InvalidURL as e:
-            # A user-supplied URL (flag/env/env-file) that httpx cannot parse -- e.g. an
-            # un-expanded "${PORT}" or a typo'd port. Fail clearly, not with a traceback.
-            raise CLIError(
-                "Invalid AgentOS URL: " + candidate + source_note + ".",
-                hint="Fix the URL" + (" in " + url_source_file if url_source_file else "") + " or pass --url.",
-            ) from e
-        with api:
-            if api.health() is None:
-                continue
-            info = api.info() or {}
+def _str_or_none(value: Any) -> Optional[str]:
+    return value if isinstance(value, str) and value else None
 
-            mcp_field = info.get("mcp")
-            auth_mode = info.get("auth_mode")
-            if isinstance(mcp_field, dict) and isinstance(auth_mode, str):
-                return OSInfo(
-                    base_url=candidate,
-                    version=info.get("agno_version"),
-                    mcp_enabled=bool(mcp_field.get("enabled")),
-                    mcp_path=mcp_field.get("path") or ("/mcp" if mcp_field.get("enabled") else None),
-                    auth_mode=auth_mode,
-                    discovered_via="info",
-                    url_source=url_source,
-                    url_source_file=url_source_file,
-                )
 
-            mcp_enabled = _probe_mcp(candidate)
+def _probe_candidate(candidate: str, url_source: str, url_source_file: Optional[str]) -> Optional[OSInfo]:
+    """Probe one candidate URL; an OSInfo when a live AgentOS answers, else None."""
+    try:
+        api = AgentOSAPI(candidate, timeout=DISCOVERY_TIMEOUT)
+    except httpx.InvalidURL as e:
+        # A user-supplied URL (flag/env/env-file) that httpx cannot parse -- e.g. an
+        # un-expanded "${PORT}" or a typo'd port. Fail clearly, not with a traceback.
+        raise CLIError(
+            "Invalid AgentOS URL: " + candidate + _source_note(url_source, url_source_file) + ".",
+            hint="Fix the URL" + (" in " + url_source_file if url_source_file else "") + " or pass --url.",
+        ) from e
+    with api:
+        if api.health() is None:
+            return None
+        info = api.info() or {}
+
+        mcp_field = info.get("mcp")
+        auth_mode = info.get("auth_mode")
+        if isinstance(mcp_field, dict) and isinstance(auth_mode, str):
             return OSInfo(
                 base_url=candidate,
                 version=info.get("agno_version"),
-                mcp_enabled=mcp_enabled,
-                mcp_path="/mcp" if mcp_enabled else None,
-                auth_mode=api.probe_auth_mode(),
-                discovered_via="probe",
+                mcp_enabled=bool(mcp_field.get("enabled")),
+                mcp_path=mcp_field.get("path") or ("/mcp" if mcp_field.get("enabled") else None),
+                auth_mode=auth_mode,
+                discovered_via="info",
                 url_source=url_source,
                 url_source_file=url_source_file,
+                name=_str_or_none(info.get("name")),
+                os_id=_str_or_none(info.get("os_id")),
             )
 
-    tried = ", ".join(candidates)
-    if url_source == "env-file":
+        mcp_enabled = _probe_mcp(candidate)
+        return OSInfo(
+            base_url=candidate,
+            version=info.get("agno_version"),
+            mcp_enabled=mcp_enabled,
+            mcp_path="/mcp" if mcp_enabled else None,
+            auth_mode=api.probe_auth_mode(),
+            discovered_via="probe",
+            url_source=url_source,
+            url_source_file=url_source_file,
+        )
+
+
+def _no_os_error(sources: "List[tuple[str, str, Optional[str]]]") -> CLIError:
+    """The "nothing answered" error, with each tried URL annotated with its own provenance."""
+    tried = ", ".join(url + _source_note(source, source_file) for url, source, source_file in sources)
+    env_file_sources = [s for s in sources if s[1] == "env-file"]
+    if env_file_sources:
         hint = (
             "The URL came from AGENTOS_URL in "
-            + (url_source_file or "an env file")
+            + (env_file_sources[0][2] or "an env file")
             + " in this directory -- fix or remove it, pass --url, or start your AgentOS (agent_os.serve())."
         )
     else:
@@ -226,10 +298,42 @@ def discover(url: Optional[str] = None) -> OSInfo:
             + URL_ENV_VAR
             + " (in your shell or a .env.production / .env file)."
         )
-    raise CLIError(
-        "No running AgentOS found (tried: " + tried + source_note + ").",
-        hint=hint,
-    )
+    return CLIError("No running AgentOS found (tried: " + tried + ").", hint=hint)
+
+
+def discover(url: Optional[str] = None) -> OSInfo:
+    """Find a running AgentOS and return what the CLI needs to know about it.
+
+    Single-target: only the highest-priority source is probed, and the first live
+    candidate wins. Non-interactive connect/disconnect runs use this too, so automation
+    always resolves the same deterministic target and a dead env-file OS stays a hard
+    failure instead of silently falling through to a different server.
+    """
+    sources = _primary_sources(url)
+    for candidate, url_source, url_source_file in sources:
+        os_info = _probe_candidate(candidate, url_source, url_source_file)
+        if os_info is not None:
+            return os_info
+    raise _no_os_error(sources)
+
+
+def discover_all(url: Optional[str] = None) -> List[OSInfo]:
+    """Every running AgentOS among the candidate sources, in priority order.
+
+    Unlike discover(), an ambient env-file URL does not short-circuit the localhost
+    defaults: all candidates are probed and every live one is returned, so an
+    interactive caller can offer a choice. Raises the same "no running AgentOS"
+    CLIError when none answer.
+    """
+    sources = _candidate_sources(url)
+    found: List[OSInfo] = []
+    for candidate, url_source, url_source_file in sources:
+        os_info = _probe_candidate(candidate, url_source, url_source_file)
+        if os_info is not None:
+            found.append(os_info)
+    if not found:
+        raise _no_os_error(sources)
+    return found
 
 
 MCP_ENABLE_INSTRUCTIONS = """MCP is not enabled on this AgentOS. Enable it and restart:

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -73,7 +73,7 @@ class OSInfo:
     version: Optional[str]
     mcp_enabled: bool
     mcp_path: Optional[str]
-    auth_mode: str  # "none" | "security_key" | "jwt" | "oauth" | "unknown"
+    auth_mode: str  # REST/WS plane only: "none" | "security_key" | "jwt" | "unknown"; MCP OAuth is signaled by `oauth`
     discovered_via: str  # "info" | "probe"
     url_source: str = "default"  # "flag" | "env" | "env-file" | "default"
     url_source_file: Optional[str] = None  # env file AGENTOS_URL came from, when url_source == "env-file"
@@ -86,8 +86,9 @@ class OSInfo:
         """Whether /mcp is OAuth-protected AND apps can actually sign in: the OS must
         advertise at least one authorization server, or there is nothing to sign in
         through. A provider with none (e.g. a bare fastmcp TokenVerifier as mcp_auth)
-        still reports auth_mode "oauth", but its bearers are issued out of band, so
-        connect treats it like any other token-protected endpoint."""
+        still serves an mcp.oauth block, but its bearers are issued out of band, so
+        connect treats it like any other token-protected endpoint. auth_mode plays no
+        part here: it describes the REST/WS plane, which is independent of /mcp."""
         return self.oauth is not None and bool(self.oauth.authorization_servers)
 
     @property

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -83,9 +83,12 @@ class OSInfo:
 
     @property
     def oauth_enabled(self) -> bool:
-        """Whether /mcp is OAuth-protected: clients sign in through the authorization
-        server instead of carrying a minted bearer token."""
-        return self.oauth is not None or self.auth_mode == "oauth"
+        """Whether /mcp is OAuth-protected AND apps can actually sign in: the OS must
+        advertise at least one authorization server, or there is nothing to sign in
+        through. A provider with none (e.g. a bare fastmcp TokenVerifier as mcp_auth)
+        still reports auth_mode "oauth", but its bearers are issued out of band, so
+        connect treats it like any other token-protected endpoint."""
+        return self.oauth is not None and bool(self.oauth.authorization_servers)
 
     @property
     def mcp_url(self) -> str:

--- a/libs/agnoctl/agnoctl/discovery.py
+++ b/libs/agnoctl/agnoctl/discovery.py
@@ -75,8 +75,10 @@ class OSInfo:
     mcp_path: Optional[str]
     auth_mode: str  # REST/WS plane only: "none" | "security_key" | "jwt" | "unknown"; MCP OAuth is signaled by `oauth`
     discovered_via: str  # "info" | "probe"
-    url_source: str = "default"  # "flag" | "env" | "env-file" | "default"
-    url_source_file: Optional[str] = None  # env file AGENTOS_URL came from, when url_source == "env-file"
+    url_source: str = "default"  # "flag" | "env" | "env-file" | "client-config" | "default"
+    # Provenance detail: the env file AGENTOS_URL came from ("env-file"), or the client
+    # display names whose configs point at this OS ("client-config").
+    url_source_file: Optional[str] = None
     name: Optional[str] = None  # AgentOS(name=...), served on /info by agno >= 2.8; None on older servers
     os_id: Optional[str] = None
     oauth: Optional[McpOAuth] = None  # set when the MCP endpoint is OAuth-protected
@@ -238,6 +240,8 @@ def _source_note(url_source: str, url_source_file: Optional[str]) -> str:
         return " (from AGENTOS_URL in " + url_source_file + ")"
     if url_source == "env":
         return " (from AGENTOS_URL)"
+    if url_source == "client-config" and url_source_file:
+        return " (configured in " + url_source_file + ")"
     return ""
 
 
@@ -356,15 +360,27 @@ def discover(url: Optional[str] = None) -> OSInfo:
     raise _no_os_error(sources)
 
 
-def discover_all(url: Optional[str] = None) -> List[OSInfo]:
+def discover_all(
+    url: Optional[str] = None,
+    extra_sources: Optional["List[tuple[str, str, Optional[str]]]"] = None,
+) -> List[OSInfo]:
     """Every running AgentOS among the candidate sources, in priority order.
 
     Unlike discover(), an ambient env-file URL does not short-circuit the localhost
     defaults: all candidates are probed and every live one is returned, so an
-    interactive caller can offer a choice. Raises the same "no running AgentOS"
-    CLIError when none answer.
+    interactive caller can offer a choice. ``extra_sources`` are additional
+    (url, source, note) candidates -- e.g. OSes the client configs already point at --
+    probed after the standard ones and deduped against them; they are ignored when an
+    explicit --url or exported AGENTOS_URL names a deliberate single target. Raises
+    the same "no running AgentOS" CLIError when none answer.
     """
-    sources = _candidate_sources(url)
+    sources = list(_candidate_sources(url))
+    if extra_sources and sources[0][1] not in ("flag", "env"):
+        seen = {_dedup_key(candidate) for candidate, _, _ in sources}
+        for candidate, url_source, url_source_file in extra_sources:
+            if _dedup_key(candidate) not in seen:
+                seen.add(_dedup_key(candidate))
+                sources.append((candidate.rstrip("/"), url_source, url_source_file))
     found: List[OSInfo] = []
     for candidate, url_source, url_source_file in sources:
         os_info = _probe_candidate(candidate, url_source, url_source_file)

--- a/libs/agnoctl/agnoctl/errors.py
+++ b/libs/agnoctl/agnoctl/errors.py
@@ -12,6 +12,11 @@ class CLIError(Exception):
         self.exit_code = exit_code
         self.hint = hint
 
+    @property
+    def full_message(self) -> str:
+        """Message and hint as one line, for per-client result rows in reports."""
+        return self.message + ((" " + self.hint) if self.hint else "")
+
 
 class APIError(CLIError):
     """An AgentOS API call failed."""

--- a/libs/agnoctl/agnoctl/http.py
+++ b/libs/agnoctl/agnoctl/http.py
@@ -311,11 +311,11 @@ def service_accounts_open(base_url: str, timeout: float = DEFAULT_TIMEOUT) -> bo
     """Whether the service-accounts API answers without any credential.
 
     True means no auth middleware guards the REST plane -- an OS whose only auth is an
-    ``mcp_auth`` provider on /mcp. Such a server refuses every mint (anonymous callers
-    must never create durable credentials), so no admin credential the operator could
-    supply would help; it also "accepts" any credential on reads, which would make a
-    credential check pass right before the mint fails. Unreachable or odd answers count
-    as not-open, so callers fall through to the normal credential flow and its errors.
+    ``mcp_auth`` provider on /mcp. Such a server refuses anonymous mints (durable
+    credentials must never come from anonymous callers) and can authenticate only a
+    verified service-account bearer; any other credential "passes" its open reads right
+    up until the mint fails. Unreachable or odd answers count as not-open, so callers
+    fall through to the normal credential flow and its errors.
     """
     try:
         with build_client(base_url=base_url.rstrip("/"), timeout=timeout) as client:

--- a/libs/agnoctl/agnoctl/http.py
+++ b/libs/agnoctl/agnoctl/http.py
@@ -236,6 +236,19 @@ class AgentOSAPI:
                 return
             page += 1
 
+    def check_admin_credential(self) -> None:
+        """One cheap authed call, so a bad admin credential fails fast and legibly.
+
+        _request already turns a 401/403 into the rejected-credential APIError with the
+        where-to-get-a-token hint; any other non-200 is surfaced the same way.
+        """
+        response = self._request("GET", "/service-accounts", params={"page": 1, "limit": 1})
+        if response.status_code != 200:
+            raise APIError(
+                "Could not verify the admin credential: " + _error_detail(response),
+                status_code=response.status_code,
+            )
+
     def find_service_account(self, name: str) -> Optional[ServiceAccount]:
         # Active accounts only, one page at a time, stopping at the first match --
         # token rotation grows the revoked history monotonically, so downloading the
@@ -286,6 +299,9 @@ class AgentOSAPI:
             raise APIError(
                 "The AgentOS rejected the admin credential (" + _error_detail(response) + ").",
                 status_code=response.status_code,
-                hint="Set AGNO_ADMIN_TOKEN (or OS_SECURITY_KEY) to a credential with admin access.",
+                hint=(
+                    "Generate a short-lived admin token in the AgentOS UI (Settings -> OS & Security), "
+                    "or set AGNO_ADMIN_TOKEN (or OS_SECURITY_KEY) to a credential with admin access."
+                ),
             )
         return response

--- a/libs/agnoctl/agnoctl/http.py
+++ b/libs/agnoctl/agnoctl/http.py
@@ -305,3 +305,21 @@ class AgentOSAPI:
                 ),
             )
         return response
+
+
+def service_accounts_open(base_url: str, timeout: float = DEFAULT_TIMEOUT) -> bool:
+    """Whether the service-accounts API answers without any credential.
+
+    True means no auth middleware guards the REST plane -- an OS whose only auth is an
+    ``mcp_auth`` provider on /mcp. Such a server refuses every mint (anonymous callers
+    must never create durable credentials), so no admin credential the operator could
+    supply would help; it also "accepts" any credential on reads, which would make a
+    credential check pass right before the mint fails. Unreachable or odd answers count
+    as not-open, so callers fall through to the normal credential flow and its errors.
+    """
+    try:
+        with build_client(base_url=base_url.rstrip("/"), timeout=timeout) as client:
+            response = client.get("/service-accounts", params={"page": 1, "limit": 1})
+    except httpx.HTTPError:
+        return False
+    return response.status_code == 200

--- a/libs/agnoctl/agnoctl/main.py
+++ b/libs/agnoctl/agnoctl/main.py
@@ -7,6 +7,7 @@ from rich.text import Text
 from agnoctl import __version__
 from agnoctl.commands.connect import connect
 from agnoctl.commands.create import create
+from agnoctl.commands.disconnect import disconnect
 from agnoctl.commands.lifecycle import down, restart, up
 from agnoctl.commands.status import status
 from agnoctl.commands.tokens import tokens_app
@@ -21,6 +22,7 @@ app = typer.Typer(
 )
 
 app.command(name="connect")(connect)
+app.command(name="disconnect")(disconnect)
 app.command(name="create")(create)
 app.command(name="status")(status)
 app.add_typer(tokens_app, name="tokens")
@@ -45,6 +47,7 @@ _GROUPS: List[Tuple[str, List[Tuple[str, str]]]] = [
         [
             ("agno create <name>", "Create a new AgentOS"),
             ("agno connect", "Connect your AI apps to your AgentOS using MCP"),
+            ("agno disconnect", "Disconnect your AI apps from your AgentOS"),
         ],
     ),
     (

--- a/libs/agnoctl/agnoctl/mcp_client.py
+++ b/libs/agnoctl/agnoctl/mcp_client.py
@@ -25,9 +25,19 @@ class MCPVerifyResult:
     tools: List[str] = field(default_factory=list)
     status_code: Optional[int] = None
     error: Optional[str] = None
+    # True when the endpoint answered with an OAuth challenge (401 + WWW-Authenticate):
+    # for an OAuth-protected server that IS the healthy outcome -- the client completes
+    # the sign-in itself -- so ok is True but no tools could be listed.
+    oauth_challenge: bool = False
 
     def public_dict(self) -> Dict[str, Any]:
-        return {"ok": self.ok, "tools": len(self.tools), "status_code": self.status_code, "error": self.error}
+        return {
+            "ok": self.ok,
+            "tools": len(self.tools),
+            "status_code": self.status_code,
+            "error": self.error,
+            "oauth_challenge": self.oauth_challenge,
+        }
 
 
 def _parse_jsonrpc_body(response: httpx.Response) -> Optional[Dict[str, Any]]:
@@ -54,19 +64,24 @@ def _parse_jsonrpc_body(response: httpx.Response) -> Optional[Dict[str, Any]]:
     return parsed if isinstance(parsed, dict) else None
 
 
-def verify_mcp(mcp_url: str, token: Optional[str] = None, timeout: float = 15.0) -> MCPVerifyResult:
+def verify_mcp(
+    mcp_url: str, token: Optional[str] = None, timeout: float = 15.0, expect_oauth_challenge: bool = False
+) -> MCPVerifyResult:
     """Handshake with an MCP streamable-HTTP endpoint and list its tools.
 
-    Never raises: connection problems and malformed payloads come back as a failed
-    MCPVerifyResult so callers can report per-client outcomes.
+    With ``expect_oauth_challenge``, a 401 that carries a WWW-Authenticate header is the
+    healthy outcome (the endpoint is OAuth-protected and the client will run the sign-in
+    flow itself); the CLI cannot list tools in that case. Never raises: connection
+    problems and malformed payloads come back as a failed MCPVerifyResult so callers can
+    report per-client outcomes.
     """
     try:
-        return _verify_mcp(mcp_url, token, timeout)
+        return _verify_mcp(mcp_url, token, timeout, expect_oauth_challenge)
     except Exception as e:  # never-raises contract
         return MCPVerifyResult(ok=False, error="MCP verification failed: " + str(e))
 
 
-def _verify_mcp(mcp_url: str, token: Optional[str], timeout: float) -> MCPVerifyResult:
+def _verify_mcp(mcp_url: str, token: Optional[str], timeout: float, expect_oauth_challenge: bool) -> MCPVerifyResult:
     headers = {
         "Accept": "application/json, text/event-stream",
         "Content-Type": "application/json",
@@ -91,6 +106,17 @@ def _verify_mcp(mcp_url: str, token: Optional[str], timeout: float) -> MCPVerify
                 },
             )
             if init_response.status_code in (401, 403):
+                if expect_oauth_challenge:
+                    if init_response.headers.get("www-authenticate"):
+                        return MCPVerifyResult(ok=True, status_code=init_response.status_code, oauth_challenge=True)
+                    return MCPVerifyResult(
+                        ok=False,
+                        status_code=init_response.status_code,
+                        error=(
+                            "The MCP endpoint rejected the request without an OAuth challenge "
+                            "(no WWW-Authenticate header); clients will not be able to sign in."
+                        ),
+                    )
                 return MCPVerifyResult(
                     ok=False,
                     status_code=init_response.status_code,

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -14,6 +14,9 @@ class FakeAgentOS:
     auth_mode: "none" | "security_key" | "jwt" | "oauth"
     info_discovery: serve the mcp/auth_mode fields on /info (newer servers)
     mcp_requires_token: enforce tokens on /mcp (False models servers predating enforcement)
+    open_rest: an OS whose ONLY auth is the mcp_auth provider on /mcp -- /info still says
+        "oauth", but no middleware guards the REST plane: reads and deletes answer any
+        caller, while the server's anonymous-mint gate refuses every POST /service-accounts
     """
 
     def __init__(
@@ -28,9 +31,11 @@ class FakeAgentOS:
         name: Optional[str] = None,
         os_id: Optional[str] = None,
         oauth: Optional[Dict[str, Any]] = None,
+        open_rest: bool = False,
     ):
         self.auth_mode = auth_mode
         self.security_key = security_key
+        self.open_rest = open_rest
         self.mcp_enabled = mcp_enabled
         self.info_discovery = info_discovery
         self.mcp_requires_token = mcp_requires_token
@@ -123,7 +128,7 @@ class FakeAgentOS:
             return httpx.Response(200, json=payload)
 
         if path == "/config":
-            if self.auth_mode == "none":
+            if self.auth_mode == "none" or self.open_rest:
                 return httpx.Response(200, json={"os_id": "fake"})
             if self._bearer(request) == self.security_key:
                 return httpx.Response(200, json={"os_id": "fake"})
@@ -133,6 +138,10 @@ class FakeAgentOS:
             return httpx.Response(401, json={"detail": detail})
 
         if path == "/service-accounts" and method == "POST":
+            # With no auth middleware, no caller is ever "authenticated", so the real
+            # server's anonymous-mint gate refuses every mint regardless of the bearer.
+            if self.open_rest:
+                return httpx.Response(401, json={"detail": "JWT authentication is required to mint a service account."})
             if not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
             body = json.loads(request.content)
@@ -168,7 +177,7 @@ class FakeAgentOS:
             return httpx.Response(201, json=self._account_response(account, include_token=True))
 
         if path == "/service-accounts" and method == "GET":
-            if not self._is_admin(request):
+            if not self.open_rest and not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
             data = [self._account_response(a) for a in self.accounts.values()]
             return httpx.Response(
@@ -177,7 +186,7 @@ class FakeAgentOS:
             )
 
         if path.startswith("/service-accounts/") and method == "DELETE":
-            if not self._is_admin(request):
+            if not self.open_rest and not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
             account_id = path.rsplit("/", 1)[1]
             for account in self.accounts.values():

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -2,21 +2,30 @@
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 import pytest
+
+DEFAULT_OAUTH = {
+    "authorization_servers": ["http://localhost:7777/mcp/auth"],
+    "resource": "http://localhost:7777/mcp",
+}
 
 
 class FakeAgentOS:
     """Simulates the AgentOS endpoints the CLI touches.
 
-    auth_mode: "none" | "security_key" | "jwt" | "oauth"
+    auth_mode: the REST/WS plane only, "none" | "security_key" | "jwt" -- like the real
+        server, it says nothing about /mcp. "none" means the REST plane is OPEN: reads
+        and deletes answer any caller, while the server's anonymous-mint gate refuses
+        every POST /service-accounts (minted PATs must never come from anonymous calls).
+    oauth: the /info mcp.oauth block -- a dict, or True for a default authorization
+        server. When set, /mcp is OAuth-protected: unauthenticated requests get 401 +
+        a WWW-Authenticate challenge like fastmcp's middleware, and minted PATs still
+        pass (the server composes them via MultiAuth).
     info_discovery: serve the mcp/auth_mode fields on /info (newer servers)
     mcp_requires_token: enforce tokens on /mcp (False models servers predating enforcement)
-    open_rest: an OS whose ONLY auth is the mcp_auth provider on /mcp -- /info still says
-        "oauth", but no middleware guards the REST plane: reads and deletes answer any
-        caller, while the server's anonymous-mint gate refuses every POST /service-accounts
     """
 
     def __init__(
@@ -30,12 +39,11 @@ class FakeAgentOS:
         agno_version: str = "2.7.0",
         name: Optional[str] = None,
         os_id: Optional[str] = None,
-        oauth: Optional[Dict[str, Any]] = None,
-        open_rest: bool = False,
+        oauth: Union[bool, Dict[str, Any], None] = None,
     ):
+        assert auth_mode in ("none", "security_key", "jwt"), "auth_mode is the REST plane; use oauth= for MCP OAuth"
         self.auth_mode = auth_mode
         self.security_key = security_key
-        self.open_rest = open_rest
         self.mcp_enabled = mcp_enabled
         self.info_discovery = info_discovery
         self.mcp_requires_token = mcp_requires_token
@@ -43,14 +51,7 @@ class FakeAgentOS:
         self.agno_version = agno_version
         self.name = name
         self.os_id = os_id
-        # OAuth-protected /mcp (auth_mode "oauth"): served on /info, and unauthenticated
-        # MCP requests get 401 + a WWW-Authenticate challenge like fastmcp's middleware.
-        self.oauth = oauth
-        if auth_mode == "oauth" and oauth is None:
-            self.oauth = {
-                "authorization_servers": ["http://localhost:7777/mcp/auth"],
-                "resource": "http://localhost:7777/mcp",
-            }
+        self.oauth: Optional[Dict[str, Any]] = dict(DEFAULT_OAUTH) if oauth is True else (oauth or None)
 
         self.accounts: Dict[str, Dict[str, Any]] = {}  # name -> account dict (with plaintext token)
         self.create_calls = 0
@@ -128,7 +129,7 @@ class FakeAgentOS:
             return httpx.Response(200, json=payload)
 
         if path == "/config":
-            if self.auth_mode == "none" or self.open_rest:
+            if self.auth_mode == "none":
                 return httpx.Response(200, json={"os_id": "fake"})
             if self._bearer(request) == self.security_key:
                 return httpx.Response(200, json={"os_id": "fake"})
@@ -138,9 +139,10 @@ class FakeAgentOS:
             return httpx.Response(401, json={"detail": detail})
 
         if path == "/service-accounts" and method == "POST":
-            # With no auth middleware, no caller is ever "authenticated", so the real
-            # server's anonymous-mint gate refuses every mint regardless of the bearer.
-            if self.open_rest:
+            # An open REST plane ("none") installs no auth middleware, so no caller is
+            # ever "authenticated" and the real server's anonymous-mint gate refuses
+            # every mint regardless of the bearer.
+            if self.auth_mode == "none":
                 return httpx.Response(401, json={"detail": "JWT authentication is required to mint a service account."})
             if not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
@@ -177,7 +179,7 @@ class FakeAgentOS:
             return httpx.Response(201, json=self._account_response(account, include_token=True))
 
         if path == "/service-accounts" and method == "GET":
-            if not self.open_rest and not self._is_admin(request):
+            if not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
             data = [self._account_response(a) for a in self.accounts.values()]
             return httpx.Response(
@@ -186,7 +188,7 @@ class FakeAgentOS:
             )
 
         if path.startswith("/service-accounts/") and method == "DELETE":
-            if not self.open_rest and not self._is_admin(request):
+            if not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
             account_id = path.rsplit("/", 1)[1]
             for account in self.accounts.values():
@@ -198,20 +200,22 @@ class FakeAgentOS:
         if path == "/mcp":
             if not self.mcp_enabled:
                 return httpx.Response(404, json={"detail": "Not Found"})
-            if self.mcp_requires_token and self.auth_mode != "none":
+            if self.oauth is not None:
+                # OAuth-protected /mcp: fastmcp's middleware guards it regardless of the
+                # REST plane -- 401 + the RFC 9728 challenge for anything but a minted
+                # PAT (which the real server accepts via MultiAuth).
+                if self._bearer(request) not in self.active_tokens():
+                    return httpx.Response(
+                        401,
+                        json={"detail": "Unauthorized"},
+                        headers={
+                            "WWW-Authenticate": "Bearer resource_metadata="
+                            '"http://localhost:7777/.well-known/oauth-protected-resource/mcp"'
+                        },
+                    )
+            elif self.mcp_requires_token and self.auth_mode != "none":
                 token = self._bearer(request)
                 if token != self.security_key and token not in self.active_tokens():
-                    # An OAuth-protected /mcp answers with the RFC 9728 challenge (via
-                    # fastmcp's RequireAuthMiddleware); PATs still pass (MultiAuth).
-                    if self.auth_mode == "oauth":
-                        return httpx.Response(
-                            401,
-                            json={"detail": "Unauthorized"},
-                            headers={
-                                "WWW-Authenticate": "Bearer resource_metadata="
-                                '"http://localhost:7777/.well-known/oauth-protected-resource/mcp"'
-                            },
-                        )
                     return httpx.Response(401, json={"detail": "Invalid authentication token"})
             message = json.loads(request.content) if request.content else {}
             rpc_method = message.get("method")

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -77,6 +77,34 @@ class FakeAgentOS:
             return True
         return self._bearer(request) == self.security_key
 
+    def _account_for_bearer(self, request: httpx.Request) -> Optional[Dict[str, Any]]:
+        token = self._bearer(request)
+        for account in self.accounts.values():
+            if account["token"] == token and not account.get("revoked_at"):
+                return account
+        return None
+
+    def seed_account(self, name: str, scopes: List[str]) -> str:
+        """Insert a service account directly (as if minted in an earlier, protected era)
+        and return its plaintext token -- for scenarios where minting is impossible now
+        (open REST plane) but a durable credential survives."""
+        token = "agno_pat_" + (name.replace("-", "") + str(self._next_id) + "y" * 40)[:43]
+        self.accounts[name] = {
+            "id": "sa-" + str(self._next_id),
+            "name": name,
+            "principal": "sa:" + name,
+            "token_prefix": token[:16],
+            "scopes": scopes,
+            "created_at": 1780000000,
+            "expires_at": 1790000000,
+            "last_used_at": None,
+            "revoked_at": None,
+            "created_by": None,
+            "token": token,
+        }
+        self._next_id += 1
+        return token
+
     def _account_response(self, account: Dict[str, Any], include_token: bool = False) -> Dict[str, Any]:
         payload = {k: v for k, v in account.items() if k != "token"}
         # Render scopes in the parsed RBAC shape the server returns; the store keeps raw strings.
@@ -139,12 +167,19 @@ class FakeAgentOS:
             return httpx.Response(401, json={"detail": detail})
 
         if path == "/service-accounts" and method == "POST":
-            # An open REST plane ("none") installs no auth middleware, so no caller is
-            # ever "authenticated" and the real server's anonymous-mint gate refuses
-            # every mint regardless of the bearer.
+            # An open REST plane ("none") installs no auth middleware, so anonymous
+            # mints are refused -- but like the real server, a VERIFIED service-account
+            # bearer still authenticates by prefix, and one holding admin or
+            # service_accounts:write may mint.
             if self.auth_mode == "none":
-                return httpx.Response(401, json={"detail": "JWT authentication is required to mint a service account."})
-            if not self._is_admin(request):
+                minter = self._account_for_bearer(request)
+                if minter is None:
+                    return httpx.Response(
+                        401, json={"detail": "JWT authentication is required to mint a service account."}
+                    )
+                if not set(minter.get("scopes") or []) & {"admin", "service_accounts:write"}:
+                    return httpx.Response(403, json={"detail": "Missing required scope: service_accounts:write"})
+            elif not self._is_admin(request):
                 return httpx.Response(401, json={"detail": "Invalid authentication token"})
             body = json.loads(request.content)
             name = body["name"]
@@ -284,9 +319,11 @@ def fake_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
     import agnoctl.commands.connect as connect_module
     import agnoctl.commands.disconnect as disconnect_module
+    import agnoctl.commands.status as status_module
 
     monkeypatch.setattr(connect_module, "build_adapters", build)
     monkeypatch.setattr(disconnect_module, "build_adapters", build)
+    monkeypatch.setattr(status_module, "build_adapters", build)
     return tmp_path
 
 

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -11,7 +11,7 @@ import pytest
 class FakeAgentOS:
     """Simulates the AgentOS endpoints the CLI touches.
 
-    auth_mode: "none" | "security_key" | "jwt"
+    auth_mode: "none" | "security_key" | "jwt" | "oauth"
     info_discovery: serve the mcp/auth_mode fields on /info (newer servers)
     mcp_requires_token: enforce tokens on /mcp (False models servers predating enforcement)
     """
@@ -27,6 +27,7 @@ class FakeAgentOS:
         agno_version: str = "2.7.0",
         name: Optional[str] = None,
         os_id: Optional[str] = None,
+        oauth: Optional[Dict[str, Any]] = None,
     ):
         self.auth_mode = auth_mode
         self.security_key = security_key
@@ -37,6 +38,14 @@ class FakeAgentOS:
         self.agno_version = agno_version
         self.name = name
         self.os_id = os_id
+        # OAuth-protected /mcp (auth_mode "oauth"): served on /info, and unauthenticated
+        # MCP requests get 401 + a WWW-Authenticate challenge like fastmcp's middleware.
+        self.oauth = oauth
+        if auth_mode == "oauth" and oauth is None:
+            self.oauth = {
+                "authorization_servers": ["http://localhost:7777/mcp/auth"],
+                "resource": "http://localhost:7777/mcp",
+            }
 
         self.accounts: Dict[str, Dict[str, Any]] = {}  # name -> account dict (with plaintext token)
         self.create_calls = 0
@@ -101,7 +110,11 @@ class FakeAgentOS:
         if path == "/info":
             payload: Dict[str, Any] = {"agno_version": self.agno_version, "agents": 1, "teams": 0, "workflows": 0}
             if self.info_discovery:
-                payload["mcp"] = {"enabled": self.mcp_enabled, "path": "/mcp" if self.mcp_enabled else None}
+                payload["mcp"] = {
+                    "enabled": self.mcp_enabled,
+                    "path": "/mcp" if self.mcp_enabled else None,
+                    "oauth": self.oauth,
+                }
                 payload["auth_mode"] = self.auth_mode
                 if self.name is not None:
                     payload["name"] = self.name
@@ -179,6 +192,17 @@ class FakeAgentOS:
             if self.mcp_requires_token and self.auth_mode != "none":
                 token = self._bearer(request)
                 if token != self.security_key and token not in self.active_tokens():
+                    # An OAuth-protected /mcp answers with the RFC 9728 challenge (via
+                    # fastmcp's RequireAuthMiddleware); PATs still pass (MultiAuth).
+                    if self.auth_mode == "oauth":
+                        return httpx.Response(
+                            401,
+                            json={"detail": "Unauthorized"},
+                            headers={
+                                "WWW-Authenticate": "Bearer resource_metadata="
+                                '"http://localhost:7777/.well-known/oauth-protected-resource/mcp"'
+                            },
+                        )
                     return httpx.Response(401, json={"detail": "Invalid authentication token"})
             message = json.loads(request.content) if request.content else {}
             rpc_method = message.get("method")

--- a/libs/agnoctl/tests/conftest.py
+++ b/libs/agnoctl/tests/conftest.py
@@ -25,6 +25,8 @@ class FakeAgentOS:
         mcp_requires_token: bool = True,
         sse_responses: bool = False,
         agno_version: str = "2.7.0",
+        name: Optional[str] = None,
+        os_id: Optional[str] = None,
     ):
         self.auth_mode = auth_mode
         self.security_key = security_key
@@ -33,6 +35,8 @@ class FakeAgentOS:
         self.mcp_requires_token = mcp_requires_token
         self.sse_responses = sse_responses
         self.agno_version = agno_version
+        self.name = name
+        self.os_id = os_id
 
         self.accounts: Dict[str, Dict[str, Any]] = {}  # name -> account dict (with plaintext token)
         self.create_calls = 0
@@ -99,6 +103,10 @@ class FakeAgentOS:
             if self.info_discovery:
                 payload["mcp"] = {"enabled": self.mcp_enabled, "path": "/mcp" if self.mcp_enabled else None}
                 payload["auth_mode"] = self.auth_mode
+                if self.name is not None:
+                    payload["name"] = self.name
+                if self.os_id is not None:
+                    payload["os_id"] = self.os_id
             return httpx.Response(200, json=payload)
 
         if path == "/config":
@@ -215,6 +223,42 @@ def fake_os(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> FakeAgentOS:
     install_fake(monkeypatch, fake)
     monkeypatch.chdir(tmp_path)
     return fake
+
+
+@pytest.fixture
+def fake_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Claude Code, Codex, and Cursor 'installed' under a tmp home, wired into every
+    command that builds adapters -- so no test can ever touch the developer's real
+    client configs."""
+    from agnoctl.clients.claude_code import ClaudeCodeAdapter
+    from agnoctl.clients.codex import CodexAdapter
+    from agnoctl.clients.cursor import CursorAdapter
+
+    (tmp_path / ".claude.json").write_text("{}")
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".cursor").mkdir()
+
+    def build(home=None, cwd=None, project=False):
+        return {
+            "claude-code": ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None),
+            "codex": CodexAdapter(home=tmp_path),
+            "cursor": CursorAdapter(home=tmp_path, cwd=tmp_path, project=project),
+        }
+
+    import agnoctl.commands.connect as connect_module
+    import agnoctl.commands.disconnect as disconnect_module
+
+    monkeypatch.setattr(connect_module, "build_adapters", build)
+    monkeypatch.setattr(disconnect_module, "build_adapters", build)
+    return tmp_path
+
+
+def all_output(result) -> str:
+    """A CliRunner result's stdout plus stderr, whichever way this click version captures them."""
+    try:
+        return result.output + result.stderr
+    except (ValueError, AttributeError):
+        return result.output
 
 
 def install_fake(monkeypatch: pytest.MonkeyPatch, fake: FakeAgentOS) -> None:

--- a/libs/agnoctl/tests/test_adapters.py
+++ b/libs/agnoctl/tests/test_adapters.py
@@ -541,3 +541,241 @@ def test_atomic_write_text_direct_secure(tmp_path: Path, permissive_umask):
     atomic_write_text(target, "s3cr3t", secure=True)
     assert target.read_text() == "s3cr3t"
     assert _mode(target) == 0o600
+
+
+# -- remove ------------------------------------------------------------------------------
+
+
+def test_claude_remove_from_all_scopes(tmp_path: Path):
+    """The same name in local, project, and user scope: remove clears every one, so no
+    shadowed entry silently takes over after the restart."""
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {
+                "projects": {str(tmp_path): {"mcpServers": {"agentos": {"url": URL}}}},
+                "mcpServers": {"agentos": {"url": URL}, "other": {"url": "http://elsewhere/mcp"}},
+                "unrelated": {"keep": True},
+            }
+        )
+    )
+    (tmp_path / ".mcp.json").write_text(json.dumps({"mcpServers": {"agentos": {"url": URL}}}))
+
+    result = adapter.remove("agentos")
+    assert result.removed is True
+    assert "(local scope)" in result.location and "(user scope)" in result.location
+    assert str(tmp_path / ".mcp.json") in result.location
+
+    assert adapter.read_existing("agentos") is None
+    config = json.loads((tmp_path / ".claude.json").read_text())
+    assert config["mcpServers"]["other"]["url"] == "http://elsewhere/mcp"
+    assert config["unrelated"] == {"keep": True}
+    assert "agentos" not in json.loads((tmp_path / ".mcp.json").read_text())["mcpServers"]
+
+
+def test_claude_remove_not_found_is_clean_noop(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    (tmp_path / ".claude.json").write_text(json.dumps({"mcpServers": {"other": {"url": URL}}}))
+    before = (tmp_path / ".claude.json").read_text()
+
+    result = adapter.remove("agentos")
+    assert result.removed is False
+    assert result.location is None
+    assert (tmp_path / ".claude.json").read_text() == before
+
+
+def test_claude_remove_refuses_corrupt_config(tmp_path: Path):
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    (tmp_path / ".claude.json").write_text("{corrupt")
+    with pytest.raises(CLIError, match="Refusing to modify"):
+        adapter.remove("agentos")
+
+
+def test_codex_remove_drops_table_and_preserves_rest(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text(
+        "# keep this comment\n"
+        'model = "o4"\n'
+        "\n"
+        "[mcp_servers.agentos]\n"
+        'url = "' + URL + '"\n'
+        "\n"
+        "[mcp_servers.other]\n"
+        'url = "http://elsewhere/mcp"\n'
+    )
+
+    result = adapter.remove("agentos")
+    assert result.removed is True
+    assert result.location == str(adapter.config_path)
+
+    text = adapter.config_path.read_text()
+    parsed = tomllib.loads(text)
+    assert "agentos" not in parsed["mcp_servers"]
+    assert parsed["mcp_servers"]["other"]["url"] == "http://elsewhere/mcp"
+    assert parsed["model"] == "o4"
+    assert "# keep this comment" in text
+
+
+def test_codex_remove_not_found_is_clean_noop(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    assert adapter.remove("agentos").removed is False  # no config file at all
+
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text('[mcp_servers.other]\nurl = "http://elsewhere/mcp"\n')
+    before = adapter.config_path.read_text()
+    assert adapter.remove("agentos").removed is False
+    assert adapter.config_path.read_text() == before
+
+
+def test_codex_remove_refuses_corrupt_config(tmp_path: Path):
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text("[mcp_servers.agentos\nbroken")
+    with pytest.raises(CLIError, match="does not parse"):
+        adapter.remove("agentos")
+
+
+def test_codex_remove_handles_write_layouts(tmp_path: Path):
+    """Whatever spelling write() handles, remove() must too: quoted headers and inline
+    entries under a bare [mcp_servers] table."""
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text('[mcp_servers."agentos"]\nurl = "' + URL + '"\n')
+    assert adapter.remove("agentos").removed is True
+    assert "agentos" not in (tomllib.loads(adapter.config_path.read_text()).get("mcp_servers") or {})
+
+    adapter.config_path.write_text('[mcp_servers]\nagentos = { url = "' + URL + '" }\n')
+    assert adapter.remove("agentos").removed is True
+    assert "agentos" not in (tomllib.loads(adapter.config_path.read_text()).get("mcp_servers") or {})
+
+
+def test_cursor_remove_clears_project_and_global(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path / "proj")
+    (tmp_path / ".cursor").mkdir()
+    (tmp_path / "proj" / ".cursor").mkdir(parents=True)
+    (tmp_path / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"agentos": {"url": URL}, "other": {"url": "http://elsewhere/mcp"}}})
+    )
+    (tmp_path / "proj" / ".cursor" / "mcp.json").write_text(json.dumps({"mcpServers": {"agentos": {"url": URL}}}))
+
+    result = adapter.remove("agentos")
+    assert result.removed is True
+    assert adapter.read_existing("agentos") is None
+    kept = json.loads((tmp_path / ".cursor" / "mcp.json").read_text())
+    assert kept["mcpServers"]["other"]["url"] == "http://elsewhere/mcp"
+
+
+def test_cursor_remove_not_found_is_clean_noop(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    assert adapter.remove("agentos").removed is False
+
+
+def test_claude_desktop_remove(tmp_path: Path):
+    cfg = tmp_path / "claude_desktop_config.json"
+    adapter = ClaudeDesktopAdapter(home=tmp_path, config_path=cfg, which=lambda name: None)
+    adapter.write("agentos", URL, TOKEN)
+    assert adapter.read_existing("agentos") is not None
+
+    result = adapter.remove("agentos")
+    assert result.removed is True
+    assert result.location == str(cfg)
+    assert adapter.read_existing("agentos") is None
+    assert adapter.remove("agentos").removed is False
+
+
+def test_remove_preserves_file_mode(tmp_path: Path):
+    """A 0600 config (it still holds other tokens) must stay 0600 after a removal."""
+    cfg = tmp_path / ".cursor" / "mcp.json"
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    adapter.write("agentos", URL, TOKEN)
+    adapter.write("other", URL, TOKEN)
+    assert _mode(cfg) == 0o600
+
+    adapter.remove("agentos")
+    assert _mode(cfg) == 0o600
+    assert "other" in json.loads(cfg.read_text())["mcpServers"]
+
+
+def test_remove_with_url_guard_spares_other_os_entries(tmp_path: Path):
+    """The matches predicate protects same-named entries per scope: a shadowed entry
+    pointing at a different OS survives while the matching one goes."""
+    adapter = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {
+                "projects": {str(tmp_path): {"mcpServers": {"agno": {"url": URL}}}},
+                "mcpServers": {"agno": {"url": "http://other-os:9999/mcp"}},
+            }
+        )
+    )
+
+    result = adapter.remove("agno", matches=lambda u: u == URL)
+    assert result.removed is True
+    assert "(local scope)" in (result.location or "")
+    config = json.loads((tmp_path / ".claude.json").read_text())
+    # The user-scope entry pointed elsewhere: untouched.
+    assert config["mcpServers"]["agno"]["url"] == "http://other-os:9999/mcp"
+    assert "agno" not in config["projects"][str(tmp_path)]["mcpServers"]
+
+
+def test_remove_with_url_guard_no_match_is_not_found(tmp_path: Path):
+    adapter = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    adapter.write("agno", "http://other-os:9999/mcp", None)
+    result = adapter.remove("agno", matches=lambda u: u == URL)
+    assert result.removed is False
+    assert "agno" in json.loads((tmp_path / ".cursor" / "mcp.json").read_text())["mcpServers"]
+
+
+def test_claude_desktop_remove_url_guard_reads_bridge_url(tmp_path: Path):
+    """Desktop entries hold the URL inside the mcp-remote args; the guard must still see it."""
+    cfg = tmp_path / "claude_desktop_config.json"
+    adapter = ClaudeDesktopAdapter(home=tmp_path, config_path=cfg, which=lambda name: None)
+    adapter.write("agentos", URL, TOKEN)
+
+    assert adapter.remove("agentos", matches=lambda u: u == "http://elsewhere/mcp").removed is False
+    assert adapter.remove("agentos", matches=lambda u: u == URL).removed is True
+
+
+def test_codex_remove_refuses_unsupported_dotted_layout(tmp_path: Path):
+    """A dotted-key spelling parses to the entry but the line scanner cannot drop it;
+    claiming 'removed' would be a lie, so it must refuse loudly instead."""
+    adapter = CodexAdapter(home=tmp_path)
+    adapter.config_path.parent.mkdir(parents=True)
+    adapter.config_path.write_text('[mcp_servers]\nagentos.url = "' + URL + '"\n')
+    with pytest.raises(CLIError, match="unsupported TOML layout"):
+        adapter.remove("agentos")
+    # And the file was not rewritten.
+    assert "agentos.url" in adapter.config_path.read_text()
+
+
+def test_list_entries_across_scopes_and_clients(tmp_path: Path):
+    claude = ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None)
+    (tmp_path / ".claude.json").write_text(
+        json.dumps(
+            {
+                "projects": {str(tmp_path): {"mcpServers": {"agentos": {"url": URL}}}},
+                "mcpServers": {"agentos": {"url": "http://shadowed/mcp"}, "user-only": {"url": URL}},
+            }
+        )
+    )
+    entries = claude.list_entries()
+    # Precedence applies on collisions: the local-scope entry wins.
+    assert entries["agentos"].url == URL
+    assert entries["user-only"].url == URL
+
+    codex = CodexAdapter(home=tmp_path)
+    codex.write("agentos", URL, TOKEN)
+    codex_entries = codex.list_entries()
+    assert codex_entries["agentos"].url == URL
+    assert codex_entries["agentos"].token == TOKEN
+
+    cursor = CursorAdapter(home=tmp_path, cwd=tmp_path)
+    assert cursor.list_entries() == {}
+    cursor.write("agentos", URL, None)
+    assert cursor.list_entries()["agentos"].url == URL
+
+    cfg = tmp_path / "claude_desktop_config.json"
+    desktop = ClaudeDesktopAdapter(home=tmp_path, config_path=cfg, which=lambda name: None)
+    desktop.write("agentos", URL, TOKEN)
+    assert desktop.list_entries()["agentos"].url == URL

--- a/libs/agnoctl/tests/test_adapters.py
+++ b/libs/agnoctl/tests/test_adapters.py
@@ -779,3 +779,33 @@ def test_list_entries_across_scopes_and_clients(tmp_path: Path):
     desktop = ClaudeDesktopAdapter(home=tmp_path, config_path=cfg, which=lambda name: None)
     desktop.write("agentos", URL, TOKEN)
     assert desktop.list_entries()["agentos"].url == URL
+
+
+def test_base_url_of_entry_variants():
+    from agnoctl.clients import _base_url_of_entry
+
+    assert _base_url_of_entry("https://host/mcp") == "https://host"
+    assert _base_url_of_entry("https://host:8443/team1/mcp") == "https://host:8443/team1"
+    assert _base_url_of_entry("http://host/mcp/") == "http://host"
+    assert _base_url_of_entry("https://host/other") is None
+    assert _base_url_of_entry("not-a-url") is None
+
+
+def test_configured_sources_collects_and_labels(tmp_path):
+    import json as _json
+
+    from agnoctl.clients import configured_sources
+    from agnoctl.clients.codex import CodexAdapter
+    from agnoctl.clients.cursor import CursorAdapter
+
+    (tmp_path / ".cursor").mkdir()
+    (tmp_path / ".cursor" / "mcp.json").write_text(
+        _json.dumps({"mcpServers": {"prod": {"url": "https://prod.example.com/mcp"}, "x": {"url": "https://h/api"}}})
+    )
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text('[mcp_servers.prod]\nurl = "https://prod.example.com/mcp"\n')
+
+    sources = configured_sources(
+        {"cursor": CursorAdapter(home=tmp_path, cwd=tmp_path), "codex": CodexAdapter(home=tmp_path)}
+    )
+    assert sources == [("https://prod.example.com", "client-config", "Cursor, Codex")]

--- a/libs/agnoctl/tests/test_claude_desktop.py
+++ b/libs/agnoctl/tests/test_claude_desktop.py
@@ -182,7 +182,7 @@ def test_connect_configures_claude_desktop_end_to_end(monkeypatch, fake_os, tmp_
     assert payload["results"][0]["status"] == "connected"
     assert payload["results"][0]["verify"]["ok"] is True
 
-    entry = json.loads(cfg.read_text())["mcpServers"]["agno"]
+    entry = json.loads(cfg.read_text())["mcpServers"]["agentos"]
     assert entry["env"]["AGNO_AUTH_HEADER"].startswith("Bearer agno_pat_")
     # The minted token never leaks into the JSON report.
     assert fake_os.accounts["claude-desktop"]["token"] not in result.output

--- a/libs/agnoctl/tests/test_connect_cmd.py
+++ b/libs/agnoctl/tests/test_connect_cmd.py
@@ -736,7 +736,7 @@ def test_connect_leaves_foreign_agno_entry_alone(monkeypatch, fake_os, fake_clie
 def test_connect_oauth_writes_tokenless_entries_and_mints_nothing(monkeypatch, fake_clients):
     """On an OAuth-protected /mcp, apps sign in themselves: entries carry no token, no
     service accounts are minted, and each result says how to complete the sign-in."""
-    fake = FakeAgentOS(auth_mode="oauth", name="OAuth OS")
+    fake = FakeAgentOS(auth_mode="none", oauth=True, name="OAuth OS")
     install_fake(monkeypatch, fake)
 
     result = _connect()
@@ -755,7 +755,7 @@ def test_connect_oauth_writes_tokenless_entries_and_mints_nothing(monkeypatch, f
 
 
 def test_connect_oauth_rerun_is_already_connected(monkeypatch, fake_clients):
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
     assert _connect(["--clients", "cursor"]).exit_code == 0
 
     result = _connect(["--clients", "cursor"])
@@ -765,8 +765,9 @@ def test_connect_oauth_rerun_is_already_connected(monkeypatch, fake_clients):
 
 def test_connect_oauth_pat_flag_mints_bearers(monkeypatch, fake_os, fake_clients):
     """--pat opts back into minted tokens on an OAuth OS (headless clients cannot run
-    a browser flow); the server accepts both kinds of credential."""
-    fake = FakeAgentOS(auth_mode="oauth")
+    a browser flow); the server accepts both kinds of credential. Minting needs a REST
+    credential, so this is the composed shape (security key + OAuth on /mcp)."""
+    fake = FakeAgentOS(auth_mode="security_key", oauth=True)
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
 
@@ -781,7 +782,7 @@ def test_connect_oauth_pat_flag_mints_bearers(monkeypatch, fake_os, fake_clients
 def test_connect_oauth_existing_pat_entry_stays_connected(monkeypatch, fake_clients):
     """A round-1 PAT entry keeps verifying on an OAuth OS (the server accepts both), so
     a re-run without --pat reports already-connected instead of tearing it down."""
-    fake = FakeAgentOS(auth_mode="oauth")
+    fake = FakeAgentOS(auth_mode="security_key", oauth=True)
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
     assert _connect(["--clients", "cursor", "--pat"]).exit_code == 0
@@ -792,7 +793,7 @@ def test_connect_oauth_existing_pat_entry_stays_connected(monkeypatch, fake_clie
 
 
 def test_connect_oauth_rotate_converts_pat_entry_to_oauth(monkeypatch, fake_clients):
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
     fake_token_entry = {"mcpServers": {"agentos": {"url": MCP_URL, "headers": {"Authorization": "Bearer stale"}}}}
     (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(fake_token_entry))
 
@@ -806,7 +807,7 @@ def test_connect_oauth_rotate_converts_pat_entry_to_oauth(monkeypatch, fake_clie
 def test_connect_oauth_auto_surfaces_chat_apps(monkeypatch, fake_clients):
     """OAuth is exactly what the hosted Connectors UIs speak: a public HTTPS OAuth OS
     auto-surfaces claude.ai and ChatGPT setup steps (previously auth_mode none only)."""
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
     result = runner.invoke(app, ["connect", "--json", "--url", "https://os.example.com"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
@@ -817,13 +818,16 @@ def test_connect_oauth_auto_surfaces_chat_apps(monkeypatch, fake_clients):
 
 
 def test_connect_oauth_prints_signin_summary(monkeypatch, fake_clients):
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth", name="OAuth OS"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True, name="OAuth OS"))
     result = runner.invoke(app, ["connect"] + URL_ARGS + ["--clients", "cursor"])
     assert result.exit_code == 0, _all_output(result)
     out = _all_output(result)
     assert "OAuth-protected" in out
     assert "sign in" in out
     assert "Restart" in out
+    # auth_mode "none" describes only the REST plane; saying authorization is disabled
+    # would misdescribe the OAuth-protected /mcp being connected.
+    assert "Authorization is disabled" not in out
 
 
 def test_connect_pat_on_oauth_only_os_fails_before_credentials(monkeypatch, fake_clients):
@@ -831,7 +835,7 @@ def test_connect_pat_on_oauth_only_os_fails_before_credentials(monkeypatch, fake
     must never create durable credentials), so --pat must fail up front naming the
     server's missing REST credential -- not accept a typed credential (any value passes
     the open read used by the preflight) and then blame it when the mint 401s."""
-    fake = FakeAgentOS(auth_mode="oauth", open_rest=True)
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", "any-typed-value")
 
@@ -848,7 +852,7 @@ def test_connect_oauth_mint_shaping_flags_require_pat(monkeypatch, fake_clients)
     """--name/--scopes/--expires/--privileged shape minted tokens; an OAuth run mints
     nothing, so silently ignoring them would connect with different access than the
     operator asked for. Erroring names the flags and the way out."""
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
 
     result = _connect(["--clients", "cursor", "--scopes", "agents:run", "--expires", "7d"])
     assert result.exit_code == 1
@@ -858,7 +862,7 @@ def test_connect_oauth_mint_shaping_flags_require_pat(monkeypatch, fake_clients)
 
 
 def test_connect_oauth_shaping_flags_with_pat_still_mint(monkeypatch, fake_os, fake_clients):
-    fake = FakeAgentOS(auth_mode="oauth")
+    fake = FakeAgentOS(auth_mode="security_key", oauth=True)
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
 
@@ -871,7 +875,7 @@ def test_connect_oauth_rotate_notes_dangling_account(monkeypatch, fake_clients):
     """Converting a PAT entry to OAuth sign-in erases the bearer from disk but cannot
     revoke the account behind it (an OAuth run resolves no admin credential); the
     operator must be pointed at `agno tokens revoke`."""
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
     fake_token_entry = {"mcpServers": {"agentos": {"url": MCP_URL, "headers": {"Authorization": "Bearer stale"}}}}
     (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(fake_token_entry))
 
@@ -888,10 +892,10 @@ def test_connect_oauth_rotate_notes_dangling_account(monkeypatch, fake_clients):
 
 
 def test_connect_treats_oauth_without_authorization_servers_as_token_protected(monkeypatch, fake_os, fake_clients):
-    """A bare token verifier as mcp_auth reports auth_mode "oauth" with no authorization
+    """A bare token verifier as mcp_auth serves an mcp.oauth block with no authorization
     servers; there is nothing to sign in through, so connect mints as usual instead of
     writing a tokenless entry whose sign-in could never complete."""
-    fake = FakeAgentOS(auth_mode="oauth", oauth={"authorization_servers": None, "resource": None})
+    fake = FakeAgentOS(auth_mode="security_key", oauth={"authorization_servers": None, "resource": None})
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
 

--- a/libs/agnoctl/tests/test_connect_cmd.py
+++ b/libs/agnoctl/tests/test_connect_cmd.py
@@ -728,3 +728,99 @@ def test_connect_leaves_foreign_agno_entry_alone(monkeypatch, fake_os, fake_clie
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
     assert cursor_config["mcpServers"]["agno"]["url"] == "http://other-os:9999/mcp"
     assert cursor_config["mcpServers"]["agentos"]["url"] == MCP_URL
+
+
+# -- OAuth-protected MCP endpoints -------------------------------------------------------
+
+
+def test_connect_oauth_writes_tokenless_entries_and_mints_nothing(monkeypatch, fake_clients):
+    """On an OAuth-protected /mcp, apps sign in themselves: entries carry no token, no
+    service accounts are minted, and each result says how to complete the sign-in."""
+    fake = FakeAgentOS(auth_mode="oauth", name="OAuth OS")
+    install_fake(monkeypatch, fake)
+
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "needs-login" for r in payload["results"])
+    assert all(r["verify"]["oauth_challenge"] for r in payload["results"])
+    assert fake.create_calls == 0
+    by_client = {r["client"]: r for r in payload["results"]}
+    assert "codex mcp login oauth-os" in by_client["codex"]["instructions"][0]
+    assert "claude mcp login oauth-os" in by_client["claude-code"]["instructions"][0]
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "headers" not in cursor_config["mcpServers"]["oauth-os"]
+    assert payload["os"]["mcp"]["oauth"]["authorization_servers"] == ["http://localhost:7777/mcp/auth"]
+
+
+def test_connect_oauth_rerun_is_already_connected(monkeypatch, fake_clients):
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    assert _connect(["--clients", "cursor"]).exit_code == 0
+
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["status"] == "already-connected"
+
+
+def test_connect_oauth_pat_flag_mints_bearers(monkeypatch, fake_os, fake_clients):
+    """--pat opts back into minted tokens on an OAuth OS (headless clients cannot run
+    a browser flow); the server accepts both kinds of credential."""
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+
+    result = _connect(["--clients", "cursor", "--pat"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["status"] == "connected"
+    assert list(fake.accounts.keys()) == ["cursor"]
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["agentos"]["headers"]["Authorization"].startswith("Bearer agno_pat_")
+
+
+def test_connect_oauth_existing_pat_entry_stays_connected(monkeypatch, fake_clients):
+    """A round-1 PAT entry keeps verifying on an OAuth OS (the server accepts both), so
+    a re-run without --pat reports already-connected instead of tearing it down."""
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+    assert _connect(["--clients", "cursor", "--pat"]).exit_code == 0
+
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["status"] == "already-connected"
+
+
+def test_connect_oauth_rotate_converts_pat_entry_to_oauth(monkeypatch, fake_clients):
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    fake_token_entry = {"mcpServers": {"agentos": {"url": MCP_URL, "headers": {"Authorization": "Bearer stale"}}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(fake_token_entry))
+
+    result = _connect(["--clients", "cursor", "--rotate"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["status"] == "needs-login"
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "headers" not in cursor_config["mcpServers"]["agentos"]
+
+
+def test_connect_oauth_auto_surfaces_chat_apps(monkeypatch, fake_clients):
+    """OAuth is exactly what the hosted Connectors UIs speak: a public HTTPS OAuth OS
+    auto-surfaces claude.ai and ChatGPT setup steps (previously auth_mode none only)."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    result = runner.invoke(app, ["connect", "--json", "--url", "https://os.example.com"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    by_client = {r["client"]: r for r in payload["results"]}
+    assert by_client["claude-ai"]["status"] == "manual"
+    assert by_client["chatgpt"]["status"] == "manual"
+    assert any("asked to authorize" in step for step in by_client["chatgpt"]["instructions"])
+
+
+def test_connect_oauth_prints_signin_summary(monkeypatch, fake_clients):
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth", name="OAuth OS"))
+    result = runner.invoke(app, ["connect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "OAuth-protected" in out
+    assert "sign in" in out
+    assert "Restart" in out

--- a/libs/agnoctl/tests/test_connect_cmd.py
+++ b/libs/agnoctl/tests/test_connect_cmd.py
@@ -824,3 +824,78 @@ def test_connect_oauth_prints_signin_summary(monkeypatch, fake_clients):
     assert "OAuth-protected" in out
     assert "sign in" in out
     assert "Restart" in out
+
+
+def test_connect_pat_on_oauth_only_os_fails_before_credentials(monkeypatch, fake_clients):
+    """An OS whose ONLY auth is the OAuth provider refuses every mint (anonymous callers
+    must never create durable credentials), so --pat must fail up front naming the
+    server's missing REST credential -- not accept a typed credential (any value passes
+    the open read used by the preflight) and then blame it when the mint 401s."""
+    fake = FakeAgentOS(auth_mode="oauth", open_rest=True)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", "any-typed-value")
+
+    result = _connect(["--clients", "cursor", "--pat"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "no authentication configured" in payload["error"]
+    assert "OS_SECURITY_KEY" in payload["hint"]
+    assert "drop --pat" in payload["hint"]
+    assert fake.create_calls == 0
+
+
+def test_connect_oauth_mint_shaping_flags_require_pat(monkeypatch, fake_clients):
+    """--name/--scopes/--expires/--privileged shape minted tokens; an OAuth run mints
+    nothing, so silently ignoring them would connect with different access than the
+    operator asked for. Erroring names the flags and the way out."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+
+    result = _connect(["--clients", "cursor", "--scopes", "agents:run", "--expires", "7d"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "--scopes" in payload["error"] and "--expires" in payload["error"]
+    assert "--pat" in payload["hint"]
+
+
+def test_connect_oauth_shaping_flags_with_pat_still_mint(monkeypatch, fake_os, fake_clients):
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+
+    result = _connect(["--clients", "cursor", "--pat", "--scopes", "agents:run"])
+    assert result.exit_code == 0, result.output
+    assert fake.accounts["cursor"]["scopes"] == ["agents:run"]
+
+
+def test_connect_oauth_rotate_notes_dangling_account(monkeypatch, fake_clients):
+    """Converting a PAT entry to OAuth sign-in erases the bearer from disk but cannot
+    revoke the account behind it (an OAuth run resolves no admin credential); the
+    operator must be pointed at `agno tokens revoke`."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    fake_token_entry = {"mcpServers": {"agentos": {"url": MCP_URL, "headers": {"Authorization": "Bearer stale"}}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(fake_token_entry))
+
+    result = _connect(["--clients", "cursor", "--rotate"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["replaced_token_entry"] is True
+
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(fake_token_entry))
+    human = runner.invoke(app, ["connect"] + URL_ARGS + ["--clients", "cursor", "--rotate"])
+    assert human.exit_code == 0, _all_output(human)
+    out = _all_output(human)
+    assert "stay valid" in out
+    assert "agno tokens revoke" in out
+
+
+def test_connect_treats_oauth_without_authorization_servers_as_token_protected(monkeypatch, fake_os, fake_clients):
+    """A bare token verifier as mcp_auth reports auth_mode "oauth" with no authorization
+    servers; there is nothing to sign in through, so connect mints as usual instead of
+    writing a tokenless entry whose sign-in could never complete."""
+    fake = FakeAgentOS(auth_mode="oauth", oauth={"authorization_servers": None, "resource": None})
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["status"] == "connected"
+    assert list(fake.accounts.keys()) == ["cursor"]

--- a/libs/agnoctl/tests/test_connect_cmd.py
+++ b/libs/agnoctl/tests/test_connect_cmd.py
@@ -831,13 +831,11 @@ def test_connect_oauth_prints_signin_summary(monkeypatch, fake_clients):
 
 
 def test_connect_pat_on_oauth_only_os_fails_before_credentials(monkeypatch, fake_clients):
-    """An OS whose ONLY auth is the OAuth provider refuses every mint (anonymous callers
-    must never create durable credentials), so --pat must fail up front naming the
-    server's missing REST credential -- not accept a typed credential (any value passes
-    the open read used by the preflight) and then blame it when the mint 401s."""
+    """An OS whose ONLY auth is the OAuth provider refuses anonymous mints, so --pat
+    with no exported credential must fail up front naming the server's missing REST
+    credential -- before any prompt or config write."""
     fake = FakeAgentOS(auth_mode="none", oauth=True)
     install_fake(monkeypatch, fake)
-    monkeypatch.setenv("AGNO_ADMIN_TOKEN", "any-typed-value")
 
     result = _connect(["--clients", "cursor", "--pat"])
     assert result.exit_code == 1
@@ -846,6 +844,85 @@ def test_connect_pat_on_oauth_only_os_fails_before_credentials(monkeypatch, fake
     assert "OS_SECURITY_KEY" in payload["hint"]
     assert "drop --pat" in payload["hint"]
     assert fake.create_calls == 0
+
+
+def test_connect_pat_with_non_pat_credential_on_open_plane_names_the_mismatch(monkeypatch, fake_clients):
+    """The open plane "accepts" any credential on reads, so a typed non-PAT value would
+    pass a preflight and then fail the mint. Only a service-account bearer can
+    authenticate on a server with no REST auth; the error must say exactly that
+    instead of blaming a credential the server never evaluated."""
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", "any-typed-value")
+
+    result = _connect(["--clients", "cursor", "--pat"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "only a service-account token" in payload["error"]
+    assert fake.create_calls == 0
+
+
+def test_connect_pat_with_seeded_admin_pat_mints_on_open_plane(monkeypatch, fake_clients):
+    """The anonymous-mint refusal is anonymous-only: a verified service-account bearer
+    authenticates by prefix even on an open REST plane, and one holding a minting
+    scope may mint. A durable admin PAT from a protected era must keep working."""
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.seed_account("ops", ["admin"]))
+
+    result = _connect(["--clients", "cursor", "--pat"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["status"] == "connected"
+    assert "cursor" in fake.accounts
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["agentos"]["headers"]["Authorization"].startswith("Bearer agno_pat_")
+
+
+def test_connect_pat_on_plain_open_os_errors_instead_of_silently_connecting(monkeypatch, fake_clients):
+    """--pat asks for durable bearers; a plain open OS cannot mint any, and silently
+    writing the tokenless entry the operator opted out of would misreport success."""
+    fake = FakeAgentOS(auth_mode="none")
+    install_fake(monkeypatch, fake)
+
+    result = _connect(["--clients", "cursor", "--pat"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "refuses anonymous minting" in payload["error"]
+    assert "drop --pat" in payload["hint"]
+    assert not (fake_clients / ".cursor" / "mcp.json").exists()
+
+
+def test_connect_bare_verifier_on_open_plane_fails_before_writes(monkeypatch, fake_clients):
+    """A token-protected /mcp with no authorization server to sign in through and no
+    way to mint is a dead end: fail up front, never write an entry that can only 401."""
+    fake = FakeAgentOS(auth_mode="none", oauth={"authorization_servers": None, "resource": None})
+    install_fake(monkeypatch, fake)
+
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "refuses anonymous minting" in payload["error"]
+    assert "--pat" in payload["hint"]
+    assert not (fake_clients / ".cursor" / "mcp.json").exists()
+
+
+def test_connect_reverify_requires_secure_url_for_stored_token(monkeypatch, fake_clients):
+    """Re-verification re-sends a token already stored in a matching entry, so the
+    plaintext-HTTP rule applies to re-runs too, not only to fresh mints."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
+    remote_mcp = "http://10.0.0.5:7777/mcp"
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"agentos": {"url": remote_mcp, "headers": {"Authorization": "Bearer agno_pat_x"}}}})
+    )
+
+    result = runner.invoke(app, ["connect", "--json", "--url", "http://10.0.0.5:7777", "--clients", "cursor"])
+    assert result.exit_code == 1
+    assert "Refusing to send" in json.loads(result.output)["error"]
+
+    allowed = runner.invoke(
+        app, ["connect", "--json", "--url", "http://10.0.0.5:7777", "--clients", "cursor", "--allow-http"]
+    )
+    assert allowed.exit_code == 0, allowed.output
 
 
 def test_connect_oauth_mint_shaping_flags_require_pat(monkeypatch, fake_clients):
@@ -903,3 +980,35 @@ def test_connect_treats_oauth_without_authorization_servers_as_token_protected(m
     assert result.exit_code == 0, result.output
     assert json.loads(result.output)["results"][0]["status"] == "connected"
     assert list(fake.accounts.keys()) == ["cursor"]
+
+
+def test_connect_oauth_report_consolidates_next_steps(monkeypatch, fake_clients):
+    """The prod-connect story in one readable arc: one-line rows, a single aggregated
+    note for the entries this run replaced (with how to keep both OSes), a numbered
+    To-finish section holding restart + per-app sign-in, and the auto-surfaced chat
+    apps as one compact aside instead of two full instruction blocks."""
+    prod = "https://os.example.com"
+    fake = FakeAgentOS(
+        auth_mode="none",
+        oauth={"authorization_servers": [prod + "/"], "resource": prod + "/mcp"},
+        name="AgentOS",
+    )
+    install_fake(monkeypatch, fake)
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"agentos": {"url": "http://localhost:8000/mcp"}}})
+    )
+
+    result = runner.invoke(app, ["connect", "--url", prod])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    # The builtin AS is the OS itself; naming it as an issuer reads like a third party.
+    assert "one-time sign-in." in out and "sign-in via" not in out
+    # rich wraps at the console width, so assert the pieces, not the whole line
+    assert "which pointed at" in out and "http://localhost:8000/mcp" in out
+    assert "To use both" in out
+    assert "To finish:" in out
+    assert "1. Restart" in out
+    assert "claude mcp login agentos" in out
+    assert "Also reachable from the hosted chat apps" in out
+    # The compact aside replaces the two full manual blocks for auto-surfaced apps.
+    assert "action needed" not in out

--- a/libs/agnoctl/tests/test_connect_cmd.py
+++ b/libs/agnoctl/tests/test_connect_cmd.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
@@ -13,29 +14,12 @@ from agnoctl.clients.cursor import CursorAdapter
 from agnoctl.errors import CLIError
 from agnoctl.main import app
 from tests.conftest import FakeAgentOS, install_fake
+from tests.conftest import all_output as _all_output
 
 runner = CliRunner()
 
 URL_ARGS = ["--url", "http://localhost:7777"]
 MCP_URL = "http://localhost:7777/mcp"
-
-
-@pytest.fixture
-def fake_clients(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """All three clients 'installed' under a tmp home, wired into the connect command."""
-    (tmp_path / ".claude.json").write_text("{}")
-    (tmp_path / ".codex").mkdir()
-    (tmp_path / ".cursor").mkdir()
-
-    def build(home=None, cwd=None, project=False):
-        return {
-            "claude-code": ClaudeCodeAdapter(home=tmp_path, cwd=tmp_path, which=lambda name: None),
-            "codex": CodexAdapter(home=tmp_path),
-            "cursor": CursorAdapter(home=tmp_path, cwd=tmp_path, project=project),
-        }
-
-    monkeypatch.setattr(connect_module, "build_adapters", build)
-    return tmp_path
 
 
 @pytest.fixture
@@ -72,11 +56,12 @@ def test_connect_happy_path(monkeypatch, fake_os, fake_clients):
     for account in fake_os.accounts.values():
         assert account["token"] not in result.output
 
-    # Tokens landed in the client configs (Claude user scope = ~/.claude.json).
+    # Tokens landed in the client configs (Claude user scope = ~/.claude.json), under
+    # the derived default entry name (the fake OS serves no name -> "agentos").
     claude_config = json.loads((fake_clients / ".claude.json").read_text())
-    assert claude_config["mcpServers"]["agno"]["url"] == MCP_URL
+    assert claude_config["mcpServers"]["agentos"]["url"] == MCP_URL
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
-    token = cursor_config["mcpServers"]["agno"]["headers"]["Authorization"]
+    token = cursor_config["mcpServers"]["agentos"]["headers"]["Authorization"]
     assert token == "Bearer " + fake_os.accounts["cursor"]["token"]
 
 
@@ -119,7 +104,7 @@ def test_connect_rotate_replaces_accounts(monkeypatch, fake_os, fake_clients):
     assert new_token != old_token
 
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
-    assert cursor_config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer " + new_token
+    assert cursor_config["mcpServers"]["agentos"]["headers"]["Authorization"] == "Bearer " + new_token
 
 
 def test_connect_rotate_flags_rotated_in_json(monkeypatch, fake_os, fake_clients):
@@ -171,7 +156,7 @@ def test_connect_no_auth_mode(monkeypatch, fake_clients):
     assert all(r["status"] == "connected" for r in payload["results"])
     assert fake.create_calls == 0
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
-    assert "headers" not in cursor_config["mcpServers"]["agno"]
+    assert "headers" not in cursor_config["mcpServers"]["agentos"]
 
 
 def test_connect_mcp_disabled(monkeypatch, fake_clients):
@@ -271,7 +256,9 @@ def test_connect_skip_existing_leaves_broken_entry(monkeypatch, fake_os, fake_cl
 def test_connect_skip_existing_never_touches_foreign_entry(monkeypatch, fake_os, fake_clients):
     """An entry pointing at a DIFFERENT AgentOS is untouchable under --skip-existing."""
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
-    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp", "headers": {"Authorization": "Bearer keep"}}}}
+    foreign = {
+        "mcpServers": {"agentos": {"url": "http://other-os:9999/mcp", "headers": {"Authorization": "Bearer keep"}}}
+    }
     (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
 
     result = _connect(["--clients", "cursor", "--skip-existing"])
@@ -279,14 +266,14 @@ def test_connect_skip_existing_never_touches_foreign_entry(monkeypatch, fake_os,
     assert payload["results"][0]["status"] == "skipped"
     assert "other-os" in payload["results"][0]["error"]
     config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
-    assert config["mcpServers"]["agno"]["url"] == "http://other-os:9999/mcp"
-    assert config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer keep"
+    assert config["mcpServers"]["agentos"]["url"] == "http://other-os:9999/mcp"
+    assert config["mcpServers"]["agentos"]["headers"]["Authorization"] == "Bearer keep"
     assert fake_os.create_calls == 0
 
 
 def test_connect_replacing_foreign_entry_is_reported(monkeypatch, fake_os, fake_clients):
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
-    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp"}}}
+    foreign = {"mcpServers": {"agentos": {"url": "http://other-os:9999/mcp"}}}
     (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
 
     result = _connect(["--clients", "cursor"])
@@ -314,7 +301,7 @@ def test_connect_detects_shadowing_claude_local_entry(monkeypatch, fake_os, fake
     """A stale local-scope entry shadows the user-scope write; connect must fail loudly, not lie."""
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
     (fake_clients / ".claude.json").write_text(
-        json.dumps({"projects": {str(fake_clients): {"mcpServers": {"agno": {"url": "http://stale:1/mcp"}}}}})
+        json.dumps({"projects": {str(fake_clients): {"mcpServers": {"agentos": {"url": "http://stale:1/mcp"}}}}})
     )
 
     result = _connect(["--clients", "claude-code", "--rotate"])
@@ -494,7 +481,7 @@ def test_connect_shared_account_reuses_token_for_new_client(monkeypatch, fake_os
     assert fake_os.create_calls == 1
 
     claude_config = json.loads((fake_clients / ".claude.json").read_text())
-    shared_token = claude_config["mcpServers"]["agno"]["headers"]["Authorization"].split(" ", 1)[1]
+    shared_token = claude_config["mcpServers"]["agentos"]["headers"]["Authorization"].split(" ", 1)[1]
 
     # A new client appears after the first run: cursor has no entry yet.
     (fake_clients / ".cursor" / "mcp.json").unlink(missing_ok=True)
@@ -510,4 +497,234 @@ def test_connect_shared_account_reuses_token_for_new_client(monkeypatch, fake_os
     assert fake_os.create_calls == 1
     assert fake_os.active_tokens() == [shared_token]
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
-    assert cursor_config["mcpServers"]["agno"]["headers"]["Authorization"] == "Bearer " + shared_token
+    assert cursor_config["mcpServers"]["agentos"]["headers"]["Authorization"] == "Bearer " + shared_token
+
+
+# -- multi-target selection, derived names, restart hints, legacy migration ------------
+
+
+def _install_two_hosts(monkeypatch, tmp_path):
+    """A deployed OS (env-file URL) and a local one, both live: the reported scenario."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    remote = FakeAgentOS(auth_mode="none", name="Live Railway")
+    local = FakeAgentOS(auth_mode="none", name="Local Dev")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        key = request.url.host + ":" + str(request.url.port)
+        if key == "prodhost:9000":
+            return remote.handler(request)
+        if key == "localhost:7777":
+            return local.handler(request)
+        raise httpx.ConnectError("connection refused", request=request)
+
+    import agnoctl.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
+    for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGENTOS_URL"):
+        monkeypatch.delenv(var, raising=False)
+    return remote, local
+
+
+def _make_interactive(monkeypatch):
+    import agnoctl.commands._common as common
+
+    monkeypatch.setattr(common, "stdin_is_interactive", lambda: True)
+    monkeypatch.setattr(connect_module, "stdin_is_interactive", lambda: True)
+
+
+def test_connect_menu_pick_local_skips_trust_prompt(monkeypatch, tmp_path, fake_clients):
+    """Selecting the local OS from the menu connects silently: no env-file trust prompt."""
+    _install_two_hosts(monkeypatch, tmp_path)
+    _make_interactive(monkeypatch)
+
+    result = runner.invoke(app, ["connect", "--clients", "cursor"], input="2\n")
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Which one do you want to connect?" in out
+    assert "Trust AGENTOS_URL" not in out
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["local-dev"]["url"] == MCP_URL
+
+
+def test_connect_menu_default_is_remote_and_trust_defaults_yes(monkeypatch, tmp_path, fake_clients):
+    """Enter-Enter targets the env-file (deployed) OS: the menu defaults to it, and the
+    trust prompt accepts on Enter ([Y/n])."""
+    _install_two_hosts(monkeypatch, tmp_path)
+    _make_interactive(monkeypatch)
+
+    result = runner.invoke(app, ["connect", "--clients", "cursor"], input="\n\n")
+    assert result.exit_code == 0, _all_output(result)
+    assert "Trust AGENTOS_URL=http://prodhost:9000" in _all_output(result)
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["live-railway"]["url"] == "http://prodhost:9000/mcp"
+
+
+def test_connect_menu_explicit_no_still_aborts_trust(monkeypatch, tmp_path, fake_clients):
+    _install_two_hosts(monkeypatch, tmp_path)
+    _make_interactive(monkeypatch)
+
+    result = runner.invoke(app, ["connect", "--clients", "cursor"], input="1\nn\n")
+    assert result.exit_code != 0
+    assert "did not trust" in _all_output(result)
+
+
+def test_connect_json_multi_candidate_is_deterministic(monkeypatch, tmp_path, fake_clients):
+    """--json never prompts: the single highest-priority (env-file) target is resolved,
+    and the remote env-file trust gate still requires --yes -- no automation regression."""
+    _install_two_hosts(monkeypatch, tmp_path)
+
+    refused = runner.invoke(app, ["connect", "--json", "--clients", "cursor"])
+    assert refused.exit_code == 1
+    assert "--yes" in json.loads(refused.output)["hint"]
+
+    result = runner.invoke(app, ["connect", "--json", "--clients", "cursor", "--yes"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["os"]["url"] == "http://prodhost:9000"
+    assert payload["server_name"] == "live-railway"
+
+
+def test_connect_json_dead_env_file_target_stays_a_hard_failure(monkeypatch, tmp_path, fake_clients):
+    """Automation must never be silently retargeted: with the env-file OS down and a
+    local OS up, --json fails like single-target discovery always has, instead of
+    minting against whatever else happens to be running."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    local = FakeAgentOS(auth_mode="none")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host + ":" + str(request.url.port) == "localhost:7777":
+            return local.handler(request)
+        raise httpx.ConnectError("connection refused", request=request)
+
+    import agnoctl.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
+    for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGENTOS_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = runner.invoke(app, ["connect", "--json", "--clients", "cursor", "--yes"])
+    assert result.exit_code == 1
+    assert "No running AgentOS" in json.loads(result.output)["error"]
+    cursor_config = (
+        json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+        if (fake_clients / ".cursor" / "mcp.json").exists()
+        else {"mcpServers": {}}
+    )
+    assert cursor_config.get("mcpServers", {}) == {}
+
+
+def test_connect_interactive_notes_dead_env_file_url(monkeypatch, tmp_path, fake_clients):
+    """Interactively, a dead env-file OS falls through to the local one -- with a note,
+    so the stale AGENTOS_URL does not go unnoticed forever."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    local = FakeAgentOS(auth_mode="none", name="Local Dev")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host + ":" + str(request.url.port) == "localhost:7777":
+            return local.handler(request)
+        raise httpx.ConnectError("connection refused", request=request)
+
+    import agnoctl.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
+    for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGENTOS_URL"):
+        monkeypatch.delenv(var, raising=False)
+    _make_interactive(monkeypatch)
+
+    result = runner.invoke(app, ["connect", "--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "did not answer" in out
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["local-dev"]["url"] == MCP_URL
+
+
+def test_connect_custom_scopes_skip_legacy_token_reuse(monkeypatch, fake_os, fake_clients):
+    """Explicit --scopes means the operator wants a freshly provisioned account, so the
+    legacy entry's old (differently scoped) token is not silently reused."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect(["--server-name", "agno", "--clients", "cursor"]).exit_code == 0
+
+    result = _connect(["--clients", "cursor", "--scopes", "agents:run"])
+    assert result.exit_code == 1
+    assert "already exists" in (json.loads(result.output)["results"][0]["error"] or "")
+
+
+def test_connect_derives_server_name_from_os_name(monkeypatch, fake_clients):
+    fake = FakeAgentOS(name="Customer Support", os_id="os-123")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["server_name"] == "customer-support"
+    assert payload["os"]["name"] == "Customer Support"
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "customer-support" in cursor_config["mcpServers"]
+
+
+def test_connect_server_name_flag_overrides_derived(monkeypatch, fake_clients):
+    fake = FakeAgentOS(name="Customer Support")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+
+    result = _connect(["--clients", "cursor", "--server-name", "custom"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["server_name"] == "custom"
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "custom" in cursor_config["mcpServers"]
+    assert "customer-support" not in cursor_config["mcpServers"]
+
+
+def test_connect_fresh_connect_prints_restart_hint(monkeypatch, fake_os, fake_clients):
+    """A fresh connect (not just a rotation) tells the operator to restart the apps."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = runner.invoke(app, ["connect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Restart" in out
+    assert "Cursor" in out
+
+
+def test_connect_renames_legacy_agno_entry(monkeypatch, fake_os, fake_clients):
+    """Round-1 configs hold an entry named "agno". A re-connect under the derived name
+    must rename it in place: reuse its working token (no re-mint, no revocation) and
+    drop the stale "agno" entry instead of leaving two servers behind."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect(["--server-name", "agno"]).exit_code == 0
+    creates_after_round1 = fake_os.create_calls
+    old_tokens = set(fake_os.active_tokens())
+
+    result = _connect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "connected" for r in payload["results"])
+    assert all(r.get("replaced_legacy") == "agno" for r in payload["results"])
+
+    # Tokens were reused, not re-minted: no new accounts, nothing revoked.
+    assert fake_os.create_calls == creates_after_round1
+    assert set(fake_os.active_tokens()) == old_tokens
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "agno" not in cursor_config["mcpServers"]
+    assert cursor_config["mcpServers"]["agentos"]["url"] == MCP_URL
+
+
+def test_connect_leaves_foreign_agno_entry_alone(monkeypatch, fake_os, fake_clients):
+    """An "agno" entry pointing at a DIFFERENT OS is not ours to clean up."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    foreign = {"mcpServers": {"agno": {"url": "http://other-os:9999/mcp"}}}
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps(foreign))
+
+    result = _connect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0].get("replaced_legacy") is None
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"]["agno"]["url"] == "http://other-os:9999/mcp"
+    assert cursor_config["mcpServers"]["agentos"]["url"] == MCP_URL

--- a/libs/agnoctl/tests/test_connect_cmd.py
+++ b/libs/agnoctl/tests/test_connect_cmd.py
@@ -1012,3 +1012,29 @@ def test_connect_oauth_report_consolidates_next_steps(monkeypatch, fake_clients)
     assert "Also reachable from the hosted chat apps" in out
     # The compact aside replaces the two full manual blocks for auto-surfaced apps.
     assert "action needed" not in out
+
+
+def test_connect_menu_offers_client_config_os(monkeypatch, tmp_path, fake_clients):
+    """A previously connected OS lives only in the client configs (there is no other
+    memory of it); the interactive picker offers it next to the local default with
+    provenance, and picking the remote still runs the trust gate."""
+    from tests.test_discovery import _install_hosts
+
+    monkeypatch.chdir(tmp_path)
+    _make_interactive(monkeypatch)
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"prod-os": {"url": "http://prodhost:9000/mcp"}}})
+    )
+    _install_hosts(
+        monkeypatch,
+        {"localhost:7777": FakeAgentOS(), "prodhost:9000": FakeAgentOS(name="Prod OS", auth_mode="none", oauth=True)},
+    )
+
+    result = runner.invoke(app, ["connect", "--clients", "cursor"], input="2\n\n")
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Which one do you want to connect?" in out
+    assert "configured in Cursor" in out
+    assert "from your Cursor MCP config" in out
+    # The existing tokenless entry for the OAuth-protected prod OS verifies in place.
+    assert "already ok" in out

--- a/libs/agnoctl/tests/test_disconnect_cmd.py
+++ b/libs/agnoctl/tests/test_disconnect_cmd.py
@@ -293,6 +293,34 @@ def test_disconnect_oauth_os_removes_entry_without_token_note(monkeypatch, fake_
     assert cursor_config["mcpServers"] == {}
 
 
+def test_disconnect_oauth_os_reminds_when_removed_entry_carried_pat(monkeypatch, fake_clients):
+    """connect --pat mints real accounts on an OAuth OS, so the revoke reminder must key
+    on what the removed entries carried, not on the server's auth mode: this machine's
+    entry holds a token whose account stays valid after the config removal."""
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+    assert _connect(["--clients", "cursor", "--pat"]).exit_code == 0
+
+    result = runner.invoke(app, ["disconnect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    assert "stay valid" in _all_output(result)
+
+
+def test_disconnect_no_token_note_for_tokenless_entries_on_protected_os(monkeypatch, fake_clients):
+    """The inverse direction of keying the reminder on removed tokens: a token-protected
+    OS whose removed entry carries no token (written when auth was off) has nothing to
+    revoke, so no reminder prints."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="security_key"))
+    (fake_clients / ".cursor" / "mcp.json").write_text(json.dumps({"mcpServers": {"agentos": {"url": MCP_URL}}}))
+
+    result = runner.invoke(app, ["disconnect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Restart" in out
+    assert "stay valid" not in out
+
+
 def test_matches_targets_respects_base_path():
     """Path-routed deployments: two AgentOS on one host must never match each other,
     and a path prefix only matches on a segment boundary."""

--- a/libs/agnoctl/tests/test_disconnect_cmd.py
+++ b/libs/agnoctl/tests/test_disconnect_cmd.py
@@ -276,3 +276,18 @@ def test_disconnect_partial_failure_exit_code(monkeypatch, fake_os, fake_clients
     assert by_client["cursor"]["status"] == "failed"
     assert "Refusing to modify" in by_client["cursor"]["error"]
     assert by_client["claude-code"]["status"] == "removed"
+
+
+def test_disconnect_oauth_os_removes_entry_without_token_note(monkeypatch, fake_clients):
+    """Disconnecting from an OAuth OS: URL-matched removal works on tokenless entries,
+    and no revoke reminder prints (nothing was minted; sign-in state lives in the app)."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    assert _connect(["--clients", "cursor"]).exit_code == 0
+
+    result = runner.invoke(app, ["disconnect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Restart" in out
+    assert "stay valid" not in out
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert cursor_config["mcpServers"] == {}

--- a/libs/agnoctl/tests/test_disconnect_cmd.py
+++ b/libs/agnoctl/tests/test_disconnect_cmd.py
@@ -291,3 +291,76 @@ def test_disconnect_oauth_os_removes_entry_without_token_note(monkeypatch, fake_
     assert "stay valid" not in out
     cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
     assert cursor_config["mcpServers"] == {}
+
+
+def test_matches_targets_respects_base_path():
+    """Path-routed deployments: two AgentOS on one host must never match each other,
+    and a path prefix only matches on a segment boundary."""
+    from agnoctl.commands.disconnect import _matches_targets
+
+    assert _matches_targets("https://os.example.com/customer-a/mcp", ["https://os.example.com/customer-a"])
+    assert not _matches_targets("https://os.example.com/customer-b/mcp", ["https://os.example.com/customer-a"])
+    assert not _matches_targets("https://os.example.com/customer-abc/mcp", ["https://os.example.com/customer-a"])
+    # A pathless target (the usual base URL) matches any path on that host.
+    assert _matches_targets("http://localhost:7777/mcp", ["http://localhost:7777"])
+    assert _matches_targets("http://localhost:7777/custom/mcp", ["http://localhost:7777"])
+    assert not _matches_targets("http://localhost:7778/mcp", ["http://localhost:7777"])
+
+
+def test_disconnect_path_routed_os_leaves_sibling_entries(monkeypatch, tmp_path, fake_clients):
+    """Disconnecting a path-routed OS (--url https://host/customer-a) must not remove a
+    sibling tenant's entry on the same host."""
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "customer-a": {"url": "https://os.example.com/customer-a/mcp"},
+                    "customer-b": {"url": "https://os.example.com/customer-b/mcp"},
+                }
+            }
+        )
+    )
+    _refuse_all(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app, ["disconnect", "--json", "--url", "https://os.example.com/customer-a", "--clients", "cursor"]
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["customer-a"]
+    kept = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert list(kept) == ["customer-b"]
+
+
+def test_disconnect_removes_target_entry_shadowed_by_foreign_same_name(monkeypatch, fake_os, fake_clients):
+    """A project-scope entry for ANOTHER OS shadows the global entry for the target OS
+    under the same name: the target's entry must still be removed (per-scope URL guard),
+    and the foreign shadowing entry must survive."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".cursor").joinpath("mcp.json").write_text(
+        json.dumps({"mcpServers": {"agentos": {"url": MCP_URL}}})
+    )
+    # fake_clients uses one directory as both home and cwd, so the project scope is
+    # cwd/.cursor/mcp.json == home/.cursor/mcp.json; build a distinct project dir.
+    import agnoctl.commands.disconnect as disconnect_module
+    from agnoctl.clients.cursor import CursorAdapter
+
+    proj = fake_clients / "proj"
+    (proj / ".cursor").mkdir(parents=True)
+    (proj / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"agentos": {"url": "http://other-os:9999/mcp"}}})
+    )
+
+    def build(home=None, cwd=None, project=False):
+        return {"cursor": CursorAdapter(home=fake_clients, cwd=proj)}
+
+    monkeypatch.setattr(disconnect_module, "build_adapters", build)
+
+    result = _disconnect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["agentos"]
+    # The target's global entry is gone; the foreign project entry survives.
+    global_servers = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert "agentos" not in global_servers
+    project_servers = json.loads((proj / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert project_servers["agentos"]["url"] == "http://other-os:9999/mcp"

--- a/libs/agnoctl/tests/test_disconnect_cmd.py
+++ b/libs/agnoctl/tests/test_disconnect_cmd.py
@@ -281,7 +281,7 @@ def test_disconnect_partial_failure_exit_code(monkeypatch, fake_os, fake_clients
 def test_disconnect_oauth_os_removes_entry_without_token_note(monkeypatch, fake_clients):
     """Disconnecting from an OAuth OS: URL-matched removal works on tokenless entries,
     and no revoke reminder prints (nothing was minted; sign-in state lives in the app)."""
-    install_fake(monkeypatch, FakeAgentOS(auth_mode="oauth"))
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
     assert _connect(["--clients", "cursor"]).exit_code == 0
 
     result = runner.invoke(app, ["disconnect"] + URL_ARGS + ["--clients", "cursor"])
@@ -297,7 +297,7 @@ def test_disconnect_oauth_os_reminds_when_removed_entry_carried_pat(monkeypatch,
     """connect --pat mints real accounts on an OAuth OS, so the revoke reminder must key
     on what the removed entries carried, not on the server's auth mode: this machine's
     entry holds a token whose account stays valid after the config removal."""
-    fake = FakeAgentOS(auth_mode="oauth")
+    fake = FakeAgentOS(auth_mode="security_key", oauth=True)
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
     assert _connect(["--clients", "cursor", "--pat"]).exit_code == 0

--- a/libs/agnoctl/tests/test_disconnect_cmd.py
+++ b/libs/agnoctl/tests/test_disconnect_cmd.py
@@ -1,0 +1,278 @@
+"""`agno disconnect` flows: URL-matched removal, offline fallback, and --revoke."""
+
+import json
+
+import httpx
+from typer.testing import CliRunner
+
+from agnoctl.main import app
+from tests.conftest import FakeAgentOS, install_fake
+from tests.conftest import all_output as _all_output
+
+runner = CliRunner()
+
+URL_ARGS = ["--url", "http://localhost:7777"]
+MCP_URL = "http://localhost:7777/mcp"
+
+
+def _connect(args=(), **kwargs):
+    return runner.invoke(app, ["connect", "--json"] + URL_ARGS + list(args), **kwargs)
+
+
+def _disconnect(args=(), **kwargs):
+    return runner.invoke(app, ["disconnect", "--json"] + URL_ARGS + list(args), **kwargs)
+
+
+def _refuse_all(monkeypatch):
+    """No AgentOS answers anywhere: the torn-down-deployment situation."""
+
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused", request=request)
+
+    import agnoctl.http as http_module
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(refuse))
+
+
+def test_disconnect_removes_connected_entries(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+
+    result = _disconnect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert {r["client"] for r in payload["results"]} == {"claude-code", "codex", "cursor"}
+    assert all(r["status"] == "removed" for r in payload["results"])
+    assert all(r["removed"] == ["agentos"] for r in payload["results"])
+
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "agentos" not in cursor_config["mcpServers"]
+    claude_config = json.loads((fake_clients / ".claude.json").read_text())
+    assert "agentos" not in (claude_config.get("mcpServers") or {})
+
+
+def test_disconnect_json_document_shape(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    payload = json.loads(_disconnect().output)
+    assert set(payload) == {"os", "server_name", "target_urls", "results", "revocations", "exit_code"}
+    assert payload["os"]["url"] == "http://localhost:7777"
+    assert payload["server_name"] is None
+    assert payload["target_urls"] == ["http://localhost:7777"]
+    assert payload["revocations"] == []
+    assert payload["exit_code"] == 0
+
+
+def test_disconnect_absent_entry_is_not_found(monkeypatch, fake_os, fake_clients):
+    result = _disconnect()
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert all(r["status"] == "not-found" for r in payload["results"])
+
+
+def test_disconnect_scopes_to_requested_clients(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+
+    result = _disconnect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [r["client"] for r in payload["results"]] == ["cursor"]
+
+    # Only cursor was cleared; the Claude Code entry is untouched.
+    cursor_config = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())
+    assert "agentos" not in cursor_config["mcpServers"]
+    claude_config = json.loads((fake_clients / ".claude.json").read_text())
+    assert "agentos" in claude_config["mcpServers"]
+
+
+def test_disconnect_prints_restart_hint_and_token_note(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect(["--clients", "cursor"]).exit_code == 0
+
+    result = runner.invoke(app, ["disconnect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Restart" in out and "Cursor" in out
+    # Without --revoke the minted tokens stay live; the operator must be told.
+    assert "stay valid" in out
+
+
+def test_disconnect_no_token_note_on_authless_os(monkeypatch, fake_clients):
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none"))
+    assert _connect(["--clients", "cursor"]).exit_code == 0
+
+    result = runner.invoke(app, ["disconnect"] + URL_ARGS + ["--clients", "cursor"])
+    assert result.exit_code == 0, _all_output(result)
+    # Nothing was ever minted, so there is nothing to tell the operator to revoke.
+    assert "stay valid" not in _all_output(result)
+
+
+def test_disconnect_removes_derived_named_entry(monkeypatch, fake_clients):
+    fake = FakeAgentOS(name="Customer Support")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+    assert _connect(["--clients", "cursor"]).exit_code == 0
+
+    result = _disconnect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["customer-support"]
+
+
+def test_disconnect_server_name_flag_removes_exactly_that_entry(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect(["--clients", "cursor", "--server-name", "custom"]).exit_code == 0
+
+    result = _disconnect(["--clients", "cursor", "--server-name", "custom"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["custom"]
+
+
+def test_disconnect_server_name_flag_never_touches_other_entries(monkeypatch, fake_os, fake_clients):
+    """--server-name means that one entry: an "agno" entry for another OS survives."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"custom": {"url": MCP_URL}, "agno": {"url": "http://other-os:9999/mcp"}}})
+    )
+
+    result = _disconnect(["--clients", "cursor", "--server-name", "custom"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["custom"]
+    kept = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert kept["agno"]["url"] == "http://other-os:9999/mcp"
+
+
+def test_disconnect_offline_removes_entries_by_url(monkeypatch, tmp_path, fake_clients):
+    """The OS is gone (the usual reason to disconnect): entries are located by the
+    addresses discovery would have tried -- including identity-derived names the
+    offline path could never guess -- and foreign entries survive."""
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "customer-support": {"url": MCP_URL},
+                    "agno": {"url": MCP_URL},
+                    "keep-me": {"url": "http://other-os:9999/mcp"},
+                }
+            }
+        )
+    )
+    _refuse_all(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    result = _disconnect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["os"] is None
+    assert "http://localhost:7777" in payload["target_urls"]
+    assert sorted(payload["results"][0]["removed"]) == ["agno", "customer-support"]
+    kept = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert list(kept) == ["keep-me"]
+
+
+def test_disconnect_offline_uses_env_file_url(monkeypatch, tmp_path, fake_clients):
+    """A torn-down deployed OS: its env-file address still locates the entries."""
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"live-railway": {"url": "https://prodhost:9000/mcp"}}})
+    )
+    (tmp_path / "work").mkdir()
+    (tmp_path / "work" / ".env.production").write_text("AGENTOS_URL=https://prodhost:9000\n")
+    _refuse_all(monkeypatch)
+    monkeypatch.chdir(tmp_path / "work")
+
+    result = runner.invoke(app, ["disconnect", "--json", "--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["results"][0]["removed"] == ["live-railway"]
+
+
+def test_disconnect_targeted_os_leaves_other_os_entries(monkeypatch, fake_os, fake_clients):
+    """Two OSes connected: disconnecting one never touches the other's entries, even
+    the legacy-named one."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    (fake_clients / ".cursor" / "mcp.json").write_text(
+        json.dumps({"mcpServers": {"agentos": {"url": MCP_URL}, "agno": {"url": "http://other-os:9999/mcp"}}})
+    )
+
+    result = _disconnect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["agentos"]
+    kept = json.loads((fake_clients / ".cursor" / "mcp.json").read_text())["mcpServers"]
+    assert kept["agno"]["url"] == "http://other-os:9999/mcp"
+
+
+def test_disconnect_also_clears_legacy_agno_entry(monkeypatch, fake_os, fake_clients):
+    """An agnoctl 0.1.x config (entry named "agno") pointing at this OS is cleaned."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect(["--clients", "cursor", "--server-name", "agno"]).exit_code == 0
+
+    result = _disconnect(["--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["results"][0]["removed"] == ["agno"]
+
+
+def test_disconnect_revoke_revokes_service_accounts(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    assert fake_os.active_tokens()
+
+    result = _disconnect(["--revoke"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    revoked = {r["account"]: r["status"] for r in payload["revocations"]}
+    assert revoked == {"claude-code": "revoked", "codex": "revoked", "cursor": "revoked"}
+    assert fake_os.active_tokens() == []
+
+
+def test_disconnect_revoke_shared_account_name(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect(["--name", "shared"]).exit_code == 0
+
+    result = _disconnect(["--revoke", "--name", "shared"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [r["account"] for r in payload["revocations"]] == ["shared"]
+    assert fake_os.active_tokens() == []
+
+
+def test_disconnect_revoke_missing_account_is_not_found(monkeypatch, fake_os, fake_clients):
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    result = _disconnect(["--revoke", "--clients", "cursor"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["revocations"][0]["status"] == "not-found"
+
+
+def test_disconnect_revoke_requires_reachable_os(monkeypatch, tmp_path, fake_clients):
+    """--revoke must talk to the OS, so an unreachable OS is fatal there (and only there)."""
+    _refuse_all(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    result = _disconnect(["--revoke"])
+    assert result.exit_code == 1
+    assert "No running AgentOS" in json.loads(result.output)["error"]
+
+
+def test_disconnect_chat_apps_print_manual_steps(monkeypatch, fake_os, fake_clients):
+    result = _disconnect(["--clients", "chatgpt"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["results"][0]["client"] == "chatgpt"
+    assert payload["results"][0]["status"] == "manual"
+    assert "Connectors" in payload["results"][0]["instructions"][0]
+
+
+def test_disconnect_partial_failure_exit_code(monkeypatch, fake_os, fake_clients):
+    """A corrupt config fails that client only (via --server-name's strict remove);
+    output stays one JSON document, exit 3."""
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake_os.security_key)
+    assert _connect().exit_code == 0
+    (fake_clients / ".cursor" / "mcp.json").write_text("{corrupt")
+
+    result = _disconnect(["--server-name", "agentos"])
+    assert result.exit_code == 3
+    payload = json.loads(result.output)
+    by_client = {r["client"]: r for r in payload["results"]}
+    assert by_client["cursor"]["status"] == "failed"
+    assert "Refusing to modify" in by_client["cursor"]["error"]
+    assert by_client["claude-code"]["status"] == "removed"

--- a/libs/agnoctl/tests/test_discovery.py
+++ b/libs/agnoctl/tests/test_discovery.py
@@ -318,3 +318,23 @@ def test_discover_all_dedupes_loopback_aliases(monkeypatch, tmp_path):
     found = discover_all(None)
     assert [i.base_url for i in found] == ["http://127.0.0.1:7777"]
     assert found[0].url_source == "env-file"
+
+
+def test_discover_parses_mcp_oauth(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.auth_mode == "oauth"
+    assert info.oauth_enabled is True
+    assert info.oauth is not None
+    assert info.oauth.authorization_servers == ["http://localhost:7777/mcp/auth"]
+    assert info.oauth.resource == "http://localhost:7777/mcp"
+    assert info.public_dict()["mcp"]["oauth"]["resource"] == "http://localhost:7777/mcp"
+
+
+def test_discover_oauth_absent_on_older_servers(monkeypatch, tmp_path, fake_os):
+    """agno <= 2.7 serves no mcp.oauth object: the field stays None and nothing lights up."""
+    info = discover("http://localhost:7777")
+    assert info.oauth is None
+    assert info.oauth_enabled is False

--- a/libs/agnoctl/tests/test_discovery.py
+++ b/libs/agnoctl/tests/test_discovery.py
@@ -321,11 +321,12 @@ def test_discover_all_dedupes_loopback_aliases(monkeypatch, tmp_path):
 
 
 def test_discover_parses_mcp_oauth(monkeypatch, tmp_path):
+    """The MCP OAuth signal is mcp.oauth alone; auth_mode stays the REST plane."""
     monkeypatch.chdir(tmp_path)
-    fake = FakeAgentOS(auth_mode="oauth")
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
     install_fake(monkeypatch, fake)
     info = discover("http://localhost:7777")
-    assert info.auth_mode == "oauth"
+    assert info.auth_mode == "none"
     assert info.oauth_enabled is True
     assert info.oauth is not None
     assert info.oauth.authorization_servers == ["http://localhost:7777/mcp/auth"]

--- a/libs/agnoctl/tests/test_discovery.py
+++ b/libs/agnoctl/tests/test_discovery.py
@@ -3,9 +3,25 @@
 import httpx
 import pytest
 
-from agnoctl.discovery import _agentos_url_from_env_files, _read_env_value, discover
+from agnoctl.discovery import _agentos_url_from_env_files, _read_env_value, discover, discover_all
 from agnoctl.errors import CLIError
 from tests.conftest import FakeAgentOS, install_fake
+
+
+def _install_hosts(monkeypatch, live):
+    """Transport where only 'host:port' keys in `live` answer (with that fake AgentOS);
+    every other URL is connection-refused, like a dead localhost port."""
+    import agnoctl.http as http_module
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fake = live.get(request.url.host + ":" + str(request.url.port))
+        if fake is None:
+            raise httpx.ConnectError("connection refused", request=request)
+        return fake.handler(request)
+
+    monkeypatch.setattr(http_module, "_transport_override", httpx.MockTransport(handler))
+    for var in ("AGNO_ADMIN_TOKEN", "OS_SECURITY_KEY", "AGENTOS_URL"):
+        monkeypatch.delenv(var, raising=False)
 
 
 def test_discover_via_info_fields(fake_os):
@@ -199,3 +215,106 @@ def test_discover_invalid_env_file_url_raises_clean_error(monkeypatch, tmp_path)
     with pytest.raises(CLIError) as exc_info:
         discover(None)
     assert "Invalid AgentOS URL" in exc_info.value.message
+
+
+# -- discover_all ------------------------------------------------------------------------
+
+
+def test_discover_all_unions_env_file_and_localhost(monkeypatch, tmp_path):
+    """A deploy's env-file URL must not mask a locally running OS: both are returned,
+    env-file first (it is the default the selection menu offers)."""
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(
+        monkeypatch,
+        {"prodhost:9000": FakeAgentOS(name="Live Railway"), "localhost:7777": FakeAgentOS()},
+    )
+    found = discover_all(None)
+    assert [i.base_url for i in found] == ["http://prodhost:9000", "http://localhost:7777"]
+    assert found[0].url_source == "env-file"
+    assert found[0].url_source_file == ".env.production"
+    assert found[0].name == "Live Railway"
+    assert found[1].url_source == "default"
+
+
+def test_discover_all_only_local_when_env_file_target_is_down(monkeypatch, tmp_path):
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"localhost:7777": FakeAgentOS()})
+    found = discover_all(None)
+    assert [i.base_url for i in found] == ["http://localhost:7777"]
+
+
+def test_discover_all_explicit_url_is_single_target(monkeypatch, tmp_path):
+    """--url is authoritative: no localhost probing behind the operator's back."""
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"flaghost:9000": FakeAgentOS(), "localhost:7777": FakeAgentOS()})
+    found = discover_all("http://flaghost:9000")
+    assert [i.base_url for i in found] == ["http://flaghost:9000"]
+    assert found[0].url_source == "flag"
+
+
+def test_discover_all_exported_env_var_is_single_target(monkeypatch, tmp_path):
+    """An exported AGENTOS_URL is deliberate (not ambient): it stays a single target."""
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"envhost:9000": FakeAgentOS(), "localhost:7777": FakeAgentOS()})
+    monkeypatch.setenv("AGENTOS_URL", "http://envhost:9000")
+    found = discover_all(None)
+    assert [i.base_url for i in found] == ["http://envhost:9000"]
+    assert found[0].url_source == "env"
+
+
+def test_discover_all_env_file_url_equal_to_default_is_deduped(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text("AGENTOS_URL=http://localhost:7777\n")
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"localhost:7777": FakeAgentOS()})
+    found = discover_all(None)
+    assert [i.base_url for i in found] == ["http://localhost:7777"]
+    assert found[0].url_source == "env-file"
+
+
+def test_discover_all_none_alive_raises(monkeypatch, tmp_path):
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://prodhost:9000\n")
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {})
+    with pytest.raises(CLIError) as exc_info:
+        discover_all(None)
+    assert "No running AgentOS" in exc_info.value.message
+    assert "http://prodhost:9000" in exc_info.value.message
+
+
+def test_discover_invalid_env_file_url_raises_in_discover_all(monkeypatch, tmp_path):
+    (tmp_path / ".env.production").write_text("AGENTOS_URL=http://host:${PORT}\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AGENTOS_URL", raising=False)
+    with pytest.raises(CLIError) as exc_info:
+        discover_all(None)
+    assert "Invalid AgentOS URL" in exc_info.value.message
+
+
+def test_discover_populates_name_and_os_id(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    fake = FakeAgentOS(name="Customer Support", os_id="os-123")
+    install_fake(monkeypatch, fake)
+    info = discover("http://localhost:7777")
+    assert info.name == "Customer Support"
+    assert info.os_id == "os-123"
+
+
+def test_discover_name_absent_on_older_servers(monkeypatch, tmp_path, fake_os):
+    """agno <= 2.7 serves no name/os_id on /info: the fields stay None (callers fall back)."""
+    info = discover("http://localhost:7777")
+    assert info.name is None
+    assert info.os_id is None
+
+
+def test_discover_all_dedupes_loopback_aliases(monkeypatch, tmp_path):
+    """AGENTOS_URL=http://127.0.0.1:7777 (the spelling uvicorn logs) and the
+    localhost:7777 default are the same server: one candidate, not a two-entry menu."""
+    (tmp_path / ".env").write_text("AGENTOS_URL=http://127.0.0.1:7777\n")
+    monkeypatch.chdir(tmp_path)
+    fake = FakeAgentOS()
+    _install_hosts(monkeypatch, {"127.0.0.1:7777": fake, "localhost:7777": fake})
+    found = discover_all(None)
+    assert [i.base_url for i in found] == ["http://127.0.0.1:7777"]
+    assert found[0].url_source == "env-file"

--- a/libs/agnoctl/tests/test_discovery.py
+++ b/libs/agnoctl/tests/test_discovery.py
@@ -339,3 +339,28 @@ def test_discover_oauth_absent_on_older_servers(monkeypatch, tmp_path, fake_os):
     info = discover("http://localhost:7777")
     assert info.oauth is None
     assert info.oauth_enabled is False
+
+
+def test_discover_all_includes_client_config_sources(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"localhost:7777": FakeAgentOS(), "prodhost:8443": FakeAgentOS(name="Prod OS")})
+    found = discover_all(None, extra_sources=[("https://prodhost:8443", "client-config", "Claude Code, Cursor")])
+    assert [i.base_url for i in found] == ["http://localhost:7777", "https://prodhost:8443"]
+    assert found[1].url_source == "client-config"
+    assert found[1].source_note() == " (configured in Claude Code, Cursor)"
+
+
+def test_discover_all_explicit_url_ignores_client_config_sources(monkeypatch, tmp_path):
+    """--url names a deliberate single target; config-derived candidates never widen it."""
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"flaghost:9000": FakeAgentOS(), "prodhost:8443": FakeAgentOS()})
+    found = discover_all("http://flaghost:9000", extra_sources=[("https://prodhost:8443", "client-config", "Cursor")])
+    assert [i.base_url for i in found] == ["http://flaghost:9000"]
+
+
+def test_discover_all_dedupes_client_config_against_defaults(monkeypatch, tmp_path):
+    """A config entry for the local default (via a loopback alias) adds no candidate."""
+    monkeypatch.chdir(tmp_path)
+    _install_hosts(monkeypatch, {"localhost:7777": FakeAgentOS()})
+    found = discover_all(None, extra_sources=[("http://127.0.0.1:7777", "client-config", "Cursor")])
+    assert len(found) == 1

--- a/libs/agnoctl/tests/test_mcp_client.py
+++ b/libs/agnoctl/tests/test_mcp_client.py
@@ -67,3 +67,30 @@ def test_verify_never_raises_on_malformed_result(monkeypatch):
     result = verify_mcp(MCP_URL, token="anything")
     assert result.ok is True
     assert result.tools == []
+
+
+def test_verify_expect_oauth_challenge_accepts_401_with_www_authenticate(monkeypatch):
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    result = verify_mcp("http://localhost:7777/mcp", token=None, expect_oauth_challenge=True)
+    assert result.ok is True
+    assert result.oauth_challenge is True
+    assert result.status_code == 401
+    assert result.tools == []
+
+
+def test_verify_expect_oauth_challenge_rejects_bare_401(monkeypatch):
+    """A 401 without a WWW-Authenticate header means clients cannot discover the AS:
+    that is a broken OAuth setup, not a healthy one."""
+    fake = FakeAgentOS(auth_mode="security_key")
+    install_fake(monkeypatch, fake)
+    result = verify_mcp("http://localhost:7777/mcp", token=None, expect_oauth_challenge=True)
+    assert result.ok is False
+    assert "no WWW-Authenticate" in (result.error or "")
+
+
+def test_verify_401_without_expectation_still_fails(monkeypatch):
+    fake = FakeAgentOS(auth_mode="oauth")
+    install_fake(monkeypatch, fake)
+    result = verify_mcp("http://localhost:7777/mcp", token=None)
+    assert result.ok is False

--- a/libs/agnoctl/tests/test_mcp_client.py
+++ b/libs/agnoctl/tests/test_mcp_client.py
@@ -70,7 +70,7 @@ def test_verify_never_raises_on_malformed_result(monkeypatch):
 
 
 def test_verify_expect_oauth_challenge_accepts_401_with_www_authenticate(monkeypatch):
-    fake = FakeAgentOS(auth_mode="oauth")
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
     install_fake(monkeypatch, fake)
     result = verify_mcp("http://localhost:7777/mcp", token=None, expect_oauth_challenge=True)
     assert result.ok is True
@@ -90,7 +90,7 @@ def test_verify_expect_oauth_challenge_rejects_bare_401(monkeypatch):
 
 
 def test_verify_401_without_expectation_still_fails(monkeypatch):
-    fake = FakeAgentOS(auth_mode="oauth")
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
     install_fake(monkeypatch, fake)
     result = verify_mcp("http://localhost:7777/mcp", token=None)
     assert result.ok is False

--- a/libs/agnoctl/tests/test_security.py
+++ b/libs/agnoctl/tests/test_security.py
@@ -4,9 +4,11 @@ import pytest
 
 from agnoctl.commands._common import (
     _is_loopback_host,
+    derive_server_name,
     ensure_env_file_url_trusted,
     require_secure_url,
     validate_project_name,
+    validate_server_name,
 )
 from agnoctl.errors import CLIError
 
@@ -105,6 +107,46 @@ def test_env_file_gate_prompts_interactively(monkeypatch):
     ensure_env_file_url_trusted(
         "https://prod.example.com", "env-file", ".env.production", assume_yes=False, json_mode=False
     )  # must not raise
+
+
+def test_env_file_gate_interactive_default_is_trust(monkeypatch):
+    """Enter on the interactive prompt trusts the URL (the env-file URL is almost always
+    the one the operator's own deploy just wrote); automation above stays fail-closed."""
+    import agnoctl.commands._common as common
+
+    monkeypatch.setattr(common, "stdin_is_interactive", lambda: True)
+    captured = {}
+
+    def confirm(prompt, default=None):
+        captured["default"] = default
+        return default  # answer with the default, i.e. a bare Enter
+
+    monkeypatch.setattr(common.typer, "confirm", confirm)
+    ensure_env_file_url_trusted(
+        "https://prod.example.com", "env-file", ".env.production", assume_yes=False, json_mode=False
+    )  # must not raise: Enter accepts
+    assert captured["default"] is True
+
+
+# -- derive_server_name ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("os_name", "expected"),
+    [
+        ("AgentOS", "agentos"),
+        ("Customer Support", "customer-support"),
+        ("acme.prod v2", "acme-prod-v2"),
+        ("  weird -- name  ", "weird-name"),
+        ("!!!", "agentos"),
+        ("", "agentos"),
+        (None, "agentos"),
+    ],
+)
+def test_derive_server_name(os_name, expected):
+    derived = derive_server_name(os_name)
+    assert derived == expected
+    validate_server_name(derived)  # every derived name must pass the entry-name gate
 
 
 # -- validate_project_name -------------------------------------------------------------

--- a/libs/agnoctl/tests/test_status_cmd.py
+++ b/libs/agnoctl/tests/test_status_cmd.py
@@ -1,0 +1,48 @@
+"""`agno status` output: the OS posture summary and per-client connection state."""
+
+import json
+
+from typer.testing import CliRunner
+
+from agnoctl.main import app
+from tests.conftest import FakeAgentOS, install_fake
+from tests.conftest import all_output as _all_output
+
+runner = CliRunner()
+
+URL_ARGS = ["--url", "http://localhost:7777"]
+MCP_URL = "http://localhost:7777/mcp"
+
+
+def test_status_reports_mcp_oauth_alongside_rest_auth_mode(monkeypatch, fake_os, fake_clients):
+    """auth_mode is the REST plane only; without the MCP auth line an OAuth-protected
+    /mcp would read as an unsecured deployment ("Auth mode: none")."""
+    install_fake(monkeypatch, FakeAgentOS(auth_mode="none", oauth=True))
+
+    result = runner.invoke(app, ["status"] + URL_ARGS)
+    assert result.exit_code == 0, _all_output(result)
+    out = _all_output(result)
+    assert "Auth mode: none" in out
+    assert "MCP auth: OAuth via http://localhost:7777/mcp/auth" in out
+
+
+def test_status_no_mcp_auth_line_without_oauth_block(monkeypatch, fake_os, fake_clients):
+    result = runner.invoke(app, ["status"] + URL_ARGS)
+    assert result.exit_code == 0, _all_output(result)
+    assert "MCP auth" not in _all_output(result)
+
+
+def test_status_finds_the_derived_entry_name_connect_writes(monkeypatch, fake_clients):
+    """The default lookup must match what connect writes today (the OS-name slug),
+    not the legacy "agno" naming -- otherwise every default status run reports
+    freshly connected clients as not connected."""
+    fake = FakeAgentOS(name="Customer Support")
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.security_key)
+    connect = runner.invoke(app, ["connect", "--json"] + URL_ARGS + ["--clients", "cursor"])
+    assert connect.exit_code == 0, connect.output
+
+    result = runner.invoke(app, ["status", "--json"] + URL_ARGS)
+    assert result.exit_code == 0, result.output
+    clients = {c["client"]: c for c in json.loads(result.output)["clients"]}
+    assert clients["cursor"]["configured"] is True

--- a/libs/agnoctl/tests/test_tokens_cmd.py
+++ b/libs/agnoctl/tests/test_tokens_cmd.py
@@ -181,3 +181,21 @@ def test_revoke_yes_skips_confirmation(monkeypatch, fake_os):
     result = _run(["tokens", "revoke", "ci-runner", "--yes"] + URL_ARGS)
     assert result.exit_code == 0, result.output
     assert fake_os.accounts["ci-runner"]["revoked_at"] is not None
+
+
+def test_create_on_oauth_only_os_fails_naming_the_server_gap(monkeypatch, fake_os):
+    """An OS whose only auth is the OAuth provider on /mcp refuses every mint, and its
+    open REST plane would "accept" any credential right up to the failing POST; create
+    must fail before resolving a credential, naming what the server is missing."""
+    from tests.conftest import FakeAgentOS, install_fake
+
+    fake = FakeAgentOS(auth_mode="oauth", open_rest=True)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", "any-typed-value")
+
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "no authentication configured" in payload["error"]
+    assert "OS_SECURITY_KEY" in payload["hint"]
+    assert fake.create_calls == 0

--- a/libs/agnoctl/tests/test_tokens_cmd.py
+++ b/libs/agnoctl/tests/test_tokens_cmd.py
@@ -189,7 +189,7 @@ def test_create_on_oauth_only_os_fails_naming_the_server_gap(monkeypatch, fake_o
     must fail before resolving a credential, naming what the server is missing."""
     from tests.conftest import FakeAgentOS, install_fake
 
-    fake = FakeAgentOS(auth_mode="oauth", open_rest=True)
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
     install_fake(monkeypatch, fake)
     monkeypatch.setenv("AGNO_ADMIN_TOKEN", "any-typed-value")
 

--- a/libs/agnoctl/tests/test_tokens_cmd.py
+++ b/libs/agnoctl/tests/test_tokens_cmd.py
@@ -183,10 +183,24 @@ def test_revoke_yes_skips_confirmation(monkeypatch, fake_os):
     assert fake_os.accounts["ci-runner"]["revoked_at"] is not None
 
 
-def test_create_on_oauth_only_os_fails_naming_the_server_gap(monkeypatch, fake_os):
-    """An OS whose only auth is the OAuth provider on /mcp refuses every mint, and its
-    open REST plane would "accept" any credential right up to the failing POST; create
-    must fail before resolving a credential, naming what the server is missing."""
+def test_create_on_open_plane_without_credential_fails_naming_the_server_gap(monkeypatch, fake_os):
+    """An OS whose only auth is the OAuth provider on /mcp refuses anonymous mints, and
+    its open REST plane would "accept" any credential right up to the failing POST;
+    create must fail before resolving a credential, naming what the server is missing."""
+    from tests.conftest import FakeAgentOS, install_fake
+
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
+    install_fake(monkeypatch, fake)
+
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "no authentication configured" in payload["error"]
+    assert "OS_SECURITY_KEY" in payload["hint"]
+    assert fake.create_calls == 0
+
+
+def test_create_on_open_plane_with_non_pat_credential_names_the_mismatch(monkeypatch, fake_os):
     from tests.conftest import FakeAgentOS, install_fake
 
     fake = FakeAgentOS(auth_mode="none", oauth=True)
@@ -195,7 +209,20 @@ def test_create_on_oauth_only_os_fails_naming_the_server_gap(monkeypatch, fake_o
 
     result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
     assert result.exit_code == 1
-    payload = json.loads(result.output)
-    assert "no authentication configured" in payload["error"]
-    assert "OS_SECURITY_KEY" in payload["hint"]
+    assert "only a service-account token" in json.loads(result.output)["error"]
     assert fake.create_calls == 0
+
+
+def test_create_on_open_plane_with_admin_pat_mints(monkeypatch, fake_os):
+    """The anonymous-mint refusal is anonymous-only: a verified service-account bearer
+    holding a minting scope mints even on an open REST plane."""
+    from tests.conftest import FakeAgentOS, install_fake
+
+    fake = FakeAgentOS(auth_mode="none", oauth=True)
+    install_fake(monkeypatch, fake)
+    monkeypatch.setenv("AGNO_ADMIN_TOKEN", fake.seed_account("ops", ["admin"]))
+
+    result = _run(["tokens", "create", "ci-runner", "--json"] + URL_ARGS)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["name"] == "ci-runner"
+    assert "ci-runner" in fake.accounts


### PR DESCRIPTION
## Summary

Round 2 of the `agno connect` workstream, per `specs/agno/agno-connect/spec-v0.md`. Round 1 shipped `connect`/`tokens`/service accounts; this round adds what dogfooding a real deploy surfaced: multi-target discovery with selection, `agno disconnect`, identity-named entries, restart hints, a legible credential flow — and **OAuth-first registration**, which pairs with #8793 (OAuth on the AgentOS MCP endpoint via `AgentOS(mcp_auth=...)`).

**Ship together with #8793.** Against servers without it the `mcp.oauth` field is absent and behavior is unchanged, so this PR is safe to merge first; the OAuth flow only lights up with both in.

### The decision model (read this first)

`/info` describes two independent auth planes, and connect never conflates them:

- **`mcp.oauth`** — the MCP surface. `/mcp` is OAuth-protected when this block is present with a non-empty `authorization_servers`. (A block with no authorization servers — e.g. a bare fastmcp `TokenVerifier` as `mcp_auth` — offers nothing to sign in through and is treated as a plain token-protected surface.)
- **`auth_mode`** (`"none"` | `"security_key"` | `"jwt"`) — the REST/WS plane. It picks the admin credential for minting and says nothing about `/mcp`. `"none"` means the REST plane is open, and an open server refuses every mint (anonymous callers must never create durable credentials).

| MCP surface | REST plane | `agno connect` | `agno connect --pat` |
|---|---|---|---|
| OAuth | open (`none`) | tokenless entry + sign-in (`needs-login`) | mints with an exported `agno_pat_` credential; otherwise fails fast naming the gap |
| OAuth | `security_key` / `jwt` | tokenless entry + sign-in | mints PATs (`/mcp` accepts both via the server's `MultiAuth`) |
| token-protected | `security_key` / `jwt` | mints PATs | same |
| open | `none` | tokenless entry + "authorization is disabled" note | mints with an exported `agno_pat_` credential; otherwise fails fast |

### Multi-target discovery + selection

`discovery.discover_all()` probes the ambient env-file URL, the localhost defaults, **and the AgentOS base URLs harvested from existing client-config MCP entries** — the one durable record of previously connected OSes, so a bare `agno connect` after a deploy offers "prod vs local" (explicit `--url` / exported `AGENTOS_URL` stay single-target; loopback aliases like `127.0.0.1` vs `localhost` are deduped). When more than one AgentOS is live, interactive `connect`/`disconnect` present a numbered menu with provenance (`(configured in Claude Code, Cursor)`); Enter keeps today's target (the env-file URL). Config-derived candidates are interactive-only — automation never sees them — and picking a remote one runs the same trust confirm as an env-file URL, since a project-scoped MCP entry is plantable by an untrusted directory exactly like a `.env.production`. Picking the remote URL still runs the env-file trust gate; picking local connects silently.

**Non-interactive runs (`--json` / no TTY) keep single-target `discover()` semantics**: automation resolves the same deterministic target as before, and a dead env-file OS stays a hard failure — it can never be silently retargeted at whatever else is running locally. Interactively, a dead env-file URL falls through to the local OS with a printed note, and discovery probes use a 5s timeout so a stale URL costs seconds per run, not the full API timeout.

### `agno disconnect`

The inverse of connect: removes the MCP entry from each client config. **Entries are located by where they point, not by guessing names**: `--server-name` removes exactly that entry; otherwise every entry pointing at the target AgentOS is removed — its live address when the OS answers, else every address discovery would have tried (env-file URL + localhost defaults). So tearing down a deployed OS never blocks disconnect, identity-derived entry names are found even offline, and entries pointing at any *other* server are never touched (this also makes a planted `.env.production` useless for tricking disconnect into deleting an unrelated entry). URL matching is base-path-scoped, so two AgentOS behind one host on different path prefixes never match each other.

Adapters gain `list_entries()` and a URL-guarded `remove(name, matches=...)`; removal clears **every** scope the entry lives in (Claude Code local/project/user, Cursor project+global) so no shadowed entry silently takes over — with the URL guard applied per scope. Codex removal verifies the entry is actually gone after the rewrite and refuses loudly on TOML layouts the section-replacer cannot handle, instead of reporting a false "removed".

After a removal, the report prints the restart hint (a running client holds its MCP connection in-process) and — when any removed entry carried a token — a reminder that the accounts behind those tokens stay valid, with the `agno tokens revoke` command. The reminder keys on what was actually removed, not the server's auth mode: tokenless entries (OAuth sign-in, auth-less OS) have nothing to revoke, while `--pat`-minted entries on an OAuth OS do.

Opt-in `--revoke` also revokes the service accounts connect minted (requires the OS; reuses the trust + secure-URL + admin-credential gates); `--name` targets a shared account.

### Identity-named entries

`/info` now serves `name` and `os_id` (backward-compatible framework addition in `libs/agno`). `--server-name` defaults to a slug of the OS name (`"Customer Support"` → `customer-support`), falling back to `agentos` on older servers; explicit `--server-name` still overrides.

**Legacy migration:** an entry named `agno` (agnoctl 0.1.x naming) pointing at the same OS is renamed in place on re-connect — its working token is reused (no re-mint, no revocation, no mint-name conflict) and the stale entry is dropped, URL-guarded per scope so a same-named entry for a different OS survives. Token reuse is skipped when the operator passes explicit `--scopes`/`--expires` (they want a freshly provisioned account).

### OAuth-first registration (pairs with #8793)

When `mcp.oauth` advertises an authorization server, connect switches to the registration model MCP clients natively speak: **tokenless entries plus a one-time in-client sign-in**, instead of minted service-account tokens. Each result reports `needs-login` with the exact step — `claude mcp login <name>` (or `/mcp` → Authenticate), `codex mcp login <name>`, Cursor Settings → MCP → Connect, and mcp-remote's automatic browser flow for Claude Desktop (all verified against current client docs; all default to Dynamic Client Registration, which the built-in AS serves).

Verification treats a 401 **with** a `WWW-Authenticate` challenge as the healthy outcome for a tokenless entry, and a bare 401 as a broken OAuth setup. The chat-app auto-surface fires for OAuth-protected OSes too — claude.ai/ChatGPT Connectors authenticate with exactly this flow. Existing PAT entries keep verifying (`already-connected`), and `--rotate` converts a PAT entry to OAuth registration.

Credential hygiene around the OAuth ⇄ PAT boundary:

- **`--pat`** opts back into minted bearers for headless clients. It needs a credential the server can authenticate: a protected REST plane, or — on an open plane — an exported `agno_pat_` token (the server dispatches service-account bearers by prefix in every auth mode and scope-checks the mint, so a durable admin PAT from a protected era keeps working). Every dead end fails before any credential prompt or config write, naming the exact gap: no credential on an open plane (an unauthenticated `GET /service-accounts` probe confirms it first), an exported non-PAT credential the open plane would "accept" on reads and reject at the mint, `--pat` against a plain open OS, and a bare-token-verifier `/mcp` on an open plane (entries could only ever 401). The same gate guards `agno tokens create`.
- **Mint-shaping flags error in OAuth mode.** `--name`/`--scopes`/`--expires`/`--privileged` shape minted tokens; an OAuth run mints nothing, so they fail with a pointer to `--pat` instead of being silently ignored.
- **Converting a token entry to tokenless reports the dangling account.** `--rotate` (and the legacy-entry rename) erase the bearer from disk but cannot revoke the account behind it; the report says so and points at `agno tokens revoke`.

### UX

The human report tells one story top-down: one-line rows per client, then — when entries for another OS were replaced (the same-name case, e.g. local and prod both named "AgentOS") — a single note saying what happened and how to keep both (`--server-name`), then a numbered **To finish** section holding the restart step and the per-app one-time sign-ins together, then auto-surfaced chat apps as one compact aside (explicitly requested ones keep their full instruction blocks). The builtin AS is the OS itself, so the OAuth banner names an issuer only for external IdPs; home-directory prefixes render as `~` in report rows. `agno status` shows the `mcp.oauth` posture next to the REST auth mode and looks up the OS-name-derived entry connect actually writes. Disconnect prints the matching drop-the-connection hint; rotated clients get the keeps-using-the-old-token warning. The interactive env-file trust confirm defaults to Yes (`[Y/n]`) — the URL being trusted is almost always the one the operator's own deploy just wrote; the non-interactive path still hard-refuses without `--yes`, and loopback URLs remain auto-trusted. A `rich` status spinner tracks mint → write → verify per client (human path only; `--json` stays a single document). One cheap authed preflight makes a bad credential paste fail fast instead of reading like a hang — a 403 (credential scoped to `service_accounts:write` only) is tolerated and the run proceeds to the mint. The credential prompt and 401 hint point at the AgentOS UI (Settings → OS & Security "Generate token" — UI side tracked separately) alongside `AGNO_ADMIN_TOKEN`/`OS_SECURITY_KEY`.

### Review guide

Where the behavior lives:

- `agnoctl/discovery.py` — `discover_all`, `OSInfo` (incl. `oauth_enabled`, the one place OAuth-or-not is decided), `mcp.oauth` parsing
- `agnoctl/commands/connect.py` — the decision block (`oauth_mode` / `minting` / the `--pat` gate), `_connect_one` (idempotency, rotate, legacy rename, verify), report
- `agnoctl/commands/disconnect.py` — URL-matched removal, `--revoke`, token-keyed reminder
- `agnoctl/commands/_common.py` — `require_mint_capable`, `derive_server_name`, trust gate
- `agnoctl/clients/*` — `list_entries` / URL-guarded `remove` per adapter
- `agnoctl/mcp_client.py` — `verify_mcp(expect_oauth_challenge=...)`
- `libs/agno/agno/os/{schema,router}.py` — the two-line `/info` addition (`name`, `os_id`)

Commit shape: `aa7d06ecc` (multi-target select, disconnect, identity names) → `135ab3788` (OAuth-first registration) → `5b8377f8d` (disconnect URL-matching hardening) → `b385ec7cd` (credential-hygiene fixes from an adversarial compatibility review against #8793: the `--pat` dead-end gate, token-keyed reminders, dangling-account notices, shaping-flag errors) → `e9328c474` (realignment after #8793 corrected `auth_mode` to the REST plane only) → `f293f8f6c` (exported PATs honored on open planes, all mint dead-ends fail before writes, status realignment, and the consolidated report) → `211834e40` (interactive picker offers previously connected OSes from the client configs — the decision model above is the final semantics).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- **Testing:** 294 agnoctl tests pass (discovery union/dedup, menu selection, derived names, legacy migration incl. scope/URL guards, per-adapter `remove`/`list_entries`, full `disconnect` flows incl. offline URL-matching and `--revoke`, automation-regression guards, OAuth-mode flows incl. the open-REST mint gate and shaping-flag errors); the framework `/info` tests cover the `name`/`os_id` additions. The test fake models the real server's two auth planes, including the anonymous-mint refusal on an open REST plane.
- **Live verification:** the full flow matrix ran against a real AgentOS on the `feat/agentos-mcp-oauth` branch with the builtin authorization server (`AgentOSBuiltinAuth`), in both deployment shapes — OAuth-only (open REST: needs-login flow, fail-fast `--pat`/`tokens create`, no misleading "authorization is disabled" note) and composed (security key + OAuth: needs-login without `--pat`, `--pat` mints and the PAT lists all 8 tools through `MultiAuth`, disconnect prints the revoke reminder) — plus offline disconnect with the server torn down.
- **Version skew:** against agno ≤ 2.7.x servers, `name` is absent (derived name falls back to `agentos`) and `mcp.oauth` is absent (the OAuth flow never lights up); servers predating `/info` discovery entirely fall back to probing.
- **Known limitations:** two instances sharing a name slug map to the same entry, so connecting the second replaces the first (distinct `AgentOS(name=...)` or `--server-name` disambiguates). Disconnect's URL-matched mode reports `not-found` on a corrupt config file (the lenient read cannot distinguish corrupt from absent); the `--server-name` path surfaces corruption loudly. `already-connected` for a tokenless entry verifies the challenge, not that the in-client sign-in was completed.
- **Follow-up (cross-team, not in this PR):** AgentOS UI "Generate token" button on Settings → OS & Security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)