### PR TITLE
Cache Postgres table lookups

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -334,130 +334,41 @@ class AsyncPostgresDb(AsyncBaseDb):
             raise
 
     async def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
-        if table_type == "sessions":
-            self.session_table = await self._get_or_create_table(
-                table_name=self.session_table_name,
-                table_type="sessions",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.session_table
+        table_config = {
+            "sessions": ("session_table", self.session_table_name),
+            "memories": ("memory_table", self.memory_table_name),
+            "metrics": ("metrics_table", self.metrics_table_name),
+            "evals": ("eval_table", self.eval_table_name),
+            "knowledge": ("knowledge_table", self.knowledge_table_name),
+            "culture": ("culture_table", self.culture_table_name),
+            "versions": ("versions_table", self.versions_table_name),
+            "traces": ("traces_table", self.trace_table_name),
+            "spans": ("spans_table", self.span_table_name),
+            "learnings": ("learnings_table", self.learnings_table_name),
+            "schedules": ("schedules_table", self.schedules_table_name),
+            "schedule_runs": ("schedule_runs_table", self.schedule_runs_table_name),
+            "approvals": ("approvals_table", self.approvals_table_name),
+            "auth_tokens": ("auth_tokens_table", self.auth_tokens_table_name),
+            "service_accounts": ("service_accounts_table", self.service_accounts_table_name),
+        }
+        if table_type not in table_config:
+            raise ValueError(f"Unknown table type: {table_type}")
 
-        if table_type == "memories":
-            self.memory_table = await self._get_or_create_table(
-                table_name=self.memory_table_name,
-                table_type="memories",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.memory_table
+        table_attr, table_name = table_config[table_type]
+        cached_table = getattr(self, table_attr, None)
+        if cached_table is not None:
+            return cached_table
 
-        if table_type == "metrics":
-            self.metrics_table = await self._get_or_create_table(
-                table_name=self.metrics_table_name,
-                table_type="metrics",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.metrics_table
+        if table_type == "spans" and create_table_if_not_found:
+            await self._get_table(table_type="traces", create_table_if_not_found=True)
 
-        if table_type == "evals":
-            self.eval_table = await self._get_or_create_table(
-                table_name=self.eval_table_name,
-                table_type="evals",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.eval_table
-
-        if table_type == "knowledge":
-            self.knowledge_table = await self._get_or_create_table(
-                table_name=self.knowledge_table_name,
-                table_type="knowledge",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.knowledge_table
-
-        if table_type == "culture":
-            self.culture_table = await self._get_or_create_table(
-                table_name=self.culture_table_name,
-                table_type="culture",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.culture_table
-
-        if table_type == "versions":
-            self.versions_table = await self._get_or_create_table(
-                table_name=self.versions_table_name,
-                table_type="versions",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.versions_table
-
-        if table_type == "traces":
-            self.traces_table = await self._get_or_create_table(
-                table_name=self.trace_table_name,
-                table_type="traces",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.traces_table
-
-        if table_type == "spans":
-            # Ensure traces table exists first (spans has FK to traces)
-            if create_table_if_not_found:
-                await self._get_table(table_type="traces", create_table_if_not_found=True)
-            self.spans_table = await self._get_or_create_table(
-                table_name=self.span_table_name,
-                table_type="spans",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.spans_table
-
-        if table_type == "learnings":
-            self.learnings_table = await self._get_or_create_table(
-                table_name=self.learnings_table_name,
-                table_type="learnings",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.learnings_table
-
-        if table_type == "schedules":
-            self.schedules_table = await self._get_or_create_table(
-                table_name=self.schedules_table_name,
-                table_type="schedules",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.schedules_table
-
-        if table_type == "schedule_runs":
-            self.schedule_runs_table = await self._get_or_create_table(
-                table_name=self.schedule_runs_table_name,
-                table_type="schedule_runs",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.schedule_runs_table
-
-        if table_type == "approvals":
-            self.approvals_table = await self._get_or_create_table(
-                table_name=self.approvals_table_name,
-                table_type="approvals",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.approvals_table
-
-        if table_type == "auth_tokens":
-            self.auth_tokens_table = await self._get_or_create_table(
-                table_name=self.auth_tokens_table_name,
-                table_type="auth_tokens",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.auth_tokens_table
-
-        if table_type == "service_accounts":
-            self.service_accounts_table = await self._get_or_create_table(
-                table_name=self.service_accounts_table_name,
-                table_type="service_accounts",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.service_accounts_table
-
-        raise ValueError(f"Unknown table type: {table_type}")
+        table = await self._get_or_create_table(
+            table_name=table_name,
+            table_type=table_type,
+            create_table_if_not_found=create_table_if_not_found,
+        )
+        setattr(self, table_attr, table)
+        return table
 
     async def _get_or_create_table(
         self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -476,154 +476,44 @@ class PostgresDb(BaseDb):
         return table_map.get(logical_name, logical_name)
 
     def _get_table(self, table_type: str, create_table_if_not_found: Optional[bool] = False) -> Optional[Table]:
-        if table_type == "sessions":
-            self.session_table = self._get_or_create_table(
-                table_name=self.session_table_name,
-                table_type="sessions",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.session_table
+        table_config = {
+            "sessions": ("session_table", self.session_table_name),
+            "memories": ("memory_table", self.memory_table_name),
+            "metrics": ("metrics_table", self.metrics_table_name),
+            "evals": ("eval_table", self.eval_table_name),
+            "knowledge": ("knowledge_table", self.knowledge_table_name),
+            "culture": ("culture_table", self.culture_table_name),
+            "versions": ("versions_table", self.versions_table_name),
+            "traces": ("traces_table", self.trace_table_name),
+            "spans": ("spans_table", self.span_table_name),
+            "components": ("component_table", self.components_table_name),
+            "component_configs": ("component_configs_table", self.component_configs_table_name),
+            "component_links": ("component_links_table", self.component_links_table_name),
+            "learnings": ("learnings_table", self.learnings_table_name),
+            "schedules": ("schedules_table", self.schedules_table_name),
+            "schedule_runs": ("schedule_runs_table", self.schedule_runs_table_name),
+            "approvals": ("approvals_table", self.approvals_table_name),
+            "auth_tokens": ("auth_tokens_table", self.auth_tokens_table_name),
+            "service_accounts": ("service_accounts_table", self.service_accounts_table_name),
+        }
+        if table_type not in table_config:
+            raise ValueError(f"Unknown table type: {table_type}")
 
-        if table_type == "memories":
-            self.memory_table = self._get_or_create_table(
-                table_name=self.memory_table_name,
-                table_type="memories",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.memory_table
+        table_attr, table_name = table_config[table_type]
+        cached_table = getattr(self, table_attr, None)
+        if cached_table is not None:
+            return cached_table
 
-        if table_type == "metrics":
-            self.metrics_table = self._get_or_create_table(
-                table_name=self.metrics_table_name,
-                table_type="metrics",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.metrics_table
+        if table_type == "spans" and create_table_if_not_found:
+            self._get_table(table_type="traces", create_table_if_not_found=True)
 
-        if table_type == "evals":
-            self.eval_table = self._get_or_create_table(
-                table_name=self.eval_table_name,
-                table_type="evals",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.eval_table
-
-        if table_type == "knowledge":
-            self.knowledge_table = self._get_or_create_table(
-                table_name=self.knowledge_table_name,
-                table_type="knowledge",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.knowledge_table
-
-        if table_type == "culture":
-            self.culture_table = self._get_or_create_table(
-                table_name=self.culture_table_name,
-                table_type="culture",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.culture_table
-
-        if table_type == "versions":
-            self.versions_table = self._get_or_create_table(
-                table_name=self.versions_table_name,
-                table_type="versions",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.versions_table
-
-        if table_type == "traces":
-            self.traces_table = self._get_or_create_table(
-                table_name=self.trace_table_name,
-                table_type="traces",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.traces_table
-
-        if table_type == "spans":
-            # Ensure traces table exists first (spans has FK to traces)
-            if create_table_if_not_found:
-                self._get_table(table_type="traces", create_table_if_not_found=True)
-
-            self.spans_table = self._get_or_create_table(
-                table_name=self.span_table_name,
-                table_type="spans",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.spans_table
-
-        if table_type == "components":
-            self.component_table = self._get_or_create_table(
-                table_name=self.components_table_name,
-                table_type="components",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.component_table
-
-        if table_type == "component_configs":
-            self.component_configs_table = self._get_or_create_table(
-                table_name=self.component_configs_table_name,
-                table_type="component_configs",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.component_configs_table
-
-        if table_type == "component_links":
-            self.component_links_table = self._get_or_create_table(
-                table_name=self.component_links_table_name,
-                table_type="component_links",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.component_links_table
-        if table_type == "learnings":
-            self.learnings_table = self._get_or_create_table(
-                table_name=self.learnings_table_name,
-                table_type="learnings",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.learnings_table
-
-        if table_type == "schedules":
-            self.schedules_table = self._get_or_create_table(
-                table_name=self.schedules_table_name,
-                table_type="schedules",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.schedules_table
-
-        if table_type == "schedule_runs":
-            self.schedule_runs_table = self._get_or_create_table(
-                table_name=self.schedule_runs_table_name,
-                table_type="schedule_runs",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.schedule_runs_table
-
-        if table_type == "approvals":
-            self.approvals_table = self._get_or_create_table(
-                table_name=self.approvals_table_name,
-                table_type="approvals",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.approvals_table
-
-        if table_type == "auth_tokens":
-            self.auth_tokens_table = self._get_or_create_table(
-                table_name=self.auth_tokens_table_name,
-                table_type="auth_tokens",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.auth_tokens_table
-
-        if table_type == "service_accounts":
-            self.service_accounts_table = self._get_or_create_table(
-                table_name=self.service_accounts_table_name,
-                table_type="service_accounts",
-                create_table_if_not_found=create_table_if_not_found,
-            )
-            return self.service_accounts_table
-
-        raise ValueError(f"Unknown table type: {table_type}")
+        table = self._get_or_create_table(
+            table_name=table_name,
+            table_type=table_type,
+            create_table_if_not_found=create_table_if_not_found,
+        )
+        setattr(self, table_attr, table)
+        return table
 
     def _get_or_create_table(
         self, table_name: str, table_type: str, create_table_if_not_found: Optional[bool] = False

--- a/libs/agno/tests/unit/db/test_async_postgres.py
+++ b/libs/agno/tests/unit/db/test_async_postgres.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.schema import Table
 
 from agno.db.postgres.async_postgres import AsyncPostgresDb
 
@@ -64,3 +65,21 @@ async def test_get_or_create_table_creates_when_not_available_and_create_flag_se
 
     assert result == mock_table
     async_postgres_db._create_table.assert_called_once_with(table_name="test_table", table_type="sessions")
+
+
+@pytest.mark.asyncio
+async def test_get_table_sessions_returns_cached_table(async_postgres_db):
+    """Test repeated async session table lookups reuse the cached Table object."""
+    mock_table = Mock(spec=Table)
+    async_postgres_db._get_or_create_table = AsyncMock(return_value=mock_table)
+
+    first = await async_postgres_db._get_table("sessions", create_table_if_not_found=True)
+    second = await async_postgres_db._get_table("sessions", create_table_if_not_found=True)
+
+    assert first is mock_table
+    assert second is mock_table
+    async_postgres_db._get_or_create_table.assert_awaited_once_with(
+        table_name=async_postgres_db.session_table_name,
+        table_type="sessions",
+        create_table_if_not_found=True,
+    )

--- a/libs/agno/tests/unit/db/test_postgres.py
+++ b/libs/agno/tests/unit/db/test_postgres.py
@@ -258,6 +258,23 @@ def test_get_table_sessions(postgres_db):
     assert hasattr(postgres_db, "session_table")
 
 
+def test_get_table_sessions_returns_cached_table(postgres_db):
+    """Test repeated session table lookups reuse the cached Table object."""
+    mock_table = Mock(spec=Table)
+
+    with patch.object(postgres_db, "_get_or_create_table", return_value=mock_table) as mock_get_or_create:
+        first = postgres_db._get_table("sessions", create_table_if_not_found=True)
+        second = postgres_db._get_table("sessions", create_table_if_not_found=True)
+
+    assert first is mock_table
+    assert second is mock_table
+    mock_get_or_create.assert_called_once_with(
+        table_name=postgres_db.session_table_name,
+        table_type="sessions",
+        create_table_if_not_found=True,
+    )
+
+
 def test_get_table_memories(postgres_db):
     """Test getting memories table"""
     mock_table = Mock(spec=Table)


### PR DESCRIPTION
Summary:
- return cached Postgres table objects from _get_table before calling _get_or_create_table again
- apply the same cache path to AsyncPostgresDb
- add sync and async regression tests for repeated session table lookups with create_table_if_not_found=True

Tests:
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/db/test_postgres.py::test_get_table_sessions_returns_cached_table tests/unit/db/test_async_postgres.py::test_get_table_sessions_returns_cached_table -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/db/test_postgres.py tests/unit/db/test_async_postgres.py -q
- .venv-py/bin/python -m ruff check agno/db/postgres/postgres.py agno/db/postgres/async_postgres.py tests/unit/db/test_postgres.py tests/unit/db/test_async_postgres.py
- .venv-py/bin/python -m ruff format --check agno/db/postgres/postgres.py agno/db/postgres/async_postgres.py tests/unit/db/test_postgres.py tests/unit/db/test_async_postgres.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/db/postgres/postgres.py agno/db/postgres/async_postgres.py tests/unit/db/test_postgres.py tests/unit/db/test_async_postgres.py
- git diff --check

Fixes #6257