### PR TITLE
cookbook: update MiniMax M3 cookbook metadata

### DIFF
--- a/cookbook/90_models/minimax/README.md
+++ b/cookbook/90_models/minimax/README.md
@@ -38,7 +38,7 @@ current catalog. As of writing:
 
 | Model id | Notes |
 | --- | --- |
-| `MiniMax-M3` | Latest flagship, 512K context, 128K max output, image input (default) |
+| `MiniMax-M3` | Latest flagship, 1M context, 128K max output, image input; $0.60/M input tokens, $2.40/M output tokens, $0.12/M cache-read tokens (default) |
 | `MiniMax-M2.7` | Previous flagship MoE (230B total / 10B active), 205k context |
 | `MiniMax-M2.7-highspeed` | Same weights as M2.7, ~1.6–1.7× throughput |
 


### PR DESCRIPTION
Reason: MiniMax M3 provider exists but cookbook metadata still says 512K context; align docs with 1M context and current pricing.

## Summary
- Update the MiniMax M3 cookbook model table to show the 1M context window.
- Add current MiniMax M3 input, output, and cache-read pricing metadata.

## Checks
- python3 -m compileall /root/octopatch-4/work/repos/agno-agi_agno/libs/agno/agno/models/minimax /root/octopatch-4/work/repos/agno-agi_agno/libs/agno/tests/unit/models/minimax
- secret scan on git diff