### PR TITLE
fix: include metrics in workflow completed events

### DIFF
--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -107,13 +107,16 @@ class BaseWorkflowRunOutputEvent(BaseRunOutputEvent):
         if saved_run_output is not None:
             object.__setattr__(self, "run_output", None)
         try:
-            _dict = {k: v for k, v in asdict(self).items() if v is not None and k != "run_output"}
+            _dict = {k: v for k, v in asdict(self).items() if v is not None and k not in ("run_output", "metrics")}
         finally:
             if saved_run_output is not None:
                 object.__setattr__(self, "run_output", saved_run_output)
 
         if hasattr(self, "content") and self.content and isinstance(self.content, BaseModel):
             _dict["content"] = self.content.model_dump(exclude_none=True)
+
+        if hasattr(self, "metrics") and self.metrics is not None:
+            _dict["metrics"] = self.metrics.to_dict()
 
         # Handle StepOutput fields that contain Message objects
         if hasattr(self, "step_results") and self.step_results is not None:
@@ -203,9 +206,20 @@ class WorkflowCompletedEvent(BaseWorkflowRunOutputEvent):
     # Store underlying agent/team runs (parallels WorkflowRunOutput.step_executor_runs)
     step_executor_runs: Optional[List[Union[RunOutput, TeamRunOutput, "WorkflowRunOutput"]]] = None
     metadata: Optional[Dict[str, Any]] = None
+    metrics: Optional[WorkflowMetrics] = None
 
     # Full workflow run output for nested workflows
     run_output: Optional["WorkflowRunOutput"] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "WorkflowCompletedEvent":
+        metrics_data = data.pop("metrics", None)
+        event = super().from_dict(data)
+        if metrics_data:
+            from agno.workflow.types import WorkflowMetrics
+
+            event.metrics = WorkflowMetrics.from_dict(metrics_data)
+        return event
 
 
 @dataclass

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1707,6 +1707,9 @@ class Workflow:
         if isinstance(event, (RunOutput, TeamRunOutput)):
             return event
 
+        if isinstance(event, WorkflowCompletedEvent) and event.metrics is None:
+            event.metrics = workflow_run_response.metrics
+
         if self.store_events:
             # Check if this event type should be skipped
             if self.events_to_skip:

--- a/libs/agno/tests/integration/workflows/test_workflow_metrics.py
+++ b/libs/agno/tests/integration/workflows/test_workflow_metrics.py
@@ -227,6 +227,10 @@ def test_workflow_duration_streaming_with_agent(shared_db, test_agent):
     last_run = session.runs[-1]
 
     assert last_run.metrics is not None
+    completed_event = completed_events[0]
+    assert completed_event.metrics is not None
+    assert completed_event.to_dict()["metrics"] == last_run.metrics.to_dict()
+
     assert isinstance(last_run.metrics, WorkflowMetrics)
     assert last_run.metrics.duration is not None
     assert last_run.metrics.duration > 0
@@ -284,6 +288,10 @@ async def test_workflow_duration_async_streaming(shared_db, test_agent):
     last_run = session.runs[-1]
 
     assert last_run.metrics is not None
+    completed_event = completed_events[0]
+    assert completed_event.metrics is not None
+    assert completed_event.to_dict()["metrics"] == last_run.metrics.to_dict()
+
     assert isinstance(last_run.metrics, WorkflowMetrics)
     assert last_run.metrics.duration is not None
     assert last_run.metrics.duration > 0

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -87,6 +87,42 @@ def test_workflow_run_events():
     assert json.loads(event.to_json(indent=None)) == expected_json_dict
 
 
+def test_workflow_completed_event_serializes_token_metrics():
+    from agno.models.metrics import RunMetrics
+    from agno.run.workflow import WorkflowCompletedEvent
+    from agno.workflow.types import StepMetrics, WorkflowMetrics
+
+    event = WorkflowCompletedEvent(
+        run_id="workflow-run",
+        metrics=WorkflowMetrics(
+            steps={
+                "research": StepMetrics(
+                    step_name="research",
+                    executor_type="agent",
+                    executor_name="Research Agent",
+                    metrics=RunMetrics(input_tokens=12, output_tokens=8, total_tokens=20),
+                )
+            },
+            duration=1.5,
+        ),
+    )
+
+    metrics = event.to_dict()["metrics"]
+
+    assert metrics["duration"] == 1.5
+    assert metrics["steps"]["research"]["metrics"] == {
+        "input_tokens": 12,
+        "output_tokens": 8,
+        "total_tokens": 20,
+    }
+
+    reconstructed = WorkflowCompletedEvent.from_dict(event.to_dict())
+
+    assert isinstance(reconstructed.metrics, WorkflowMetrics)
+    assert reconstructed.metrics.steps["research"].metrics is not None
+    assert reconstructed.metrics.steps["research"].metrics.total_tokens == 20
+
+
 def test_agent_session_state_in_run_output():
     """Test that RunOutput includes session_state field."""
     from agno.run.agent import RunOutput


### PR DESCRIPTION
## Summary

Fix workflow token usage missing from realtime consumers by including structured workflow metrics on `WorkflowCompletedEvent`.

The SDK already aggregated and persisted per-step `WorkflowMetrics` on `WorkflowRunOutput`, but the terminal streaming event did not expose them. Clients therefore received a completed status without token totals and had to wait for or reconstruct metrics from history.

This change:

- adds `metrics` to `WorkflowCompletedEvent`
- attaches the current run's aggregated workflow metrics in the central workflow event pipeline
- serializes metrics with `WorkflowMetrics.to_dict()`
- reconstructs `WorkflowMetrics` during event deserialization
- covers sync and async streaming propagation plus deterministic token serialization and round-tripping

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (not applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

- `./scripts/format.sh` — passed
- `.venv/bin/pytest libs/agno/tests/unit/run/test_run_events.py libs/agno/tests/integration/workflows/test_workflow_metrics.py` — 28 passed
- targeted mypy for `agno/run/workflow.py` — passed
- `./scripts/validate.sh` — Ruff, agnoctl mypy, and cookbook checks passed; the full Agno mypy pass remains blocked by 43 existing dependency/API mismatches in unrelated modules such as FastMCP, AG-UI, Gemini Interactions, and parallel tools. No reported error is in a changed file.

## Additional Notes

PR #8416 also mentions metrics, but addresses nested-run aggregation rather than exposing finalized workflow metrics on terminal streaming events.