### PR TITLE
fix(agent): emit native reasoning deltas from model chunks

### DIFF
--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1199,6 +1199,17 @@ def handle_model_response_stream(
                 events_to_skip=agent.events_to_skip,  # type: ignore
                 store_events=agent.store_events,
             )
+        elif run_response.reasoning_content:
+            yield handle_event(  # type: ignore
+                create_reasoning_completed_event(
+                    from_run_response=run_response,
+                    content=run_response.reasoning_content,
+                    content_type="str",
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,  # type: ignore
+                store_events=agent.store_events,
+            )
 
     # Update the run_response audio if streaming
     if model_response.audio is not None:
@@ -1361,6 +1372,17 @@ async def ahandle_model_response_stream(
                 events_to_skip=agent.events_to_skip,  # type: ignore
                 store_events=agent.store_events,
             )
+        elif run_response.reasoning_content:
+            yield handle_event(  # type: ignore
+                create_reasoning_completed_event(
+                    from_run_response=run_response,
+                    content=run_response.reasoning_content,
+                    content_type="str",
+                ),
+                run_response,
+                events_to_skip=agent.events_to_skip,  # type: ignore
+                store_events=agent.store_events,
+            )
 
     # Update the run_response audio if streaming
     if model_response.audio is not None:
@@ -1429,11 +1451,13 @@ def handle_model_response_chunk(
                     run_response.content_type = "str"
 
             # Process reasoning content
+            reasoning_content_delta = ""
             if model_response_event.reasoning_content is not None:
                 model_response.reasoning_content = (
                     model_response.reasoning_content or ""
                 ) + model_response_event.reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
+                reasoning_content_delta += model_response_event.reasoning_content
 
             if model_response_event.redacted_reasoning_content is not None:
                 if not model_response.reasoning_content:
@@ -1441,6 +1465,29 @@ def handle_model_response_chunk(
                 else:
                     model_response.reasoning_content += model_response_event.redacted_reasoning_content
                 run_response.reasoning_content = model_response.reasoning_content
+                reasoning_content_delta += model_response_event.redacted_reasoning_content
+
+            emitted_reasoning_delta = False
+            if stream_events and reasoning_content_delta:
+                if reasoning_state and not reasoning_state["reasoning_started"]:
+                    yield handle_event(  # type: ignore
+                        create_reasoning_started_event(from_run_response=run_response),
+                        run_response,
+                        events_to_skip=agent.events_to_skip,  # type: ignore
+                        store_events=agent.store_events,
+                    )
+                    reasoning_state["reasoning_started"] = True
+
+                yield handle_event(  # type: ignore
+                    create_reasoning_content_delta_event(
+                        from_run_response=run_response,
+                        reasoning_content=reasoning_content_delta,
+                    ),
+                    run_response,
+                    events_to_skip=agent.events_to_skip,  # type: ignore
+                    store_events=agent.store_events,
+                )
+                emitted_reasoning_delta = True
 
             # Handle provider data (one chunk)
             if model_response_event.provider_data is not None:
@@ -1464,8 +1511,13 @@ def handle_model_response_chunk(
                 )
             elif (
                 model_response_event.content is not None
-                or model_response_event.reasoning_content is not None
-                or model_response_event.redacted_reasoning_content is not None
+                or (
+                    not emitted_reasoning_delta
+                    and (
+                        model_response_event.reasoning_content is not None
+                        or model_response_event.redacted_reasoning_content is not None
+                    )
+                )
                 or model_response_event.citations is not None
                 or model_response_event.provider_data is not None
             ):
@@ -1473,8 +1525,10 @@ def handle_model_response_chunk(
                     create_run_output_content_event(
                         from_run_response=run_response,
                         content=model_response_event.content,
-                        reasoning_content=model_response_event.reasoning_content,
-                        redacted_reasoning_content=model_response_event.redacted_reasoning_content,
+                        reasoning_content=None if emitted_reasoning_delta else model_response_event.reasoning_content,
+                        redacted_reasoning_content=None
+                        if emitted_reasoning_delta
+                        else model_response_event.redacted_reasoning_content,
                         citations=model_response_event.citations,
                         model_provider_data=model_response_event.provider_data,
                     ),

--- a/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
+++ b/libs/agno/tests/unit/reasoning/test_reasoning_streaming.py
@@ -4,13 +4,16 @@ These tests verify that reasoning_content_delta events are properly emitted
 during streaming reasoning, without requiring actual API calls.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from agno.models.message import Message
+from agno.models.response import ModelResponse, ModelResponseEvent
 from agno.reasoning.step import ReasoningStep, ReasoningSteps
-from agno.run.agent import RunEvent
+from agno.run.agent import RunEvent, RunOutput
+from agno.run.messages import RunMessages
 
 # ============================================================================
 # Test RunEvent enum has required events
@@ -223,6 +226,98 @@ def test_reasoning_event_string_values():
     assert RunEvent.reasoning_started.value == "ReasoningStarted"
     assert RunEvent.reasoning_content_delta.value == "ReasoningContentDelta"
     assert RunEvent.reasoning_completed.value == "ReasoningCompleted"
+
+
+def test_model_response_reasoning_content_emits_native_delta_event():
+    """Streaming model reasoning chunks should enter the native reasoning event pipeline."""
+    from agno.agent._response import handle_model_response_chunk
+
+    agent = SimpleNamespace(id="agent-id", name="Agent", events_to_skip=[], store_events=False)
+    session = SimpleNamespace(session_id="session-id")
+    run_response = RunOutput(run_id="run-id", agent_id="agent-id", agent_name="Agent", session_id="session-id")
+    model_response = ModelResponse()
+    reasoning_state = {"reasoning_started": False, "reasoning_time_taken": 0.0}
+
+    events = list(
+        handle_model_response_chunk(
+            agent=agent,
+            session=session,  # type: ignore[arg-type]
+            run_response=run_response,
+            model_response=model_response,
+            model_response_event=ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                reasoning_content="The user ",
+            ),
+            reasoning_state=reasoning_state,
+            stream_events=True,
+        )
+    )
+
+    assert [event.event for event in events[:2]] == [
+        RunEvent.reasoning_started.value,
+        RunEvent.reasoning_content_delta.value,
+    ]
+    assert events[1].reasoning_content == "The user "  # type: ignore[attr-defined]
+    assert run_response.reasoning_content == "The user "
+    assert reasoning_state["reasoning_started"] is True
+
+
+@patch("agno.agent._response.call_model_stream_with_fallback")
+def test_model_response_stream_completes_native_reasoning_content(mock_call_model_stream):
+    """Native reasoning content from the model stream should get a completed event."""
+    from agno.agent._response import handle_model_response_stream
+
+    agent = SimpleNamespace(
+        id="agent-id",
+        name="Agent",
+        model=SimpleNamespace(id="compatible-reasoner", provider="OpenAILike"),
+        fallback_config=None,
+        parse_response=False,
+        parser_model=None,
+        tool_choice=None,
+        tool_call_limit=None,
+        send_media_to_model=True,
+        compress_tool_results=False,
+        compression_manager=None,
+        checkpoint=None,
+        events_to_skip=[],
+        store_events=False,
+    )
+    session = SimpleNamespace(session_id="session-id")
+    run_response = RunOutput(run_id="run-id", agent_id="agent-id", agent_name="Agent", session_id="session-id")
+    run_messages = RunMessages(messages=[Message(role="user", content="Hi")])
+    mock_call_model_stream.return_value = iter(
+        [
+            ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                reasoning_content="Thinking ",
+            ),
+            ModelResponse(
+                event=ModelResponseEvent.assistant_response.value,
+                content="Hello",
+            ),
+        ]
+    )
+
+    events = list(
+        handle_model_response_stream(
+            agent=agent,  # type: ignore[arg-type]
+            session=session,  # type: ignore[arg-type]
+            run_response=run_response,
+            run_messages=run_messages,
+            stream_events=True,
+        )
+    )
+
+    assert [event.event for event in events] == [
+        RunEvent.reasoning_started.value,
+        RunEvent.reasoning_content_delta.value,
+        RunEvent.run_content.value,
+        RunEvent.reasoning_completed.value,
+    ]
+    assert events[-1].content == "Thinking "  # type: ignore[attr-defined]
+    assert run_response.reasoning_content == "Thinking "
+    assert run_response.content == "Hello"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- route streamed `ModelResponse.reasoning_content` chunks through the native reasoning event pipeline
- emit `ReasoningStarted`, `ReasoningContentDelta`, and text-backed `ReasoningCompleted` for native model reasoning streams without reasoning steps
- avoid duplicating reasoning-only chunks as ordinary `RunContent` events while preserving normal text content streaming
- add regression coverage for chunk-level and stream-level reasoning events

Fixes #8400

## Tests
- `.venv-py/bin/python -m pytest tests/unit/reasoning -q`
- `.venv-py/bin/python -m pytest tests/unit/app/test_agui_app.py tests/unit/app/test_agui_reasoning_tools.py -q`
- `.venv-py/bin/python -m ruff check agno/agent/_response.py tests/unit/reasoning/test_reasoning_streaming.py`
- `.venv-py/bin/python -m ruff format --check agno/agent/_response.py tests/unit/reasoning/test_reasoning_streaming.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/agent/_response.py tests/unit/reasoning/test_reasoning_streaming.py`
- `git diff --check`