### PR TITLE
Fix SQLite session timestamp defaults

### DIFF
--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -30,6 +30,7 @@ from agno.db.sqlite.utils import (
     deserialize_cultural_knowledge_from_db,
     fetch_all_sessions_data,
     get_dates_to_calculate_metrics_for,
+    normalize_session_timestamps,
     serialize_cultural_knowledge_for_db,
 )
 from agno.db.utils import (
@@ -812,6 +813,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return None
 
             serialized_session = serialize_session_json_fields(session.to_dict())
+            created_at, updated_at = normalize_session_timestamps(serialized_session)
 
             if isinstance(session, AgentSession):
                 async with self.async_session_factory() as sess, sess.begin():
@@ -825,8 +827,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                         metadata=serialized_session.get("metadata"),
                         runs=serialized_session.get("runs"),
                         summary=serialized_session.get("summary"),
-                        created_at=serialized_session.get("created_at"),
-                        updated_at=serialized_session.get("created_at"),
+                        created_at=created_at,
+                        updated_at=updated_at,
                     )
                     stmt = stmt.on_conflict_do_update(
                         index_elements=["session_id"],
@@ -860,8 +862,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                         user_id=serialized_session.get("user_id"),
                         runs=serialized_session.get("runs"),
                         summary=serialized_session.get("summary"),
-                        created_at=serialized_session.get("created_at"),
-                        updated_at=serialized_session.get("created_at"),
+                        created_at=created_at,
+                        updated_at=updated_at,
                         team_data=serialized_session.get("team_data"),
                         session_data=serialized_session.get("session_data"),
                         metadata=serialized_session.get("metadata"),
@@ -899,8 +901,8 @@ class AsyncSqliteDb(AsyncBaseDb):
                         user_id=serialized_session.get("user_id"),
                         runs=serialized_session.get("runs"),
                         summary=serialized_session.get("summary"),
-                        created_at=serialized_session.get("created_at") or int(time.time()),
-                        updated_at=serialized_session.get("updated_at") or int(time.time()),
+                        created_at=created_at,
+                        updated_at=updated_at,
                         workflow_data=serialized_session.get("workflow_data"),
                         session_data=serialized_session.get("session_data"),
                         metadata=serialized_session.get("metadata"),
@@ -988,8 +990,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                     agent_data = []
                     for session in agent_sessions:
                         serialized_session = serialize_session_json_fields(session.to_dict())
-                        # Use preserved updated_at if flag is set and value exists, otherwise use current time
-                        updated_at = serialized_session.get("updated_at") if preserve_updated_at else int(time.time())
+                        created_at, updated_at = normalize_session_timestamps(
+                            serialized_session, preserve_updated_at=preserve_updated_at
+                        )
                         agent_data.append(
                             {
                                 "session_id": serialized_session.get("session_id"),
@@ -1001,7 +1004,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                                 "metadata": serialized_session.get("metadata"),
                                 "runs": serialized_session.get("runs"),
                                 "summary": serialized_session.get("summary"),
-                                "created_at": serialized_session.get("created_at"),
+                                "created_at": created_at,
                                 "updated_at": updated_at,
                             }
                         )
@@ -1043,8 +1046,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                     team_data = []
                     for session in team_sessions:
                         serialized_session = serialize_session_json_fields(session.to_dict())
-                        # Use preserved updated_at if flag is set and value exists, otherwise use current time
-                        updated_at = serialized_session.get("updated_at") if preserve_updated_at else int(time.time())
+                        created_at, updated_at = normalize_session_timestamps(
+                            serialized_session, preserve_updated_at=preserve_updated_at
+                        )
                         team_data.append(
                             {
                                 "session_id": serialized_session.get("session_id"),
@@ -1053,7 +1057,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                                 "user_id": serialized_session.get("user_id"),
                                 "runs": serialized_session.get("runs"),
                                 "summary": serialized_session.get("summary"),
-                                "created_at": serialized_session.get("created_at"),
+                                "created_at": created_at,
                                 "updated_at": updated_at,
                                 "team_data": serialized_session.get("team_data"),
                                 "session_data": serialized_session.get("session_data"),
@@ -1098,8 +1102,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                     workflow_data = []
                     for session in workflow_sessions:
                         serialized_session = serialize_session_json_fields(session.to_dict())
-                        # Use preserved updated_at if flag is set and value exists, otherwise use current time
-                        updated_at = serialized_session.get("updated_at") if preserve_updated_at else int(time.time())
+                        created_at, updated_at = normalize_session_timestamps(
+                            serialized_session, preserve_updated_at=preserve_updated_at
+                        )
                         workflow_data.append(
                             {
                                 "session_id": serialized_session.get("session_id"),
@@ -1108,7 +1113,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                                 "user_id": serialized_session.get("user_id"),
                                 "runs": serialized_session.get("runs"),
                                 "summary": serialized_session.get("summary"),
-                                "created_at": serialized_session.get("created_at"),
+                                "created_at": created_at,
                                 "updated_at": updated_at,
                                 "workflow_data": serialized_session.get("workflow_data"),
                                 "session_data": serialized_session.get("session_data"),

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -28,6 +28,7 @@ from agno.db.sqlite.utils import (
     get_dates_to_calculate_metrics_for,
     is_table_available,
     is_valid_table,
+    normalize_session_timestamps,
     serialize_cultural_knowledge_for_db,
 )
 from agno.db.utils import (
@@ -972,6 +973,7 @@ class SqliteDb(BaseDb):
                 return None
 
             serialized_session = serialize_session_json_fields(session.to_dict())
+            created_at, updated_at = normalize_session_timestamps(serialized_session)
 
             if isinstance(session, AgentSession):
                 with self.Session() as sess, sess.begin():
@@ -985,8 +987,8 @@ class SqliteDb(BaseDb):
                         metadata=serialized_session.get("metadata"),
                         runs=serialized_session.get("runs"),
                         summary=serialized_session.get("summary"),
-                        created_at=serialized_session.get("created_at"),
-                        updated_at=serialized_session.get("created_at"),
+                        created_at=created_at,
+                        updated_at=updated_at,
                     )
                     stmt = stmt.on_conflict_do_update(
                         index_elements=["session_id"],
@@ -1020,8 +1022,8 @@ class SqliteDb(BaseDb):
                         user_id=serialized_session.get("user_id"),
                         runs=serialized_session.get("runs"),
                         summary=serialized_session.get("summary"),
-                        created_at=serialized_session.get("created_at"),
-                        updated_at=serialized_session.get("created_at"),
+                        created_at=created_at,
+                        updated_at=updated_at,
                         team_data=serialized_session.get("team_data"),
                         session_data=serialized_session.get("session_data"),
                         metadata=serialized_session.get("metadata"),
@@ -1059,8 +1061,8 @@ class SqliteDb(BaseDb):
                         user_id=serialized_session.get("user_id"),
                         runs=serialized_session.get("runs"),
                         summary=serialized_session.get("summary"),
-                        created_at=serialized_session.get("created_at") or int(time.time()),
-                        updated_at=serialized_session.get("updated_at") or int(time.time()),
+                        created_at=created_at,
+                        updated_at=updated_at,
                         workflow_data=serialized_session.get("workflow_data"),
                         session_data=serialized_session.get("session_data"),
                         metadata=serialized_session.get("metadata"),
@@ -1148,8 +1150,9 @@ class SqliteDb(BaseDb):
                     agent_data = []
                     for session in agent_sessions:
                         serialized_session = serialize_session_json_fields(session.to_dict())
-                        # Use preserved updated_at if flag is set and value exists, otherwise use current time
-                        updated_at = serialized_session.get("updated_at") if preserve_updated_at else int(time.time())
+                        created_at, updated_at = normalize_session_timestamps(
+                            serialized_session, preserve_updated_at=preserve_updated_at
+                        )
                         agent_data.append(
                             {
                                 "session_id": serialized_session.get("session_id"),
@@ -1161,7 +1164,7 @@ class SqliteDb(BaseDb):
                                 "metadata": serialized_session.get("metadata"),
                                 "runs": serialized_session.get("runs"),
                                 "summary": serialized_session.get("summary"),
-                                "created_at": serialized_session.get("created_at"),
+                                "created_at": created_at,
                                 "updated_at": updated_at,
                             }
                         )
@@ -1203,8 +1206,9 @@ class SqliteDb(BaseDb):
                     team_data = []
                     for session in team_sessions:
                         serialized_session = serialize_session_json_fields(session.to_dict())
-                        # Use preserved updated_at if flag is set and value exists, otherwise use current time
-                        updated_at = serialized_session.get("updated_at") if preserve_updated_at else int(time.time())
+                        created_at, updated_at = normalize_session_timestamps(
+                            serialized_session, preserve_updated_at=preserve_updated_at
+                        )
                         team_data.append(
                             {
                                 "session_id": serialized_session.get("session_id"),
@@ -1213,7 +1217,7 @@ class SqliteDb(BaseDb):
                                 "user_id": serialized_session.get("user_id"),
                                 "runs": serialized_session.get("runs"),
                                 "summary": serialized_session.get("summary"),
-                                "created_at": serialized_session.get("created_at"),
+                                "created_at": created_at,
                                 "updated_at": updated_at,
                                 "team_data": serialized_session.get("team_data"),
                                 "session_data": serialized_session.get("session_data"),
@@ -1258,8 +1262,9 @@ class SqliteDb(BaseDb):
                     workflow_data = []
                     for session in workflow_sessions:
                         serialized_session = serialize_session_json_fields(session.to_dict())
-                        # Use preserved updated_at if flag is set and value exists, otherwise use current time
-                        updated_at = serialized_session.get("updated_at") if preserve_updated_at else int(time.time())
+                        created_at, updated_at = normalize_session_timestamps(
+                            serialized_session, preserve_updated_at=preserve_updated_at
+                        )
                         workflow_data.append(
                             {
                                 "session_id": serialized_session.get("session_id"),
@@ -1268,7 +1273,7 @@ class SqliteDb(BaseDb):
                                 "user_id": serialized_session.get("user_id"),
                                 "runs": serialized_session.get("runs"),
                                 "summary": serialized_session.get("summary"),
-                                "created_at": serialized_session.get("created_at"),
+                                "created_at": created_at,
                                 "updated_at": updated_at,
                                 "workflow_data": serialized_session.get("workflow_data"),
                                 "session_data": serialized_session.get("session_data"),

--- a/libs/agno/agno/db/sqlite/utils.py
+++ b/libs/agno/agno/db/sqlite/utils.py
@@ -1,7 +1,7 @@
 import json
 import time
 from datetime import date, datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import uuid4
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
@@ -58,6 +58,19 @@ def apply_sorting(stmt, table: Table, sort_by: Optional[str] = None, sort_order:
         return stmt.order_by(sort_column.asc())
     else:
         return stmt.order_by(sort_column.desc())
+
+
+def normalize_session_timestamps(
+    serialized_session: Dict[str, Any], preserve_updated_at: bool = True
+) -> Tuple[int, int]:
+    current_time = int(time.time())
+    created_at = serialized_session.get("created_at") or current_time
+    updated_at = serialized_session.get("updated_at") if preserve_updated_at else None
+
+    if updated_at is None:
+        updated_at = created_at if preserve_updated_at else current_time
+
+    return created_at, updated_at
 
 
 def is_table_available(session: Session, table_name: str, db_schema: Optional[str] = None) -> bool:

--- a/libs/agno/tests/integration/db/sqlite/test_session.py
+++ b/libs/agno/tests/integration/db/sqlite/test_session.py
@@ -174,6 +174,99 @@ def test_update_team_session(sqlite_db_real: SqliteDb, sample_team_session: Team
     assert result.team_data["foo"] == "bar"
 
 
+def test_upsert_agent_session_without_timestamps_sets_defaults(sqlite_db_real: SqliteDb):
+    """Ensure minimal AgentSession rows receive database-safe timestamps"""
+    result = sqlite_db_real.upsert_session(AgentSession(session_id="minimal_agent_session", agent_id="agent"))
+
+    assert result is not None
+    assert isinstance(result, AgentSession)
+    assert result.created_at is not None
+    assert result.updated_at == result.created_at
+
+
+def test_upsert_team_session_without_timestamps_sets_defaults(sqlite_db_real: SqliteDb):
+    """Ensure minimal TeamSession rows receive database-safe timestamps"""
+    result = sqlite_db_real.upsert_session(TeamSession(session_id="minimal_team_session", team_id="team"))
+
+    assert result is not None
+    assert isinstance(result, TeamSession)
+    assert result.created_at is not None
+    assert result.updated_at == result.created_at
+
+
+def test_upsert_session_preserves_explicit_updated_at(sqlite_db_real: SqliteDb):
+    """Ensure insert uses the session updated_at value when provided"""
+    result = sqlite_db_real.upsert_session(
+        AgentSession(session_id="explicit_timestamps", agent_id="agent", created_at=100, updated_at=200)
+    )
+
+    assert result is not None
+    assert isinstance(result, AgentSession)
+    assert result.created_at == 100
+    assert result.updated_at == 200
+
+
+def test_upsert_sessions_without_timestamps_sets_defaults(sqlite_db_real: SqliteDb):
+    """Ensure bulk upsert fills timestamps for minimal AgentSession and TeamSession rows"""
+    results = sqlite_db_real.upsert_sessions(
+        [
+            AgentSession(session_id="bulk_minimal_agent_session", agent_id="agent"),
+            TeamSession(session_id="bulk_minimal_team_session", team_id="team"),
+        ]
+    )
+
+    assert len(results) == 2
+    results_by_id = {result.session_id: result for result in results}
+    agent_result = results_by_id["bulk_minimal_agent_session"]
+    team_result = results_by_id["bulk_minimal_team_session"]
+
+    assert isinstance(agent_result, AgentSession)
+    assert agent_result.created_at is not None
+    assert agent_result.updated_at == agent_result.created_at
+    assert isinstance(team_result, TeamSession)
+    assert team_result.created_at is not None
+    assert team_result.updated_at == team_result.created_at
+
+
+@pytest.mark.asyncio
+async def test_async_upsert_session_without_timestamps_sets_defaults(async_shared_db):
+    """Ensure async upsert fills timestamps for minimal AgentSession and TeamSession rows"""
+    agent_result = await async_shared_db.upsert_session(
+        AgentSession(session_id="async_minimal_agent", agent_id="agent")
+    )
+    team_result = await async_shared_db.upsert_session(TeamSession(session_id="async_minimal_team", team_id="team"))
+
+    assert isinstance(agent_result, AgentSession)
+    assert agent_result.created_at is not None
+    assert agent_result.updated_at == agent_result.created_at
+    assert isinstance(team_result, TeamSession)
+    assert team_result.created_at is not None
+    assert team_result.updated_at == team_result.created_at
+
+
+@pytest.mark.asyncio
+async def test_async_upsert_sessions_without_timestamps_sets_defaults(async_shared_db):
+    """Ensure async bulk upsert fills timestamps for minimal AgentSession and TeamSession rows"""
+    results = await async_shared_db.upsert_sessions(
+        [
+            AgentSession(session_id="async_bulk_minimal_agent", agent_id="agent"),
+            TeamSession(session_id="async_bulk_minimal_team", team_id="team"),
+        ]
+    )
+
+    assert len(results) == 2
+    results_by_id = {result.session_id: result for result in results}
+    agent_result = results_by_id["async_bulk_minimal_agent"]
+    team_result = results_by_id["async_bulk_minimal_team"]
+
+    assert isinstance(agent_result, AgentSession)
+    assert agent_result.created_at is not None
+    assert agent_result.updated_at == agent_result.created_at
+    assert isinstance(team_result, TeamSession)
+    assert team_result.created_at is not None
+    assert team_result.updated_at == team_result.created_at
+
+
 def test_upserting_without_deserialization(sqlite_db_real: SqliteDb, sample_agent_session: AgentSession):
     """Ensure the upsert method works as expected when upserting a session without deserialization"""
     result = sqlite_db_real.upsert_session(sample_agent_session, deserialize=False)


### PR DESCRIPTION
## Summary
- add shared SQLite session timestamp normalization for sync and async upserts
- fill missing created_at/updated_at values for minimal AgentSession and TeamSession inserts
- preserve explicit updated_at values on insert and cover sync/async single and bulk upserts

Fixes #8676

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/integration/db/sqlite/test_session.py -q
- .venv-py/bin/python -m ruff check agno/db/sqlite/utils.py agno/db/sqlite/sqlite.py agno/db/sqlite/async_sqlite.py tests/integration/db/sqlite/test_session.py
- .venv-py/bin/python -m ruff format --check agno/db/sqlite/utils.py agno/db/sqlite/sqlite.py agno/db/sqlite/async_sqlite.py tests/integration/db/sqlite/test_session.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-issue-8676-pycache PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m py_compile agno/db/sqlite/utils.py agno/db/sqlite/sqlite.py agno/db/sqlite/async_sqlite.py tests/integration/db/sqlite/test_session.py