### PR TITLE
[fix] Strip backend DB credentials from resolved component configs (#8706)

### DIFF
--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -32,6 +32,27 @@ from agno.utils.string import generate_id_from_name
 logger = logging.getLogger(__name__)
 
 
+# Connection-secret fields that must never be persisted in / returned with a
+# component config. When a db is resolved by id, the live connection is
+# re-resolved from the registry/OS db at load time, so these secrets round-trip
+# through the config for no benefit and leak backend DB credentials to any
+# caller with components:read (agno-agi/agno#8706).
+_DB_SECRET_FIELDS = ("db_url", "db_file", "db_password")
+
+
+def _redact_db_secrets(db_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of a resolved db dict with connection-secret fields removed.
+
+    Args:
+        db_dict: The resolved db serialization (output of ``to_dict()``).
+
+    Returns:
+        A new dict without ``db_url`` / ``db_file`` / ``db_password``. The input
+        is not mutated.
+    """
+    return {k: v for k, v in db_dict.items() if k not in _DB_SECRET_FIELDS}
+
+
 def _resolve_db_in_config(
     config: Dict[str, Any],
     os_db: BaseDb,
@@ -70,12 +91,15 @@ def _resolve_db_in_config(
                 resolved_db = registry.get_db(component_db_id)
 
             # Merge resolved db with caller-provided table-name overrides.
-            # Connection-defining fields (type, db_url, db_file, db_schema,
-            # id, ...) always come from the resolved db so the caller can't
-            # redirect a referenced db to a different backend. Only the
-            # whitelisted table-name keys are taken from the caller.
+            # Connection-defining fields (type, db_schema, id, ...) always come
+            # from the resolved db so the caller can't redirect a referenced db
+            # to a different backend. Only the whitelisted table-name keys are
+            # taken from the caller. Connection SECRETS (db_url / db_file) are
+            # stripped: the db is resolved by id, so the live connection is
+            # re-resolved at load time and the secrets must not round-trip into
+            # the persisted / returned config (agno-agi/agno#8706).
             if resolved_db is not None:
-                resolved_dict = resolved_db.to_dict()
+                resolved_dict = _redact_db_secrets(resolved_db.to_dict())
                 table_overrides = {key: component_db[key] for key in DB_TABLE_NAME_KEYS if key in component_db}
                 config["db"] = {**resolved_dict, **table_overrides}
             else:

--- a/libs/agno/tests/unit/os/routers/test_components_config_secrets.py
+++ b/libs/agno/tests/unit/os/routers/test_components_config_secrets.py
@@ -1,0 +1,143 @@
+"""Tests that component config resolution never leaks backend DB credentials (#8706).
+
+_resolve_db_in_config expands a db id-reference into resolved_db.to_dict(), which
+for PostgresDb/SqliteDb carries db_url (and a Postgres URL embeds the password).
+That expanded config is persisted and returned by GET /components/*/configs* under
+the non-admin components:read scope. These tests assert the secret-bearing fields
+are stripped from the resolved config when the db is an id-reference.
+"""
+
+from typing import Any, Dict
+
+from sqlalchemy import create_engine
+
+from agno.db.postgres.postgres import PostgresDb
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.os.routers.components.components import _resolve_db_in_config
+
+
+class _FakeRegistry:
+    def __init__(self, db=None):
+        self._db = db
+
+    def get_db(self, db_id):
+        if self._db is not None and getattr(self._db, "id", None) == db_id:
+            return self._db
+        return None
+
+
+# --- Postgres: db_url (password) must not leak when resolved by id ---
+
+
+def test_postgres_db_url_stripped_from_resolved_config():
+    engine = create_engine("sqlite:///:memory:")
+    os_db = PostgresDb(
+        db_url="postgresql://agno_admin:SuperSecretDbPassw0rd@prod-db.internal:5432/agno_prod",
+        db_engine=engine,
+        db_schema="ai",
+    )
+    registry = _FakeRegistry(os_db)
+
+    config: Dict[str, Any] = {"db": {"id": os_db.id}}
+    resolved = _resolve_db_in_config(config, os_db, registry=registry)
+
+    resolved_db = resolved["db"]
+    # The connection secret must never appear in the persisted/returned config.
+    assert "db_url" not in resolved_db
+    assert "SuperSecretDbPassw0rd" not in str(resolved_db)
+    # The non-secret id reference and table overrides are preserved.
+    assert resolved_db.get("id") == os_db.id
+    assert resolved_db.get("type") == "postgres"
+
+
+def test_postgres_table_overrides_preserved_without_secrets():
+    engine = create_engine("sqlite:///:memory:")
+    os_db = PostgresDb(
+        db_url="postgresql://u:p@host/db",
+        db_engine=engine,
+    )
+    registry = _FakeRegistry(os_db)
+
+    config = {"db": {"id": os_db.id, "session_table": "custom_sessions", "memory_table": "custom_memories"}}
+    resolved = _resolve_db_in_config(config, os_db, registry=registry)
+
+    resolved_db = resolved["db"]
+    assert "db_url" not in resolved_db
+    assert resolved_db["session_table"] == "custom_sessions"
+    assert resolved_db["memory_table"] == "custom_memories"
+
+
+# --- SQLite: db_file / db_url must not leak when resolved by id ---
+
+
+def test_sqlite_db_file_and_url_stripped_from_resolved_config(tmp_path):
+    os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    registry = _FakeRegistry(os_db)
+
+    config = {"db": {"id": os_db.id}}
+    resolved = _resolve_db_in_config(config, os_db, registry=registry)
+
+    resolved_db = resolved["db"]
+    assert "db_file" not in resolved_db
+    assert "db_url" not in resolved_db
+    assert resolved_db.get("id") == os_db.id
+    assert resolved_db.get("type") == "sqlite"
+
+
+def test_sqlite_table_overrides_preserved_without_secrets(tmp_path):
+    os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    registry = _FakeRegistry(os_db)
+
+    config = {"db": {"id": os_db.id, "session_table": "s", "memory_table": "m"}}
+    resolved = _resolve_db_in_config(config, os_db, registry=registry)
+
+    resolved_db = resolved["db"]
+    assert "db_file" not in resolved_db
+    assert resolved_db["session_table"] == "s"
+    assert resolved_db["memory_table"] == "m"
+
+
+# --- OS db resolution path (id matches os_db) ---
+
+
+def test_os_db_match_strips_secrets(tmp_path):
+    os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+
+    # id references the OS db directly (no registry needed)
+    config = {"db": {"id": os_db.id}}
+    resolved = _resolve_db_in_config(config, os_db, registry=None)
+
+    resolved_db = resolved["db"]
+    assert "db_file" not in resolved_db
+    assert "db_url" not in resolved_db
+    assert resolved_db.get("id") == os_db.id
+
+
+# --- config without a db id is left intact (caller-supplied connection) ---
+
+
+def test_inline_db_without_id_is_left_intact(tmp_path):
+    """A db dict with no id is caller-supplied connection info, not an expansion
+    of an OS/registry secret — leave it alone (no secret exfiltration occurs)."""
+    config = {"db": {"type": "sqlite", "db_file": str(tmp_path / "inline.db")}}
+    resolved = _resolve_db_in_config(config, os_db=SqliteDb(db_file=str(tmp_path / "os.db")), registry=None)
+
+    assert resolved["db"]["db_file"] == str(tmp_path / "inline.db")
+
+
+def test_unresolvable_id_logs_error_and_leaves_config(tmp_path):
+    os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    registry = _FakeRegistry(None)  # nothing registered
+
+    config = {"db": {"id": "does-not-exist"}}
+    resolved = _resolve_db_in_config(config, os_db, registry=registry)
+
+    # The original (id-only, secret-free) db reference is preserved unchanged.
+    assert resolved["db"] == {"id": "does-not-exist"}
+
+
+def test_no_db_key_passes_through(tmp_path):
+    os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+    config: Dict[str, Any] = {"some_field": "value"}
+    resolved = _resolve_db_in_config(config, os_db, registry=None)
+    assert resolved == {"some_field": "value"}

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -628,9 +628,12 @@ class TestResolveDbInConfig:
 
         assert out["db"]["session_table"] == "custom_sessions"
         assert out["db"]["memory_table"] == "custom_memories"
-        # Connection metadata is filled in from the resolved db.
+        # Connection metadata is filled in from the resolved db, but the
+        # connection SECRET (db_file / db_url) is stripped — the db is resolved
+        # by id, so secrets must not round-trip into the stored config (#8706).
         assert out["db"]["type"] == "sqlite"
-        assert out["db"]["db_file"] == os_db.db_file
+        assert "db_file" not in out["db"]
+        assert "db_url" not in out["db"]
         # Fields the caller didn't override inherit os_db's values.
         assert out["db"]["knowledge_table"] == os_db.knowledge_table_name
 
@@ -654,10 +657,12 @@ class TestResolveDbInConfig:
         out = _resolve_db_in_config(dict(payload), os_db, None)
 
         resolved_db_dict = out["db"]
-        # Connection fields MUST come from os_db, never from the caller.
+        # Connection fields MUST come from os_db, never from the caller. The
+        # connection SECRETS are stripped entirely (#8706), so the caller's
+        # db_url / db_file values are rejected outright rather than echoed back.
         assert resolved_db_dict["type"] == "sqlite"
-        assert resolved_db_dict["db_file"] == os_db.db_file
-        assert resolved_db_dict.get("db_url") == os_db.db_url
+        assert "db_file" not in resolved_db_dict
+        assert "db_url" not in resolved_db_dict
         assert resolved_db_dict["id"] == os_db.id
         # The only caller-provided field that is allowed through is the
         # whitelisted table-name override.


### PR DESCRIPTION
## Summary

`_resolve_db_in_config` expanded a component's `db` **id-reference** into the fully-resolved `resolved_db.to_dict()`, which for `PostgresDb`/`SqliteDb` includes `db_url` — and a Postgres URL embeds the password (`agno-agi/agno#8706`). That expanded block was persisted and returned verbatim by `GET /components/{id}/configs/current | /configs/{version} | /configs`, gated only by `components:read`/`components:write` (NOT admin/`config:read`). A low-privilege Studio/components principal could thus recover the backend DB master credentials → full data-plane compromise (sessions, memories, the `auth_tokens` table, all tenants) and lateral movement to the DB host.

**Sink patched:** `os/routers/components/components.py` `_resolve_db_in_config` — `config["db"] = {**resolved_db.to_dict(), **table_overrides}` baked `db_url` into the stored/returned config.

## Fix

Strip the connection-secret fields from the resolved db dict before merging it into the stored/returned config. The db is resolved **by id**, so the live connection is re-resolved from the registry/OS db at load time — the secrets round-tripped through the config for no functional benefit and only served to leak credentials.

- New `_redact_db_secrets` helper + `_DB_SECRET_FIELDS = ("db_url", "db_file", "db_password")` constant; applied at the single resolve-and-merge site so **every write path** (create component, create/update config) and the corresponding **read responses** (`list_configs`, `get_current_config`, `get_config`) are covered — responses return the stored config directly via `ComponentConfigResponse(**config)`, so redacting at write time covers reads too.
- **Inline db configs with no `id`** (caller-supplied connection info) are left intact: those are not an expansion of an OS/registry secret, so there is no cross-privilege exfiltration.
- **Unresolvable ids** and **configs without a `db` key** are unchanged.

This matches the issue's "Expected Behavior" — the component config never contains connection secrets; the `db` stays a non-secret id reference.

## Scope notes (deliberately narrow)

- The **reload path** (`resolve_db_from_config` / `from_dict` in `db/utils.py`) is **untouched** — it rebuilds the live db in-memory from the registry or the stored connection fields and still requires those fields. Only the HTTP-facing config serialization is redacted.
- This addresses the live expansion going forward. Pre-existing Studio configs already carry resolved creds (as the issue notes); a migration/backfill to redact stored rows is left to maintainers as a separate operational step.

## Type of change

- [x] Bug fix (security — non-breaking for valid usage; resolved configs no longer echo `db_url`/`db_file`)

## Checklist

- [x] Code follows the project style (`./scripts/format.sh`)
- [x] `ruff check` clean on all changed files
- [x] `mypy` introduces **zero new errors** (one pre-existing error in `resend.py` on `main`, unrelated — addressed in #8855)
- [x] Tests added + existing tests updated where they codified the old leaking behavior
- [x] Self-review completed

## Test plan

- [x] New `tests/unit/os/routers/test_components_config_secrets.py` (8 cases): for both `PostgresDb` and `SqliteDb`, asserts `db_url`/`db_file` (and the literal password) never appear in the resolved config when resolved by id; table overrides, `id`, and `type` are preserved. Plus inline-db (no id, left intact), unresolvable-id (unchanged), and no-db-key passthrough.
- [x] Two existing assertions in `test_components_router.py` that codified the **old leaking behavior** (`db_file`/`db_url` present in resolved config) are updated to the redacted behavior. Their core intent — *a caller cannot redirect a referenced backend; only whitelisted table overrides pass through* — still holds and is now stronger (caller-supplied `db_url`/`db_file` are rejected outright).
- [x] Reload-path tests (`test_resolve_db_from_config.py`) still pass — the in-memory rebuild is unaffected.
- [x] 56 tests across the three files pass; no regressions.

## AI-generated disclosure

This PR was implemented with the assistance of Claude Code (Anthropic). Changes were reviewed and tested locally against the project's CI scripts before submission. Reported as defensive security research; reproduction was local-only with fake credentials.
