### PR TITLE
fix(openai): normalize empty tool call arguments

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -310,6 +310,23 @@ class OpenAIChat(Model):
         """
         return cls(**data)
 
+    @staticmethod
+    def _format_tool_calls(tool_calls: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+        if tool_calls is None:
+            return None
+
+        formatted_tool_calls: List[Dict[str, Any]] = []
+        for tool_call in tool_calls:
+            formatted_tool_call = dict(tool_call)
+            function = formatted_tool_call.get("function")
+            if isinstance(function, dict):
+                formatted_function = dict(function)
+                if "arguments" not in formatted_function or formatted_function["arguments"] in (None, ""):
+                    formatted_function["arguments"] = "{}"
+                formatted_tool_call["function"] = formatted_function
+            formatted_tool_calls.append(formatted_tool_call)
+        return formatted_tool_calls
+
     def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
         """
         Format a message into the format expected by OpenAI.
@@ -328,7 +345,7 @@ class OpenAIChat(Model):
             "content": tool_result,
             "name": message.name,
             "tool_call_id": message.tool_call_id,
-            "tool_calls": message.tool_calls,
+            "tool_calls": self._format_tool_calls(message.tool_calls),
         }
         message_dict = {k: v for k, v in message_dict.items() if v is not None}
 

--- a/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
+++ b/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from agno.models.message import Message
 from agno.models.openai.chat import OpenAIChat
 
 
@@ -69,6 +70,48 @@ def test_parse_tool_calls_multiple_tools_independent():
     assert result[0]["function"]["name"] == "tool_a"
     assert result[1]["function"]["name"] == "tool_b"
     assert result[0] is not result[1]
+
+
+def test_format_message_normalizes_empty_tool_call_arguments():
+    """Assistant history must send zero-argument tool calls as a valid JSON object."""
+    model = OpenAIChat(id="gpt-4o")
+    message = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "api_schema_inspect", "arguments": ""},
+            }
+        ],
+    )
+
+    formatted = model._format_message(message)
+
+    assert formatted["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert message.tool_calls[0]["function"]["arguments"] == ""
+
+
+def test_format_message_normalizes_missing_tool_call_arguments():
+    """Missing arguments are equivalent to zero arguments for OpenAI-compatible APIs."""
+    model = OpenAIChat(id="gpt-4o")
+    message = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "api_schema_inspect"},
+            }
+        ],
+    )
+
+    formatted = model._format_message(message)
+
+    assert formatted["tool_calls"][0]["function"]["arguments"] == "{}"
+    assert "arguments" not in message.tool_calls[0]["function"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- format completed assistant tool calls with empty or missing `function.arguments` as `{}`
- keep existing non-empty tool arguments unchanged
- avoid mutating the original `Message.tool_calls` while preparing OpenAI-compatible request payloads
- add regression coverage for zero-argument tool-call history formatting

Fixes #8312

## Tests
- `.venv-py/bin/python -m pytest tests/unit/models/openai/test_parse_tool_calls.py -q`
- `.venv-py/bin/python -m pytest tests/unit/models/openai/test_mixed_external_tools.py -q`
- `.venv-py/bin/python -m pytest tests/unit/models/test_parse_tool_calls_name.py -k openai -q`
- `.venv-py/bin/python -m pytest tests/unit/models/xiaomi/test_mimo.py::test_mimo_formats_reasoning_content_for_assistant_history -q`
- `.venv-py/bin/python -m ruff check agno/models/openai/chat.py tests/unit/models/openai/test_parse_tool_calls.py`
- `.venv-py/bin/python -m ruff format --check agno/models/openai/chat.py tests/unit/models/openai/test_parse_tool_calls.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/models/openai/chat.py tests/unit/models/openai/test_parse_tool_calls.py`
- `git diff --check`