### PR TITLE
feat: make agno create interactive like ag infra create

### DIFF
--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -3,17 +3,22 @@
 The mechanism is deliberately simple (inherited from `ag infra create`): shallow-clone
 the template repository, strip its git history, and copy example secrets into place.
 No registry file is kept — commands operate on the current directory.
+
+Bare `agno create` (no args) is interactive: pick a starter template, then a project
+directory name. Flags and positional args skip the prompts. Automation (`--json` or a
+non-TTY) requires an explicit name (and template or `--url`).
 """
 
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
 
 import typer
 
-from agnoctl.commands._common import handle_cli_error, validate_project_name
-from agnoctl.console import emit_json, print_info, print_success
+from agnoctl.commands._common import handle_cli_error, stdin_is_interactive, validate_project_name
+from agnoctl.console import emit_json, print_info, print_success, print_warning
 from agnoctl.errors import CLIError
 
 TEMPLATES: Dict[str, str] = {
@@ -23,6 +28,15 @@ TEMPLATES: Dict[str, str] = {
     "agentos-gcp": "https://github.com/agno-agi/agentos-gcp",
     "agentos-railway": "https://github.com/agno-agi/agentos-railway",
 }
+
+# Display order for the interactive menu; first entry is the Enter default.
+TEMPLATE_ORDER: List[str] = [
+    "agentos-docker",
+    "agentos-aws",
+    "agentos-fly",
+    "agentos-gcp",
+    "agentos-railway",
+]
 
 DEFAULT_TEMPLATE = "agentos-docker"
 
@@ -48,18 +62,112 @@ def _clone(repo_url: str, target: Path) -> None:
     shutil.rmtree(target / ".git", ignore_errors=True)
 
 
+def _default_name_from_url(url: str) -> str:
+    """Best-effort directory name from a custom template URL (last path segment)."""
+    path = urlsplit(url).path.rstrip("/")
+    leaf = path.rsplit("/", 1)[-1] if path else ""
+    if leaf.endswith(".git"):
+        leaf = leaf[: -len(".git")]
+    return leaf or "agentos"
+
+
+def _prompt_template() -> str:
+    """Numbered template menu; Enter selects the default (agentos-docker)."""
+    print_info("Select starter template or press Enter for default (" + DEFAULT_TEMPLATE + ")")
+    for index, template_name in enumerate(TEMPLATE_ORDER, start=1):
+        print_info("  [" + str(index) + "] " + template_name)
+    print_info("")
+    while True:
+        raw = str(typer.prompt("Chosen Template", default="1")).strip()
+        if raw.isdigit() and 1 <= int(raw) <= len(TEMPLATE_ORDER):
+            return TEMPLATE_ORDER[int(raw) - 1]
+        print_warning("Enter a number between 1 and " + str(len(TEMPLATE_ORDER)) + ".")
+
+
+def _prompt_project_name(default: str) -> str:
+    """Ask for the project directory name, validating until the name is usable."""
+    while True:
+        name = str(typer.prompt("Project Directory", default=default)).strip()
+        try:
+            validate_project_name(name)
+            return name
+        except CLIError as e:
+            print_warning(e.message)
+            if e.hint:
+                print_warning(e.hint)
+
+
+def _resolve_create_inputs(
+    name: Optional[str],
+    template: Optional[str],
+    template_url: Optional[str],
+    *,
+    json_output: bool,
+) -> Tuple[str, Optional[str], Optional[str]]:
+    """Fill in missing name/template via prompts, or fail clearly in non-interactive mode.
+
+    Interactive (TTY, not --json): missing template → numbered menu; missing name →
+    directory prompt (defaulted from the chosen template / URL). Non-interactive: a
+    missing name is an error; a missing template falls back to agentos-docker when a
+    name was supplied (automation / `agno create <name> --json`), matching prior
+    behavior.
+    """
+    interactive = not json_output and stdin_is_interactive()
+
+    if template_url is None and template is None:
+        if interactive:
+            template = _prompt_template()
+        elif name is not None:
+            # Explicit name in automation: keep the historical docker default.
+            template = DEFAULT_TEMPLATE
+        else:
+            raise CLIError(
+                "A project name and starter template are required in non-interactive mode.",
+                hint="Pass a directory name and --template / -t (one of: "
+                + ", ".join(TEMPLATE_ORDER)
+                + "), or run `agno create` in a terminal.",
+            )
+
+    if name is None:
+        if template_url is not None:
+            default_name = _default_name_from_url(template_url)
+        else:
+            default_name = template or DEFAULT_TEMPLATE
+        if interactive:
+            name = _prompt_project_name(default_name)
+        else:
+            raise CLIError(
+                "A project name is required in non-interactive mode.",
+                hint="Pass a directory name: agno create <name> [--template ...] [--json]",
+            )
+
+    return name, template, template_url
+
+
 def create(
-    name: str = typer.Argument(..., help="Directory name for the new AgentOS project."),
-    template: str = typer.Option(
-        DEFAULT_TEMPLATE, "--template", "-t", help="Starter template: " + ", ".join(sorted(TEMPLATES)) + "."
+    name: Optional[str] = typer.Argument(
+        None,
+        help="Directory name for the new AgentOS project. Prompted interactively when omitted.",
+    ),
+    template: Optional[str] = typer.Option(
+        None,
+        "--template",
+        "-t",
+        help="Starter template: " + ", ".join(TEMPLATE_ORDER) + ". Prompted interactively when omitted.",
+        show_default=False,
     ),
     template_url: Optional[str] = typer.Option(
         None, "--url", "-u", help="Clone from a custom template repository URL instead."
     ),
     json_output: bool = typer.Option(False, "--json", help="Emit a single JSON document for machine consumption."),
 ) -> None:
-    """Create a new AgentOS project from a starter template."""
+    """Create a new AgentOS project from a starter template.
+
+    With no arguments, prompts for a starter template and project directory name
+    (same flow as the legacy `ag infra create`).
+    """
     try:
+        name, template, template_url = _resolve_create_inputs(name, template, template_url, json_output=json_output)
         payload = _create(name=name, template=template, template_url=template_url)
     except CLIError as e:
         raise handle_cli_error(e, json_output)
@@ -76,7 +184,7 @@ def create(
     print_info("  agno connect         # make it available in your coding agents")
 
 
-def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, Any]:
+def _create(name: str, template: Optional[str], template_url: Optional[str]) -> Dict[str, Any]:
     validate_project_name(name)
     target = Path.cwd() / name
     if target.exists():
@@ -89,13 +197,14 @@ def _create(name: str, template: str, template_url: Optional[str]) -> Dict[str, 
         repo_url = template_url
         template_label = template_url
     else:
-        repo_url = TEMPLATES.get(template, "")
+        chosen = template or DEFAULT_TEMPLATE
+        repo_url = TEMPLATES.get(chosen, "")
         if not repo_url:
             raise CLIError(
-                "Unknown template: " + template,
-                hint="Available templates: " + ", ".join(sorted(TEMPLATES)) + ", or pass --url for a custom repo.",
+                "Unknown template: " + chosen,
+                hint="Available templates: " + ", ".join(TEMPLATE_ORDER) + ", or pass --url for a custom repo.",
             )
-        template_label = template
+        template_label = chosen
 
     _clone(repo_url, target)
     return {"path": str(target), "template": template_label}

--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -6,7 +6,8 @@ No registry file is kept — commands operate on the current directory.
 
 Bare `agno create` (no args) is interactive: pick a starter template, then a project
 directory name. Flags and positional args skip the prompts. Automation (`--json` or a
-non-TTY) requires an explicit name (and template or `--url`).
+non-TTY) requires an explicit name; the default template is used unless `--template`
+or `--url` is provided.
 """
 
 import shutil
@@ -122,8 +123,8 @@ def _resolve_create_inputs(
             template = DEFAULT_TEMPLATE
         else:
             raise CLIError(
-                "A project name and starter template are required in non-interactive mode.",
-                hint="Pass a directory name and --template / -t (one of: "
+                "A project name is required in non-interactive mode.",
+                hint="Pass a directory name, and optionally --template / -t (one of: "
                 + ", ".join(TEMPLATE_ORDER)
                 + "), or run `agno create` in a terminal.",
             )

--- a/libs/agnoctl/agnoctl/commands/create.py
+++ b/libs/agnoctl/agnoctl/commands/create.py
@@ -85,9 +85,9 @@ def _prompt_template() -> str:
 
 
 def _prompt_project_name(default: str) -> str:
-    """Ask for the project directory name, validating until the name is usable."""
+    """Ask for the project name, validating until the name is usable."""
     while True:
-        name = str(typer.prompt("Project Directory", default=default)).strip()
+        name = str(typer.prompt("Project Name", default=default)).strip()
         try:
             validate_project_name(name)
             return name

--- a/libs/agnoctl/agnoctl/main.py
+++ b/libs/agnoctl/agnoctl/main.py
@@ -45,7 +45,7 @@ _GROUPS: List[Tuple[str, List[Tuple[str, str]]]] = [
     (
         "Get started",
         [
-            ("agno create <name>", "Create a new AgentOS"),
+            ("agno create", "Create a new AgentOS"),
             ("agno connect", "Connect your AI apps to your AgentOS using MCP"),
             ("agno disconnect", "Disconnect your AI apps from your AgentOS"),
         ],

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -142,7 +142,7 @@ def test_create_interactive_template_only_prompts_name(fake_git, monkeypatch):
     result = runner.invoke(app, ["create", "-t", "agentos-fly"], input="fly-os\n")
     assert result.exit_code == 0, result.output
     assert "Select starter template" not in result.output
-    assert "Project Directory" in result.output
+    assert "Project Name" in result.output
     assert create_module.TEMPLATES["agentos-fly"] in fake_git.calls[0]
     assert (Path.cwd() / "fly-os" / "docker-compose.yml").exists()
 

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -112,6 +112,7 @@ def test_create_bare_json_requires_name(fake_git):
     assert result.exit_code == 1
     payload = json.loads(result.output)
     assert "project name" in payload["error"].lower()
+    assert "optionally --template" in payload["hint"]
     assert fake_git.calls == []
 
 

--- a/libs/agnoctl/tests/test_create_lifecycle.py
+++ b/libs/agnoctl/tests/test_create_lifecycle.py
@@ -107,6 +107,46 @@ def test_create_clone_failure(monkeypatch, tmp_path):
     assert "git clone failed" in json.loads(result.output)["error"]
 
 
+def test_create_bare_json_requires_name(fake_git):
+    result = runner.invoke(app, ["create", "--json"])
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert "project name" in payload["error"].lower()
+    assert fake_git.calls == []
+
+
+def test_create_interactive_prompts_template_and_name(fake_git, monkeypatch):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+    # Template choice 2 = agentos-aws; then accept the default project directory name.
+    result = runner.invoke(app, ["create"], input="2\n\n")
+    assert result.exit_code == 0, result.output
+    assert "Select starter template" in result.output
+    assert "Created" in result.output
+    assert "agentos-aws" in result.output
+    assert create_module.TEMPLATES["agentos-aws"] in fake_git.calls[0]
+    assert (Path.cwd() / "agentos-aws" / "docker-compose.yml").exists()
+
+
+def test_create_interactive_name_only_still_prompts_template(fake_git, monkeypatch):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+    # Name provided; still ask which template (Enter = docker default).
+    result = runner.invoke(app, ["create", "my-os"], input="\n")
+    assert result.exit_code == 0, result.output
+    assert "Select starter template" in result.output
+    assert create_module.TEMPLATES["agentos-docker"] in fake_git.calls[0]
+    assert (Path.cwd() / "my-os" / "docker-compose.yml").exists()
+
+
+def test_create_interactive_template_only_prompts_name(fake_git, monkeypatch):
+    monkeypatch.setattr(create_module, "stdin_is_interactive", lambda: True)
+    result = runner.invoke(app, ["create", "-t", "agentos-fly"], input="fly-os\n")
+    assert result.exit_code == 0, result.output
+    assert "Select starter template" not in result.output
+    assert "Project Directory" in result.output
+    assert create_module.TEMPLATES["agentos-fly"] in fake_git.calls[0]
+    assert (Path.cwd() / "fly-os" / "docker-compose.yml").exists()
+
+
 # -- infra -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Make `agno create` interactive when required inputs are omitted:

- prompt for a starter template when no template or URL is supplied
- prompt for a project name when the positional name is omitted
- keep non-interactive/json usage automation-friendly by requiring an explicit project name
- clarify the non-interactive error message now that the template still defaults to `agentos-docker`
- update the home screen command hint from `agno create <name>` to `agno create`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Local checks run:

- `PYTHONPATH=libs/agnoctl /Users/anurag/labs/agno/.venv/bin/python -m pytest libs/agnoctl/tests -q` - 298 passed
- `PYTHONPATH=libs/agnoctl /Users/anurag/labs/agno/.venv/bin/python -m mypy libs/agnoctl/agnoctl/commands/create.py` - passed
- `git diff --check` - passed
- `./scripts/format.sh` - passed with no file changes

Full `./scripts/validate.sh` is intentionally left to GitHub Actions for this PR.