### PR TITLE
cookbook: improve AG-UI cookbooks with db persistence and better README

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/README.md
+++ b/cookbook/05_agent_os/interfaces/agui/README.md
@@ -1,26 +1,148 @@
 # AG-UI Cookbook
 
-Examples for `interfaces/agui` in AgentOS.
+Examples for connecting Agno agents and teams to frontend UIs using the AG-UI
+protocol. AG-UI enables real-time streaming, tool execution, state synchronization,
+and human-in-the-loop workflows between your backend agents and React frontends.
 
-## Files
-- `agent_with_media.py` — Accept multimodal user input (image, audio, video, document).
-- `agent_with_tools.py` — Agent with backend tools.
-- `agentic_chat.py` — Chat with frontend tools (change_background) and backend tools (get_weather).
-- `backend_tool_rendering.py` — Render backend tools in frontend via useRenderTool.
-- `basic.py` — Basic agent setup.
-- `human_in_the_loop.py` — HITL with confirmation and user input.
-- `multiple_instances.py` — Multiple agent instances.
-- `reasoning_agent.py` — Agent with reasoning/thinking display.
-- `research_team.py` — Multi-agent research team.
-- `shared_state.py` — Shared state between agents.
-- `showcase.py` — Single server exposing all Dojo demo endpoints.
-- `state_events.py` — Outbound state synchronization via STATE_SNAPSHOT + STATE_DELTA events.
-- `structured_output.py` — Structured output schema.
-- `team_state_events.py` — Team state synchronization.
-- `tool_based_generative_ui.py` — Generative UI using tool-based approach.
+Works with any AG-UI compatible frontend, including [CopilotKit](https://github.com/CopilotKit/CopilotKit) and [Dojo](https://github.com/CopilotKit/CopilotKit/tree/main/examples/coagents-dojo).
 
-## Prerequisites
-- Load environment variables with `direnv allow` (requires `.envrc`).
-- Run examples with `.venvs/demo/bin/python <path-to-file>.py`.
-- Some examples require local services (Postgres, Redis, Slack, or MCP servers).
-- For Dojo compatibility, run `showcase.py` on port 9001.
+## Quick Start
+
+```python
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+
+agent = Agent(
+    name="Assistant",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/assistant.db"),
+    instructions="You are a helpful assistant.",
+)
+
+agent_os = AgentOS(
+    agents=[agent],
+    interfaces=[AGUI(agent=agent)],
+)
+
+if __name__ == "__main__":
+    agent_os.serve(port=9001, reload=True)
+```
+
+Run with `.venvs/demo/bin/python basic.py`, then connect your frontend to
+`http://localhost:9001/Assistant/agui`.
+
+## Examples
+
+### Getting Started
+
+Start here to learn the basics, then explore features as needed.
+
+| File | Description |
+|------|-------------|
+| `basic.py` | Minimal agent with AG-UI interface |
+| `agent_with_tools.py` | Agent with backend tools (web search) and frontend tools |
+| `structured_output.py` | Agent with Pydantic output schema |
+| `reasoning_agent.py` | Agent with reasoning model (o4-mini) and thinking display |
+| `agent_with_media.py` | Multimodal input (images, audio, video, documents) via Gemini |
+
+### Tools and Generative UI
+
+Frontend tools execute in the browser; backend tools render via `useRenderTool`.
+
+| File | Description |
+|------|-------------|
+| `agentic_chat.py` | Frontend tool (change_background) + backend tool (get_weather) |
+| `backend_tool_rendering.py` | Backend tool rendered as weather card in frontend |
+| `tool_based_generative_ui.py` | Frontend tool that generates styled haiku cards |
+
+### State Synchronization
+
+Agents can read and update session state, which syncs to the frontend in real-time
+via `STATE_SNAPSHOT` and `STATE_DELTA` events.
+
+| File | Description |
+|------|-------------|
+| `state_events.py` | Agent with `enable_agentic_state` that modifies recipe state |
+| `shared_state.py` | Same pattern with pre-populated initial state |
+
+### Human in the Loop
+
+Tools can pause for user confirmation before executing.
+
+| File | Description |
+|------|-------------|
+| `human_in_the_loop.py` | Tool with `requires_confirmation` that shows step selector UI |
+
+### Teams
+
+Multi-agent teams with AG-UI interface.
+
+| File | Description |
+|------|-------------|
+| `research_team.py` | Researcher + Writer team with web search |
+| `team_state_events.py` | Team with shared session state (recipe creator + nutrition advisor) |
+| `multiple_instances.py` | Multiple agent instances on one server |
+
+### Dojo Demos
+
+These examples are designed for the Dojo frontend at `localhost:3002`.
+
+| File | Description |
+|------|-------------|
+| `showcase.py` | All Dojo demo endpoints on one server (port 9001) |
+
+Run `showcase.py` to expose all demos at their expected paths:
+- `/agentic_chat` - Chat with tools
+- `/backend_tool_rendering` - Weather card rendering
+- `/human_in_the_loop` - Step confirmation UI
+- `/tool_based_generative_ui` - Haiku generator
+- `/shared_state` - Recipe state sync
+- `/agentic_chat_reasoning` - Reasoning model
+- `/agentic_chat_multimodal` - Image/audio/video input
+
+## Running Examples
+
+```bash
+# Activate demo environment
+source .venvs/demo/bin/activate
+
+# Or use the demo Python directly
+.venvs/demo/bin/python cookbook/05_agent_os/interfaces/agui/basic.py
+```
+
+Set your API keys:
+```bash
+export OPENAI_API_KEY="sk-..."
+export GOOGLE_API_KEY="..."  # For agent_with_media.py (Gemini)
+```
+
+## Frontend Setup (Dojo)
+
+To test with the Dojo frontend:
+
+1. Clone and run Dojo:
+   ```bash
+   git clone https://github.com/CopilotKit/CopilotKit.git
+   cd CopilotKit/examples/coagents-dojo
+   pnpm install && pnpm dev
+   ```
+
+2. Run the showcase server:
+   ```bash
+   .venvs/demo/bin/python cookbook/05_agent_os/interfaces/agui/showcase.py
+   ```
+
+3. Open `http://localhost:3002` and select a demo.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Connection refused | Server not running | Start with `agent_os.serve(port=9001)` |
+| No streaming | Missing `AGUI` interface | Add `interfaces=[AGUI(agent=agent)]` to AgentOS |
+| State not syncing | Missing state config | Set `enable_agentic_state=True` on agent |
+| HITL not working | Tool missing flag | Add `requires_confirmation=True` to tool decorator |
+| Multimodal fails | Wrong model | Use Gemini or GPT-4o for image/audio input |

--- a/cookbook/05_agent_os/interfaces/agui/agent_with_media.py
+++ b/cookbook/05_agent_os/interfaces/agui/agent_with_media.py
@@ -7,6 +7,7 @@ Uses Google Gemini to analyze attached files. Set GOOGLE_API_KEY env var.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.google import Gemini
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -18,6 +19,7 @@ from agno.os.interfaces.agui import AGUI
 media_agent = Agent(
     name="Media Agent",
     model=Gemini(id="gemini-2.5-flash"),
+    db=SqliteDb(db_file="/tmp/agui_agent_with_media.db"),
     instructions="Analyze any image, audio, video, or document the user sends and answer their question about it.",
     add_datetime_to_context=True,
     markdown=True,

--- a/cookbook/05_agent_os/interfaces/agui/agent_with_tools.py
+++ b/cookbook/05_agent_os/interfaces/agui/agent_with_tools.py
@@ -8,6 +8,7 @@ Demonstrates agent with tools.
 from typing import List
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -30,6 +31,7 @@ def generate_haiku(
 
 agent = Agent(
     model=OpenAIResponses(id="gpt-5.4"),
+    db=SqliteDb(db_file="/tmp/agui_agent_with_tools.db"),
     tools=[
         WebSearchTools(),
         generate_haiku,

--- a/cookbook/05_agent_os/interfaces/agui/backend_tool_rendering.py
+++ b/cookbook/05_agent_os/interfaces/agui/backend_tool_rendering.py
@@ -10,6 +10,7 @@ Dojo expects get_weather(location: str) with detailed return:
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.tools import tool
 
@@ -69,6 +70,7 @@ def get_weather(location: str) -> dict:
 backend_tool_agent = Agent(
     name="backend_tool_rendering",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/agui_backend_tool_rendering.db"),
     tools=[get_weather],
     instructions="""You help users check weather. When asked about weather, always use the get_weather tool.
 

--- a/cookbook/05_agent_os/interfaces/agui/basic.py
+++ b/cookbook/05_agent_os/interfaces/agui/basic.py
@@ -6,6 +6,7 @@ Demonstrates basic.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -17,6 +18,7 @@ from agno.os.interfaces.agui import AGUI
 chat_agent = Agent(
     name="Assistant",
     model=OpenAIResponses(id="gpt-5.4"),
+    db=SqliteDb(db_file="/tmp/agui_basic.db"),
     instructions="You are a helpful AI assistant.",
     add_datetime_to_context=True,
     markdown=True,

--- a/cookbook/05_agent_os/interfaces/agui/human_in_the_loop.py
+++ b/cookbook/05_agent_os/interfaces/agui/human_in_the_loop.py
@@ -13,6 +13,7 @@ The frontend renders a step selector UI where user can toggle steps and confirm/
 from typing import List
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.tools import tool
 from pydantic import BaseModel, Field
@@ -41,6 +42,7 @@ def generate_task_steps(steps: List[TaskStep]) -> str:
 hitl_agent = Agent(
     name="human_in_the_loop",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/agui_human_in_the_loop.db"),
     tools=[generate_task_steps],
     instructions="""You help users plan tasks that require confirmation.
 

--- a/cookbook/05_agent_os/interfaces/agui/reasoning_agent.py
+++ b/cookbook/05_agent_os/interfaces/agui/reasoning_agent.py
@@ -6,6 +6,7 @@ Demonstrates reasoning agent.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -18,6 +19,7 @@ from agno.tools.websearch import WebSearchTools
 chat_agent = Agent(
     name="Assistant",
     model=OpenAIResponses(id="o4-mini"),
+    db=SqliteDb(db_file="/tmp/agui_reasoning_agent.db"),
     instructions="You are a helpful AI assistant.",
     add_datetime_to_context=True,
     add_history_to_context=True,

--- a/cookbook/05_agent_os/interfaces/agui/research_team.py
+++ b/cookbook/05_agent_os/interfaces/agui/research_team.py
@@ -6,6 +6,7 @@ Demonstrates research team.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -16,10 +17,13 @@ from agno.tools.websearch import WebSearchTools
 # Create Example
 # ---------------------------------------------------------------------------
 
+db = SqliteDb(db_file="/tmp/agui_research_team.db")
+
 researcher = Agent(
     name="researcher",
     role="Research Assistant",
     model=OpenAIResponses(id="gpt-5.4"),
+    db=db,
     instructions="You are a research assistant. Find information and provide detailed analysis.",
     tools=[WebSearchTools()],
     markdown=True,
@@ -29,6 +33,7 @@ writer = Agent(
     name="writer",
     role="Content Writer",
     model=OpenAIResponses(id="gpt-5.4"),
+    db=db,
     instructions="You are a content writer. Create well-structured content based on research.",
     tools=[WebSearchTools()],
     markdown=True,

--- a/cookbook/05_agent_os/interfaces/agui/shared_state.py
+++ b/cookbook/05_agent_os/interfaces/agui/shared_state.py
@@ -21,11 +21,13 @@ STATE_DELTA events that the frontend uses to update the recipe UI.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 
 shared_state_agent = Agent(
     name="shared_state",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/agui_shared_state.db"),
     session_state={
         "recipe": {
             "title": "Make Your Recipe",

--- a/cookbook/05_agent_os/interfaces/agui/state_events.py
+++ b/cookbook/05_agent_os/interfaces/agui/state_events.py
@@ -7,6 +7,7 @@ The LLM uses the generic update_session_state tool to modify recipe state.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -14,6 +15,7 @@ from agno.os.interfaces.agui import AGUI
 agent = Agent(
     name="RecipeAssistant",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/agui_state_events.db"),
     session_state={
         "recipe": {
             "title": "",

--- a/cookbook/05_agent_os/interfaces/agui/structured_output.py
+++ b/cookbook/05_agent_os/interfaces/agui/structured_output.py
@@ -8,6 +8,7 @@ Demonstrates structured output.
 from typing import List
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
@@ -40,6 +41,7 @@ class MovieScript(BaseModel):
 chat_agent = Agent(
     name="Output Schema Agent",
     model=OpenAIResponses(id="gpt-5.4"),
+    db=SqliteDb(db_file="/tmp/agui_structured_output.db"),
     description="You write movie scripts.",
     markdown=True,
     output_schema=MovieScript,

--- a/cookbook/05_agent_os/interfaces/agui/team_state_events.py
+++ b/cookbook/05_agent_os/interfaces/agui/team_state_events.py
@@ -7,15 +7,19 @@ The team coordinates multiple agents while maintaining shared session state.
 """
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
 from agno.team.team import Team
 
+db = SqliteDb(db_file="/tmp/agui_team_state_events.db")
+
 recipe_creator = Agent(
     name="recipe_creator",
     role="Recipe Creator",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
     instructions="You create recipes with ingredients and instructions. Focus on the cooking process.",
     markdown=True,
 )
@@ -24,6 +28,7 @@ nutrition_advisor = Agent(
     name="nutrition_advisor",
     role="Nutrition Advisor",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=db,
     instructions="You advise on dietary preferences and nutritional aspects of recipes.",
     markdown=True,
 )

--- a/cookbook/05_agent_os/interfaces/agui/tool_based_generative_ui.py
+++ b/cookbook/05_agent_os/interfaces/agui/tool_based_generative_ui.py
@@ -26,6 +26,7 @@ Valid image names (from Dojo):
 from typing import List
 
 from agno.agent.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIResponses
 from agno.tools import tool
 
@@ -61,6 +62,7 @@ def generate_haiku(
 generative_ui_agent = Agent(
     name="tool_based_generative_ui",
     model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/agui_tool_based_generative_ui.db"),
     tools=[generate_haiku],
     instructions=f"""You are a haiku poet. When asked to create a haiku:
 


### PR DESCRIPTION
## Summary
- Add `SqliteDb` to all 12 AG-UI cookbook examples for session persistence
- Rewrite README with categorized examples, quick start code, and troubleshooting guide
- Organize examples into logical sections: Getting Started, Tools, State, HITL, Teams, Dojo

## Changes

### README Improvements
- Added Quick Start code example showing minimal AG-UI setup
- Categorized 15 examples into 6 sections with tables
- Added Running Examples and Frontend Setup (Dojo) instructions
- Added Troubleshooting table for common issues

### Database Persistence
Added `db=SqliteDb(db_file="/tmp/agui_*.db")` to all cookbook agents:
- `basic.py`, `agent_with_tools.py`, `agent_with_media.py`
- `structured_output.py`, `reasoning_agent.py`
- `backend_tool_rendering.py`, `human_in_the_loop.py`, `tool_based_generative_ui.py`
- `shared_state.py`, `state_events.py`
- `research_team.py`, `team_state_events.py` (shared db for team agents)

## Type of change
- [x] Cookbook improvement

## Checklist
- [x] Formatted with `./scripts/format.sh`
- [x] All examples follow existing patterns
- [x] README follows sibling interface (Slack) documentation style