### PR TITLE
[feat] Add HuggingFace image generation tool

### DIFF
--- a/cookbook/91_tools/huggingface_image_tools.py
+++ b/cookbook/91_tools/huggingface_image_tools.py
@@ -1,0 +1,59 @@
+"""
+Example showing how to use the HuggingFaceImageTools toolkit with your Agno Agent.
+
+Generates images from text prompts using the Hugging Face Inference API.
+Supports any text-to-image model hosted on Hugging Face Hub (FLUX, Stable Diffusion, etc.).
+Default model: black-forest-labs/FLUX.1-schnell (Apache 2.0, free tier compatible).
+
+Usage:
+- Set your Hugging Face token as environment variable: `export HF_TOKEN="hf_xxxxx"`
+- Run `uv pip install agno huggingface_hub` to install dependencies
+"""
+
+from agno.agent import Agent
+from agno.tools.huggingface_images import HuggingFaceImageTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+# Example 1: Basic image generation with default model (FLUX.1 Schnell)
+agent = Agent(
+    tools=[HuggingFaceImageTools()],
+    name="HuggingFace Image Generator",
+)
+
+# Example 2: Custom model and provider
+agent_custom = Agent(
+    tools=[
+        HuggingFaceImageTools(
+            model="black-forest-labs/FLUX.1-dev",
+            provider="hf-inference",
+            image_format="png",
+        )
+    ],
+    name="Custom HuggingFace Generator",
+)
+
+# Example 3: With explicit API key
+agent_with_key = Agent(
+    tools=[HuggingFaceImageTools(api_key="hf_xxxxx")],
+    name="HuggingFace Generator with Key",
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Generate an image of a futuristic city with flying cars and tall skyscrapers",
+        markdown=True,
+    )
+
+    response = agent_custom.run(
+        "Create a peaceful mountain lake at sunset",
+        markdown=True,
+    )
+    if response.images:
+        for img in response.images:
+            print(f"Image ID: {img.id}, Size: {len(img.content)} bytes")

--- a/libs/agno/agno/tools/huggingface_images.py
+++ b/libs/agno/agno/tools/huggingface_images.py
@@ -1,0 +1,86 @@
+from io import BytesIO
+from os import getenv
+from typing import Any, List, Optional
+from uuid import uuid4
+
+from agno.media import Image
+from agno.tools import Toolkit
+from agno.tools.function import ToolResult
+from agno.utils.log import log_debug, log_error, logger
+
+try:
+    from huggingface_hub import InferenceClient
+except ImportError:
+    raise ImportError("`huggingface_hub` not installed. Please install using `pip install huggingface_hub`")
+
+
+class HuggingFaceImageTools(Toolkit):
+    """Toolkit for generating images using Hugging Face Inference API.
+
+    Args:
+        model: The model ID on Hugging Face Hub. Default: "black-forest-labs/FLUX.1-schnell".
+        provider: The inference provider. Default: "hf-inference".
+        api_key: Hugging Face API token. Defaults to HF_TOKEN environment variable.
+        image_format: Output image format. Default: "png".
+        enable_create_image: Register the create_image tool. Default: True.
+    """
+
+    def __init__(
+        self,
+        model: str = "black-forest-labs/FLUX.1-schnell",
+        provider: str = "hf-inference",
+        api_key: Optional[str] = None,
+        image_format: str = "png",
+        enable_create_image: bool = True,
+        **kwargs: Any,
+    ):
+        self.model = model
+        self.provider = provider
+        self.api_key = api_key or getenv("HF_TOKEN")
+        self.image_format = image_format
+
+        if not self.api_key:
+            log_error("HF_TOKEN not set. Please set the HF_TOKEN environment variable or pass api_key.")
+
+        tools: List[Any] = []
+        if enable_create_image:
+            tools.append(self.create_image)
+
+        super().__init__(name="huggingface_images", tools=tools, **kwargs)
+
+    def create_image(self, prompt: str) -> ToolResult:
+        """Generate an image from a text prompt using Hugging Face Inference API.
+
+        Args:
+            prompt: A detailed text description of the image to generate.
+
+        Returns:
+            ToolResult containing the generated image.
+        """
+        if not self.api_key:
+            return ToolResult(content="Error: HF_TOKEN not set. Please set the HF_TOKEN environment variable.")
+
+        try:
+            log_debug(f"Generating image with model: {self.model}")
+            client = InferenceClient(provider=self.provider, api_key=self.api_key)
+            image = client.text_to_image(prompt, model=self.model)
+
+            buffer = BytesIO()
+            image.save(buffer, format=self.image_format.upper())
+            image_bytes = buffer.getvalue()
+
+            generated_image = Image(
+                id=str(uuid4()),
+                content=image_bytes,
+                format=self.image_format,
+                original_prompt=prompt,
+            )
+
+            log_debug(f"Image generated successfully: {generated_image.id}")
+            return ToolResult(
+                content=f"Image generated successfully from prompt: {prompt}",
+                images=[generated_image],
+            )
+        except Exception as e:
+            log_error(f"Failed to generate image: {e}")
+            return ToolResult(content=f"Error generating image: {e}")

--- a/libs/agno/tests/unit/tools/test_huggingface_images.py
+++ b/libs/agno/tests/unit/tools/test_huggingface_images.py
@@ -1,0 +1,139 @@
+"""Unit tests for HuggingFaceImageTools class."""
+
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from PIL import Image as PILImage
+
+from agno.tools.huggingface_images import HuggingFaceImageTools
+
+
+def _make_test_image(width=64, height=64):
+    """Create a minimal test image."""
+    return PILImage.new("RGB", (width, height), color="red")
+
+
+@pytest.fixture
+def tools():
+    """Create a HuggingFaceImageTools instance with a test API key."""
+    return HuggingFaceImageTools(api_key="test-key")
+
+
+def test_default_model(tools):
+    assert tools.model == "black-forest-labs/FLUX.1-schnell"
+
+
+def test_custom_model():
+    t = HuggingFaceImageTools(model="stabilityai/stable-diffusion-xl-base-1.0", api_key="test-key")
+    assert t.model == "stabilityai/stable-diffusion-xl-base-1.0"
+
+
+def test_default_provider(tools):
+    assert tools.provider == "hf-inference"
+
+
+def test_api_key_from_param():
+    t = HuggingFaceImageTools(api_key="my-key")
+    assert t.api_key == "my-key"
+
+
+@patch.dict("os.environ", {"HF_TOKEN": "env-key"})
+def test_api_key_from_env():
+    t = HuggingFaceImageTools()
+    assert t.api_key == "env-key"
+
+
+def test_tool_registered(tools):
+    assert "create_image" in tools.functions
+
+
+def test_tool_disabled():
+    t = HuggingFaceImageTools(api_key="test-key", enable_create_image=False)
+    assert "create_image" not in t.functions
+
+
+def test_toolkit_name(tools):
+    assert tools.name == "huggingface_images"
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_create_image_returns_image(mock_client_cls, tools):
+    mock_client_cls.return_value.text_to_image.return_value = _make_test_image()
+
+    result = tools.create_image("a red circle")
+
+    assert result.images is not None
+    assert len(result.images) == 1
+    assert result.images[0].content is not None
+    assert result.images[0].original_prompt == "a red circle"
+    assert "successfully" in result.content.lower()
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_create_image_passes_model(mock_client_cls):
+    mock_client_cls.return_value.text_to_image.return_value = _make_test_image()
+
+    t = HuggingFaceImageTools(model="custom/model", api_key="test-key")
+    t.create_image("test prompt")
+
+    mock_client_cls.return_value.text_to_image.assert_called_once_with("test prompt", model="custom/model")
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_create_image_passes_provider(mock_client_cls):
+    mock_client_cls.return_value.text_to_image.return_value = _make_test_image()
+
+    t = HuggingFaceImageTools(provider="fal-ai", api_key="test-key")
+    t.create_image("test")
+
+    mock_client_cls.assert_called_once_with(provider="fal-ai", api_key="test-key")
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_create_image_error(mock_client_cls, tools):
+    mock_client_cls.return_value.text_to_image.side_effect = Exception("API down")
+
+    result = tools.create_image("test")
+
+    assert result.images is None
+    assert "error" in result.content.lower()
+    assert "API down" in result.content
+
+
+def test_create_image_no_api_key():
+    t = HuggingFaceImageTools(api_key=None)
+    t.api_key = None
+    result = t.create_image("test")
+
+    assert result.images is None
+    assert "HF_TOKEN" in result.content
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_image_has_unique_id(mock_client_cls, tools):
+    mock_client_cls.return_value.text_to_image.return_value = _make_test_image()
+
+    r1 = tools.create_image("test 1")
+    r2 = tools.create_image("test 2")
+
+    assert r1.images[0].id != r2.images[0].id
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_image_format(mock_client_cls, tools):
+    mock_client_cls.return_value.text_to_image.return_value = _make_test_image()
+
+    result = tools.create_image("test")
+
+    assert result.images[0].format == "png"
+
+
+@patch("agno.tools.huggingface_images.InferenceClient")
+def test_image_content_is_valid(mock_client_cls, tools):
+    mock_client_cls.return_value.text_to_image.return_value = _make_test_image()
+
+    result = tools.create_image("test")
+
+    img = PILImage.open(BytesIO(result.images[0].content))
+    assert img.size == (64, 64)


### PR DESCRIPTION
Closes #8835

## Summary
- Adds `HuggingFaceImageTools` toolkit for generating images using the Hugging Face Inference API
- Supports any text-to-image model on HuggingFace Hub (FLUX, Stable Diffusion, etc.)
- Free tier compatible — no credit card required
- Follows the same pattern as `DalleTools` and `NanoBananaTools`

## What's included
- `libs/agno/agno/tools/huggingface_images.py` — Tool class with `create_image()` method
- `libs/agno/tests/unit/tools/test_huggingface_images.py` — 16 unit tests (all mocked)
- `cookbook/91_tools/huggingface_image_tools.py` — Usage examples

## Why
Agno has image generation tools for paid APIs (DALL-E, Gemini) but none for free providers. This fills that gap using Hugging Face's Inference API with FLUX.1 Schnell as the default model.

## AI Disclosure
This PR was developed with assistance from Claude Code. All code has been reviewed, tested, and understood by the author.