### PR TITLE
fix(remote-agent): accept list tool configs

### DIFF
--- a/libs/agno/agno/agent/remote.py
+++ b/libs/agno/agno/agent/remote.py
@@ -157,15 +157,28 @@ class RemoteAgent(BaseRemote):
             return self._agent_config.role
         return None
 
+    def _parse_tools_config(self) -> Optional[List[Dict[str, Any]]]:
+        agent_config = self._agent_config
+        if agent_config is None or agent_config.tools is None:
+            return None
+
+        tools_config = agent_config.tools.get("tools")
+        if tools_config is None:
+            return None
+        if isinstance(tools_config, str):
+            tools_config = json.loads(tools_config)
+        if isinstance(tools_config, list):
+            return tools_config
+
+        raise TypeError(f"Expected tools config to be a list or JSON string, got {type(tools_config).__name__}")
+
     @property
     def tools(self) -> Optional[List[Dict[str, Any]]]:
-        if self._agent_config is not None:
-            try:
-                return json.loads(self._agent_config.tools["tools"]) if self._agent_config.tools else None
-            except Exception as e:
-                log_warning(f"Failed to load tools for agent {self.agent_id}: {str(e)}")
-                return None
-        return None
+        try:
+            return self._parse_tools_config()
+        except Exception as e:
+            log_warning(f"Failed to load tools for agent {self.agent_id}: {str(e)}")
+            return None
 
     @property
     def db(self) -> Optional[RemoteDb]:
@@ -203,9 +216,11 @@ class RemoteAgent(BaseRemote):
         return None
 
     async def aget_tools(self, **kwargs: Any) -> List[Dict]:
-        if self._agent_config is not None and self._agent_config.tools is not None:
-            return json.loads(self._agent_config.tools["tools"])
-        return []
+        try:
+            return self._parse_tools_config() or []
+        except Exception as e:
+            log_warning(f"Failed to load tools for agent {self.agent_id}: {str(e)}")
+            return []
 
     @overload
     async def arun(

--- a/libs/agno/tests/unit/agent/test_remote_agent_tools.py
+++ b/libs/agno/tests/unit/agent/test_remote_agent_tools.py
@@ -1,0 +1,38 @@
+import json
+import time
+
+import pytest
+
+from agno.agent.remote import RemoteAgent
+from agno.os.routers.agents.schema import AgentResponse
+
+
+def _remote_agent_with_tools(tools_value):
+    remote_agent = RemoteAgent(base_url="http://example.invalid", agent_id="remote-agent")
+    remote_agent._cached_agent_config = (
+        AgentResponse(id="remote-agent", tools={"tools": tools_value}),
+        time.time(),
+    )
+    return remote_agent
+
+
+def test_remote_agent_tools_accepts_list_config():
+    tools = [{"name": "search", "description": "Search things"}]
+    remote_agent = _remote_agent_with_tools(tools)
+
+    assert remote_agent.tools == tools
+
+
+def test_remote_agent_tools_accepts_json_string_config():
+    tools = [{"name": "search", "description": "Search things"}]
+    remote_agent = _remote_agent_with_tools(json.dumps(tools))
+
+    assert remote_agent.tools == tools
+
+
+@pytest.mark.asyncio
+async def test_remote_agent_aget_tools_accepts_list_config():
+    tools = [{"name": "search", "description": "Search things"}]
+    remote_agent = _remote_agent_with_tools(tools)
+
+    assert await remote_agent.aget_tools() == tools


### PR DESCRIPTION
## Summary
- accept remote agent tool configs when AgentOS returns an already-decoded list
- keep backwards compatibility with JSON-string tool configs
- share parsing between the sync `tools` property and async `aget_tools()` path
- add regression coverage for list and JSON-string tool configs

Fixes #6274

## Tests
- `.venv-py/bin/python -m pytest tests/unit/agent/test_remote_agent_tools.py -q`
- `.venv-py/bin/python -m pytest tests/unit/team/test_remote_team.py -q`
- `.venv-py/bin/python -m ruff check agno/agent/remote.py tests/unit/agent/test_remote_agent_tools.py`
- `.venv-py/bin/python -m ruff format --check agno/agent/remote.py tests/unit/agent/test_remote_agent_tools.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/agent/remote.py tests/unit/agent/test_remote_agent_tools.py`
- `git diff --check`