### PR TITLE
feat(authz): AuthorizationProvider seam + managed roles + user directory on v2.7 (enforced incl. OAuth'd MCP)

### DIFF
--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -157,6 +157,22 @@ See `symmetric/advanced_scopes.py` for comprehensive examples of:
 - Multiple permission levels
 - Audience verification
 
+### Beyond token scopes: managed roles, a user directory, custom providers
+
+The examples above authorize straight from the token's `scopes`. When you'd rather
+decide access *inside* AgentOS -- assign someone a role at runtime, keep a list of
+users, or plug in your own policy -- use these. Each one is runnable
+(`python <file>`) and prints a real ALLOWED/BLOCKED transcript.
+
+| Example | What it shows |
+|---------|---------------|
+| `managed_roles.py` | Assign a **role** to a user and change it at runtime. The token carries no scopes; the store decides. |
+| `managed_users.py` | The credential-less **user directory** + the disabled kill-switch: disabling someone blocks their next request even though their token is still valid. |
+| `managed_roles_sessions.py` | Role-based control over the session surface (read vs rename vs delete). |
+| `managed_roles_audit.py` | The **audit trail**: a change trail (who changed which role) plus a decision trail (every allow/deny). |
+| `custom_authorization_provider.py` | Write your **own** `AuthorizationProvider` (here: pricing tiers) and plug it into the same enforcement points. |
+| `idp_workos_auth0.py` | Map **roles from your IdP** (WorkOS/Auth0/Okta) claims onto AgentOS permissions, verified against a JWKS. |
+
 ## Quick Start
 
 ### 1. Enable RBAC

--- a/cookbook/05_agent_os/rbac/custom_authorization_provider.py
+++ b/cookbook/05_agent_os/rbac/custom_authorization_provider.py
@@ -1,0 +1,177 @@
+"""
+Custom AuthorizationProvider - the minimal "bring your own decision engine" path.
+
+(New to authorization? Read managed_roles.py first. For a production-shaped custom
+provider that integrates a login service like WorkOS/Auth0, see idp_workos_auth0.py.)
+
+The scope tier (default) and the managed-roles tier both think in agno SCOPES. If
+your access model isn't scopes - it's ReBAC ("is this user an owner of this
+resource?"), ABAC ("same tenant?"), or a call out to your own policy engine - you
+write an AuthorizationProvider and plug it in. That ONE object is the whole
+integration; the rest of AgentOS (the request pipeline, the two enforcement points)
+stays the same.
+
+An AuthorizationProvider answers two questions (the ABC's two abstract methods):
+
+  - check(ctx)                  -> "may THIS caller do THIS action on THIS resource?"
+  - accessible_resource_ids(ctx)-> for list endpoints: which ids may they see?
+                                   ({"*"} means "all of them".)
+
+Two more methods have sensible defaults you can override:
+
+  - authorize_route(ctx, required_scopes)  the route-level gate the JWT middleware
+                                   runs BEFORE the request reaches a handler. The
+                                   default defers to check(); override it to gate a
+                                   route without understanding scope strings.
+  - require / filter_accessible    built on check / accessible_resource_ids.
+
+The example below uses a deliberately tiny, NON-scope decision model to make the
+seam obvious: the token carries a `tier` claim, and a small Python dict says what
+each tier may do. Swap the body of check()/accessible_resource_ids() for a call to
+your own engine and nothing else changes.
+
+Run it:
+    pip install agno
+    python custom_authorization_provider.py
+(no extra services, no database needed - we only check who is allowed.)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Set
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "custom-provider-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# The whole integration: implement the AuthorizationProvider ABC.
+# ---------------------------------------------------------------------------
+
+# Our (toy) access model: a "tier" on the token decides what actions are allowed.
+# This is NOT scopes - it's whatever model you like. Replace with your own engine.
+TIER_ACTIONS = {
+    "reader": {"read"},  # may read any resource
+    "runner": {"read", "run"},  # may read + run any resource
+    "owner": {"read", "run", "write"},  # may do anything
+}
+
+
+class TierAuthorizationProvider(AuthorizationProvider):
+    """Decide access from a custom `tier` claim on the token.
+
+    agno hands every decision an AuthorizationContext describing the caller and
+    what they're trying to do. We read our `tier` claim off ctx.claims and answer
+    from a plain dict. The fields we use here:
+      ctx.claims        the full decoded JWT payload (where our `tier` lives)
+      ctx.resource_type "agents" / "teams" / "workflows" / ... (None = non-resource)
+      ctx.action        "read" / "run" / "write" / ... (None = non-resource)
+    (ctx also exposes principal_id, scopes, resource_id, admin_scope for richer
+    models - we just don't need them here.)
+    """
+
+    def _allowed_actions(self, ctx: AuthorizationContext) -> Set[str]:
+        tier = ctx.claims.get("tier")
+        return TIER_ACTIONS.get(tier, set())
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type/action) is DEFERRED, not denied:
+        # the route-level gate (authorize_route) governs those paths. Returning
+        # False here would wrongly block non-resource routes. This mirrors the
+        # framework's native engine convention.
+        if not ctx.resource_type or not ctx.action:
+            return True
+        return ctx.action in self._allowed_actions(ctx)
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        # For list endpoints (GET /agents, ...): which ids may they see? Here a
+        # tier either may read everything or nothing, so it's "*" (all) or empty.
+        # A ReBAC model would instead return the specific ids this user owns.
+        if "read" in self._allowed_actions(ctx):
+            return {"*"}
+        return set()
+
+    # authorize_route() / require() / filter_accessible() use the ABC defaults,
+    # which are built on check() / accessible_resource_ids() above. Override
+    # authorize_route() if you want route gating that doesn't go through check().
+
+
+# ---------------------------------------------------------------------------
+# Wire it in: AuthorizationConfig(authorization_provider=<your provider>).
+# ---------------------------------------------------------------------------
+
+db = SqliteDb(db_file="tmp/agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="AgentOS with a custom authorization provider",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        # The seam: hand AgentOS your provider. That's the entire integration.
+        authorization_provider=TierAuthorizationProvider(),
+    ),
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)
+    client = TestClient(app)
+
+    def token(sub: str, tier: str) -> str:
+        return jwt.encode(
+            {
+                "sub": sub,
+                "aud": OS_ID,
+                "tier": tier,  # our custom claim - the provider reads this
+                "exp": datetime.now(UTC) + timedelta(hours=24),
+            },
+            JWT_SECRET,
+            algorithm="HS256",
+        )
+
+    def show(label: str, tok: str, method: str, path: str, note: str = "") -> None:
+        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 80)
+    print("CUSTOM PROVIDER - a `tier` claim decides what you can do")
+    print("=" * 80)
+    print("  tiers:  reader = read | runner = read + run | owner = anything")
+    print("  each caller makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
+
+    show("reader  LOOK at the agent", token("r", "reader"), "GET", "/agents/research-agent", "readers can read")
+    show("reader  RUN the agent", token("r", "reader"), "POST", "/agents/research-agent/runs", "readers can't run -> bounced")
+    show("runner  RUN the agent", token("n", "runner"), "POST", "/agents/research-agent/runs", "runners can run")
+    show("owner   RUN the agent", token("o", "owner"), "POST", "/agents/research-agent/runs", "owners can do anything")
+    show("guest   LOOK at the agent", token("g", "guest"), "GET", "/agents/research-agent", "unknown tier -> bounced")
+
+    print("=" * 80)
+    print("the point: one AuthorizationProvider IS the whole integration. Swap the body")
+    print("of check()/accessible_resource_ids() for your own engine; nothing else changes.")
+    print("=" * 80)

--- a/cookbook/05_agent_os/rbac/idp_workos_auth0.py
+++ b/cookbook/05_agent_os/rbac/idp_workos_auth0.py
@@ -1,0 +1,225 @@
+"""
+Using AgentOS with a login service (WorkOS / Auth0 / Okta) - you only enforce
+
+(New to this? Read managed_roles.py first.)
+
+When a company already has a login service, that service logs people in and puts
+each person's role on their token. You don't store any users or who-has-which-role
+- that's the login service's job. You keep one small thing: what each role is
+allowed to do, and you enforce it on every request.
+
+This file shows the realistic, production-shaped version of that:
+
+1. The token is signed by the login service with its private key (RS256). You
+   verify it against the service's PUBLIC keys, which it publishes as a "JWKS"
+   (e.g. at https://<tenant>.auth0.com/.well-known/jwks.json). Download it and
+   point agno at the file:
+       AuthorizationConfig(jwks_file="auth0_jwks.json", ...)
+   (Here we generate a throwaway key and publish it to a local file so the example
+   runs offline; the behaviour is identical.)
+2. The token says who issued it (`iss`) and who it's for (`aud`). We pin both, so
+   a token meant for a different app can't be replayed against this one.
+3. The person's role rides the token in a claim. WorkOS uses a single string;
+   Auth0 uses a list. You write a tiny AuthorizationProvider that turns those role
+   names into permissions. That provider is the whole integration - about 30 lines
+   below - and it's where you'd plug in any logic you like.
+
+The split to remember: the login service owns WHO is a "member" or "admin"; you
+own WHAT those words are allowed to do.
+
+Run it:
+    pip install agno
+    python idp_workos_auth0.py
+(no extra services, no database, no OpenAI key - we only check who is allowed.)
+"""
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from typing import Set
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.config import AuthorizationConfig
+from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+from agno.utils.cryptography import generate_rsa_keys
+from jwt.algorithms import RSAAlgorithm
+
+OS_ID = "acme-agentos"  # the token "aud" - who the token is for
+ISSUER = "https://acme.example-idp.com/"  # the token "iss" - who minted it
+JWKS_PATH = "tmp/idp_jwks.json"
+os.makedirs("tmp", exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# The integration: map the login service's role names -> what they can do.
+# ---------------------------------------------------------------------------
+
+# What each role is allowed to do, in agno's permission terms ("scopes"):
+#   "agents:*:read"               -> look at any agent
+#   "agents:research-agent:run"   -> run the one agent called research-agent
+#   "agent_os:admin"              -> do anything
+# The login service decides who has each role; this dict decides what they mean.
+ROLE_PERMISSIONS = {
+    "member": ["agents:*:read", "agents:research-agent:run"],
+    "admin": ["agent_os:admin"],
+}
+
+
+class RoleClaimAuthorizationProvider(AuthorizationProvider):
+    """Turns the role names on the token into AgentOS permissions.
+
+    This is the entire login-service integration. agno hands you a context with
+    the decoded token claims; you decide what the caller may do. Here we look up
+    the caller's role(s) on the token and expand them into agno scopes, then let
+    agno's scope matcher answer the question. Swap the body for anything you like
+    (call your own service, read attributes, etc.) - the rest of AgentOS doesn't
+    change.
+    """
+
+    def __init__(self, role_permissions, roles_claim="roles", admin_scope="agent_os:admin"):
+        self.role_permissions = role_permissions
+        self.roles_claim = roles_claim  # the claim your IdP puts roles in
+        self.admin_scope = admin_scope
+
+    def _scopes_for(self, ctx: AuthorizationContext):
+        """The permissions this caller has, from the role(s) on their token."""
+        roles = ctx.claims.get(self.roles_claim) or []
+        if isinstance(roles, str):  # WorkOS sends one string; Auth0 sends a list
+            roles = [roles]
+        scopes = []
+        for role in roles:
+            scopes.extend(self.role_permissions.get(role, []))
+        return scopes
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # Per-resource question, e.g. "may they run agent X?"
+        if not ctx.resource_type or not ctx.action:
+            # Non-resource check: defer (do NOT deny here). This mirrors the
+            # framework's native engine (native_engine.check_resource: "non-resource
+            # check: defer"). The route-level gate (authorize_route) already governs
+            # these paths; returning False would wrongly deny non-resource routes
+            # that the route gate has already decided on.
+            return True
+        return has_required_scopes(
+            self._scopes_for(ctx),
+            [f"{ctx.resource_type}:{ctx.action}"],
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=self.admin_scope,
+        )
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes) -> bool:
+        # Route-level gate the middleware runs before the request reaches a handler.
+        if not required_scopes:
+            return True
+        return has_required_scopes(
+            self._scopes_for(ctx),
+            required_scopes,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=self.admin_scope,
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        # For list endpoints: which ids may they see ({"*"} = all).
+        if not ctx.resource_type:
+            return set()
+        return get_accessible_resource_ids(
+            self._scopes_for(ctx),
+            ctx.resource_type,
+            admin_scope=self.admin_scope,
+            action=ctx.action,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Stand in for the login service: an RS256 keypair whose public half is published
+# as a JWKS (exactly what you'd FETCH from WorkOS/Auth0). You never have this
+# private key in real life - the login service holds it and signs tokens with it.
+# ---------------------------------------------------------------------------
+
+idp_private, idp_public = generate_rsa_keys()
+_jwk = json.loads(RSAAlgorithm.to_jwk(RSAAlgorithm(RSAAlgorithm.SHA256).prepare_key(idp_public)))
+_jwk.update({"kid": "idp-key-1", "use": "sig", "alg": "RS256"})
+with open(JWKS_PATH, "w") as f:
+    json.dump({"keys": [_jwk]}, f)
+
+db = SqliteDb(db_file="tmp/agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Enforce-only AgentOS behind a login service",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        # Verify tokens against the login service's published public keys
+        # (in production, its JWKS downloaded from .well-known/jwks.json).
+        jwks_file=JWKS_PATH,
+        algorithm="RS256",
+        verify_audience=True,
+        audience=OS_ID,  # the token must be for THIS app
+        issuer=ISSUER,  # ...and minted by the login service we trust
+        # The integration: roles ride the token in the "roles" claim.
+        authorization_provider=RoleClaimAuthorizationProvider(ROLE_PERMISSIONS, roles_claim="roles"),
+    ),
+)
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)
+    client = TestClient(app)
+
+    def idp_token(sub, roles=None, *, key=idp_private, iss=ISSUER, aud=OS_ID):
+        """A token as the login service would mint it: signed with its key, with
+        the person's role(s) in the 'roles' claim."""
+        claims = {"sub": sub, "aud": aud, "iss": iss, "exp": datetime.now(UTC) + timedelta(hours=8)}
+        if roles is not None:
+            claims["roles"] = roles
+        return jwt.encode(claims, key, algorithm="RS256", headers={"kid": "idp-key-1"})
+
+    def show(label, tok, method, path, note=""):
+        r = client.request(method, path, headers={"Authorization": f"Bearer {tok}"}, data={"message": "hi"})
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:52s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 84)
+    print("LOGIN SERVICE OWNS IDENTITY + ROLES - WE ONLY ENFORCE")
+    print("=" * 84)
+    print("  the login service signs the token and stamps the role. we verify it and")
+    print("  decide what that role may do. no users or assignments stored on our side.\n")
+
+    # Auth0-style: roles is a list. WorkOS-style: roles is a single string. Both
+    # work through the same provider (it normalises a string to a list).
+    show("alice (roles=['member']) RUN the agent", idp_token("alice", ["member"]), "POST", "/agents/research-agent/runs", "member can run")
+    show("bob   (roles='member')   LOOK at agent", idp_token("bob", "member"), "GET", "/agents/research-agent", "single-string role also works")
+    show("carol (roles=['guest'])  LOOK at agent", idp_token("carol", ["guest"]), "GET", "/agents/research-agent", "guest maps to nothing -> bounced")
+    show("dave  (no roles claim)   LOOK at agent", idp_token("dave"), "GET", "/agents/research-agent", "no role -> bounced")
+    show("root  (roles=['admin'])  RUN the agent", idp_token("root", ["admin"]), "POST", "/agents/research-agent/runs", "admin can do anything")
+
+    print("\n  the token plumbing is enforced too (not just the role):\n")
+    # A token signed by some OTHER key (an attacker who doesn't have the IdP key).
+    attacker_priv, _ = generate_rsa_keys()
+    show("mallory (token signed by a DIFFERENT key)", idp_token("mallory", ["admin"], key=attacker_priv), "GET", "/agents/research-agent", "signature doesn't match the JWKS -> rejected")
+    # A real-looking token but minted for a different issuer.
+    show("eve (valid role but wrong issuer)", idp_token("eve", ["admin"], iss="https://evil.example/"), "GET", "/agents/research-agent", "issuer not trusted -> rejected")
+
+    print("=" * 84)
+    print("the point: the login service owns WHO has a role; the ~30-line provider owns")
+    print("WHAT a role can do. tokens are verified against the service's published keys,")
+    print("and pinned to the right issuer + audience. nothing about users is stored here.")
+    print("=" * 84)

--- a/cookbook/05_agent_os/rbac/managed_roles.py
+++ b/cookbook/05_agent_os/rbac/managed_roles.py
@@ -1,0 +1,172 @@
+"""
+Managed Roles - controlling who can do what in AgentOS
+
+New to this? Start with this file. "Authorization" just means deciding who is
+allowed to do what. Two pieces make it work:
+
+1. A token. When a user signs in they get a token: a small signed ID card they
+   send with every request. It says who they are (e.g. "bob") and can't be faked.
+2. Permissions. On the AgentOS side you decide what each person can do, like
+   "can look at agents" or "can run the research agent".
+
+Listing permissions per person gets messy fast, so we use ROLES: a named bundle
+of permissions. You say once what a role can do ("a viewer can read"), then hand
+people roles ("bob is a viewer"). Change the role and everyone with it changes too.
+
+Permissions are written in a short code called a "scope":
+- "agents:*:read"              -> can look at any agent
+- "agents:research-agent:run"  -> can run the one agent called research-agent
+- "agent_os:admin"             -> can do everything (a super-admin)
+
+This file creates three roles and two people, then makes real requests and prints
+ALLOWED or BLOCKED for each. It also shows the neat part: you can change someone's
+role while the server is running and their very next request reflects it, with no
+new login and no new token.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_roles.py
+(no OpenAI key needed here - we are only checking who is allowed, not actually chatting)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define your roles in agno scope terms. Policy persists to your DB (point the
+# url at Postgres in production). This is the entire authorization model.
+#
+# ManagedRoleStore constructor parameters (a DB is REQUIRED - there is no
+# in-memory mode; roles must persist and stay consistent across replicas):
+#   db_url       SQLAlchemy URL for the DB that holds the policy, e.g.
+#                "postgresql+psycopg://..." or "sqlite:///roles.db".
+#   db           an agno Db object (e.g. SqliteDb/PostgresDb) instead of a url;
+#                reuses that DB's engine so roles live beside your agent data.
+#                Takes precedence over db_url. (Pass one of db_url / db - or hand
+#                the store to AuthorizationConfig(role_store=...) and let AgentOS
+#                adopt its db for you.)
+#   roles_claim  JWT claim carrying a caller's roles (external-IdP case). Omitted
+#                here, so roles come from this store's own assignments below.
+#   audit        an AuditSink: when set, every role/assignment change emits an
+#                append-only AuditEvent (the actor + before/after). Off here.
+#                See managed_roles_audit.py.
+#   decision_log when True, raises the "agno.authz.engine" logger to INFO so every
+#                allow/deny decision is logged. Off by default. Off here.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles.db")
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("bob", "viewer")  # bob can read agents but not run them
+roles.assign("alice", "admin")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos.db")
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the managed-role store. The only wiring.
+# `role_store=store` is the preferred shortcut: AgentOS uses the store's provider
+# internally (equivalent to authorization_provider=roles.provider, which also
+# works). The store already has its own db_url above; had we created it without a
+# db, this shortcut would also let AgentOS adopt the OS db= for it.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        role_store=roles,
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to print managed-role decisions for each caller.
+
+    Roles (defined above, persisted to tmp/managed_roles.db):
+    - viewer -> read agents
+    - member -> read agents + run research-agent
+    - admin  -> everything
+    bob is a viewer, alice is an admin. No scopes are baked into the tokens; the
+    store decides what each user can do. The scenario below promotes bob to member
+    at runtime, shows his run flip to 200, then revokes it, all with the same token.
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        # 200 means the request got in; 401/403 means it was bounced.
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:46s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 78)
+    print("WHO CAN DO WHAT - three roles, two people")
+    print("=" * 78)
+    print("  roles:  viewer = look at agents | member = look + run | admin = anything")
+    print("  people: bob is a viewer         | alice is an admin")
+    print("  below, each person makes a real request. ALLOWED = got in, BLOCKED = bounced.\n")
+
+    show("bob (viewer)  asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
+    show("bob (viewer)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "viewers can't run, so he's bounced")
+
+    print("\n  >> now we make bob a 'member' while the server is running...\n")
+    roles.assign("bob", "member")
+    show("bob (member)  asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "same bob, same token, now allowed")
+
+    print("\n  >> ...and now we take the 'member' role back...\n")
+    roles.unassign("bob", "member")
+    show("bob (no role) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("bob"), data={"message": "hi"}), "bounced again, instantly")
+
+    show("alice (admin) asks to RUN the agent", client.post("/agents/research-agent/runs", headers=auth("alice"), data={"message": "hi"}), "admins can do anything")
+    print("=" * 78)
+    print("the point: you control access by handing out roles, and a change takes effect")
+    print("on the very next request - no new login, no new token.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_roles_audit.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_audit.py
@@ -1,0 +1,102 @@
+"""
+Managed Roles - the audit trail (who changed what, and every allow/deny)
+
+New to this? Read managed_roles.py first.
+
+Once people can change roles at runtime, you need to answer two questions later:
+
+  1. "Who gave Bob admin, and when?"        -> the CHANGE trail
+  2. "Was Alice allowed to delete that?"    -> the DECISION trail
+
+agno keeps these as two separate, append-only tables (rows are only ever inserted,
+never updated or deleted - tamper-evident, the kind of thing an auditor wants):
+
+  - authz_audit      : one row per role/assignment change, with the actor and a
+                       before/after diff.
+  - authz_decisions  : one row per protected request, allow or deny, with the
+                       route, the scopes required, and a NON-secret reference to
+                       the token used (its `jti`, or a short hash - never the token
+                       itself).
+
+You turn it on by handing the store (and the OS) a `DbAuditSink` pointed at a DB.
+That's it - every change and every decision is recorded from then on.
+
+This file makes a few role changes and a couple of real requests, then prints both
+trails. No server, no OpenAI key needed.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_roles_audit.py
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.authz.audit import DbAuditSink
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+from fastapi.testclient import TestClient
+
+SECRET = "managed-roles-audit-demo-secret-at-least-256-bits-long-xx"
+OS_ID = "audit-demo-os"
+
+
+def token(sub: str) -> dict:
+    t = jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {t}"}
+
+
+def main() -> None:
+    # One DB for everything; the SAME sink records both trails.
+    audit = DbAuditSink(db_url="sqlite:///tmp/audit_demo.db")
+    store = ManagedRoleStore(db_url="sqlite:///tmp/audit_demo.db", audit=audit)
+
+    # --- role changes (each is recorded on the change trail, with the actor) ---
+    store.set_role_scopes("viewer", ["agents:*:read"], actor="alice")
+    store.set_role_scopes("viewer", ["agents:*:read", "agents:research-agent:run"], actor="alice")  # widened
+    store.assign("bob", "viewer", actor="alice")
+
+    # --- a couple of real requests (each is recorded on the decision trail) ---
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=audit,  # <- decision audit on
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+    client.get("/agents/research-agent", headers=token("bob"))  # allowed (viewer can read)
+    client.post("/agents/research-agent/runs", headers=token("nobody"), data={"message": "hi"})  # denied
+
+    # --- read both trails back ---
+    print("\n=== CHANGE TRAIL (authz_audit) — who changed what ===")
+    for e in store.audit_log(limit=20):
+        print(f"  {e['actor'] or 'system':>6}  {e['action']:<16} {e['target']:<10} {e.get('before')} -> {e.get('after')}")
+
+    print("\n=== DECISION TRAIL (authz_decisions) — every allow/deny ===")
+    for d in audit.read_decisions(limit=20):
+        m = d.get("metadata", {})
+        print(f"  {d['actor'] or '-':>6}  {d['action']:<14} {d['target']:<28} required={m.get('required')}")
+
+    print("\nBoth tables are INSERT-only. token references are jti/short-hash, never the raw token.")
+
+
+if __name__ == "__main__":
+    import os
+
+    os.makedirs("tmp", exist_ok=True)
+    main()

--- a/cookbook/05_agent_os/rbac/managed_roles_sessions.py
+++ b/cookbook/05_agent_os/rbac/managed_roles_sessions.py
@@ -1,0 +1,152 @@
+"""
+Roles protecting real data - who can delete a chat session
+
+(If roles are new to you, read managed_roles.py first.)
+
+A "session" is one saved conversation with an agent. Deleting one throws away real
+data, so not everyone should be allowed to. This file shows roles protecting an
+actual operation, not a toy one.
+
+Three jobs:
+- support  -> can LOOK at sessions, nothing else
+- operator -> can look, edit, and DELETE sessions
+- admin    -> can do anything
+
+We put two saved sessions in the database, then watch what each person is allowed
+to do. The key moment: the support person tries to delete a session and gets
+BLOCKED, while the operator deletes one for real and the count drops from 2 to 1.
+That is the whole idea of authorization in one screen: the right people get
+through, the wrong ones get stopped, before any data is touched.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_roles_sessions.py
+"""
+
+import os
+import time
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.config import AuthorizationConfig
+from agno.session import AgentSession
+
+# ---------------------------------------------------------------------------
+# Create Example
+# ---------------------------------------------------------------------------
+
+# JWT Secret (use environment variable in production)
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-roles-sessions-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Define roles in agno scope terms. support is read-only; operator can delete.
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_roles_sessions.db")
+roles.set_role_scopes("support", ["sessions:read"])
+roles.set_role_scopes("operator", ["sessions:read", "sessions:write", "sessions:delete"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.assign("bob", "support")
+roles.assign("val", "operator")
+roles.assign("alice", "admin")
+
+# Setup database
+db = SqliteDb(db_file="tmp/agentos_sessions.db")
+
+# Demo fixture: seed two sessions directly so the delete is observable without an
+# API key. Real apps don't do this; sessions are created by running an agent
+# (e.g. agent.print_response("hi", session_id="...")). We seed to stay self-contained.
+_now = int(time.time())
+db.upsert_session(AgentSession(session_id="sess-123", agent_id="research-agent", user_id="customer-a", created_at=_now))
+db.upsert_session(AgentSession(session_id="sess-456", agent_id="research-agent", user_id="customer-b", created_at=_now))
+
+research_agent = Agent(
+    id="research-agent",
+    name="Research Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+)
+
+# Create AgentOS using the managed-role store as the provider.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-roles AgentOS gating session access",
+    agents=[research_agent],
+    db=db,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+    ),
+)
+
+# Get the app
+app = agent_os.get_app()
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    """
+    Run this file to see roles gate the real session endpoints.
+
+    Roles:
+    - support  -> sessions:read                 (view only)
+    - operator -> sessions:read/write/delete    (full session control)
+    - admin    -> everything
+    bob is support, val is operator. The scenario below shows support being
+    blocked from edit/delete (403) while operator deletes for real (the session
+    count drops from 2 to 1).
+    """
+
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        # 200/204 means it went through; 401/403 means it was bounced.
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:44s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    def count(sub: str) -> int:
+        r = client.get("/sessions?type=agent", headers=auth(sub))
+        return r.json()["meta"]["total_count"] if r.status_code == 200 else -1
+
+    print("\n" + "=" * 78)
+    print("WHO CAN TOUCH THE SAVED SESSIONS")
+    print("=" * 78)
+    print("  bob = support (look only) | val = operator (look, edit, delete)")
+    print(f"  saved sessions right now: {count('val')}\n")
+
+    show("bob (support)  tries to LOOK at sessions", client.get("/sessions?type=agent", headers=auth("bob")), "support can look")
+    show("bob (support)  tries to RENAME a session", client.patch("/sessions/sess-123", headers=auth("bob"), json={"name": "x"}), "editing isn't allowed -> bounced")
+    show("bob (support)  tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("bob")), "deleting isn't allowed -> bounced")
+    show("val (operator) tries to DELETE a session", client.delete("/sessions/sess-123", headers=auth("val")), "operators can delete -> done for real")
+
+    print(f"\n  saved sessions now: {count('val')}  (was 2 - the operator's delete really happened)")
+    print("=" * 78)
+    print("the point: the support person was stopped before any data was touched.")
+    print("only the operator's delete went through, and you can see the count drop.")
+    print("=" * 78)

--- a/cookbook/05_agent_os/rbac/managed_users.py
+++ b/cookbook/05_agent_os/rbac/managed_users.py
@@ -1,0 +1,132 @@
+"""
+Managed Users - a user directory for AgentOS, no identity provider needed
+
+Already did managed_roles.py? That showed ROLES (who can do what). This shows
+USERS (who exists), for the case where you DON'T have an external login system
+(no Okta/Auth0/WorkOS). Your own app still signs people in its own way and hands
+them a token; AgentOS keeps the list of users and decides what they can do.
+
+Important: AgentOS does NOT store passwords and does not log anyone in. It keeps
+a directory - just id, optional email/name, and an on/off switch per person -
+plus their roles. Think "address book with an off switch", not "login system".
+
+Why bother keeping users at all (instead of only roles)?
+1. You can SEE everyone who exists and pick a person to give a role to, instead
+   of typing a raw id you have to remember.
+2. You get a real OFF SWITCH. Disable someone and their very next request is
+   blocked - even though their token is still valid and unexpired. A token alone
+   can't be "un-issued"; the directory can.
+3. The audit trail can say "bob@co" instead of an opaque id.
+
+This file creates a few users, gives them roles, then:
+- lists the directory,
+- shows bob working normally,
+- DISABLES bob and shows his next request bounce (same valid token),
+- re-enables him.
+
+Run it:
+    pip install "agno[roles]"
+    python managed_users.py
+(no OpenAI key needed - we are only checking who is allowed, not chatting)
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.authz.user_store import ManagedUserStore
+from agno.os.config import AuthorizationConfig
+
+JWT_SECRET = os.getenv("JWT_VERIFICATION_KEY", "your-secret-key-at-least-256-bits-long")
+OS_ID = "managed-users-os"
+
+os.makedirs("tmp", exist_ok=True)
+
+# Roles: what each role can do (same as managed_roles.py).
+roles = ManagedRoleStore(db_url="sqlite:///tmp/managed_users_roles.db")
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("admin", ["agent_os:admin"])
+
+# Users: the directory. Just people, no passwords. We give each one a role too.
+users = ManagedUserStore(db_url="sqlite:///tmp/managed_users.db")
+users.upsert("alice", email="alice@co", name="Alice")
+roles.assign("alice", "admin")
+users.upsert("bob", email="bob@co", name="Bob")
+roles.assign("bob", "viewer")
+
+db = SqliteDb(db_file="tmp/managed_users_agentos.db")
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+# Wire BOTH stores into AgentOS. user_store= turns on the directory + off-switch.
+agent_os = AgentOS(
+    id=OS_ID,
+    description="Managed-users AgentOS",
+    agents=[research_agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[JWT_SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=roles.provider,
+        user_store=users,  # <- the directory + disabled kill-switch
+    ),
+)
+app = agent_os.get_app()
+# The directory is managed through the store itself here (upsert / set_disabled), which
+# is all the enforcement needs. An admin HTTP API for it (/authz/users, /authz/roles)
+# ships with the `/authz` router -- see manage_users_and_roles.py.
+
+
+if __name__ == "__main__":
+    import logging
+
+    from fastapi.testclient import TestClient
+
+    logging.disable(logging.CRITICAL)  # quiet framework logs for a clean transcript
+    client = TestClient(app)
+
+    def token(sub: str) -> str:
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=24)},
+            JWT_SECRET, algorithm="HS256",
+        )
+
+    def auth(sub: str) -> dict:
+        return {"Authorization": f"Bearer {token(sub)}"}
+
+    def show(label: str, r, note: str = "") -> None:
+        verdict = "BLOCKED" if r.status_code in (401, 403) else "ALLOWED"
+        print(f"  {label:48s} -> {verdict:7s} ({r.status_code})  {note}")
+
+    print("\n" + "=" * 80)
+    print("A USER DIRECTORY - no identity provider, just AgentOS")
+    print("=" * 80)
+
+    # Everyone in the directory, with the role each one was assigned.
+    print("\n  the directory:")
+    for u in users.list():
+        role = (roles.roles_of(u["id"]) or [None])[0]
+        print(f"    - {u['id']:8s} {str(u['email'] or ''):12s} role={role}  disabled={u['disabled']}")
+
+    print("\n  bob is a viewer, so he can look at the agent:")
+    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "viewers can look")
+
+    print("\n  >> now an admin DISABLES bob (e.g. he left the company)...\n")
+    users.set_disabled("bob", True, actor="alice")
+    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "same valid token, but he's blocked now")
+
+    print("\n  >> ...bob is back, re-enable him...\n")
+    users.set_disabled("bob", False, actor="alice")
+    show("bob asks to LOOK at the agent", client.get("/agents/research-agent", headers=auth("bob")), "allowed again, instantly")
+
+    print("=" * 80)
+    print("the point: you keep the list of users and an off-switch per person. disabling")
+    print("someone blocks their NEXT request even though their token is still valid -")
+    print("something you can't do with tokens alone. no passwords are ever stored here.")
+    print("=" * 80)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1541,6 +1541,16 @@ class AgentOS:
         if audit is not None:
             fastapi_app.state.authz_audit = audit
 
+        # Optional user directory (no-IdP). When present, the middleware (and the
+        # WebSocket connect path) denies disabled users and — when auto-provision is
+        # on — creates a directory row from token claims. Seed the store and the
+        # claim/policy flags the middleware reads off app.state.
+        fastapi_app.state.user_store = getattr(config, "user_store", None)
+        fastapi_app.state.user_auto_provision = getattr(config, "auto_provision_users", False)
+        fastapi_app.state.user_email_claim = getattr(config, "user_email_claim", "email")
+        fastapi_app.state.user_name_claim = getattr(config, "user_name_claim", "name")
+        fastapi_app.state.user_directory_fail_closed = getattr(config, "directory_error_fail_closed", False)
+
     def get_routes(self) -> List[Any]:
         """Retrieve all routes from the FastAPI app.
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1411,6 +1411,14 @@ class AgentOS:
         # added by the user-scoped-DB work stay dormant.
         fastapi_app.state.user_isolation_enabled = user_isolation
 
+        # Seed the pluggable AuthorizationProvider that the REST route gate, per-resource
+        # gate, WebSocket gates, and MCP tool gate all resolve through. When nothing is
+        # configured we leave app.state.authorization_provider unset and the resolver
+        # falls back to the default ScopeAuthorizationProvider — so behaviour is exactly
+        # v2.7's scope RBAC. A role_store or a custom provider is enforced at the SAME
+        # four points instead.
+        self._seed_authorization_provider(fastapi_app)
+
         # Only interfaces that verify the authenticity of their own inbound requests
         # (Slack HMAC, Telegram/WhatsApp webhook secrets -- see
         # BaseInterface.authenticates_own_requests) are excluded from the central auth
@@ -1475,6 +1483,49 @@ class AgentOS:
             middleware_kwargs["scope_mappings"] = interface_mappings
 
         fastapi_app.add_middleware(AuthMiddleware, **middleware_kwargs)
+
+    def _seed_authorization_provider(self, fastapi_app: FastAPI) -> None:
+        """Seed ``app.state.authorization_provider`` (and ``authz_audit``) from the
+        AuthorizationConfig, so the four choke points resolve the right enforcer.
+
+        Precedence, matching AuthorizationConfig's ``role_store`` XOR
+        ``authorization_provider`` validator:
+
+        - ``role_store`` set: adopt the OS db into the store (``attach_db``) so managed
+          roles persist alongside agent data, then use the store's provider. A managed
+          store MUST have a DB — an in-memory store can't stay consistent across the
+          replicas an AgentOS deployment runs — so if it ends up unbound (no store db
+          and no SQL-capable OS db to adopt) we fail fast rather than silently enforce
+          an empty policy.
+        - ``authorization_provider`` set: use it directly.
+        - neither: leave the state unset; the resolver defaults to
+          ScopeAuthorizationProvider (v2.7 behaviour).
+        """
+        config = self.authorization_config
+        if config is None:
+            return
+
+        role_store = getattr(config, "role_store", None)
+        provider = getattr(config, "authorization_provider", None)
+
+        if role_store is not None:
+            # Adopt the OS db so a store created without one persists to it (no-op if the
+            # store already has its own db or the OS db isn't SQL-capable).
+            role_store.attach_db(self.db)
+            if not role_store.is_bound:
+                raise ValueError(
+                    "AuthorizationConfig(role_store=...) needs a SQL database: managed roles must be "
+                    "persisted (an in-memory store can't stay consistent across replicas). Give the "
+                    "store a db (ManagedRoleStore(db_url=...) / db=...) or pass a SQL-capable db to "
+                    "AgentOS(db=...) for it to adopt."
+                )
+            fastapi_app.state.authorization_provider = role_store.provider
+        elif provider is not None:
+            fastapi_app.state.authorization_provider = provider
+
+        audit = getattr(config, "audit", None)
+        if audit is not None:
+            fastapi_app.state.authz_audit = audit
 
     def get_routes(self) -> List[Any]:
         """Retrieve all routes from the FastAPI app.

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -88,6 +88,8 @@ if TYPE_CHECKING:
     # runtime here would break `import agno.os` when the extra is not installed.
     from fastmcp.server.auth import AuthProvider
 
+    from agno.os.authz.provider import AuthorizationProvider
+
 
 @asynccontextmanager
 async def mcp_lifespan(_, mcp_tools):
@@ -1508,6 +1510,7 @@ class AgentOS:
         role_store = getattr(config, "role_store", None)
         provider = getattr(config, "authorization_provider", None)
 
+        resolved_provider: Optional[AuthorizationProvider] = None
         if role_store is not None:
             # Adopt the OS db so a store created without one persists to it (no-op if the
             # store already has its own db or the OS db isn't SQL-capable).
@@ -1519,9 +1522,20 @@ class AgentOS:
                     "store a db (ManagedRoleStore(db_url=...) / db=...) or pass a SQL-capable db to "
                     "AgentOS(db=...) for it to adopt."
                 )
-            fastapi_app.state.authorization_provider = role_store.provider
+            resolved_provider = role_store.provider
         elif provider is not None:
-            fastapi_app.state.authorization_provider = provider
+            resolved_provider = provider
+
+        if resolved_provider is not None:
+            fastapi_app.state.authorization_provider = resolved_provider
+            # The MCP tools are a mounted sub-app: the tool gate resolves the provider
+            # from the in-flight request's ``.app``, which is this sub-app (request.state
+            # crosses the mount boundary, request.app does not). Without mirroring the
+            # provider here the gate falls back to the default ScopeAuthorizationProvider,
+            # silently degrading a managed-role / custom provider to scope-only over MCP.
+            # Mirror it so all four choke points enforce the same provider.
+            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
+                self._mcp_app.state.authorization_provider = resolved_provider
 
         audit = getattr(config, "audit", None)
         if audit is not None:

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -559,10 +559,39 @@ class AgentOS:
 
         self._reprovision_routers(app=app)
 
+    def _mirror_authz_state_to_mcp_app(self, app: FastAPI) -> None:
+        """Copy the authz state the MCP tool gate reads onto the mounted sub-app.
+
+        The MCP tools are a mounted sub-app, so ``request.app`` inside the tool gate is
+        that sub-app, not this AgentOS's app -- ``request.state`` crosses the mount
+        boundary but ``request.app`` does not. Anything the gate resolves off
+        ``app.state`` therefore has to be mirrored here, or it silently degrades: a
+        missing provider drops managed-role/composite/FGA policy to scope-only, and a
+        missing sink drops every MCP decision from the access trail.
+
+        Kept next to the mount (and called from there as well as from seeding) so that
+        ANY future rebuild or re-mount of ``_mcp_app`` re-applies it. Today the sub-app
+        is built once, which is the only reason a seed-time-only mirror was correct --
+        an implicit dependency worth not relying on.
+        """
+        if self._mcp_app is None or not hasattr(self._mcp_app, "state"):
+            return
+        parent = getattr(app, "state", None)
+        if parent is None:
+            return
+        for attr in ("authorization_provider", "authz_audit"):
+            value = getattr(parent, attr, None)
+            if value is not None:
+                setattr(self._mcp_app.state, attr, value)
+
     def _mount_mcp_app(self, app: FastAPI) -> None:
         """Mount the MCP app at root exactly once (idempotent across get_app/resync calls)."""
         if self._mcp_app is None:
             return
+        # Re-apply on every mount, so a rebuilt sub-app can't silently lose the authz
+        # state (on the first get_app() this is a no-op: seeding runs after the mount
+        # and does the mirror itself).
+        self._mirror_authz_state_to_mcp_app(app)
         if any(getattr(route, "app", None) is self._mcp_app for route in app.router.routes):
             return
         app.mount("/", self._mcp_app)
@@ -1528,24 +1557,16 @@ class AgentOS:
 
         if resolved_provider is not None:
             fastapi_app.state.authorization_provider = resolved_provider
-            # The MCP tools are a mounted sub-app: the tool gate resolves the provider
-            # from the in-flight request's ``.app``, which is this sub-app (request.state
-            # crosses the mount boundary, request.app does not). Without mirroring the
-            # provider here the gate falls back to the default ScopeAuthorizationProvider,
-            # silently degrading a managed-role / custom provider to scope-only over MCP.
-            # Mirror it so all four choke points enforce the same provider.
-            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
-                self._mcp_app.state.authorization_provider = resolved_provider
 
         audit = getattr(config, "audit", None)
         if audit is not None:
             fastapi_app.state.authz_audit = audit
-            # Same mount-boundary reason as the provider above: the MCP tool gate
-            # resolves the sink from the in-flight request's ``.app``, which is the
-            # mounted sub-app. Without this mirror MCP decisions can't be recorded at
-            # all, leaving a hole in the access trail that REST/WS decisions fill.
-            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
-                self._mcp_app.state.authz_audit = audit
+
+        # The MCP tools run in a mounted sub-app whose ``request.app`` is NOT this app,
+        # so everything the tool gate resolves off ``app.state`` (the provider, the audit
+        # sink) must be mirrored onto it -- see _mirror_authz_state_to_mcp_app. Seeding
+        # runs after the mount, so this is where the first mirror happens.
+        self._mirror_authz_state_to_mcp_app(fastapi_app)
 
         # Optional user directory (no-IdP). When present, the middleware (and the
         # WebSocket connect path) denies disabled users and — when auto-provision is

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1540,6 +1540,12 @@ class AgentOS:
         audit = getattr(config, "audit", None)
         if audit is not None:
             fastapi_app.state.authz_audit = audit
+            # Same mount-boundary reason as the provider above: the MCP tool gate
+            # resolves the sink from the in-flight request's ``.app``, which is the
+            # mounted sub-app. Without this mirror MCP decisions can't be recorded at
+            # all, leaving a hole in the access trail that REST/WS decisions fill.
+            if self._mcp_app is not None and hasattr(self._mcp_app, "state"):
+                self._mcp_app.state.authz_audit = audit
 
         # Optional user directory (no-IdP). When present, the middleware (and the
         # WebSocket connect path) denies disabled users and — when auto-provision is

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -8,8 +8,8 @@ from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from starlette.concurrency import run_in_threadpool
 
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
 from agno.os.scopes import (
-    get_accessible_resource_ids,
     get_default_scope_mappings,
     has_required_scopes,
 )
@@ -19,6 +19,66 @@ from agno.os.settings import AgnoAPISettings
 
 # Create a global HTTPBearer instance
 security = HTTPBearer(auto_error=False)
+
+
+@lru_cache(maxsize=1)
+def _default_authorization_provider() -> AuthorizationProvider:
+    """The default scope-based provider, cached so the fast path (no custom provider
+    configured) reuses one stateless instance rather than allocating per request.
+
+    Deferred import keeps this module free of the concrete provider at import time
+    and avoids a cycle (scope_provider imports scopes, which is fine, but keeping it
+    lazy mirrors the rest of the authz seam)."""
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    return ScopeAuthorizationProvider()
+
+
+def resolve_authorization_provider(app_or_request: Any) -> AuthorizationProvider:
+    """Resolve the AuthorizationProvider enforcing this AgentOS instance.
+
+    Returns ``app.state.authorization_provider`` when AgentOS seeded one (a custom
+    provider or a managed-role store's provider), otherwise the cached default
+    :class:`ScopeAuthorizationProvider`. Accepts either a FastAPI ``app`` or a
+    ``Request``/``WebSocket`` (from which ``.app`` is read), so all four choke
+    points can call it with whatever object they hold.
+
+    Because the default reproduces the exact scope math the pipeline used before
+    the seam existed, resolving here is behaviour-preserving whenever no provider
+    is configured.
+    """
+    app = getattr(app_or_request, "app", app_or_request)
+    provider = getattr(getattr(app, "state", None), "authorization_provider", None)
+    if provider is not None:
+        return provider
+    return _default_authorization_provider()
+
+
+def _authorization_context(
+    request: Request,
+    *,
+    resource_type: Optional[str] = None,
+    resource_id: Optional[str] = None,
+    action: Optional[str] = None,
+) -> AuthorizationContext:
+    """Build an :class:`AuthorizationContext` from the per-request auth state.
+
+    Reads exactly the fields the JWT middleware attaches (``user_id``, ``scopes``,
+    ``claims``, ``admin_scope``); the scope-based default provider uses the scope
+    fields and produces the same decision the pre-seam scope math did, while a
+    managed-role / custom provider keys off ``principal_id`` + ``claims`` instead.
+    """
+    admin_scope_raw = getattr(request.state, "admin_scope", None)
+    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
+    return AuthorizationContext(
+        principal_id=getattr(request.state, "user_id", None),
+        scopes=list(getattr(request.state, "scopes", None) or []),
+        claims=getattr(request.state, "claims", None) or {},
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        admin_scope=admin_scope,
+    )
 
 
 @lru_cache(maxsize=1)
@@ -250,6 +310,11 @@ def get_authentication_dependency(settings: AgnoAPISettings):
             request.state.authenticated = True
             request.state.user_id = "__scheduler__"
             request.state.scopes = list(INTERNAL_SERVICE_SCOPES)
+            # Mark as a trusted internal caller AFTER the constant-time token match so a
+            # provider-backed per-resource gate short-circuits (the scheduler principal
+            # has no role/subject in a managed store). Unforgeable: request.state is
+            # server-only — no client input maps onto this attribute.
+            request.state.is_internal_service = True
             return True
 
         # Verify the token against security key
@@ -357,29 +422,17 @@ def get_accessible_resources(request: Request, resource_type: str) -> Set[str]:
         {'*'}
     """
     # Check if accessible_resource_ids is already cached in request state (set by JWT middleware)
-    # This happens when user doesn't have global scope but has specific resource scopes
+    # This happens when user doesn't have global scope but has specific resource scopes.
+    # The cache is populated by the route gate (which now runs through the same provider),
+    # so honouring it keeps the listing decision consistent with the gate that let the
+    # request in — for both the default scope provider and a custom one.
     cached_ids = getattr(request.state, "accessible_resource_ids", None)
     if cached_ids is not None:
         return cached_ids
 
-    # Get user's scopes from request state (set by JWT middleware)
-    user_scopes = getattr(request.state, "scopes", [])
-
-    # Honour any custom admin_scope configured on JWTMiddleware (set on
-    # request.state by the middleware). Without this, list endpoints reject
-    # custom-admin tokens with 403 even though check_resource_access would
-    # accept them.
-    admin_scope_raw = getattr(request.state, "admin_scope", None)
-    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-
-    # Get accessible resource IDs
-    accessible_ids = get_accessible_resource_ids(
-        user_scopes=user_scopes,
-        resource_type=resource_type,
-        admin_scope=admin_scope,
-    )
-
-    return accessible_ids
+    provider = resolve_authorization_provider(request)
+    ctx = _authorization_context(request, resource_type=resource_type)
+    return provider.accessible_resource_ids(ctx)
 
 
 def filter_resources_by_access(request: Request, resources: List, resource_type: str) -> List:
@@ -411,14 +464,20 @@ def filter_resources_by_access(request: Request, resources: List, resource_type:
         >>> filter_resources_by_access(request, agents, "agents")
         [Agent(id="agent-1"), Agent(id="agent-2"), Agent(id="agent-3")]
     """
-    accessible_ids = get_accessible_resources(request, resource_type)
+    # When the route gate cached an accessible-id set on request.state (the caller
+    # holds only per-resource scopes on a GET listing), honour it directly so the
+    # listing matches the gate decision — same behaviour as before the seam.
+    cached_ids = getattr(request.state, "accessible_resource_ids", None)
+    if cached_ids is not None:
+        if "*" in cached_ids:
+            return resources
+        return [r for r in resources if getattr(r, "id", None) in cached_ids]
 
-    # Wildcard access - return all resources
-    if "*" in accessible_ids:
-        return resources
-
-    # Filter to only accessible resources
-    return [r for r in resources if r.id in accessible_ids]
+    # Otherwise delegate to the provider, which may filter more richly than a plain
+    # id-set membership test (e.g. deny-overrides for managed roles).
+    provider = resolve_authorization_provider(request)
+    ctx = _authorization_context(request, resource_type=resource_type)
+    return provider.filter_accessible(ctx, resources)
 
 
 def check_resource_access(request: Request, resource_id: str, resource_type: str, action: str = "read") -> bool:
@@ -447,25 +506,25 @@ def check_resource_access(request: Request, resource_id: str, resource_type: str
         >>> check_resource_access(request, "my-agent", "agents", "run")
         False
     """
-    user_scopes = getattr(request.state, "scopes", [])
-    # Honour the configured admin scope (set by JWTMiddleware on request.state)
-    # so custom-admin tokens are recognised here too. Non-string values (e.g.
-    # MagicMock attributes in tests) are ignored.
-    admin_scope_raw = getattr(request.state, "admin_scope", None)
-    admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-    accessible_ids = get_accessible_resource_ids(
-        user_scopes=user_scopes,
-        resource_type=resource_type,
-        action=action,
-        admin_scope=admin_scope,
-    )
-
-    # Wildcard access grants all permissions
-    if "*" in accessible_ids:
+    # Internal service credentials (the scheduler executor's token, or a validated
+    # security key) are trusted first-party callers with no role/subject in a managed
+    # store, so a provider-backed per-resource gate would 403 them. The route gate has
+    # already enforced their INTERNAL_SERVICE_SCOPES, so short-circuit here.
+    # is_internal_service is set ONLY by the middleware's internal-token branch (and the
+    # security-key dependency) AFTER a constant-time token match; it lives on
+    # request.state, which is server-populated per request and cannot be set by a client
+    # (no header/body maps onto it), so it is unforgeable.
+    if getattr(request.state, "is_internal_service", False):
         return True
 
-    # Check if user has access to this specific resource
-    return resource_id in accessible_ids
+    provider = resolve_authorization_provider(request)
+    ctx = _authorization_context(
+        request,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+    )
+    return provider.check(ctx)
 
 
 def require_resource_access(resource_type: str, action: str, resource_id_param: str):

--- a/libs/agno/agno/os/auth.py
+++ b/libs/agno/agno/os/auth.py
@@ -582,6 +582,24 @@ def require_resource_access(resource_type: str, action: str, resource_id_param: 
         # Get the resource_id from path parameters
         resource_id = request.path_params.get(resource_id_param)
         if resource_id and not check_resource_access(request, resource_id, resource_type, action):
+            # Record the per-resource DENY. The route gate already logged an allow for
+            # this request (with the concrete resource in the path), so a per-resource
+            # ALLOW would only duplicate it -- but a per-resource DENY is otherwise
+            # invisible: the trail would show the route allowed and never show what
+            # actually blocked the request. For a role/ReBAC model this is the
+            # security-relevant decision, so it must appear in the access audit.
+            from agno.os.authz.audit import record_decision
+
+            record_decision(
+                request,
+                allowed=False,
+                target=f"{request.method} /{resource_type}/{resource_id}",
+                principal=getattr(request.state, "user_id", None),
+                required_scopes=[f"{resource_type}:{resource_id}:{action}"],
+                scopes=list(getattr(request.state, "scopes", None) or []),
+                claims=getattr(request.state, "claims", None),
+                reason="resource_access_denied",
+            )
             raise HTTPException(status_code=403, detail=f"Access denied to {action} this {resource_singular}")
 
     return dependency

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -1,0 +1,41 @@
+"""Pluggable authorization providers for AgentOS.
+
+The ``AuthorizationProvider`` interface is the seam between AgentOS's request
+handling and the logic that decides "can this principal do this action on this
+resource". The built-in :class:`ScopeAuthorizationProvider` implements the
+existing JWT-scope RBAC with zero external dependencies, so the default
+behaviour is unchanged.
+
+Customers who need a richer model (relationship-based / ReBAC, attribute-based,
+or an external engine such as OpenFGA, SpiceDB or Cerbos) implement the same
+interface and pass it via ``AuthorizationConfig(authorization_provider=...)``.
+
+Managed roles (runtime-editable RBAC) are backed by agno's own
+:class:`NativePolicyEngine` behind the swappable :class:`PolicyEngine` port — no
+third-party policy engine in the default path.
+"""
+
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink, LoggingAuditSink
+from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, ScopeEntry
+from agno.os.authz.native_engine import NativePolicyEngine
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+__all__ = [
+    "AuthorizationContext",
+    "AuthorizationProvider",
+    "ScopeAuthorizationProvider",
+    # Managed roles: the product surface + swappable backend (port, generic
+    # provider, native default engine). get_roles_router lives in role_router and
+    # is imported directly to keep this package import FastAPI-free.
+    "ManagedRoleStore",
+    "PolicyEngine",
+    "ScopeEntry",
+    "EngineAuthorizationProvider",
+    "NativePolicyEngine",
+    "AuditEvent",
+    "AuditSink",
+    "LoggingAuditSink",
+    "DbAuditSink",
+]

--- a/libs/agno/agno/os/authz/_db.py
+++ b/libs/agno/agno/os/authz/_db.py
@@ -1,0 +1,47 @@
+"""Shared helper: reuse an agno database's SQLAlchemy engine.
+
+Lets the managed-roles / user-directory / audit stores share the exact connection
+(and pool) of the database you already pass to ``AgentOS(db=...)``, instead of
+opening a second one against a duplicated ``db_url``.
+"""
+
+from typing import Any
+
+# Raised/shown when a managed-roles component is used without a database. Managed
+# roles must be persisted: an in-memory store can't stay consistent across the
+# multiple workers/replicas an AgentOS deployment runs, so a DB is required.
+NO_DB_MESSAGE = (
+    "ManagedRoleStore requires a SQL database — managed roles must be persisted, "
+    "and an in-memory store cannot stay consistent across multiple workers/replicas. "
+    "Pass db=/db_url= to the store, or hand it to AgentOS via "
+    "AuthorizationConfig(role_store=...) together with a SQL db on AgentOS so the "
+    "store adopts it."
+)
+
+
+def engine_from_db(db: Any) -> Any:
+    """Return the SQLAlchemy ``Engine`` backing an agno database object.
+
+    agno's relational databases (``SqliteDb``, ``PostgresDb``, ...) expose their
+    engine as ``.db_engine``. Anything with that attribute works.
+    """
+    engine = getattr(db, "db_engine", None)
+    if engine is None:
+        raise ValueError(
+            "db= must be an agno database backed by SQLAlchemy (e.g. SqliteDb, "
+            f"PostgresDb) exposing a .db_engine; got {type(db)!r}. "
+            "Pass db_url=... instead if you want a separate connection."
+        )
+    return engine
+
+
+def engine_from_url(db_url: str) -> Any:
+    """Create a SQLAlchemy ``Engine`` from a URL. SQLite is configured for
+    multi-threaded server use (``check_same_thread=False``) so a connection opened
+    on one request thread can be reused on another — the same property AgentOS
+    needs from any DB it serves decisions from."""
+    import sqlalchemy as sa
+
+    if db_url.startswith("sqlite"):
+        return sa.create_engine(db_url, connect_args={"check_same_thread": False})
+    return sa.create_engine(db_url)

--- a/libs/agno/agno/os/authz/_scope_policy.py
+++ b/libs/agno/agno/os/authz/_scope_policy.py
@@ -1,0 +1,83 @@
+"""The agno scope <-> policy convention.
+
+How an agno scope string is written as a policy ``(resource, action)`` pair and
+read back. This is the single source of truth shared by every :class:`PolicyEngine`
+implementation, so policy is *written* and *checked* with the same spelling.
+
+Resources use a ``type/id`` shape with ``/*`` for the collection/global form;
+``agent_os:admin`` maps to the all-resources/all-actions wildcard ``("*", "*")``.
+"""
+
+from typing import Tuple
+
+ADMIN_SCOPE = "agent_os:admin"
+
+
+def scope_to_resource_action(scope: str) -> Tuple[str, str]:
+    """Map an agno scope string to its policy ``(resource, action)`` pair.
+
+    - ``agent_os:admin``             -> ("*", "*")
+    - ``sessions:write``             -> ("sessions/*", "write")   (collection/global)
+    - ``agents:research-agent:run``  -> ("agents/research-agent", "run")
+    - ``agents:*:run``               -> ("agents/*", "run")
+    """
+    if scope == ADMIN_SCOPE:
+        return ("*", "*")
+    parts = scope.split(":")
+    if any(part == "" for part in parts):
+        raise ValueError(f"Unrecognised scope (empty component): {scope!r}")
+    if len(parts) == 2:
+        resource, action = f"{parts[0]}/*", parts[1]
+    elif len(parts) == 3:
+        resource, action = f"{parts[0]}/{parts[1]}", parts[2]
+    else:
+        raise ValueError(f"Unrecognised scope: {scope!r}")
+    # Reject an action wildcard. ``*`` in the matcher means "all actions", but the
+    # scope provider compares actions literally, so the SAME scope string (e.g.
+    # ``agents:*:*``) would grant everything here and nothing there. Refuse it so a
+    # managed role can't carry a silently-divergent broad grant; the one documented
+    # way to grant all actions is ``agent_os:admin``.
+    if action == "*":
+        raise ValueError(
+            f"Action wildcard '*' is not allowed in scope {scope!r}: it would mean 'all actions' "
+            f"in policy but nothing under the scope provider. List explicit actions "
+            f"(read/run/write/delete), use a resource-id wildcard like 'agents:*:run', or grant "
+            f"'agent_os:admin'."
+        )
+    return (resource, action)
+
+
+def resource_action_to_scope(resource: str, action: str) -> str:
+    """Best-effort reverse of :func:`scope_to_resource_action`, for display/read-back.
+
+    Lossy where two scope spellings collapse to the same policy (``agents:read``
+    and ``agents:*:read`` both store as ``("agents/*", "read")``); we render the
+    global ``resource:action`` form in that case.
+    """
+    if resource == "*":
+        return ADMIN_SCOPE
+    if resource.endswith("/*"):
+        return f"{resource[:-2]}:{action}"
+    rtype, _, rid = resource.partition("/")
+    return f"{rtype}:{rid}:{action}"
+
+
+def resource_matches(pattern: str, request: str) -> bool:
+    """Does a policy's ``pattern`` resource match a request's ``request`` resource?
+
+    Glob-style matching over our restricted resource space
+    (``"*"`` / ``"type/*"`` / ``"type/id"``):
+
+    - ``"*"``        matches anything (admin),
+    - ``"type/*"``   matches ``"type/<id>"`` but NOT the bare collection
+      ``"type"`` (a collection request is handled via accessible-ids, not the
+      route gate),
+    - otherwise an exact match.
+    """
+    if pattern == "*":
+        return True
+    if pattern == request:
+        return True
+    if pattern.endswith("/*"):
+        return request.startswith(pattern[:-1])  # "type/" prefix
+    return False

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -1,0 +1,245 @@
+"""Audit trail for authorization changes.
+
+There are two kinds of "audit" people mean, and we keep them in two separate
+tables (see :class:`DbAuditSink`) because they answer different questions:
+
+1. Decision audit ("was alice allowed to run agent X, and with which token?") —
+   recorded by the JWT middleware on every protected request when an
+   :class:`AuditSink` is set on ``AuthorizationConfig(audit=...)``. Each row is an
+   ``access.allowed`` / ``access.denied`` event with the principal, the route, the
+   required scopes, the caller's scopes, and a NON-secret token reference (the
+   token's ``jti`` when present, otherwise a short hash — never the token itself).
+   (The native policy engine also logs every decision to the ``agno.authz.engine``
+   logger; ``ManagedRoleStore(decision_log=True)`` bumps it to INFO.)
+
+2. Change audit ("who granted alice the admin role, when, before/after?") — the
+   policy engine cannot provide this: it never sees the acting principal, and its
+   policy rows are overwrite-in-place with no history. So it must be captured at
+   the layer that knows the actor — the management API / store. Plug an
+   :class:`AuditSink` into :class:`~agno.os.authz.role_store.ManagedRoleStore`
+   (directly or via ``get_roles_router``) and every role/assignment mutation emits
+   a structured, append-only :class:`AuditEvent` with the actor and before/after.
+
+The same :class:`DbAuditSink` instance can serve both: ``record()`` routes change
+events to ``authz_audit`` and decision events to ``authz_decisions``.
+"""
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class AuditEvent:
+    """One authorization-change record. Append-only; never mutated after emit.
+
+    Attributes:
+        action: what happened — ``role.set_scopes`` / ``role.removed`` /
+            ``user.assigned`` / ``user.unassigned``.
+        actor: the principal who made the change (JWT ``sub`` of the admin), or
+            None for changes made in code outside a request (treated as system).
+        target: the role name (role changes) or subject id (assignment changes).
+        before: prior state (the role's scopes, or the subject's roles), or None.
+        after: new state, or None (e.g. on removal).
+        timestamp: epoch seconds when the change was recorded.
+    """
+
+    action: str
+    actor: Optional[str]
+    target: str
+    before: Optional[List[str]] = None
+    after: Optional[List[str]] = None
+    timestamp: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "ts": self.timestamp,
+            "actor": self.actor,
+            "action": self.action,
+            "target": self.target,
+            "before": self.before,
+            "after": self.after,
+            **({"metadata": self.metadata} if self.metadata else {}),
+        }
+
+
+class AuditSink(ABC):
+    """Where audit events go. Implement ``record`` to send them anywhere."""
+
+    @abstractmethod
+    def record(self, event: AuditEvent) -> None:
+        """Persist/emit one event. Must not raise into the caller's path."""
+        ...
+
+
+class LoggingAuditSink(AuditSink):
+    """Emit each event as one JSON line to a logger (default ``agno.authz.audit``)."""
+
+    def __init__(self, logger_name: str = "agno.authz.audit", level: int = logging.INFO):
+        self._logger = logging.getLogger(logger_name)
+        self._level = level
+
+    def record(self, event: AuditEvent) -> None:
+        self._logger.log(self._level, json.dumps(event.to_dict()))
+
+
+def _is_decision(action: str) -> bool:
+    """Decision events (``access.allowed`` / ``access.denied``) vs change events."""
+    return action.startswith("access.")
+
+
+class DbAuditSink(AuditSink):
+    """Append-only audit tables in your own DB (SQLAlchemy).
+
+    The two kinds of audit are kept in two physically separate tables, because
+    they answer different questions, have different shapes, and grow at very
+    different rates:
+
+    - **changes** (``authz_audit``): who granted/changed a role, with before/after.
+      Low volume, one row per admin action.
+    - **decisions** (``authz_decisions``): every allow/deny on a request, with the
+      required scopes, the granted scopes, and a non-secret token reference. High
+      volume, one row per protected request.
+
+    Keeping them apart means a decision-log flood never buries the change trail,
+    each table has only the columns it needs, and you can retain/export them on
+    different schedules. ``record()`` routes by action; you read each side with
+    :meth:`read` (changes) and :meth:`read_decisions`.
+
+    Writes are INSERT-only — rows are never updated or deleted — so both tables are
+    tamper-evident trails suitable for SOC2-style evidence. Point it at the same DB
+    as the role store or a separate one.
+    """
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        engine: Optional[Any] = None,
+        table_name: str = "authz_audit",
+        decision_table_name: str = "authz_decisions",
+        create_table: bool = True,
+    ):
+        import sqlalchemy as sa
+
+        if engine is None and db_url is None:
+            raise ValueError("DbAuditSink needs either db_url or engine")
+        self._engine = engine if engine is not None else sa.create_engine(db_url)  # type: ignore[arg-type]
+        metadata = sa.MetaData()
+        # change trail: role/assignment mutations with before/after
+        self._table = sa.Table(
+            table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("actor", sa.String(255)),
+            sa.Column("action", sa.String(255), nullable=False),
+            sa.Column("target", sa.String(255), nullable=False),
+            sa.Column("before", sa.Text),
+            sa.Column("after", sa.Text),
+        )
+        # decision trail: per-request allow/deny with the token reference
+        self._decisions = sa.Table(
+            decision_table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("actor", sa.String(255)),
+            sa.Column("action", sa.String(255), nullable=False),  # access.allowed / access.denied
+            sa.Column("target", sa.String(512), nullable=False),  # "METHOD /path"
+            sa.Column("token_ref", sa.String(255)),  # jti (preferred) or short hash — never the token
+            sa.Column("required", sa.Text),  # scopes the route required (JSON)
+            sa.Column("scopes", sa.Text),  # scopes the caller had (JSON)
+        )
+        if create_table:
+            metadata.create_all(self._engine)
+
+    def record(self, event: AuditEvent) -> None:
+        # The AuditSink contract is that record() must NOT raise into the caller's
+        # path: a role change (or a request) must still succeed even if its audit row
+        # can't be written. Log and swallow DB errors rather than turning a
+        # successful mutation into a 500 with no audit row.
+        try:
+            if _is_decision(event.action):
+                self._record_decision(event)
+            else:
+                self._record_change(event)
+        except Exception:
+            logging.getLogger("agno.authz.audit").exception("failed to write audit event %r", event.action)
+
+    def _record_change(self, event: AuditEvent) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                self._table.insert().values(
+                    ts=event.timestamp,
+                    actor=event.actor,
+                    action=event.action,
+                    target=event.target,
+                    before=json.dumps(event.before) if event.before is not None else None,
+                    after=json.dumps(event.after) if event.after is not None else None,
+                )
+            )
+
+    def _record_decision(self, event: AuditEvent) -> None:
+        meta = event.metadata or {}
+        with self._engine.begin() as conn:
+            conn.execute(
+                self._decisions.insert().values(
+                    ts=event.timestamp,
+                    actor=event.actor,
+                    action=event.action,
+                    target=event.target,
+                    token_ref=meta.get("token"),
+                    required=json.dumps(meta.get("required")) if meta.get("required") is not None else None,
+                    scopes=json.dumps(meta.get("scopes")) if meta.get("scopes") is not None else None,
+                )
+            )
+
+    def read(self, limit: int = 100) -> List[dict]:
+        """Recent *change* events (newest first) as plain dicts."""
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = conn.execute(sa.select(self._table).order_by(self._table.c.id.desc()).limit(limit)).mappings().all()
+        return [
+            {
+                "ts": r["ts"],
+                "actor": r["actor"],
+                "action": r["action"],
+                "target": r["target"],
+                "before": json.loads(r["before"]) if r["before"] else None,
+                "after": json.loads(r["after"]) if r["after"] else None,
+            }
+            for r in rows
+        ]
+
+    def read_decisions(self, limit: int = 100) -> List[dict]:
+        """Recent *decision* events (newest first) as plain dicts.
+
+        ``metadata`` is reassembled to the same ``{required, token, scopes}`` shape
+        the in-memory event carried, so readers don't care which table it came from.
+        """
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = (
+                conn.execute(sa.select(self._decisions).order_by(self._decisions.c.id.desc()).limit(limit))
+                .mappings()
+                .all()
+            )
+        return [
+            {
+                "ts": r["ts"],
+                "actor": r["actor"],
+                "action": r["action"],
+                "target": r["target"],
+                "metadata": {
+                    "required": json.loads(r["required"]) if r["required"] else None,
+                    "token": r["token_ref"],
+                    "scopes": json.loads(r["scopes"]) if r["scopes"] else None,
+                },
+            }
+            for r in rows
+        ]

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -26,9 +26,12 @@ events to ``authz_audit`` and decision events to ``authz_decisions``.
 
 import json
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+from agno.utils.log import log_debug
 
 
 @dataclass
@@ -89,6 +92,84 @@ class LoggingAuditSink(AuditSink):
 def _is_decision(action: str) -> bool:
     """Decision events (``access.allowed`` / ``access.denied``) vs change events."""
     return action.startswith("access.")
+
+
+def resolve_audit_sink(app_or_request: Any) -> Optional[AuditSink]:
+    """The AuditSink recording this AgentOS's decisions, or None if none is configured.
+
+    Accepts a FastAPI ``app``, a ``Request`` or a ``WebSocket`` (``.app`` is read from
+    the latter two), mirroring ``resolve_authorization_provider`` so every choke point
+    can resolve the sink with whatever object it holds.
+    """
+    app = getattr(app_or_request, "app", app_or_request)
+    return getattr(getattr(app, "state", None), "authz_audit", None)
+
+
+def token_reference(token: Optional[str], claims: Optional[Dict[str, Any]]) -> Optional[str]:
+    """A non-secret reference to the presented token, for the decision trail.
+
+    Prefer the token's ``jti`` (RFC 7519 JWT ID): an opaque identifier the issuer
+    already minted, so it correlates to the issuer's own logs and any revocation list.
+    When the token has no ``jti``, fall back to a short SHA-256 of the raw token so two
+    distinct tokens stay distinguishable -- without ever storing the credential itself.
+    """
+    if claims:
+        jti = claims.get("jti")
+        if jti:
+            return str(jti)
+    if token:
+        import hashlib
+
+        return hashlib.sha256(token.encode()).hexdigest()[:12]
+    return None
+
+
+def record_decision(
+    app_or_request: Any,
+    *,
+    allowed: bool,
+    target: str,
+    principal: Optional[str],
+    required_scopes: Optional[List[str]] = None,
+    scopes: Optional[List[str]] = None,
+    claims: Optional[Dict[str, Any]] = None,
+    token: Optional[str] = None,
+    reason: Optional[str] = None,
+) -> None:
+    """Record ONE authorization decision to the configured sink.
+
+    This is shared by every enforcement choke point -- the REST route gate, the
+    per-resource gate, the WebSocket gates and the MCP tool gate -- so the access
+    trail covers all of them rather than only the transport that happens to run
+    inside the JWT middleware. ``target`` is the thing being decided on, formatted
+    like the route it corresponds to (e.g. ``"POST /agents/x/runs"``).
+
+    Never raises into the request path: an audit failure must not turn a served
+    request into a 500. No-op when no sink is configured, so the default (no audit)
+    deployment is untouched.
+    """
+    sink = resolve_audit_sink(app_or_request)
+    if sink is None:
+        return
+    try:
+        metadata: Dict[str, Any] = {
+            "required": list(required_scopes or []),
+            "token": token_reference(token, claims),
+            "scopes": list(scopes or []),
+        }
+        if reason:
+            metadata["reason"] = reason
+        sink.record(
+            AuditEvent(
+                action="access.allowed" if allowed else "access.denied",
+                actor=principal,
+                target=target,
+                timestamp=int(time.time()),
+                metadata=metadata,
+            )
+        )
+    except Exception as e:  # pragma: no cover - audit must never break requests
+        log_debug(f"decision audit failed: {e}")
 
 
 class DbAuditSink(AuditSink):

--- a/libs/agno/agno/os/authz/engine.py
+++ b/libs/agno/agno/os/authz/engine.py
@@ -1,0 +1,204 @@
+"""The pluggable policy engine behind managed roles — the swappable backend seam.
+
+:class:`~agno.os.authz.role_store.ManagedRoleStore` is the agno-native product
+surface (create roles, set scopes, assign, audit). The *engine* underneath —
+which actually stores policy and answers "is this allowed?" — is a swappable
+adapter behind this narrow port. agno's own
+:class:`~agno.os.authz.native_engine.NativePolicyEngine` is the default (zero
+third-party dependencies); swapping to another backend (OpenFGA, SpiceDB, ...)
+means implementing :class:`PolicyEngine` and passing it as
+``ManagedRoleStore(engine=...)`` — no change to the store's API, the ``/authz``
+router, the cookbooks, or anything SDK users see.
+
+The port speaks only agno terms — roles, subjects, scope strings, allow/deny.
+No engine types (obj/act tuples, OpenFGA tuples) leak across it.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+# A scope with its effect, e.g. ("agents:*:read", "allow") / ("agents:x:run", "deny").
+ScopeEntry = Tuple[str, str]
+
+
+def normalize_roles_claim(claims: Optional[Dict[str, Any]], roles_claim: Optional[str]) -> Optional[List[str]]:
+    """A caller's roles from a JWT claim, or None when absent/unusable. Accepts a
+    single string (e.g. WorkOS sends one ``role``) or a list. One owner for this
+    coercion so the gate (``EngineAuthorizationProvider``) and the admin check
+    (``ManagedRoleStore.can_manage``) can't drift — both are security-relevant."""
+    if not roles_claim or not claims:
+        return None
+    raw = claims.get(roles_claim)
+    if isinstance(raw, str):
+        raw = [raw]
+    if isinstance(raw, list) and raw:
+        return raw
+    return None
+
+
+class PolicyEngine(ABC):
+    """The backend that stores managed-role policy and answers access questions.
+
+    Implement these ~dozen methods (all in agno terms) to back managed roles with
+    a different engine. Identity for decisions is given two ways, mirroring the two
+    populations: ``subject`` (the engine resolves its roles from stored
+    assignments — the no-IdP case) and ``roles`` (roles carried on the token — the
+    IdP case). When ``roles`` is provided it takes precedence; otherwise the
+    ``subject``'s stored assignments decide.
+    """
+
+    # --- authoring: roles -> scopes ---
+    @abstractmethod
+    def set_role_scopes(self, role: str, entries: List[ScopeEntry]) -> None:
+        """Replace a role's entire scope set with ``entries`` (scope, effect)."""
+
+    @abstractmethod
+    def add_scope(self, role: str, scope: str, effect: str = "allow") -> None:
+        """Add (or flip the effect of) a single scope on a role."""
+
+    @abstractmethod
+    def remove_scope(self, role: str, scope: str) -> None:
+        """Remove a single scope from a role (no-op if absent)."""
+
+    @abstractmethod
+    def get_role_scopes(self, role: str) -> List[ScopeEntry]:
+        """A role's scopes as (scope, effect) entries."""
+
+    @abstractmethod
+    def remove_role(self, role: str) -> None:
+        """Delete a role: its scopes and any assignments to it."""
+
+    @abstractmethod
+    def list_roles(self) -> List[str]:
+        """All role names known to the engine."""
+
+    # --- assignments: subject -> roles ---
+    @abstractmethod
+    def assign(self, subject: str, role: str) -> None: ...
+
+    @abstractmethod
+    def unassign(self, subject: str, role: str) -> None: ...
+
+    @abstractmethod
+    def roles_of(self, subject: str) -> List[str]: ...
+
+    # --- decisions ---
+    @abstractmethod
+    def check_resource(
+        self,
+        resource_type: Optional[str],
+        resource_id: Optional[str],
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> bool:
+        """May the identity perform ``action`` on this resource (or collection)?"""
+
+    @abstractmethod
+    def check_scope(self, scope: str, *, subject: Optional[str] = None, roles: Optional[List[str]] = None) -> bool:
+        """Does the identity satisfy a required ``scope`` string? (Unmappable
+        scope -> False.)"""
+
+    @abstractmethod
+    def accessible_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Resource ids of ``resource_type`` the identity may access for ``action``
+        (``{"*"}`` = all)."""
+
+    def denied_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Concrete resource ids of ``resource_type`` the identity is explicitly
+        DENIED for ``action`` (deny-overrides). Used to carve denials out of the
+        list-visibility set so a wildcard allow + per-resource deny doesn't leak the
+        denied resource into list endpoints. Default: no engine-level denies."""
+        return set()
+
+
+class EngineAuthorizationProvider(AuthorizationProvider):
+    """An :class:`AuthorizationProvider` backed by any :class:`PolicyEngine`.
+
+    Engine-agnostic: it resolves the caller's identity (subject + optional
+    token-carried roles) from the request context and delegates every decision to
+    the engine. This is what ``ManagedRoleStore.provider`` returns, regardless of
+    which engine is plugged in.
+    """
+
+    def __init__(self, engine: PolicyEngine, roles_claim: Optional[str] = None):
+        self._engine = engine
+        self._roles_claim = roles_claim
+
+    def _identity(self, ctx: AuthorizationContext) -> Tuple[Optional[str], Optional[List[str]]]:
+        """(subject, roles) for the engine. ``roles`` is the token-carried list
+        when a ``roles_claim`` is configured and present; otherwise None so the
+        subject's stored assignments decide."""
+        return ctx.principal_id, normalize_roles_claim(ctx.claims, self._roles_claim)
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        subject, roles = self._identity(ctx)
+        return self._engine.check_resource(ctx.resource_type, ctx.resource_id, ctx.action, subject=subject, roles=roles)
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        subject, roles = self._identity(ctx)
+        # A resource route with a concrete single action: decide on the extracted
+        # (type, id, action) — the per-resource gate.
+        if ctx.resource_type and ctx.action:
+            return self._engine.check_resource(
+                ctx.resource_type, ctx.resource_id, ctx.action, subject=subject, roles=roles
+            )
+        # Otherwise — a non-resource route, or a resource route whose required scopes
+        # span more than one action (ctx.action is None) — require ALL of the route's
+        # scopes, matching the scope provider's AND semantics. Never fall through to a
+        # blanket allow: a multi-action resource route used to hit check_resource with
+        # action=None and be waved through. Evaluate each scope against the specific
+        # resource when one is known, else as a generic scope string.
+        if not required_scopes:
+            return True
+        for scope in required_scopes:
+            if ctx.resource_type and ctx.resource_id:
+                action = scope.rsplit(":", 1)[1] if ":" in scope else scope
+                ok = self._engine.check_resource(
+                    ctx.resource_type, ctx.resource_id, action, subject=subject, roles=roles
+                )
+            else:
+                ok = self._engine.check_scope(scope, subject=subject, roles=roles)
+            if not ok:
+                return False
+        return True
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type:
+            return set()
+        subject, roles = self._identity(ctx)
+        return self._engine.accessible_resource_ids(ctx.resource_type, ctx.action, subject=subject, roles=roles)
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        """Deny-aware list filtering: accessible ids MINUS explicitly-denied ids, so a
+        wildcard allow with a per-resource deny (``agents:*:read`` + a deny on
+        ``agents:secret``) excludes the denied resource — keeping list endpoints
+        consistent with :meth:`check` / the per-resource gate (deny-overrides)."""
+        if not ctx.resource_type:
+            return resources
+        subject, roles = self._identity(ctx)
+        accessible = self._engine.accessible_resource_ids(ctx.resource_type, ctx.action, subject=subject, roles=roles)
+        denied = self._engine.denied_resource_ids(ctx.resource_type, ctx.action, subject=subject, roles=roles)
+        wildcard = "*" in accessible
+        return [
+            r
+            for r in resources
+            if getattr(r, "id", None) not in denied and (wildcard or getattr(r, "id", None) in accessible)
+        ]

--- a/libs/agno/agno/os/authz/native_engine.py
+++ b/libs/agno/agno/os/authz/native_engine.py
@@ -1,0 +1,371 @@
+"""The native managed-roles policy engine — agno's default, zero third-party deps.
+
+A :class:`~agno.os.authz.engine.PolicyEngine` implemented directly in agno: roles
+hold scopes (with allow/deny), subjects are assigned roles, and decisions use
+**deny-overrides** matching the cloud RBAC semantics. No external policy engine.
+
+Storage is **always a database** (``db`` / ``db_url``): policy + assignments live in
+two SQLAlchemy tables (``authz_policy``, ``authz_grouping``) and every decision reads
+them **fresh** with small indexed queries. There is no in-process cache, so a change
+on one worker/replica is visible to all of them on their very next request — the
+right default for AgentOS's multi-container deployments. Authz is a tiny,
+index-served part of a request (which is otherwise an agent run), so the round-trips
+are negligible, and a DB outage fails closed. A DB is *required*: an in-memory store
+can't stay consistent across replicas, so an engine with no DB raises on any use
+(see :data:`~agno.os.authz._db.NO_DB_MESSAGE`).
+
+The decision model, in agno terms:
+
+- a role's scopes are stored as ``(resource, action, effect)`` via the shared
+  :mod:`~agno.os.authz._scope_policy` convention (deduped per ``(role, resource, action)``),
+- a subject (or a token-carried role) is allowed an action on a resource iff some
+  matching grant says *allow* and none says *deny* — evaluated per identity root
+  and OR'd across token-carried roles, so a deny on one role can't silently veto
+  an allow carried by another.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from agno.os.authz._db import NO_DB_MESSAGE
+from agno.os.authz._db import engine_from_db as _engine_from_db
+from agno.os.authz._db import engine_from_url as _engine_from_url
+from agno.os.authz._scope_policy import resource_action_to_scope, resource_matches, scope_to_resource_action
+from agno.os.authz.engine import PolicyEngine, ScopeEntry
+
+_DENY = "deny"
+_ALLOW = "allow"
+# A policy row carried through the decision logic: (role, resource, action, effect).
+_PolicyRow = Tuple[str, str, str, str]
+
+
+def _normalize_effect(effect: str) -> str:
+    """Validate/lowercase a policy effect. Reject anything but allow/deny so a
+    typo'd effect can't silently become an *allow* (deny-overrides keys off the
+    exact string ``"deny"``)."""
+    e = effect.lower() if isinstance(effect, str) else effect
+    if e not in (_ALLOW, _DENY):
+        raise ValueError(f"effect must be 'allow' or 'deny', got {effect!r}")
+    return e
+
+
+class NativePolicyEngine(PolicyEngine):
+    """agno-native :class:`PolicyEngine`. Queries the DB fresh per decision. A DB is
+    required (``db`` or ``db_url``); without one — and until AgentOS adopts the OS DB
+    via :meth:`attach_db` — every operation raises, because an in-memory store can't
+    stay consistent across the workers/replicas an AgentOS deployment runs."""
+
+    def __init__(self, db_url: Optional[str] = None, db: Optional[Any] = None):
+        # A DB is required. It may arrive later via attach_db() (the AgentOS
+        # role_store= shortcut), so an engine built with neither db nor db_url starts
+        # "unbound" and raises on use until bound — it is never an operating mode.
+        self._engine: Any = None  # SQLAlchemy Engine once bound, else None (unbound)
+        self._policy_tbl: Any = None
+        self._group_tbl: Any = None
+        self._log = logging.getLogger("agno.authz.engine")
+
+        target = _engine_from_db(db) if db is not None else (_engine_from_url(db_url) if db_url else None)
+        if target is not None:
+            self._setup_db(target)
+
+    # --- storage ---------------------------------------------------------
+    @property
+    def is_bound(self) -> bool:
+        """True once a DB is bound (directly or via :meth:`attach_db`)."""
+        return self._engine is not None
+
+    def _require_engine(self) -> None:
+        if self._engine is None:
+            raise RuntimeError(NO_DB_MESSAGE)
+
+    def _setup_db(self, engine: Any) -> None:
+        import sqlalchemy as sa
+
+        self._engine = engine
+        metadata = sa.MetaData()
+        self._policy_tbl = sa.Table(
+            "authz_policy",
+            metadata,
+            sa.Column("role", sa.String(255), primary_key=True),
+            sa.Column("resource", sa.String(512), primary_key=True),
+            sa.Column("action", sa.String(255), primary_key=True),
+            sa.Column("effect", sa.String(16), nullable=False),
+        )
+        self._group_tbl = sa.Table(
+            "authz_grouping",
+            metadata,
+            sa.Column("subject", sa.String(255), primary_key=True),
+            sa.Column("role", sa.String(255), primary_key=True),
+        )
+        metadata.create_all(self._engine)
+
+    def attach_db(self, db: Any) -> None:
+        """Bind an agno ``Db`` to a still-unbound engine, then read the DB fresh.
+
+        No-op if a DB is already bound (the caller's explicit choice wins) or the db
+        isn't SQL-capable (e.g. a NoSQL agno Db) — in which case the engine stays
+        unbound and the next operation raises. Lets AgentOS adopt the OS database for
+        a managed store created without one."""
+        if self._engine is not None:
+            return  # already bound — respect the explicit choice
+        try:
+            engine = _engine_from_db(db)
+        except Exception:
+            return  # not a SQL-capable db; stay unbound (use will raise)
+        self._setup_db(engine)
+
+    # --- read helpers (DB-backed) ----------------------------------------
+    def _direct_roles(self, node: str) -> Set[str]:
+        """Roles directly assigned to ``node`` (a subject, or a role when nesting).
+        Indexed point-lookup on the grouping PK."""
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            rows = conn.execute(sa.select(self._group_tbl.c.role).where(self._group_tbl.c.subject == node))
+            return {r[0] for r in rows}
+
+    def _closure(self, seed: str) -> Set[str]:
+        """``seed`` plus the roles it is (transitively) assigned. The seed itself is
+        included so a token-carried role matches policies written for that role."""
+        seen: Set[str] = set()
+        stack = [seed]
+        while stack:
+            node = stack.pop()
+            if node in seen:
+                continue
+            seen.add(node)
+            stack.extend(self._direct_roles(node))
+        return seen
+
+    def _policies_for(self, principals: Set[str]) -> List[_PolicyRow]:
+        """All (role, resource, action, effect) rows whose role is in ``principals``."""
+        if not principals:
+            return []
+        self._require_engine()
+        import sqlalchemy as sa
+
+        t = self._policy_tbl
+        with self._engine.connect() as conn:
+            rows = conn.execute(sa.select(t).where(t.c.role.in_(principals))).mappings()
+            return [(row["role"], row["resource"], row["action"], row["effect"]) for row in rows]
+
+    # --- persistence (db-backed mutations) -------------------------------
+    def _persist_policies_set(self, role: str, rows: List[Tuple[str, str, str]]) -> None:
+        """Replace a role's persisted policy rows with ``rows`` ((resource, action, effect))."""
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(sa.delete(self._policy_tbl).where(self._policy_tbl.c.role == role))
+            if rows:
+                conn.execute(
+                    sa.insert(self._policy_tbl),
+                    [{"role": role, "resource": res, "action": act, "effect": eff} for res, act, eff in rows],
+                )
+
+    def _persist_policy(self, role: str, resource: str, action: str, effect: str) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.delete(self._policy_tbl).where(
+                    self._policy_tbl.c.role == role,
+                    self._policy_tbl.c.resource == resource,
+                    self._policy_tbl.c.action == action,
+                )
+            )
+            conn.execute(sa.insert(self._policy_tbl).values(role=role, resource=resource, action=action, effect=effect))
+
+    def _delete_policy(self, role: str, resource: Optional[str] = None, action: Optional[str] = None) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        clause = [self._policy_tbl.c.role == role]
+        if resource is not None:
+            clause.append(self._policy_tbl.c.resource == resource)
+        if action is not None:
+            clause.append(self._policy_tbl.c.action == action)
+        with self._engine.begin() as conn:
+            conn.execute(sa.delete(self._policy_tbl).where(*clause))
+
+    def _persist_grouping(self, subject: str, role: str, add: bool) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(
+                sa.delete(self._group_tbl).where(self._group_tbl.c.subject == subject, self._group_tbl.c.role == role)
+            )
+            if add:
+                conn.execute(sa.insert(self._group_tbl).values(subject=subject, role=role))
+
+    def _delete_grouping_role(self, role: str) -> None:
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.begin() as conn:
+            conn.execute(sa.delete(self._group_tbl).where(self._group_tbl.c.role == role))
+
+    # --- authoring: roles -> scopes -------------------------------------
+    def set_role_scopes(self, role: str, entries: List[ScopeEntry]) -> None:
+        # Stage + validate EVERY entry first: a bad scope raises before anything is
+        # written, and mapping to a dict dedups colliding (resource, action) pairs
+        # (e.g. agents:read & agents:*:read) so the insert can't hit a duplicate PK.
+        staged: Dict[Tuple[str, str], str] = {}
+        for scope, effect in entries:
+            resource, action = scope_to_resource_action(scope)
+            staged[(resource, action)] = _normalize_effect(effect)
+        self._persist_policies_set(role, [(res, act, eff) for (res, act), eff in staged.items()])
+
+    def add_scope(self, role: str, scope: str, effect: str = _ALLOW) -> None:
+        resource, action = scope_to_resource_action(scope)  # validate before mutating
+        effect = _normalize_effect(effect)
+        self._persist_policy(role, resource, action, effect)
+
+    def remove_scope(self, role: str, scope: str) -> None:
+        resource, action = scope_to_resource_action(scope)  # validate before mutating
+        self._delete_policy(role, resource, action)
+
+    def get_role_scopes(self, role: str) -> List[ScopeEntry]:
+        return [(resource_action_to_scope(res, act), eff) for (r, res, act, eff) in self._policies_for({role})]
+
+    def remove_role(self, role: str) -> None:
+        self._delete_policy(role)
+        self._delete_grouping_role(role)
+
+    def list_roles(self) -> List[str]:
+        # Roles defined by scope policies PLUS roles that only exist as assignments,
+        # so an assignment-only role is still inspectable/cleanable.
+        self._require_engine()
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:
+            roles = {r[0] for r in conn.execute(sa.select(self._policy_tbl.c.role).distinct())}
+            roles |= {r[0] for r in conn.execute(sa.select(self._group_tbl.c.role).distinct())}
+        return sorted(roles)
+
+    # --- assignments: subject -> roles ----------------------------------
+    def assign(self, subject: str, role: str) -> None:
+        self._persist_grouping(subject, role, add=True)
+
+    def unassign(self, subject: str, role: str) -> None:
+        self._persist_grouping(subject, role, add=False)
+
+    def roles_of(self, subject: str) -> List[str]:
+        return sorted(self._direct_roles(subject))
+
+    # --- decisions -------------------------------------------------------
+    def _allowed_for_root(self, root: str, request_resource: str, request_action: str) -> bool:
+        """deny-overrides within one identity root: allowed iff some grant in the
+        root's closure matches and allows, and none matches and denies."""
+        allow = deny = False
+        for _role, resource, action, effect in self._policies_for(self._closure(root)):
+            if action != "*" and action != request_action:
+                continue
+            if not resource_matches(resource, request_resource):
+                continue
+            if effect == _DENY:
+                deny = True
+            else:
+                allow = True
+        return allow and not deny
+
+    def _enforce(self, resource: str, action: str, subject: Optional[str], roles: Optional[List[str]]) -> bool:
+        """One decision for ``(resource, action)``. Token-carried roles take precedence
+        (each evaluated as its own root and OR'd); else the subject's assignments."""
+        if roles:
+            decision = any(self._allowed_for_root(role, resource, action) for role in roles)
+        elif subject:
+            decision = self._allowed_for_root(subject, resource, action)
+        else:
+            decision = False
+        if self._log.isEnabledFor(logging.INFO):
+            who = f"roles={roles}" if roles else f"subject={subject!r}"
+            self._log.info("authz decision: %s resource=%r action=%r -> %s", who, resource, action, decision)
+        return decision
+
+    def check_resource(
+        self,
+        resource_type: Optional[str],
+        resource_id: Optional[str],
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> bool:
+        if not resource_type or not action:
+            return True  # non-resource check: defer (the route gate handles it)
+        resource = f"{resource_type}/{resource_id}" if resource_id else resource_type
+        return self._enforce(resource, action, subject, roles)
+
+    def check_scope(self, scope: str, *, subject: Optional[str] = None, roles: Optional[List[str]] = None) -> bool:
+        try:
+            resource, action = scope_to_resource_action(scope)
+        except ValueError:
+            return False  # unmappable scope -> not satisfied
+        return self._enforce(resource, action, subject, roles)
+
+    def _principals_for(self, subject: Optional[str], roles: Optional[List[str]]) -> Set[str]:
+        roots = list(roles) if roles else ([subject] if subject else [])
+        principals: Set[str] = set()
+        for root in roots:
+            principals |= self._closure(root)
+        return principals
+
+    def accessible_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Resource ids of ``resource_type`` the identity may access for ``action``
+        (``{"*"}`` = wildcard/collection grant). Mirrors :meth:`_enforce`: roles
+        take precedence, else the subject's stored assignments; deny rows skipped."""
+        if not resource_type:
+            return set()
+        principals = self._principals_for(subject, roles)
+        if not principals:
+            return set()
+        ids: Set[str] = set()
+        prefix = f"{resource_type}/"
+        for _role, resource, policy_action, effect in self._policies_for(principals):
+            if effect == _DENY:
+                continue
+            if action is not None and policy_action != action and policy_action != "*":
+                continue
+            if resource in ("*", f"{resource_type}/*", resource_type):
+                return {"*"}
+            if resource.startswith(prefix):
+                ids.add(resource[len(prefix) :])
+        return ids
+
+    def denied_resource_ids(
+        self,
+        resource_type: str,
+        action: Optional[str],
+        *,
+        subject: Optional[str] = None,
+        roles: Optional[List[str]] = None,
+    ) -> Set[str]:
+        """Concrete ids of ``resource_type`` explicitly denied for ``action`` (the
+        deny rows). Lets the provider carve denials out of a wildcard-allow list so
+        list endpoints honour deny-overrides like the per-resource gate does."""
+        if not resource_type:
+            return set()
+        principals = self._principals_for(subject, roles)
+        if not principals:
+            return set()
+        ids: Set[str] = set()
+        prefix = f"{resource_type}/"
+        for _role, resource, policy_action, effect in self._policies_for(principals):
+            if effect != _DENY:
+                continue
+            if action is not None and policy_action != action and policy_action != "*":
+                continue
+            if resource.startswith(prefix):
+                ids.add(resource[len(prefix) :])
+        return ids

--- a/libs/agno/agno/os/authz/provider.py
+++ b/libs/agno/agno/os/authz/provider.py
@@ -1,0 +1,114 @@
+"""Authorization provider interface.
+
+Defines the decision context handed to a provider and the abstract base every
+provider implements. Keeping this dependency-free (only stdlib + typing) means
+the interface can live in the OSS SDK while concrete providers — including ones
+that call out to an external policy engine — are layered on top.
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Set
+
+
+@dataclass
+class AuthorizationContext:
+    """Everything a provider needs to make an access decision.
+
+    A provider is free to use as much or as little of this as its model
+    requires. The built-in scope provider only looks at ``scopes`` /
+    ``resource_type`` / ``resource_id`` / ``action`` / ``admin_scope``; a ReBAC
+    or ABAC provider would additionally lean on ``principal_id`` and the full
+    ``claims`` (tenant, groups, ownership hints, etc.).
+
+    Attributes:
+        principal_id: The authenticated subject (JWT ``sub``), or None when
+            unauthenticated.
+        scopes: Scope strings from the token's ``scopes`` claim.
+        claims: The full decoded JWT payload, for providers that key off
+            arbitrary claims (tenant_id, groups, ...).
+        resource_type: Resource family being accessed ("agents", "teams",
+            "workflows", ...), or None for non-resource checks.
+        resource_id: Specific resource id, or None for list/collection checks.
+        action: Action being attempted ("read", "run", "write", ...).
+        admin_scope: The scope string that grants full bypass (default
+            ``agent_os:admin``), honoured by the built-in provider.
+    """
+
+    principal_id: Optional[str] = None
+    scopes: List[str] = field(default_factory=list)
+    claims: Dict[str, Any] = field(default_factory=dict)
+    resource_type: Optional[str] = None
+    resource_id: Optional[str] = None
+    action: Optional[str] = None
+    admin_scope: Optional[str] = None
+
+
+class AuthorizationProvider(ABC):
+    """Strategy for answering AgentOS authorization questions.
+
+    Two primitives every provider must answer:
+
+    - :meth:`check` — boolean "may this context do this action on this
+      resource?"
+    - :meth:`accessible_resource_ids` — for list endpoints, which resource ids
+      of a type the principal may access (``{"*"}`` means all).
+
+    :meth:`require` and :meth:`filter_accessible` have sensible default
+    implementations on top of those two; override them only if the provider can
+    do something smarter (e.g. a single batch call to an external engine).
+    """
+
+    @abstractmethod
+    def check(self, ctx: AuthorizationContext) -> bool:
+        """Return True if the action in ``ctx`` is allowed."""
+        ...
+
+    @abstractmethod
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        """Return the set of resource ids of ``ctx.resource_type`` the
+        principal may access for ``ctx.action``. ``{"*"}`` denotes wildcard
+        (all) access.
+        """
+        ...
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Route-level gate run by the JWT middleware before the request reaches
+        the endpoint.
+
+        ``required_scopes`` is the scope vocabulary the default route→scope
+        mapping produced for this path (e.g. ``["agents:run"]``). A scope-based
+        provider uses it directly; a provider with a different model (ReBAC/ABAC)
+        ignores it and decides from :meth:`check` instead.
+
+        Default implementation defers to :meth:`check`, so a custom provider
+        gets full control of the route gate without having to understand scope
+        strings. :class:`~agno.os.authz.scope_provider.ScopeAuthorizationProvider`
+        overrides this to preserve the original scope-matching behaviour.
+        """
+        return self.check(ctx)
+
+    def require(self, ctx: AuthorizationContext) -> None:
+        """Raise ``PermissionError`` if :meth:`check` denies ``ctx``.
+
+        The HTTP layer translates this into a 403; keeping the provider raising
+        a plain ``PermissionError`` avoids coupling it to FastAPI.
+        """
+        if not self.check(ctx):
+            raise PermissionError(
+                f"Access denied to {ctx.action} {ctx.resource_type}"
+                + (f"/{ctx.resource_id}" if ctx.resource_id else "")
+            )
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        """Filter ``resources`` (objects with an ``id``) to those the principal
+        may access, using :meth:`accessible_resource_ids`.
+
+        Default implementation does one ``accessible_resource_ids`` call and
+        filters in-process. Providers backed by an external engine may override
+        with a batched authorization query.
+        """
+        accessible = self.accessible_resource_ids(ctx)
+        if "*" in accessible:
+            return resources
+        return [r for r in resources if getattr(r, "id", None) in accessible]

--- a/libs/agno/agno/os/authz/provider.py
+++ b/libs/agno/agno/os/authz/provider.py
@@ -32,7 +32,20 @@ class AuthorizationContext:
         resource_id: Specific resource id, or None for list/collection checks.
         action: Action being attempted ("read", "run", "write", ...).
         admin_scope: The scope string that grants full bypass (default
-            ``agent_os:admin``), honoured by the built-in provider.
+            ``agent_os:admin``).
+
+            IMPORTANT -- this is a *scope-plane* feature. It is honoured by
+            :class:`~agno.os.authz.scope_provider.ScopeAuthorizationProvider`,
+            which reads it off the caller's token scopes. Providers that do not
+            authorize from token scopes deliberately ignore it and model admin in
+            their own terms instead: the managed-role engine grants an admin ROLE
+            (a role whose scopes include ``agent_os:admin``), and a relationship
+            (ReBAC) provider expects an admin RELATIONSHIP. So a token carrying
+            ``agent_os:admin`` is NOT automatically an admin under a role or ReBAC
+            provider used on its own -- if you want token-scope admins alongside
+            one of those, run the scope provider as a second plane
+            (``authorization_provider=[ScopeAuthorizationProvider(), other]``),
+            where the OR composition gives you the bypass.
     """
 
     principal_id: Optional[str] = None

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -1,0 +1,146 @@
+"""HTTP management API for :class:`ManagedRoleStore` — the governance product surface.
+
+This is the productisation of the managed-roles tier: a small, admin-only REST
+API to create roles, set their permissions (in agno scope terms), and grant or
+revoke them at runtime. Mount it on your AgentOS app:
+
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.authz.role_router import get_roles_router
+
+    roles = ManagedRoleStore(db_url="postgresql+psycopg://...")
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(roles))
+
+Every route requires the caller to be an admin (satisfies ``agent_os:admin``,
+whether that comes from a token scope or an admin role in the store). The JWT
+middleware still runs first, so an unauthenticated request is rejected (401)
+before these handlers; a valid-but-non-admin caller gets 403.
+
+Endpoints (default prefix ``/authz``):
+    GET    /authz/roles                          list roles
+    GET    /authz/roles/{role}                   a role's scopes
+    PUT    /authz/roles/{role}                   set a role's scopes  {"scopes": [...]}
+    DELETE /authz/roles/{role}                   delete a role
+    GET    /authz/users/{subject}/roles          a subject's roles
+    POST   /authz/users/{subject}/roles          assign a role        {"role": "..."}
+    DELETE /authz/users/{subject}/roles/{role}   revoke a role
+"""
+
+from enum import Enum
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from agno.os.authz.role_store import ManagedRoleStore
+
+
+class SetRoleScopesRequest(BaseModel):
+    scopes: List[str] = Field(..., description="Permissions in agno scope terms, e.g. ['agents:*:read']")
+
+
+class AssignRoleRequest(BaseModel):
+    role: str = Field(..., description="Role to grant the subject")
+
+
+def get_roles_router(
+    store: "ManagedRoleStore", prefix: str = "/authz", tags: Optional[List[Union[str, Enum]]] = None
+) -> APIRouter:
+    """Build the admin-only roles-management router bound to ``store``."""
+    if tags is None:
+        tags = ["Authorization"]
+
+    def require_admin(request: Request) -> str:
+        """Gate: caller must be authenticated and an admin of the store."""
+        if not getattr(request.state, "authenticated", False):
+            raise HTTPException(status_code=401, detail="Not authenticated")
+        principal_id = getattr(request.state, "user_id", None)
+        claims = getattr(request.state, "claims", {}) or {}
+        if not store.can_manage(principal_id, claims):
+            raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
+        return principal_id or ""
+
+    router = APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_admin)])
+
+    # ---- roles ----------------------------------------------------------
+    @router.get("/roles")
+    def list_roles() -> dict:
+        return {"roles": store.list_roles()}
+
+    @router.get("/roles/{role}")
+    def get_role(role: str) -> dict:
+        return {"role": role, "scopes": store.get_role_scopes(role)}
+
+    @router.put("/roles/{role}")
+    def set_role(role: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)) -> dict:
+        try:
+            store.set_role_scopes(role, body.scopes, actor=actor)
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return {"role": role, "scopes": store.get_role_scopes(role)}
+
+    @router.delete("/roles/{role}")
+    def delete_role(role: str, actor: str = Depends(require_admin)) -> dict:
+        store.remove_role(role, actor=actor)
+        return {"role": role, "deleted": True}
+
+    # ---- scope catalog --------------------------------------------------
+    @router.get("/scopes")
+    def list_scopes() -> dict:
+        """The catalog of scopes this AgentOS understands, grouped by resource.
+
+        Derived from the OS's own route→scope map, so it always matches what the
+        OS actually enforces. A UI renders this as a resource×action grid; a role
+        is then just a set of the resulting ``resource:action`` strings (plus the
+        ``agent_os:admin`` super-scope).
+        """
+        from agno.os.scopes import get_default_scope_mappings
+
+        grouped: dict = {}
+        for required in get_default_scope_mappings().values():
+            for scope in required:
+                parts = scope.split(":")
+                if len(parts) == 2:
+                    grouped.setdefault(parts[0], set()).add(parts[1])
+        grouped_sorted = {r: sorted(a) for r, a in sorted(grouped.items())}
+        flat = sorted(f"{r}:{a}" for r, acts in grouped_sorted.items() for a in acts)
+        return {"grouped": grouped_sorted, "scopes": flat, "admin_scope": "agent_os:admin"}
+
+    # ---- audit ----------------------------------------------------------
+    @router.get("/audit")
+    def list_audit(limit: int = 100) -> dict:
+        """Recent *change* events (role/assignment mutations, newest first). Empty
+        unless the store was given a readable audit sink (e.g. DbAuditSink)."""
+        return {"events": store.audit_log(limit)}
+
+    @router.get("/decisions")
+    def list_decisions(request: Request, limit: int = 100) -> dict:
+        """Recent *decision* events (allow/deny per request, newest first).
+
+        Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
+        on ``app.state.authz_audit`` — a separate table from the change trail above,
+        so a high-volume decision log never buries the change history. Empty unless a
+        readable decision sink (e.g. DbAuditSink) is configured."""
+        sink = getattr(request.app.state, "authz_audit", None)
+        events = sink.read_decisions(limit) if sink is not None and hasattr(sink, "read_decisions") else []
+        return {"events": events}
+
+    # ---- assignments ----------------------------------------------------
+    @router.get("/users/{subject}/roles")
+    def get_user_roles(subject: str) -> dict:
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    @router.post("/users/{subject}/roles")
+    def assign_role(subject: str, body: AssignRoleRequest, actor: str = Depends(require_admin)) -> dict:
+        """Set the subject's role. One role per subject: this REPLACES any
+        current role (a role select in a UI, not a multi-grant)."""
+        store.assign(subject, body.role, actor=actor)
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    @router.delete("/users/{subject}/roles/{role}")
+    def revoke_role(subject: str, role: str, actor: str = Depends(require_admin)) -> dict:
+        store.unassign(subject, role, actor=actor)
+        return {"subject": subject, "roles": store.roles_of(subject)}
+
+    return router

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -1,0 +1,224 @@
+"""Managed roles for AgentOS — agno-native API, native policy engine inside.
+
+This is the "governance product" middle tier: create roles, assign them, and
+change them at runtime, persisted to your own DB. You work entirely in agno
+scope terms (``agents:*:read``, ``agents:research-agent:run``,
+``agent_os:admin``). The decision engine underneath is agno's own
+:class:`~agno.os.authz.native_engine.NativePolicyEngine` (deny-overrides RBAC, no
+third-party dependency). The engine is swappable behind the :class:`PolicyEngine`
+port. A change persists and takes effect on the next request across every
+worker/replica, because decisions read the DB fresh (no in-process cache to go
+stale).
+
+A DB is **required** — managed roles must be persisted, and an in-memory store
+can't stay consistent across the replicas an AgentOS deployment runs. Give the
+store a DB directly (``db=``/``db_url=``) or let AgentOS adopt the OS DB via
+``AuthorizationConfig(role_store=...)``; without one, every operation raises.
+Persistence to a DB needs SQLAlchemy: ``pip install "agno[roles]"`` (or ``agno[os]``).
+
+Example::
+
+    store = ManagedRoleStore(db_url="postgresql+psycopg://...", roles_claim="roles")
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "member")           # runtime, persisted
+
+    agent_os = AgentOS(
+        agents=[...],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[...],
+            authorization_provider=store.provider,   # plug it in
+        ),
+    )
+
+    # later, live (no redeploy, same token):
+    store.assign("carol", "member")
+    store.unassign("bob", "member")
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, normalize_roles_claim
+
+if TYPE_CHECKING:
+    from agno.os.authz.audit import AuditSink
+
+
+class ManagedRoleStore:
+    """Runtime-mutable, persisted role store. agno-native API; the policy engine
+    (the native engine by default) is a swappable backend behind the
+    :class:`PolicyEngine` port — pass ``engine=`` to use a different one."""
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        roles_claim: Optional[str] = None,
+        audit: Optional["AuditSink"] = None,
+        decision_log: bool = False,
+        db: Optional[Any] = None,
+        engine: Optional[PolicyEngine] = None,
+    ):
+        """
+        Args:
+            db_url: SQLAlchemy URL for the DB that holds the policy (e.g.
+                ``postgresql+psycopg://...`` or ``sqlite:///roles.db``). Use your
+                own database. If omitted (and no ``db``/``engine``), the store is
+                unbound and must be bound before use — by AgentOS adopting the OS DB
+                via ``role_store=``, or it raises. A DB is required; there is no
+                in-memory mode (it couldn't stay consistent across replicas).
+            roles_claim: JWT claim carrying a caller's roles (the external-IdP
+                case). When absent, roles come from this store's own assignments
+                (the no-IdP case). Both are served by the same store.
+            audit: optional :class:`~agno.os.authz.audit.AuditSink`. When set,
+                every role/assignment change emits an append-only AuditEvent with
+                the acting principal and the before/after (the change audit the
+                policy engine can't give you, since it never sees the actor).
+            decision_log: when True, bump the ``agno.authz.engine`` logger to INFO
+                so every allow/deny decision is logged. Off by default so we don't
+                touch global logging behind your back.
+            db: an agno database (the same object you pass to ``AgentOS(db=...)``).
+                Its SQLAlchemy engine is reused, so roles live in the same database
+                as your agent data. Takes precedence over ``db_url``.
+            engine: a custom :class:`~agno.os.authz.engine.PolicyEngine` backend.
+                Defaults to the native engine built from ``db``/``db_url``.
+        """
+        if engine is not None:
+            self._engine: PolicyEngine = engine
+        else:
+            from agno.os.authz.native_engine import NativePolicyEngine
+
+            self._engine = NativePolicyEngine(db_url=db_url, db=db)
+        self._roles_claim = roles_claim
+        self._audit = audit
+
+        if decision_log:
+            import logging
+
+            logging.getLogger("agno.authz.engine").setLevel(logging.INFO)
+
+    def _emit(
+        self,
+        action: str,
+        target: str,
+        before: Optional[List[str]],
+        after: Optional[List[str]],
+        actor: Optional[str],
+    ) -> None:
+        """Record one change to the audit sink (no-op when no sink is configured)."""
+        if self._audit is None:
+            return
+        import time
+
+        from agno.os.authz.audit import AuditEvent
+
+        self._audit.record(
+            AuditEvent(
+                action=action,
+                actor=actor,
+                target=target,
+                before=before,
+                after=after,
+                timestamp=int(time.time()),
+            )
+        )
+
+    # ------------------------------------------------------------------ roles
+    def set_role_scopes(self, role: str, scopes: List[str], actor: Optional[str] = None) -> None:
+        """Define (or replace) what a role can do, in agno scope terms."""
+        before = self.get_role_scopes(role) if self._audit else None
+        self._engine.set_role_scopes(role, [(scope, "allow") for scope in scopes])
+        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+
+    def get_role_scopes(self, role: str) -> List[str]:
+        """Return a role's scopes in agno terms (best-effort read-back)."""
+        return sorted(scope for scope, _effect in self._engine.get_role_scopes(role))
+
+    def remove_role(self, role: str, actor: Optional[str] = None) -> None:
+        before = self.get_role_scopes(role) if self._audit else None
+        self._engine.remove_role(role)
+        self._emit("role.removed", role, before, None, actor)
+
+    def list_roles(self) -> List[str]:
+        return sorted(self._engine.list_roles())
+
+    # ------------------------------------------------------------- assignments
+    def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
+        """Give a subject THE role (runtime, persisted).
+
+        A subject holds at most ONE role at a time — assigning replaces any
+        current role rather than accumulating. This mirrors the cloud RBAC model
+        (a membership has one role). No-op if the subject already holds exactly
+        this role.
+        """
+        before = self.roles_of(subject)
+        if before == [role]:
+            return  # already exactly this role; no change, no audit noise
+        for existing in before:
+            self._engine.unassign(subject, existing)
+        self._engine.assign(subject, role)
+        self._emit(
+            "user.assigned",
+            subject,
+            before if self._audit else None,
+            self.roles_of(subject) if self._audit else None,
+            actor,
+        )
+
+    def unassign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
+        before = self.roles_of(subject) if self._audit else None
+        self._engine.unassign(subject, role)
+        self._emit("user.unassigned", subject, before, self.roles_of(subject) if self._audit else None, actor)
+
+    def roles_of(self, subject: str) -> List[str]:
+        return self._engine.roles_of(subject)
+
+    @property
+    def is_bound(self) -> bool:
+        """True once the store has a DB (passed directly or adopted via
+        :meth:`attach_db`). A custom ``engine=`` is assumed self-managed (bound)."""
+        flag = getattr(self._engine, "is_bound", None)
+        return bool(flag) if flag is not None else True
+
+    def attach_db(self, db: Any) -> None:
+        """Bind an agno ``Db`` to a store created without one, so managed roles
+        persist in (and read fresh from) that DB. No-op if the store already has its
+        own DB, or the db isn't SQL-capable. AgentOS calls this to default a managed
+        store to the OS database when you pass ``AuthorizationConfig(role_store=...)``."""
+        attach = getattr(self._engine, "attach_db", None)
+        if callable(attach):
+            attach(db)
+
+    # ------------------------------------------------------------------ audit
+    def audit_log(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Recent change-audit events (newest first), if the audit sink supports
+        reading (e.g. ``DbAuditSink``). Returns ``[]`` when no readable sink is
+        configured (e.g. a logging-only sink, or no audit at all)."""
+        sink = self._audit
+        if sink is not None and hasattr(sink, "read"):
+            return sink.read(limit)
+        return []
+
+    # ----------------------------------------------------------------- gating
+    def can_manage(self, principal_id: Optional[str], claims: Optional[Dict[str, Any]] = None) -> bool:
+        """True if the caller may administer roles (i.e. satisfies ``agent_os:admin``).
+
+        An admin can be defined two ways, both handled here:
+          - by a role in this store, or
+          - by a role carried on the token, when ``roles_claim`` is set.
+        Note this is intentionally NOT the generic provider ``check`` (which
+        defers non-resource decisions to route scope mappings and would let any
+        authenticated caller through).
+        """
+        roles = normalize_roles_claim(claims, self._roles_claim)
+        if roles and self._engine.check_scope("agent_os:admin", roles=roles):
+            return True
+        if principal_id:
+            return self._engine.check_scope("agent_os:admin", subject=principal_id)
+        return False
+
+    # --------------------------------------------------------------- provider
+    @property
+    def provider(self) -> EngineAuthorizationProvider:
+        """The AuthorizationProvider to plug into AuthorizationConfig."""
+        return EngineAuthorizationProvider(self._engine, roles_claim=self._roles_claim)

--- a/libs/agno/agno/os/authz/scope_provider.py
+++ b/libs/agno/agno/os/authz/scope_provider.py
@@ -1,0 +1,60 @@
+"""Default authorization provider: JWT-scope RBAC.
+
+This is the built-in implementation and preserves AgentOS's existing behaviour
+exactly — it delegates to :func:`agno.os.scopes.has_required_scopes` and
+:func:`agno.os.scopes.get_accessible_resource_ids`, the same functions the
+request pipeline used before the provider seam existed. No external service, no
+new dependency: it runs against the scopes already in the JWT.
+
+Swapping to a different model (OpenFGA, Cerbos, a bespoke ReBAC engine)
+means implementing :class:`agno.os.authz.provider.AuthorizationProvider`
+instead of this class — the rest of the pipeline is unchanged.
+"""
+
+from typing import List, Set
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.os.scopes import get_accessible_resource_ids, has_required_scopes
+
+
+class ScopeAuthorizationProvider(AuthorizationProvider):
+    """RBAC via JWT scope strings (``resource:action``, ``resource:<id>:action``)."""
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type) can't be expressed as a scope
+        # here; treat it as allowed and let route-level scope mappings handle it.
+        if not ctx.resource_type or not ctx.action:
+            return True
+
+        required = [f"{ctx.resource_type}:{ctx.action}"]
+        return has_required_scopes(
+            ctx.scopes,
+            required,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=ctx.admin_scope,
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type:
+            return set()
+        return get_accessible_resource_ids(
+            ctx.scopes,
+            ctx.resource_type,
+            admin_scope=ctx.admin_scope,
+            action=ctx.action,
+        )
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        """Original middleware route gate: does the token satisfy the scopes the
+        route requires, in the context of the resource being accessed.
+        """
+        if not required_scopes:
+            return True
+        return has_required_scopes(
+            ctx.scopes,
+            required_scopes,
+            resource_type=ctx.resource_type,
+            resource_id=ctx.resource_id,
+            admin_scope=ctx.admin_scope,
+        )

--- a/libs/agno/agno/os/authz/user_store.py
+++ b/libs/agno/agno/os/authz/user_store.py
@@ -1,0 +1,403 @@
+"""Managed users for AgentOS — a credential-less user directory.
+
+This is the "no IdP" tier. When a customer has no external identity provider,
+their app still authenticates users its own way and mints a JWT that AgentOS
+verifies (see :class:`~agno.os.middleware.jwt.JWTValidator`). agno does NOT store
+passwords and is NOT an authenticator — it owns a *directory* of the users the
+app asserts, plus their roles (via :class:`ManagedRoleStore`) and enforcement.
+
+What this store buys you over "roles only":
+    - **Enumeration / management UX**: list the users that exist, not just react
+      to whatever ``sub`` shows up in a token. Pick a user to assign a role.
+    - **A real off-switch**: ``disabled`` is checked at the enforcement point, so
+      a disabled user is denied *even with a still-valid token* — instant
+      revocation you can't get from token expiry alone.
+    - **Audit/identity enrichment**: map an opaque ``sub`` to an email/name in the
+      decision and change trails.
+
+It is deliberately small: a user is ``id`` (the JWT ``sub``), optional ``email``
+/ ``name``, a ``disabled`` flag, timestamps, and free-form ``metadata``. No
+credentials, ever.
+
+Two ways users land in the directory:
+    - **Explicit**: an admin creates them up front (``upsert``) and assigns roles.
+    - **Just-in-time**: on the first valid token from an unknown subject, AgentOS
+      can auto-provision a row from the token's claims (opt-in; see
+      ``provision_from_claims`` and ``AuthorizationConfig``).
+
+Backed by your own DB via SQLAlchemy (pass ``db_url``/``engine``); falls back to
+in-memory when neither is given (fine for tests, not for production).
+"""
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from agno.os.authz.audit import AuditSink
+
+# The directory's list contract: which fields a page can be sorted by / searched
+# over, and the defaults. The roles router validates request params against
+# these, so they have one owner.
+USER_SORT_FIELDS = ("created_at", "updated_at", "id", "email", "name")
+USER_SEARCH_FIELDS = ("id", "email", "name")
+DEFAULT_USER_SORT_FIELD = "created_at"
+DEFAULT_USER_SORT_ORDER = "desc"
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+class ManagedUserStore:
+    """Credential-less user directory. agno-native; identity asserted externally."""
+
+    def __init__(
+        self,
+        db_url: Optional[str] = None,
+        engine: Optional[Any] = None,
+        table_name: str = "authz_users",
+        create_table: bool = True,
+        audit: Optional["AuditSink"] = None,
+        db: Optional[Any] = None,
+    ):
+        """
+        Args:
+            db_url: SQLAlchemy URL for the DB that holds the directory (e.g.
+                ``postgresql+psycopg://...`` or ``sqlite:///users.db``). If
+                ``db_url``, ``engine`` and ``db`` are all omitted, the store is
+                in-memory.
+            engine: an existing SQLAlchemy engine (takes precedence over db_url).
+            table_name: directory table name (default ``authz_users``).
+            create_table: create the table if missing (default True).
+            audit: optional :class:`~agno.os.authz.audit.AuditSink`. When set,
+                every directory change emits an append-only AuditEvent with the
+                acting principal and the before/after (same trail as role changes).
+            db: an agno database (the same object you pass to ``AgentOS(db=...)``).
+                Its SQLAlchemy engine is reused, so the directory lives in the same
+                database as your agent data. Takes precedence over ``db_url``.
+        """
+        self._audit = audit
+        self._mem: Optional[Dict[str, dict]] = None
+        self._engine: Any = None  # SQLAlchemy Engine when db-backed, else None
+        self._table: Any = None  # SQLAlchemy Table for authz_users
+
+        if db is not None and engine is None:
+            from agno.os.authz._db import engine_from_db
+
+            engine = engine_from_db(db)
+
+        if engine is not None or db_url is not None:
+            import sqlalchemy as sa
+
+            self._engine = engine if engine is not None else sa.create_engine(db_url)  # type: ignore[arg-type]
+            metadata = sa.MetaData()
+            self._table = sa.Table(
+                table_name,
+                metadata,
+                sa.Column("id", sa.String(255), primary_key=True),  # the JWT sub
+                sa.Column("email", sa.String(320)),
+                sa.Column("name", sa.String(255)),
+                sa.Column("disabled", sa.Boolean, nullable=False, default=False),
+                sa.Column("created_at", sa.Integer, nullable=False),
+                sa.Column("updated_at", sa.Integer, nullable=False),
+                sa.Column("user_metadata", sa.Text),
+            )
+            if create_table:
+                metadata.create_all(self._engine)
+        else:
+            # In-memory directory (not persisted). Fine for tests/dev.
+            self._mem = {}
+
+    # ------------------------------------------------------------------ audit
+    def _emit(
+        self,
+        action: str,
+        target: str,
+        before: Optional[List[str]],
+        after: Optional[List[str]],
+        actor: Optional[str],
+    ) -> None:
+        if self._audit is None:
+            return
+        from agno.os.authz.audit import AuditEvent
+
+        self._audit.record(
+            AuditEvent(action=action, actor=actor, target=target, before=before, after=after, timestamp=_now())
+        )
+
+    # ------------------------------------------------------------------ writes
+    def upsert(
+        self,
+        id: str,
+        email: Optional[str] = None,
+        name: Optional[str] = None,
+        metadata: Optional[dict] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Create a user, or update the provided fields of an existing one.
+
+        Only fields you pass are changed; omitted fields are left as-is on an
+        existing user (so a metadata-light update can't blank out an email).
+        ``disabled`` is intentionally NOT settable here — use
+        :meth:`set_disabled` so enable/disable is an explicit, audited action.
+        """
+        existing = self.get(id)
+        now = _now()
+        if existing is None:
+            row = {
+                "id": id,
+                "email": email,
+                "name": name,
+                "disabled": False,
+                "created_at": now,
+                "updated_at": now,
+                "metadata": metadata or None,
+            }
+            self._write(row, insert=True)
+            self._emit("user.created", id, None, [self._summary(row)], actor)
+            return row
+
+        row = dict(existing)
+        if email is not None:
+            row["email"] = email
+        if name is not None:
+            row["name"] = name
+        if metadata is not None:
+            row["metadata"] = metadata
+        row["updated_at"] = now
+        self._write(row, insert=False)
+        self._emit("user.updated", id, [self._summary(existing)], [self._summary(row)], actor)
+        return row
+
+    def set_disabled(self, id: str, disabled: bool, actor: Optional[str] = None) -> dict:
+        """Disable (or re-enable) a user. A disabled user is denied at the
+        enforcement point even with a valid token — this is the revocation hook."""
+        existing = self.get(id)
+        if existing is None:
+            # Unknown subject: write a single durable tombstone in the TARGET state
+            # (the app may mint tokens for a sub we've not seen) and emit only the
+            # disable/enable event — no spurious "user.created … active" round-trip.
+            now = _now()
+            row = {
+                "id": id,
+                "email": None,
+                "name": None,
+                "disabled": bool(disabled),
+                "created_at": now,
+                "updated_at": now,
+                "metadata": None,
+            }
+            self._write(row, insert=True)
+            self._emit("user.disabled" if disabled else "user.enabled", id, None, [self._summary(row)], actor)
+            return row
+
+        if bool(existing["disabled"]) == bool(disabled):
+            return existing  # no-op, no event
+
+        row = dict(existing)
+        row["disabled"] = bool(disabled)
+        row["updated_at"] = _now()
+        self._write(row, insert=False)
+        self._emit(
+            "user.disabled" if disabled else "user.enabled", id, [self._summary(existing)], [self._summary(row)], actor
+        )
+        return row
+
+    def remove(self, id: str, actor: Optional[str] = None) -> bool:
+        """Delete a user from the directory. Does NOT remove role assignments —
+        those live in the role store; remove them there if needed.
+
+        NOTE: delete is NOT a revocation primitive. With JIT auto-provisioning on
+        (``AuthorizationConfig(auto_provision_users=True)``), the next valid token
+        from this subject re-creates the row as *active*, and any surviving role
+        assignments come back with it. To revoke access, use :meth:`set_disabled`
+        (a durable tombstone enforced at every request), not :meth:`remove`."""
+        existing = self.get(id)
+        if existing is None:
+            return False
+        if self._mem is not None:
+            self._mem.pop(id, None)
+        else:
+            import sqlalchemy as sa
+
+            with self._engine.begin() as conn:  # type: ignore[union-attr]
+                conn.execute(sa.delete(self._table).where(self._table.c.id == id))  # type: ignore[union-attr]
+        self._emit("user.removed", id, [self._summary(existing)], None, actor)
+        return True
+
+    def provision_from_claims(
+        self,
+        subject: str,
+        claims: Dict[str, Any],
+        email_claim: str = "email",
+        name_claim: str = "name",
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Just-in-time: create a directory row for ``subject`` from token claims if
+        it doesn't exist yet. No-op if the user is already present. Returns the user."""
+        existing = self.get(subject)
+        if existing is not None:
+            return existing
+        return self.upsert(
+            subject,
+            email=claims.get(email_claim),
+            name=claims.get(name_claim),
+            actor=actor or "system:jit",
+        )
+
+    # ------------------------------------------------------------------ reads
+    def get(self, id: str) -> Optional[dict]:
+        if self._mem is not None:
+            row = self._mem.get(id)
+            return dict(row) if row else None
+
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:  # type: ignore[union-attr]
+            r = conn.execute(sa.select(self._table).where(self._table.c.id == id)).mappings().first()  # type: ignore[union-attr]
+        return self._row_to_dict(r) if r else None
+
+    # list() and count() apply the same filters (include_disabled + search) over
+    # whichever backend is active; these two helpers are that shared filtering.
+    def _filtered_mem_rows(self, include_disabled: bool, search: Optional[str]) -> List[dict]:
+        def matches(row: dict, needle: str) -> bool:
+            return any(needle in (row.get(f) or "").casefold() for f in USER_SEARCH_FIELDS)
+
+        rows = list(self._mem.values())  # type: ignore[union-attr]
+        if not include_disabled:
+            rows = [r for r in rows if not r["disabled"]]
+        if search:
+            needle = search.casefold()
+            rows = [r for r in rows if matches(r, needle)]
+        return rows
+
+    def _sql_filters(self, include_disabled: bool, search: Optional[str]) -> list:
+        import sqlalchemy as sa
+
+        clauses = []
+        if not include_disabled:
+            clauses.append(self._table.c.disabled.is_(False))  # type: ignore[union-attr]
+        if search:
+            pattern = f"%{search}%"
+            clauses.append(sa.or_(*(self._table.c[f].ilike(pattern) for f in USER_SEARCH_FIELDS)))  # type: ignore[index]
+        return clauses
+
+    def list(
+        self,
+        limit: int = 1000,
+        include_disabled: bool = True,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_USER_SORT_FIELD,
+        order: str = DEFAULT_USER_SORT_ORDER,
+    ) -> List[dict]:
+        """A page of users, optionally excluding disabled ones.
+
+        ``offset``/``limit`` page in the store so callers don't materialise the
+        whole directory; pair with :meth:`count` for the total. ``search``
+        filters case-insensitively by substring across id, email, and name;
+        ``sort_by`` is any of :data:`USER_SORT_FIELDS` (newest first by default)."""
+        if sort_by not in USER_SORT_FIELDS:
+            raise ValueError(f"sort_by must be one of {USER_SORT_FIELDS}, got {sort_by!r}")
+        descending = order != "asc"
+        if self._mem is not None:
+            # Rows missing the field (email/name are optional) go last in either
+            # direction, matching the nullslast() on the SQL path.
+            rows = self._filtered_mem_rows(include_disabled, search)
+            present = sorted(
+                (r for r in rows if r.get(sort_by) is not None), key=lambda r: r[sort_by], reverse=descending
+            )
+            missing = [r for r in rows if r.get(sort_by) is None]
+            return [dict(r) for r in (present + missing)[offset : offset + limit]]
+
+        import sqlalchemy as sa
+
+        sort_col = self._table.c[sort_by]  # type: ignore[index]
+        stmt = (
+            sa.select(self._table)
+            .where(*self._sql_filters(include_disabled, search))
+            # nullslast: backends disagree on NULL placement (and email/name are
+            # nullable); pin them last in either direction.
+            .order_by(sa.nullslast(sort_col.desc() if descending else sort_col.asc()))
+            .limit(limit)
+            .offset(offset)
+        )
+        with self._engine.connect() as conn:
+            db_rows = conn.execute(stmt).mappings().all()
+        return [self._row_to_dict(r) for r in db_rows]
+
+    def count(self, include_disabled: bool = True, search: Optional[str] = None) -> int:
+        """Total number of users (for pagination), with the same filters as
+        :meth:`list`."""
+        if self._mem is not None:
+            return len(self._filtered_mem_rows(include_disabled, search))
+
+        import sqlalchemy as sa
+
+        stmt = sa.select(sa.func.count()).select_from(self._table).where(*self._sql_filters(include_disabled, search))  # type: ignore[arg-type]
+        with self._engine.connect() as conn:  # type: ignore[union-attr]
+            return int(conn.execute(stmt).scalar() or 0)
+
+    def is_disabled(self, id: Optional[str]) -> bool:
+        """Fast path for the enforcement point: True only if the user exists AND is
+        disabled. Unknown subjects are NOT disabled (the app may legitimately mint
+        tokens for users not yet in the directory)."""
+        if not id:
+            return False
+        if self._mem is not None:
+            row = self._mem.get(id)
+            return bool(row and row["disabled"])
+
+        import sqlalchemy as sa
+
+        with self._engine.connect() as conn:  # type: ignore[union-attr]
+            r = conn.execute(
+                sa.select(self._table.c.disabled).where(self._table.c.id == id)  # type: ignore[union-attr]
+            ).first()
+        return bool(r and r[0])
+
+    # ------------------------------------------------------------------ helpers
+    @staticmethod
+    def _summary(row: dict) -> str:
+        """Compact, non-secret one-line representation for the audit before/after."""
+        bits = [row["id"]]
+        if row.get("email"):
+            bits.append(row["email"])
+        bits.append("disabled" if row.get("disabled") else "active")
+        return " ".join(bits)
+
+    def _row_to_dict(self, r) -> dict:
+        return {
+            "id": r["id"],
+            "email": r["email"],
+            "name": r["name"],
+            "disabled": bool(r["disabled"]),
+            "created_at": r["created_at"],
+            "updated_at": r["updated_at"],
+            "metadata": json.loads(r["user_metadata"]) if r["user_metadata"] else None,
+        }
+
+    def _write(self, row: dict, insert: bool) -> None:
+        if self._mem is not None:
+            self._mem[row["id"]] = dict(row)
+            return
+
+        import sqlalchemy as sa
+
+        values = {
+            "id": row["id"],
+            "email": row["email"],
+            "name": row["name"],
+            "disabled": bool(row["disabled"]),
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+            "user_metadata": json.dumps(row["metadata"]) if row.get("metadata") else None,
+        }
+        with self._engine.begin() as conn:  # type: ignore[union-attr]
+            if insert:
+                conn.execute(sa.insert(self._table).values(**values))  # type: ignore[union-attr]
+            else:
+                conn.execute(
+                    sa.update(self._table).where(self._table.c.id == row["id"]).values(**values)  # type: ignore[union-attr]
+                )

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -147,6 +147,23 @@ class AuthorizationConfig(BaseModel):
     # (allow/deny) alongside the change trail, so you get an access audit, not just a
     # change audit. Pass the same sink you give ManagedRoleStore to unify both.
     audit: Optional[AuditSink] = None
+    # Optional ManagedUserStore — the credential-less user directory for the no-IdP
+    # case. When set, AgentOS denies a disabled user at the enforcement point
+    # (revocation that outlives a valid token) and can auto-provision a directory row
+    # from token claims. Identity is still asserted by the JWT; this never stores
+    # credentials.
+    user_store: Optional[Any] = None
+    # Just-in-time provisioning: when True, the first valid token from a subject not
+    # yet in the directory creates a row from the token claims below.
+    auto_provision_users: bool = False
+    user_email_claim: str = "email"
+    user_name_claim: str = "name"
+    # How to treat a user-directory read that errors (e.g. the directory DB is
+    # unreachable) while checking the disabled flag. Default False = fail OPEN (let
+    # the request through; availability over the kill-switch). Set True to fail CLOSED
+    # (reject with 503) so a directory outage can't silently re-enable every
+    # disabled/compromised account.
+    directory_error_fail_closed: bool = False
     # Opt-in per-user data isolation. When True, AgentOS:
     #   - threads the JWT sub as ``user_id`` on every user-scoped DB read
     #     (sessions, memory, traces) for non-admin callers

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -4,6 +4,10 @@ from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, T
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agno.os.authz.audit import AuditSink
+from agno.os.authz.provider import AuthorizationProvider
+from agno.os.authz.role_store import ManagedRoleStore
+
 # Tags carried by the built-in MCP tools, exposed here so callers (and the IDE) can see
 # the valid values for ``MCPServerConfig.include_tags`` / ``exclude_tags`` without reading
 # ``agno/os/mcp.py``. Keep in sync with the ``tags={...}`` argument on each
@@ -121,12 +125,28 @@ class MCPServerConfig(BaseModel):
 class AuthorizationConfig(BaseModel):
     """Configuration for the JWT middleware"""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     verification_keys: Optional[List[str]] = None
     jwks_file: Optional[str] = None
     algorithm: Optional[str] = None
     verify_audience: Optional[bool] = None
     audience: Optional[str] = None
     admin_scope: Optional[str] = None
+    # Pluggable authorization strategy. When None, AgentOS uses scope-based RBAC
+    # (JWT/PAT scopes, no external dependency). Supply an AuthorizationProvider to
+    # swap in a richer model (managed roles, ReBAC/ABAC, OpenFGA, ...) enforced at
+    # the same points as scopes — the REST route gate, per-resource gate, WS gates,
+    # and MCP tool gate all resolve through it.
+    authorization_provider: Optional[AuthorizationProvider] = None
+    # Managed-roles shortcut: pass a ManagedRoleStore and AgentOS uses its provider
+    # (mutually exclusive with authorization_provider). If the store has no DB, AgentOS
+    # binds the OS database to it so roles persist alongside agent data.
+    role_store: Optional[ManagedRoleStore] = None
+    # Optional AuditSink. When set, AgentOS records each authorization decision
+    # (allow/deny) alongside the change trail, so you get an access audit, not just a
+    # change audit. Pass the same sink you give ManagedRoleStore to unify both.
+    audit: Optional[AuditSink] = None
     # Opt-in per-user data isolation. When True, AgentOS:
     #   - threads the JWT sub as ``user_id`` on every user-scoped DB read
     #     (sessions, memory, traces) for non-admin callers
@@ -137,6 +157,15 @@ class AuthorizationConfig(BaseModel):
     # When False (default) JWT/RBAC still apply, but routes operate on the
     # unscoped DB and don't add per-user ownership gates on top of RBAC.
     user_isolation: bool = False
+
+    @model_validator(mode="after")
+    def _provider_xor_role_store(self) -> "AuthorizationConfig":
+        if self.role_store is not None and self.authorization_provider is not None:
+            raise ValueError(
+                "Pass either authorization_provider or role_store on AuthorizationConfig, not both — "
+                "role_store is the shortcut that wires the store's provider for you."
+            )
+        return self
 
 
 class EvalsDomainConfig(BaseModel):

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -1171,7 +1171,19 @@ def _identity_bridge_kwargs(os: "AgentOS") -> Dict[str, Any]:
     config = getattr(os, "authorization_config", None)
     admin_scope = getattr(config, "admin_scope", None) if config is not None else None
     user_isolation = bool(getattr(config, "user_isolation", False)) if config is not None else False
-    return {"admin_scope": admin_scope or AgentOSScope.ADMIN.value, "user_isolation": user_isolation}
+    # User directory: mcp_auth exempts /mcp from the parent AuthMiddleware, so the bridge
+    # must re-apply the disabled-user kill-switch itself. Thread the store + policy through.
+    return {
+        "admin_scope": admin_scope or AgentOSScope.ADMIN.value,
+        "user_isolation": user_isolation,
+        "user_store": getattr(config, "user_store", None) if config is not None else None,
+        "user_auto_provision": bool(getattr(config, "auto_provision_users", False)) if config is not None else False,
+        "user_email_claim": getattr(config, "user_email_claim", "email") if config is not None else "email",
+        "user_name_claim": getattr(config, "user_name_claim", "name") if config is not None else "name",
+        "user_directory_fail_closed": bool(getattr(config, "directory_error_fail_closed", False))
+        if config is not None
+        else False,
+    }
 
 
 # Localhost defaults so a desktop / local MCP server is protected with zero extra config.

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -261,8 +261,9 @@ def _require_tool_scopes(method: str, path: str) -> None:
     """
     from fastmcp.server.dependencies import get_http_request
 
-    from agno.os.auth import build_insufficient_permissions_detail
-    from agno.os.scopes import check_route_scopes
+    from agno.os.auth import build_insufficient_permissions_detail, resolve_authorization_provider
+    from agno.os.authz.provider import AuthorizationContext
+    from agno.os.scopes import get_required_scopes_for_route, get_resource_context_from_path
 
     try:
         request = get_http_request()
@@ -283,16 +284,39 @@ def _require_tool_scopes(method: str, path: str) -> None:
             raise Exception(_MISSING_BRIDGE_DETAIL)
         return
 
+    required_scopes = get_required_scopes_for_route(_tool_scope_mappings(), method, path)
+    if not required_scopes:
+        return
+
     admin_scope_raw = getattr(state, "admin_scope", None)
     admin_scope = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-    scope_check = check_route_scopes(
-        list(getattr(state, "scopes", None) or []),
-        _tool_scope_mappings(),
-        method,
-        path,
+
+    # Derive the resource context from the SYNTHETIC REST path the tool maps onto
+    # (e.g. "/agents/<id>/runs" -> agents/<id>), preserving v2.7's per-resource
+    # subtlety: the provider decides on the specific resource, not just the family.
+    resource_type, resource_id = get_resource_context_from_path(path)
+    actions = {s.rsplit(":", 1)[1] for s in required_scopes if ":" in s}
+    action = next(iter(actions)) if len(actions) == 1 else None
+
+    # Resolve the provider from the in-flight request's app.state — with none configured
+    # this is the default ScopeAuthorizationProvider, whose authorize_route delegates to
+    # has_required_scopes, so the tool gate stays byte-identical to v2.7's
+    # check_route_scopes. (The MCP tools have no GET-listing escape hatch: an
+    # unauthorised call is a hard denial, matching the prior behaviour.)
+    provider = resolve_authorization_provider(request)
+    ctx = AuthorizationContext(
+        principal_id=getattr(state, "user_id", None),
+        scopes=list(getattr(state, "scopes", None) or []),
+        claims=getattr(state, "claims", None) or {},
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
         admin_scope=admin_scope,
     )
-    if not scope_check.allowed:
+    # The provider decides — default ScopeAuthorizationProvider is byte-identical to
+    # v2.7's check_route_scopes; a managed-role/custom provider enforces its own model
+    # on the OAuth-authenticated caller here too.
+    if not provider.authorize_route(ctx, required_scopes):
         # Under mcp_auth, a scope denial is most often an external-AS misconfiguration
         # (the token carries non-agno scopes), which the client-facing 403 can't point at.
         # Log the presented-vs-required scopes and the AS-config hint so the deployer can
@@ -302,11 +326,11 @@ def _require_tool_scopes(method: str, path: str) -> None:
 
             log_warning(
                 f"MCP tool scope check failed for {method} {path}: caller presented "
-                f"{list(getattr(state, 'scopes', None) or [])}, required {scope_check.required_scopes}. "
+                f"{list(getattr(state, 'scopes', None) or [])}, required {required_scopes}. "
                 "If this is a Tier-2 (external authorization server) deployment, configure your AS to emit "
                 "agno-format scopes in the token 'scope' claim."
             )
-        raise Exception(build_insufficient_permissions_detail(scope_check.required_scopes))
+        raise Exception(build_insufficient_permissions_detail(required_scopes))
 
 
 async def _enforce_run_continuation_allowed(db: Any, run_id: str) -> None:

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -316,7 +316,28 @@ def _require_tool_scopes(method: str, path: str) -> None:
     # The provider decides — default ScopeAuthorizationProvider is byte-identical to
     # v2.7's check_route_scopes; a managed-role/custom provider enforces its own model
     # on the OAuth-authenticated caller here too.
-    if not provider.authorize_route(ctx, required_scopes):
+    from agno.os.authz.audit import record_decision
+
+    allowed = provider.authorize_route(ctx, required_scopes)
+    # Record the decision on the SAME trail the REST gate writes to, so an access audit
+    # covers the MCP transport too (the tools are an alternate front door to the same
+    # surface). The sink is mirrored onto this sub-app's state; no sink -> no-op.
+    # Same non-secret token reference the REST gate captures (jti, else a short hash),
+    # so an MCP row correlates to the issuer's logs exactly like a REST row does.
+    auth_header = request.headers.get("Authorization") or ""
+    bearer = auth_header[7:] if auth_header[:7].lower() == "bearer " else None
+    record_decision(
+        request,
+        allowed=allowed,
+        target=f"{method} {path}",
+        principal=ctx.principal_id,
+        required_scopes=required_scopes,
+        scopes=ctx.scopes,
+        claims=ctx.claims,
+        token=bearer,
+        reason=None if allowed else "mcp_tool_scope_denied",
+    )
+    if not allowed:
         # Under mcp_auth, a scope denial is most often an external-AS misconfiguration
         # (the token carries non-agno scopes), which the client-facing 403 can't point at.
         # Log the presented-vs-required scopes and the AS-config hint so the deployer can

--- a/libs/agno/agno/os/mcp_auth.py
+++ b/libs/agno/agno/os/mcp_auth.py
@@ -158,10 +158,28 @@ class MCPIdentityBridgeMiddleware:
     challenge on the MCP path) pass through untouched.
     """
 
-    def __init__(self, app: Any, admin_scope: Optional[str] = None, user_isolation: bool = False) -> None:
+    def __init__(
+        self,
+        app: Any,
+        admin_scope: Optional[str] = None,
+        user_isolation: bool = False,
+        user_store: Any = None,
+        user_auto_provision: bool = False,
+        user_email_claim: str = "email",
+        user_name_claim: str = "name",
+        user_directory_fail_closed: bool = False,
+    ) -> None:
         self.app = app
         self.admin_scope = admin_scope
         self.user_isolation = user_isolation
+        # User directory (no-IdP). mcp_auth exempts /mcp from the parent AuthMiddleware,
+        # so the disabled-user kill-switch that lives there does not run for OAuth'd MCP
+        # traffic unless the bridge re-applies it. Carry the store + policy here.
+        self.user_store = user_store
+        self.user_auto_provision = user_auto_provision
+        self.user_email_claim = user_email_claim
+        self.user_name_claim = user_name_claim
+        self.user_directory_fail_closed = user_directory_fail_closed
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
         if scope["type"] == "http":
@@ -189,6 +207,33 @@ class MCPIdentityBridgeMiddleware:
                     log_warning(f"MCP token claims a reserved principal {user_id!r}; refusing to bridge its identity")
                     await self.app(scope, receive, send)
                     return
+                # User directory kill-switch: a disabled user is denied even with a valid
+                # OAuth token. This mirrors the parent AuthMiddleware's gate, which mcp_auth
+                # bypasses (the /mcp mount is exempt from it). Service-account principals
+                # (sa:) are not directory users and are skipped. If the check errors, honour
+                # user_directory_fail_closed. On denial we simply do NOT bridge the identity,
+                # leaving request.state.authenticated unset so the fail-closed tool gate
+                # rejects the call -- same shape as the reserved-principal path above.
+                if self.user_store is not None and user_id and service_account_name is None:
+                    try:
+                        if self.user_auto_provision:
+                            self.user_store.provision_from_claims(
+                                user_id,
+                                claims,
+                                email_claim=self.user_email_claim,
+                                name_claim=self.user_name_claim,
+                            )
+                        disabled = self.user_store.is_disabled(user_id)
+                    except Exception as e:  # directory unreachable: honour the configured policy
+                        disabled = self.user_directory_fail_closed
+                        log_warning(
+                            f"MCP user directory check failed for {user_id!r}: {e} "
+                            f"(failing {'closed' if self.user_directory_fail_closed else 'open'})"
+                        )
+                    if disabled:
+                        log_warning(f"Disabled user denied on MCP endpoint: {user_id!r}")
+                        await self.app(scope, receive, send)
+                        return
                 # request.state is backed by scope["state"]; the mounted sub-app and the
                 # parent share it, so the tools read these exactly as they do under the
                 # parent AuthMiddleware.

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -6,7 +6,7 @@ import json
 import re
 from enum import Enum
 from os import getenv
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
 
 from fastapi import Request, Response
 from fastapi.responses import JSONResponse
@@ -15,9 +15,10 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from agno.os.auth import INTERNAL_SERVICE_SCOPES, build_insufficient_permissions_detail
 from agno.os.scopes import (
     AgentOSScope,
-    check_route_scopes,
+    RouteScopeCheck,
     get_default_scope_mappings,
     get_required_scopes_for_route,
+    get_resource_context_from_path,
     has_required_scopes,
 )
 from agno.os.service_accounts import SERVICE_ACCOUNT_PRINCIPAL_PREFIX, authenticate_service_account_request
@@ -86,6 +87,20 @@ def resolve_expected_audience(
     if not verify_audience:
         return None
     return audience or os_id
+
+
+def _route_action(required_scopes: List[str]) -> Optional[str]:
+    """The single action a route requires (``read`` / ``run`` / ``write`` / ...),
+    or None when the route's required scopes span more than one action.
+
+    Only used to populate ``AuthorizationContext.action`` for providers that decide
+    per-resource (managed roles). The default scope provider's ``authorize_route``
+    ignores ``ctx.action`` and matches against ``required_scopes`` directly, so this
+    can never change the default decision. A resource route in the shipped mappings
+    requires exactly one scope, hence one action; returning None for the ambiguous
+    case makes ``EngineAuthorizationProvider`` fall back to AND-ing every scope."""
+    actions = {s.rsplit(":", 1)[1] for s in required_scopes if ":" in s}
+    return next(iter(actions)) if len(actions) == 1 else None
 
 
 class TokenSource(str, Enum):
@@ -799,6 +814,148 @@ class AuthMiddleware(BaseHTTPMiddleware):
         """
         return get_required_scopes_for_route(self.scope_mappings, method, path)
 
+    def _authorize_route(
+        self,
+        request: Request,
+        scopes: List[str],
+        mappings: Dict[str, List[str]],
+        method: str,
+        path: str,
+    ) -> "RouteScopeCheck":
+        """Route-level authorization decision, delegated to the configured provider.
+
+        This is the choke point that used to call ``check_route_scopes`` directly. It
+        preserves that function's structure exactly — the route→scope lookup, the
+        resource-context extraction, and the GET-listing filtered-access escape hatch —
+        but routes the two actual *decisions* (allow? and which resource ids for a
+        listing?) through the resolved :class:`AuthorizationProvider`.
+
+        With no provider configured the resolver returns
+        :class:`ScopeAuthorizationProvider`, whose ``authorize_route`` /
+        ``accessible_resource_ids`` are thin wrappers over ``has_required_scopes`` /
+        ``get_accessible_resource_ids`` — the very functions ``check_route_scopes``
+        called — so the result is byte-identical to v2.7. A managed-role / custom
+        provider enforces its own model at the same point instead.
+        """
+        from agno.os.auth import resolve_authorization_provider
+        from agno.os.authz.provider import AuthorizationContext
+
+        required_scopes = get_required_scopes_for_route(mappings, method, path)
+        if not required_scopes:
+            return RouteScopeCheck(allowed=True, required_scopes=required_scopes)
+
+        resource_type, resource_id = get_resource_context_from_path(path)
+
+        provider = resolve_authorization_provider(request)
+        ctx = AuthorizationContext(
+            principal_id=getattr(request.state, "user_id", None),
+            scopes=scopes,
+            claims=getattr(request.state, "claims", None) or {},
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=_route_action(required_scopes),
+            admin_scope=self.admin_scope,
+        )
+        allowed = provider.authorize_route(ctx, required_scopes)
+
+        accessible_resource_ids: Optional[Set[str]] = None
+        first_required = required_scopes[0]
+        required_family = first_required.split(":", 1)[0] if ":" in first_required else None
+        if not allowed and method == "GET" and not resource_id and resource_type and required_family == resource_type:
+            # GET-listing escape hatch, identical to check_route_scopes: a caller
+            # without the collection-wide grant is still allowed through, but the
+            # endpoint is told which ids to expose (possibly none) so it returns a
+            # filtered list instead of a 403. The action comes from the required scope
+            # so the provider only surfaces ids the caller is authorised for under it.
+            required_action: Optional[str] = None
+            if ":" in first_required:
+                required_action = first_required.rsplit(":", 1)[1]
+            listing_ctx = AuthorizationContext(
+                principal_id=ctx.principal_id,
+                scopes=scopes,
+                claims=ctx.claims,
+                resource_type=resource_type,
+                resource_id=None,
+                action=required_action,
+                admin_scope=self.admin_scope,
+            )
+            accessible_resource_ids = provider.accessible_resource_ids(listing_ctx)
+            allowed = True
+
+        return RouteScopeCheck(
+            allowed=allowed,
+            required_scopes=required_scopes,
+            accessible_resource_ids=accessible_resource_ids,
+        )
+
+    def _record_decision(
+        self,
+        request: Request,
+        *,
+        allowed: bool,
+        method: str,
+        path: str,
+        principal: Optional[str],
+        required_scopes: List[str],
+        scopes: List[str],
+        reason: Optional[str] = None,
+    ) -> None:
+        """Record one authorization decision to the audit sink, if one is configured
+        on ``app.state.authz_audit`` (seeded from ``AuthorizationConfig(audit=...)``).
+
+        Captures the principal, route, required scopes, the caller's scopes, and a
+        NON-secret token reference (see :meth:`_token_reference`). Never the token
+        itself, and never raises into the request path — audit must not turn a served
+        request into a 500. No-op when no decision sink is configured, so the default
+        (no audit) path is untouched.
+        """
+        state = getattr(getattr(request, "app", None), "state", None)
+        sink = getattr(state, "authz_audit", None) if state is not None else None
+        if sink is None:
+            return
+        try:
+            import time
+
+            from agno.os.authz.audit import AuditEvent
+
+            claims = getattr(request.state, "claims", None)
+            token = self._extract_token(request)
+            token_ref = self._token_reference(token, claims)
+            metadata: Dict[str, Any] = {"required": required_scopes, "token": token_ref, "scopes": scopes}
+            if reason:
+                metadata["reason"] = reason
+            sink.record(
+                AuditEvent(
+                    action="access.allowed" if allowed else "access.denied",
+                    actor=principal,
+                    target=f"{method} {path}",
+                    timestamp=int(time.time()),
+                    metadata=metadata,
+                )
+            )
+        except Exception as e:  # pragma: no cover - audit must never break requests
+            log_debug(f"decision audit failed: {e}")
+
+    @staticmethod
+    def _token_reference(token: Optional[str], claims: Optional[dict]) -> Optional[str]:
+        """A non-secret reference to the presented token, for the decision trail.
+
+        Prefer the token's ``jti`` (RFC 7519 JWT ID): an opaque identifier the issuer
+        already minted, so it correlates to the issuer's own logs and any revocation
+        list. When the token has no ``jti``, fall back to a short SHA-256 of the raw
+        token so two distinct tokens are still distinguishable — without ever storing
+        the credential itself.
+        """
+        if claims:
+            jti = claims.get("jti")
+            if jti:
+                return str(jti)
+        if token:
+            import hashlib
+
+            return hashlib.sha256(token.encode()).hexdigest()[:12]
+        return None
+
     def _check_scopes(
         self,
         request: Request,
@@ -820,7 +977,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             An error response when access is denied, None when access is allowed.
         """
         mappings = scope_mappings if scope_mappings is not None else self.scope_mappings
-        result = check_route_scopes(scopes, mappings, method, path, admin_scope=self.admin_scope)
+        result = self._authorize_route(request, scopes, mappings, method, path)
 
         request.state.required_scopes = result.required_scopes
         if result.accessible_resource_ids is not None:
@@ -829,6 +986,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 log_debug(f"Caller has specific resource scopes. Accessible IDs: {result.accessible_resource_ids}")
             else:
                 log_debug("Caller has no matching resource scopes. Will return empty list.")
+
+        # Decision audit: record the allow/deny with a non-secret token reference, if a
+        # sink is configured. Emitted for EVERY authenticated request that reaches this
+        # gate (including allow-by-default routes with no required scopes) so the trail
+        # is complete. No-op when no decision sink is set, so the default path is untouched.
+        self._record_decision(
+            request,
+            allowed=result.allowed,
+            method=method,
+            path=path,
+            principal=getattr(request.state, "user_id", None),
+            required_scopes=result.required_scopes,
+            scopes=scopes,
+            reason=None if result.required_scopes else "no_scopes_required",
+        )
 
         if not result.allowed:
             log_warning(
@@ -988,6 +1160,12 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.session_id = None
             internal_scopes = list(INTERNAL_SERVICE_SCOPES)
             request.state.scopes = internal_scopes
+            # Trusted internal caller: mark AFTER the constant-time hmac match above so the
+            # provider-backed per-resource gate (check_resource_access) short-circuits — the
+            # scheduler principal has no role/subject in a managed store. The route gate below
+            # still enforces INTERNAL_SERVICE_SCOPES. Unforgeable: request.state is server-only,
+            # no client input maps onto this attribute.
+            request.state.is_internal_service = True
             request.state.authorization_enabled = self.authorization or False
             request.state.admin_scope = self.admin_scope
             request.state.user_isolation_enabled = self.user_isolation

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -1249,6 +1249,47 @@ class AuthMiddleware(BaseHTTPMiddleware):
             # ownership gates stay dormant.
             request.state.user_isolation_enabled = self.user_isolation
 
+            # User directory (no-IdP): optionally auto-provision the subject from
+            # token claims, then enforce the disabled flag. This is the revocation
+            # kill-switch — a disabled user is denied even with a valid token, on
+            # EVERY route (independent of per-route scopes). Identity is still the
+            # app's to assert; we only gate it.
+            user_store = getattr(getattr(request.app, "state", None), "user_store", None)
+            if user_store is not None and user_id:
+                try:
+                    if getattr(request.app.state, "user_auto_provision", False):
+                        user_store.provision_from_claims(
+                            user_id,
+                            payload,
+                            email_claim=getattr(request.app.state, "user_email_claim", "email"),
+                            name_claim=getattr(request.app.state, "user_name_claim", "name"),
+                        )
+                    disabled = user_store.is_disabled(user_id)
+                except Exception as e:  # directory unreachable: honour the configured policy
+                    fail_closed = bool(getattr(request.app.state, "user_directory_fail_closed", False))
+                    log_warning(
+                        f"user directory check failed for {user_id!r}: {e} "
+                        f"(failing {'closed' if fail_closed else 'open'})"
+                    )
+                    if fail_closed:
+                        return self._create_error_response(
+                            503, "User directory unavailable", origin, cors_allowed_origins
+                        )
+                    disabled = False
+                if disabled:
+                    log_warning(f"Disabled user denied: {user_id} for {method} {path}")
+                    self._record_decision(
+                        request,
+                        allowed=False,
+                        method=method,
+                        path=path,
+                        principal=user_id,
+                        required_scopes=[],
+                        scopes=scopes,
+                        reason="user_disabled",
+                    )
+                    return self._create_error_response(403, "User is disabled", origin, cors_allowed_origins)
+
             # Extract dependencies claims
             dependencies = {}
             if self.dependencies_claims:

--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -909,32 +909,19 @@ class AuthMiddleware(BaseHTTPMiddleware):
         request into a 500. No-op when no decision sink is configured, so the default
         (no audit) path is untouched.
         """
-        state = getattr(getattr(request, "app", None), "state", None)
-        sink = getattr(state, "authz_audit", None) if state is not None else None
-        if sink is None:
-            return
-        try:
-            import time
+        from agno.os.authz.audit import record_decision
 
-            from agno.os.authz.audit import AuditEvent
-
-            claims = getattr(request.state, "claims", None)
-            token = self._extract_token(request)
-            token_ref = self._token_reference(token, claims)
-            metadata: Dict[str, Any] = {"required": required_scopes, "token": token_ref, "scopes": scopes}
-            if reason:
-                metadata["reason"] = reason
-            sink.record(
-                AuditEvent(
-                    action="access.allowed" if allowed else "access.denied",
-                    actor=principal,
-                    target=f"{method} {path}",
-                    timestamp=int(time.time()),
-                    metadata=metadata,
-                )
-            )
-        except Exception as e:  # pragma: no cover - audit must never break requests
-            log_debug(f"decision audit failed: {e}")
+        record_decision(
+            request,
+            allowed=allowed,
+            target=f"{method} {path}",
+            principal=principal,
+            required_scopes=required_scopes,
+            scopes=scopes,
+            claims=getattr(request.state, "claims", None),
+            token=self._extract_token(request),
+            reason=reason,
+        )
 
     @staticmethod
     def _token_reference(token: Optional[str], claims: Optional[dict]) -> Optional[str]:

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -476,6 +476,55 @@ def get_websocket_router(
                                 )
                                 continue
 
+                            # User directory kill-switch: enforce the disabled flag
+                            # at WS connect, mirroring the HTTP middleware. A disabled
+                            # user is rejected even with a valid token. (HTTP enforces
+                            # this per-request; the WebSocket enforces it at connect.)
+                            user_store = getattr(getattr(websocket.app, "state", None), "user_store", None)
+                            ws_user_id = claims.get("user_id")
+                            if user_store is not None and ws_user_id:
+                                try:
+                                    if getattr(websocket.app.state, "user_auto_provision", False):
+                                        user_store.provision_from_claims(
+                                            ws_user_id,
+                                            payload,
+                                            email_claim=getattr(websocket.app.state, "user_email_claim", "email"),
+                                            name_claim=getattr(websocket.app.state, "user_name_claim", "name"),
+                                        )
+                                    ws_disabled = user_store.is_disabled(ws_user_id)
+                                except Exception as e:  # directory unreachable: honour configured policy
+                                    fail_closed = bool(
+                                        getattr(websocket.app.state, "user_directory_fail_closed", False)
+                                    )
+                                    logger.warning(
+                                        f"user directory check failed for {ws_user_id!r}: {e} "
+                                        f"(failing {'closed' if fail_closed else 'open'})"
+                                    )
+                                    if fail_closed:
+                                        await websocket.send_text(
+                                            json.dumps(
+                                                {
+                                                    "event": "auth_error",
+                                                    "error": "User directory unavailable",
+                                                    "error_type": "server_error",
+                                                }
+                                            )
+                                        )
+                                        continue
+                                    ws_disabled = False
+                                if ws_disabled:
+                                    logger.warning(f"Disabled user denied on WebSocket: {ws_user_id}")
+                                    await websocket.send_text(
+                                        json.dumps(
+                                            {
+                                                "event": "auth_error",
+                                                "error": "User is disabled",
+                                                "error_type": "user_disabled",
+                                            }
+                                        )
+                                    )
+                                    continue
+
                             await websocket_manager.authenticate_websocket(websocket)
 
                             # Store user context from JWT

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -50,7 +50,6 @@ from agno.os.scopes import (
     AgentOSScope,
     get_default_scope_mappings,
     get_required_scopes_for_route,
-    has_required_scopes,
 )
 from agno.os.service_accounts import TOKEN_PREFIX as SERVICE_ACCOUNT_TOKEN_PREFIX
 from agno.os.service_accounts import VerificationStatus
@@ -343,6 +342,30 @@ def get_websocket_router(
         ws_workflow_run_scopes: List[str] = get_required_scopes_for_route(
             get_default_scope_mappings(), "POST", "/workflows/_/runs"
         )
+        # Resolve the authorization provider once for this connection. With no provider
+        # configured this is the default ScopeAuthorizationProvider, whose
+        # authorize_route is a thin wrapper over has_required_scopes — so the WS gate
+        # stays byte-identical to v2.7. A managed-role / custom provider enforces its
+        # model at the same three points (start / reconnect / continue) instead.
+        from agno.os.auth import resolve_authorization_provider
+        from agno.os.authz.provider import AuthorizationContext
+
+        ws_authorization_provider = resolve_authorization_provider(websocket.app)
+
+        def ws_authorize_workflow(workflow_id: Optional[str]) -> bool:
+            """Route-gate a workflow WS action through the provider, mirroring the REST
+            POST /workflows/{id}/runs gate (same required scopes, same resource ctx)."""
+            ctx = AuthorizationContext(
+                principal_id=websocket_user_context.get("user_id"),
+                scopes=list(websocket_user_context.get("scopes", []) or []),
+                claims=websocket_user_context.get("payload") or {},
+                resource_type="workflows",
+                resource_id=workflow_id,
+                action="run",
+                admin_scope=ws_admin_scope,
+            )
+            return ws_authorization_provider.authorize_route(ctx, ws_workflow_run_scopes)
+
         jwt_auth_enabled = jwt_validator is not None
         # auth_required is True when JWTMiddleware is configured, even if the
         # validator could not be constructed (e.g. bad JWKS path). This prevents
@@ -510,14 +533,7 @@ def get_websocket_router(
                     # side-effects.
                     workflow_id = message.get("workflow_id")
                     if scope_enforcement_active():
-                        user_scopes = websocket_user_context.get("scopes", [])
-                        if not has_required_scopes(
-                            user_scopes,
-                            ws_workflow_run_scopes,
-                            resource_type="workflows",
-                            resource_id=workflow_id,
-                            admin_scope=ws_admin_scope,
-                        ):
+                        if not ws_authorize_workflow(workflow_id):
                             await websocket.send_text(
                                 json.dumps({"event": "error", "error": "Insufficient permissions to run this workflow"})
                             )
@@ -570,14 +586,7 @@ def get_websocket_router(
                             )
                             continue
 
-                        user_scopes = websocket_user_context.get("scopes", [])
-                        if not has_required_scopes(
-                            user_scopes,
-                            ws_workflow_run_scopes,
-                            resource_type="workflows",
-                            resource_id=workflow_id_for_reconnect,
-                            admin_scope=ws_admin_scope,
-                        ):
+                        if not ws_authorize_workflow(workflow_id_for_reconnect):
                             await websocket.send_text(
                                 json.dumps(
                                     {
@@ -601,14 +610,7 @@ def get_websocket_router(
                     # Enforce workflow-level RBAC, mirroring start-workflow.
                     workflow_id = message.get("workflow_id")
                     if scope_enforcement_active():
-                        user_scopes = websocket_user_context.get("scopes", [])
-                        if not has_required_scopes(
-                            user_scopes,
-                            ws_workflow_run_scopes,
-                            resource_type="workflows",
-                            resource_id=workflow_id,
-                            admin_scope=ws_admin_scope,
-                        ):
+                        if not ws_authorize_workflow(workflow_id):
                             await websocket.send_text(
                                 json.dumps(
                                     {"event": "error", "error": "Insufficient permissions to continue this workflow"}

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -364,7 +364,23 @@ def get_websocket_router(
                 action="run",
                 admin_scope=ws_admin_scope,
             )
-            return ws_authorization_provider.authorize_route(ctx, ws_workflow_run_scopes)
+            allowed = ws_authorization_provider.authorize_route(ctx, ws_workflow_run_scopes)
+            # Same access trail the REST gate writes to: the equivalent
+            # POST /workflows/{id}/runs decision is recorded, so the streaming
+            # transport must not be a blind spot in the audit.
+            from agno.os.authz.audit import record_decision
+
+            record_decision(
+                websocket.app,
+                allowed=allowed,
+                target=f"WS /workflows/{workflow_id or '_'}/runs",
+                principal=ctx.principal_id,
+                required_scopes=ws_workflow_run_scopes,
+                scopes=ctx.scopes,
+                claims=ctx.claims,
+                reason=None if allowed else "ws_workflow_denied",
+            )
+            return allowed
 
         jwt_auth_enabled = jwt_validator is not None
         # auth_required is True when JWTMiddleware is configured, even if the

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -169,6 +169,10 @@ redis = ["redis", "redisvl>=0.12.1"]
 sql = ["sqlalchemy"]
 sqlite = ["sqlalchemy", "aiosqlite"]
 
+# Managed roles + credential-less user directory (ManagedRoleStore / ManagedUserStore),
+# which persist to a SQL database. Referenced by the role_store/user_store docstrings.
+roles = ["sqlalchemy"]
+
 # Dependencies for Vector databases
 cassandra = ["cassio"]
 chromadb = ["chromadb"]

--- a/libs/agno/tests/integration/os/test_managed_roles.py
+++ b/libs/agno/tests/integration/os/test_managed_roles.py
@@ -1,0 +1,311 @@
+"""Integration tests for ManagedRoleStore — the agno-native managed-roles tier.
+
+Verifies the governance product surface end to end: roles defined in agno scope
+terms, runtime assign/revoke, persistence to a DB, and enforcement through the
+AgentOS request pipeline via the store's provider. No engine types appear in the
+test body — the same as user code.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-test-secret-at-least-256-bits-long-xxxxx"
+OS_ID = "managed-roles-test-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def _build(store: ManagedRoleStore) -> TestClient:
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    other = Agent(id="other-agent", name="Other Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent, other],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    return TestClient(agent_os.get_app())
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+def test_role_scopes_enforced_through_pipeline():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "viewer")
+    store.assign("alice", "admin")
+    client = _build(store)
+
+    # viewer can read
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    # viewer cannot run
+    r = client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403
+    # admin can run
+    r = client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code != 403
+
+
+def test_unassigned_subject_is_denied():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    client = _build(store)
+    assert client.get("/agents/research-agent", headers=_auth("nobody")).status_code == 403
+
+
+def test_runtime_grant_takes_effect_same_token():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    client = _build(store)
+
+    # bob has no role yet -> denied to run, with a stable token
+    headers = _auth("bob")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code == 403
+
+    # grant at runtime; SAME token
+    store.assign("bob", "member")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code != 403
+
+    # revoke at runtime; SAME token
+    store.unassign("bob", "member")
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code == 403
+
+
+def test_per_resource_scope_is_granular():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("member", ["agents:*:read", "agents:research-agent:run"])
+    store.assign("bob", "member")
+    client = _build(store)
+
+    # may run the specific agent
+    assert client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code != 403
+    # but not a different one
+    assert client.post("/agents/other-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
+
+
+def test_roles_from_external_idp_claim():
+    """Roles carried on the token (external IdP) authorize against the same store."""
+    store = ManagedRoleStore(roles_claim="roles", db_url=_db_url())
+    store.set_role_scopes("editor", ["agents:*:read", "agents:research-agent:run"])
+    client = _build(store)
+
+    # token carries roles=["editor"]; sub is unknown to the store
+    tok = jwt.encode(
+        {
+            "sub": "idp-user-999",
+            "aud": OS_ID,
+            "scopes": [],
+            "roles": ["editor"],
+            "exp": datetime.now(UTC) + timedelta(hours=1),
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+    headers = {"Authorization": f"Bearer {tok}"}
+    assert client.post("/agents/research-agent/runs", headers=headers, data={"message": "hi"}).status_code != 403
+
+
+def test_non_resource_routes_are_gated_sessions():
+    """Sessions endpoints (which the middleware can't tag with a resource_type)
+    are governed by the same role policy — read/write/delete enforced, not open.
+    """
+    from agno.session import AgentSession
+
+    db = InMemoryDb()
+    db.upsert_session(AgentSession(session_id="s1", agent_id="research-agent", user_id="u"))
+
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("support", ["sessions:read"])  # read only
+    store.set_role_scopes("operator", ["sessions:read", "sessions:delete"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("bob", "support")
+    store.assign("val", "operator")
+    store.assign("alice", "admin")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # support can view but NOT delete (the gap this closes: previously open)
+    assert client.get("/sessions?type=agent", headers=_auth("bob")).status_code == 200
+    assert client.delete("/sessions/s1", headers=_auth("bob")).status_code == 403
+    # operator can delete
+    assert client.delete("/sessions/s1", headers=_auth("val")).status_code != 403
+    # admin can view
+    assert client.get("/sessions?type=agent", headers=_auth("alice")).status_code == 200
+    # a subject with no role is denied even on a non-resource route
+    assert client.get("/sessions?type=agent", headers=_auth("nobody")).status_code == 403
+
+
+def test_management_helpers():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("a", ["agents:*:read"])
+    store.set_role_scopes("b", ["teams:*:read"])
+    store.assign("bob", "a")
+    assert store.roles_of("bob") == ["a"]
+    # One role per subject: assigning another REPLACES, never stacks.
+    store.assign("bob", "b")
+    assert set(store.list_roles()) == {"a", "b"}
+    assert store.roles_of("bob") == ["b"]
+    # Re-assigning the same role is a no-op.
+    store.assign("bob", "b")
+    assert store.roles_of("bob") == ["b"]
+    store.unassign("bob", "b")
+    assert store.roles_of("bob") == []
+
+
+def test_role_store_shortcut_wires_provider_and_defaults_os_db(tmp_path):
+    """#4: AuthorizationConfig(role_store=...) wires the store's provider (no manual
+    .provider). #3: a store with no DB of its own adopts the OS DB when AgentOS wires
+    it (a DB is required — there is no in-memory mode), and roles persist there."""
+    from agno.db.sqlite import SqliteDb
+
+    store = ManagedRoleStore()  # no DB yet -> AgentOS will adopt the OS DB
+    db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    agent = Agent(id="research-agent", name="R", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            role_store=store,  # <- the shortcut; AgentOS adopts the OS db + uses store.provider
+        ),
+    )
+    client = TestClient(agent_os.get_app())  # adopts the OS DB -> store is now bound
+
+    # configure after wiring (the store is bound to the OS DB now)
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+    assert store.is_bound is True
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    assert client.get("/agents/research-agent", headers=_auth("nobody")).status_code == 403
+
+    # roles persisted to the OS DB -> a fresh store on the same DB sees them
+    fresh = ManagedRoleStore(db=db)
+    assert fresh.roles_of("bob") == ["viewer"]
+    assert fresh.get_role_scopes("viewer") == ["agents:read"]
+
+
+def test_managed_roles_enforce_on_rest_gate_via_shortcut(tmp_path):
+    """The payoff, end to end on the v2.7 REST route gate: an AgentOS wired with the
+    ``role_store=`` shortcut (no manual .provider) enforces a managed role for a caller
+    whose JWT carries NO scopes at all — the ``viewer`` role (agents:*:read) is resolved
+    from the store, not the token. Same viewer, same token: GET /agents/{id} is 200 but
+    POST /agents/{id}/runs is 403, proving action granularity flows through the same gate
+    that v2.7 gates scopes on. With no provider configured this gate is byte-identical
+    scope RBAC; here it is managed roles, at the very same choke point."""
+    from agno.db.sqlite import SqliteDb
+
+    store = ManagedRoleStore()  # no DB of its own -> AgentOS adopts the OS DB
+    db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    agent = Agent(id="research-agent", name="R", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            role_store=store,  # the shortcut: AgentOS binds the OS db + uses store.provider
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # viewer = read-only on agents; assigned to bob via the store (not via any token scope)
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    # The token carries scopes: [] — authorization comes entirely from the managed role.
+    assert jwt.decode(_token("bob"), SECRET, algorithms=["HS256"], audience=OS_ID)["scopes"] == []
+
+    # read allowed, run denied — same subject, same (empty-scope) token
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+    assert (
+        client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}).status_code == 403
+    )
+
+
+def test_role_store_and_provider_are_mutually_exclusive():
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    with pytest.raises(ValueError, match="not both"):
+        AuthorizationConfig(role_store=ManagedRoleStore(), authorization_provider=ScopeAuthorizationProvider())
+
+
+def test_role_store_without_any_db_fails_loud_at_wiring():
+    """A managed store with no DB, wired into an AgentOS that also has no SQL DB,
+    must fail loudly rather than silently run an in-memory store that can't stay
+    consistent across replicas."""
+    store = ManagedRoleStore()  # no DB
+    agent = Agent(id="research-agent", name="R", db=InMemoryDb())  # not SQL-capable
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            role_store=store,
+        ),
+    )
+    with pytest.raises(ValueError, match="needs a SQL database"):
+        agent_os.get_app()

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -1,0 +1,202 @@
+"""Integration tests for the ManagedRoleStore HTTP management API.
+
+Exercises the admin-only governance surface end to end: CRUD over roles and
+assignments through HTTP, the admin gate (401/403), and the payoff — a role
+granted via the API takes effect on the target user's next request.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-api-test-secret-at-least-256-bits-long-xx"
+OS_ID = "managed-roles-api-test-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+@pytest.fixture
+def client_and_store():
+    store = ManagedRoleStore(db_url=_db_url())  # in-memory
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    store.assign("bob", "viewer")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    return TestClient(app), store
+
+
+def test_unauthenticated_is_401(client_and_store):
+    client, _ = client_and_store
+    assert client.get("/authz/roles").status_code == 401
+
+
+def test_non_admin_is_403(client_and_store):
+    client, _ = client_and_store
+    # bob is a viewer, not an admin
+    assert client.get("/authz/roles", headers=_auth("bob")).status_code == 403
+    assert client.post(
+        "/authz/users/carol/roles", headers=_auth("bob"), json={"role": "viewer"}
+    ).status_code == 403
+
+
+def test_admin_can_list_and_read_roles(client_and_store):
+    client, _ = client_and_store
+    r = client.get("/authz/roles", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert set(r.json()["roles"]) == {"viewer", "admin"}
+
+    r = client.get("/authz/roles/viewer", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert r.json()["scopes"] == ["agents:read"]  # global read-back form
+
+
+def test_admin_crud_role(client_and_store):
+    client, store = client_and_store
+    # create a new role
+    r = client.put(
+        "/authz/roles/editor",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:read", "agents:research-agent:run"]},
+    )
+    assert r.status_code == 200
+    assert store.get_role_scopes("editor") == sorted(["agents:read", "agents:research-agent:run"])
+
+    # delete it
+    r = client.delete("/authz/roles/editor", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert "editor" not in store.list_roles()
+
+
+def test_admin_assign_and_revoke(client_and_store):
+    client, store = client_and_store
+    r = client.post("/authz/users/carol/roles", headers=_auth("alice"), json={"role": "viewer"})
+    assert r.status_code == 200
+    assert r.json()["roles"] == ["viewer"]
+    assert store.roles_of("carol") == ["viewer"]
+
+    r = client.delete("/authz/users/carol/roles/viewer", headers=_auth("alice"))
+    assert r.status_code == 200
+    assert store.roles_of("carol") == []
+
+
+def test_granting_via_api_takes_effect_on_next_request(client_and_store):
+    client, _ = client_and_store
+    # bob is a viewer: cannot run the agent
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+    # admin defines a runner role and grants it to bob via the HTTP API
+    assert client.put(
+        "/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
+    ).status_code == 200
+    assert client.post(
+        "/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}
+    ).status_code == 200
+
+    # bob can now run — same token, no re-mint
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code != 403
+
+    # admin revokes it; bob is blocked again
+    assert client.delete("/authz/users/bob/roles/runner", headers=_auth("alice")).status_code == 200
+    assert client.post(
+        "/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}
+    ).status_code == 403
+
+
+def test_scope_catalog_endpoint(client_and_store):
+    client, _ = client_and_store
+    r = client.get("/authz/scopes", headers=_auth("alice"))
+    assert r.status_code == 200
+    body = r.json()
+    assert "agents" in body["grouped"] and "read" in body["grouped"]["agents"]
+    assert "agents:run" in body["scopes"]
+    assert body["admin_scope"] == "agent_os:admin"
+    # non-admin is blocked
+    assert client.get("/authz/scopes", headers=_auth("bob")).status_code == 403
+
+
+def test_admin_via_token_claim_can_manage():
+    """When roles come from the token (external IdP), an admin role on the token grants management."""
+    store = ManagedRoleStore(roles_claim="roles", db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.set_role_scopes("viewer", ["agents:*:read"])
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    def idp_token(sub, roles):
+        return jwt.encode(
+            {"sub": sub, "aud": OS_ID, "scopes": [], "roles": roles,
+             "exp": datetime.now(UTC) + timedelta(hours=1)},
+            SECRET, algorithm="HS256",
+        )
+
+    admin_h = {"Authorization": f"Bearer {idp_token('idp-admin', ['admin'])}"}
+    viewer_h = {"Authorization": f"Bearer {idp_token('idp-viewer', ['viewer'])}"}
+
+    assert client.get("/authz/roles", headers=admin_h).status_code == 200
+    assert client.get("/authz/roles", headers=viewer_h).status_code == 403

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -1,0 +1,357 @@
+"""Audit trail for managed-role changes.
+
+The policy engine can't attribute who changed a policy (it never sees the actor),
+so change-audit lives at our layer. These tests verify that role and
+assignment mutations emit append-only AuditEvents with the acting principal and
+the before/after, both via the store directly and through the admin HTTP API.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-audit-secret-at-least-256-bits-long-xxxx"
+OS_ID = "managed-roles-audit-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+class _CapturingSink(AuditSink):
+    def __init__(self):
+        self.events: list[AuditEvent] = []
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+def _token(sub: str, jti: str | None = None) -> str:
+    claims = {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)}
+    if jti is not None:
+        claims["jti"] = jti
+    return jwt.encode(claims, SECRET, algorithm="HS256")
+
+
+def _auth(sub: str, jti: str | None = None) -> dict:
+    return {"Authorization": f"Bearer {_token(sub, jti)}"}
+
+
+def test_store_emits_change_events_with_actor_and_diff():
+    sink = _CapturingSink()
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.set_role_scopes("member", ["agents:*:read", "agents:*:run"], actor="alice")  # widen
+    store.assign("bob", "member", actor="alice")
+    store.unassign("bob", "member", actor="alice")
+    store.remove_role("member", actor="alice")
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("role.set_scopes", "member", "alice"),
+        ("role.set_scopes", "member", "alice"),
+        ("user.assigned", "bob", "alice"),
+        ("user.unassigned", "bob", "alice"),
+        ("role.removed", "member", "alice"),
+    ]
+    # before/after captured on the widen
+    widen = sink.events[1]
+    assert widen.before == ["agents:read"]
+    assert set(widen.after) == {"agents:read", "agents:run"}
+    # assignment diff
+    assign = sink.events[2]
+    assert assign.before == [] and assign.after == ["member"]
+    # every event is timestamped
+    assert all(e.timestamp > 0 for e in sink.events)
+
+
+def test_no_sink_means_no_overhead_and_no_events():
+    store = ManagedRoleStore(db_url=_db_url())  # no audit
+    # should not raise and should be a no-op for auditing
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.assign("bob", "member", actor="alice")
+    assert store.roles_of("bob") == ["member"]
+
+
+def test_db_audit_sink_is_append_only_table(tmp_path):
+    import sqlalchemy as sa
+
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite:///{db_file}"
+    sink = DbAuditSink(db_url=url)
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+
+    store.set_role_scopes("member", ["agents:*:read"], actor="alice")
+    store.assign("bob", "member", actor="alice")
+    store.unassign("bob", "member", actor="carol")
+
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        rows = c.execute(sa.text("select actor, action, target, before, after from authz_audit order by id")).fetchall()
+    assert [tuple(r[:3]) for r in rows] == [
+        ("alice", "role.set_scopes", "member"),
+        ("alice", "user.assigned", "bob"),
+        ("carol", "user.unassigned", "bob"),
+    ]
+    # before/after persisted as JSON
+    assert rows[1].before == "[]" and rows[1].after == '["member"]'
+
+
+def test_http_api_records_actor_from_jwt():
+    sink = _CapturingSink()
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")  # bootstrap admin (not audited: no actor route)
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    sink.events.clear()
+    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
+    client.delete("/authz/users/bob/roles/runner", headers=_auth("alice"))
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("role.set_scopes", "runner", "alice"),
+        ("user.assigned", "bob", "alice"),
+        ("user.unassigned", "bob", "alice"),
+    ]
+
+
+def _decision_os(sink):
+    """An AgentOS where viewer can read agents but not delete sessions, with the
+    given sink wired for decision audit."""
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    db = InMemoryDb()
+    agent = Agent(id="research-agent", name="Research Agent", db=db)
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=sink,  # <- decision audit
+        ),
+    )
+    return store, agent_os
+
+
+def test_decision_audit_records_allow_and_deny():
+    """Each authorization decision (allow/deny) is recorded with the principal and
+    a non-secret token reference when an audit sink is on AuthorizationConfig."""
+    sink = _CapturingSink()
+    _, agent_os = _decision_os(sink)
+    client = TestClient(agent_os.get_app())
+
+    client.get("/agents/research-agent", headers=_auth("bob"))  # allowed (viewer reads)
+    client.delete("/sessions/s1", headers=_auth("bob"))  # denied (no sessions:delete)
+
+    by_action = {(e.action, e.actor) for e in sink.events}
+    assert ("access.allowed", "bob") in by_action
+    assert ("access.denied", "bob") in by_action
+
+    denied = next(e for e in sink.events if e.action == "access.denied")
+    assert denied.target.startswith("DELETE /sessions")
+    assert "sessions:delete" in (denied.metadata.get("required") or [])
+    # a token reference is captured, but NOT the raw token
+    assert denied.metadata.get("token") and len(denied.metadata["token"]) <= 16
+
+
+def test_decision_token_ref_prefers_jti_over_hash():
+    """The token reference is the token's jti when present (so it correlates to the
+    issuer's logs); only without a jti do we fall back to a short hash."""
+    sink = _CapturingSink()
+    _, agent_os = _decision_os(sink)
+    client = TestClient(agent_os.get_app())
+
+    client.get("/agents/research-agent", headers=_auth("bob", jti="tok-abc-123"))  # has jti
+    client.get("/agents/research-agent", headers=_auth("bob"))  # no jti -> hash
+
+    refs = [e.metadata.get("token") for e in sink.events if e.action == "access.allowed"]
+    assert "tok-abc-123" in refs  # jti used verbatim
+    hashed = [r for r in refs if r != "tok-abc-123"]
+    assert hashed and all(len(r) == 12 for r in hashed)  # fallback is the short hash
+
+
+def test_decision_and_change_audit_go_to_separate_tables(tmp_path):
+    """One DbAuditSink, two physically separate tables: role/assignment changes in
+    authz_audit, per-request decisions in authz_decisions."""
+    import sqlalchemy as sa
+
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite:///{db_file}"
+    sink = DbAuditSink(db_url=url)
+
+    store, agent_os = _decision_os(sink)
+    # also route the store's change events to the same sink
+    store._audit = sink  # noqa: SLF001 (test wiring)
+    store.set_role_scopes("viewer", ["agents:*:read", "agents:*:run"], actor="alice")  # a change
+
+    client = TestClient(agent_os.get_app())
+    client.get("/agents/research-agent", headers=_auth("bob", jti="jti-1"))  # a decision (allow)
+    client.delete("/sessions/s1", headers=_auth("bob", jti="jti-2"))  # a decision (deny)
+
+    eng = sa.create_engine(url)
+    with eng.connect() as c:
+        changes = c.execute(sa.text("select action, target from authz_audit order by id")).fetchall()
+        decisions = c.execute(sa.text("select action, target, token_ref from authz_decisions order by id")).fetchall()
+
+    # change table holds only the role change, no access.* rows
+    assert [tuple(r) for r in changes] == [("role.set_scopes", "viewer")]
+    # decision table holds only access.* rows, with the jti as the token ref
+    actions = {(r[0], r[2]) for r in decisions}
+    assert ("access.allowed", "jti-1") in actions
+    assert ("access.denied", "jti-2") in actions
+    assert all(r[0].startswith("access.") for r in decisions)
+
+    # the readers are separated too
+    assert all(not e["action"].startswith("access.") for e in sink.read())
+    assert all(e["action"].startswith("access.") for e in sink.read_decisions())
+
+
+def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
+    """GET /authz/decisions returns the decision trail (newest first) for admins;
+    it is separate from /authz/audit (changes)."""
+    db_file = tmp_path / "audit.db"
+    sink = DbAuditSink(db_url=f"sqlite:///{db_file}")
+    store = ManagedRoleStore(audit=sink, db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("bob", "viewer")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+            audit=sink,  # decisions land here too
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    client.get("/agents/research-agent", headers=_auth("bob", jti="dec-1"))  # allowed decision
+
+    # admin reads the decision trail
+    r = client.get("/authz/decisions", headers=_auth("alice"))
+    assert r.status_code == 200
+    events = r.json()["events"]
+    assert any(e["action"] == "access.allowed" and e["metadata"]["token"] == "dec-1" for e in events)
+
+    # /authz/audit (changes) does NOT contain the access.* decisions
+    changes = client.get("/authz/audit", headers=_auth("alice")).json()["events"]
+    assert all(not e["action"].startswith("access.") for e in changes)
+
+    # non-admin and anonymous are blocked
+    assert client.get("/authz/decisions", headers=_auth("bob")).status_code == 403
+    assert client.get("/authz/decisions").status_code == 401
+
+
+def test_audit_endpoint_returns_trail(tmp_path):
+    """GET /authz/audit returns the change trail (newest first) for admins only."""
+    db_file = tmp_path / "audit.db"
+    store = ManagedRoleStore(audit=DbAuditSink(db_url=f"sqlite:///{db_file}"), db_url=_db_url())
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    # make a couple of changes over the API
+    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
+
+    # admin can read the trail; newest first
+    r = client.get("/authz/audit", headers=_auth("alice"))
+    assert r.status_code == 200
+    events = r.json()["events"]
+    assert events[0]["action"] == "user.assigned" and events[0]["actor"] == "alice"
+    assert events[0]["after"] == ["runner"]
+    assert any(e["action"] == "role.set_scopes" and e["target"] == "runner" for e in events)
+
+    # non-admin and anonymous are blocked
+    store.assign("bob", "runner")  # bob still isn't an admin
+    assert client.get("/authz/audit", headers=_auth("bob")).status_code == 403
+    assert client.get("/authz/audit").status_code == 401
+
+
+def test_db_audit_sink_never_raises_into_caller(tmp_path, monkeypatch):
+    """#7: DbAuditSink.record must swallow DB errors (contract) so a failing audit
+    write can't turn a successful role change into a 500."""
+    from agno.os.authz.audit import AuditEvent, DbAuditSink
+
+    sink = DbAuditSink(db_url=f"sqlite:///{tmp_path / 'audit.db'}")
+
+    def boom(_event):
+        raise RuntimeError("db unavailable")
+
+    monkeypatch.setattr(sink, "_record_change", boom)
+    monkeypatch.setattr(sink, "_record_decision", boom)
+    # both trails: must not propagate
+    sink.record(AuditEvent(action="role.set_scopes", actor="alice", target="m"))
+    sink.record(AuditEvent(action="access.denied", actor="bob", target="GET /x"))

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -355,3 +355,85 @@ def test_db_audit_sink_never_raises_into_caller(tmp_path, monkeypatch):
     # both trails: must not propagate
     sink.record(AuditEvent(action="role.set_scopes", actor="alice", target="m"))
     sink.record(AuditEvent(action="access.denied", actor="bob", target="GET /x"))
+
+
+def test_per_resource_deny_is_recorded_when_it_denies_independently():
+    """The per-resource gate records its own DENY.
+
+    Note the route gate is ALREADY resource-aware (it puts resource_id in the context,
+    so a managed-role per-resource denial is decided -- and recorded -- there, with the
+    concrete resource in the target). The gap this covers is the case the route gate
+    can't: a provider whose ``check`` is stricter than its ``authorize_route``, so the
+    route is allowed and the per-resource dependency is what actually blocks. Without
+    recording here that denial would be invisible -- the trail would show the route
+    allowed and never show what stopped the request.
+    """
+    from agno.os.authz.provider import AuthorizationProvider
+
+    class RouteOpenResourceClosed(AuthorizationProvider):
+        """Lets every route through, then denies the specific resource."""
+
+        def check(self, ctx):
+            return False
+
+        def accessible_resource_ids(self, ctx):
+            return {"*"}
+
+        def authorize_route(self, ctx, required_scopes):
+            return True
+
+    sink = _CapturingSink()
+    db = InMemoryDb()
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[Agent(id="yours", name="Yours", db=db)],
+        db=db,
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=RouteOpenResourceClosed(),
+            audit=sink,
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+    r = client.post("/agents/yours/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403, r.text
+
+    resource_denials = [e for e in sink.events if e.metadata.get("reason") == "resource_access_denied"]
+    assert resource_denials, f"per-resource deny not recorded; got {[(e.action, e.target) for e in sink.events]}"
+    ev = resource_denials[0]
+    assert ev.action == "access.denied" and ev.actor == "bob"
+    assert "yours" in ev.target
+
+
+def test_audit_sink_is_mirrored_onto_the_mcp_subapp():
+    """The MCP tool gate resolves its sink from the mounted sub-app's state (request.app
+    is the sub-app, not the main app). Without this mirror MCP decisions can't be
+    recorded at all, leaving the access trail covering REST/WS but silently missing the
+    entire MCP transport."""
+    pytest.importorskip("fastmcp")
+    sink = _CapturingSink()
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+
+    db = InMemoryDb()
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[Agent(id="research-agent", name="Research Agent", db=db)],
+        db=db,
+        authorization=True,
+        mcp_server=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            authorization_provider=store.provider,
+            audit=sink,
+        ),
+    )
+    app = agent_os.get_app()
+    assert getattr(app.state, "authz_audit", None) is sink
+    sub = getattr(getattr(agent_os, "_mcp_app", None), "state", None)
+    assert getattr(sub, "authz_audit", None) is sink, "MCP sub-app must resolve the SAME audit sink"

--- a/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_internal_token.py
@@ -1,0 +1,96 @@
+"""Regression tests: the internal service token (scheduler executor) must pass the
+per-resource handler gate under a managed-roles (EngineAuthorizationProvider)
+deployment, while a normal user with no role is still denied at that same gate.
+
+Background: the scheduler executor POSTs to ``/agents/{id}/runs`` (and team/workflow
+equivalents) with ``Authorization: Bearer <internal_service_token>``. The JWT
+middleware authorizes that token at the route gate via ``INTERNAL_SERVICE_SCOPES``.
+But those run endpoints ALSO carry a per-resource handler gate
+(``require_resource_access`` -> ``check_resource_access`` -> ``provider.check``).
+Under managed roles, ``provider.check`` keys off the subject (``__scheduler__``) and
+token-carried roles, ignoring scopes — and ``__scheduler__`` has no assignment, so
+the handler gate used to return 403 even though the route gate passed.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "managed-roles-internal-token-test-secret-at-least-256-bits-long"
+OS_ID = "managed-roles-internal-token-os"
+INTERNAL_TOKEN = "internal-service-token-for-scheduler-test-xxxxxxxxxxxxxxxx"
+
+
+def _db_url() -> str:
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _user_token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+@pytest.fixture
+def client_and_store():
+    store = ManagedRoleStore(db_url=_db_url())
+    # A real user with NO role assigned — should be denied at the per-resource gate.
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        internal_service_token=INTERNAL_TOKEN,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=store.provider,
+        ),
+    )
+    app = agent_os.get_app()
+    return TestClient(app), store
+
+
+def _get_run(client: TestClient, token: str) -> int:
+    """Hit a per-resource-gated endpoint. The handler gate runs before the body, so:
+    403 => denied at the gate; anything else (404 for missing run) => gate passed."""
+    return client.get(
+        "/agents/research-agent/runs/nonexistent-run",
+        params={"session_id": "s1"},
+        headers={"Authorization": f"Bearer {token}"},
+    ).status_code
+
+
+def test_internal_token_passes_per_resource_gate(client_and_store):
+    """The scheduler's internal token must NOT be 403'd at the per-resource handler
+    gate under managed roles (it already passed the route gate)."""
+    client, _ = client_and_store
+    status = _get_run(client, INTERNAL_TOKEN)
+    assert status != 403, f"internal service token was denied at the per-resource gate (got {status})"
+
+
+def test_normal_user_without_role_still_denied(client_and_store):
+    """A normal user with no role assignment is STILL denied at the per-resource gate —
+    proving the internal-token bypass is strictly internal-only."""
+    client, _ = client_and_store
+    status = _get_run(client, _user_token("nobody"))
+    assert status == 403, f"normal user with no role should be denied at the gate (got {status})"

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -1,0 +1,224 @@
+"""The credential-less user directory (no-IdP tier).
+
+Covers the store itself (in-memory + SQLite), the admin HTTP surface
+(``/authz/users`` with roles merged in), and the enforcement value-add: a
+disabled user is denied at the gate even with a valid token, and just-in-time
+provisioning creates a directory row from token claims.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+from agno.os.authz.audit import AuditEvent, AuditSink  # noqa: E402
+from agno.os.authz.user_store import ManagedUserStore  # noqa: E402
+
+SECRET = "managed-users-secret-at-least-256-bits-long-padding-xxxxxx"
+OS_ID = "managed-users-os"
+
+
+class _CapturingSink(AuditSink):
+    def __init__(self):
+        self.events: list[AuditEvent] = []
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+def _token(sub: str, **claims) -> str:
+    payload = {"sub": sub, "aud": OS_ID, "scopes": claims.pop("scopes", []), "exp": datetime.now(UTC) + timedelta(hours=1)}
+    payload.update(claims)
+    return jwt.encode(payload, SECRET, algorithm="HS256")
+
+
+def _auth(sub: str, **claims) -> dict:
+    return {"Authorization": f"Bearer {_token(sub, **claims)}"}
+
+
+# ----------------------------------------------------------------- store unit
+@pytest.mark.parametrize("db_url", [None, "sqlite"])
+def test_store_crud_and_disable(tmp_path, db_url):
+    url = None if db_url is None else f"sqlite:///{tmp_path / 'users.db'}"
+    store = ManagedUserStore(db_url=url)
+
+    # create
+    u = store.upsert("u1", email="u1@co", name="One")
+    assert u["id"] == "u1" and u["email"] == "u1@co" and u["disabled"] is False
+    assert store.get("u1")["name"] == "One"
+
+    # partial update keeps untouched fields
+    store.upsert("u1", name="Uno")
+    after = store.get("u1")
+    assert after["name"] == "Uno" and after["email"] == "u1@co"
+
+    # list newest-first
+    store.upsert("u2", email="u2@co")
+    ids = [u["id"] for u in store.list()]
+    assert set(ids) == {"u1", "u2"}
+
+    # disable / enable + is_disabled fast path
+    assert store.is_disabled("u1") is False
+    store.set_disabled("u1", True)
+    assert store.is_disabled("u1") is True
+    assert [u["id"] for u in store.list(include_disabled=False)] == ["u2"]
+    store.set_disabled("u1", False)
+    assert store.is_disabled("u1") is False
+
+    # unknown subject is not disabled (app may mint tokens for unseen users)
+    assert store.is_disabled("ghost") is False
+
+    # remove
+    assert store.remove("u2") is True
+    assert store.get("u2") is None
+    assert store.remove("u2") is False
+
+
+def test_store_emits_audit_with_actor_and_diff():
+    sink = _CapturingSink()
+    store = ManagedUserStore(audit=sink)
+
+    store.upsert("u1", email="u1@co", actor="admin")
+    store.upsert("u1", name="One", actor="admin")  # update
+    store.set_disabled("u1", True, actor="admin")
+    store.set_disabled("u1", True, actor="admin")  # no-op, no event
+    store.set_disabled("u1", False, actor="admin")
+    store.remove("u1", actor="admin")
+
+    actions = [(e.action, e.target, e.actor) for e in sink.events]
+    assert actions == [
+        ("user.created", "u1", "admin"),
+        ("user.updated", "u1", "admin"),
+        ("user.disabled", "u1", "admin"),
+        ("user.enabled", "u1", "admin"),
+        ("user.removed", "u1", "admin"),
+    ]
+
+
+def test_provision_from_claims_is_idempotent():
+    store = ManagedUserStore()
+    created = store.provision_from_claims("u1", {"email": "u1@co", "name": "One"})
+    assert created["email"] == "u1@co" and created["name"] == "One"
+    # second call is a no-op, returns existing (doesn't overwrite)
+    again = store.provision_from_claims("u1", {"email": "changed@co"})
+    assert again["email"] == "u1@co"
+
+
+# ----------------------------------------------------- HTTP API + enforcement
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def _os(role_store, user_store, **cfg):
+    agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    return AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=role_store.provider,
+            user_store=user_store,
+            **cfg,
+        ),
+    )
+
+
+def test_disabled_user_is_denied_even_with_valid_token():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+    users.upsert("bob", email="bob@co")
+
+    client = TestClient(_os(roles, users).get_app())
+
+    # bob (viewer) can read while active
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+
+    # disable bob -> denied on the next request despite the still-valid token + role
+    users.set_disabled("bob", True)
+    blocked = client.get("/agents/research-agent", headers=_auth("bob"))
+    assert blocked.status_code == 403
+    assert "disabled" in blocked.json()["detail"].lower()
+
+    # re-enable -> allowed again
+    users.set_disabled("bob", False)
+    assert client.get("/agents/research-agent", headers=_auth("bob")).status_code == 200
+
+
+def test_disabled_user_is_denied_on_websocket():
+    """The kill-switch must also fire on the WebSocket connect path, not just HTTP:
+    a disabled user with a valid token is rejected at WS authenticate."""
+    import json as _json
+
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("viewer", ["agents:*:read", "workflows:*:run"])
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+    users.upsert("bob", email="bob@co")
+
+    client = TestClient(_os(roles, users).get_app())
+
+    def _auth_result():
+        with client.websocket_connect("/workflows/ws") as ws:
+            for _ in range(8):
+                if _json.loads(ws.receive_text()).get("event") == "connected":
+                    break
+            ws.send_text(_json.dumps({"action": "authenticate", "token": _token("bob", scopes=["workflows:run"])}))
+            for _ in range(8):
+                frame = _json.loads(ws.receive_text())
+                if frame.get("event") in ("authenticated", "auth_error"):
+                    return frame
+        raise AssertionError("no auth result frame within 8 messages")
+
+    # active -> authenticates over WS
+    assert _auth_result()["event"] == "authenticated"
+
+    # disabled -> rejected at WS authenticate despite a valid token
+    users.set_disabled("bob", True)
+    err = _auth_result()
+    assert err["event"] == "auth_error" and err.get("error_type") == "user_disabled", err
+
+
+def test_auto_provision_from_claims_at_the_gate():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("carol", "viewer")
+    users = ManagedUserStore()
+
+    client = TestClient(_os(roles, users, auto_provision_users=True).get_app())
+
+    assert users.get("carol") is None
+    # carol's first request provisions her from the token claims
+    r = client.get("/agents/research-agent", headers=_auth("carol", email="carol@co", name="Carol"))
+    assert r.status_code == 200
+    provisioned = users.get("carol")
+    assert provisioned is not None and provisioned["email"] == "carol@co" and provisioned["name"] == "Carol"
+
+
+def test_db_takes_precedence_and_bad_db_errors():
+    from agno.os.authz._db import engine_from_db
+
+    with pytest.raises(ValueError, match="db_engine"):
+        engine_from_db(object())  # not an agno db

--- a/libs/agno/tests/integration/os/test_native_engine.py
+++ b/libs/agno/tests/integration/os/test_native_engine.py
@@ -1,0 +1,334 @@
+"""NativePolicyEngine — agno's default managed-roles backend.
+
+Covers the decision model directly (deny-overrides, object wildcards, the
+scope<->policy read-back, roles-from-token vs stored subjects, transitive roles,
+accessible-ids) and SQLAlchemy persistence. Managed roles always require a DB —
+there is no in-memory mode, since an in-memory store can't stay consistent across
+the workers/replicas an AgentOS deployment runs — so every test runs on a
+throwaway SQLite DB and an unbound engine raises.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+pytest.importorskip("sqlalchemy")  # managed roles require a SQL DB; no in-memory mode
+
+from agno.os.authz.native_engine import NativePolicyEngine  # noqa: E402
+
+
+def _engine() -> NativePolicyEngine:
+    """A throwaway file-backed SQLite engine. File (not ``:memory:``) so the same DB
+    is visible across any threads, and each call is isolated to its own DB file."""
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return NativePolicyEngine(db_url=f"sqlite:///{path}")
+
+
+def test_basic_allow_and_deny_overrides():
+    eng = _engine()
+    eng.set_role_scopes(
+        "member",
+        [("agents:*:read", "allow"), ("agents:secret-agent:read", "deny")],
+    )
+    eng.assign("bob", "member")
+
+    # allowed on a normal agent, denied on the explicitly-denied one (deny wins)
+    assert eng.check_resource("agents", "public-agent", "read", subject="bob") is True
+    assert eng.check_resource("agents", "secret-agent", "read", subject="bob") is False
+    # action not granted at all
+    assert eng.check_resource("agents", "public-agent", "run", subject="bob") is False
+    # unknown subject
+    assert eng.check_resource("agents", "public-agent", "read", subject="nobody") is False
+
+
+def test_object_wildcard_matching():
+    eng = _engine()
+    eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    eng.assign("v", "viewer")
+    # resource/* matches resource/<id> ...
+    assert eng.check_resource("agents", "x", "read", subject="v") is True
+    # ... but a per-id grant does not match a different id
+    eng.set_role_scopes("runner", [("agents:a1:run", "allow")])
+    eng.assign("r", "runner")
+    assert eng.check_resource("agents", "a1", "run", subject="r") is True
+    assert eng.check_resource("agents", "a2", "run", subject="r") is False
+
+
+def test_admin_scope_allows_everything():
+    eng = _engine()
+    eng.set_role_scopes("admin", [("agent_os:admin", "allow")])
+    eng.assign("alice", "admin")
+    assert eng.check_resource("agents", "any", "run", subject="alice") is True
+    assert eng.check_resource("teams", "any", "delete", subject="alice") is True
+    assert eng.check_scope("sessions:delete", subject="alice") is True
+    assert eng.accessible_resource_ids("agents", "read", subject="alice") == {"*"}
+
+
+def test_scope_read_back_is_canonical():
+    """agents:*:read and agents:read collapse to the same policy and read back as
+    the global form — matching the documented (lossy) convention."""
+    eng = _engine()
+    eng.set_role_scopes("v", [("agents:*:read", "allow")])
+    assert eng.get_role_scopes("v") == [("agents:read", "allow")]
+
+
+def test_add_remove_and_effect_flip():
+    eng = _engine()
+    eng.add_scope("e", "agents:read")
+    eng.add_scope("e", "agents:run")
+    assert {s for s, _ in eng.get_role_scopes("e")} == {"agents:read", "agents:run"}
+    # adding the same (obj, act) flips its effect rather than duplicating
+    eng.add_scope("e", "agents:read", effect="deny")
+    assert eng.get_role_scopes("e").count(("agents:read", "deny")) == 1
+    assert ("agents:read", "allow") not in eng.get_role_scopes("e")
+    eng.remove_scope("e", "agents:run")
+    assert [s for s, _ in eng.get_role_scopes("e")] == ["agents:read"]
+
+
+def test_roles_from_token_take_precedence():
+    eng = _engine()
+    eng.set_role_scopes("editor", [("agents:*:read", "allow"), ("agents:a1:run", "allow")])
+    # subject has no stored assignment; role carried on the token authorizes
+    assert eng.check_resource("agents", "a1", "run", subject="idp-user", roles=["editor"]) is True
+    assert eng.check_resource("agents", "a1", "run", subject="idp-user") is False
+
+
+def test_deny_on_one_token_role_does_not_veto_allow_on_another():
+    """Per-root deny-overrides: a deny in role A must not cancel an allow in role B
+    when both are carried on the token."""
+    eng = _engine()
+    eng.set_role_scopes("A", [("agents:a1:read", "deny")])
+    eng.set_role_scopes("B", [("agents:*:read", "allow")])
+    assert eng.check_resource("agents", "a1", "read", roles=["A", "B"]) is True
+    # but a single role with both allow and deny IS deny-overridden
+    eng.set_role_scopes("C", [("agents:*:read", "allow"), ("agents:a1:read", "deny")])
+    assert eng.check_resource("agents", "a1", "read", roles=["C"]) is False
+
+
+def test_transitive_role_assignment():
+    eng = _engine()
+    eng.set_role_scopes("super", [("agent_os:admin", "allow")])
+    eng.assign("lead", "super")  # a role assigned to a role
+    eng.assign("bob", "lead")
+    assert eng.check_resource("agents", "x", "run", subject="bob") is True
+
+
+def test_accessible_resource_ids_specific_and_wildcard():
+    eng = _engine()
+    eng.set_role_scopes("m", [("agents:a1:read", "allow"), ("agents:a2:read", "allow")])
+    eng.assign("bob", "m")
+    assert eng.accessible_resource_ids("agents", "read", subject="bob") == {"a1", "a2"}
+    # a collection/global grant widens to wildcard
+    eng.set_role_scopes("m", [("agents:*:read", "allow")])
+    assert eng.accessible_resource_ids("agents", "read", subject="bob") == {"*"}
+    # wrong action -> nothing
+    assert eng.accessible_resource_ids("agents", "run", subject="bob") == set()
+
+
+def test_remove_role_drops_policies_and_assignments():
+    eng = _engine()
+    eng.set_role_scopes("temp", [("agents:*:read", "allow")])
+    eng.assign("bob", "temp")
+    eng.remove_role("temp")
+    assert eng.get_role_scopes("temp") == []
+    assert eng.roles_of("bob") == []
+    assert "temp" not in eng.list_roles()
+
+
+def test_list_roles_includes_assignment_only_roles():
+    eng = _engine()
+    eng.assign("bob", "ghost")  # assigned but never given scopes
+    assert "ghost" in eng.list_roles()
+
+
+def test_unmappable_scope_is_not_satisfied():
+    eng = _engine()
+    eng.set_role_scopes("admin", [("agent_os:admin", "allow")])
+    eng.assign("alice", "admin")
+    # a malformed required scope returns False rather than raising
+    assert eng.check_scope("not::a::valid::scope::x", subject="alice") is False
+
+
+def test_persistence_round_trip(tmp_path):
+    """Policies and assignments survive a fresh engine pointed at the same DB."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'policy.db'}"
+
+    eng = NativePolicyEngine(db_url=url)
+    eng.set_role_scopes("member", [("agents:*:read", "allow"), ("agents:a1:run", "allow")])
+    eng.assign("bob", "member")
+    assert eng.check_resource("agents", "a1", "run", subject="bob") is True
+
+    # a brand-new engine on the same DB loads the persisted state
+    eng2 = NativePolicyEngine(db_url=url)
+    assert eng2.roles_of("bob") == ["member"]
+    assert eng2.check_resource("agents", "a1", "run", subject="bob") is True
+    assert {s for s, _ in eng2.get_role_scopes("member")} == {"agents:read", "agents:a1:run"}
+
+    # mutations through the new engine also persist
+    eng2.unassign("bob", "member")
+    eng3 = NativePolicyEngine(db_url=url)
+    assert eng3.roles_of("bob") == []
+
+
+def test_list_filter_honours_deny_overrides_like_the_gate():
+    """Regression: a wildcard allow + per-resource deny must hide the denied
+    resource from list endpoints, matching the per-resource gate (deny-overrides).
+    Previously accessible_resource_ids returned {'*'} and leaked the denied one."""
+    from agno.os.authz.engine import EngineAuthorizationProvider
+    from agno.os.authz.provider import AuthorizationContext
+
+    class R:
+        def __init__(self, rid):
+            self.id = rid
+
+    eng = _engine()
+    # "read every agent EXCEPT the secret one"
+    eng.set_role_scopes("analyst", [("agents:*:read", "allow"), ("agents:secret:read", "deny")])
+    eng.assign("bob", "analyst")
+
+    # engine surfaces the denied id even though the allow is a wildcard
+    assert eng.accessible_resource_ids("agents", "read", subject="bob") == {"*"}
+    assert eng.denied_resource_ids("agents", "read", subject="bob") == {"secret"}
+
+    prov = EngineAuthorizationProvider(eng)
+    resources = [R("public"), R("secret"), R("other")]
+    # production list path builds the ctx with action=None (any-action visibility)
+    list_ctx = AuthorizationContext(principal_id="bob", resource_type="agents")
+    visible = {r.id for r in prov.filter_accessible(list_ctx, resources)}
+    assert visible == {"public", "other"}  # secret carved out, not leaked
+
+    # list visibility is consistent with the per-resource read gate
+    for r in resources:
+        gate = prov.check(
+            AuthorizationContext(principal_id="bob", resource_type="agents", resource_id=r.id, action="read")
+        )
+        assert (r.id in visible) == gate
+
+
+def test_denied_resource_ids_empty_without_denies():
+    eng = _engine()
+    eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    eng.assign("v", "viewer")
+    assert eng.denied_resource_ids("agents", "read", subject="v") == set()
+
+
+def test_db_backed_is_fresh_across_engines_no_cache(tmp_path):
+    """Multi-container (#2): db-backed engines read fresh per decision, so a second
+    engine (another worker/replica) sees a revocation immediately — no reload, no
+    stale cache."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'roles.db'}"
+
+    a = NativePolicyEngine(db_url=url)
+    a.set_role_scopes("admin", [("agent_os:admin", "allow")])
+    a.assign("bob", "admin")
+
+    b = NativePolicyEngine(db_url=url)  # a second "worker"
+    assert b.check_resource("agents", "x", "run", subject="bob") is True
+
+    a.unassign("bob", "admin")  # revoked on the first worker
+    # the second worker sees it on its very next decision — no reload() needed
+    assert b.check_resource("agents", "x", "run", subject="bob") is False
+    assert b.roles_of("bob") == []
+
+    # a scope change is seen live too
+    a.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    a.assign("carol", "viewer")
+    assert b.check_resource("agents", "x", "read", subject="carol") is True
+    assert b.get_role_scopes("viewer") == [("agents:read", "allow")]
+
+
+def test_db_is_the_only_store_no_in_process_state(tmp_path):
+    """The DB is the only source of truth — there are no in-process policy/grouping
+    dicts to go stale (they were removed; a DB is required)."""
+    pytest.importorskip("sqlalchemy")
+    eng = NativePolicyEngine(db_url=f"sqlite:///{tmp_path / 'roles.db'}")
+    eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    eng.assign("bob", "viewer")
+    assert not hasattr(eng, "_policies") and not hasattr(eng, "_grouping")
+    assert eng.is_bound is True
+    assert eng.roles_of("bob") == ["viewer"]  # reads work (fresh from DB)
+
+
+def test_unbound_engine_raises():
+    """No DB anywhere -> the engine is unbound and every operation raises, rather
+    than silently running an in-memory store that can't work across replicas."""
+    eng = NativePolicyEngine()  # no db / db_url
+    assert eng.is_bound is False
+    with pytest.raises(RuntimeError, match="requires a SQL database"):
+        eng.set_role_scopes("viewer", [("agents:*:read", "allow")])
+    with pytest.raises(RuntimeError, match="requires a SQL database"):
+        eng.check_resource("agents", "x", "read", subject="bob")
+    with pytest.raises(RuntimeError, match="requires a SQL database"):
+        eng.roles_of("bob")
+
+
+def test_set_role_scopes_atomic_on_bad_scope(tmp_path):
+    """#3: a bad scope mid-list must raise and leave the role's existing scopes
+    intact (cache AND db), not half-applied."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'r.db'}"
+    eng = NativePolicyEngine(db_url=url)
+    eng.set_role_scopes("m", [("agents:*:read", "allow")])
+
+    with pytest.raises(ValueError):
+        eng.set_role_scopes("m", [("agents:*:run", "allow"), ("a:b:c:d", "allow")])  # 2nd is malformed
+
+    assert eng.get_role_scopes("m") == [("agents:read", "allow")]  # unchanged
+    # a fresh engine on the same DB agrees -> cache and DB never diverged
+    assert NativePolicyEngine(db_url=url).get_role_scopes("m") == [("agents:read", "allow")]
+
+
+def test_set_role_scopes_dedups_colliding_mappings(tmp_path):
+    """#6: two scopes that map to the same (resource, action) must not raise an
+    IntegrityError on persist; they collapse to one row (last effect wins)."""
+    pytest.importorskip("sqlalchemy")
+    url = f"sqlite:///{tmp_path / 'r.db'}"
+    eng = NativePolicyEngine(db_url=url)
+    # agents:read and agents:*:read both -> ('agents/*', 'read')
+    eng.set_role_scopes("m", [("agents:read", "allow"), ("agents:*:read", "allow")])
+    assert eng.get_role_scopes("m") == [("agents:read", "allow")]
+    assert NativePolicyEngine(db_url=url).get_role_scopes("m") == [("agents:read", "allow")]
+
+
+def test_authorize_route_requires_all_scopes_and_no_blanket_allow():
+    """#5: a route requiring >1 scope must satisfy ALL (was ANY). #4: a resource
+    route with mixed actions (ctx.action=None) must not blanket-allow."""
+    from agno.os.authz.engine import EngineAuthorizationProvider
+    from agno.os.authz.provider import AuthorizationContext
+
+    eng = _engine()
+    eng.set_role_scopes("partial", [("sessions:read", "allow")])
+    eng.set_role_scopes("full", [("sessions:read", "allow"), ("sessions:write", "allow")])
+    eng.assign("p", "partial")
+    eng.assign("f", "full")
+    prov = EngineAuthorizationProvider(eng)
+
+    # #5 — non-resource route requiring read AND write
+    req = ["sessions:read", "sessions:write"]
+    assert prov.authorize_route(AuthorizationContext(principal_id="p"), req) is False  # read only -> ALL fails
+    assert prov.authorize_route(AuthorizationContext(principal_id="f"), req) is True
+
+    # #4 — resource route, mixed actions => ctx.action is None; must require all, not allow
+    eng.set_role_scopes("reader", [("agents:secret:read", "allow")])
+    eng.assign("r", "reader")
+    mixed = AuthorizationContext(principal_id="r", resource_type="agents", resource_id="secret", action=None)
+    assert prov.authorize_route(mixed, ["agents:read", "agents:run"]) is False  # has read, not run
+    eng.set_role_scopes("reader", [("agents:secret:read", "allow"), ("agents:secret:run", "allow")])
+    assert prov.authorize_route(mixed, ["agents:read", "agents:run"]) is True
+
+
+def test_effect_must_be_allow_or_deny_fail_closed():
+    """A typo'd effect must raise, not silently become an allow (deny-overrides
+    keys off the exact string 'deny')."""
+    eng = _engine()
+    with pytest.raises(ValueError):
+        eng.add_scope("r", "agents:read", effect="denied")  # typo
+    with pytest.raises(ValueError):
+        eng.set_role_scopes("r", [("agents:read", "allw")])  # typo
+    # canonical effects (any case) are accepted
+    eng.add_scope("r", "agents:read", effect="DENY")
+    assert eng.get_role_scopes("r") == [("agents:read", "deny")]

--- a/libs/agno/tests/unit/os/test_mcp_auth_builtin.py
+++ b/libs/agno/tests/unit/os/test_mcp_auth_builtin.py
@@ -997,3 +997,43 @@ def test_loopback_redirect_matching():
     assert matches("https://claude.ai/cb", "http://claude.ai/cb") is False
     # Refused: userinfo in the URI must never participate in matching.
     assert matches("http://x@127.0.0.1:62000/callback", reg) is False
+
+
+async def test_identity_bridge_denies_disabled_user_over_mcp_auth(tmp_path):
+    """mcp_auth exempts /mcp from the parent AuthMiddleware, so the disabled-user
+    kill-switch that lives there does not run for OAuth'd MCP traffic. The identity
+    bridge must re-apply it: a disabled user's valid token is NOT bridged (leaving
+    request.state.authenticated unset), so the fail-closed tool gate denies. An enabled
+    user is bridged normally. Locks the revocation-over-OAuth'd-MCP fix in."""
+    from types import SimpleNamespace
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.authz.user_store import ManagedUserStore
+    from agno.os.mcp_auth import MCPIdentityBridgeMiddleware
+
+    users = ManagedUserStore(db=SqliteDb(db_file=str(tmp_path / "u.db")))
+    users.upsert("alice", email="alice@co")
+    users.upsert("bob", email="bob@co")
+    users.set_disabled("bob", True)
+
+    captured: dict = {}
+
+    async def inner(scope, receive, send):
+        captured["state"] = dict(scope.get("state", {}))
+
+    bridge = MCPIdentityBridgeMiddleware(inner, admin_scope="agent_os:admin", user_store=users)
+
+    def make_scope(sub):
+        token = SimpleNamespace(claims={"sub": sub}, scopes=["agents:*:run"], client_id=sub)
+        return {"type": "http", "user": SimpleNamespace(access_token=token), "state": {}}
+
+    # enabled user -> identity bridged
+    await bridge(make_scope("alice"), None, None)
+    assert captured["state"].get("authenticated") is True
+    assert captured["state"].get("user_id") == "alice"
+
+    # disabled user -> identity NOT bridged; tool gate then fails closed
+    captured.clear()
+    await bridge(make_scope("bob"), None, None)
+    assert captured["state"].get("authenticated") is not True
+    assert "user_id" not in captured["state"]

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1176,3 +1176,36 @@ async def test_assigning_config_to_mcp_server_attribute_applies_config():
     assert os.mcp_server is True
     assert os.mcp_config is not None
     assert await _tool_names(os) == {"ping"}
+
+
+def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
+    """The MCP tools are a mounted sub-app whose ``request.app`` is the sub-app, not the
+    main AgentOS app. The tool gate resolves its AuthorizationProvider from that ``.app``,
+    so a role_store / custom provider must be mirrored onto the sub-app's state. Without
+    the mirror the gate silently falls back to the default ScopeAuthorizationProvider and a
+    scope-less (role-only) token is denied every tool -- managed RBAC degrades to scope-only
+    over MCP. This locks the mirror in.
+    """
+    import tempfile
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.config import AuthorizationConfig
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        roles = ManagedRoleStore(db=SqliteDb(db_file=f.name))
+        roles.set_role_scopes("admin", ["agent_os:admin"])
+        os = AgentOS(
+            id="mcp-authz",
+            agents=[_agent()],
+            authorization=True,
+            mcp_server=True,
+            authorization_config=AuthorizationConfig(
+                verification_keys=["x" * 40], algorithm="HS256", role_store=roles
+            ),
+        )
+        app = os.get_app()
+        main_provider = getattr(app.state, "authorization_provider", None)
+        assert main_provider is not None, "main app should carry the managed-role provider"
+        sub_provider = getattr(getattr(os._mcp_app, "state", None), "authorization_provider", None)
+        assert sub_provider is main_provider, "MCP sub-app must resolve the SAME provider as the main app"

--- a/libs/agno/tests/unit/os/test_mcp_server.py
+++ b/libs/agno/tests/unit/os/test_mcp_server.py
@@ -1209,3 +1209,49 @@ def test_managed_role_provider_is_mirrored_onto_mcp_subapp():
         assert main_provider is not None, "main app should carry the managed-role provider"
         sub_provider = getattr(getattr(os._mcp_app, "state", None), "authorization_provider", None)
         assert sub_provider is main_provider, "MCP sub-app must resolve the SAME provider as the main app"
+
+
+def test_authz_mirror_survives_a_rebuilt_mcp_subapp():
+    """The mirror lives next to the mount, so a REBUILT sub-app gets it re-applied.
+
+    Previously the mirror happened only at seed time, which was correct purely because
+    _mcp_app is built once and never replaced. If anything ever rebuilds it (or remounts
+    onto a fresh app), a seed-time-only mirror would leave the new sub-app with no
+    provider -- silently degrading managed-role RBAC to scope-only over MCP, the exact
+    bug this guards. Simulate the rebuild and assert the state is restored.
+    """
+    import tempfile
+
+    from agno.db.sqlite import SqliteDb
+    from agno.os.authz.audit import LoggingAuditSink
+    from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.config import AuthorizationConfig
+
+    with tempfile.NamedTemporaryFile(suffix=".db") as f:
+        roles = ManagedRoleStore(db=SqliteDb(db_file=f.name))
+        roles.set_role_scopes("admin", ["agent_os:admin"])
+        sink = LoggingAuditSink()
+        os = AgentOS(
+            id="mcp-mirror",
+            agents=[_agent()],
+            authorization=True,
+            mcp_server=True,
+            authorization_config=AuthorizationConfig(
+                verification_keys=["x" * 40], algorithm="HS256", role_store=roles, audit=sink
+            ),
+        )
+        app = os.get_app()
+        provider = app.state.authorization_provider
+        assert os._mcp_app.state.authorization_provider is provider
+        assert os._mcp_app.state.authz_audit is sink
+
+        # Simulate a rebuilt sub-app by clearing the state a fresh one would not have.
+        sub = os._mcp_app
+        for attr in ("authorization_provider", "authz_audit"):
+            delattr(sub.state, attr)
+        assert not hasattr(sub.state, "authorization_provider")
+
+        # Re-mounting must restore both, rather than leaving the gate scope-only.
+        os._mount_mcp_app(app)
+        assert sub.state.authorization_provider is provider
+        assert sub.state.authz_audit is sink


### PR DESCRIPTION
## Summary

Re-inserts the pluggable **`AuthorizationProvider`** seam onto v2.7.2 so managed roles (and, later, ReBAC/ABAC/OpenFGA) enforce at the same points AgentOS currently gates scopes — with the **default path byte-identical to today**.

v2.7's `AuthMiddleware` is scope-only end to end. This wires our authorization model back in so a deployment can define roles, assign users, and change them at runtime, and have that enforced on **every request and every tool call** — REST, WebSockets, and MCP (including OAuth-authenticated `/mcp` from #8793). OAuth/JWT proves *who* the caller is; the role store decides *what* they can do. No hand-configuring an IdP to emit agno-format scopes per user.

Supersedes the pre-v2.7 stack (#8318 / #8322 / #8419); this is the foundation, rebased onto current main.

## What's in it

- **Model** (`os/authz/**`) added unchanged — main never touches that dir. `AuthorizationConfig` gains `authorization_provider` / `role_store` / `audit` + an xor validator.
- **Default parity:** `ScopeAuthorizationProvider` delegates to main's own `has_required_scopes` / `get_accessible_resource_ids`, so with no provider configured behaviour is identical to v2.7.
- **Four choke points** now resolve through the provider:
  - `AuthMiddleware._check_scopes` (REST route gate) — reproduces `check_route_scopes`'s structure incl. the GET-listing filtered-access hatch.
  - `auth.check_resource_access` / `get_accessible_resources` / `filter_resources_by_access` (per-resource).
  - the 3 WebSocket workflow gates (start / reconnect / continue).
  - `mcp._require_tool_scopes` (MCP tool gate) — resource id preserved from the synthetic REST path; integrates with #8793 (the provider decides on OAuth-authenticated `/mcp` callers, and #8793's fail-closed bridge + external-AS misconfig warning are kept).
- `app.state.authorization_provider` seeded from `AuthorizationConfig` (role_store.provider, else provider, else default); `role_store` binds the OS DB or fails loud.
- **Carry-forward:** `is_internal_service` set after the constant-time token match in both internal-token branches and honoured by `check_resource_access`, so scheduler runs aren't 403'd under a provider-backed gate. Decision-audit sink wired at the gate.

## The payoff (tested)

`AuthorizationConfig(role_store=<store with a "viewer" role = agents:*:read>)`, an **empty-scopes JWT** for a user assigned `viewer` → `GET /agents/{id}` `200`, `POST /agents/{id}/runs` `403`. Assign a role instead of crafting token scopes.

## Validation

On current v2.7.2 main:
- Managed-roles / native-engine suite + the managed-roles-on-main e2e — **35 pass**
- Full **MCP-OAuth suite (#8793) — 106 pass** (proving the seam and OAuth coexist)
- v2.7 core (scopes / jwt middleware / service accounts / MCP surface v2) — **221 pass**
- ruff + mypy clean; default (no-provider) path byte-identical.

## Scope / follow-ups

- This is the **foundation** (managed-roles model + the seam). The user-directory / multi-plane composite / FGA layers (from #8322 / #8419) stack on the same seam next.
- JWT hardening (issuer pinning, `require_expiration`, HS-with-public-key refusal, audience fail-closed) is a small follow-up.

## Type of change
- [x] New feature (non-breaking; opt-in)
