### PR TITLE
Fix RemoteTeam member delegation

### DIFF
--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -11,6 +11,7 @@ import asyncio
 import contextlib
 import json
 from copy import copy
+from inspect import isawaitable
 from typing import (
     Any,
     AsyncIterator,
@@ -113,6 +114,12 @@ async def _acascading_cancel_run(run_id: str) -> bool:
     from agno.team._run import acancel_run as _team_acancel_run
 
     return await _team_acancel_run(run_id)
+
+
+async def _await_if_needed(value: Any) -> Any:
+    if isawaitable(value):
+        return await value
+    return value
 
 
 def _get_update_user_memory_function(team: "Team", user_id: Optional[str] = None, async_mode: bool = False) -> Function:
@@ -833,6 +840,7 @@ def _get_delegate_task_function(
                     run_id=member_run_id,
                     yield_run_output=True,
                 )
+                member_agent_run_response_stream = await _await_if_needed(member_agent_run_response_stream)
                 draining_after_cancel = False
                 async for member_agent_run_response_event in member_agent_run_response_stream:
                     # Do NOT break out of the loop, AsyncIterator need to exit properly
@@ -1177,6 +1185,7 @@ def _get_delegate_task_function(
                     run_id=member_run_id,
                     yield_run_output=True,
                 )
+                member_stream = await _await_if_needed(member_stream)
                 member_agent_run_response = None
                 try:
                     try:

--- a/libs/agno/agno/team/_task_tools.py
+++ b/libs/agno/agno/team/_task_tools.py
@@ -57,6 +57,7 @@ from agno.run.team import (
 from agno.session import TeamSession
 from agno.team._default_tools import (
     _acascading_cancel_run,
+    _await_if_needed,
     _cascading_cancel_run,
 )
 from agno.team.task import TaskList, TaskStatus, save_task_list
@@ -647,6 +648,7 @@ def _get_task_management_tools(
                     run_id=member_run_id,
                     yield_run_output=True,
                 )
+                member_stream = await _await_if_needed(member_stream)
                 draining_after_cancel = False
                 async for event in member_stream:
                     if isinstance(event, (TeamRunOutput, RunOutput)):

--- a/libs/agno/agno/team/remote.py
+++ b/libs/agno/agno/team/remote.py
@@ -23,6 +23,16 @@ class RemoteTeam(BaseRemote):
 
     knowledge_filters: Optional[Dict[str, Any]] = None
     enable_agentic_knowledge_filters: Optional[bool] = False
+    output_schema: Optional[Any] = None
+    store_media: bool = True
+    store_tool_messages: bool = True
+    store_history_messages: bool = False
+    send_media_to_model: bool = True
+    add_history_to_context: bool = False
+    num_history_runs: Optional[int] = None
+    num_history_messages: Optional[int] = None
+    debug_mode: bool = False
+    debug_level: Literal[1, 2] = 1
 
     def __init__(
         self,

--- a/libs/agno/tests/unit/team/test_remote_team.py
+++ b/libs/agno/tests/unit/team/test_remote_team.py
@@ -1,4 +1,14 @@
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agno.os.routers.teams.schema import TeamResponse
+from agno.run import RunContext
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
 from agno.team.remote import RemoteTeam
+from agno.team.team import Team
 
 
 def test_remote_team_exposes_knowledge_filter_attributes() -> None:
@@ -8,3 +18,64 @@ def test_remote_team_exposes_knowledge_filter_attributes() -> None:
     assert remote_team.knowledge_filters is None
     assert remote_team.enable_agentic_knowledge_filters is False
     assert (not remote_team.knowledge_filters and remote_team.knowledge) is None
+
+
+def _make_remote_team() -> RemoteTeam:
+    remote_team = RemoteTeam(base_url="http://example.invalid", team_id="remote-team")
+    remote_team._cached_team_config = (
+        TeamResponse(id="remote-team", name="Remote Team", description="Delegates to a remote team"),
+        time.time(),
+    )
+    return remote_team
+
+
+def _make_delegate_function(remote_team: RemoteTeam, *, stream: bool = False):
+    team = Team(id="local-team", members=[remote_team])
+    return team._get_delegate_task_function(
+        session=TeamSession(session_id="test-session"),
+        run_response=TeamRunOutput(run_id="parent-run", team_id="local-team"),
+        run_context=RunContext(session_state={}, run_id="parent-run", session_id="test-session"),
+        team_run_context={},
+        stream=stream,
+        async_mode=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_delegate_to_remote_team_member() -> None:
+    remote_team = _make_remote_team()
+    remote_team.arun = AsyncMock(
+        return_value=TeamRunOutput(run_id="remote-run", team_id="remote-team", content="remote answer")
+    )
+
+    delegate_function = _make_delegate_function(remote_team)
+
+    response = [
+        item
+        async for item in delegate_function.entrypoint(member_id="remote-team", task="Ask the remote team")  # type: ignore[misc]
+    ]
+
+    assert response == ["remote answer"]
+    remote_team.arun.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_delegate_awaits_remote_team_stream_coroutine() -> None:
+    remote_team = _make_remote_team()
+
+    async def remote_stream():
+        yield TeamRunOutput(run_id="remote-stream-run", team_id="remote-team", content="streamed answer")
+
+    async def remote_arun(**kwargs):
+        return remote_stream()
+
+    remote_team.arun = remote_arun  # type: ignore[method-assign]
+
+    delegate_function = _make_delegate_function(remote_team, stream=True)
+
+    response = [
+        item
+        async for item in delegate_function.entrypoint(member_id="remote-team", task="Ask the remote team")  # type: ignore[misc]
+    ]
+
+    assert response == []


### PR DESCRIPTION
Summary:
- add RemoteTeam member defaults used by team delegation cleanup and storage handling
- await coroutine-returned member streams before async iteration in team and task delegation
- cover async RemoteTeam member delegation, including coroutine-returned streams

Tests:
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/team/test_remote_team.py -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/team/test_remote_team.py tests/unit/team/test_delegate_closure_bug.py -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/team/test_team_mode.py tests/unit/team/test_task_model.py -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/team/test_continue_run_requirements.py -q
- .venv-py/bin/python -m ruff check agno/team/remote.py agno/team/_default_tools.py agno/team/_task_tools.py tests/unit/team/test_remote_team.py
- .venv-py/bin/python -m ruff format --check agno/team/remote.py agno/team/_default_tools.py agno/team/_task_tools.py tests/unit/team/test_remote_team.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/team/remote.py agno/team/_default_tools.py agno/team/_task_tools.py tests/unit/team/test_remote_team.py
- git diff --check

Fixes #6206