### PR TITLE
fix(scrapegraph): gate sensitive fetch headers by host

### DIFF
--- a/libs/agno/agno/tools/scrapegraph.py
+++ b/libs/agno/agno/tools/scrapegraph.py
@@ -19,6 +19,7 @@ import time
 from os import getenv
 from typing import Any, Dict, List, Optional
 
+from agno.knowledge.reader.utils.url_validation import is_host_allowed, validate_allowed_hosts
 from agno.tools import Toolkit
 from agno.utils.log import log_debug, log_error
 
@@ -34,6 +35,15 @@ except ImportError:
     raise ImportError("`scrapegraph-py` not installed. Please install using `pip install scrapegraph-py`")
 
 
+SENSITIVE_FETCH_HEADERS = {
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "x-api-key",
+    "x-auth-token",
+}
+
+
 class ScrapeGraphTools(Toolkit):
     def __init__(
         self,
@@ -45,6 +55,7 @@ class ScrapeGraphTools(Toolkit):
         enable_scrape: bool = False,
         render_heavy_js: bool = False,
         headers: Optional[Dict[str, str]] = None,
+        allowed_hosts: Optional[List[str]] = None,
         crawl_poll_interval: int = 3,
         crawl_max_wait: int = 180,
         all: bool = False,
@@ -60,7 +71,8 @@ class ScrapeGraphTools(Toolkit):
             enable_crawl (bool): Enable multi-page crawl with structured extraction. Defaults to False.
             enable_scrape (bool): Enable raw HTML scraping. Defaults to False.
             render_heavy_js (bool): Request JavaScript rendering on every call. Defaults to False.
-            headers (Optional[Dict[str, str]]): Custom HTTP headers to send with every outbound fetch (e.g. User-Agent, Cookie, Authorization). Applied to every tool call when set. Defaults to None.
+            headers (Optional[Dict[str, str]]): Custom HTTP headers to send with outbound fetches. Sensitive headers such as Cookie and Authorization are only sent to allowed_hosts when configured. Defaults to None.
+            allowed_hosts (Optional[List[str]]): Hostnames allowed to receive sensitive headers. Defaults to None.
             crawl_poll_interval (int): Seconds between crawl status polls. Defaults to 3. Raise this for very large crawls.
             crawl_max_wait (int): Max seconds to wait for a crawl to complete. Defaults to 180. Raise this if your crawls legitimately take longer.
             all (bool): Enable all tools. Defaults to False.
@@ -72,6 +84,7 @@ class ScrapeGraphTools(Toolkit):
         self.client: ScrapeGraphAI = ScrapeGraphAI(api_key=self.api_key)
         self.render_heavy_js: bool = render_heavy_js
         self.headers: Optional[Dict[str, str]] = headers
+        self.allowed_hosts: Optional[List[str]] = validate_allowed_hosts(allowed_hosts)
         self.crawl_poll_interval: int = crawl_poll_interval
         self.crawl_max_wait: int = crawl_max_wait
 
@@ -89,12 +102,24 @@ class ScrapeGraphTools(Toolkit):
 
         super().__init__(name="scrapegraph_tools", tools=tools, **kwargs)
 
-    def _fetch_config(self) -> Optional[FetchConfig]:
+    def _headers_for_url(self, url: Optional[str] = None) -> Optional[Dict[str, str]]:
+        if not self.headers:
+            return None
+        if url is not None and self.allowed_hosts is not None and is_host_allowed(url, self.allowed_hosts):
+            return self.headers
+
+        safe_headers = {
+            name: value for name, value in self.headers.items() if name.lower() not in SENSITIVE_FETCH_HEADERS
+        }
+        return safe_headers or None
+
+    def _fetch_config(self, url: Optional[str] = None) -> Optional[FetchConfig]:
         config_kwargs: Dict[str, Any] = {}
         if self.render_heavy_js:
             config_kwargs["mode"] = "js"
-        if self.headers:
-            config_kwargs["headers"] = self.headers
+        headers = self._headers_for_url(url)
+        if headers:
+            config_kwargs["headers"] = headers
         return FetchConfig(**config_kwargs) if config_kwargs else None
 
     def smartscraper(self, url: str, prompt: str) -> str:
@@ -109,7 +134,7 @@ class ScrapeGraphTools(Toolkit):
         """
         try:
             log_debug(f"ScrapeGraph smartscraper request for URL: {url}")
-            response = self.client.extract(prompt=prompt, url=url, fetch_config=self._fetch_config())
+            response = self.client.extract(prompt=prompt, url=url, fetch_config=self._fetch_config(url))
             if response.status != "success" or response.data is None:
                 return f"Error extracting from {url}: {response.error or 'unknown error'}"
             payload = response.data.json_data if response.data.json_data is not None else response.data.raw
@@ -131,7 +156,7 @@ class ScrapeGraphTools(Toolkit):
             response = self.client.scrape(
                 url,
                 formats=[MarkdownFormatConfig()],
-                fetch_config=self._fetch_config(),
+                fetch_config=self._fetch_config(url),
             )
             if response.status != "success" or response.data is None:
                 return f"Error converting {url} to markdown: {response.error or 'unknown error'}"
@@ -189,7 +214,7 @@ class ScrapeGraphTools(Toolkit):
                 formats=[JsonFormatConfig(prompt=prompt, schema=schema)],
                 max_depth=max_depth,
                 max_pages=max_pages,
-                fetch_config=self._fetch_config(),
+                fetch_config=self._fetch_config(url),
             )
             if start_response.status != "success" or start_response.data is None:
                 return f"Error starting crawl of {url}: {start_response.error or 'unknown error'}"
@@ -224,7 +249,7 @@ class ScrapeGraphTools(Toolkit):
             response = self.client.scrape(
                 url,
                 formats=[HtmlFormatConfig()],
-                fetch_config=self._fetch_config(),
+                fetch_config=self._fetch_config(url),
             )
             if response.status != "success" or response.data is None:
                 return f"Error scraping {url}: {response.error or 'unknown error'}"

--- a/libs/agno/tests/unit/tools/test_scrapegraph.py
+++ b/libs/agno/tests/unit/tools/test_scrapegraph.py
@@ -1,10 +1,48 @@
 import json
 import os
+import sys
+import types
 from unittest.mock import Mock, patch
 
 import pytest
 
-pytest.importorskip("scrapegraph_py")
+
+class FakeFetchConfig:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class FakeFormatConfig:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class FakeHtmlFormatConfig(FakeFormatConfig):
+    type = "html"
+
+
+class FakeJsonFormatConfig(FakeFormatConfig):
+    type = "json"
+
+
+class FakeMarkdownFormatConfig(FakeFormatConfig):
+    type = "markdown"
+
+
+class FakeScrapeGraphAI:
+    def __init__(self, api_key):
+        self.api_key = api_key
+
+
+fake_scrapegraph_py = types.ModuleType("scrapegraph_py")
+fake_scrapegraph_py.FetchConfig = FakeFetchConfig
+fake_scrapegraph_py.HtmlFormatConfig = FakeHtmlFormatConfig
+fake_scrapegraph_py.JsonFormatConfig = FakeJsonFormatConfig
+fake_scrapegraph_py.MarkdownFormatConfig = FakeMarkdownFormatConfig
+fake_scrapegraph_py.ScrapeGraphAI = FakeScrapeGraphAI
+sys.modules["scrapegraph_py"] = fake_scrapegraph_py
 
 from agno.tools.scrapegraph import ScrapeGraphTools  # noqa: E402
 
@@ -192,6 +230,51 @@ def test_toolkit_level_headers_applied_to_every_call(mock_scrapegraph):
         tools.scrape("https://x.com")
         _, scrape_kwargs = mock_scrapegraph.scrape.call_args
         assert scrape_kwargs["fetch_config"].headers == {"User-Agent": "custom-ua"}
+
+
+def test_sensitive_headers_are_not_forwarded_without_allowed_host(mock_scrapegraph):
+    """Sensitive headers should not be reused on arbitrary tool-call URLs."""
+    with patch.dict("os.environ", {"SGAI_API_KEY": TEST_API_KEY}):
+        tools = ScrapeGraphTools(
+            headers={
+                "Authorization": "Bearer site-secret",
+                "Cookie": "sid=secret",
+                "User-Agent": "custom-ua",
+            }
+        )
+        tools.client = mock_scrapegraph
+
+        data = Mock()
+        data.json_data = {"ok": True}
+        data.raw = None
+        mock_scrapegraph.extract.return_value = _api_result(data)
+
+        tools.smartscraper("https://untrusted.example/page", "extract")
+
+        _, kwargs = mock_scrapegraph.extract.call_args
+        assert kwargs["fetch_config"].headers == {"User-Agent": "custom-ua"}
+
+
+def test_sensitive_headers_are_forwarded_to_allowed_host(mock_scrapegraph):
+    """Sensitive headers may be sent when the URL host is explicitly allowed."""
+    headers = {
+        "Authorization": "Bearer site-secret",
+        "Cookie": "sid=secret",
+        "User-Agent": "custom-ua",
+    }
+    with patch.dict("os.environ", {"SGAI_API_KEY": TEST_API_KEY}):
+        tools = ScrapeGraphTools(headers=headers, allowed_hosts=["docs.example.com"])
+        tools.client = mock_scrapegraph
+
+        data = Mock()
+        data.json_data = {"ok": True}
+        data.raw = None
+        mock_scrapegraph.extract.return_value = _api_result(data)
+
+        tools.smartscraper("https://docs.example.com/page", "extract")
+
+        _, kwargs = mock_scrapegraph.extract.call_args
+        assert kwargs["fetch_config"].headers == headers
 
 
 def test_scrape_error(scrapegraph_tools, mock_scrapegraph):


### PR DESCRIPTION
## Summary
- add `allowed_hosts` for ScrapeGraphTools sensitive fetch headers
- strip Authorization/Cookie-style headers unless the target URL host is explicitly allowed
- keep non-sensitive headers such as User-Agent flowing by default
- make ScrapeGraph unit tests use a local SDK stub and add regression coverage

Fixes #8620

## Tests
- `.venv-py/bin/python -m pytest tests/unit/tools/test_scrapegraph.py -q`
- `.venv-py/bin/python -m ruff check agno/tools/scrapegraph.py tests/unit/tools/test_scrapegraph.py`
- `.venv-py/bin/python -m ruff format --check agno/tools/scrapegraph.py tests/unit/tools/test_scrapegraph.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/tools/scrapegraph.py tests/unit/tools/test_scrapegraph.py`
- `git diff --check`