### PR TITLE
[fix] Merge streamed OpenRouter reasoning_details fragments before replay (#8794)

### DIFF
--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -11,6 +11,59 @@ from agno.models.openai.like import OpenAILike
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 
+# Fields that carry reasoning text. Streamed fragments split a single reasoning
+# block across many chunks (text in pieces, signature in a final text-less
+# fragment); these text fields must be concatenated when merging by index.
+_REASONING_TEXT_FIELDS = ("text", "data")
+
+
+def _merge_reasoning_details(reasoning_details: Optional[List[Any]]) -> List[Any]:
+    """Reconstruct one complete reasoning detail object per ``index``.
+
+    OpenRouter streams one reasoning block across multiple chunks sharing the
+    same ``index`` — text arrives in pieces and the signature (Anthropic) or
+    encrypted payload (Gemini) can arrive in a final text-less fragment. The
+    streaming accumulator appends each fragment to a list, so the stored
+    ``reasoning_details`` would otherwise be separate partial fragments. Replaying
+    those verbatim corrupts Anthropic's signed thinking blocks and fails the next
+    request with ``Invalid signature in thinking block`` (agno-agi/agno#8794).
+
+    Fragments sharing an ``index`` are merged into a single block: text/data
+    fields are concatenated in arrival order, all other structural fields
+    (``type``, ``format``, ``id``, ``signature``, ...) are carried through. Entries
+    without an ``index`` or that are not dicts are passed through unchanged. Other
+    provider-data lists (e.g. ``server_tool_blocks``) are never touched.
+    """
+    if not reasoning_details:
+        return []
+
+    grouped: Dict[Any, Dict[str, Any]] = {}
+    order: List[Any] = []
+    passthrough: List[Any] = []
+
+    for fragment in reasoning_details:
+        if not isinstance(fragment, dict) or "index" not in fragment:
+            passthrough.append(fragment)
+            continue
+
+        idx = fragment["index"]
+        if idx not in grouped:
+            grouped[idx] = {}
+            order.append(idx)
+        target = grouped[idx]
+        for key, value in fragment.items():
+            if value is None:
+                continue
+            if key in _REASONING_TEXT_FIELDS and isinstance(value, str):
+                target[key] = target.get(key, "") + value
+            else:
+                target[key] = value
+
+    # Merge order: grouped blocks (in first-seen index order) then passthrough.
+    merged: List[Any] = [grouped[idx] for idx in order]
+    merged.extend(passthrough)
+    return merged
+
 
 @dataclass
 class OpenRouter(OpenAILike):
@@ -95,7 +148,10 @@ class OpenRouter(OpenAILike):
 
         if message.role == "assistant" and message.provider_data:
             if message.provider_data.get("reasoning_details"):
-                message_dict["reasoning_details"] = message.provider_data["reasoning_details"]
+                # Reconstruct complete reasoning detail blocks per index before
+                # replay. Streaming accumulates fragments into a list; replaying
+                # them verbatim corrupts Anthropic's signed thinking blocks (#8794).
+                message_dict["reasoning_details"] = _merge_reasoning_details(message.provider_data["reasoning_details"])
 
         return message_dict
 

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_reasoning_merge.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_reasoning_merge.py
@@ -1,0 +1,148 @@
+"""Tests for OpenRouter streamed reasoning_details fragment merging (#8794).
+
+OpenRouter streams one reasoning block across multiple chunks with the same
+``index``; text arrives in pieces and the signature can arrive in a final
+text-less fragment. Agno's streaming accumulator ``extend``s each fragment into a
+list, so the stored ``reasoning_details`` becomes separate partial fragments
+instead of one complete signed block per index. Replaying those fragments
+verbatim makes Anthropic reject the next request with an invalid ``signature``
+in the ``thinking`` block.
+
+These tests verify the OpenRouter model reconstructs one complete reasoning
+detail object per ``index`` (concatenated text + carried signature) before
+replay, while leaving other provider-data lists (e.g. server_tool_blocks) and
+Gemini-style encrypted entries with distinct indexes untouched.
+"""
+
+from agno.models.message import Message
+from agno.models.openrouter.openrouter import OpenRouter, _merge_reasoning_details
+
+
+def test_merges_text_fragments_and_carries_signature_for_one_index():
+    """The issue's streaming shape: 3 fragments for index 0 -> 1 complete block."""
+    fragments = [
+        {"type": "reasoning.text", "text": "Let", "format": "anthropic-claude-v1", "index": 0},
+        {"type": "reasoning.text", "text": " me compute 17 * 23.", "format": "anthropic-claude-v1", "index": 0},
+        {"type": "reasoning.text", "signature": "Et8BCmUIDxgC...", "format": "anthropic-claude-v1", "index": 0},
+    ]
+
+    merged = _merge_reasoning_details(fragments)
+
+    assert merged == [
+        {
+            "type": "reasoning.text",
+            "text": "Let me compute 17 * 23.",
+            "signature": "Et8BCmUIDxgC...",
+            "format": "anthropic-claude-v1",
+            "index": 0,
+        }
+    ]
+
+
+def test_separate_indexes_remain_separate_blocks():
+    """Distinct indexes produce distinct merged blocks (Gemini encrypted entries)."""
+    fragments = [
+        {"type": "reasoning.encrypted", "data": "AAA", "index": 0},
+        {"type": "reasoning.encrypted", "data": "BBB", "index": 1},
+    ]
+
+    merged = _merge_reasoning_details(fragments)
+
+    assert len(merged) == 2
+    assert merged[0]["data"] == "AAA"
+    assert merged[0]["index"] == 0
+    assert merged[1]["data"] == "BBB"
+    assert merged[1]["index"] == 1
+
+
+def test_concatenates_text_in_arrival_order():
+    fragments = [
+        {"type": "reasoning.text", "text": "a", "index": 0},
+        {"type": "reasoning.text", "text": "b", "index": 0},
+        {"type": "reasoning.text", "text": "c", "index": 0},
+    ]
+    merged = _merge_reasoning_details(fragments)
+    assert merged[0]["text"] == "abc"
+
+
+def test_carries_structural_fields_type_format_id():
+    """Non-text structural fields are carried onto the merged block."""
+    fragments = [
+        {"type": "reasoning.text", "text": "hello", "format": "anthropic-claude-v1", "index": 0},
+        {"type": "reasoning.text", "id": "r-123", "index": 0},
+    ]
+    merged = _merge_reasoning_details(fragments)
+    assert merged[0]["type"] == "reasoning.text"
+    assert merged[0]["format"] == "anthropic-claude-v1"
+    assert merged[0]["id"] == "r-123"
+    assert merged[0]["text"] == "hello"
+
+
+def test_fragment_without_index_is_preserved():
+    """A fragment that lacks an index is passed through unchanged (cannot group)."""
+    fragments = [{"type": "reasoning.text", "text": "lonely"}]
+    merged = _merge_reasoning_details(fragments)
+    assert merged == [{"type": "reasoning.text", "text": "lonely"}]
+
+
+def test_none_or_empty_returns_empty():
+    assert _merge_reasoning_details(None) == []
+    assert _merge_reasoning_details([]) == []
+
+
+def test_non_dict_entries_pass_through():
+    """Malformed (non-dict) entries are preserved as-is rather than crashing."""
+    fragments = [{"type": "reasoning.text", "text": "ok", "index": 0}, "garbage"]  # type: ignore[list-item]
+    merged = _merge_reasoning_details(fragments)
+    # The dict is grouped; the stray string is preserved unchanged.
+    assert any(isinstance(m, dict) and m.get("text") == "ok" for m in merged)
+    assert "garbage" in merged
+
+
+def test_format_message_replays_merged_reasoning_details():
+    """_format_message must reconstruct complete blocks before emitting for replay."""
+    model = OpenRouter(api_key="test-key")
+    # The stored assistant message holds the streamed FRAGMENTS (the broken shape).
+    message = Message(
+        role="assistant",
+        content="42",
+        provider_data={
+            "reasoning_details": [
+                {"type": "reasoning.text", "text": "Let", "format": "anthropic-claude-v1", "index": 0},
+                {"type": "reasoning.text", "text": " me compute.", "format": "anthropic-claude-v1", "index": 0},
+                {"type": "reasoning.text", "signature": "sig", "format": "anthropic-claude-v1", "index": 0},
+            ]
+        },
+    )
+
+    formatted = model._format_message(message)
+
+    rd = formatted["reasoning_details"]
+    # Exactly ONE complete block per index — no partial fragments.
+    assert len(rd) == 1
+    assert rd[0]["text"] == "Let me compute."
+    assert rd[0]["signature"] == "sig"
+
+
+def test_format_message_leaves_other_provider_data_lists_untouched():
+    """server_tool_blocks and other provider-data keys must not be altered.
+
+    The base _format_message only carries explicitly-mapped provider-data keys
+    (OpenRouter maps reasoning_details); the stored message's provider_data is
+    never mutated by the merge.
+    """
+    model = OpenRouter(api_key="test-key")
+    message = Message(
+        role="assistant",
+        content="ok",
+        provider_data={
+            "server_tool_blocks": [{"type": "tool_use", "id": "t1"}],
+        },
+    )
+
+    formatted = model._format_message(message)
+
+    # No reasoning_details key is added (there were none to merge).
+    assert "reasoning_details" not in formatted
+    # The stored message's other provider-data list is untouched.
+    assert message.provider_data["server_tool_blocks"] == [{"type": "tool_use", "id": "t1"}]


### PR DESCRIPTION
## Summary

When using OpenRouter Chat Completions with Anthropic reasoning enabled, streaming + tool use fails on the follow-up request with `messages.1.content.0: Invalid signature in thinking block` (`agno-agi/agno#8794`).

OpenRouter streams one reasoning block across multiple chunks sharing the same `index` — text arrives in pieces and the signature can arrive in a final text-less fragment. Agno's streaming accumulator (`_populate_stream_data` in `base.py`) `extend()`s each fragment into a list, so the stored `reasoning_details` becomes separate partial fragments `[frag1, frag2, frag3]` instead of one complete signed block per `index`. `_format_message` then replayed those fragments verbatim, corrupting Anthropic's signed thinking block.

**Sink:** `agno/models/openrouter/openrouter.py::_format_message` — emitted `message.provider_data["reasoning_details"]` verbatim.

## Fix

Add `_merge_reasoning_details` in the OpenRouter model and apply it in `_format_message` so replay reconstructs complete blocks:

- group fragments by `index` (in first-seen order)
- concatenate `text`/`data` fields in arrival order
- carry structural fields (`type`, `format`, `id`, `signature`, …)
- pass through entries without an `index` or non-dict entries unchanged
- never touch other provider-data lists (`server_tool_blocks`, etc.)

Provider-general: Anthropic text/signature fragments merge into one complete signed block; Gemini encrypted entries with distinct `index`es remain separate.

**Why the replay point (`_format_message`) and not the accumulator:** the streaming accumulator lives in the shared `Model` base class (`base.py::_populate_stream_data`), which is provider-agnostic — adding an OpenRouter-specific `reasoning_details` merge there would bleed provider knowledge into the generic layer. Fixing at `_format_message` is the boundary OpenRouter owns, is fully self-contained, fixes the actual reported error (the *next* request), and also repairs already-stored / legacy messages. `run_context`/`provider_data` internals are not mutated; only the emitted request dict is normalized.

## Scope

- Scoped to the **Chat Completions** `OpenRouter` model. `OpenRouterResponses` uses the Responses API and does not use the `reasoning_details` path, so it is unaffected.
- Does **not** overlap with the configuration work in #5802 (Gemini 3 thought-signature *config* + reasoning param normalization) — that PR adds the `reasoning` request param and preserves `reasoning_details`; this PR fixes the **streamed-fragment replay** corruption. They are complementary. (Prior attempt #8802 was closed by its author to defer to #5802's author; this PR keeps the scope tightly to the Anthropic streaming-replay bug from #8794.)

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Code follows the project style (`./scripts/format.sh`)
- [x] `ruff check` clean
- [x] `mypy` introduces **zero new errors** (one pre-existing error in `resend.py` on `main`, unrelated — addressed in #8855)
- [x] Tests added
- [x] Self-review completed

## Test plan

- [x] New `tests/unit/models/openrouter_model/test_openrouter_reasoning_merge.py` (9 cases):
  - the issue's exact streaming shape (3 fragments for `index 0` → 1 complete block with concatenated text + signature),
  - distinct indexes remain separate (Gemini encrypted entries),
  - text concatenation order,
  - structural-field carry-through (`type`/`format`/`id`),
  - index-less and non-dict entries pass through unchanged,
  - `None`/empty → `[]`,
  - `_format_message` leaves `server_tool_blocks` and other provider-data untouched.
- [x] 146 model unit tests pass (openrouter + openai + helpers); no regressions.

## AI-generated disclosure

This PR was implemented with the assistance of Claude Code (Anthropic). Changes were reviewed and tested locally against the project's CI scripts before submission. The reproduction was static (the streamed-fragment shape is asserted directly); no live OpenRouter credentials or network were used.
