### PR TITLE
feat(authz): relationship-based access (ReBAC) via OpenFGA (part 3, stacked on #8857)

### DIFF
--- a/cookbook/05_agent_os/rbac/README.md
+++ b/cookbook/05_agent_os/rbac/README.md
@@ -173,6 +173,7 @@ users, or plug in your own policy -- use these. Each one is runnable
 | `custom_authorization_provider.py` | Write your **own** `AuthorizationProvider` (here: pricing tiers) and plug it into the same enforcement points. |
 | `idp_workos_auth0.py` | Map **roles from your IdP** (WorkOS/Auth0/Okta) claims onto AgentOS permissions, verified against a JWKS. |
 | `manage_users_and_roles.py` | Serves the **`/authz` admin API** so a frontend can create roles, add users, and disable people live -- running the token-scope plane and the managed-role plane **at the same time**. Ships with `console.html`, a zero-setup test client: run the server, then open the file in a browser and paste the printed admin token. |
+| `fga_relationship_based.py` | **Relationship-based** access (ReBAC) via OpenFGA: decide on "is this user the *owner* of that resource / in the same tenant?" rather than on scopes or roles. Needs a running OpenFGA (`pip install "agno[fga]"`). |
 
 ## Quick Start
 

--- a/cookbook/05_agent_os/rbac/fga_relationship_based.py
+++ b/cookbook/05_agent_os/rbac/fga_relationship_based.py
@@ -1,0 +1,133 @@
+"""Fine-grained / relationship-based authorization (ReBAC) for AgentOS.
+
+RBAC says "what may a *role* do?". Sometimes that's not enough — you want "alice
+may run *this* workflow because she *owns the folder it's in*", or "a member of
+team-x may read the agents that belong to team-x". That's relationship-based
+access control (ReBAC), the model behind OpenFGA / WorkOS FGA / Zanzibar.
+
+AgentOS doesn't embed a relationship engine — it plugs one in through the same
+`AuthorizationProvider` seam everything else uses. `FGAAuthorizationProvider`
+turns each AgentOS check into one relationship query:
+
+    can alice RUN agents:research-agent?  ->  fga.check("user:alice", "run", "agents:research-agent")
+    which agents can alice READ?          ->  fga.list_objects("user:alice", "read", "agents")
+
+Run this example:
+    python fga_relationship_based.py
+
+It uses a tiny in-memory relationship store so it runs with zero infra. For
+production you swap that one object for OpenFGA (or WorkOS FGA) — see the bottom.
+
+The idiomatic wiring composes TWO providers (a feature of AgentOS): FGA decides
+the per-resource families (agents/teams/workflows) relationally, while the scope
+provider gates everything else (config, sessions, ...) — because FGA has no
+notion of a non-resource route. A request is allowed if either grants.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+from fastapi.testclient import TestClient
+
+from agno.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.authz import FGAAuthorizationProvider, ScopeAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+SECRET = "fga-cookbook-secret-at-least-256-bits-long-padding-xx"
+OS_ID = "fga-cookbook-os"
+
+
+# --- a toy relationship store (stands in for OpenFGA / WorkOS FGA) -----------
+# Each entry is (user, relation, object) — exactly what an FGA engine stores.
+# In a real OpenFGA model these would often be *derived* (e.g. "run" inherited
+# from "owner of the parent folder"); here we list them directly so it runs with
+# no server.
+class InMemoryFGA:
+    def __init__(self, tuples):
+        self._tuples = set(tuples)
+
+    def check(self, user, relation, obj):
+        return (user, relation, obj) in self._tuples
+
+    def list_objects(self, user, relation, object_type):
+        return [o for (u, r, o) in self._tuples if u == user and r == relation and o.startswith(f"{object_type}:")]
+
+
+fga = InMemoryFGA(
+    {
+        # alice owns the research agent — she can read and run it
+        ("user:alice", "read", "agents:research-agent"),
+        ("user:alice", "run", "agents:research-agent"),
+        # bob can only read it
+        ("user:bob", "read", "agents:research-agent"),
+    }
+)
+
+agent = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+agent_os = AgentOS(
+    id=OS_ID,
+    agents=[agent],
+    authorization=True,
+    authorization_config=AuthorizationConfig(
+        verification_keys=[SECRET],
+        algorithm="HS256",
+        verify_audience=True,
+        audience=OS_ID,
+        authorization_provider=[
+            ScopeAuthorizationProvider(),       # coarse: gates non-resource routes by scope
+            FGAAuthorizationProvider(fga),      # fine: per-resource agents/teams/workflows by relationship
+        ],
+    ),
+)
+app = agent_os.get_app()
+
+
+def _token(sub):
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub):
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+if __name__ == "__main__":
+    client = TestClient(app)
+
+    def show(who, what, resp):
+        verdict = "DENIED" if resp.status_code in (401, 403) else f"OK ({resp.status_code})"
+        print(f"  {who:6s} {what:32s} -> {verdict}")
+
+    print("\nrelationships decide access (no roles, no scopes — just who is related to what):\n")
+    show("alice", "GET  /agents/research-agent", client.get("/agents/research-agent", headers=_auth("alice")))
+    show("alice", "POST .../runs (alice owns it)",
+         client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"}))
+    show("bob", "GET  /agents/research-agent", client.get("/agents/research-agent", headers=_auth("bob")))
+    show("bob", "POST .../runs (bob can only read)",
+         client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"}))
+    show("carol", "GET  /agents/research-agent (no relationship)",
+         client.get("/agents/research-agent", headers=_auth("carol")))
+    print("\nalice owns it (read+run), bob can only read, carol has no relationship at all.\n")
+
+# --- production: point at real OpenFGA --------------------------------------
+# Swap the in-memory store for OpenFGA (pip install "agno[fga]"); the provider is
+# unchanged. Your OpenFGA authorization model must define relations matching the
+# agno actions you gate (read / run / write / delete) on the agents/teams/
+# workflows object types — and is where you express inheritance like
+# "run if owner of the parent folder".
+#
+#   from agno.os.authz.fga import OpenFGAClient
+#
+#   fga = OpenFGAClient(
+#       api_url="http://localhost:8080",
+#       store_id="<your-store-id>",
+#       authorization_model_id="<your-model-id>",
+#   )
+#   ...authorization_provider=[ScopeAuthorizationProvider(), FGAAuthorizationProvider(fga)]
+#
+# WorkOS FGA (or SpiceDB, ...) works the same way — implement the two-method
+# FGAClient port over their SDK and pass it to FGAAuthorizationProvider.

--- a/libs/agno/agno/os/authz/__init__.py
+++ b/libs/agno/agno/os/authz/__init__.py
@@ -17,6 +17,7 @@ third-party policy engine in the default path.
 
 from agno.os.authz.audit import AuditEvent, AuditSink, DbAuditSink, LoggingAuditSink
 from agno.os.authz.engine import EngineAuthorizationProvider, PolicyEngine, ScopeEntry
+from agno.os.authz.fga import FGAAuthorizationProvider, FGAClient
 from agno.os.authz.native_engine import NativePolicyEngine
 from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
 from agno.os.authz.role_store import ManagedRoleStore
@@ -34,6 +35,10 @@ __all__ = [
     "ScopeEntry",
     "EngineAuthorizationProvider",
     "NativePolicyEngine",
+    # Fine-grained / relationship-based authz (ReBAC). The provider + port are
+    # dependency-free; the OpenFGA adapter (OpenFGAClient) lives behind agno[fga].
+    "FGAAuthorizationProvider",
+    "FGAClient",
     "AuditEvent",
     "AuditSink",
     "LoggingAuditSink",

--- a/libs/agno/agno/os/authz/fga.py
+++ b/libs/agno/agno/os/authz/fga.py
@@ -1,0 +1,191 @@
+"""Fine-grained / relationship-based authorization (ReBAC) for AgentOS.
+
+RBAC answers "what may a *role* do?"; FGA answers "what may *this user* do on
+*this specific object*, given the relationships between them?" — e.g. "alice may
+run workflow-7 because she owns the folder it lives in." That's the model behind
+Zanzibar, OpenFGA, and WorkOS FGA.
+
+AgentOS doesn't embed an FGA engine — relationship evaluation belongs in a
+purpose-built store (OpenFGA, a WorkOS FGA tenant, SpiceDB, ...). Instead this
+plugs any such store into the existing :class:`AuthorizationProvider` seam:
+
+    AuthorizationContext            FGA query
+    ─────────────────────────────   ─────────────────────────────────────────
+    principal_id  = "alice"     →   user     = "user:alice"
+    action        = "run"       →   relation = "run"
+    resource_type = "workflows"     object   = "workflows:workflow-7"
+    resource_id   = "workflow-7"
+
+So a per-resource check becomes one FGA ``Check`` call, and list-filtering becomes
+one ``ListObjects`` call — the two primitives every FGA engine has.
+
+Bring your own backend by implementing the tiny :class:`FGAClient` port (two
+methods). :class:`OpenFGAClient` is a batteries-included adapter for OpenFGA
+(``pip install "agno[fga]"``); the same provider works against WorkOS FGA or any
+other engine by writing an equally small client.
+
+Typical wiring composes FGA (per-resource ReBAC) with the scope provider (coarse
+route gating), since FGA has no notion of non-resource routes like ``/config``::
+
+    AuthorizationConfig(authorization_provider=[
+        ScopeAuthorizationProvider(),          # gates /config, /sessions, ... by scope
+        FGAAuthorizationProvider(fga_client),  # per-resource agents/teams/workflows by relationship
+    ])
+"""
+
+from typing import List, Optional, Set
+
+from agno.os.authz.provider import AuthorizationContext, AuthorizationProvider
+
+try:  # Protocol is the right type for a duck-typed port; fall back for old pythons.
+    from typing import Protocol
+except ImportError:  # pragma: no cover
+    Protocol = object  # type: ignore[assignment,misc]
+
+
+class FGAClient(Protocol):
+    """The two relationship queries AgentOS needs from any FGA engine.
+
+    Both speak the engine's own object notation (``"type:id"``), e.g.
+    ``check("user:alice", "run", "workflows:wf-7")``. Implement this over OpenFGA,
+    WorkOS FGA, SpiceDB, or a test double — :class:`FGAAuthorizationProvider`
+    doesn't care which.
+    """
+
+    def check(self, user: str, relation: str, obj: str) -> bool:
+        """True if ``user`` has ``relation`` to ``obj``."""
+        ...
+
+    def list_objects(self, user: str, relation: str, object_type: str) -> List[str]:
+        """The objects of ``object_type`` that ``user`` has ``relation`` to,
+        as ``"type:id"`` strings (the engine's ListObjects)."""
+        ...
+
+
+class FGAAuthorizationProvider(AuthorizationProvider):
+    """An :class:`AuthorizationProvider` that decides via relationship checks
+    against an :class:`FGAClient` (OpenFGA / WorkOS FGA / any ReBAC engine).
+
+    It governs the per-resource families (agents/teams/workflows) relationally.
+    Routes it can't express as a single object (``/config``, ``/sessions``, the
+    scope-gated routes) it ABSTAINS on — so pair it with a scope provider via the
+    list form of ``authorization_provider`` (see the module docstring).
+
+    NOTE — ``admin_scope`` does not apply here. The ``agent_os:admin`` bypass is a
+    scope-plane feature (``ScopeAuthorizationProvider`` reads it off the token's
+    scopes); this provider decides purely on relationships, so a token carrying
+    ``agent_os:admin`` gets NO bypass from it and must instead hold an admin
+    RELATIONSHIP in the engine. That is the intended ReBAC behaviour, but it means a
+    standalone FGA deployment has no token-scope admins at all. Running it alongside
+    a scope provider (the recommended pairing above) restores the bypass, since the
+    composition is an OR.
+    """
+
+    def __init__(
+        self,
+        client: FGAClient,
+        *,
+        user_type: str = "user",
+        relation_map: Optional[dict] = None,
+    ):
+        """
+        Args:
+            client: the relationship engine (see :class:`FGAClient`).
+            user_type: the engine's user object type — the subject is sent as
+                ``f"{user_type}:{principal_id}"`` (OpenFGA convention, default
+                ``"user"``).
+            relation_map: optional ``{agno_action: fga_relation}`` overrides when
+                your model's relation names differ from agno actions
+                (``read``/``run``/``write``/``delete``). Identity by default.
+        """
+        self._client = client
+        self._user_type = user_type
+        self._relation_map = relation_map or {}
+
+    def _user(self, ctx: AuthorizationContext) -> Optional[str]:
+        return f"{self._user_type}:{ctx.principal_id}" if ctx.principal_id else None
+
+    def _relation(self, action: str) -> str:
+        return self._relation_map.get(action, action)
+
+    def check(self, ctx: AuthorizationContext) -> bool:
+        # Non-resource check: nothing to ask the relationship engine; defer (the
+        # route gate / a composed scope provider handles it). Same contract the
+        # scope and engine providers follow.
+        if not ctx.resource_type or not ctx.action:
+            return True
+        user = self._user(ctx)
+        if not user:
+            return False
+        # List endpoint (no specific id): allow, and let accessible_resource_ids
+        # narrow the response — mirrors how the middleware filters collections.
+        if not ctx.resource_id:
+            return True
+        return bool(self._client.check(user, self._relation(ctx.action), f"{ctx.resource_type}:{ctx.resource_id}"))
+
+    def accessible_resource_ids(self, ctx: AuthorizationContext) -> Set[str]:
+        if not ctx.resource_type or not ctx.action:
+            return set()
+        user = self._user(ctx)
+        if not user:
+            return set()
+        objects = self._client.list_objects(user, self._relation(ctx.action), ctx.resource_type)
+        prefix = f"{ctx.resource_type}:"
+        # FGA returns concrete objects (never a wildcard), so we return concrete
+        # ids — list endpoints get exactly the set the user is related to.
+        return {o[len(prefix) :] for o in objects if o.startswith(prefix)}
+
+    def authorize_route(self, ctx: AuthorizationContext, required_scopes: List[str]) -> bool:
+        # Per-resource routes: decide relationally. Everything else (non-resource
+        # routes the FGA model doesn't describe) we ABSTAIN on by returning False,
+        # so it never fail-opens a /config or /sessions route when OR-composed —
+        # a scope provider in the list is expected to authorize those.
+        if ctx.resource_type:
+            return self.check(ctx)
+        return False
+
+
+class OpenFGAClient:
+    """Reference :class:`FGAClient` for OpenFGA. Requires ``pip install "agno[fga]"``.
+
+    Thin wrapper over the OpenFGA Python SDK's *sync* client. Your OpenFGA
+    authorization model must define relations matching the agno actions you gate
+    (``read``/``run``/``write``/``delete``) on the agent/team/workflow object
+    types. Point it at a self-hosted OpenFGA or any OpenFGA-compatible endpoint.
+    """
+
+    def __init__(
+        self,
+        api_url: str,
+        store_id: str,
+        authorization_model_id: Optional[str] = None,
+        credentials=None,
+    ):
+        try:
+            from openfga_sdk import ClientConfiguration
+            from openfga_sdk.sync import OpenFgaClient as _OpenFgaClient
+        except ImportError as e:  # pragma: no cover
+            raise ImportError(
+                'OpenFGA support needs the optional extra. Install it with: pip install "agno[fga]"'
+            ) from e
+
+        self._client = _OpenFgaClient(
+            ClientConfiguration(
+                api_url=api_url,
+                store_id=store_id,
+                authorization_model_id=authorization_model_id,
+                credentials=credentials,
+            )
+        )
+
+    def check(self, user: str, relation: str, obj: str) -> bool:
+        from openfga_sdk import ClientCheckRequest
+
+        resp = self._client.check(ClientCheckRequest(user=user, relation=relation, object=obj))
+        return bool(getattr(resp, "allowed", False))
+
+    def list_objects(self, user: str, relation: str, object_type: str) -> List[str]:
+        from openfga_sdk import ClientListObjectsRequest
+
+        resp = self._client.list_objects(ClientListObjectsRequest(user=user, relation=relation, type=object_type))
+        return list(getattr(resp, "objects", []) or [])

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -72,6 +72,8 @@ dev = [
 # AgentOS server bundle
 os = ["fastapi", "python-multipart>=0.0.18", "uvicorn", "websockets", "sqlalchemy", "PyJWT", "opentelemetry-sdk", "openinference-instrumentation-agno", "agno[scheduler]"]
 mcp = ["mcp>=1.9.2", "fastmcp>=3.4.3,<4"]
+# Optional extra for fine-grained / relationship-based authorization (ReBAC) via OpenFGA.
+fga = ["openfga-sdk>=0.9"]
 scheduler = ["croniter>=1.3", "pytz>=2023.3"]
 
 # Dependencies for Telemetry
@@ -560,6 +562,7 @@ module = [
   "newspaper.*",
   "numpy.*",
   "ollama.*",
+  "openfga_sdk.*",
   "openpyxl.*",
   "openai.*",
   "cv2.*",

--- a/libs/agno/tests/integration/os/test_fga_provider.py
+++ b/libs/agno/tests/integration/os/test_fga_provider.py
@@ -1,0 +1,140 @@
+"""Fine-grained / relationship-based authorization via the FGA provider.
+
+Proves the provider maps AgentOS authorization to relationship queries (Check /
+ListObjects) correctly, and gates a real AgentOS end-to-end when composed with
+the scope provider — all against an in-memory FGA store, so no OpenFGA server is
+needed. The same provider runs against real OpenFGA / WorkOS FGA by swapping the
+client (see OpenFGAClient).
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import List, Set, Tuple
+
+import jwt
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.db.in_memory import InMemoryDb
+from agno.os import AgentOS
+from agno.os.authz import AuthorizationContext, FGAAuthorizationProvider, ScopeAuthorizationProvider
+from agno.os.config import AuthorizationConfig
+
+SECRET = "fga-provider-test-secret-at-least-256-bits-long-xxxxxx"
+OS_ID = "fga-test-os"
+
+
+class InMemoryFGA:
+    """A toy FGAClient: a set of (user, relation, object) relationship tuples.
+    Stands in for OpenFGA/WorkOS FGA so the tests need no external engine."""
+
+    def __init__(self, tuples: Set[Tuple[str, str, str]]):
+        self._tuples = set(tuples)
+
+    def check(self, user: str, relation: str, obj: str) -> bool:
+        return (user, relation, obj) in self._tuples
+
+    def list_objects(self, user: str, relation: str, object_type: str) -> List[str]:
+        return [o for (u, r, o) in self._tuples if u == user and r == relation and o.startswith(f"{object_type}:")]
+
+
+def _ctx(sub, rt, rid, act):
+    return AuthorizationContext(principal_id=sub, resource_type=rt, resource_id=rid, action=act)
+
+
+# ----------------------------------------------------------------- provider unit
+def test_check_maps_to_a_relationship_query():
+    fga = InMemoryFGA({("user:alice", "run", "workflows:wf-7")})
+    prov = FGAAuthorizationProvider(fga)
+    assert prov.check(_ctx("alice", "workflows", "wf-7", "run")) is True
+    # different object, different relation, different user -> denied
+    assert prov.check(_ctx("alice", "workflows", "wf-8", "run")) is False
+    assert prov.check(_ctx("alice", "workflows", "wf-7", "read")) is False
+    assert prov.check(_ctx("bob", "workflows", "wf-7", "run")) is False
+    # unauthenticated principal -> denied on a resource check
+    assert prov.check(_ctx(None, "workflows", "wf-7", "run")) is False
+
+
+def test_accessible_ids_maps_to_list_objects():
+    fga = InMemoryFGA({
+        ("user:alice", "read", "agents:a1"),
+        ("user:alice", "read", "agents:a2"),
+        ("user:alice", "run", "agents:a1"),  # different relation, excluded for read
+        ("user:bob", "read", "agents:a3"),
+    })
+    prov = FGAAuthorizationProvider(fga)
+    assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "read")) == {"a1", "a2"}
+    assert prov.accessible_resource_ids(_ctx("alice", "agents", None, "run")) == {"a1"}
+    assert prov.accessible_resource_ids(_ctx("bob", "agents", None, "read")) == {"a3"}
+    assert prov.accessible_resource_ids(_ctx("nobody", "agents", None, "read")) == set()
+
+
+def test_list_endpoint_defers_to_accessible_ids():
+    # No resource_id => a listing: check() allows so the handler runs, and
+    # accessible_resource_ids narrows the result.
+    prov = FGAAuthorizationProvider(InMemoryFGA(set()))
+    assert prov.check(_ctx("alice", "agents", None, "read")) is True
+
+
+def test_custom_user_type_and_relation_map():
+    fga = InMemoryFGA({("account:alice", "can_execute", "agents:a1")})
+    prov = FGAAuthorizationProvider(fga, user_type="account", relation_map={"run": "can_execute"})
+    assert prov.check(_ctx("alice", "agents", "a1", "run")) is True
+
+
+def test_authorize_route_abstains_on_non_resource_routes():
+    """FGA can't express /config or /sessions as a single object, so it must
+    ABSTAIN (False) there — never fail-open when OR-composed with a scope provider."""
+    prov = FGAAuthorizationProvider(InMemoryFGA({("user:alice", "run", "agents:a1")}))
+    # resource route -> relational decision
+    assert prov.authorize_route(_ctx("alice", "agents", "a1", "run"), ["agents:run"]) is True
+    # non-resource route -> abstain (a composed scope provider authorizes these)
+    assert prov.authorize_route(AuthorizationContext(principal_id="alice"), ["config:read"]) is False
+
+
+# ----------------------------------------------------------------- end to end
+def _token(sub: str) -> str:
+    return jwt.encode(
+        {"sub": sub, "aud": OS_ID, "scopes": [], "exp": datetime.now(UTC) + timedelta(hours=1)},
+        SECRET, algorithm="HS256",
+    )
+
+
+def _auth(sub: str) -> dict:
+    return {"Authorization": f"Bearer {_token(sub)}"}
+
+
+def test_fga_gates_a_real_agentos_per_resource():
+    """End to end: relationships in the FGA store decide who can run which agent,
+    with FGA composed alongside the scope provider on one OS."""
+    fga = InMemoryFGA({
+        ("user:alice", "run", "agents:research-agent"),   # alice may run research-agent
+        ("user:alice", "read", "agents:research-agent"),
+    })
+    research = Agent(id="research-agent", name="Research Agent", db=InMemoryDb())
+    other = Agent(id="other-agent", name="Other Agent", db=InMemoryDb())
+    agent_os = AgentOS(
+        id=OS_ID,
+        agents=[research, other],
+        authorization=True,
+        authorization_config=AuthorizationConfig(
+            verification_keys=[SECRET],
+            algorithm="HS256",
+            verify_audience=True,
+            audience=OS_ID,
+            # ReBAC for resources (alice's relationships) + scopes for everything else.
+            authorization_provider=[ScopeAuthorizationProvider(), FGAAuthorizationProvider(fga)],
+        ),
+    )
+    client = TestClient(agent_os.get_app())
+
+    # alice is related (run) to research-agent -> allowed
+    r = client.post("/agents/research-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code != 403
+    # alice has no relationship to other-agent -> denied
+    r = client.post("/agents/other-agent/runs", headers=_auth("alice"), data={"message": "hi"})
+    assert r.status_code == 403
+    # bob has no relationships at all -> denied
+    r = client.post("/agents/research-agent/runs", headers=_auth("bob"), data={"message": "hi"})
+    assert r.status_code == 403
+    # alice can read research-agent (relationship exists)
+    assert client.get("/agents/research-agent", headers=_auth("alice")).status_code == 200


### PR DESCRIPTION
## Summary

Part 3 of the authz stack, **stacked on #8857** (directory + composite), itself on #8856 (foundation). Adds relationship-based access control (ReBAC) via OpenFGA.

> Review #8856 → #8857 first; this branch builds on both.

## What's in it

- **`os/authz/fga.py`** — an `FGAClient` port + `OpenFGAClient` (lazy `openfga-sdk` import) + `FGAAuthorizationProvider`. It plugs into the **existing** `AuthorizationProvider` seam via `authorization_provider=FGAAuthorizationProvider(...)` — **no middleware/app changes**, because the seam from #8856 already routes every gate through the provider. So relationship policy the scope/role model can't express ("is this user an *owner* of this resource?", "same tenant?") is enforced at the same REST / WebSocket / MCP points.
- **`agno[fga]`** optional extra (`openfga-sdk>=0.9`) + mypy override. The provider imports without the dep (lazy), so it's zero-cost unless used.
- Cookbook (`fga_relationship_based.py`) + `test_fga_provider.py`.

## Validation
`test_fga_provider` — 6 pass; ruff clean; cookbook parses; provider imports without the optional dep.

## Note
The `roles = ["sqlalchemy"]` extra is missing from the foundation's pyproject — a small follow-up on #8856.

- [x] New feature (non-breaking; opt-in)
