### PR TITLE
Handle serialized media in TeamRunOutput

### DIFF
--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -872,22 +872,26 @@ class TeamRunOutput:
             _dict["followups"] = self.followups
 
         if self.images is not None:
-            _dict["images"] = [img.to_dict() for img in self.images]
+            _dict["images"] = [img.to_dict() if hasattr(img, "to_dict") else img for img in self.images]
 
         if self.videos is not None:
-            _dict["videos"] = [vid.to_dict() for vid in self.videos]
+            _dict["videos"] = [vid.to_dict() if hasattr(vid, "to_dict") else vid for vid in self.videos]
 
         if self.audio is not None:
-            _dict["audio"] = [aud.to_dict() for aud in self.audio]
+            _dict["audio"] = [aud.to_dict() if hasattr(aud, "to_dict") else aud for aud in self.audio]
 
         if self.files is not None:
-            _dict["files"] = [file.to_dict() for file in self.files]
+            _dict["files"] = [file.to_dict() if hasattr(file, "to_dict") else file for file in self.files]
 
         if self.response_audio is not None:
-            _dict["response_audio"] = self.response_audio.to_dict()
+            _dict["response_audio"] = (
+                self.response_audio.to_dict() if hasattr(self.response_audio, "to_dict") else self.response_audio
+            )
 
         if self.member_responses:
-            _dict["member_responses"] = [response.to_dict() for response in self.member_responses]
+            _dict["member_responses"] = [
+                response.to_dict() if hasattr(response, "to_dict") else response for response in self.member_responses
+            ]
 
         if self.citations is not None:
             if isinstance(self.citations, Citations):

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -213,6 +213,30 @@ def test_team_session_state_in_run_output():
     assert reconstructed.session_state == {"phase": "planning", "tasks": 3}
 
 
+def test_team_run_output_to_dict_accepts_serialized_media_dicts():
+    """TeamRunOutput.to_dict should be idempotent for JSON-loaded media fields."""
+    from agno.run.team import TeamRunOutput
+
+    team_output = TeamRunOutput(
+        run_id="team_123",
+        images=[{"url": "https://example.com/image.png"}],
+        videos=[{"url": "https://example.com/video.mp4"}],
+        audio=[{"url": "https://example.com/audio.mp3"}],
+        files=[{"url": "https://example.com/report.pdf"}],
+        response_audio={"id": "audio_123", "content": "base64-audio"},
+        member_responses=[{"run_id": "member_123", "content": "done"}],
+    )
+
+    team_dict = team_output.to_dict()
+
+    assert team_dict["images"] == [{"url": "https://example.com/image.png"}]
+    assert team_dict["videos"] == [{"url": "https://example.com/video.mp4"}]
+    assert team_dict["audio"] == [{"url": "https://example.com/audio.mp3"}]
+    assert team_dict["files"] == [{"url": "https://example.com/report.pdf"}]
+    assert team_dict["response_audio"] == {"id": "audio_123", "content": "base64-audio"}
+    assert team_dict["member_responses"] == [{"run_id": "member_123", "content": "done"}]
+
+
 def test_team_session_state_in_completed_event():
     """Test that TeamRunCompletedEvent includes session_state field."""
     from agno.run.team import TeamRunOutput


### PR DESCRIPTION
## Summary
- make TeamRunOutput.to_dict tolerate already-serialized media dictionaries
- apply the same defensive conversion to response_audio and member_responses
- add regression coverage for JSON-loaded TeamRunOutput media fields

Fixes #8678

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/run/test_run_events.py::test_team_run_output_to_dict_accepts_serialized_media_dicts -q
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/run/test_run_events.py -q
- .venv-py/bin/python -m ruff check agno/run/team.py tests/unit/run/test_run_events.py
- .venv-py/bin/python -m ruff format --check agno/run/team.py tests/unit/run/test_run_events.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-issue-8678-pycache PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m py_compile agno/run/team.py tests/unit/run/test_run_events.py