### PR TITLE
Fix JSONReader default chunk setting

### DIFF
--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -17,11 +17,11 @@ class JSONReader(Reader):
 
     chunk: bool = False
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, chunk: bool = False, **kwargs):
         if chunking_strategy is None:
             chunk_size = kwargs.get("chunk_size", 5000)
             chunking_strategy = FixedSizeChunking(chunk_size=chunk_size)
-        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
+        super().__init__(chunk=chunk, chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -51,6 +51,23 @@ def test_read_json_list():
     assert [json.loads(doc.content) for doc in documents] == test_data
 
 
+def test_default_reader_does_not_chunk_large_json_objects(tmp_path):
+    test_data = [
+        {"id": 1, "text": "alpha " * 1200},
+        {"id": 2, "text": "beta " * 1200},
+    ]
+    json_path = tmp_path / "large.json"
+    json_path.write_text(json.dumps(test_data), encoding="utf-8")
+
+    reader = JSONReader()
+    documents = reader.read(json_path)
+
+    assert reader.chunk is False
+    assert len(documents) == 2
+    assert [json.loads(document.content)["id"] for document in documents] == [1, 2]
+    assert all("chunk" not in document.meta_data for document in documents)
+
+
 def test_chunking():
     # Test document chunking functionality
     test_data = {"key": "value"}


### PR DESCRIPTION
## Summary
- pass JSONReader's intended chunk=False default into the base Reader constructor
- keep explicit JSONReader(chunk=True) behavior available
- add a regression for large top-level JSON objects staying valid JSON by default

Fixes #8679

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/reader/test_json_reader.py -q
- .venv-py/bin/python -m ruff check agno/knowledge/reader/json_reader.py tests/unit/reader/test_json_reader.py
- .venv-py/bin/python -m ruff format --check agno/knowledge/reader/json_reader.py tests/unit/reader/test_json_reader.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-issue-8679-pycache PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m py_compile agno/knowledge/reader/json_reader.py tests/unit/reader/test_json_reader.py