### PR TITLE
[cookbook] Document tool failure impact on state and memory

### DIFF
--- a/cookbook/02_agents/04_tools/README.md
+++ b/cookbook/02_agents/04_tools/README.md
@@ -2,6 +2,8 @@
 
 Examples for callable tool factories, tool choice, and tool call limits.
 
+> **Tool failures:** See [../05_state_and_session/TOOL_FAILURE_AND_STATE.md](../05_state_and_session/TOOL_FAILURE_AND_STATE.md) for persistence behavior when a tool errors.
+
 ## Files
 - `01_callable_tools.py` - Vary the toolset per user role using callable factories.
 - `02_session_state_tools.py` - Use session_state directly as a parameter with caching disabled.

--- a/cookbook/02_agents/05_state_and_session/README.md
+++ b/cookbook/02_agents/05_state_and_session/README.md
@@ -2,6 +2,8 @@
 
 Examples for session state management, chat history, and session persistence.
 
+> **Tool failures:** See [TOOL_FAILURE_AND_STATE.md](./TOOL_FAILURE_AND_STATE.md) for how errors affect session state and memory.
+
 ## Files
 - `agentic_session_state.py` - Agent-managed session state updates.
 - `chat_history.py` - Access and manage chat history.

--- a/cookbook/02_agents/05_state_and_session/TOOL_FAILURE_AND_STATE.md
+++ b/cookbook/02_agents/05_state_and_session/TOOL_FAILURE_AND_STATE.md
@@ -1,0 +1,47 @@
+# Tool Failures, Session State, and Memory
+
+When a tool fails during an agent run, persistence behavior depends on **what failed** and **when state was written**.
+
+## Tool raises an exception (most common)
+
+If a tool raises a regular Python exception (for example `ValueError`):
+
+1. The model loop **catches** the error internally.
+2. The failure is recorded as a tool-role message with `tool_call_error=True`.
+3. The model can retry with a different approach or explain the error to the user.
+4. The run typically **completes normally**; no conversation data is lost.
+
+**Session state:** Changes made by tools that ran **before** the failing call are kept. If the failing tool was supposed to update `session_state`, that update does not happen.
+
+**Memory:** `update_memory_on_run` and agentic memory run after a successful response. A completed run still extracts memories; a run that ends in `ERROR` may not.
+
+See: `../18_checkpointing/02_tool_error_persistence.py` (Scenario A)
+
+## Model call fails before tools run
+
+If the model API call itself fails (auth error, rate limit, timeout):
+
+1. The exception may **escape** the inner tool loop.
+2. Per-batch checkpoint hooks may not have fired yet.
+3. Without error flushing, the persisted run row can end up with **empty messages**.
+
+Agno flushes in-flight messages on error so the conversation that led to the failure is preserved. Use checkpointing when you need crash-safe recovery.
+
+See: `../18_checkpointing/02_tool_error_persistence.py` (Scenario B)
+
+## Practical checklist
+
+| Question | Guidance |
+|---|---|
+| Did my tool update `session_state` before failing? | Earlier updates persist; the failed tool's changes do not. |
+| Will the user see the error? | Yes, as a tool error message in the chat transcript. |
+| Should I use checkpointing? | Yes, for long multi-tool runs or HITL flows where recovery matters. |
+| Does memory update on tool failure? | Only if the run completes and memory extraction runs successfully. |
+
+## Related examples
+
+| Topic | Location |
+|---|---|
+| Tool error vs model error | `../18_checkpointing/02_tool_error_persistence.py` |
+| Session state basics | `session_state_basic.py` |
+| HITL + session state survival | `../10_human_in_the_loop/confirmation_with_session_state.py` |


### PR DESCRIPTION
﻿## Summary
Adds a troubleshooting note explaining how tool errors vs model errors affect session state, chat history, and memory extraction.

## Why
Checkpointing cookbooks cover error persistence in depth, but there was no short guide for developers using session state or memory.
