### PR TITLE
Include config available models in AgentOS models endpoint

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -63,6 +63,21 @@ if TYPE_CHECKING:
     from agno.os.app import AgentOS
 
 
+def _model_from_available_model(model_reference: str) -> Optional[Model]:
+    model_reference = model_reference.strip()
+    if not model_reference:
+        return None
+
+    provider, separator, model_id = model_reference.partition(":")
+    if separator:
+        model_id = model_id.strip()
+        if not model_id:
+            return None
+        return Model(id=model_id, provider=provider.strip() or None)
+
+    return Model(id=model_reference)
+
+
 def get_base_router(
     os: "AgentOS",
     settings: AgnoAPISettings = AgnoAPISettings(),
@@ -235,6 +250,14 @@ def get_base_router(
     async def get_models() -> List[Model]:
         """Return the list of all models used by agents and teams in the contextual OS"""
         unique_models = {}
+
+        if os.config and os.config.available_models:
+            for model_reference in os.config.available_models:
+                model = _model_from_available_model(model_reference)
+                if model and model.id is not None:
+                    key = (model.id, model.provider)
+                    if key not in unique_models:
+                        unique_models[key] = model
 
         # Collect models from local agents
         if os.agents:

--- a/libs/agno/tests/unit/os/test_config.py
+++ b/libs/agno/tests/unit/os/test_config.py
@@ -261,6 +261,34 @@ class TestConfigEndpointSerialization:
         assert "manifest" not in resp.json()
 
 
+class TestModelsEndpointSerialization:
+    """End-to-end tests for config-backed model discovery."""
+
+    def test_available_models_from_yaml_are_returned_by_models_endpoint(self, tmp_path):
+        config_path = tmp_path / "agent_os_config.yaml"
+        config_path.write_text(
+            """
+            available_models:
+              - "openai:gpt-oss-120b"
+              - "openai:gpt-oss-20b"
+            """
+        )
+        agent = Agent(name="Marketing Agent", id="marketing-agent", telemetry=False)
+        os_instance = AgentOS(agents=[agent], telemetry=False, config=str(config_path))
+        client = TestClient(os_instance.get_app())
+
+        config_resp = client.get("/config")
+        assert config_resp.status_code == 200
+        assert config_resp.json()["available_models"] == ["openai:gpt-oss-120b", "openai:gpt-oss-20b"]
+
+        models_resp = client.get("/models")
+        assert models_resp.status_code == 200
+        assert models_resp.json() == [
+            {"id": "gpt-oss-120b", "provider": "openai"},
+            {"id": "gpt-oss-20b", "provider": "openai"},
+        ]
+
+
 class TestAgentSummaryModelField:
     def test_from_agent_extracts_model(self):
         agent = Agent(


### PR DESCRIPTION
## Summary
- include AgentOS config available_models entries in the /models response
- parse provider:model references into the existing model id/provider schema
- add regression coverage for YAML-backed available_models

Fixes #7060

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/os/test_config.py::TestModelsEndpointSerialization::test_available_models_from_yaml_are_returned_by_models_endpoint -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/os/test_config.py -q
- .venv-py/bin/python -m ruff check agno/os/router.py tests/unit/os/test_config.py
- .venv-py/bin/python -m ruff format --check agno/os/router.py tests/unit/os/test_config.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-issue-7060-pycache PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m py_compile agno/os/router.py tests/unit/os/test_config.py