### PR TITLE
[cookbook] Add long-term memory cross-session example

### DIFF
--- a/cookbook/02_agents/06_memory_and_learning/README.md
+++ b/cookbook/02_agents/06_memory_and_learning/README.md
@@ -4,6 +4,7 @@ Examples for persistent memory and learning behavior.
 
 ## Files
 - `learning_machine.py` - Demonstrates LearningMachine-based learning.
+- `long_term_memory_cross_session.py` - Persist user facts across separate sessions with `user_id`.
 - `memory_manager.py` - Use MemoryManager for persistent memory across sessions.
 
 ## Prerequisites

--- a/cookbook/02_agents/06_memory_and_learning/long_term_memory_cross_session.py
+++ b/cookbook/02_agents/06_memory_and_learning/long_term_memory_cross_session.py
@@ -1,0 +1,63 @@
+"""
+Long-Term Memory Across Sessions
+================================
+
+Demonstrates how user memories persist across separate sessions.
+
+Key concepts:
+- user_id: scopes memories to a person (not a conversation)
+- session_id: isolates chat history per conversation
+- update_memory_on_run: captures facts after every response
+
+Example prompts to try:
+- Session 1: "I am a backend engineer who prefers TypeScript."
+- Session 2 (new session_id): "What language do I prefer?"
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+db = SqliteDb(db_file="tmp/long_term_memory.db")
+user_id = "demo-engineer"
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5-mini"),
+    db=db,
+    update_memory_on_run=True,
+    instructions=[
+        "You are a helpful assistant.",
+        "Use stored user memories when answering follow-up questions.",
+    ],
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=== Session 1: capture a long-term preference ===")
+    agent.print_response(
+        "I am a backend engineer who prefers TypeScript over Python.",
+        user_id=user_id,
+        session_id="onboarding_session",
+        stream=True,
+    )
+
+    print("\n=== Session 2: new session, same user ===")
+    agent.print_response(
+        "What programming language do I prefer?",
+        user_id=user_id,
+        session_id="follow_up_session",
+        stream=True,
+    )
+
+    print("\n=== Stored memories ===")
+    for memory in agent.get_user_memories(user_id=user_id):
+        print(f"- {memory.memory}")


### PR DESCRIPTION
﻿## Summary
Adds a runnable cookbook showing how user memories persist across separate session_id values when scoped by user_id.

## Why
06_memory_and_learning/ had only two examples. Cross-session recall is a common question and was not demonstrated in the agents cookbook path.
