### PR TITLE
fix: serialize media for remote agent and team runs

### DIFF
--- a/libs/agno/agno/client/os.py
+++ b/libs/agno/agno/client/os.py
@@ -576,13 +576,15 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.model_dump() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images])
         if audio:
-            data["audio"] = json.dumps([a.model_dump() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio])
         if videos:
-            data["videos"] = json.dumps([v.model_dump() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos])
         if files:
-            data["files"] = json.dumps([f.model_dump() for f in files])
+            # Sent as "input_files" because the run endpoints already use the "files"
+            # field for multipart uploads (List[UploadFile]).
+            data["input_files"] = json.dumps([f.to_dict() for f in files])
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
@@ -636,13 +638,15 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps([img.model_dump() for img in images])
+            data["images"] = json.dumps([img.to_dict() for img in images])
         if audio:
-            data["audio"] = json.dumps([a.model_dump() for a in audio])
+            data["audio"] = json.dumps([a.to_dict() for a in audio])
         if videos:
-            data["videos"] = json.dumps([v.model_dump() for v in videos])
+            data["videos"] = json.dumps([v.to_dict() for v in videos])
         if files:
-            data["files"] = json.dumps([f.model_dump() for f in files])
+            # Sent as "input_files" because the run endpoints already use the "files"
+            # field for multipart uploads (List[UploadFile]).
+            data["input_files"] = json.dumps([f.to_dict() for f in files])
 
         for key, value in kwargs.items():
             if isinstance(value, dict):
@@ -848,13 +852,15 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps(images)
+            data["images"] = json.dumps([img.to_dict() for img in images])
         if audio:
-            data["audio"] = json.dumps(audio)
+            data["audio"] = json.dumps([a.to_dict() for a in audio])
         if videos:
-            data["videos"] = json.dumps(videos)
+            data["videos"] = json.dumps([v.to_dict() for v in videos])
         if files:
-            data["files"] = json.dumps(files)
+            # Sent as "input_files" because the run endpoints already use the "files"
+            # field for multipart uploads (List[UploadFile]).
+            data["input_files"] = json.dumps([f.to_dict() for f in files])
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
@@ -908,13 +914,15 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps(images)
+            data["images"] = json.dumps([img.to_dict() for img in images])
         if audio:
-            data["audio"] = json.dumps(audio)
+            data["audio"] = json.dumps([a.to_dict() for a in audio])
         if videos:
-            data["videos"] = json.dumps(videos)
+            data["videos"] = json.dumps([v.to_dict() for v in videos])
         if files:
-            data["files"] = json.dumps(files)
+            # Sent as "input_files" because the run endpoints already use the "files"
+            # field for multipart uploads (List[UploadFile]).
+            data["input_files"] = json.dumps([f.to_dict() for f in files])
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
@@ -1152,13 +1160,15 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps(images)
+            data["images"] = json.dumps([img.to_dict() for img in images])
         if audio:
-            data["audio"] = json.dumps(audio)
+            data["audio"] = json.dumps([a.to_dict() for a in audio])
         if videos:
-            data["videos"] = json.dumps(videos)
+            data["videos"] = json.dumps([v.to_dict() for v in videos])
         if files:
-            data["files"] = json.dumps(files)
+            # Sent as "input_files" because the run endpoints already use the "files"
+            # field for multipart uploads (List[UploadFile]).
+            data["input_files"] = json.dumps([f.to_dict() for f in files])
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():
@@ -1212,13 +1222,15 @@ class AgentOSClient:
         if user_id is not None:
             data["user_id"] = user_id
         if images:
-            data["images"] = json.dumps(images)
+            data["images"] = json.dumps([img.to_dict() for img in images])
         if audio:
-            data["audio"] = json.dumps(audio)
+            data["audio"] = json.dumps([a.to_dict() for a in audio])
         if videos:
-            data["videos"] = json.dumps(videos)
+            data["videos"] = json.dumps([v.to_dict() for v in videos])
         if files:
-            data["files"] = json.dumps(files)
+            # Sent as "input_files" because the run endpoints already use the "files"
+            # field for multipart uploads (List[UploadFile]).
+            data["input_files"] = json.dumps([f.to_dict() for f in files])
 
         # Add kwargs to data, serializing dicts as JSON
         for key, value in kwargs.items():

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -696,6 +696,14 @@ def get_agent_router(
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
 
+        # Merge media passed as JSON form fields (sent by AgnoClient, e.g. when a team
+        # delegates to this agent as a remote member) with media from uploaded files.
+        # Popped from kwargs since they are passed explicitly to the run methods below.
+        base64_images.extend(kwargs.pop("images", None) or [])
+        base64_audios.extend(kwargs.pop("audio", None) or [])
+        base64_videos.extend(kwargs.pop("videos", None) or [])
+        input_files.extend(kwargs.pop("files", None) or [])
+
         # Extract auth token for remote agents
         auth_token = get_auth_token_from_request(request)
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -670,6 +670,14 @@ def get_team_router(
                 else:
                     raise HTTPException(status_code=400, detail="Unsupported file type")
 
+        # Merge media passed as JSON form fields (sent by AgnoClient, e.g. when this team
+        # is used as a remote member) with media from uploaded files.
+        # Popped from kwargs since they are passed explicitly to the run methods below.
+        base64_images.extend(kwargs.pop("images", None) or [])
+        base64_audios.extend(kwargs.pop("audio", None) or [])
+        base64_videos.extend(kwargs.pop("videos", None) or [])
+        document_files.extend(kwargs.pop("files", None) or [])
+
         # Extract auth token for remote teams
         auth_token = get_auth_token_from_request(request)
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime, timezone
 from os import getenv
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
 
 from fastapi import FastAPI, HTTPException, Request, UploadFile
 from fastapi.routing import APIRoute, APIRouter
@@ -108,6 +108,31 @@ async def get_request_kwargs(request: Request, endpoint_func: Callable) -> Dict[
         except json.JSONDecodeError as e:
             kwargs.pop("metadata")
             log_warning(f"Invalid metadata parameter couldn't be loaded: {metadata}: {str(e)}")
+
+    # Handle media parameters. AgnoClient (e.g. remote agent/team members) sends them as
+    # JSON strings of media dicts with base64-encoded content, the format produced by
+    # Image/Audio/Video/File.to_dict(). Documents arrive as "input_files" (the "files"
+    # form field is reserved for multipart uploads) but are stored under the "files"
+    # kwarg, the parameter name the run methods expect.
+    from agno.utils.media import reconstruct_audio_list, reconstruct_files, reconstruct_images, reconstruct_videos
+
+    media_params: Dict[str, Tuple[str, Callable]] = {
+        "images": ("images", reconstruct_images),
+        "audio": ("audio", reconstruct_audio_list),
+        "videos": ("videos", reconstruct_videos),
+        "input_files": ("files", reconstruct_files),
+    }
+    for form_key, (kwarg_key, reconstructor) in media_params.items():
+        media_value = kwargs.get(form_key)
+        if not media_value or not isinstance(media_value, str):
+            continue
+        kwargs.pop(form_key)
+        try:
+            reconstructed_media = reconstructor(json.loads(media_value))
+            if reconstructed_media:
+                kwargs[kwarg_key] = reconstructed_media
+        except json.JSONDecodeError as e:
+            log_warning(f"Invalid {form_key} parameter couldn't be loaded: {str(e)}")
 
     if knowledge_filters := kwargs.get("knowledge_filters"):
         try:

--- a/libs/agno/tests/integration/os/test_run_media_form_fields.py
+++ b/libs/agno/tests/integration/os/test_run_media_form_fields.py
@@ -1,0 +1,109 @@
+"""Integration tests for media passed as JSON form fields to the run endpoints.
+
+AgnoClient (used by the Team API to delegate to a RemoteAgent member) sends media as JSON form fields with base64-encoded
+RemoteAgent/RemoteTeam members) sends media as JSON form fields with base64-encoded
+content, the format produced by Image/Audio/Video/File.to_dict(). The run endpoints must
+reconstruct these into media objects and pass them to the run — previously the raw JSON
+string collided with the explicit media kwargs and the media never reached the agent.
+"""
+
+import json
+import struct
+import zlib
+
+from agno.agent.agent import Agent
+from agno.media import Image
+from agno.team.team import Team
+
+
+def make_png(width: int = 64, height: int = 64, rgb: tuple = (255, 0, 0)) -> bytes:
+    """Build a solid-color PNG in pure Python (no pillow dependency)."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    row = b"\x00" + bytes(rgb) * width
+    idat = zlib.compress(row * height)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def red_image_form_field() -> str:
+    """Serialize a red image exactly like AgnoClient.run_agent/run_team do."""
+    image = Image(content=make_png(rgb=(255, 0, 0)), format="png", mime_type="image/png")
+    return json.dumps([image.to_dict()])
+
+
+def test_agent_run_with_images_form_field(test_os_client, test_agent: Agent):
+    """An images JSON form field (AgnoClient wire format) reaches the agent."""
+    response = test_os_client.post(
+        f"/agents/{test_agent.id}/runs",
+        data={
+            "message": "What is the dominant color of the attached image? Answer with the color name only.",
+            "stream": "false",
+            "images": red_image_form_field(),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["run_id"] is not None
+    assert "red" in str(response_json["content"]).lower()
+
+
+def test_agent_run_streaming_with_images_form_field(test_os_client, test_agent: Agent):
+    """Same as above via the streaming path."""
+    with test_os_client.stream(
+        "POST",
+        f"/agents/{test_agent.id}/runs",
+        data={
+            "message": "What is the dominant color of the attached image? Answer with the color name only.",
+            "stream": "true",
+            "images": red_image_form_field(),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    ) as response:
+        assert response.status_code == 200
+
+        content = ""
+        for line in response.iter_lines():
+            if line.startswith("data: "):
+                data = line[6:]
+                if data != "[DONE]":
+                    content += json.loads(data).get("content") or ""
+
+    assert "red" in content.lower()
+
+
+def test_team_run_with_images_form_field(test_os_client, test_team: Team):
+    """An images JSON form field reaches the team run."""
+    response = test_os_client.post(
+        f"/teams/{test_team.id}/runs",
+        data={
+            "message": "What is the dominant color of the attached image? Answer with the color name only.",
+            "stream": "false",
+            "images": red_image_form_field(),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+
+    response_json = response.json()
+    assert response_json["run_id"] is not None
+    assert "red" in str(response_json["content"]).lower()
+
+
+def test_agent_run_with_invalid_images_form_field(test_os_client, test_agent: Agent):
+    """An unparseable images field is dropped with a warning instead of failing the run."""
+    response = test_os_client.post(
+        f"/agents/{test_agent.id}/runs",
+        data={
+            "message": "Hello, world!",
+            "stream": "false",
+            "images": "not-valid-json",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 200
+    assert response.json()["content"] is not None


### PR DESCRIPTION
## Summary

Fixes #8789.

A Team with a `RemoteAgent` member failed when the run included multimodal media
(e.g. images uploaded to `/teams/{team_id}/runs`). When the team leader delegated
to the remote member, `AgnoClient` serialized media with
`json.dumps([img.model_dump() for img in images])` — and since `Image.content` is
raw `bytes`, delegation crashed with:

    Error while iterating async generator for delegate_task_to_member:
    Object of type bytes is not JSON serializable

**The bug was actually two bugs.** Even with serialization fixed, media could
never reach the remote agent: the receiving run endpoints have no `images`/`audio`/
`videos` form parameters, so the field was swept into `**kwargs` by
`get_request_kwargs()` as a raw JSON string — and since the endpoints also pass
media explicitly (`agent.arun(..., images=..., **kwargs)`), the request died with
`TypeError: arun() got multiple values for keyword argument 'images'`.
Additionally, `run_team`/`run_team_stream`/`run_workflow` called
`json.dumps(images)` directly on pydantic objects, which crashed for *any* media,
even URL-only images.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
