### PR TITLE
fix: merge streamed OpenRouter reasoning_details fragments before replay

### DIFF
--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -12,6 +12,44 @@ from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 
 
+def _merge_streamed_reasoning_details(reasoning_details: List[Any]) -> List[Any]:
+    """Reconstruct complete reasoning detail blocks from streamed fragments.
+
+    OpenRouter streams one reasoning block as multiple fragments sharing the
+    same ``index`` (text arrives in pieces; the signature may arrive in a
+    final text-less fragment). Replaying those fragments verbatim corrupts
+    Anthropic signed thinking blocks, whose signature validates the complete
+    text. Fragments with the same type and index are merged into a single
+    block: ``text`` fields are concatenated, the last non-null ``signature``
+    wins, and other fields keep their first non-null value. Entries without
+    an integer ``index`` (e.g. blocks from non-streaming responses) pass
+    through unchanged.
+    """
+    merged: Dict[Any, Dict[str, Any]] = {}
+    result: List[Any] = []
+    for entry in reasoning_details:
+        if not isinstance(entry, dict) or not isinstance(entry.get("index"), int):
+            result.append(entry)
+            continue
+        key = (entry.get("type"), entry["index"])
+        existing = merged.get(key)
+        if existing is None:
+            fragment = dict(entry)
+            merged[key] = fragment
+            result.append(fragment)
+            continue
+        for field, value in entry.items():
+            if value is None:
+                continue
+            if field == "text":
+                existing["text"] = (existing.get("text") or "") + value
+            elif field == "signature":
+                existing["signature"] = value
+            elif existing.get(field) is None:
+                existing[field] = value
+    return result
+
+
 @dataclass
 class OpenRouter(OpenAILike):
     """
@@ -95,7 +133,9 @@ class OpenRouter(OpenAILike):
 
         if message.role == "assistant" and message.provider_data:
             if message.provider_data.get("reasoning_details"):
-                message_dict["reasoning_details"] = message.provider_data["reasoning_details"]
+                message_dict["reasoning_details"] = _merge_streamed_reasoning_details(
+                    message.provider_data["reasoning_details"]
+                )
 
         return message_dict
 

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_reasoning_details.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_reasoning_details.py
@@ -1,0 +1,105 @@
+"""Tests for merging streamed OpenRouter reasoning_details fragments.
+
+Regression tests for https://github.com/agno-agi/agno/issues/8794: streamed
+reasoning_details fragments were stored and replayed unmerged, which corrupts
+Anthropic signed thinking blocks on the follow-up request of a tool loop.
+"""
+
+from agno.models.message import Message
+from agno.models.openrouter import OpenRouter
+from agno.models.openrouter.openrouter import _merge_streamed_reasoning_details
+
+
+def test_fragments_with_same_index_are_merged():
+    fragments = [
+        {"type": "reasoning.text", "text": "Let", "format": "anthropic-claude-v1", "index": 0},
+        {"type": "reasoning.text", "text": " me compute 17 * 23.", "format": "anthropic-claude-v1", "index": 0},
+        {"type": "reasoning.text", "signature": "Et8BCmUIDxgC", "format": "anthropic-claude-v1", "index": 0},
+    ]
+    merged = _merge_streamed_reasoning_details(fragments)
+    assert merged == [
+        {
+            "type": "reasoning.text",
+            "text": "Let me compute 17 * 23.",
+            "format": "anthropic-claude-v1",
+            "index": 0,
+            "signature": "Et8BCmUIDxgC",
+        }
+    ]
+
+
+def test_multiple_indexes_produce_one_block_each_in_order():
+    fragments = [
+        {"type": "reasoning.text", "text": "first", "index": 0},
+        {"type": "reasoning.text", "text": "second", "index": 1},
+        {"type": "reasoning.text", "text": " block", "index": 0},
+        {"type": "reasoning.text", "signature": "sig-1", "index": 1},
+    ]
+    merged = _merge_streamed_reasoning_details(fragments)
+    assert merged == [
+        {"type": "reasoning.text", "text": "first block", "index": 0},
+        {"type": "reasoning.text", "text": "second", "signature": "sig-1", "index": 1},
+    ]
+
+
+def test_complete_blocks_without_index_pass_through_unchanged():
+    blocks = [
+        {"type": "reasoning.text", "text": "complete block", "signature": "sig"},
+        {"type": "reasoning.encrypted", "data": "opaque"},
+    ]
+    assert _merge_streamed_reasoning_details(blocks) == blocks
+
+
+def test_non_dict_entries_pass_through_unchanged():
+    entries = ["not-a-dict", {"type": "reasoning.text", "text": "x", "index": 0}]
+    merged = _merge_streamed_reasoning_details(entries)
+    assert merged[0] == "not-a-dict"
+    assert merged[1]["text"] == "x"
+
+
+def test_last_signature_wins_and_none_values_ignored():
+    fragments = [
+        {"type": "reasoning.text", "text": "a", "signature": None, "index": 0},
+        {"type": "reasoning.text", "text": None, "signature": "final-sig", "index": 0},
+    ]
+    merged = _merge_streamed_reasoning_details(fragments)
+    assert merged == [{"type": "reasoning.text", "text": "a", "signature": "final-sig", "index": 0}]
+
+
+def test_format_message_replays_merged_reasoning_details():
+    model = OpenRouter(api_key="test-key")
+    message = Message(
+        role="assistant",
+        content="391",
+        provider_data={
+            "reasoning_details": [
+                {"type": "reasoning.text", "text": "Let", "format": "anthropic-claude-v1", "index": 0},
+                {"type": "reasoning.text", "text": " me think.", "format": "anthropic-claude-v1", "index": 0},
+                {"type": "reasoning.text", "signature": "sig", "format": "anthropic-claude-v1", "index": 0},
+            ]
+        },
+    )
+    message_dict = model._format_message(message)
+    assert message_dict["reasoning_details"] == [
+        {
+            "type": "reasoning.text",
+            "text": "Let me think.",
+            "format": "anthropic-claude-v1",
+            "index": 0,
+            "signature": "sig",
+        }
+    ]
+
+
+def test_format_message_does_not_mutate_stored_provider_data():
+    model = OpenRouter(api_key="test-key")
+    original = [
+        {"type": "reasoning.text", "text": "a", "index": 0},
+        {"type": "reasoning.text", "text": "b", "index": 0},
+    ]
+    message = Message(role="assistant", content="x", provider_data={"reasoning_details": original})
+    model._format_message(message)
+    assert message.provider_data["reasoning_details"] == [
+        {"type": "reasoning.text", "text": "a", "index": 0},
+        {"type": "reasoning.text", "text": "b", "index": 0},
+    ]


### PR DESCRIPTION
## Summary

Fixes #8794.

When streaming OpenRouter responses with Anthropic reasoning enabled, each streamed `reasoning_details` fragment was stored on the assistant message as a separate list entry (`_parse_provider_response_delta` emits per-chunk fragments, and `_populate_stream_data`'s list-aware merge extends them into one list). `_format_message` then replayed those partial fragments verbatim on the next request of a tool loop. Anthropic's `signature` validates the complete thinking text, so replaying fragments fails with `messages.1.content.0: Invalid 'signature' in 'thinking' block`.

This PR adds `_merge_streamed_reasoning_details`, which reconstructs one complete block per `(type, index)` before replay: `text` fragments are concatenated in stream order, the last non-null `signature` wins, and other fields keep their first non-null value. Entries without an integer `index` (complete blocks from non-streaming responses) and non-dict entries pass through unchanged. Merging happens at replay time in `_format_message`, so previously persisted sessions containing fragmented `reasoning_details` are also repaired on their next request, and the stored provider_data is not mutated.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

New unit tests in `libs/agno/tests/unit/models/openrouter_model/test_openrouter_reasoning_details.py` cover: same-index fragment merging (text concat + trailing signature-only fragment), multiple indexes preserving order, pass-through of complete blocks without `index` and non-dict entries, None-value handling, replay through `_format_message`, and no mutation of stored `provider_data`. All 19 openrouter_model unit tests pass. `./scripts/format.sh` is clean; `./scripts/validate.sh` reports the same pre-existing mypy errors on this branch as on current main (none in the changed lines; verified identical error counts for this file on both).

This PR was generated with Claude Code, driven and reviewed by @AnayGarodia.
