### PR TITLE
Include file contents in knowledge hashes

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2242,25 +2242,24 @@ class Knowledge(RemoteKnowledge):
             hash_parts.append(str(content.path))
         elif content.url:
             hash_parts.append(content.url)
-        elif content.file_data and content.file_data.content:
-            # For file_data, always add filename, type, size, or content for uniqueness
+        elif content.file_data and content.file_data.content is not None:
+            # For file_data, combine metadata with a content digest for uniqueness.
             if content.file_data.filename:
                 hash_parts.append(content.file_data.filename)
-            elif content.file_data.type:
+            if content.file_data.type:
                 hash_parts.append(content.file_data.type)
-            elif content.file_data.size is not None:
+            if content.file_data.size is not None:
                 hash_parts.append(str(content.file_data.size))
-            else:
-                # Fallback: use the content for uniqueness
-                # Include type information to distinguish str vs bytes
-                content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
-                content_bytes = (
-                    content.file_data.content.encode()
-                    if isinstance(content.file_data.content, str)
-                    else content.file_data.content
-                )
-                content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]  # Use first 16 chars
-                hash_parts.append(f"{content_type}:{content_hash}")
+
+            # Include type information to distinguish str vs bytes with the same bytes.
+            content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
+            content_bytes = (
+                content.file_data.content.encode()
+                if isinstance(content.file_data.content, str)
+                else content.file_data.content
+            )
+            content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]
+            hash_parts.append(f"{content_type}:{content_hash}")
         elif content.topics and len(content.topics) > 0:
             topic = content.topics[0]
             reader = type(content.reader).__name__ if content.reader else "unknown"

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -241,7 +241,7 @@ def test_hash_with_only_description():
 
 
 def test_file_data_hash_with_filename():
-    """Test that file_data hash uses filename when available."""
+    """Test that file_data hash includes filename and content."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test content", filename="file1.pdf"))
     content2 = Content(file_data=FileData(content="test content", filename="file2.pdf"))
@@ -253,12 +253,12 @@ def test_file_data_hash_with_filename():
 
     # Different filenames should produce different hashes
     assert hash1 != hash2
-    # Same filename should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same filename with different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_type():
-    """Test that file_data hash uses type when filename is not available."""
+    """Test that file_data hash includes type and content when filename is not available."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test content", type="application/pdf"))
     content2 = Content(file_data=FileData(content="test content", type="text/plain"))
@@ -270,12 +270,24 @@ def test_file_data_hash_with_type():
 
     # Different types should produce different hashes
     assert hash1 != hash2
-    # Same type should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same type with different content should produce different hashes
+    assert hash1 != hash3
+
+
+def test_file_data_hash_with_text_type_includes_content():
+    """Different text_content values should not collide when FileData.type is set."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    content1 = Content(file_data=FileData(content="alpha text", type="Text"))
+    content2 = Content(file_data=FileData(content="beta text", type="Text"))
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+
+    assert hash1 != hash2
 
 
 def test_file_data_hash_with_size():
-    """Test that file_data hash uses size when filename and type are not available."""
+    """Test that file_data hash includes size and content when filename and type are not available."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test content", size=1024))
     content2 = Content(file_data=FileData(content="test content", size=2048))
@@ -287,8 +299,8 @@ def test_file_data_hash_with_size():
 
     # Different sizes should produce different hashes
     assert hash1 != hash2
-    # Same size should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same size with different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_content_fallback():
@@ -337,16 +349,16 @@ def test_file_data_hash_with_name_and_description():
     hash3 = knowledge._build_content_hash(content3)
     hash4 = knowledge._build_content_hash(content4)
 
-    # Same name/description/filename should produce same hash (content difference ignored when filename present)
-    assert hash1 == hash2
+    # Same name/description/filename with different content should produce different hashes
+    assert hash1 != hash2
     # Different filename should produce different hash
     assert hash1 != hash3
     # Different name should produce different hash
     assert hash1 != hash4
 
 
-def test_file_data_hash_priority_filename_over_type():
-    """Test that filename takes priority over type."""
+def test_file_data_hash_includes_filename_and_type():
+    """Test that filename and type both contribute to the hash."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test", filename="file.pdf", type="application/pdf"))
     content2 = Content(file_data=FileData(content="test", filename="file.pdf", type="text/plain"))
@@ -354,12 +366,12 @@ def test_file_data_hash_priority_filename_over_type():
     hash1 = knowledge._build_content_hash(content1)
     hash2 = knowledge._build_content_hash(content2)
 
-    # Same filename should produce same hash regardless of type
-    assert hash1 == hash2
+    # Same filename with different type should produce different hashes
+    assert hash1 != hash2
 
 
-def test_file_data_hash_priority_type_over_size():
-    """Test that type takes priority over size."""
+def test_file_data_hash_includes_type_and_size():
+    """Test that type and size both contribute to the hash."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test", type="application/pdf", size=1024))
     content2 = Content(file_data=FileData(content="test", type="application/pdf", size=2048))
@@ -367,8 +379,8 @@ def test_file_data_hash_priority_type_over_size():
     hash1 = knowledge._build_content_hash(content1)
     hash2 = knowledge._build_content_hash(content2)
 
-    # Same type should produce same hash regardless of size
-    assert hash1 == hash2
+    # Same type with different size should produce different hashes
+    assert hash1 != hash2
 
 
 def test_file_data_hash_with_name_only():
@@ -458,8 +470,8 @@ def test_file_data_hash_all_fields_present():
     hash2 = knowledge._build_content_hash(content2)
     hash3 = knowledge._build_content_hash(content3)
 
-    # Same name/description/filename should produce same hash (content/type/size differences ignored when filename present)
-    assert hash1 == hash2
+    # Same name/description/filename with different content should produce different hashes
+    assert hash1 != hash2
     # Different filename should produce different hash
     assert hash1 != hash3
 


### PR DESCRIPTION
Summary:
- include a digest of FileData.content in knowledge content hashes even when filename, type, or size is present
- update file_data hash expectations so metadata and content both contribute to identity
- add a regression test for distinct text_content values with FileData.type=Text

Tests:
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/knowledge/test_knowledge_content_hash.py::test_file_data_hash_with_text_type_includes_content -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/knowledge/test_knowledge_content_hash.py -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/knowledge/test_knowledge_content_hash.py tests/unit/knowledge/test_knowledge_insert_many_auth.py tests/unit/knowledge/test_knowledge_metadata_propagation.py -q
- .venv-py/bin/python -m ruff check agno/knowledge/knowledge.py tests/unit/knowledge/test_knowledge_content_hash.py
- .venv-py/bin/python -m ruff format --check agno/knowledge/knowledge.py tests/unit/knowledge/test_knowledge_content_hash.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-pycache .venv-py/bin/python -m py_compile agno/knowledge/knowledge.py tests/unit/knowledge/test_knowledge_content_hash.py
- git diff --check

Fixes #6952