### PR TITLE
Fix DoclingReader local string paths

### DIFF
--- a/libs/agno/agno/knowledge/reader/docling_reader.py
+++ b/libs/agno/agno/knowledge/reader/docling_reader.py
@@ -20,6 +20,8 @@ except ImportError:
     raise ImportError("The `docling` package is not installed. Please install it via `pip install docling`.")
 
 
+VTT_OUTPUT_FORMAT = getattr(OutputFormat, "VTT", "vtt")
+
 # Mapping of string values to OutputFormat enum
 OUTPUT_FORMAT_MAP = {
     "markdown": OutputFormat.MARKDOWN,
@@ -29,7 +31,7 @@ OUTPUT_FORMAT_MAP = {
     "html": OutputFormat.HTML,
     "html_split_page": OutputFormat.HTML_SPLIT_PAGE,
     "doctags": OutputFormat.DOCTAGS,
-    "vtt": OutputFormat.VTT,
+    "vtt": VTT_OUTPUT_FORMAT,
 }
 
 
@@ -205,6 +207,13 @@ class DoclingReader(Reader):
                 doc_name = name or Path(url_path).stem
                 log_debug(f"Reading from URL: {file}")
                 source = file
+            elif isinstance(file, str):
+                file_path = Path(file)
+                if not file_path.exists():
+                    raise FileNotFoundError(f"Could not find file: {file_path}")
+                log_debug(f"Reading: {file_path}")
+                doc_name = name or file_path.stem
+                source = file_path
             elif isinstance(file, BytesIO):
                 # Handle BytesIO objects
                 log_debug(f"Reading uploaded file: {getattr(file, 'name', 'BytesIO')}")
@@ -234,7 +243,7 @@ class DoclingReader(Reader):
                 doc_content = result.document.export_to_html(split_page_view=True)
             elif self.output_format == OutputFormat.DOCTAGS:
                 doc_content = result.document.export_to_doctags()
-            elif self.output_format == OutputFormat.VTT:
+            elif self.output_format == VTT_OUTPUT_FORMAT:
                 doc_content = result.document.export_to_vtt()
                 if doc_content.strip() == "WEBVTT":
                     log_debug(f"VTT export contains only headers for: {doc_name}")

--- a/libs/agno/tests/unit/reader/test_docling_reader.py
+++ b/libs/agno/tests/unit/reader/test_docling_reader.py
@@ -48,6 +48,44 @@ def test_read_file(mock_converter):
         mock_converter.convert.assert_called_once()
 
 
+def test_read_file_str_path(tmp_path, mock_converter):
+    """Test reading a local file path string with DoclingReader"""
+    file_path = tmp_path / "test.pdf"
+    file_path.write_bytes(b"%PDF-1.4\n")
+
+    reader = DoclingReader(converter=mock_converter)
+    documents = reader.read(str(file_path))
+
+    assert len(documents) == 1
+    assert documents[0].name == "test"
+    mock_converter.convert.assert_called_once_with(file_path)
+
+
+@pytest.mark.asyncio
+async def test_async_read_file_str_path(tmp_path, mock_converter):
+    """Test async reading a local file path string with DoclingReader"""
+    file_path = tmp_path / "test.pdf"
+    file_path.write_bytes(b"%PDF-1.4\n")
+
+    reader = DoclingReader(converter=mock_converter)
+    documents = await reader.async_read(str(file_path))
+
+    assert len(documents) == 1
+    assert documents[0].name == "test"
+    mock_converter.convert.assert_called_once_with(file_path)
+
+
+def test_invalid_file_str_path(tmp_path, mock_converter):
+    """Test reading a non-existent local file path string"""
+    file_path = tmp_path / "missing.pdf"
+
+    reader = DoclingReader(converter=mock_converter)
+    with pytest.raises(FileNotFoundError, match="Could not find file"):
+        reader.read(str(file_path))
+
+    mock_converter.convert.assert_not_called()
+
+
 def test_markdown_output(mock_converter):
     """Test markdown output format"""
     with (


### PR DESCRIPTION
## Summary
- accept non-URL string inputs as local paths in DoclingReader.read()
- keep URL allowlist handling unchanged before local path normalization
- add sync, async, and missing-file regressions for local string paths
- tolerate Docling versions without an OutputFormat.VTT enum while preserving the vtt export branch

Fixes #8674

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m pytest tests/unit/reader/test_docling_reader.py -q
- .venv-py/bin/python -m ruff check agno/knowledge/reader/docling_reader.py tests/unit/reader/test_docling_reader.py
- .venv-py/bin/python -m ruff format --check agno/knowledge/reader/docling_reader.py tests/unit/reader/test_docling_reader.py
- PYTHONPYCACHEPREFIX=/private/tmp/agno-issue-8674-pycache PYTHONDONTWRITEBYTECODE=1 .venv-py/bin/python -m py_compile agno/knowledge/reader/docling_reader.py tests/unit/reader/test_docling_reader.py