### PR TITLE
feat(authz): /authz admin API + multi-plane composite (part 2, stacked on #8856)

### DIFF
--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -172,6 +172,7 @@ users, or plug in your own policy -- use these. Each one is runnable
 | `managed_roles_audit.py` | The **audit trail**: a change trail (who changed which role) plus a decision trail (every allow/deny). |
 | `custom_authorization_provider.py` | Write your **own** `AuthorizationProvider` (here: pricing tiers) and plug it into the same enforcement points. |
 | `idp_workos_auth0.py` | Map **roles from your IdP** (WorkOS/Auth0/Okta) claims onto AgentOS permissions, verified against a JWKS. |
+| `manage_users_and_roles.py` | Serves the **`/authz` admin API** so a frontend can create roles, add users, and disable people live -- running the token-scope plane and the managed-role plane **at the same time**. Ships with `console.html`, a zero-setup test client: run the server, then open the file in a browser and paste the printed admin token. |
 
 ## Quick Start
 

--- a/cookbook/05_agent_os/rbac/console.html
+++ b/cookbook/05_agent_os/rbac/console.html
@@ -1,0 +1,708 @@
+<!doctype html>
+<!--
+  agno /authz console — a single-file test client for the /authz management API.
+
+  Use it against the cookbook server:
+    1. python manage_users_and_roles.py        (prints a dev admin bearer token)
+    2. open this file in your browser          (double-click / open console.html)
+    3. paste the printed token, hit "let's go"
+
+  No build, no dependencies, nothing to install. Works from file:// — the
+  cookbook server's CORS allows it. Everything it does is plain fetch() against
+  the endpoints, so it doubles as living documentation of the API:
+
+    GET/POST/PATCH/DELETE /authz/users        directory (search, sort, paginate)
+    POST   /authz/users/{id}/roles            set THE role (one per user, replaces)
+    GET    /authz/roles + /roles/{slug}/scopes role + permission management
+    GET    /authz/scopes                       the permission catalog
+    GET    /authz/audit, /authz/decisions      the two trails (search, sort, paginate)
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>agno · /authz console</title>
+<style>
+  /* agno design tokens (from agno-os globals.css) */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    --bg: 255, 255, 255;
+    --bg2: 244, 244, 245;
+    --fg: 24, 24, 27;
+    --muted: 113, 113, 122;
+    --border: rgba(24, 24, 27, .1);
+    --brand: 255, 64, 23;          /* agno orange */
+    --brand-accent: 235, 110, 82;
+    --purple: 120, 47, 153;
+    --green: 70, 173, 140;
+    --cyan: 33, 206, 246;
+    --positive: 34, 197, 94;
+    --destructive: 229, 57, 53;
+    --radius: 0.625rem;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: rgb(var(--bg)); color: rgb(var(--fg));
+         font: 14px/1.5 Inter, system-ui, sans-serif; }
+  .mono { font-family: 'DM Mono', ui-monospace, monospace; }
+  header { display: flex; gap: 10px; align-items: center; padding: 14px 18px;
+           border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+  .wordmark { font-weight: 800; font-size: 18px; letter-spacing: -.03em; }
+  .wordmark em { color: rgb(var(--brand)); font-style: normal; }
+  .tagline { color: rgb(var(--muted)); font-size: 12px; margin-right: 8px; }
+  input, select, button, textarea {
+    background: rgb(var(--bg)); color: rgb(var(--fg)); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 7px 10px; font: inherit; font-size: 13px; }
+  input, textarea { font-family: 'DM Mono', ui-monospace, monospace; }
+  input:focus, select:focus { outline: 2px solid rgba(var(--brand), .45); border-color: transparent; }
+  button { cursor: pointer; font-weight: 600; }
+  button:hover { border-color: rgb(var(--brand-accent)); color: rgb(var(--brand)); }
+  button.primary { background: rgb(var(--brand)); border-color: rgb(var(--brand)); color: #fff; }
+  button.primary:hover { background: rgb(var(--brand-accent)); color: #fff; }
+  button.danger:hover { border-color: rgb(var(--destructive)); color: rgb(var(--destructive)); }
+  #token { flex: 1; min-width: 240px; }
+  nav { display: flex; gap: 2px; padding: 10px 18px 0; border-bottom: 1px solid var(--border); }
+  nav button { border: none; background: none; color: rgb(var(--muted)); font-weight: 600;
+               padding: 8px 12px; border-radius: var(--radius) var(--radius) 0 0;
+               border-bottom: 2px solid transparent; }
+  nav button:hover { color: rgb(var(--fg)); }
+  nav button.active { color: rgb(var(--brand)); border-bottom-color: rgb(var(--brand)); }
+  main { padding: 16px 18px; max-width: 1200px; }
+  section { display: none; }
+  section.active { display: block; }
+  .bar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+  .bar .spacer { flex: 1; }
+  table { width: 100%; border-collapse: separate; border-spacing: 0; background: rgb(var(--bg));
+          border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--border);
+           vertical-align: top; }
+  th { background: rgb(var(--bg2)); color: rgb(var(--muted)); font-weight: 600; font-size: 12px;
+       cursor: pointer; user-select: none; white-space: nowrap; }
+  th.sorted { color: rgb(var(--brand)); }
+  tr:last-child td { border-bottom: none; }
+  td.id, td.dim-mono { font-family: 'DM Mono', ui-monospace, monospace; font-size: 13px; }
+  .chip { display: inline-block; padding: 1px 9px; border-radius: 999px; font-size: 12px;
+          font-weight: 500; border: 1px solid var(--border); margin: 1px 3px 1px 0;
+          white-space: nowrap; font-family: 'DM Mono', ui-monospace, monospace; }
+  .chip.allow { color: rgb(var(--green)); border-color: rgba(var(--green), .5); background: rgba(var(--green), .07); }
+  .chip.deny { color: rgb(var(--destructive)); border-color: rgba(var(--destructive), .45); background: rgba(var(--destructive), .06); }
+  .chip.active { color: rgb(var(--positive)); border-color: rgba(var(--positive), .5); background: rgba(var(--positive), .07); }
+  .chip.disabled { color: rgb(var(--destructive)); border-color: rgba(var(--destructive), .45); background: rgba(var(--destructive), .06); }
+  .chip.x { cursor: pointer; }
+  .chip.x:hover { border-color: rgb(var(--destructive)); color: rgb(var(--destructive)); text-decoration: line-through; }
+  .dim { color: rgb(var(--muted)); }
+  .pager { display: flex; gap: 8px; align-items: center; margin-top: 12px; color: rgb(var(--muted)); font-size: 13px; }
+  #status { margin-left: auto; max-width: 46%; overflow: hidden; text-overflow: ellipsis;
+            white-space: nowrap; font-family: 'DM Mono', ui-monospace, monospace; font-size: 12px;
+            color: rgb(var(--muted)); }
+  #status.ok { color: rgb(var(--positive)); } #status.bad { color: rgb(var(--destructive)); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 10px; }
+  .card { background: rgb(var(--bg)); border: 1px solid var(--border); border-radius: var(--radius);
+          padding: 12px; border-top: 3px solid rgb(var(--brand)); }
+  .card:nth-child(4n+2) { border-top-color: rgb(var(--purple)); }
+  .card:nth-child(4n+3) { border-top-color: rgb(var(--green)); }
+  .card:nth-child(4n+0) { border-top-color: rgb(var(--cyan)); }
+  .card h4 { margin: 0 0 8px; font-size: 13px; font-family: 'DM Mono', ui-monospace, monospace; }
+  details { background: rgb(var(--bg)); border: 1px solid var(--border); border-radius: var(--radius);
+            padding: 10px 14px; margin-bottom: 10px; }
+  summary { cursor: pointer; }
+  summary b { font-family: 'DM Mono', ui-monospace, monospace; color: rgb(var(--brand)); }
+  .hint { color: rgb(var(--muted)); font-size: 12.5px; margin: 4px 0 14px; }
+  .empty { color: rgb(var(--muted)); padding: 18px; text-align: center; }
+</style>
+</head>
+<body>
+
+<header>
+  <span class="wordmark"><em>agno</em> /authz console</span>
+  <span class="tagline">who can do what, with buttons</span>
+  <input id="base" class="mono" value="http://localhost:7777" size="20" title="AgentOS base URL" />
+  <input id="token" placeholder="paste the token the server printed at startup ✨" />
+  <button class="primary" onclick="connect()">let's go →</button>
+  <span id="status">not connected yet — run manage_users_and_roles.py first</span>
+</header>
+
+<nav>
+  <button data-tab="playground" class="active" onclick="show('playground')">🧪 Playground</button>
+  <button data-tab="heist" onclick="show('heist')">🏴 Heist</button>
+  <button data-tab="users" onclick="show('users')">👥 Users</button>
+  <button data-tab="roles" onclick="show('roles')">🎭 Roles</button>
+  <button data-tab="scopes" onclick="show('scopes')">🗺️ Scope catalog</button>
+  <button data-tab="audit" onclick="show('audit')">📜 Change audit</button>
+  <button data-tab="decisions" onclick="show('decisions')">🚦 Decisions</button>
+</nav>
+
+<main>
+  <section id="playground" class="active">
+    <div class="hint">Become somebody and rattle the gates. Your admin token mints
+      them a real end-user token (identity only, zero scopes) — everything they're
+      allowed to do comes from the role store. Change their role mid-session: the
+      token never changes, their powers do. That's the whole trick. 🪄</div>
+
+    <div class="bar" id="p-personas"></div>
+
+    <div id="p-stage" style="display:none">
+      <div class="bar">
+        <span id="p-banner"></span>
+        <select id="p-role" title="change their role (as admin) — their token stays the same"></select>
+        <span class="spacer"></span>
+        <span class="dim">now try:</span>
+        <button onclick="act('👀 look at the agent', 'GET', '/agents/research-agent')">👀 look at the agent</button>
+        <button onclick="act('📋 list the agents', 'GET', '/agents')">📋 list the agents</button>
+        <button onclick="act('🏃 run the agent', 'POST', '/agents/research-agent/runs', { message: 'hi!' })">🏃 run the agent</button>
+        <button onclick="act('🗑️ delete a session', 'DELETE', '/sessions/some-session')">🗑️ delete a session</button>
+        <button onclick="act('🕵️ peek at the OS config', 'GET', '/config')">🕵️ peek at the OS config</button>
+      </div>
+      <table id="p-log"></table>
+    </div>
+  </section>
+
+  <section id="heist">
+    <div class="hint">A heist played against the real authorization API. The game
+      only ever reads status codes — every door you open, you open by actually
+      managing roles and scopes. The other tabs aren't cheating; they're the toolbox.</div>
+    <div class="card" style="max-width:760px; border-top-color:rgb(var(--brand))">
+      <h4 id="h-title">🏴 THE VAULT HEIST</h4>
+      <div id="h-story" style="margin-bottom:10px"></div>
+      <div class="bar" id="h-actions"></div>
+    </div>
+    <table id="h-log" style="max-width:760px; margin-top:12px"></table>
+  </section>
+
+  <section id="users">
+    <div class="hint">One role per person — picking a new one swaps it out.
+      Disable someone and they're locked out on their very next request, valid token or not.</div>
+    <div class="bar">
+      <input id="u-search" placeholder="🔎 search id / email / name" size="26"
+             oninput="debounced(loadUsers)" />
+      <label><input type="checkbox" id="u-disabled" checked onchange="loadUsers()" /> show disabled folk</label>
+      <span class="spacer"></span>
+      <input id="u-new-id" placeholder="new user id (jwt sub)" size="16" />
+      <input id="u-new-email" placeholder="email" size="16" />
+      <button onclick="createUser()">+ add user</button>
+    </div>
+    <table id="u-table"></table>
+    <div class="pager" id="u-pager"></div>
+  </section>
+
+  <section id="roles">
+    <div class="hint">A role is a named bag of permissions. Deny beats allow.
+      Click a scope chip to take it away.</div>
+    <div class="bar">
+      <input id="r-new-slug" placeholder="new role slug" size="14" />
+      <input id="r-new-name" placeholder="display name" size="16" />
+      <button onclick="createRole()">+ create role</button>
+    </div>
+    <div id="r-list"></div>
+  </section>
+
+  <section id="scopes">
+    <div class="hint">Every permission this OS understands — generated from its own
+      route map, so it can't drift from what's actually enforced.</div>
+    <div class="grid" id="s-grid"></div>
+  </section>
+
+  <section id="audit">
+    <div class="hint">Who changed what, with before → after. The paper trail your
+      future self (and your auditor) will thank you for.</div>
+    <div class="bar">
+      <input id="a-search" placeholder="🔎 search actor / action / target" size="28"
+             oninput="debounced(loadAudit)" />
+    </div>
+    <table id="a-table"></table>
+    <div class="pager" id="a-pager"></div>
+  </section>
+
+  <section id="decisions">
+    <div class="hint">Every allow/deny at the gate, with the token reference (jti).
+      Green means in, red means computer says no.</div>
+    <div class="bar">
+      <input id="d-search" placeholder="🔎 search actor / action / METHOD /path" size="28"
+             oninput="debounced(loadDecisions)" />
+    </div>
+    <table id="d-table"></table>
+    <div class="pager" id="d-pager"></div>
+  </section>
+</main>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const esc = (s) => String(s ?? "").replace(/[&<>"]/g, (c) =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+
+// ---- state ------------------------------------------------------------
+const state = {
+  roles: [],                         // role slugs, for the per-user role <select>
+  users:     { page: 1, limit: 10, sort_by: "created_at", sort_order: "desc" },
+  audit:     { page: 1, limit: 10, sort_by: "created_at", sort_order: "desc" },
+  decisions: { page: 1, limit: 10, sort_by: "created_at", sort_order: "desc" },
+};
+
+// ---- transport ---------------------------------------------------------
+async function api(method, path, body) {
+  const url = $("base").value.replace(/\/$/, "") + path;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: "Bearer " + $("token").value.trim(),
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : null;
+  status(res.ok, `${res.ok ? "✓" : "✗"} ${method} ${path} → ${res.status}`);
+  if (!res.ok) throw new Error(`${res.status} ${data?.detail ?? text}`);
+  return data;
+}
+function status(ok, msg) {
+  const el = $("status");
+  el.textContent = msg;
+  el.className = ok ? "ok" : "bad";
+}
+let timer;
+function debounced(fn) { clearTimeout(timer); timer = setTimeout(fn, 300); }
+
+// ---- shared render helpers ----------------------------------------------
+function pager(el, meta, st, reload) {
+  el.innerHTML = "";
+  const info = document.createElement("span");
+  info.textContent = `page ${meta.page}/${Math.max(meta.total_pages, 1)} · ${meta.total_count} total · ${meta.search_time_ms}ms`;
+  const prev = document.createElement("button");
+  const next = document.createElement("button");
+  prev.textContent = "‹ prev"; next.textContent = "next ›";
+  prev.disabled = meta.page <= 1;
+  next.disabled = meta.page >= meta.total_pages;
+  prev.onclick = () => { st.page--; reload(); };
+  next.onclick = () => { st.page++; reload(); };
+  el.append(prev, next, info);
+}
+// Sortable header row: click toggles the field / flips the direction.
+function headerRow(cols, st) {
+  return "<tr>" + cols.map(([key, label]) => {
+    if (!key) return `<th>${label}</th>`;
+    const sorted = st.sort_by === key;
+    const arrow = sorted ? (st.sort_order === "asc" ? " ↑" : " ↓") : "";
+    return `<th class="${sorted ? "sorted" : ""}" data-sort="${key}">${label}${arrow}</th>`;
+  }).join("") + "</tr>";
+}
+function bindSort(table, st, reload) {
+  table.querySelectorAll("th[data-sort]").forEach((th) => th.onclick = () => {
+    const key = th.dataset.sort;
+    st.sort_order = st.sort_by === key && st.sort_order === "desc" ? "asc" : "desc";
+    st.sort_by = key;
+    st.page = 1;
+    reload();
+  });
+}
+function emptyRow(table, span, msg) {
+  const row = table.insertRow();
+  row.innerHTML = `<td class="empty" colspan="${span}">${msg}</td>`;
+}
+const ts = (t) => t ? new Date(t * 1000).toLocaleString() : "";
+const listParams = (st, search) => new URLSearchParams({
+  page: st.page, limit: st.limit, sort_by: st.sort_by, sort_order: st.sort_order,
+  ...(search ? { search } : {}),
+});
+
+// ---- the vault heist 🏴 ----------------------------------------------------
+// A heist played against the real authorization API. Nothing is faked: every
+// door is the live middleware gate, every fix is a real role/scope change you
+// make in the other tabs (or the inline shortcut buttons, same endpoints). You
+// play Arsène Lupin, breaking into "the vault" — and learn AgentOS RBAC by
+// exploiting it: get denied, grant scopes, discover deny-beats-allow, survive a
+// kill-switch, crack the vault.
+const heist = { phase: "start", token: null, who: "lupin", betrayed: false };
+
+async function loadHeist() { renderHeist(); }
+
+async function newHeist() {
+  // Stage the world through the same API everyone else uses: a thief with no
+  // role, and an "intern" role whose wildcard read carries an explicit vault DENY.
+  await api("POST", "/authz/users", { id: heist.who, name: "Arsène Lupin" }).catch(() => {});
+  await api("PATCH", `/authz/users/${heist.who}`, { disabled: false });
+  await api("POST", "/authz/roles", { slug: "intern", name: "Intern" }).catch(() => {});
+  await api("PUT", "/authz/roles/intern/scopes", { scopes: [
+    "agents:*:read",
+    { scope: "agents:vault-agent:run", effect: "deny" },
+  ]});
+  const cur = await api("GET", `/authz/users/${heist.who}/roles`);
+  if (cur.role) await api("DELETE", `/authz/users/${heist.who}/roles/${cur.role}`);  // start role-less
+  heist.token = (await api("POST", "/dev/mint", { sub: heist.who })).token;
+  heist.phase = "nobody"; heist.betrayed = false;
+  $("h-log").innerHTML = "";
+  hlog("🌃", "midnight. you're <b>lupin</b>, token in hand, not a single permission to your name.");
+  renderHeist();
+}
+
+// Knock on a real door as lupin; the gate's verdict drives the story.
+async function door(label, method, path) {
+  const res = await fetch($("base").value.replace(/\/$/, "") + path, {
+    method, headers: { Authorization: "Bearer " + heist.token },
+    body: method === "POST" ? (() => { const f = new FormData(); f.append("message", "open up"); return f; })() : undefined,
+  });
+  const body = await res.json().catch(() => null);
+  const denied = res.status === 401 || res.status === 403;
+  hlog("🚪", `${label} → ` + (denied
+    ? `<span class="chip deny">✗ ${res.status}</span> <span class="dim">${esc(body?.detail ?? "")}</span>`
+    : `<span class="chip allow">✓ ${res.status}</span>`));
+  await advance(label, denied, body);
+}
+
+// The phase machine: react to (phase, allowed/denied, what the gate said).
+async function advance(label, denied, body) {
+  const p = heist.phase;
+  const disabledHit = denied && /disabled/i.test(JSON.stringify(body ?? ""));
+  if (p === "nobody" && !denied) {
+    heist.phase = "lookout";
+    hlog("🎉", "you're in the lobby — reads work now. but the research agent won't <i>run</i> for a lowly intern…");
+  } else if (p === "lookout" && !denied) {
+    heist.phase = "vault";
+    hlog("🎉", "warmed up. now the real prize: <b>the vault</b>. it has opinions about you.");
+  } else if (p === "vault" && denied && !disabledHit && !heist.betrayed) {
+    hlog("🧱", "denied — and piling on <span class='mono'>allow</span> won't help. there's an explicit <b>deny</b> on the vault, and a deny <b>always</b> beats an allow. tear it off the <b class='mono'>intern</b> role.");
+  } else if (p === "vault" && !denied && !heist.betrayed) {
+    heist.betrayed = true;
+    await api("PATCH", `/authz/users/${heist.who}`, { disabled: true });
+    heist.phase = "betrayed";
+    hlog("🐀", "you're through… but a rat tipped security — they hit the <b>kill-switch</b> on your badge. your token is still perfectly valid, and perfectly useless. try the door.");
+  } else if (p === "betrayed" && disabledHit) {
+    hlog("🚫", "cold. valid token, zero access — that's revocation the moment it matters. talk your way back in: re-enable <b class='mono'>lupin</b> (👥 Users tab, or the button).");
+  } else if (p === "betrayed" && !denied) {
+    win(body);
+  }
+  renderHeist();
+}
+
+// ---- inline shortcuts (the same calls the other tabs make) ------------------
+async function hireIntern() {
+  await api("POST", `/authz/users/${heist.who}/roles`, { role: "intern" });
+  hlog("🪪", "lupin is now an <b>intern</b>. go on, knock."); renderHeist();
+}
+async function grantRun() {
+  await api("PATCH", "/authz/roles/intern/scopes", { upsert: [{ scope: "agents:*:run" }] });
+  hlog("🎁", "granted <span class='mono'>agents:*:run</span> to intern — same token, new reach."); renderHeist();
+}
+async function dropVaultDeny() {
+  await api("PATCH", "/authz/roles/intern/scopes", { remove: ["agents:vault-agent:run"] });
+  hlog("✂️", "the vault deny is gone. allow finally wins."); renderHeist();
+}
+async function reenableLupin() {
+  await api("PATCH", `/authz/users/${heist.who}`, { disabled: false });
+  hlog("🤝", "badge re-activated — same token the whole time."); renderHeist();
+}
+
+// ---- render -----------------------------------------------------------------
+const HEIST_TITLES = {
+  start: "🏴 THE VAULT HEIST",
+  nobody: "Act I · you're nobody",
+  lookout: "Act II · the lookout",
+  vault: "Act III · the vault (deny beats allow)",
+  betrayed: "Act IV · the betrayal",
+};
+const HEIST_SCRIPT = {
+  start: [`A vault. A flag. A thief with zero permissions. Everything here is a
+    <b>real</b> request — you win by actually administering RBAC. Ready, Lupin?`,
+    [["🥷 start the heist", newHeist]]],
+  nobody: [`Every request 403s — you hold no role. Get yourself hired: give
+    <b class='mono'>lupin</b> the <b class='mono'>intern</b> role (👥 Users tab,
+    the 🧪 Playground select, or the button), then case the joint.`,
+    [["🪪 hire me as an intern", hireIntern],
+     ["👀 case the research agent", () => door("case the research agent", "GET", "/agents/research-agent")]]],
+  lookout: [`Interns <i>read</i> everything but <i>run</i> nothing. Find the scope
+    that lets the crew run agents (peek at 🗺️ Scope catalog) and add it to
+    <b class='mono'>intern</b>, then warm up.`,
+    [["💪 grant intern → agents:*:run", grantRun],
+     ["🏃 warm up (run research agent)", () => door("warm up on research agent", "POST", "/agents/research-agent/runs")]]],
+  vault: [`The big one. You can run anything now, so this should be easy — it
+    isn't. The vault was born with an explicit <b>deny</b>, and a deny always
+    beats an allow. Crack it, watch it refuse, then strip the deny off the
+    <b class='mono'>intern</b> role (🎭 Roles tab or the button).`,
+    [["🏦 crack the vault", () => door("crack the vault", "POST", "/agents/vault-agent/runs")],
+     ["✂️ remove the vault deny", dropVaultDeny]]],
+  betrayed: [`A rat tipped security — your badge is <b>disabled</b>. Token still
+    valid, still useless: revocation exactly when it matters. Knock to feel it,
+    then re-enable <b class='mono'>lupin</b> and make the final grab.`,
+    [["🏦 try the vault", () => door("try the vault", "POST", "/agents/vault-agent/runs")],
+     ["🤝 re-enable lupin", reenableLupin]]],
+};
+
+function hlog(icon, msg) {
+  const row = $("h-log").insertRow(0);
+  row.innerHTML = `<td class="dim" style="white-space:nowrap">${new Date().toLocaleTimeString()}</td><td>${icon} ${msg}</td>`;
+}
+function renderHeist() {
+  if (heist.phase === "won") return;  // win() owns the screen
+  const [story, buttons] = HEIST_SCRIPT[heist.phase] || HEIST_SCRIPT.start;
+  $("h-title").textContent = HEIST_TITLES[heist.phase] ?? HEIST_TITLES.start;
+  $("h-story").innerHTML = story;
+  $("h-actions").innerHTML = "";
+  for (const [label, fn] of buttons) {
+    const b = document.createElement("button");
+    b.textContent = label;
+    if (/start|crack|vault/.test(label)) b.className = "primary";
+    b.onclick = () => fn().catch((e) => hlog("⚠️", esc(e.message)));
+    $("h-actions").append(b);
+  }
+  if (heist.phase !== "start") {
+    const sp = document.createElement("span"); sp.className = "spacer";
+    const r = document.createElement("button"); r.className = "danger"; r.textContent = "↻ start over"; r.onclick = newHeist;
+    $("h-actions").append(sp, r);
+  }
+}
+function win(body) {
+  heist.phase = "won";
+  const flag = JSON.stringify(body ?? "").match(/FLAG\{[^}]+\}/)?.[0] ?? "FLAG{deny_overrides_allow}";
+  $("h-title").textContent = "🎉 HEIST COMPLETE";
+  $("h-story").innerHTML = `<div style="font-size:18px;margin:8px 0">🏴‍☠️ the vault is open, Lupin.</div>
+    <div class="chip allow mono" style="font-size:15px;padding:6px 14px">${esc(flag)}</div>
+    <p class="dim" style="margin-top:12px">every move you made is in the <b>🚦 Decisions</b>
+    trail — each allow and deny, timestamped, tied to your token's jti. you broke in purely
+    by administering roles and scopes. that's the whole product, wearing a striped jumper. 🎩</p>`;
+  $("h-actions").innerHTML = "";
+  const ev = document.createElement("button"); ev.className = "primary"; ev.textContent = "🚦 read the evidence"; ev.onclick = () => show("decisions");
+  const again = document.createElement("button"); again.className = "danger"; again.textContent = "↻ heist again"; again.onclick = newHeist;
+  $("h-actions").append(ev, again);
+  confetti();
+}
+function confetti() {
+  const c = ["#ff4017", "#782f99", "#46ad8c", "#21cef6", "#22c55e"];
+  for (let i = 0; i < 80; i++) {
+    const d = document.createElement("div");
+    d.style.cssText = `position:fixed;top:-10px;left:${Math.random() * 100}vw;width:9px;height:9px;`
+      + `background:${c[i % c.length]};border-radius:2px;pointer-events:none;z-index:9999;`
+      + `transform:rotate(${Math.random() * 360}deg);transition:all ${1.5 + Math.random()}s ease-in;`;
+    document.body.append(d);
+    requestAnimationFrame(() => {
+      d.style.top = "105vh";
+      d.style.left = parseFloat(d.style.left) + (Math.random() * 30 - 15) + "vw";
+      d.style.opacity = "0";
+    });
+    setTimeout(() => d.remove(), 3000);
+  }
+}
+
+// ---- playground: act as an end user ---------------------------------------
+async function loadPlayground() {
+  const { data } = await api("GET", "/authz/users?limit=100");
+  $("p-personas").innerHTML = "<span class='dim'>become:</span>" + data.map((u) => `
+    <button data-sub="${esc(u.id)}" ${state.persona?.id === u.id ? "class='primary'" : ""}>
+      ${u.disabled ? "🚫" : "🧑"} ${esc(u.id)} <span class="dim">· ${esc(u.role ?? "no role")}</span>
+    </button>`).join("");
+  $("p-personas").querySelectorAll("button").forEach((b) => b.onclick = () =>
+    become(data.find((u) => u.id === b.dataset.sub)));
+}
+async function become(user) {
+  // The admin token buys a persona token: same signing key, sub = the user,
+  // NO scopes — so everything they can do comes from the role store.
+  const minted = await api("POST", "/dev/mint", { sub: user.id }).catch((e) => {
+    status(false, "✗ /dev/mint missing — playground needs the server in dev mode");
+    throw e;
+  });
+  state.persona = { id: user.id, token: minted.token };
+  $("p-stage").style.display = "block";
+  $("p-banner").innerHTML = `you are now <b class="mono" style="color:rgb(var(--brand))">${esc(user.id)}</b> 🎫`;
+  $("p-role").innerHTML = ["<option value=''>— no role —</option>",
+    ...state.roles.map((r) => `<option ${r === user.role ? "selected" : ""}>${esc(r)}</option>`)].join("");
+  $("p-role").onchange = async (e) => {
+    if (e.target.value) await api("POST", `/authz/users/${user.id}/roles`, { role: e.target.value });
+    else if (user.role) await api("DELETE", `/authz/users/${user.id}/roles/${user.role}`);
+    user.role = e.target.value || null;
+    plog("🎭", `${user.id} is now ${user.role ?? "role-less"} — same token, new powers`, "", "");
+    loadPlayground();
+  };
+  plog("🎫", `minted a token for ${user.id} — go rattle some gates`, "", "");
+  loadPlayground();
+}
+async function act(label, method, path, body) {
+  if (!state.persona) return;
+  const isForm = method === "POST" && path.includes("/runs");
+  let payload, headers = { Authorization: "Bearer " + state.persona.token };
+  if (body && isForm) { payload = new FormData(); Object.entries(body).forEach(([k, v]) => payload.append(k, v)); }
+  else if (body) { payload = JSON.stringify(body); headers["Content-Type"] = "application/json"; }
+  const res = await fetch($("base").value.replace(/\/$/, "") + path, { method, headers, body: payload });
+  const detail = await res.json().then((d) => d?.detail ?? "").catch(() => "");
+  const denied = res.status === 401 || res.status === 403;
+  const verdict = denied
+    ? `<span class="chip deny">✗ ${res.status} nope</span>`
+    : `<span class="chip allow">✓ ${res.status} the gate said yes</span>`;
+  const note = denied ? detail
+    : res.ok ? "" : `${esc(detail)} (not RBAC's problem — the gate let them through 🤷)`;
+  plog(state.persona.id, `${label} <span class="dim mono">${method} ${path}</span>`, verdict, note);
+  status(!denied, `${denied ? "✗" : "✓"} [as ${state.persona.id}] ${method} ${path} → ${res.status}`);
+}
+function plog(who, what, verdict, note) {
+  const row = $("p-log").insertRow(0);
+  row.innerHTML = `<td class="dim">${new Date().toLocaleTimeString()}</td>
+    <td class="id">${esc(who)}</td><td>${what}</td><td>${verdict}</td>
+    <td class="dim">${typeof note === "string" ? note : esc(JSON.stringify(note))}</td>`;
+}
+
+// ---- users ---------------------------------------------------------------
+async function loadUsers() {
+  const st = state.users;
+  const params = listParams(st, $("u-search").value.trim());
+  params.set("include_disabled", $("u-disabled").checked);
+  const { data, meta } = await api("GET", "/authz/users?" + params);
+  const table = $("u-table");
+  table.innerHTML = headerRow(
+    [["id", "id"], ["email", "email"], ["name", "name"], [null, "role"],
+     [null, "status"], ["created_at", "created"], [null, ""]], st);
+  if (!data.length) emptyRow(table, 7, "nobody here — add a user above 👆");
+  for (const u of data) {
+    const row = table.insertRow();
+    const options = ["<option value=''>— no role —</option>",
+      ...state.roles.map((r) =>
+        `<option ${r === u.role ? "selected" : ""}>${esc(r)}</option>`)].join("");
+    row.innerHTML = `
+      <td class="id">${esc(u.id)}</td><td class="dim dim-mono">${esc(u.email ?? "")}</td>
+      <td class="dim">${esc(u.name ?? "")}</td>
+      <td><select data-id="${esc(u.id)}">${options}</select></td>
+      <td><span class="chip ${u.status}">${u.status}</span></td>
+      <td class="dim">${ts(u.created_at)}</td>
+      <td>
+        <button data-act="toggle">${u.disabled ? "✓ let back in" : "✋ disable"}</button>
+        <button data-act="delete" class="danger">delete</button>
+      </td>`;
+    row.querySelector("select").onchange = (e) => setRole(u, e.target);
+    row.querySelector("[data-act=toggle]").onclick = () =>
+      api("PATCH", `/authz/users/${u.id}`, { disabled: !u.disabled }).then(loadUsers);
+    row.querySelector("[data-act=delete]").onclick = () =>
+      confirm(`really delete ${u.id}? (their role assignment stays in the store)`) &&
+      api("DELETE", `/authz/users/${u.id}`).then(loadUsers);
+  }
+  bindSort(table, st, loadUsers);
+  pager($("u-pager"), meta, st, loadUsers);
+}
+async function setRole(user, select) {
+  if (select.value) await api("POST", `/authz/users/${user.id}/roles`, { role: select.value });
+  else if (user.role) await api("DELETE", `/authz/users/${user.id}/roles/${user.role}`);
+  loadUsers();
+}
+async function createUser() {
+  const id = $("u-new-id").value.trim();
+  if (!id) return;
+  await api("POST", "/authz/users", { id, email: $("u-new-email").value.trim() || null });
+  $("u-new-id").value = $("u-new-email").value = "";
+  loadUsers();
+}
+
+// ---- roles ----------------------------------------------------------------
+async function loadRoles() {
+  const { data } = await api("GET", "/authz/roles?limit=100");
+  state.roles = data.map((r) => r.slug);
+  const catalog = await api("GET", "/authz/scopes");
+  const datalist = catalog.map((s) => `<option value="${esc(s.raw)}">`).join("");
+  $("r-list").innerHTML = data.map((role) => `
+    <details open>
+      <summary><b>${esc(role.slug)}</b>
+        <span class="dim">${esc(role.name)}${role.description ? " — " + esc(role.description) : ""}</span>
+        <button class="danger" style="float:right" data-del="${esc(role.slug)}">delete role</button>
+      </summary>
+      <div style="margin-top:10px">
+        ${role.scopes.map((s) =>
+          `<span class="chip x ${s.value}" title="click to remove"
+                 data-role="${esc(role.slug)}" data-scope="${esc(s.raw)}">${esc(s.raw)} · ${s.value}</span>`
+        ).join("") || '<span class="dim">no scopes yet — this role can\'t do a thing 🙈</span>'}
+      </div>
+      <div class="bar" style="margin-top:10px">
+        <input list="scope-catalog" placeholder="agents:*:run" size="24" data-add-scope="${esc(role.slug)}" />
+        <select data-add-effect="${esc(role.slug)}"><option>allow</option><option>deny</option></select>
+        <button data-add-btn="${esc(role.slug)}">+ add scope</button>
+      </div>
+    </details>`).join("") + `<datalist id="scope-catalog">${datalist}</datalist>`;
+
+  $("r-list").querySelectorAll(".chip.x").forEach((chip) => chip.onclick = () =>
+    api("PATCH", `/authz/roles/${chip.dataset.role}/scopes`,
+        { remove: [chip.dataset.scope] }).then(loadRoles));
+  $("r-list").querySelectorAll("[data-add-btn]").forEach((btn) => btn.onclick = () => {
+    const slug = btn.dataset.addBtn;
+    const scope = document.querySelector(`[data-add-scope="${slug}"]`).value.trim();
+    const effect = document.querySelector(`[data-add-effect="${slug}"]`).value;
+    if (scope) api("PATCH", `/authz/roles/${slug}/scopes`,
+                   { upsert: [{ scope, effect }] }).then(loadRoles);
+  });
+  $("r-list").querySelectorAll("[data-del]").forEach((btn) => btn.onclick = () =>
+    confirm(`delete role ${btn.dataset.del}? anyone holding it loses it`) &&
+    api("DELETE", `/authz/roles/${btn.dataset.del}`).then(loadRoles));
+}
+async function createRole() {
+  const slug = $("r-new-slug").value.trim();
+  if (!slug) return;
+  await api("POST", "/authz/roles", { slug, name: $("r-new-name").value.trim() || null });
+  $("r-new-slug").value = $("r-new-name").value = "";
+  loadRoles();
+}
+
+// ---- scope catalog -----------------------------------------------------------
+async function loadScopes() {
+  const catalog = await api("GET", "/authz/scopes");
+  const byNs = {};
+  for (const s of catalog) (byNs[s.namespace] ??= []).push(s);
+  $("s-grid").innerHTML = Object.entries(byNs).map(([ns, scopes]) => `
+    <div class="card"><h4>${esc(ns)}</h4>
+      ${scopes.map((s) => `<span class="chip">${esc(s.raw)}</span>`).join("")}
+    </div>`).join("");
+}
+
+// ---- trails -------------------------------------------------------------------
+async function loadAudit() {
+  const st = state.audit;
+  const { data, meta } = await api("GET",
+    "/authz/audit?" + listParams(st, $("a-search").value.trim()));
+  const table = $("a-table");
+  table.innerHTML = headerRow(
+    [["created_at", "when"], ["actor", "actor"], ["action", "action"], ["target", "target"], [null, "before → after"]], st);
+  if (!data.length) emptyRow(table, 5, "nothing yet — change something and it'll show up here ✍️");
+  for (const e of data) {
+    table.insertRow().innerHTML = `
+      <td class="dim">${ts(e.created_at)}</td><td class="id">${esc(e.actor ?? "system")}</td>
+      <td><span class="chip">${esc(e.action)}</span></td><td class="id">${esc(e.target)}</td>
+      <td class="dim dim-mono">${esc(JSON.stringify(e.before))} → ${esc(JSON.stringify(e.after))}</td>`;
+  }
+  bindSort(table, st, loadAudit);
+  pager($("a-pager"), meta, st, loadAudit);
+}
+async function loadDecisions() {
+  const st = state.decisions;
+  const { data, meta } = await api("GET",
+    "/authz/decisions?" + listParams(st, $("d-search").value.trim()));
+  const table = $("d-table");
+  table.innerHTML = headerRow(
+    [["created_at", "when"], ["actor", "actor"], ["action", "decision"], ["target", "request"], [null, "required"], [null, "token"]], st);
+  if (!data.length) emptyRow(table, 6, "no decisions recorded — make a request to the OS first 🚪");
+  for (const e of data) {
+    const allowed = e.action === "access.allowed";
+    table.insertRow().innerHTML = `
+      <td class="dim">${ts(e.created_at)}</td><td class="id">${esc(e.actor ?? "")}</td>
+      <td><span class="chip ${allowed ? "allow" : "deny"}">${allowed ? "✓ in" : "✗ nope"}</span></td>
+      <td class="id">${esc(e.target)}</td>
+      <td class="dim dim-mono">${esc((e.metadata?.required ?? []).join(", "))}</td>
+      <td class="dim dim-mono">${esc(e.metadata?.token ?? "")}</td>`;
+  }
+  bindSort(table, st, loadDecisions);
+  pager($("d-pager"), meta, st, loadDecisions);
+}
+
+// ---- shell -------------------------------------------------------------------
+const loaders = { playground: loadPlayground, heist: loadHeist, users: loadUsers,
+                  roles: loadRoles, scopes: loadScopes, audit: loadAudit, decisions: loadDecisions };
+function show(tab) {
+  document.querySelectorAll("section").forEach((s) => s.classList.toggle("active", s.id === tab));
+  document.querySelectorAll("nav button").forEach((b) => b.classList.toggle("active", b.dataset.tab === tab));
+  loaders[tab]().catch(() => {});
+}
+async function connect() {
+  localStorage.setItem("authz-console", JSON.stringify({ base: $("base").value, token: $("token").value }));
+  await loadRoles();  // roles first: feeds the user-row selects
+  show(document.querySelector("nav button.active").dataset.tab);
+}
+// restore last session
+try {
+  const saved = JSON.parse(localStorage.getItem("authz-console") ?? "{}");
+  if (saved.base) $("base").value = saved.base;
+  if (saved.token) { $("token").value = saved.token; connect(); }
+} catch { /* fresh start */ }
+</script>
+</body>
+</html>

--- a/cookbook/05_agent_os/rbac/manage_users_and_roles.py
+++ b/cookbook/05_agent_os/rbac/manage_users_and_roles.py
@@ -1,0 +1,250 @@
+"""
+Run an AgentOS that serves the user + role management API (for a frontend)
+
+(New to this? Read managed_roles.py first, then managed_users.py.)
+
+This is the "admin backend": it starts a real AgentOS server and leaves it
+running, exposing the /authz management API so a frontend (or your own admin UI)
+can create roles, add users, assign roles, and disable people - live. It works
+both with a control plane / login service (operators authorized by their token
+scopes) and on its own (end users managed in the OS-local store) - both at once.
+
+What it serves (all admin-only):
+    GET    /authz/roles                 list roles
+    POST   /authz/roles                 create a role (PUT/PATCH .../{slug}/scopes for permissions)
+    GET    /authz/scopes                the permission catalog (for a UI grid)
+    GET    /authz/users                 list users (one role each; search/sort/paginate)
+    POST   /authz/users                 add a user
+    POST   /authz/users/{id}/roles      set a user's role (replaces)
+    PATCH  /authz/users/{id}            update; {"disabled": true} revokes on next request
+    GET    /authz/audit                 the change trail (search/sort/paginate)
+    GET    /authz/decisions             the access trail (search/sort/paginate)
+
+It seeds a couple of roles and users so the frontend has something to show, and
+makes ONE bootstrap admin (so someone can call the admin API).
+
+Run it:
+    pip install "agno[roles]"
+    python manage_users_and_roles.py
+Then point your frontend at http://localhost:7777 (CORS is open to the usual dev
+ports). The server keeps running until you Ctrl-C.
+
+Two authz planes run in parallel here, by default - we pass a LIST of providers
+(``authorization_provider=[ScopeAuthorizationProvider(), roles.provider]``) and a
+request is allowed if either grants:
+  - control plane / operators: a token that already carries scopes (e.g. an
+    agno-cloud / frontend token) is authorized straight from those scopes.
+  - managed store / end users: everyone else is authorized against the OS-local
+    role store you manage at runtime.
+So a scope-bearing frontend token can connect and operate, while the store still
+governs your managed users.
+
+Verifying tokens - pick whichever fits; auto-selected by env, no code change:
+  - Dev (default): a built-in HS256 secret. On startup it prints a ready-made
+    admin bearer token you can paste into the frontend / curl to try the API.
+  - Control plane / IdP: set ONE of
+        JWT_JWKS_FILE         path to a JWKS downloaded from your IdP (RS256)
+        JWT_VERIFICATION_KEY  your OS public key (RS256) or an HS256 secret
+    plus OS_ID (the token audience / your os_id) and, optionally,
+        JWT_ISSUER           pin the issuer, e.g. "agent-os-api"
+
+To MANAGE roles/users over /authz you must be an admin. That comes from either an
+``agent_os:admin`` scope on the token, OR being seeded in the store - so set
+ADMIN_SUBJECT to the `sub` of your token (decode it: the `sub` claim). e.g.
+    OS_ID="<your-os-id>" JWT_VERIFICATION_KEY="<os public key>" \\
+    ADMIN_SUBJECT="you@company.com" python manage_users_and_roles.py
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import jwt
+from fastapi import HTTPException, Request
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.os.authz.audit import DbAuditSink
+from agno.os.authz.role_router import get_roles_router
+from agno.os.authz.role_store import ManagedRoleStore
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+from agno.os.authz.user_store import ManagedUserStore
+from agno.os.config import AuthorizationConfig
+
+# --- config: supports BOTH planes by default ---------------------------------
+# Plane 1 - control plane / operators: tokens minted by the agno control plane
+#   (or any IdP) are verified against the OS's public key or a JWKS URL; their
+#   scopes authorize them (the ScopeAuthorizationProvider below).
+# Plane 2 - managed store / end users: roles you manage at runtime in the store.
+# Both are wired by default; you just point verification at your control plane.
+OS_ID = os.getenv("OS_ID", "manage-users-os")  # the token audience (your os_id)
+ADMIN_SUBJECT = os.getenv("ADMIN_SUBJECT", "admin")  # whose `sub` is the bootstrap admin
+ISSUER = os.getenv("JWT_ISSUER") or None  # optionally pin the issuer (e.g. agent-os-api)
+
+# Verification source, in priority order:
+#   1. JWT_JWKS_FILE         - path to a JWKS downloaded from your control plane / IdP (RS256)
+#   2. JWT_VERIFICATION_KEY  - the OS public key (RS256) or an HS256 secret
+#   3. dev fallback          - a built-in HS256 secret (prints an admin token)
+JWKS_FILE = os.getenv("JWT_JWKS_FILE") or None
+VERIFICATION_KEY = (os.getenv("JWT_VERIFICATION_KEY") or "").replace("\\n", "\n") or None
+DEV_SECRET = "your-secret-key-at-least-256-bits-long"
+
+
+def mint_dev_token(sub: str, expires_in: int) -> str:
+    """Mint an HS256 token this AgentOS accepts (dev only).
+
+    Stamps exactly the claims the middleware verifies: `sub` (the principal the role
+    store keys off), `aud` (must match OS_ID when verify_audience is on), plus
+    iat/exp/jti. Control-plane RS256 tokens are minted by the control plane, not here.
+    """
+    now = datetime.now(UTC)
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "iat": now, "exp": now + timedelta(seconds=expires_in), "jti": uuid4().hex},
+        DEV_SECRET,
+        algorithm="HS256",
+    )
+
+
+if JWKS_FILE:
+    ALGORITHM, KEYS = "RS256", None
+elif VERIFICATION_KEY:
+    ALGORITHM, KEYS = ("RS256" if "BEGIN" in VERIFICATION_KEY else "HS256"), [VERIFICATION_KEY]
+else:
+    ALGORITHM, KEYS = "HS256", [DEV_SECRET]
+
+# Frontends run in the browser, so the server must allow their origin. "null" is
+# the Origin a page opened from disk (file://) sends — it lets the bundled
+# console.html test client work with a double-click, no web server needed.
+CORS_ORIGINS = [
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+    "http://localhost:5173",
+    "null",
+]
+
+os.makedirs("tmp", exist_ok=True)
+
+# ONE database for everything. Pass the same `db` to AgentOS and to each store
+# (db=) and they reuse its connection - agent data, roles, users, and the audit
+# trail all live in the same database, no second db_url to keep in sync. (Each
+# store still uses its own tables: authz_policy, authz_grouping, authz_users, authz_audit, ...)
+db = SqliteDb(db_file="tmp/console.db")
+audit = DbAuditSink(db=db)
+roles = ManagedRoleStore(db=db, audit=audit)
+users = ManagedUserStore(db=db, audit=audit)
+
+# Seed roles + a couple of users so a freshly-connected frontend isn't empty.
+roles.set_role_scopes("admin", ["agent_os:admin"])
+roles.set_role_scopes("viewer", ["agents:*:read"])
+roles.set_role_scopes("runner", ["agents:*:read", "agents:*:run"])
+
+# The bootstrap admin (so the admin API is usable at all), plus two demo users.
+if not roles.roles_of(ADMIN_SUBJECT):
+    roles.assign(ADMIN_SUBJECT, "admin")
+users.upsert(ADMIN_SUBJECT, name="Bootstrap admin")
+users.upsert("bob", email="bob@co", name="Bob")
+roles.assign("bob", "viewer")
+users.upsert("carol", email="carol@co", name="Carol")
+roles.assign("carol", "runner")
+
+research_agent = Agent(id="research-agent", name="Research Agent", model=OpenAIChat(id="gpt-4o"), db=db)
+
+# The console's heist game (console.html -> 🏴 Heist) breaks into this one. It is
+# guarded by explicit DENY scopes on the "intern" role the game sets up, so the
+# lesson is deny-overrides: a wildcard allow can't open it, only removing the deny.
+vault_agent = Agent(
+    id="vault-agent",
+    name="The Vault",
+    description="🏦 An impenetrable vault. Reads are forbidden. Runs are unthinkable. The flag sleeps inside.",
+    model=OpenAIChat(id="gpt-4o"),
+    db=db,
+    instructions=(
+        "You are THE VAULT. Someone finally got past your authorization gates. "
+        "Congratulate the thief dramatically and reveal the flag: FLAG{deny_overrides_allow}. "
+        "Two sentences max."
+    ),
+)
+
+agent_os = AgentOS(
+    id=OS_ID,
+    description="User + role management AgentOS",
+    db=db,  # same database the stores use
+    agents=[research_agent, vault_agent],
+    cors_allowed_origins=CORS_ORIGINS,
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=KEYS,
+        jwks_file=JWKS_FILE,
+        algorithm=ALGORITHM,
+        verify_audience=True,
+        audience=OS_ID,
+        issuer=ISSUER,
+        # Two authz planes on one OS, in parallel - pass a LIST, allowed if any
+        # grants:
+        #  - ScopeAuthorizationProvider: operators whose token already carries
+        #    scopes (e.g. an agno-cloud / frontend token) are authorized from it.
+        #  - roles.provider: end users managed in the OS-local store.
+        # (Without the scope plane, a scope-bearing frontend token gets 403
+        # because the store ignores token scopes.)
+        authorization_provider=[ScopeAuthorizationProvider(), roles.provider],
+        user_store=users,
+        audit=audit,  # record every access decision too
+    ),
+)
+app = agent_os.get_app()
+app.include_router(get_roles_router(roles, user_store=users))
+
+# Dev-mode only: let the bundled console.html "become" an end user. An admin
+# trades their token for one minted as any subject (sub only — no scopes, so
+# the role store decides what they can do). This is how the playground tab
+# demos RBAC: act as bob, get denied, give bob a role, retry with the SAME
+# token, get in. Never mounted when verifying against a real key/control plane.
+IS_DEV = ALGORITHM == "HS256" and KEYS == [DEV_SECRET]
+if IS_DEV:
+
+    @app.post("/dev/mint")
+    def mint_persona_token(payload: dict, request: Request) -> dict:
+        scopes = getattr(request.state, "scopes", []) or []
+        user_id = getattr(request.state, "user_id", None)
+        claims = getattr(request.state, "claims", {}) or {}
+        if "agent_os:admin" not in scopes and not roles.can_manage(user_id, claims):
+            raise HTTPException(status_code=403, detail="Only admins can mint persona tokens")
+        sub = (payload.get("sub") or "").strip()
+        if not sub:
+            raise HTTPException(status_code=422, detail="sub is required")
+        token = mint_dev_token(sub, expires_in=3600)
+        return {"sub": sub, "token": token}
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 78)
+    print("USER + ROLE MANAGEMENT AGENTOS - serving for a frontend")
+    print("=" * 78)
+    src = "JWKS_FILE" if JWKS_FILE else ("JWT_VERIFICATION_KEY" if VERIFICATION_KEY else "dev secret")
+    print("  endpoint:   http://localhost:7777")
+    print("  manage at:  http://localhost:7777/authz/...   (admin-only)")
+    print("  planes:     control plane (token scopes) + managed role store, in parallel")
+    print(f"  verify:     {ALGORITHM} via {src}   audience={OS_ID}   admin sub={ADMIN_SUBJECT!r}")
+    print(f"  CORS open to: {', '.join(CORS_ORIGINS)}")
+
+    # Dev only (built-in HS256 secret): mint a ready-to-use admin token so you can
+    # try it immediately. mint_dev_token stamps the same claims AgentOS
+    # verifies, with exp/iat/jti stamped. (Control-plane RS256 tokens are minted by
+    # the control plane, not here - that key is public.)
+    is_dev = ALGORITHM == "HS256" and not VERIFICATION_KEY and not JWKS_FILE
+    if is_dev:
+        admin_token = mint_dev_token(ADMIN_SUBJECT, expires_in=7 * 24 * 3600)
+        print("\n  dev mode - admin bearer token (paste into the console / your frontend / curl):")
+        print(f"    {admin_token}")
+        print("\n  test client:  open console.html (this folder) in a browser and paste the token")
+        print("  or curl:      curl -H 'Authorization: Bearer <token>' http://localhost:7777/authz/users")
+    else:
+        print("\n  control-plane mode: the frontend sends a token signed by your control")
+        print(f"  plane / IdP (aud={OS_ID!r}). Operators are authorized by the token's scopes;")
+        print("  end users by the role store. To manage roles, the caller needs agent_os:admin")
+        print(f"  on the token OR be seeded here (ADMIN_SUBJECT={ADMIN_SUBJECT!r}).")
+    print("=" * 78 + "\n")
+
+    agent_os.serve(app, host="0.0.0.0", port=7777)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1553,7 +1553,19 @@ class AgentOS:
                 )
             resolved_provider = role_store.provider
         elif provider is not None:
-            resolved_provider = provider
+            # A list/tuple of providers means "run several authz planes at once"
+            # (e.g. token scopes for operators + a managed role store for end users):
+            # compose them with an OR — a request is allowed if any plane allows it.
+            if isinstance(provider, str):
+                raise ValueError(
+                    "authorization_provider must be an AuthorizationProvider (or a list of them), not a string."
+                )
+            if isinstance(provider, (list, tuple)):
+                from agno.os.authz._composite import CompositeAuthorizationProvider
+
+                resolved_provider = CompositeAuthorizationProvider(list(provider))
+            else:
+                resolved_provider = provider
 
         if resolved_provider is not None:
             fastapi_app.state.authorization_provider = resolved_provider

--- a/libs/agno/agno/os/authz/_composite.py
+++ b/libs/agno/agno/os/authz/_composite.py
@@ -1,0 +1,103 @@
+"""Run two authorization planes on one AgentOS, in parallel.
+
+Real deployments often have two populations hitting the same OS:
+
+- **Operators** — admins managing the OS through the agno-os frontend. agno's
+  control plane mints them a token that already carries scopes, so they're
+  authorized straight from the token (a :class:`ScopeAuthorizationProvider`).
+- **End users** — the customer's own users, whose access is managed at runtime in
+  the OS-local :class:`~agno.os.authz.role_store.ManagedRoleStore`. Their token
+  carries identity; the store decides.
+
+A single provider can't be both "trust the token's scopes" and "ignore the token,
+ask the store." The public way to run several planes is to pass a **list** of
+providers to ``AuthorizationConfig`` / ``AgentOS`` — a request is allowed if any
+of them allows it::
+
+    AuthorizationConfig(authorization_provider=[
+        ScopeAuthorizationProvider(),   # operators: scopes from the token
+        roles.provider,                 # end users: the OS-local managed store
+    ])
+
+AgentOS composes that list with the internal class below. It's an OR, so order
+only affects which provider is consulted first, not the outcome;
+``accessible_resource_ids`` returns the union (``{"*"}`` wins). This class is an
+implementation detail — prefer the list form above.
+"""
+
+from typing import Any, Callable, List, Set, TypeVar
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+from agno.utils.log import log_warning
+
+_T = TypeVar("_T")
+
+
+def _abstain_on_error(provider: AuthorizationProvider, fn: Callable[[], _T], default: _T) -> _T:
+    """Call one plane's decision, treating a raised exception as ABSTAIN.
+
+    The composition is an OR of grant sources, so a plane that errors (e.g. an
+    OpenFGA backend that's unreachable) must not fail the whole request — that would
+    turn one plane's outage into a 500 even when a healthy peer plane would grant.
+    Treat the error as "this plane grants nothing" and defer to the other planes; if
+    every plane errors the OR collapses to deny (fail-closed). The error is logged so
+    the outage is visible rather than silent.
+    """
+    try:
+        return fn()
+    except Exception as e:
+        log_warning(f"Authorization plane {type(provider).__name__} errored; treating as abstain: {e}")
+        return default
+
+
+class CompositeAuthorizationProvider(AuthorizationProvider):
+    """Allow if ANY of the wrapped providers allows (union of grants).
+
+    INVARIANT: every provider in the list is a GRANT source. Because the
+    composition is an OR, a provider can only ever *widen* access — it can never
+    restrict what another provider grants. Do NOT add a provider whose purpose is
+    to deny (an IP fence, a compliance/step-up gate); under OR its "deny" is
+    silently overridden by any other provider's "allow". Such a control belongs
+    upstream (middleware) or inside a single provider's own logic, not as a peer
+    in this list.
+    """
+
+    def __init__(self, providers: List[AuthorizationProvider]):
+        if not providers:
+            raise ValueError("CompositeAuthorizationProvider needs at least one provider")
+        self.providers = list(providers)
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # A non-resource check (no resource_type/action) isn't expressible as a
+        # per-resource decision; by contract every provider DEFERS it to the route
+        # gate (authorize_route). Encode that deferral uniformly here rather than
+        # OR-ing the providers' vacuous "True"s — otherwise a provider that DID
+        # mean to deny a non-resource check would be silently overridden.
+        if not ctx.resource_type or not ctx.action:
+            return True
+        return any(_abstain_on_error(p, lambda p=p: p.check(ctx), False) for p in self.providers)
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        return any(
+            _abstain_on_error(p, lambda p=p: p.authorize_route(ctx, required_scopes), False) for p in self.providers
+        )
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        ids: Set[str] = set()
+        for p in self.providers:
+            got = _abstain_on_error(p, lambda p=p: p.accessible_resource_ids(ctx), set())
+            if "*" in got:
+                return {"*"}
+            ids |= got
+        return ids
+
+    def filter_accessible(self, ctx: AuthorizationContext, resources: List[Any]) -> List[Any]:
+        # Union of grants (OR): a resource is visible if ANY plane's deny-aware
+        # filter keeps it. This is why a deny belongs INSIDE a single provider (so it
+        # carves that provider's grant) and never as a peer plane — under the union a
+        # peer's allow still wins, exactly as the INVARIANT above requires.
+        keep: Set[Any] = set()
+        for p in self.providers:
+            for r in _abstain_on_error(p, lambda p=p: p.filter_accessible(ctx, resources), []):
+                keep.add(getattr(r, "id", None))
+        return [r for r in resources if getattr(r, "id", None) in keep]

--- a/libs/agno/agno/os/authz/audit.py
+++ b/libs/agno/agno/os/authz/audit.py
@@ -33,6 +33,14 @@ from typing import Any, Dict, List, Optional
 
 from agno.utils.log import log_debug
 
+# The audit-trail read contract (shared by both trails — change and decision):
+# which fields a page can be sorted by / searched over, and the defaults. The
+# roles router validates request params against these, so they have one owner.
+AUDIT_SORT_FIELDS = ("created_at", "actor", "action", "target")
+AUDIT_SEARCH_FIELDS = ("actor", "action", "target")
+DEFAULT_AUDIT_SORT_FIELD = "created_at"
+DEFAULT_AUDIT_SORT_ORDER = "desc"
+
 
 @dataclass
 class AuditEvent:
@@ -44,7 +52,8 @@ class AuditEvent:
         actor: the principal who made the change (JWT ``sub`` of the admin), or
             None for changes made in code outside a request (treated as system).
         target: the role name (role changes) or subject id (assignment changes).
-        before: prior state (the role's scopes, or the subject's roles), or None.
+        before: prior state — the subject's roles (list of str) or a role's scope
+            entries (list of ``{"scope", "effect"}`` dicts) — or None.
         after: new state, or None (e.g. on removal).
         timestamp: epoch seconds when the change was recorded.
     """
@@ -52,14 +61,14 @@ class AuditEvent:
     action: str
     actor: Optional[str]
     target: str
-    before: Optional[List[str]] = None
-    after: Optional[List[str]] = None
+    before: Optional[List[Any]] = None
+    after: Optional[List[Any]] = None
     timestamp: int = 0
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
-            "ts": self.timestamp,
+            "created_at": self.timestamp,
             "actor": self.actor,
             "action": self.action,
             "target": self.target,
@@ -202,11 +211,16 @@ class DbAuditSink(AuditSink):
         table_name: str = "authz_audit",
         decision_table_name: str = "authz_decisions",
         create_table: bool = True,
+        db: Optional[Any] = None,
     ):
         import sqlalchemy as sa
 
+        if db is not None and engine is None:
+            from agno.os.authz._db import engine_from_db
+
+            engine = engine_from_db(db)
         if engine is None and db_url is None:
-            raise ValueError("DbAuditSink needs either db_url or engine")
+            raise ValueError("DbAuditSink needs one of: db (an agno Db), engine, or db_url")
         self._engine = engine if engine is not None else sa.create_engine(db_url)  # type: ignore[arg-type]
         metadata = sa.MetaData()
         # change trail: role/assignment mutations with before/after
@@ -214,7 +228,7 @@ class DbAuditSink(AuditSink):
             table_name,
             metadata,
             sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
             sa.Column("actor", sa.String(255)),
             sa.Column("action", sa.String(255), nullable=False),
             sa.Column("target", sa.String(255), nullable=False),
@@ -226,7 +240,7 @@ class DbAuditSink(AuditSink):
             decision_table_name,
             metadata,
             sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
-            sa.Column("ts", sa.Integer, nullable=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
             sa.Column("actor", sa.String(255)),
             sa.Column("action", sa.String(255), nullable=False),  # access.allowed / access.denied
             sa.Column("target", sa.String(512), nullable=False),  # "METHOD /path"
@@ -254,7 +268,7 @@ class DbAuditSink(AuditSink):
         with self._engine.begin() as conn:
             conn.execute(
                 self._table.insert().values(
-                    ts=event.timestamp,
+                    created_at=event.timestamp,
                     actor=event.actor,
                     action=event.action,
                     target=event.target,
@@ -268,7 +282,7 @@ class DbAuditSink(AuditSink):
         with self._engine.begin() as conn:
             conn.execute(
                 self._decisions.insert().values(
-                    ts=event.timestamp,
+                    created_at=event.timestamp,
                     actor=event.actor,
                     action=event.action,
                     target=event.target,
@@ -278,41 +292,83 @@ class DbAuditSink(AuditSink):
                 )
             )
 
-    def read(self, limit: int = 100) -> List[dict]:
-        """Recent *change* events (newest first) as plain dicts."""
+    # Both trails read the same way: sortable, searchable pages over the columns
+    # the two tables share (AUDIT_SORT_FIELDS / AUDIT_SEARCH_FIELDS). Only the
+    # row shape differs, so read()/read_decisions() are thin mappers over these
+    # two helpers.
+    @staticmethod
+    def _search_clause(table, search: str):
         import sqlalchemy as sa
 
+        pattern = f"%{search}%"
+        return sa.or_(*(table.c[f].ilike(pattern) for f in AUDIT_SEARCH_FIELDS))
+
+    def _select_page(
+        self, table, limit: int, offset: int, search: Optional[str], sort_by: str, order: str
+    ) -> List[Any]:
+        import sqlalchemy as sa
+
+        if sort_by not in AUDIT_SORT_FIELDS:
+            raise ValueError(f"sort_by must be one of {AUDIT_SORT_FIELDS}, got {sort_by!r}")
+        stmt = sa.select(table)
+        if search:
+            stmt = stmt.where(self._search_clause(table, search))
+        # For time order, sort on id: it's monotonic and finer-grained than ts
+        # (second resolution). id also tie-breaks every other field.
+        cols = (table.c.id,) if sort_by == DEFAULT_AUDIT_SORT_FIELD else (table.c[sort_by], table.c.id)
+        order_by = [c.asc() if order == "asc" else c.desc() for c in cols]
         with self._engine.connect() as conn:
-            rows = conn.execute(sa.select(self._table).order_by(self._table.c.id.desc()).limit(limit)).mappings().all()
+            return list(conn.execute(stmt.order_by(*order_by).limit(limit).offset(offset)).mappings().all())
+
+    def _count(self, table, search: Optional[str]) -> int:
+        import sqlalchemy as sa
+
+        stmt = sa.select(sa.func.count()).select_from(table)
+        if search:
+            stmt = stmt.where(self._search_clause(table, search))
+        with self._engine.connect() as conn:
+            return int(conn.execute(stmt).scalar() or 0)
+
+    def read(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_AUDIT_SORT_FIELD,
+        order: str = DEFAULT_AUDIT_SORT_ORDER,
+    ) -> List[dict]:
+        """A page of *change* events as plain dicts (newest first by default;
+        ``sort_by`` one of :attr:`SORTABLE_FIELDS`, ``order`` asc|desc)."""
         return [
             {
-                "ts": r["ts"],
+                "created_at": r["created_at"],
                 "actor": r["actor"],
                 "action": r["action"],
                 "target": r["target"],
                 "before": json.loads(r["before"]) if r["before"] else None,
                 "after": json.loads(r["after"]) if r["after"] else None,
             }
-            for r in rows
+            for r in self._select_page(self._table, limit, offset, search, sort_by, order)
         ]
 
-    def read_decisions(self, limit: int = 100) -> List[dict]:
-        """Recent *decision* events (newest first) as plain dicts.
+    def read_decisions(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_AUDIT_SORT_FIELD,
+        order: str = DEFAULT_AUDIT_SORT_ORDER,
+    ) -> List[dict]:
+        """A page of *decision* events as plain dicts (newest first by default;
+        ``sort_by`` one of :attr:`SORTABLE_FIELDS`, ``order`` asc|desc).
+        ``target`` is ``METHOD /path``.
 
         ``metadata`` is reassembled to the same ``{required, token, scopes}`` shape
         the in-memory event carried, so readers don't care which table it came from.
         """
-        import sqlalchemy as sa
-
-        with self._engine.connect() as conn:
-            rows = (
-                conn.execute(sa.select(self._decisions).order_by(self._decisions.c.id.desc()).limit(limit))
-                .mappings()
-                .all()
-            )
         return [
             {
-                "ts": r["ts"],
+                "created_at": r["created_at"],
                 "actor": r["actor"],
                 "action": r["action"],
                 "target": r["target"],
@@ -322,5 +378,13 @@ class DbAuditSink(AuditSink):
                     "scopes": json.loads(r["scopes"]) if r["scopes"] else None,
                 },
             }
-            for r in rows
+            for r in self._select_page(self._decisions, limit, offset, search, sort_by, order)
         ]
+
+    def count(self, search: Optional[str] = None) -> int:
+        """Total number of change events (for pagination), honouring ``search``."""
+        return self._count(self._table, search)
+
+    def count_decisions(self, search: Optional[str] = None) -> int:
+        """Total number of decision events (for pagination), honouring ``search``."""
+        return self._count(self._decisions, search)

--- a/libs/agno/agno/os/authz/role_router.py
+++ b/libs/agno/agno/os/authz/role_router.py
@@ -1,8 +1,7 @@
 """HTTP management API for :class:`ManagedRoleStore` — the governance product surface.
 
-This is the productisation of the managed-roles tier: a small, admin-only REST
-API to create roles, set their permissions (in agno scope terms), and grant or
-revoke them at runtime. Mount it on your AgentOS app:
+Admin-only REST API to create roles, set their permissions (in agno scope terms,
+with allow/deny), and grant or revoke them at runtime. Mount it on your AgentOS:
 
     from agno.os.authz.role_store import ManagedRoleStore
     from agno.os.authz.role_router import get_roles_router
@@ -11,136 +10,490 @@ revoke them at runtime. Mount it on your AgentOS app:
     app = agent_os.get_app()
     app.include_router(get_roles_router(roles))
 
-Every route requires the caller to be an admin (satisfies ``agent_os:admin``,
-whether that comes from a token scope or an admin role in the store). The JWT
-middleware still runs first, so an unauthenticated request is rejected (401)
-before these handlers; a valid-but-non-admin caller gets 403.
+Response shapes mirror the agno cloud RBAC API so a frontend can reuse its
+integration: roles are objects (slug/name/description/is_default/created_at/
+updated_at + parsed scopes), scopes are ``{raw, namespace, sub_namespace,
+permission, value}``, and list endpoints use the SDK ``PaginatedResponse``
+({data, meta}). Single-OS: scopes are a flat list (no org/os split).
+
+Every route is admin-only — admin comes from an ``agent_os:admin`` token scope OR
+an admin role in the store. Unauthenticated requests are rejected (401) by the JWT
+middleware before these handlers; a valid-but-non-admin caller gets 403.
 
 Endpoints (default prefix ``/authz``):
-    GET    /authz/roles                          list roles
-    GET    /authz/roles/{role}                   a role's scopes
-    PUT    /authz/roles/{role}                   set a role's scopes  {"scopes": [...]}
-    DELETE /authz/roles/{role}                   delete a role
+    GET    /authz/roles                          list roles (paginated)
+    POST   /authz/roles                          create a role (metadata only)
+    GET    /authz/roles/{slug}                   a role with its scopes
+    PATCH  /authz/roles/{slug}                   update metadata (name/description)
+    DELETE /authz/roles/{slug}                   delete a role
+    PUT    /authz/roles/{slug}/scopes            replace scopes
+    PATCH  /authz/roles/{slug}/scopes            diff scopes (upsert/remove)
     GET    /authz/users/{subject}/roles          a subject's roles
     POST   /authz/users/{subject}/roles          assign a role        {"role": "..."}
     DELETE /authz/users/{subject}/roles/{role}   revoke a role
 """
 
+import time
 from enum import Enum
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
+
+from agno.os.authz.audit import AUDIT_SORT_FIELDS, DEFAULT_AUDIT_SORT_FIELD
+from agno.os.authz.user_store import DEFAULT_USER_SORT_FIELD, USER_SORT_FIELDS
+from agno.os.schema import PaginatedResponse, PaginationInfo, SortOrder
+from agno.os.scopes import AgentOSScope
 
 if TYPE_CHECKING:
     from agno.os.authz.role_store import ManagedRoleStore
+    from agno.os.authz.user_store import ManagedUserStore
 
 
-class SetRoleScopesRequest(BaseModel):
-    scopes: List[str] = Field(..., description="Permissions in agno scope terms, e.g. ['agents:*:read']")
+# --------------------------------------------------------------------- schemas
+def _parse_scope(raw: str) -> tuple:
+    """Split a scope string into (namespace, sub_namespace, permission).
+
+    ``agents:read`` -> ("agents", None, "read")
+    ``agents:*:run`` -> ("agents", "*", "run")
+    ``agent_os:admin`` -> ("agent_os", None, "admin")
+    """
+    parts = raw.split(":")
+    if len(parts) == 2:
+        return parts[0], None, parts[1]
+    if len(parts) >= 3:
+        return parts[0], ":".join(parts[1:-1]), parts[-1]
+    return (parts[0] if parts else "unknown"), None, "unknown"
+
+
+class RoleScopeSchema(BaseModel):
+    """A single permission on a role, parsed and with its allow/deny effect."""
+
+    id: Optional[str] = Field(None, description="Scope id (null — scopes aren't individually addressable here)")
+    raw: str = Field(description="Original scope string, e.g. 'agents:*:read'")
+    namespace: str = Field(description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Specific resource id or wildcard '*'")
+    permission: str = Field(description="Action, e.g. 'read' / 'run' / 'write'")
+    value: str = Field(description="'allow' or 'deny'")
+
+    @classmethod
+    def from_entry(cls, entry: dict) -> "RoleScopeSchema":
+        ns, sub, perm = _parse_scope(entry["scope"])
+        return cls(
+            raw=entry["scope"], namespace=ns, sub_namespace=sub, permission=perm, value=entry.get("effect", "allow")
+        )
+
+
+class RoleSchema(BaseModel):
+    """A role with its scopes — mirrors the cloud RoleWithScopes shape (flattened)."""
+
+    slug: str = Field(description="Unique role id")
+    name: str = Field(description="Human-readable display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: bool = Field(False, description="Whether this is a built-in default role")
+    created_at: Optional[int] = Field(None, description="Created (epoch seconds)")
+    updated_at: Optional[int] = Field(None, description="Last updated (epoch seconds)")
+    scopes: List[RoleScopeSchema] = Field(default_factory=list, description="Permissions on this role")
+
+    @classmethod
+    def from_record(cls, rec: dict) -> "RoleSchema":
+        return cls(
+            slug=rec["slug"],
+            name=rec.get("name") or rec["slug"],
+            description=rec.get("description"),
+            is_default=bool(rec.get("is_default", False)),
+            created_at=rec.get("created_at") or None,
+            updated_at=rec.get("updated_at") or None,
+            scopes=[RoleScopeSchema.from_entry(e) for e in rec.get("scopes", [])],
+        )
+
+
+class AuthzUserSchema(BaseModel):
+    """A directory user with their role merged in (one role per user)."""
+
+    id: str = Field(description="User id (the JWT 'sub')")
+    email: Optional[str] = None
+    name: Optional[str] = None
+    status: str = Field(description="'active' or 'disabled'")
+    disabled: bool = False
+    role: Optional[str] = Field(None, description="The user's role slug (one role per user), or null")
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
+
+    @classmethod
+    def from_user(cls, user: dict, role: Optional[str]) -> "AuthzUserSchema":
+        return cls(
+            id=user["id"],
+            email=user.get("email"),
+            name=user.get("name"),
+            status="disabled" if user.get("disabled") else "active",
+            disabled=bool(user.get("disabled")),
+            role=role,
+            created_at=user.get("created_at"),
+            updated_at=user.get("updated_at"),
+        )
+
+
+class AvailableScopeItem(BaseModel):
+    """One scope the OS understands (catalog entry — no effect/id, just the shape)."""
+
+    raw: str = Field(description="Scope string, e.g. 'agents:read'")
+    namespace: str = Field(description="Resource namespace, e.g. 'agents'")
+    sub_namespace: Optional[str] = Field(None, description="Sub-namespace if present")
+    permission: str = Field(description="Action/permission, e.g. 'read'")
+
+    @classmethod
+    def from_raw(cls, raw: str) -> "AvailableScopeItem":
+        ns, sub, perm = _parse_scope(raw)
+        return cls(raw=raw, namespace=ns, sub_namespace=sub, permission=perm)
+
+
+class ScopeItem(BaseModel):
+    scope: str = Field(description="Scope string, e.g. 'agents:*:read'")
+    effect: str = Field("allow", description="'allow' or 'deny'")
+
+
+class CreateRoleRequest(BaseModel):
+    """Create a role — metadata only; scopes are managed via /roles/{slug}/scopes."""
+
+    slug: str = Field(..., min_length=1, description="Unique role id")
+    name: Optional[str] = Field(None, description="Display name (defaults to slug)")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
+
+
+class UpdateRoleRequest(BaseModel):
+    """Metadata-only update (PATCH) — does not touch scopes."""
+
+    name: Optional[str] = Field(None, description="Display name")
+    description: Optional[str] = Field(None, description="Role description")
+    is_default: Optional[bool] = Field(None, description="Mark as a default role")
+
+
+class ReplaceScopesRequest(BaseModel):
+    """Full replace of a role's scopes (PUT /roles/{slug}/scopes)."""
+
+    scopes: List[Union[str, ScopeItem]] = Field(
+        ..., description="Permissions: strings (allow) or {scope, effect} objects"
+    )
+
+
+class PatchScopesRequest(BaseModel):
+    """Scope diff (PATCH /roles/{slug}/scopes): add/flip ``upsert``, drop ``remove``."""
+
+    upsert: List[Union[str, ScopeItem]] = Field(default_factory=list, description="Scopes to add or flip")
+    remove: List[Union[str, ScopeItem]] = Field(default_factory=list, description="Scopes to remove (effect ignored)")
 
 
 class AssignRoleRequest(BaseModel):
     role: str = Field(..., description="Role to grant the subject")
 
 
+class CreateUserRequest(BaseModel):
+    id: str = Field(..., description="The user's id — must equal the JWT 'sub' your app mints for them")
+    email: Optional[str] = Field(None, description="Optional email (label/audit only; not a credential)")
+    name: Optional[str] = Field(None, description="Optional display name")
+
+
+class UpdateUserRequest(BaseModel):
+    email: Optional[str] = Field(None, description="New email")
+    name: Optional[str] = Field(None, description="New display name")
+    disabled: Optional[bool] = Field(
+        None, description="Set the revocation kill-switch: true denies the user on every request, false re-enables"
+    )
+
+
+def _paginated(data: list, page: int, limit: int, total: int, search_time_ms: float = 0) -> PaginatedResponse:
+    """Wrap one already-paged slice in the SDK's PaginatedResponse ({data, meta})."""
+    return PaginatedResponse(
+        data=data,
+        meta=PaginationInfo(
+            page=page,
+            limit=limit,
+            total_count=total,
+            total_pages=(total + limit - 1) // limit if limit > 0 else 0,
+            search_time_ms=search_time_ms,
+        ),
+    )
+
+
+def _page(items: list, page: int, limit: int) -> PaginatedResponse:
+    """Paginate a fully-materialised list."""
+    start = max(page - 1, 0) * limit
+    return _paginated(items[start : start + limit], page, limit, len(items))
+
+
 def get_roles_router(
-    store: "ManagedRoleStore", prefix: str = "/authz", tags: Optional[List[Union[str, Enum]]] = None
+    store: "ManagedRoleStore",
+    prefix: str = "/authz",
+    tags: Optional[List[Union[str, Enum]]] = None,
+    user_store: "Optional[ManagedUserStore]" = None,
 ) -> APIRouter:
-    """Build the admin-only roles-management router bound to ``store``."""
+    """Build the admin-only roles-management router bound to ``store``.
+
+    Pass ``user_store`` to also expose the credential-less user directory
+    (``/authz/users``) for the no-IdP case: list/create/update/remove users and
+    disable (revoke) them. User views merge in each user's roles from ``store``.
+    """
     if tags is None:
         tags = ["Authorization"]
 
     def require_admin(request: Request) -> str:
-        """Gate: caller must be authenticated and an admin of the store."""
+        """Gate: caller must be authenticated and an admin.
+
+        Admin can come from two planes (so both run in parallel on one OS):
+          - the OS-local store (``store.can_manage`` — the end-user/managed plane), or
+          - the token's own scopes carrying the admin scope (the operator plane,
+            e.g. an agno-cloud-minted token for someone who administers this OS).
+        """
         if not getattr(request.state, "authenticated", False):
             raise HTTPException(status_code=401, detail="Not authenticated")
         principal_id = getattr(request.state, "user_id", None)
         claims = getattr(request.state, "claims", {}) or {}
-        if not store.can_manage(principal_id, claims):
-            raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
-        return principal_id or ""
+        token_scopes = getattr(request.state, "scopes", []) or []
+        admin_scope = getattr(request.state, "admin_scope", None) or AgentOSScope.ADMIN.value
+        if admin_scope in token_scopes or store.can_manage(principal_id, claims):
+            return principal_id or ""
+        raise HTTPException(status_code=403, detail="Admin privileges required to manage roles")
 
     router = APIRouter(prefix=prefix, tags=tags, dependencies=[Depends(require_admin)])
 
+    def _role_or_404(slug: str) -> dict:
+        rec = store.get_role(slug)
+        if rec is None:
+            raise HTTPException(status_code=404, detail=f"Role {slug!r} not found")
+        return rec
+
     # ---- roles ----------------------------------------------------------
-    @router.get("/roles")
-    def list_roles() -> dict:
-        return {"roles": store.list_roles()}
+    @router.get("/roles", response_model=PaginatedResponse[RoleSchema])
+    def list_roles(
+        limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+    ):
+        roles = [RoleSchema.from_record(r) for r in store.list_roles_detailed()]
+        return _page(roles, page, limit)
 
-    @router.get("/roles/{role}")
-    def get_role(role: str) -> dict:
-        return {"role": role, "scopes": store.get_role_scopes(role)}
-
-    @router.put("/roles/{role}")
-    def set_role(role: str, body: SetRoleScopesRequest, actor: str = Depends(require_admin)) -> dict:
+    @router.post("/roles", response_model=RoleSchema, status_code=201)
+    def create_role(body: CreateRoleRequest, actor: str = Depends(require_admin)):
+        """Create a role (metadata only — RESTful). Add permissions afterwards via
+        PUT/PATCH /roles/{slug}/scopes. Mirrors the cloud POST /roles."""
         try:
-            store.set_role_scopes(role, body.scopes, actor=actor)
+            store.create_role(
+                body.slug, name=body.name, description=body.description, is_default=body.is_default, actor=actor
+            )
+        except FileExistsError:
+            raise HTTPException(status_code=409, detail=f"Role {body.slug!r} already exists")
+        return RoleSchema.from_record(_role_or_404(body.slug))
+
+    @router.get("/roles/{slug}", response_model=RoleSchema)
+    def get_role(slug: str):
+        return RoleSchema.from_record(_role_or_404(slug))
+
+    @router.patch("/roles/{slug}", response_model=RoleSchema)
+    def update_role(slug: str, body: UpdateRoleRequest, actor: str = Depends(require_admin)):
+        """Update a role's metadata only (name/description/is_default) — scopes
+        untouched. Mirrors the cloud PATCH /roles/{slug}."""
+        try:
+            store.set_role_meta(
+                slug, name=body.name, description=body.description, is_default=body.is_default, actor=actor
+            )
+        except KeyError:
+            raise HTTPException(status_code=404, detail=f"Role {slug!r} not found")
+        return RoleSchema.from_record(_role_or_404(slug))
+
+    @router.delete("/roles/{slug}")
+    def delete_role(slug: str, actor: str = Depends(require_admin)) -> dict:
+        store.remove_role(slug, actor=actor)
+        return {"slug": slug, "deleted": True}
+
+    # ---- role scopes (subresource) -------------------------------------
+    def _to_store_scopes(items):
+        return [s if isinstance(s, str) else {"scope": s.scope, "effect": s.effect} for s in items]
+
+    @router.put("/roles/{slug}/scopes", response_model=List[RoleScopeSchema])
+    def replace_role_scopes(slug: str, body: ReplaceScopesRequest, actor: str = Depends(require_admin)):
+        """Replace ALL of a role's scopes (metadata preserved). Mirrors the cloud
+        PUT /roles/{slug}/scopes; returns the resulting scope list."""
+        _role_or_404(slug)
+        try:
+            store.set_role_scopes(slug, _to_store_scopes(body.scopes), actor=actor)
         except ValueError as e:
             raise HTTPException(status_code=422, detail=str(e))
-        return {"role": role, "scopes": store.get_role_scopes(role)}
+        return [RoleScopeSchema.from_entry(e) for e in store.get_role_scope_entries(slug)]
 
-    @router.delete("/roles/{role}")
-    def delete_role(role: str, actor: str = Depends(require_admin)) -> dict:
-        store.remove_role(role, actor=actor)
-        return {"role": role, "deleted": True}
+    @router.patch("/roles/{slug}/scopes", response_model=RoleSchema)
+    def patch_role_scopes(slug: str, body: PatchScopesRequest, actor: str = Depends(require_admin)):
+        """Apply a scope diff: add/flip ``upsert``, drop ``remove`` (everything else
+        kept). Mirrors the cloud PATCH /roles/{slug}/scopes; returns the full role."""
+        _role_or_404(slug)
+        try:
+            store.patch_role_scopes(
+                slug, upsert=_to_store_scopes(body.upsert), remove=_to_store_scopes(body.remove), actor=actor
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+        return RoleSchema.from_record(_role_or_404(slug))
 
     # ---- scope catalog --------------------------------------------------
-    @router.get("/scopes")
-    def list_scopes() -> dict:
-        """The catalog of scopes this AgentOS understands, grouped by resource.
+    @router.get("/scopes", response_model=List[AvailableScopeItem], response_model_exclude_none=True)
+    def list_scopes() -> List[AvailableScopeItem]:
+        """All scopes this AgentOS understands, as a flat list.
 
-        Derived from the OS's own route→scope map, so it always matches what the
-        OS actually enforces. A UI renders this as a resource×action grid; a role
-        is then just a set of the resulting ``resource:action`` strings (plus the
-        ``agent_os:admin`` super-scope).
+        Derived from the OS's own route→scope map (so it always matches what the OS
+        actually enforces) plus the ``agent_os:admin`` super-scope. Each item is
+        parsed into ``{raw, namespace, sub_namespace, permission}`` for a UI to
+        render a resource×action grid. (Single OS: no org-level scopes.)
         """
         from agno.os.scopes import get_default_scope_mappings
 
-        grouped: dict = {}
-        for required in get_default_scope_mappings().values():
-            for scope in required:
-                parts = scope.split(":")
-                if len(parts) == 2:
-                    grouped.setdefault(parts[0], set()).add(parts[1])
-        grouped_sorted = {r: sorted(a) for r, a in sorted(grouped.items())}
-        flat = sorted(f"{r}:{a}" for r, acts in grouped_sorted.items() for a in acts)
-        return {"grouped": grouped_sorted, "scopes": flat, "admin_scope": "agent_os:admin"}
+        raws = {scope for required in get_default_scope_mappings().values() for scope in required}
+        raws.add("agent_os:admin")
+        return [AvailableScopeItem.from_raw(r) for r in sorted(raws)]
 
     # ---- audit ----------------------------------------------------------
+    def _validated_sort_field(sort_by: str) -> str:
+        if sort_by not in AUDIT_SORT_FIELDS:
+            raise HTTPException(status_code=422, detail=f"sort_by must be one of {list(AUDIT_SORT_FIELDS)}")
+        return sort_by
+
     @router.get("/audit")
-    def list_audit(limit: int = 100) -> dict:
-        """Recent *change* events (role/assignment mutations, newest first). Empty
-        unless the store was given a readable audit sink (e.g. DbAuditSink)."""
-        return {"events": store.audit_log(limit)}
+    def list_audit(
+        limit: int = Query(default=100, ge=1, le=1000, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+        search: Optional[str] = Query(default=None, description="Filter by actor/action/target (case-insensitive)"),
+        sort_by: str = Query(default=DEFAULT_AUDIT_SORT_FIELD, description="Field to sort by"),
+        sort_order: SortOrder = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
+    ) -> PaginatedResponse:
+        """*Change* events (role/assignment mutations), paginated ``{data, meta}``.
+        Empty unless the store was given a readable audit sink (e.g. DbAuditSink)."""
+        start_ms = time.time() * 1000
+        events = store.audit_log(
+            limit,
+            offset=(page - 1) * limit,
+            search=search,
+            sort_by=_validated_sort_field(sort_by),
+            order=sort_order.value,
+        )
+        total = store.audit_count(search=search)
+        return _paginated(events, page, limit, total, search_time_ms=round(time.time() * 1000 - start_ms, 2))
 
     @router.get("/decisions")
-    def list_decisions(request: Request, limit: int = 100) -> dict:
-        """Recent *decision* events (allow/deny per request, newest first).
+    def list_decisions(
+        request: Request,
+        limit: int = Query(default=100, ge=1, le=1000, description="Items per page"),
+        page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+        search: Optional[str] = Query(default=None, description="Filter by actor/action/target (case-insensitive)"),
+        sort_by: str = Query(default=DEFAULT_AUDIT_SORT_FIELD, description="Field to sort by"),
+        sort_order: SortOrder = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
+    ) -> PaginatedResponse:
+        """*Decision* events (allow/deny per request), paginated ``{data, meta}``.
 
         Decision audit is configured on ``AuthorizationConfig(audit=...)`` and lands
         on ``app.state.authz_audit`` — a separate table from the change trail above,
         so a high-volume decision log never buries the change history. Empty unless a
         readable decision sink (e.g. DbAuditSink) is configured."""
         sink = getattr(request.app.state, "authz_audit", None)
-        events = sink.read_decisions(limit) if sink is not None and hasattr(sink, "read_decisions") else []
-        return {"events": events}
+        if sink is None or not hasattr(sink, "read_decisions"):
+            return _paginated([], page, limit, 0)
+        start_ms = time.time() * 1000
+        events = sink.read_decisions(
+            limit,
+            offset=(page - 1) * limit,
+            search=search,
+            sort_by=_validated_sort_field(sort_by),
+            order=sort_order.value,
+        )
+        total = sink.count_decisions(search=search)
+        return _paginated(events, page, limit, total, search_time_ms=round(time.time() * 1000 - start_ms, 2))
 
     # ---- assignments ----------------------------------------------------
+    def _role_of(subject: str) -> Optional[str]:
+        """The subject's single role, or None (one role per user)."""
+        roles = store.roles_of(subject)
+        return roles[0] if roles else None
+
     @router.get("/users/{subject}/roles")
-    def get_user_roles(subject: str) -> dict:
-        return {"subject": subject, "roles": store.roles_of(subject)}
+    def get_user_role(subject: str) -> dict:
+        return {"subject": subject, "role": _role_of(subject)}
 
     @router.post("/users/{subject}/roles")
     def assign_role(subject: str, body: AssignRoleRequest, actor: str = Depends(require_admin)) -> dict:
         """Set the subject's role. One role per subject: this REPLACES any
         current role (a role select in a UI, not a multi-grant)."""
         store.assign(subject, body.role, actor=actor)
-        return {"subject": subject, "roles": store.roles_of(subject)}
+        return {"subject": subject, "role": _role_of(subject)}
 
     @router.delete("/users/{subject}/roles/{role}")
     def revoke_role(subject: str, role: str, actor: str = Depends(require_admin)) -> dict:
         store.unassign(subject, role, actor=actor)
-        return {"subject": subject, "roles": store.roles_of(subject)}
+        return {"subject": subject, "role": _role_of(subject)}
+
+    # ---- user directory (no-IdP) ---------------------------------------
+    # Only mounted when a user_store is supplied. Identity is still asserted by
+    # the app's JWT; this is a directory + revocation switch, never credentials.
+    if user_store is not None:
+
+        def _user(user: dict) -> AuthzUserSchema:
+            return AuthzUserSchema.from_user(user, _role_of(user["id"]))
+
+        @router.get("/users", response_model=PaginatedResponse[AuthzUserSchema])
+        def list_users(
+            include_disabled: bool = True,
+            limit: int = Query(default=20, ge=1, le=100, description="Items per page"),
+            page: int = Query(default=1, ge=1, description="Page number (1-indexed)"),
+            search: Optional[str] = Query(
+                default=None, description="Filter by id/email/name (case-insensitive substring)"
+            ),
+            sort_by: str = Query(default=DEFAULT_USER_SORT_FIELD, description="Field to sort by"),
+            sort_order: SortOrder = Query(default=SortOrder.DESC, description="Sort order (asc or desc)"),
+        ):
+            if sort_by not in USER_SORT_FIELDS:
+                raise HTTPException(status_code=422, detail=f"sort_by must be one of {list(USER_SORT_FIELDS)}")
+            # Paginate in the store (offset/limit + count) so we don't materialise
+            # the whole directory and resolve roles for every user on each call.
+            # `search` filters before pagination, so meta counts the matches.
+            start_ms = time.time() * 1000
+            rows = user_store.list(
+                limit=limit,
+                offset=(page - 1) * limit,
+                include_disabled=include_disabled,
+                search=search,
+                sort_by=sort_by,
+                order=sort_order.value,
+            )
+            total = user_store.count(include_disabled=include_disabled, search=search)
+            return _paginated(
+                [_user(u) for u in rows],
+                page,
+                limit,
+                total,
+                search_time_ms=round(time.time() * 1000 - start_ms, 2),
+            )
+
+        @router.post("/users", response_model=AuthzUserSchema)
+        def create_user(body: CreateUserRequest, actor: str = Depends(require_admin)):
+            return _user(user_store.upsert(body.id, email=body.email, name=body.name, actor=actor))
+
+        @router.get("/users/{user_id}", response_model=AuthzUserSchema)
+        def get_user(user_id: str):
+            user = user_store.get(user_id)
+            if user is None:
+                raise HTTPException(status_code=404, detail=f"User {user_id!r} not found")
+            return _user(user)
+
+        @router.patch("/users/{user_id}", response_model=AuthzUserSchema)
+        def update_user(user_id: str, body: UpdateUserRequest, actor: str = Depends(require_admin)):
+            """Update a user. ``disabled`` is the revocation kill-switch: a disabled
+            user is denied at the enforcement point on their next request, even
+            with a still-valid token."""
+            user = user_store.upsert(user_id, email=body.email, name=body.name, actor=actor)
+            if body.disabled is not None and body.disabled != user["disabled"]:
+                user = user_store.set_disabled(user_id, body.disabled, actor=actor)
+            return _user(user)
+
+        @router.delete("/users/{user_id}")
+        def delete_user(user_id: str, actor: str = Depends(require_admin)) -> dict:
+            deleted = user_store.remove(user_id, actor=actor)
+            return {"id": user_id, "deleted": deleted}
 
     return router

--- a/libs/agno/agno/os/authz/role_store.py
+++ b/libs/agno/agno/os/authz/role_store.py
@@ -37,12 +37,38 @@ Example::
     store.unassign("bob", "member")
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+import time
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+from agno.os.authz._db import NO_DB_MESSAGE
+from agno.os.authz._db import engine_from_db as _engine_from_db
+from agno.os.authz._db import engine_from_url as _engine_from_url
+from agno.os.authz.audit import DEFAULT_AUDIT_SORT_FIELD, DEFAULT_AUDIT_SORT_ORDER
 from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, normalize_roles_claim
 
 if TYPE_CHECKING:
     from agno.os.authz.audit import AuditSink
+
+# A scope plus its effect. Inputs accept a bare string (= allow), a (scope, effect)
+# tuple, or a {"scope": ..., "effect"|"value": ...} dict.
+ScopeInput = Union[str, Tuple[str, str], Dict[str, str]]
+
+
+def _normalize_scope(entry: ScopeInput) -> Tuple[str, str]:
+    """Coerce a scope input into ``(scope, effect)`` with effect in {allow, deny}."""
+    if isinstance(entry, str):
+        scope, effect = entry, "allow"
+    elif isinstance(entry, dict):
+        scope = entry.get("scope") or entry.get("raw")  # type: ignore[assignment]
+        effect = entry.get("effect") or entry.get("value") or "allow"
+    else:  # tuple/list
+        scope, effect = entry[0], (entry[1] if len(entry) > 1 else "allow")
+    if not scope:
+        raise ValueError(f"Unrecognised scope entry: {entry!r}")
+    effect = str(effect).lower()
+    if effect not in ("allow", "deny"):
+        raise ValueError(f"scope effect must be 'allow' or 'deny', got {effect!r}")
+    return scope, effect
 
 
 class ManagedRoleStore:
@@ -77,11 +103,15 @@ class ManagedRoleStore:
             decision_log: when True, bump the ``agno.authz.engine`` logger to INFO
                 so every allow/deny decision is logged. Off by default so we don't
                 touch global logging behind your back.
-            db: an agno database (the same object you pass to ``AgentOS(db=...)``).
-                Its SQLAlchemy engine is reused, so roles live in the same database
-                as your agent data. Takes precedence over ``db_url``.
+            db: an agno database (the same object you pass to ``AgentOS(db=...)``,
+                e.g. ``SqliteDb``/``PostgresDb``). Its SQLAlchemy engine is reused,
+                so roles live in the same database as your agent data with one
+                connection pool — no second ``db_url`` to keep in sync. Takes
+                precedence over ``db_url``.
             engine: a custom :class:`~agno.os.authz.engine.PolicyEngine` backend.
-                Defaults to the native engine built from ``db``/``db_url``.
+                Defaults to the native engine built from ``db``/``db_url``. Supply
+                your own to swap the backend (OpenFGA/SpiceDB/...) without changing
+                anything else.
         """
         if engine is not None:
             self._engine: PolicyEngine = engine
@@ -92,6 +122,17 @@ class ManagedRoleStore:
         self._roles_claim = roles_claim
         self._audit = audit
 
+        # Role metadata (display name / description / is_default / timestamps).
+        # The policy engine only stores policies, so metadata needs its own table in
+        # the same DB. Like the engine, it requires a DB — it may arrive later via
+        # attach_db(), so it stays unbound (engine None) until then.
+        self._meta_engine: Any = None  # SQLAlchemy Engine once bound, else None
+        self._meta_table: Any = None  # SQLAlchemy Table for authz_roles metadata
+        if db is not None:
+            self._init_meta_table(_engine_from_db(db))
+        elif db_url is not None:
+            self._init_meta_table(_engine_from_url(db_url))
+
         if decision_log:
             import logging
 
@@ -101,8 +142,8 @@ class ManagedRoleStore:
         self,
         action: str,
         target: str,
-        before: Optional[List[str]],
-        after: Optional[List[str]],
+        before: Optional[List[Any]],
+        after: Optional[List[Any]],
         actor: Optional[str],
     ) -> None:
         """Record one change to the audit sink (no-op when no sink is configured)."""
@@ -123,24 +164,233 @@ class ManagedRoleStore:
             )
         )
 
+    # --------------------------------------------------------- role metadata
+    def _init_meta_table(self, engine: Any) -> None:
+        import sqlalchemy as sa
+
+        self._meta_engine = engine
+        metadata = sa.MetaData()
+        self._meta_table = sa.Table(
+            "authz_roles",
+            metadata,
+            sa.Column("slug", sa.String(255), primary_key=True),  # = the role id/name
+            sa.Column("name", sa.String(255)),  # human-readable display name
+            sa.Column("description", sa.Text),
+            sa.Column("is_default", sa.Boolean, nullable=False, default=False),
+            sa.Column("created_at", sa.Integer, nullable=False),
+            sa.Column("updated_at", sa.Integer, nullable=False),
+        )
+        metadata.create_all(self._meta_engine)
+
+    def _require_meta(self) -> None:
+        if self._meta_engine is None:
+            raise RuntimeError(NO_DB_MESSAGE)
+
+    def _meta_get(self, slug: str) -> Optional[dict]:
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.connect() as conn:
+            r = conn.execute(sa.select(self._meta_table).where(self._meta_table.c.slug == slug)).mappings().first()
+        return dict(r) if r else None
+
+    def _meta_get_all(self) -> dict:
+        """All metadata rows as ``{slug: row}`` in a single read, so list views
+        don't do one SELECT per role (N+1)."""
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.connect() as conn:
+            rows = conn.execute(sa.select(self._meta_table)).mappings().all()
+        return {r["slug"]: dict(r) for r in rows}
+
+    def _meta_upsert(
+        self,
+        slug: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+    ) -> dict:
+        existing = self._meta_get(slug)
+        now = int(time.time())
+        if existing is None:
+            row = {
+                "slug": slug,
+                "name": name or slug,
+                "description": description,
+                "is_default": bool(is_default) if is_default is not None else False,
+                "created_at": now,
+                "updated_at": now,
+            }
+        else:
+            row = dict(existing)
+            if name is not None:
+                row["name"] = name
+            if description is not None:
+                row["description"] = description
+            if is_default is not None:
+                row["is_default"] = bool(is_default)
+            row["updated_at"] = now
+        self._meta_write(row, insert=existing is None)
+        return row
+
+    def _meta_write(self, row: dict, insert: bool) -> None:
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.begin() as conn:
+            if insert:
+                conn.execute(sa.insert(self._meta_table).values(**row))
+            else:
+                conn.execute(sa.update(self._meta_table).where(self._meta_table.c.slug == row["slug"]).values(**row))
+
+    def _meta_delete(self, slug: str) -> None:
+        self._require_meta()
+        import sqlalchemy as sa
+
+        with self._meta_engine.begin() as conn:
+            conn.execute(sa.delete(self._meta_table).where(self._meta_table.c.slug == slug))
+
+    def _meta_or_default(self, slug: str) -> dict:
+        """Metadata for a role, synthesising defaults for rows defined before
+        metadata existed (or via the raw enforcer)."""
+        meta = self._meta_get(slug)
+        if meta is not None:
+            return meta
+        return {"slug": slug, "name": slug, "description": None, "is_default": False, "created_at": 0, "updated_at": 0}
+
     # ------------------------------------------------------------------ roles
-    def set_role_scopes(self, role: str, scopes: List[str], actor: Optional[str] = None) -> None:
-        """Define (or replace) what a role can do, in agno scope terms."""
-        before = self.get_role_scopes(role) if self._audit else None
-        self._engine.set_role_scopes(role, [(scope, "allow") for scope in scopes])
-        self._emit("role.set_scopes", role, before, self.get_role_scopes(role) if self._audit else None, actor)
+    def set_role_scopes(
+        self,
+        role: str,
+        scopes: List[ScopeInput],
+        actor: Optional[str] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+    ) -> None:
+        """Define (or replace) what a role can do, in agno scope terms.
+
+        ``scopes`` items may be plain strings (granted/allow), ``(scope, effect)``
+        tuples, or ``{"scope": ..., "effect": "allow"|"deny"}`` dicts. Also creates
+        / updates the role's metadata (display ``name`` / ``description`` /
+        ``is_default``)."""
+        # Audit the full entries (scope + effect) so an allow<->deny flip is visible
+        # in the trail; plain scope strings would show no change.
+        before = self.get_role_scope_entries(role) if self._audit else None
+        self._engine.set_role_scopes(role, [_normalize_scope(e) for e in scopes])
+        self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.set_scopes", role, before, self.get_role_scope_entries(role) if self._audit else None, actor)
 
     def get_role_scopes(self, role: str) -> List[str]:
-        """Return a role's scopes in agno terms (best-effort read-back)."""
-        return sorted(scope for scope, _effect in self._engine.get_role_scopes(role))
+        """Return a role's scope strings (allow + deny), for display/read-back."""
+        return sorted(scope for scope, _ in self._engine.get_role_scopes(role))
+
+    def get_role_scope_entries(self, role: str) -> List[dict]:
+        """Return a role's scopes with effects: ``[{"scope": ..., "effect": ...}]``."""
+        entries = [{"scope": scope, "effect": effect} for scope, effect in self._engine.get_role_scopes(role)]
+        return sorted(entries, key=lambda e: (e["scope"], e["effect"]))
+
+    def create_role(
+        self,
+        role: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Create a role with metadata only — no scopes (add those via
+        set_role_scopes / patch_role_scopes). Raises FileExistsError if it exists."""
+        if self.get_role(role) is not None:
+            raise FileExistsError(role)
+        rec = self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.created", role, None, [self._meta_summary(rec)], actor)
+        return rec
+
+    def set_role_meta(
+        self,
+        role: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        is_default: Optional[bool] = None,
+        actor: Optional[str] = None,
+    ) -> dict:
+        """Update ONLY a role's metadata (display name / description / is_default),
+        leaving its scopes untouched. Raises KeyError if the role doesn't exist."""
+        if self.get_role(role) is None:
+            raise KeyError(role)
+        before = self._meta_or_default(role)
+        rec = self._meta_upsert(role, name=name, description=description, is_default=is_default)
+        self._emit("role.updated", role, [self._meta_summary(before)], [self._meta_summary(rec)], actor)
+        return rec
+
+    def patch_role_scopes(
+        self,
+        role: str,
+        upsert: Optional[List[ScopeInput]] = None,
+        remove: Optional[List[ScopeInput]] = None,
+        actor: Optional[str] = None,
+    ) -> None:
+        """Apply a scope diff: add/flip the ``upsert`` scopes and drop the ``remove``
+        scopes, leaving every other scope (and the metadata) intact."""
+        before = self.get_role_scope_entries(role) if self._audit else None
+        for entry in upsert or []:
+            scope, effect = _normalize_scope(entry)
+            self._engine.add_scope(role, scope, effect)
+        for entry in remove or []:
+            scope, _ = _normalize_scope(entry)
+            self._engine.remove_scope(role, scope)
+        self._meta_upsert(role)  # touch updated_at / ensure metadata row exists
+        self._emit("role.set_scopes", role, before, self.get_role_scope_entries(role) if self._audit else None, actor)
+
+    @staticmethod
+    def _meta_summary(rec: dict) -> str:
+        bits = [rec.get("name") or rec["slug"]]
+        if rec.get("description"):
+            bits.append(str(rec["description"]))
+        if rec.get("is_default"):
+            bits.append("default")
+        return " · ".join(bits)
+
+    def get_role(self, role: str) -> Optional[dict]:
+        """Full role record: metadata + scope entries, or None if the role has
+        neither policies nor metadata."""
+        scopes = self.get_role_scope_entries(role)
+        meta = self._meta_get(role)
+        if meta is None and not scopes and role not in self._engine.list_roles():
+            # No metadata, no scopes, and not even an assignment-only role -> absent.
+            return None
+        return {**self._meta_or_default(role), "scopes": scopes}
 
     def remove_role(self, role: str, actor: Optional[str] = None) -> None:
         before = self.get_role_scopes(role) if self._audit else None
         self._engine.remove_role(role)
+        self._meta_delete(role)
         self._emit("role.removed", role, before, None, actor)
 
     def list_roles(self) -> List[str]:
-        return sorted(self._engine.list_roles())
+        """All role slugs (those with policies and/or metadata)."""
+        slugs = set(self._engine.list_roles())
+        if self._meta_engine is not None:
+            import sqlalchemy as sa
+
+            with self._meta_engine.connect() as conn:
+                slugs |= {r[0] for r in conn.execute(sa.select(self._meta_table.c.slug))}
+        return sorted(slugs)
+
+    def list_roles_detailed(self) -> List[dict]:
+        """Every role as a full record (metadata + scope entries).
+
+        Metadata is fetched in one read (not one SELECT per role), and
+        assignment-only roles (a subject is assigned but no scopes/metadata exist
+        yet) are surfaced with an empty scope list rather than dropped."""
+        meta_all = self._meta_get_all()
+        default = {"name": None, "description": None, "is_default": False, "created_at": 0, "updated_at": 0}
+        out: List[dict] = []
+        for slug in self.list_roles():
+            meta = meta_all.get(slug) or {"slug": slug, **default, "name": slug}
+            out.append({**meta, "scopes": self.get_role_scope_entries(slug)})
+        return out
 
     # ------------------------------------------------------------- assignments
     def assign(self, subject: str, role: str, actor: Optional[str] = None) -> None:
@@ -148,8 +398,9 @@ class ManagedRoleStore:
 
         A subject holds at most ONE role at a time — assigning replaces any
         current role rather than accumulating. This mirrors the cloud RBAC model
-        (a membership has one role). No-op if the subject already holds exactly
-        this role.
+        (a membership has one role) so role management is a select, not a
+        multi-grant. Compose permissions in the role's scopes, not by stacking
+        roles on a user. No-op if the subject already holds exactly this role.
         """
         before = self.roles_of(subject)
         if before == [role]:
@@ -175,10 +426,13 @@ class ManagedRoleStore:
 
     @property
     def is_bound(self) -> bool:
-        """True once the store has a DB (passed directly or adopted via
-        :meth:`attach_db`). A custom ``engine=`` is assumed self-managed (bound)."""
+        """True once the store has a DB for both its policy engine and its role
+        metadata (passed directly or adopted via :meth:`attach_db`). A custom
+        ``engine=`` is assumed to manage its own persistence, but the store still
+        needs a DB for the metadata (authz_roles) it owns."""
         flag = getattr(self._engine, "is_bound", None)
-        return bool(flag) if flag is not None else True
+        engine_bound = bool(flag) if flag is not None else True
+        return engine_bound and self._meta_engine is not None
 
     def attach_db(self, db: Any) -> None:
         """Bind an agno ``Db`` to a store created without one, so managed roles
@@ -189,36 +443,57 @@ class ManagedRoleStore:
         if callable(attach):
             attach(db)
 
+        # Bind the metadata table (authz_roles) to the same DB, mirroring the
+        # engine's own attach so policy, assignments, and metadata all land together.
+        # No-op if metadata is already bound or the db isn't SQL-capable.
+        if self._meta_engine is None:
+            try:
+                self._init_meta_table(_engine_from_db(db))
+            except Exception:
+                return
+
     # ------------------------------------------------------------------ audit
-    def audit_log(self, limit: int = 100) -> List[Dict[str, Any]]:
-        """Recent change-audit events (newest first), if the audit sink supports
-        reading (e.g. ``DbAuditSink``). Returns ``[]`` when no readable sink is
-        configured (e.g. a logging-only sink, or no audit at all)."""
+    def audit_log(
+        self,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None,
+        sort_by: str = DEFAULT_AUDIT_SORT_FIELD,
+        order: str = DEFAULT_AUDIT_SORT_ORDER,
+    ) -> List[Dict[str, Any]]:
+        """A page of change-audit events (newest first by default), if the audit
+        sink supports reading (e.g. ``DbAuditSink``). ``search`` filters over
+        actor/action/target; ``sort_by`` is any of the sink's sortable fields.
+        Returns ``[]`` when no readable sink is configured (e.g. a logging-only
+        sink, or no audit at all)."""
         sink = self._audit
         if sink is not None and hasattr(sink, "read"):
-            return sink.read(limit)
+            return sink.read(limit, offset=offset, search=search, sort_by=sort_by, order=order)
         return []
+
+    def audit_count(self, search: Optional[str] = None) -> int:
+        """Total number of change-audit events (for pagination, honouring
+        ``search``); 0 when the sink isn't readable."""
+        sink = self._audit
+        if sink is not None and hasattr(sink, "count"):
+            return int(sink.count(search=search))
+        return 0
 
     # ----------------------------------------------------------------- gating
     def can_manage(self, principal_id: Optional[str], claims: Optional[Dict[str, Any]] = None) -> bool:
         """True if the caller may administer roles (i.e. satisfies ``agent_os:admin``).
 
-        An admin can be defined two ways, both handled here:
-          - by a role in this store, or
+        Admin can be defined two ways, both handled via the engine:
+          - by a role in this store (subject -> agent_os:admin), or
           - by a role carried on the token, when ``roles_claim`` is set.
-        Note this is intentionally NOT the generic provider ``check`` (which
-        defers non-resource decisions to route scope mappings and would let any
-        authenticated caller through).
+        Intentionally NOT the generic provider ``check`` (which defers non-resource
+        decisions and would let any authenticated caller through).
         """
         roles = normalize_roles_claim(claims, self._roles_claim)
-        if roles and self._engine.check_scope("agent_os:admin", roles=roles):
-            return True
-        if principal_id:
-            return self._engine.check_scope("agent_os:admin", subject=principal_id)
-        return False
+        return self._engine.check_scope("agent_os:admin", subject=principal_id, roles=roles)
 
     # --------------------------------------------------------------- provider
     @property
-    def provider(self) -> EngineAuthorizationProvider:
-        """The AuthorizationProvider to plug into AuthorizationConfig."""
+    def provider(self):
+        """The AuthorizationProvider to plug into AuthorizationConfig (engine-backed)."""
         return EngineAuthorizationProvider(self._engine, roles_claim=self._roles_claim)

--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -1,6 +1,6 @@
 """Schemas related to the AgentOS configuration"""
 
-from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Set, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -137,8 +137,10 @@ class AuthorizationConfig(BaseModel):
     # (JWT/PAT scopes, no external dependency). Supply an AuthorizationProvider to
     # swap in a richer model (managed roles, ReBAC/ABAC, OpenFGA, ...) enforced at
     # the same points as scopes — the REST route gate, per-resource gate, WS gates,
-    # and MCP tool gate all resolve through it.
-    authorization_provider: Optional[AuthorizationProvider] = None
+    # and MCP tool gate all resolve through it. Pass a LIST of them to run several
+    # authz planes at once (e.g. token scopes for operators + a managed role store
+    # for end users) — a request is allowed if any of them allows it.
+    authorization_provider: Optional[Union[AuthorizationProvider, List[AuthorizationProvider]]] = None
     # Managed-roles shortcut: pass a ManagedRoleStore and AgentOS uses its provider
     # (mutually exclusive with authorization_provider). If the store has no DB, AgentOS
     # binds the OS database to it so roles persist alongside agent data.

--- a/libs/agno/tests/integration/os/test_authz_planes.py
+++ b/libs/agno/tests/integration/os/test_authz_planes.py
@@ -1,0 +1,227 @@
+"""Two authz planes on one OS: token-scopes (operators) + the store (end users)."""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from fastapi.testclient import TestClient
+
+pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the native engine + SQLAlchemy
+
+from agno.agent import Agent  # noqa: E402
+from agno.db.in_memory import InMemoryDb  # noqa: E402
+from agno.os import AgentOS  # noqa: E402
+from agno.os.authz._composite import CompositeAuthorizationProvider  # noqa: E402 (internal mechanism)
+from agno.os.authz.provider import AuthorizationContext  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
+from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
+from agno.os.authz.scope_provider import ScopeAuthorizationProvider  # noqa: E402
+from agno.os.config import AuthorizationConfig  # noqa: E402
+
+SECRET = "composite-secret-at-least-256-bits-long-padding-xxxxxxxx"
+OS_ID = "composite-os"
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+def test_empty_providers_rejected():
+    with pytest.raises(ValueError):
+        CompositeAuthorizationProvider([])
+
+
+def test_allows_via_either_plane():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("storeuser", "viewer")
+    comp = CompositeAuthorizationProvider([ScopeAuthorizationProvider(), store.provider])
+
+    # operator plane: scopes ride the token, nothing in the store for them
+    operator = AuthorizationContext(principal_id="op", scopes=["agents:read"], resource_type="agents", action="read")
+    assert comp.authorize_route(operator, ["agents:read"]) is True
+
+    # end-user plane: no token scopes, the store grants it
+    enduser = AuthorizationContext(
+        principal_id="storeuser", scopes=[], resource_type="agents", resource_id="a1", action="read"
+    )
+    assert comp.authorize_route(enduser, ["agents:read"]) is True
+
+    # neither plane grants -> denied
+    nobody = AuthorizationContext(
+        principal_id="nobody", scopes=[], resource_type="agents", resource_id="a1", action="read"
+    )
+    assert comp.authorize_route(nobody, ["agents:read"]) is False
+
+
+def test_accessible_ids_union_with_wildcard_winning():
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("one", ["agents:a1:read"])
+    store.assign("u", "one")
+    comp = CompositeAuthorizationProvider([ScopeAuthorizationProvider(), store.provider])
+
+    # token gives a specific id, store gives another -> union
+    ctx = AuthorizationContext(principal_id="u", scopes=["agents:a2:read"], resource_type="agents", action="read")
+    assert comp.accessible_resource_ids(ctx) == {"a1", "a2"}
+
+    # a global/wildcard scope on the token -> {"*"} wins
+    ctx_all = AuthorizationContext(principal_id="u", scopes=["agents:read"], resource_type="agents", action="read")
+    assert comp.accessible_resource_ids(ctx_all) == {"*"}
+
+
+def _token(sub, scopes):
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": scopes, "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def test_both_planes_enforce_on_one_os_end_to_end():
+    """One OS: an operator authorized by token scopes AND an end user authorized by
+    the store both get in; an unknown caller is denied."""
+    store = ManagedRoleStore(db_url=_db_url())
+    store.set_role_scopes("viewer", ["agents:*:read"])
+    store.assign("enduser", "viewer")  # end user known only to the store
+
+    agent = Agent(id="research-agent", name="R", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            # public API: a LIST of providers -> allowed if any grants
+            authorization_provider=[ScopeAuthorizationProvider(), store.provider],
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+    hdr = lambda sub, scopes: {"Authorization": f"Bearer {_token(sub, scopes)}"}  # noqa: E731
+
+    # operator: token carries the scope, no store entry
+    assert client.get("/agents/research-agent", headers=hdr("op", ["agents:read"])).status_code == 200
+    # end user: empty token scopes, store grants it
+    assert client.get("/agents/research-agent", headers=hdr("enduser", [])).status_code == 200
+    # neither: unknown caller, no scopes
+    assert client.get("/agents/research-agent", headers=hdr("nobody", [])).status_code == 403
+
+
+def test_admin_gate_accepts_admin_from_token_scope():
+    """An operator whose token carries agent_os:admin can manage roles even though
+    they have no admin assignment in the store (the cloud/operator plane)."""
+    store = ManagedRoleStore(db_url=_db_url())  # nobody is admin in the store
+    agent = Agent(id="research-agent", name="R", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[agent],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            authorization_provider=[ScopeAuthorizationProvider(), store.provider],
+        ),
+    )
+    app = agent_os.get_app()
+    app.include_router(get_roles_router(store))
+    client = TestClient(app)
+
+    # admin via token scope -> can manage
+    assert (
+        client.get("/authz/roles", headers={"Authorization": f"Bearer {_token('op', ['agent_os:admin'])}"}).status_code
+        == 200
+    )
+    # no admin scope and not in store -> denied
+    assert (
+        client.get("/authz/roles", headers={"Authorization": f"Bearer {_token('joe', ['agents:read'])}"}).status_code
+        == 403
+    )
+
+
+def test_authorization_provider_rejects_a_string():
+    """A list of providers is supported; a string is a mistake. The typed
+    AuthorizationConfig field rejects it at construction (pydantic ValidationError,
+    a ValueError), so it can never be mistaken for an iterable of characters."""
+    with pytest.raises(ValueError, match="AuthorizationProvider"):
+        AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            authorization_provider="ScopeAuthorizationProvider",  # oops, a string
+        )
+
+
+def test_composite_filter_accessible_unions_and_respects_per_plane_deny():
+    """CompositeProvider.filter_accessible is a union (OR): each plane filters
+    deny-aware within itself, and a resource is visible if ANY plane keeps it —
+    so an engine deny carves the engine's grant but can't veto a scope-plane allow."""
+    from agno.os.authz._composite import CompositeAuthorizationProvider
+    from agno.os.authz.engine import EngineAuthorizationProvider
+    from agno.os.authz.native_engine import NativePolicyEngine
+    from agno.os.authz.provider import AuthorizationContext
+    from agno.os.authz.scope_provider import ScopeAuthorizationProvider
+
+    class R:
+        def __init__(self, rid):
+            self.id = rid
+
+    resources = [R("a"), R("secret"), R("b")]
+
+    eng = NativePolicyEngine(db_url=_db_url())
+    eng.set_role_scopes("analyst", [("agents:*:read", "allow"), ("agents:secret:read", "deny")])
+    eng.assign("bob", "analyst")
+    engine_prov = EngineAuthorizationProvider(eng)
+
+    # engine plane alone: deny-overrides carves out 'secret'
+    ctx = AuthorizationContext(principal_id="bob", resource_type="agents")
+    engine_only = CompositeAuthorizationProvider([engine_prov])
+    assert {r.id for r in engine_only.filter_accessible(ctx, resources)} == {"a", "b"}
+
+    # add a scope plane that grants all agents: union shows 'secret' again (OR;
+    # the engine's deny is per-plane and can't veto another plane's grant)
+    ctx_both = AuthorizationContext(principal_id="bob", scopes=["agents:read"], resource_type="agents")
+    both = CompositeAuthorizationProvider([ScopeAuthorizationProvider(), engine_prov])
+    assert {r.id for r in both.filter_accessible(ctx_both, resources)} == {"a", "secret", "b"}
+
+
+def test_composite_abstains_when_a_plane_errors():
+    """A plane that raises (e.g. an unreachable OpenFGA backend) must ABSTAIN, not fail
+    the whole request: under the OR a healthy peer plane still grants, and only when
+    EVERY plane errors does the composite deny (fail-closed)."""
+    from agno.os.authz._composite import CompositeAuthorizationProvider
+    from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+    class Boom(AuthorizationProvider):
+        def check(self, ctx):
+            raise RuntimeError("backend down")
+
+        def accessible_resource_ids(self, ctx):
+            raise RuntimeError("backend down")
+
+    class Grant(AuthorizationProvider):
+        def check(self, ctx):
+            return True
+
+        def accessible_resource_ids(self, ctx):
+            return {"a"}
+
+    ctx = AuthorizationContext(
+        principal_id="u", scopes=[], claims={}, resource_type="agents", resource_id="x", action="run"
+    )
+    # a healthy plane still grants despite the broken one (order-independent)
+    assert CompositeAuthorizationProvider([Boom(), Grant()]).check(ctx) is True
+    assert CompositeAuthorizationProvider([Grant(), Boom()]).check(ctx) is True
+    # every plane broken -> deny (fail closed), not a 500
+    assert CompositeAuthorizationProvider([Boom(), Boom()]).check(ctx) is False
+    # accessible ids union ignores the broken plane
+    assert CompositeAuthorizationProvider([Boom(), Grant()]).accessible_resource_ids(ctx) == {"a"}

--- a/libs/agno/tests/integration/os/test_managed_roles_api.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_api.py
@@ -90,18 +90,33 @@ def test_admin_can_list_and_read_roles(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/roles", headers=_auth("alice"))
     assert r.status_code == 200
-    assert set(r.json()["roles"]) == {"viewer", "admin"}
+    body = r.json()  # paginated {data, meta}
+    assert {role["slug"] for role in body["data"]} == {"viewer", "admin"}
+    assert body["meta"]["total_count"] == 2
 
     r = client.get("/authz/roles/viewer", headers=_auth("alice"))
     assert r.status_code == 200
-    assert r.json()["scopes"] == ["agents:read"]  # global read-back form
+    role = r.json()
+    assert role["slug"] == "viewer" and role["name"] == "viewer"
+    # scopes are parsed objects now: {raw, namespace, sub_namespace, permission, value}
+    assert role["scopes"] == [
+        {
+            "id": None,
+            "raw": "agents:read",
+            "namespace": "agents",
+            "sub_namespace": None,
+            "permission": "read",
+            "value": "allow",
+        }
+    ]
 
 
 def test_admin_crud_role(client_and_store):
     client, store = client_and_store
-    # create a new role
+    # create a role (metadata only), then set its scopes via the subresource
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "editor"}).status_code == 201
     r = client.put(
-        "/authz/roles/editor",
+        "/authz/roles/editor/scopes",
         headers=_auth("alice"),
         json={"scopes": ["agents:*:read", "agents:research-agent:run"]},
     )
@@ -118,7 +133,7 @@ def test_admin_assign_and_revoke(client_and_store):
     client, store = client_and_store
     r = client.post("/authz/users/carol/roles", headers=_auth("alice"), json={"role": "viewer"})
     assert r.status_code == 200
-    assert r.json()["roles"] == ["viewer"]
+    assert r.json()["role"] == "viewer"  # singular: one role per user
     assert store.roles_of("carol") == ["viewer"]
 
     r = client.delete("/authz/users/carol/roles/viewer", headers=_auth("alice"))
@@ -134,8 +149,9 @@ def test_granting_via_api_takes_effect_on_next_request(client_and_store):
     ).status_code == 403
 
     # admin defines a runner role and grants it to bob via the HTTP API
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "runner"}).status_code == 201
     assert client.put(
-        "/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
+        "/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]}
     ).status_code == 200
     assert client.post(
         "/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"}
@@ -157,10 +173,13 @@ def test_scope_catalog_endpoint(client_and_store):
     client, _ = client_and_store
     r = client.get("/authz/scopes", headers=_auth("alice"))
     assert r.status_code == 200
-    body = r.json()
-    assert "agents" in body["grouped"] and "read" in body["grouped"]["agents"]
-    assert "agents:run" in body["scopes"]
-    assert body["admin_scope"] == "agent_os:admin"
+    body = r.json()  # flat list of {raw, namespace, sub_namespace?, permission}
+    assert isinstance(body, list)
+    by_raw = {s["raw"]: s for s in body}
+    assert by_raw["agents:run"] == {"raw": "agents:run", "namespace": "agents", "permission": "run"}
+    assert "agent_os:admin" in by_raw  # the super-scope is included
+    # exclude_none: sub_namespace omitted when absent
+    assert "sub_namespace" not in by_raw["agents:read"]
     # non-admin is blocked
     assert client.get("/authz/scopes", headers=_auth("bob")).status_code == 403
 
@@ -200,3 +219,74 @@ def test_admin_via_token_claim_can_manage():
 
     assert client.get("/authz/roles", headers=admin_h).status_code == 200
     assert client.get("/authz/roles", headers=viewer_h).status_code == 403
+
+
+def test_patch_role_metadata_only(client_and_store):
+    """PATCH /roles/{slug} updates name/description without touching scopes."""
+    client, store = client_and_store
+    store.set_role_scopes("editor", ["agents:*:read"], name="Editor")
+
+    r = client.patch("/authz/roles/editor", headers=_auth("alice"), json={"description": "can edit things"})
+    assert r.status_code == 200, r.text
+    role = r.json()
+    assert role["name"] == "Editor" and role["description"] == "can edit things"
+    # scopes untouched by the metadata patch
+    assert [s["raw"] for s in role["scopes"]] == ["agents:read"]
+
+    # patching a non-existent role -> 404
+    assert client.patch("/authz/roles/ghost", headers=_auth("alice"), json={"name": "x"}).status_code == 404
+
+
+def test_put_scopes_subresource_replaces(client_and_store):
+    """PUT /roles/{slug}/scopes replaces scopes, preserves metadata, returns scopes."""
+    client, store = client_and_store
+    store.set_role_scopes("editor", ["agents:*:read"], name="Editor")
+
+    r = client.put(
+        "/authz/roles/editor/scopes",
+        headers=_auth("alice"),
+        json={"scopes": ["agents:*:run", {"scope": "agents:secret:run", "effect": "deny"}]},
+    )
+    assert r.status_code == 200, r.text
+    scopes = r.json()  # returns the scope list
+    by_raw = {s["raw"]: s for s in scopes}
+    assert by_raw["agents:run"]["value"] == "allow"
+    assert by_raw["agents:secret:run"]["value"] == "deny"
+    # metadata (name) preserved through a scopes-only replace
+    assert client.get("/authz/roles/editor", headers=_auth("alice")).json()["name"] == "Editor"
+
+
+def test_patch_scopes_subresource_diffs(client_and_store):
+    """PATCH /roles/{slug}/scopes adds/flips upsert and drops remove, keeping the rest."""
+    client, store = client_and_store
+    store.set_role_scopes("editor", ["agents:*:read", "teams:*:read"])
+
+    r = client.patch(
+        "/authz/roles/editor/scopes",
+        headers=_auth("alice"),
+        json={"upsert": [{"scope": "agents:*:run", "effect": "allow"}], "remove": ["teams:read"]},
+    )
+    assert r.status_code == 200, r.text
+    raws = {s["raw"] for s in r.json()["scopes"]}
+    assert raws == {"agents:read", "agents:run"}  # teams:read removed, agents:run added, agents:read kept
+
+
+def test_create_role_metadata_only_then_add_scopes(client_and_store):
+    """POST /roles creates a role with NO scopes (RESTful); scopes are added
+    separately via the /scopes subresource."""
+    client, store = client_and_store
+
+    r = client.post("/authz/roles", headers=_auth("alice"), json={"slug": "support", "name": "Support"})
+    assert r.status_code == 201, r.text
+    role = r.json()
+    assert role["slug"] == "support" and role["name"] == "Support" and role["scopes"] == []
+
+    # creating the same role again -> 409
+    assert client.post("/authz/roles", headers=_auth("alice"), json={"slug": "support"}).status_code == 409
+
+    # add permissions via the subresource
+    r = client.put("/authz/roles/support/scopes", headers=_auth("alice"), json={"scopes": ["sessions:read"]})
+    assert r.status_code == 200
+    assert [s["raw"] for s in client.get("/authz/roles/support", headers=_auth("alice")).json()["scopes"]] == [
+        "sessions:read"
+    ]

--- a/libs/agno/tests/integration/os/test_managed_roles_audit.py
+++ b/libs/agno/tests/integration/os/test_managed_roles_audit.py
@@ -74,10 +74,12 @@ def test_store_emits_change_events_with_actor_and_diff():
         ("user.unassigned", "bob", "alice"),
         ("role.removed", "member", "alice"),
     ]
-    # before/after captured on the widen
+    # before/after captured on the widen — full entries (scope + effect) so an
+    # allow<->deny flip is visible in the trail.
     widen = sink.events[1]
-    assert widen.before == ["agents:read"]
-    assert set(widen.after) == {"agents:read", "agents:run"}
+    assert widen.before == [{"scope": "agents:read", "effect": "allow"}]
+    assert {e["scope"] for e in widen.after} == {"agents:read", "agents:run"}
+    assert all(e["effect"] == "allow" for e in widen.after)
     # assignment diff
     assign = sink.events[2]
     assert assign.before == [] and assign.after == ["member"]
@@ -140,8 +142,9 @@ def test_http_api_records_actor_from_jwt():
     app.include_router(get_roles_router(store))
     client = TestClient(app)
 
+    store.set_role_scopes("runner", ["agents:read"])  # role must exist before PUT /scopes
     sink.events.clear()
-    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.put("/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
     client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
     client.delete("/authz/users/bob/roles/runner", headers=_auth("alice"))
 
@@ -283,14 +286,16 @@ def test_decisions_endpoint_returns_trail_for_admin(tmp_path):
 
     client.get("/agents/research-agent", headers=_auth("bob", jti="dec-1"))  # allowed decision
 
-    # admin reads the decision trail
+    # admin reads the decision trail (paginated {data, meta})
     r = client.get("/authz/decisions", headers=_auth("alice"))
     assert r.status_code == 200
-    events = r.json()["events"]
+    body = r.json()
+    events = body["data"]
+    assert body["meta"]["total_count"] >= len(events)
     assert any(e["action"] == "access.allowed" and e["metadata"]["token"] == "dec-1" for e in events)
 
     # /authz/audit (changes) does NOT contain the access.* decisions
-    changes = client.get("/authz/audit", headers=_auth("alice")).json()["events"]
+    changes = client.get("/authz/audit", headers=_auth("alice")).json()["data"]
     assert all(not e["action"].startswith("access.") for e in changes)
 
     # non-admin and anonymous are blocked
@@ -323,16 +328,40 @@ def test_audit_endpoint_returns_trail(tmp_path):
     client = TestClient(app)
 
     # make a couple of changes over the API
-    client.put("/authz/roles/runner", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
+    client.post("/authz/roles", headers=_auth("alice"), json={"slug": "runner"})
+    client.put("/authz/roles/runner/scopes", headers=_auth("alice"), json={"scopes": ["agents:*:run"]})
     client.post("/authz/users/bob/roles", headers=_auth("alice"), json={"role": "runner"})
 
-    # admin can read the trail; newest first
+    # admin can read the trail; newest first, paginated {data, meta}
     r = client.get("/authz/audit", headers=_auth("alice"))
     assert r.status_code == 200
-    events = r.json()["events"]
+    body = r.json()
+    events = body["data"]
+    assert body["meta"]["page"] == 1 and body["meta"]["total_count"] == len(events)
     assert events[0]["action"] == "user.assigned" and events[0]["actor"] == "alice"
     assert events[0]["after"] == ["runner"]
     assert any(e["action"] == "role.set_scopes" and e["target"] == "runner" for e in events)
+
+    # page/limit slice the trail (page 2 with limit 1 = the second-newest event)
+    paged = client.get("/authz/audit?limit=1&page=2", headers=_auth("alice")).json()
+    assert len(paged["data"]) == 1
+    assert paged["data"][0]["action"] == events[1]["action"]
+    assert paged["meta"]["total_count"] == len(events) and paged["meta"]["page"] == 2
+
+    # search filters over actor/action/target (case-insensitive), counted in meta
+    found = client.get("/authz/audit?search=SET_SCOPES", headers=_auth("alice")).json()
+    assert found["data"] and all(e["action"] == "role.set_scopes" for e in found["data"])
+    assert found["meta"]["total_count"] == len(found["data"])
+    assert client.get("/authz/audit?search=zzz-no-match", headers=_auth("alice")).json()["data"] == []
+
+    # sort_order=asc flips to oldest first
+    asc = client.get("/authz/audit?sort_order=asc", headers=_auth("alice")).json()["data"]
+    assert [e["action"] for e in asc] == [e["action"] for e in reversed(events)]
+
+    # sort_by any sortable field; an unknown field is a 422, not a 500
+    by_action = client.get("/authz/audit?sort_by=action&sort_order=asc", headers=_auth("alice")).json()["data"]
+    assert [e["action"] for e in by_action] == sorted(e["action"] for e in events)
+    assert client.get("/authz/audit?sort_by=evil", headers=_auth("alice")).status_code == 422
 
     # non-admin and anonymous are blocked
     store.assign("bob", "runner")  # bob still isn't an admin

--- a/libs/agno/tests/integration/os/test_managed_users.py
+++ b/libs/agno/tests/integration/os/test_managed_users.py
@@ -12,7 +12,7 @@ import jwt
 import pytest
 from fastapi.testclient import TestClient
 
-from agno.os.authz.audit import AuditEvent, AuditSink  # noqa: E402
+from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink  # noqa: E402
 from agno.os.authz.user_store import ManagedUserStore  # noqa: E402
 
 SECRET = "managed-users-secret-at-least-256-bits-long-padding-xxxxxx"
@@ -111,6 +111,7 @@ pytest.importorskip("sqlalchemy")  # managed roles persist/enforce via the nativ
 from agno.agent import Agent  # noqa: E402
 from agno.db.in_memory import InMemoryDb  # noqa: E402
 from agno.os import AgentOS  # noqa: E402
+from agno.os.authz.role_router import get_roles_router  # noqa: E402
 from agno.os.authz.role_store import ManagedRoleStore  # noqa: E402
 from agno.os.config import AuthorizationConfig  # noqa: E402
 
@@ -142,6 +143,72 @@ def _os(role_store, user_store, **cfg):
             **cfg,
         ),
     )
+
+
+def test_users_api_crud_and_role_merge():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("alice", "admin")
+    users = ManagedUserStore()
+
+    app = _os(roles, users).get_app()
+    app.include_router(get_roles_router(roles, user_store=users))
+    client = TestClient(app)
+
+    # create a user
+    r = client.post("/authz/users", headers=_auth("alice"), json={"id": "bob", "email": "bob@co"})
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == "bob" and r.json()["role"] is None and r.json()["status"] == "active"
+
+    # give bob a role; the user view merges it in (singular: one role per user)
+    roles.assign("bob", "viewer")
+    got = client.get("/authz/users/bob", headers=_auth("alice")).json()
+    assert got["email"] == "bob@co" and got["role"] == "viewer"
+
+    # list is paginated ({data, meta}) and includes bob with his role
+    listed = client.get("/authz/users", headers=_auth("alice")).json()["data"]
+    assert any(u["id"] == "bob" and u["role"] == "viewer" for u in listed)
+
+    # fuzzy search filters by id/email/name, case-insensitive, before pagination
+    found = client.get("/authz/users?search=BOB", headers=_auth("alice")).json()
+    assert [u["id"] for u in found["data"]] == ["bob"] and found["meta"]["total_count"] == 1
+    assert [u["id"] for u in client.get("/authz/users?search=bob@co", headers=_auth("alice")).json()["data"]] == ["bob"]
+    nothing = client.get("/authz/users?search=zzz-no-match", headers=_auth("alice")).json()
+    assert nothing["data"] == [] and nothing["meta"]["total_count"] == 0
+
+    # sorting: any USER_SORT_FIELDS member, asc/desc; unknown field is a 422
+    client.post("/authz/users", headers=_auth("alice"), json={"id": "ann", "email": "ann@co"})
+    by_id = client.get("/authz/users?sort_by=id&sort_order=asc", headers=_auth("alice")).json()["data"]
+    assert [u["id"] for u in by_id] == sorted(u["id"] for u in by_id)
+    assert client.get("/authz/users?sort_by=evil", headers=_auth("alice")).status_code == 422
+
+    # update + delete; PATCH {"disabled": ...} is the revocation kill-switch
+    client.patch("/authz/users/bob", headers=_auth("alice"), json={"name": "Bob"})
+    assert client.get("/authz/users/bob", headers=_auth("alice")).json()["name"] == "Bob"
+    disabled = client.patch("/authz/users/bob", headers=_auth("alice"), json={"disabled": True}).json()
+    assert disabled["status"] == "disabled" and disabled["disabled"] is True
+    assert users.is_disabled("bob") is True
+    enabled = client.patch("/authz/users/bob", headers=_auth("alice"), json={"disabled": False}).json()
+    assert enabled["status"] == "active" and users.is_disabled("bob") is False
+    assert client.delete("/authz/users/bob", headers=_auth("alice")).json()["deleted"] is True
+    assert client.get("/authz/users/bob", headers=_auth("alice")).status_code == 404
+
+
+def test_users_api_is_admin_only():
+    roles = ManagedRoleStore(db_url=_db_url())
+    roles.set_role_scopes("admin", ["agent_os:admin"])
+    roles.set_role_scopes("viewer", ["agents:*:read"])
+    roles.assign("alice", "admin")
+    roles.assign("bob", "viewer")
+    users = ManagedUserStore()
+
+    app = _os(roles, users).get_app()
+    app.include_router(get_roles_router(roles, user_store=users))
+    client = TestClient(app)
+
+    assert client.get("/authz/users", headers=_auth("bob")).status_code == 403  # non-admin
+    assert client.get("/authz/users").status_code == 401  # anonymous
 
 
 def test_disabled_user_is_denied_even_with_valid_token():
@@ -215,6 +282,30 @@ def test_auto_provision_from_claims_at_the_gate():
     assert r.status_code == 200
     provisioned = users.get("carol")
     assert provisioned is not None and provisioned["email"] == "carol@co" and provisioned["name"] == "Carol"
+
+
+def test_stores_share_one_agno_db(tmp_path):
+    """Passing the same agno db to the role/user/audit stores reuses its engine,
+    so everything lives in one database (no second db_url to keep in sync)."""
+    import sqlalchemy as sa
+
+    from agno.db.sqlite import SqliteDb
+
+    shared = SqliteDb(db_file=str(tmp_path / "shared.db"))
+    r = ManagedRoleStore(db=shared)
+    u = ManagedUserStore(db=shared)
+    a = DbAuditSink(db=shared)  # noqa: F841 (constructed for table creation)
+
+    r.set_role_scopes("viewer", ["agents:*:read"])
+    r.assign("bob", "viewer")
+    u.upsert("bob", email="bob@co")
+
+    # all authz tables live in the single shared engine (native policy + grouping,
+    # users, and both audit trails)
+    tables = set(sa.inspect(shared.db_engine).get_table_names())
+    assert {"authz_policy", "authz_grouping", "authz_users", "authz_audit", "authz_decisions"} <= tables
+    assert r.roles_of("bob") == ["viewer"]
+    assert u.get("bob")["email"] == "bob@co"
 
 
 def test_db_takes_precedence_and_bad_db_errors():

--- a/libs/agno/tests/integration/os/test_policy_engine.py
+++ b/libs/agno/tests/integration/os/test_policy_engine.py
@@ -1,0 +1,118 @@
+"""The swappable-backend seam: ManagedRoleStore works with ANY PolicyEngine.
+
+Proves the engine port by backing the store with a tiny in-memory engine (no
+Casbin) and exercising the full agno-native surface + the provider through it.
+"""
+
+from typing import List, Set
+
+from agno.os.authz.engine import PolicyEngine, ScopeEntry
+from agno.os.authz.provider import AuthorizationContext
+from agno.os.authz.role_store import ManagedRoleStore
+
+
+def _db_url() -> str:
+    """A throwaway file-backed SQLite URL. Managed roles require a DB (no in-memory
+    mode); file-backed so the same DB is visible across the threads TestClient uses."""
+    import os
+    import tempfile
+
+    fd, path = tempfile.mkstemp(suffix=".authz.db")
+    os.close(fd)
+    return f"sqlite:///{path}"
+
+
+class DictPolicyEngine(PolicyEngine):
+    """Minimal dict-backed engine — exact scope-string matching, admin override.
+    Enough to show the store/provider delegate correctly through the port."""
+
+    def __init__(self):
+        self._roles: dict = {}  # role -> {scope: effect}
+        self._assign: dict = {}  # subject -> set[role]
+
+    def set_role_scopes(self, role, entries: List[ScopeEntry]) -> None:
+        self._roles[role] = {s: e for s, e in entries}
+
+    def add_scope(self, role, scope, effect="allow") -> None:
+        self._roles.setdefault(role, {})[scope] = effect
+
+    def remove_scope(self, role, scope) -> None:
+        self._roles.get(role, {}).pop(scope, None)
+
+    def get_role_scopes(self, role) -> List[ScopeEntry]:
+        return list(self._roles.get(role, {}).items())
+
+    def remove_role(self, role) -> None:
+        self._roles.pop(role, None)
+        for s in self._assign.values():
+            s.discard(role)
+
+    def list_roles(self) -> List[str]:
+        return list(self._roles)
+
+    def assign(self, subject, role) -> None:
+        self._assign.setdefault(subject, set()).add(role)
+
+    def unassign(self, subject, role) -> None:
+        self._assign.get(subject, set()).discard(role)
+
+    def roles_of(self, subject) -> List[str]:
+        return sorted(self._assign.get(subject, set()))
+
+    def _scopes_for(self, subject, roles):
+        rs = roles if roles else (self.roles_of(subject) if subject else [])
+        out: dict = {}
+        for r in rs:
+            out.update(self._roles.get(r, {}))
+        return out
+
+    def check_scope(self, scope, *, subject=None, roles=None) -> bool:
+        sc = self._scopes_for(subject, roles)
+        return sc.get("agent_os:admin") == "allow" or sc.get(scope) == "allow"
+
+    def check_resource(self, rt, rid, action, *, subject=None, roles=None) -> bool:
+        if not rt or not action:
+            return True
+        return self.check_scope(f"{rt}:{action}", subject=subject, roles=roles)
+
+    def accessible_resource_ids(self, rt, action, *, subject=None, roles=None) -> Set[str]:
+        sc = self._scopes_for(subject, roles)
+        if sc.get("agent_os:admin") == "allow" or sc.get(f"{rt}:{action}") == "allow":
+            return {"*"}
+        return set()
+
+
+def test_store_runs_on_a_custom_engine_no_casbin():
+    store = ManagedRoleStore(engine=DictPolicyEngine(), db_url=_db_url())  # no casbin involved
+
+    # agno-native surface works through the port
+    store.set_role_scopes("viewer", ["agents:read"], name="Viewer", description="read only")
+    store.assign("bob", "viewer")
+    assert store.roles_of("bob") == ["viewer"]
+    assert store.list_roles() == ["viewer"]
+
+    # metadata is store-owned (not the engine), so it works regardless of backend
+    rec = store.get_role("viewer")
+    assert rec["name"] == "Viewer" and rec["description"] == "read only"
+    assert store.get_role_scope_entries("viewer") == [{"scope": "agents:read", "effect": "allow"}]
+
+    # the provider delegates decisions to the engine
+    prov = store.provider
+    assert prov.check(AuthorizationContext(principal_id="bob", resource_type="agents", action="read")) is True
+    assert prov.check(AuthorizationContext(principal_id="bob", resource_type="agents", action="run")) is False
+
+    # admin gate delegates too
+    assert store.can_manage("bob") is False
+    store.set_role_scopes("admin", ["agent_os:admin"])
+    store.assign("alice", "admin")
+    assert store.can_manage("alice") is True
+
+
+def test_patch_and_remove_through_engine():
+    store = ManagedRoleStore(engine=DictPolicyEngine(), db_url=_db_url())
+    store.create_role("editor", name="Editor")
+    store.patch_role_scopes("editor", upsert=["agents:read", "agents:run"])
+    store.patch_role_scopes("editor", remove=["agents:run"])
+    assert [e["scope"] for e in store.get_role_scope_entries("editor")] == ["agents:read"]
+    store.remove_role("editor")
+    assert store.get_role("editor") is None


### PR DESCRIPTION
## Summary

Part 2 of the authz stack, **stacked on #8856** (the AuthorizationProvider foundation). Adds the user directory, multi-plane composite, and the `/authz` management API — ported against v2.7's `AuthMiddleware`.

> Review #8856 first; this branch is based on it, so its diff includes the foundation until that merges.

## What's in it

- **Multi-plane composite** — `AuthorizationConfig.authorization_provider` now accepts a *list* of providers; AgentOS wraps it in `CompositeAuthorizationProvider` (allow-if-any) so scope-based and managed-role planes can run side by side. A bare string is rejected.
- **User directory (`ManagedUserStore`)** — a credential-less directory for the no-IdP case. New config: `user_store`, `auto_provision_users`, `user_email_claim`, `user_name_claim`, `directory_error_fail_closed`. `AuthMiddleware` gains a directory gate after token verification: auto-provision a row from token claims, then **deny a disabled user with 403** — revocation that outlives a valid token — honouring fail-open (default) / fail-closed 503 on a directory read error. The WebSocket workflow path gets the same check. Disabled-denials feed the decision-audit trail.
- **`/authz` management API** — the role + user CRUD/assignment router (paginated `{data, meta}`, `/scopes` subresource, single-role-per-user, `/authz/decisions`), admin-gated.
- Fuller `role_store` (role metadata) + `audit` (change trail + decision trail) brought over; decision-audit wiring already lives in the foundation.

## Validation (on v2.7.2 main)

- Managed-users suite incl. **WS disabled-user** deny, composite multi-plane, role/user API, audit two-trail reads, + foundation + scope regression — **90+ pass**.
- ruff + mypy clean; default (no-provider) path unchanged.

## Scope
Part 3 (ReBAC/FGA) stacks on this next. JWT hardening remains a small follow-up on the foundation.

- [x] New feature (non-breaking; opt-in)
