### PR TITLE
[feat] Rolling session compaction + tool-message inclusion (#8790)

### DIFF
--- a/libs/agno/agno/session/summary.py
+++ b/libs/agno/agno/session/summary.py
@@ -93,6 +93,12 @@ class SessionSummaryManager:
     # Maximum number of messages to include in the summary conversation. None means no limit.
     conversation_limit: Optional[int] = None
 
+    # When True, tool-role messages (tool results) are included in the summary
+    # input. Defaults to False to preserve the historical behavior (only user /
+    # assistant turns were summarized). Enable for tool-heavy sessions where
+    # cross-run tool context should survive into the summary (agno-agi/agno#8790).
+    include_tool_messages: bool = False
+
     def __post_init__(self) -> None:
         if self.id is None:
             self.id = f"session_summary_manager_{uuid4().hex[:8]}"
@@ -100,6 +106,8 @@ class SessionSummaryManager:
             raise ValueError(f"last_n_runs must be a positive integer, got {self.last_n_runs}")
         if self.conversation_limit is not None and self.conversation_limit <= 0:
             raise ValueError(f"conversation_limit must be a positive integer, got {self.conversation_limit}")
+        if not isinstance(self.include_tool_messages, bool):
+            raise TypeError(f"include_tool_messages must be a bool, got {type(self.include_tool_messages).__name__}")
 
     def get_response_format(self, model: "Model") -> Union[Dict[str, Any], Type[BaseModel]]:  # type: ignore
         if model.supports_native_structured_outputs:
@@ -153,6 +161,11 @@ class SessionSummaryManager:
                     conversation_messages.append(f"User: {message.content}")
             elif message.role in ["assistant", "model"]:
                 conversation_messages.append(f"Assistant: {message.content}\n")
+            elif message.role == "tool" and self.include_tool_messages:
+                # Tool results carry cross-run context (search output, query results,
+                # API payloads) that is otherwise lost in the summary layer (#8790).
+                content = message.content if message.content is not None else ""
+                conversation_messages.append(f"Tool: {content}\n")
         system_prompt += "\n".join(conversation_messages)
         system_prompt += "</conversation>"
 
@@ -309,4 +322,128 @@ class SessionSummaryManager:
             session.summary = session_summary
             self.summaries_updated = True
 
+        return session_summary
+
+    # ------------------------------------------------------------------
+    # Rolling compaction: fold older messages into an existing summary
+    # incrementally (summaryₙ + fold batch → summaryₙ₊₁) instead of a full
+    # re-summarization of the whole session. Input size is bounded by the
+    # existing summary + the fold batch, not the total session length (#8790).
+    # ------------------------------------------------------------------
+
+    def _get_compaction_system_message(
+        self,
+        existing_summary: Optional[SessionSummary],
+        messages_to_fold: List[Message],
+        response_format: Union[Dict[str, Any], Type[BaseModel]],
+    ) -> Message:
+        """Build the system prompt for an incremental compaction step."""
+        system_prompt = dedent("""\
+        You are compacting a running conversation summary. Integrate the new
+        messages below into the existing summary, preserving all facts, removing
+        redundancy, and keeping the result concise.
+        """)
+
+        seed = existing_summary.summary if existing_summary else "(none — seed a new summary)"
+        system_prompt += f"<existing_summary>\n{seed}\n</existing_summary>\n"
+
+        system_prompt += "<messages_to_fold>\n"
+        for message in messages_to_fold:
+            if message.role == "user":
+                system_prompt += f"User: {message.content}\n"
+            elif message.role in ["assistant", "model"]:
+                system_prompt += f"Assistant: {message.content}\n"
+            elif message.role == "tool" and self.include_tool_messages:
+                content = message.content if message.content is not None else ""
+                system_prompt += f"Tool: {content}\n"
+        system_prompt += "</messages_to_fold>\n"
+
+        system_prompt += (
+            "Produce an updated summary that integrates the new information into the existing summary. "
+            "Do not make anything up."
+        )
+
+        if response_format == {"type": "json_object"}:
+            from agno.utils.prompts import get_json_output_prompt
+
+            system_prompt += "\n" + get_json_output_prompt(SessionSummaryResponse)  # type: ignore
+
+        return Message(role="system", content=system_prompt)
+
+    def compact(
+        self,
+        existing_summary: Optional[SessionSummary],
+        messages_to_fold: List[Message],
+        run_metrics: Optional["RunMetrics"] = None,
+    ) -> Optional[SessionSummary]:
+        """Fold ``messages_to_fold`` into ``existing_summary`` → a new summary (sync).
+
+        Unlike ``create_session_summary`` (which re-summarizes the whole session),
+        this seeds the model with the prior summary and only the batch being
+        folded, so cost scales with the fold batch, not the session length.
+
+        Args:
+            existing_summary: The current compacted summary (None to bootstrap).
+            messages_to_fold: Older verbatim messages to fold into the summary.
+            run_metrics: Optional metrics accumulator.
+
+        Returns:
+            The new :class:`SessionSummary`, or None if there is nothing to fold
+            or no model is configured.
+        """
+        if not messages_to_fold:
+            log_debug("No messages to fold, skipping compaction")
+            return None
+
+        self.model = get_model(self.model)
+        if self.model is None:
+            return None
+
+        log_debug("Compacting session summary", center=True)
+        response_format = self.get_response_format(self.model)
+        system_message = self._get_compaction_system_message(existing_summary, messages_to_fold, response_format)
+        messages = [system_message, Message(role="user", content=self.summary_request_message)]
+
+        summary_response = self.model.response(messages=messages, response_format=response_format)
+
+        if run_metrics is not None:
+            from agno.metrics import ModelType, accumulate_model_metrics
+
+            accumulate_model_metrics(summary_response, self.model, ModelType.SESSION_SUMMARY_MODEL, run_metrics)
+
+        session_summary = self._process_summary_response(summary_response, self.model)
+        if session_summary is not None:
+            self.summaries_updated = True
+        return session_summary
+
+    async def acompact(
+        self,
+        existing_summary: Optional[SessionSummary],
+        messages_to_fold: List[Message],
+        run_metrics: Optional["RunMetrics"] = None,
+    ) -> Optional[SessionSummary]:
+        """Async variant of :meth:`compact`."""
+        if not messages_to_fold:
+            log_debug("No messages to fold, skipping compaction")
+            return None
+
+        self.model = get_model(self.model)
+        if self.model is None:
+            return None
+
+        log_debug("Compacting session summary", center=True)
+        response_format = self.get_response_format(self.model)
+        system_message = self._get_compaction_system_message(existing_summary, messages_to_fold, response_format)
+        messages = [system_message, Message(role="user", content=self.summary_request_message)]
+
+        summary_response = await self.model.aresponse(messages=messages, response_format=response_format)
+
+        if run_metrics is not None:
+            from agno.metrics import ModelType, accumulate_model_metrics
+
+            accumulate_model_metrics(summary_response, self.model, ModelType.SESSION_SUMMARY_MODEL, run_metrics)
+
+        session_summary = self._process_summary_response(summary_response, self.model)
+        if session_summary is not None:
+            self.summaries_updated = True
         return session_summary

--- a/libs/agno/tests/unit/session/test_rolling_compaction.py
+++ b/libs/agno/tests/unit/session/test_rolling_compaction.py
@@ -1,0 +1,156 @@
+"""Unit tests for rolling session compaction + tool-message inclusion (#8790).
+
+Two focused additions to SessionSummaryManager:
+1. compact(summaryₙ, messages_to_fold) → summaryₙ₊₁ — incremental compaction
+   that folds messages into an EXISTING summary instead of full re-summarization.
+2. include_tool_messages — surface tool-role messages in the summary input
+   (previously only user/assistant were included).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.run.agent import Message
+from agno.session.summary import SessionSummary, SessionSummaryManager, SessionSummaryResponse
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_get_model():
+    """compact/acompact call get_model(model); pass the manager's mock model through unchanged."""
+    with patch("agno.session.summary.get_model", side_effect=lambda m: m):
+        yield
+
+
+def _make_mock_model(parsed_summary: SessionSummaryResponse) -> MagicMock:
+    """A mock Model whose response/aresponse return a parsed summary."""
+    mock_model = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.parsed = parsed_summary
+    mock_resp.content = parsed_summary.model_dump_json()
+    mock_model.supports_native_structured_outputs = True
+    mock_model.response.return_value = mock_resp
+    mock_model.aresponse = AsyncMock(return_value=mock_resp)
+    return mock_model
+
+
+def _manager_with_mock_model(parsed_summary: SessionSummaryResponse) -> SessionSummaryManager:
+    """Build a manager whose model.response/aresponse return a parsed summary.
+
+    get_model (called inside compact/acompact) is patched at the module level so
+    the MagicMock is returned as-is instead of being rejected as a non-Model.
+    """
+    return SessionSummaryManager(model=_make_mock_model(parsed_summary))
+
+
+# --- compact(): incremental folding ---
+
+
+def test_compact_folds_messages_into_existing_summary():
+    """summaryₙ + fold batch → summaryₙ₊₁ (one model call, input bounded)."""
+    existing = SessionSummary(summary="John is building an AI agent with Agno.")
+    fold = [
+        Message(role="user", content="Switch the DB to Postgres."),
+        Message(role="assistant", content="Done — migrated to Postgres."),
+    ]
+    expected = SessionSummaryResponse(
+        summary="John is building an AI agent with Agno using Postgres.", topics=["agno", "postgres"]
+    )
+    mgr = _manager_with_mock_model(expected)
+
+    result = mgr.compact(existing, fold)
+
+    assert result is not None
+    assert "Postgres" in result.summary
+    # Exactly one model call, and the existing summary was sent in the prompt.
+    mgr.model.response.assert_called_once()
+    sent_messages = mgr.model.response.call_args.kwargs["messages"]
+    prompt_text = sent_messages[0].content
+    assert "John is building an AI agent with Agno." in prompt_text  # existing summary seeded
+    assert "Switch the DB to Postgres." in prompt_text  # folded messages included
+
+
+@pytest.mark.asyncio
+async def test_acompact_folds_messages_into_existing_summary():
+    existing = SessionSummary(summary="Prior context: user likes Python.")
+    fold = [Message(role="user", content="Also teach me Rust.")]
+    expected = SessionSummaryResponse(summary="User likes Python and wants to learn Rust.")
+    mgr = _manager_with_mock_model(expected)
+
+    result = await mgr.acompact(existing, fold)
+
+    assert result is not None
+    assert "Rust" in result.summary
+    mgr.model.aresponse.assert_awaited_once()
+
+
+def test_compact_without_existing_summary_seeds_from_fold():
+    """When there is no prior summary, compact bootstraps one from the fold batch."""
+    fold = [Message(role="user", content="I'm Alice from Berlin.")]
+    expected = SessionSummaryResponse(summary="Alice is from Berlin.")
+    mgr = _manager_with_mock_model(expected)
+
+    result = mgr.compact(None, fold)
+
+    assert result is not None
+    assert "Alice" in result.summary
+
+
+def test_compact_no_model_returns_none():
+    mgr = SessionSummaryManager(model=None)
+    assert mgr.compact(SessionSummary(summary="x"), [Message(role="user", content="hi")]) is None
+
+
+def test_compact_empty_fold_returns_none():
+    """Nothing to fold → no model call, no new summary."""
+    mgr = _manager_with_mock_model(SessionSummaryResponse(summary="anything"))
+    assert mgr.compact(SessionSummary(summary="x"), []) is None
+    mgr.model.response.assert_not_called()
+
+
+def test_compact_updates_manager_summary_attribute():
+    existing = SessionSummary(summary="old")
+    expected = SessionSummaryResponse(summary="new integrated summary")
+    mgr = _manager_with_mock_model(expected)
+
+    mgr.compact(existing, [Message(role="user", content="more info")])
+
+    assert mgr.summary is not None
+    assert mgr.summary.summary == "new integrated summary"
+    assert mgr.summaries_updated is True
+
+
+# --- include_tool_messages ---
+
+
+def test_default_excludes_tool_messages():
+    """By default, tool messages are not rendered into the summary input."""
+    mgr = SessionSummaryManager(model=MagicMock())
+    mgr.model.supports_native_structured_outputs = True
+    conversation = [
+        Message(role="user", content="search the web"),
+        Message(role="assistant", content="calling search tool"),
+        Message(role="tool", content="result: agno is an agent SDK"),
+    ]
+    msg = mgr.get_system_message(conversation, response_format={"type": "json_object"})
+    assert "search the web" in msg.content
+    # Tool result is excluded by default.
+    assert "result: agno is an agent SDK" not in msg.content
+
+
+def test_include_tool_messages_renders_tool_results():
+    """include_tool_messages=True surfaces tool-role messages in the summary input."""
+    mgr = SessionSummaryManager(model=MagicMock(), include_tool_messages=True)
+    mgr.model.supports_native_structured_outputs = True
+    conversation = [
+        Message(role="user", content="search the web"),
+        Message(role="assistant", content="calling search tool"),
+        Message(role="tool", content="result: agno is an agent SDK"),
+    ]
+    msg = mgr.get_system_message(conversation, response_format={"type": "json_object"})
+    assert "result: agno is an agent SDK" in msg.content
+
+
+def test_include_tool_messages_validation_rejects_negative():
+    with pytest.raises(TypeError):
+        SessionSummaryManager(model=MagicMock(), include_tool_messages="yes")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

This is a focused, backward-compatible slice of the rolling-session-compaction RFC (`agno-agi/agno#8790`) — the two highest-value, independently-mergeable pieces, with default behavior unchanged.

### 1. `compact(summaryₙ, messages_to_fold) → summaryₙ₊₁` (sync + async)

The core primitive the issue asks for. Today `SessionSummaryManager.create_session_summary()` always re-summarizes the whole session from raw messages — cost grows with session length. `compact` instead **folds a batch of older messages into an existing summary**, seeding the model with the prior summary + only the fold batch:

```
summaryₙ₊₁ = compact(summaryₙ, messages_to_fold)
```

- Input is bounded by `len(summaryₙ) + len(messages_to_fold)`, not total session length.
- Bootstrappable from `None` (seed a new summary from the first batch).
- Reuses the existing response-format + response-parsing machinery (`get_response_format`, `_process_summary_response`); adds a compaction-specific system prompt that instructs the model to integrate new info, preserve facts, remove redundancy.
- Both `compact` (sync) and `acompact` (async).

### 2. `include_tool_messages: bool = False`

The summary input previously rendered only `user`/`assistant`/`model` roles (`session/summary.py`), so tool-heavy sessions lost cross-run tool context in the summary layer (a problem called out in the issue). When `True`, `tool`-role messages are now surfaced in **both** the regular summary prompt and the compaction prompt. Defaults to `False` → no behavior change.

## Scope (deliberately narrow)

This lands the **reusable algorithmic core**. Out of scope (larger design decisions the issue flags as needing RFC agreement, left for a follow-up):
- The `RollingCompactState` dataclass + `compacted_through_run_id` boundary pointer.
- Streaming events `CompactionStarted` / `CompactionCompleted`.
- The unified context-budget manager that replaces `SessionSummaryManager` / `num_history_runs` / `add_session_summary_to_context`.
- Wiring `compact` into the run loop + `DB grows unbounded` pruning.
- Deprecating `SessionSummaryManager`'s full-rewrite path.

Any final design will build on this `compact()` primitive; landing it now unblocks incremental adoption and cookbook experimentation without committing to the full manager redesign.

## Type of change

- [x] New feature (backward-compatible; new methods + an opt-in flag with safe defaults)

## Checklist

- [x] Code follows the project style (`./scripts/format.sh`)
- [x] `ruff check` clean
- [x] `mypy` introduces **zero new errors** (one pre-existing error in `resend.py` on `main`, unrelated — addressed in #8855)
- [x] Tests added
- [x] Self-review completed

## Test plan

- [x] New `tests/unit/session/test_rolling_compaction.py` (9 cases): `compact`/`acompact` folding + that the prompt seeds the existing summary and includes the fold batch; `None`-summary bootstrap; no-model short-circuit; empty-fold short-circuit (no model call); `summaries_updated` flag set; tool-message inclusion on/off; and type validation for `include_tool_messages`.
- [x] 21 session + manager unit tests pass (incl. `TestSessionSummaryManagerIdentity` confirming `__post_init__` validation still runs); no regressions.

TODO (maintainer discretion):
- [ ] A cookbook demonstrating summary₁ → summary₂ → summary₃ over a 20-turn session (happy to add once the run-loop wiring direction is agreed).

## AI-generated disclosure

This PR was implemented with the assistance of Claude Code (Anthropic). Changes were reviewed and tested locally against the project's CI scripts before submission. The author understands this is a scoped slice of a larger RFC and intentionally avoids the manager-replacement / run-loop-wiring decisions that need maintainer agreement.
