### PR TITLE
[fix] Harden ResendTools against data exfiltration (#8847)

### DIFF
--- a/cookbook/91_tools/resend_tools.py
+++ b/cookbook/91_tools/resend_tools.py
@@ -3,20 +3,37 @@ Resend Tools
 =============================
 
 Demonstrates resend tools.
+
+``send_email`` sends an arbitrary recipient/subject/body using the host's Resend
+API key. To avoid turning the agent into a data-exfiltration sink under prompt
+injection, prefer the hardened configuration below: require human approval and
+restrict recipients to an allowlist.
 """
 
 from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
 from agno.tools.resend import ResendTools
 
 # ---------------------------------------------------------------------------
 # Create Agent
 # ---------------------------------------------------------------------------
 
-
 from_email = "<enter_from_email>"
 to_email = "<enter_to_email>"
 
-agent = Agent(tools=[ResendTools(from_email=from_email)])
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[
+        ResendTools(
+            from_email=from_email,
+            # Gate every send behind human-in-the-loop approval.
+            require_confirmation=True,
+            # Only allow recipients in these domains (or use allowed_emails for
+            # exact addresses).
+            allowed_domains=["example.com"],
+        )
+    ],
+)
 
 # ---------------------------------------------------------------------------
 # Run Agent

--- a/libs/agno/agno/tools/resend.py
+++ b/libs/agno/agno/tools/resend.py
@@ -1,13 +1,18 @@
+import re
 from os import getenv
 from typing import Any, List, Optional
 
 from agno.tools import Toolkit
-from agno.utils.log import log_error, log_info, logger
+from agno.utils.log import log_error, log_info, log_warning, logger
 
 try:
     import resend  # type: ignore
 except ImportError:
     raise ImportError("`resend` not installed. Please install using `pip install resend`.")
+
+
+# Minimal email address validation: <local>@<domain>.<tld>
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
 class ResendTools(Toolkit):
@@ -16,22 +21,86 @@ class ResendTools(Toolkit):
         api_key: Optional[str] = None,
         from_email: Optional[str] = None,
         enable_send_email: bool = True,
+        require_confirmation: bool = False,
+        allowed_emails: Optional[List[str]] = None,
+        allowed_domains: Optional[List[str]] = None,
         all: bool = False,
         **kwargs,
     ):
+        """Initialize ResendTools.
+
+        .. warning::
+            ``send_email`` sends an arbitrary recipient/subject/body using the
+            host's Resend API key. By default this is a data-exfiltration sink if
+            the agent is prompt-injected. To harden it, set
+            ``require_confirmation=True`` (gates every send behind human approval)
+            and/or restrict recipients via ``allowed_emails`` / ``allowed_domains``.
+
+        Args:
+            api_key: Resend API key. Falls back to the ``RESEND_API_KEY`` env var.
+            from_email: The ``From`` address.
+            enable_send_email: Register the ``send_email`` tool.
+            require_confirmation: If True, mark ``send_email`` as requiring
+                human-in-the-loop confirmation before execution.
+            allowed_emails: Allowlist of exact recipient addresses. If set, only
+                these recipients may receive mail.
+            allowed_domains: Allowlist of recipient domains (e.g. ``["example.com"]``).
+                If set, every recipient's domain must be listed. Combined with
+                ``allowed_emails`` — a recipient passes if it matches either list.
+            all: Register all tools.
+        """
         self.from_email = from_email
         self.api_key = api_key or getenv("RESEND_API_KEY")
         if not self.api_key:
             log_error("No Resend API key provided")
 
+        self.allowed_emails = [e.lower().strip() for e in allowed_emails] if allowed_emails else None
+        self.allowed_domains = [d.lower().strip().lstrip(".") for d in allowed_domains] if allowed_domains else None
+
         tools: List[Any] = []
         if all or enable_send_email:
             tools.append(self.send_email)
 
-        super().__init__(name="resend_tools", tools=tools, **kwargs)
+        super().__init__(
+            name="resend_tools",
+            tools=tools,
+            requires_confirmation_tools=["send_email"] if require_confirmation else None,
+            **kwargs,
+        )
+
+    def _validate_recipient(self, to_email: str) -> Optional[str]:
+        """Validate a comma-separated recipient list against format + allowlists.
+
+        Returns an error message string if any recipient is invalid/blocked, or
+        None if all recipients are allowed.
+        """
+        recipients = [r.strip() for r in to_email.split(",") if r.strip()]
+        if not recipients:
+            return "Error: Please provide an email address to send the email to."
+
+        has_allowlist = self.allowed_emails is not None or self.allowed_domains is not None
+
+        for recipient in recipients:
+            if not _EMAIL_RE.match(recipient):
+                return f"Error: Invalid email address: {recipient}"
+
+            if has_allowlist:
+                normalized = recipient.lower()
+                domain = normalized.rsplit("@", 1)[-1] if "@" in normalized else ""
+                email_ok = self.allowed_emails is not None and normalized in self.allowed_emails
+                domain_ok = self.allowed_domains is not None and domain in self.allowed_domains
+                if not email_ok and not domain_ok:
+                    return f"Error: Recipient '{recipient}' is not in the allowed emails/domains list."
+
+        return None
 
     def send_email(self, to_email: str, subject: str, body: str) -> str:
         """Send an email using the Resend API. Returns if the email was sent successfully or an error message.
+
+        .. warning::
+            The recipient and body are model-controlled. Harden this tool via
+            ``require_confirmation=True`` and/or ``allowed_emails`` /
+            ``allowed_domains`` on ``ResendTools`` to prevent data exfiltration.
 
         :to_email: The email address to send the email to.
         :subject: The subject of the email.
@@ -40,14 +109,19 @@ class ResendTools(Toolkit):
         """
 
         if not self.api_key:
-            return "Please provide an API key"
-        if not to_email:
-            return "Please provide an email address to send the email to"
+            return "Error: Please provide an API key"
+
+        validation_error = self._validate_recipient(to_email)
+        if validation_error is not None:
+            log_warning(f"Blocked send_email: {validation_error}")
+            return validation_error
 
         log_info(f"Sending email to: {to_email}")
 
         resend.api_key = self.api_key
         try:
+            if not self.from_email:
+                return "Error: Please provide a from_email address"
             params = {
                 "from": self.from_email,
                 "to": to_email,
@@ -55,7 +129,9 @@ class ResendTools(Toolkit):
                 "html": body,
             }
 
-            resend.Emails.send(params)
+            # resend expects its typed SendParams; we build a plain dict as the
+            # original implementation did. SDK typing mismatch is ignored.
+            resend.Emails.send(params)  # type: ignore[arg-type]
             return f"Email sent to {to_email} successfully."
         except Exception as e:
             logger.exception("Failed to send email")

--- a/libs/agno/tests/unit/tools/test_resend_tools.py
+++ b/libs/agno/tests/unit/tools/test_resend_tools.py
@@ -1,0 +1,134 @@
+"""Tests for ResendTools security hardening (issue #8847).
+
+ResendTools.send_email sends an arbitrary recipient/subject/body using the
+host's Resend API key. By default this is a data-exfiltration sink if the agent
+is prompt-injected. These tests verify the opt-in defenses: recipient allowlist
+(allowed_emails / allowed_domains), input validation, and HITL confirmation
+gating. The network call (resend.Emails.send) is mocked throughout — no API
+key or network is required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.tools.resend import ResendTools
+
+
+@pytest.fixture
+def mock_resend():
+    """Patch the resend module's Emails.send so no network call is made."""
+    with patch("agno.tools.resend.resend") as mocked:
+        mocked.Emails.send = MagicMock(return_value={"id": "fake-id"})
+        yield mocked
+
+
+# --- defaults / opt-in posture ---
+
+
+def test_send_email_registered_by_default():
+    """send_email is registered by default (existing contract preserved)."""
+    tools = ResendTools(api_key="test-key")
+    assert "send_email" in tools.functions
+
+
+def test_send_email_no_confirmation_by_default():
+    """Default keeps backward-compatible behavior (no confirmation gate)."""
+    tools = ResendTools(api_key="test-key")
+    fn = tools.functions["send_email"]
+    assert fn.requires_confirmation is False
+
+
+def test_send_email_sends_when_unrestricted(mock_resend):
+    """Unrestricted mode sends to any recipient (backward compat)."""
+    tools = ResendTools(api_key="test-key", from_email="bot@example.com")
+    result = tools.send_email("attacker@evil.com", "hello", "<p>data</p>")
+    assert "successfully" in result
+    mock_resend.Emails.send.assert_called_once()
+
+
+# --- HITL confirmation ---
+
+
+def test_send_email_requires_confirmation_when_enabled():
+    """When require_confirmation=True, the tool is flagged for HITL."""
+    tools = ResendTools(api_key="test-key", require_confirmation=True)
+    fn = tools.functions["send_email"]
+    assert fn.requires_confirmation is True
+
+
+# --- recipient allowlist (allowed_emails) ---
+
+
+def test_allowed_emails_blocks_unlisted_recipient(mock_resend):
+    """Recipients not in allowed_emails are blocked."""
+    tools = ResendTools(api_key="test-key", allowed_emails=["friend@example.com"])
+    result = tools.send_email("attacker@evil.com", "hi", "body")
+    assert "Error" in result
+    assert "allowed" in result.lower()
+    mock_resend.Emails.send.assert_not_called()
+
+
+def test_allowed_emails_allows_listed_recipient(mock_resend):
+    """A recipient in allowed_emails is sent."""
+    tools = ResendTools(api_key="test-key", from_email="bot@example.com", allowed_emails=["friend@example.com"])
+    result = tools.send_email("friend@example.com", "hi", "body")
+    assert "successfully" in result
+    mock_resend.Emails.send.assert_called_once()
+
+
+# --- recipient allowlist (allowed_domains) ---
+
+
+def test_allowed_domains_blocks_unlisted_domain(mock_resend):
+    """Recipients whose domain is not in allowed_domains are blocked."""
+    tools = ResendTools(api_key="test-key", allowed_domains=["example.com"])
+    result = tools.send_email("attacker@evil.com", "hi", "body")
+    assert "Error" in result
+    assert "allowed" in result.lower()
+    mock_resend.Emails.send.assert_not_called()
+
+
+def test_allowed_domains_allows_listed_domain(mock_resend):
+    """A recipient whose domain is in allowed_domains is sent."""
+    tools = ResendTools(api_key="test-key", from_email="bot@example.com", allowed_domains=["example.com"])
+    result = tools.send_email("anyone@example.com", "hi", "body")
+    assert "successfully" in result
+    mock_resend.Emails.send.assert_called_once()
+
+
+def test_allowed_domains_block_applies_to_all_recipients(mock_resend):
+    """When one of several recipients is outside the allowlist, nothing is sent."""
+    tools = ResendTools(api_key="test-key", allowed_domains=["example.com"])
+    result = tools.send_email("ok@example.com, bad@evil.com", "hi", "body")
+    assert "Error" in result
+    mock_resend.Emails.send.assert_not_called()
+
+
+# --- input validation ---
+
+
+def test_missing_recipient_rejected(mock_resend):
+    """An empty recipient is rejected before sending."""
+    tools = ResendTools(api_key="test-key")
+    result = tools.send_email("", "subject", "body")
+    assert "Error" in result or "provide" in result.lower()
+    mock_resend.Emails.send.assert_not_called()
+
+
+def test_malformed_email_rejected(mock_resend):
+    """A recipient without '@' is rejected (input validation at boundary)."""
+    tools = ResendTools(api_key="test-key")
+    result = tools.send_email("not-an-email", "subject", "body")
+    assert "Error" in result
+    assert "invalid" in result.lower()
+    mock_resend.Emails.send.assert_not_called()
+
+
+def test_missing_api_key_rejected(mock_resend):
+    """Without an API key, no send is attempted."""
+    with patch("agno.tools.resend.getenv", return_value=None):
+        tools = ResendTools(api_key=None)
+    result = tools.send_email("friend@example.com", "hi", "body")
+    assert "API key" in result
+    mock_resend.Emails.send.assert_not_called()


### PR DESCRIPTION
## Summary

`ResendTools.send_email` passed the model-controlled `to_email`/`subject`/`body` directly to `resend.Emails.send` with no mediation, content filtering, or confirmation (`agno-agi/agno#8847`). Since `enable_send_email` defaults to `True`, a prompt-injected or hallucinating agent could silently exfiltrate sensitive data to an attacker-controlled address, or send spam/phishing via the host's Resend API key.

This adds **opt-in, backward-compatible** defenses:

- **`require_confirmation`** — gates `send_email` behind human-in-the-loop approval via the framework's existing `Toolkit.requires_confirmation` mechanism.
- **`allowed_emails` / `allowed_domains`** — recipient allowlists. When either is set, every recipient (comma-separated lists are supported) must match the emails list or have a domain in the domains list, or the send is blocked.
- **Input validation at the boundary** — recipients are validated with an email regex; empty and malformed addresses are rejected before the API call.
- **`from_email` guard** — reject the send when `from_email` is unset (also resolves a pre-existing mypy `Optional` type mismatch on the send params).

Defaults are deliberately unchanged (unrestricted, no confirmation) so existing callers keep working; the unsafe-by-default behavior is now documented with a `.. warning::` in the docstring. This matches the issue's "Possible Solutions" #1 (HITL confirmation) and #2 (recipient whitelisting).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Cookbook/example

## Checklist

- [x] Code follows the project style (`./scripts/format.sh`)
- [x] Validation passes (`./scripts/validate.sh`)
- [x] Tests added / updated
- [x] Self-review completed
- [x] Documented the security trade-off (opt-in, not a silent default break)

## Test plan

- [x] New unit tests in `libs/agno/tests/unit/tools/test_resend_tools.py` (12 cases): `allowed_emails` block/allow, `allowed_domains` block/allow, multi-recipient enforcement (one outside the list blocks the whole send), malformed/empty recipient rejection, missing api_key, confirmation flag on/off, and that `resend.Emails.send` is never invoked when a send is blocked.
- [x] `resend.Emails.send` is mocked throughout — no API key or network required.
- [x] `./scripts/validate.sh` green: `ruff check` + `mypy` across agno and agnoctl.

TODO (maintainer discretion):
- [ ] Consider adding `resend` to the dev/test optional dependencies so these tests run in CI without manual install (it is currently imported lazily, matching the original behavior).

## AI-generated disclosure

This PR was implemented with the assistance of Claude Code (Anthropic). The changes were reviewed, tested locally, and validated against the project's CI scripts before submission. The author understands the security implications and the backward-compatibility trade-off (opt-in hardening rather than changing defaults).
