### PR TITLE
fix(models): isolate HITL user input schemas

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import json
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field
 from hashlib import md5
 from pathlib import Path
@@ -2347,7 +2348,7 @@ class Model(ABC):
 
             # The function requires user input (HITL)
             if fc.function.requires_user_input:
-                user_input_schema = fc.function.user_input_schema
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:
@@ -2544,7 +2545,7 @@ class Model(ABC):
                 )
             # If the function requires user input, we yield a message to the user
             if fc.function.requires_user_input and not skip_pause_check:
-                user_input_schema = fc.function.user_input_schema
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:

--- a/libs/agno/tests/unit/models/test_hitl_user_input_schema.py
+++ b/libs/agno/tests/unit/models/test_hitl_user_input_schema.py
@@ -1,0 +1,54 @@
+import pytest
+
+from agno.models.openai.chat import OpenAIChat
+from agno.models.response import ModelResponseEvent
+from agno.tools.function import Function, FunctionCall, UserInputField
+
+
+def _hitl_function_calls():
+    function = Function(
+        name="submit_comment",
+        requires_user_input=True,
+        user_input_schema=[UserInputField(name="content", field_type=str, description="Comment")],
+    )
+    return [
+        FunctionCall(function=function, arguments={"content": "first"}, call_id="call_1"),
+        FunctionCall(function=function, arguments={"content": "second"}, call_id="call_2"),
+    ], function
+
+
+def _paused_tool_executions(responses):
+    return [
+        response.tool_executions[0] for response in responses if response.event == ModelResponseEvent.tool_call_paused
+    ]
+
+
+def test_parallel_hitl_function_calls_get_independent_user_input_schemas():
+    model = OpenAIChat(id="gpt-4o", api_key="test")
+    function_calls, function = _hitl_function_calls()
+
+    responses = list(model.run_function_calls(function_calls, function_call_results=[]))
+    paused_tools = _paused_tool_executions(responses)
+
+    assert len(paused_tools) == 2
+    assert paused_tools[0].user_input_schema is not paused_tools[1].user_input_schema
+    assert paused_tools[0].user_input_schema[0] is not paused_tools[1].user_input_schema[0]
+    assert paused_tools[0].user_input_schema[0].value == "first"
+    assert paused_tools[1].user_input_schema[0].value == "second"
+    assert function.user_input_schema[0].value is None
+
+
+@pytest.mark.asyncio
+async def test_parallel_hitl_function_calls_get_independent_user_input_schemas_async():
+    model = OpenAIChat(id="gpt-4o", api_key="test")
+    function_calls, function = _hitl_function_calls()
+
+    responses = [response async for response in model.arun_function_calls(function_calls, function_call_results=[])]
+    paused_tools = _paused_tool_executions(responses)
+
+    assert len(paused_tools) == 2
+    assert paused_tools[0].user_input_schema is not paused_tools[1].user_input_schema
+    assert paused_tools[0].user_input_schema[0] is not paused_tools[1].user_input_schema[0]
+    assert paused_tools[0].user_input_schema[0].value == "first"
+    assert paused_tools[1].user_input_schema[0].value == "second"
+    assert function.user_input_schema[0].value is None


### PR DESCRIPTION
## Summary
- deep-copy HITL `user_input_schema` before applying per-call argument values
- apply the same isolation in sync and async function-call pause paths
- keep the registered `Function.user_input_schema` pristine across parallel calls
- add regression coverage for two same-function HITL calls with different values

Fixes #8546

## Tests
- `.venv-py/bin/python -m pytest tests/unit/models/test_hitl_user_input_schema.py -q`
- `.venv-py/bin/python -m pytest tests/unit/tools/test_functions.py -q`
- `.venv-py/bin/python -m pytest tests/unit/team/test_continue_run_requirements.py tests/unit/team/test_run_requirement_fixes.py -q`
- `.venv-py/bin/python -m ruff check agno/models/base.py tests/unit/models/test_hitl_user_input_schema.py`
- `.venv-py/bin/python -m ruff format --check agno/models/base.py tests/unit/models/test_hitl_user_input_schema.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/models/base.py tests/unit/models/test_hitl_user_input_schema.py`
- `git diff --check`