### PR TITLE
fix(client): serialize in-memory images for remote agent runs

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -69,6 +69,11 @@ from agno.run.workflow import WorkflowRunOutput, WorkflowRunOutputEvent, workflo
 from agno.utils.http import get_default_async_client, get_default_sync_client
 
 
+def _serialize_media_for_form(media: Sequence[Any]) -> str:
+    """Serialize media objects for form fields using their JSON-safe representation."""
+    return json.dumps([item.to_dict() if hasattr(item, "to_dict") else item.model_dump() for item in media])
+
+
 class AgentOSClient:
     """Client for interacting with AgentOS API endpoints.
 
@@ -576,13 +581,13 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.model_dump() for img in images])
+            data["images"] = _serialize_media_for_form(images)
         if audio:
-            data["audio"] = json.dumps([a.model_dump() for a in audio])
+            data["audio"] = _serialize_media_for_form(audio)
         if videos:
-            data["videos"] = json.dumps([v.model_dump() for v in videos])
+            data["videos"] = _serialize_media_for_form(videos)
         if files:
-            data["files"] = json.dumps([f.model_dump() for f in files])
+            data["files"] = _serialize_media_for_form(files)
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
@@ -636,13 +641,13 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.model_dump() for img in images])
+            data["images"] = _serialize_media_for_form(images)
         if audio:
-            data["audio"] = json.dumps([a.model_dump() for a in audio])
+            data["audio"] = _serialize_media_for_form(audio)
         if videos:
-            data["videos"] = json.dumps([v.model_dump() for v in videos])
+            data["videos"] = _serialize_media_for_form(videos)
         if files:
-            data["files"] = json.dumps([f.model_dump() for f in files])
+            data["files"] = _serialize_media_for_form(files)
 
         for key, value in kwargs.items():
             if isinstance(value, dict):

--- a/libs/agno/tests/unit/os/test_client.py
+++ b/libs/agno/tests/unit/os/test_client.py
@@ -12,11 +12,13 @@ Tests cover:
 8. Run operations
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agno.client import AgentOSClient
+from agno.media import Image
 
 
 def test_init_with_base_url():
@@ -549,6 +551,31 @@ async def test_run_agent():
 
 
 @pytest.mark.asyncio
+async def test_run_agent_serializes_image_content_as_base64():
+    """Verify run_agent can send in-memory image bytes as form JSON."""
+    client = AgentOSClient(base_url="http://localhost:7777")
+    mock_data = {
+        "run_id": "run-123",
+        "agent_id": "agent-1",
+        "content": "done",
+        "created_at": 1234567890,
+    }
+    with patch.object(client, "_apost", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value = mock_data
+
+        await client.run_agent(
+            agent_id="agent-1",
+            message="Describe this",
+            images=[Image(content=b"raw-image", mime_type="image/png")],
+        )
+
+        data = mock_post.call_args.args[1]
+        images_payload = json.loads(data["images"])
+        assert images_payload[0]["content"] == "cmF3LWltYWdl"
+        assert images_payload[0]["mime_type"] == "image/png"
+
+
+@pytest.mark.asyncio
 async def test_run_team():
     """Verify run_team executes a team run."""
     client = AgentOSClient(base_url="http://localhost:7777")
@@ -657,6 +684,33 @@ async def test_run_agent_stream_returns_typed_events():
         assert isinstance(events[1], RunContentEvent)
         assert events[1].content == "Hello"
         assert isinstance(events[2], RunCompletedEvent)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_stream_serializes_image_content_as_base64():
+    """Verify streaming agent runs can send in-memory image bytes as form JSON."""
+    client = AgentOSClient(base_url="http://localhost:7777")
+
+    async def async_generator():
+        yield 'data: {"event": "RunCompleted", "run_id": "run-123", "agent_id": "agent-1", "created_at": 1234567890}'
+
+    with patch.object(client, "_astream_post_form_data") as mock_stream:
+        mock_stream.return_value = async_generator()
+
+        events = [
+            event
+            async for event in client.run_agent_stream(
+                "agent-123",
+                "Describe this",
+                images=[Image(content=b"raw-image", mime_type="image/png")],
+            )
+        ]
+
+        data = mock_stream.call_args.args[1]
+        images_payload = json.loads(data["images"])
+        assert len(events) == 1
+        assert images_payload[0]["content"] == "cmF3LWltYWdl"
+        assert images_payload[0]["mime_type"] == "image/png"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- serialize AgentOS client media form fields through their JSON-safe `to_dict()` representations
- preserve in-memory image bytes as base64 when calling `run_agent` and `run_agent_stream`
- add regression coverage for non-streaming and streaming remote agent image payloads

Fixes #8789

## Tests
- `.venv-py/bin/python -m pytest tests/unit/os/test_client.py -q`
- `.venv-py/bin/python -m ruff check agno/client/os.py tests/unit/os/test_client.py`
- `.venv-py/bin/python -m ruff format --check agno/client/os.py tests/unit/os/test_client.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/client/os.py tests/unit/os/test_client.py`
- `git diff --check`