### PR TITLE
[fix] preserve provider error code on ModelProviderError and fix Responses failed-status misclassification

### DIFF
--- a/libs/agno/agno/exceptions.py
+++ b/libs/agno/agno/exceptions.py
@@ -110,11 +110,19 @@ class ModelProviderError(AgnoError):
     ]
 
     def __init__(
-        self, message: str, status_code: int = 502, model_name: Optional[str] = None, model_id: Optional[str] = None
+        self,
+        message: str,
+        status_code: int = 502,
+        model_name: Optional[str] = None,
+        model_id: Optional[str] = None,
+        code: Optional[str] = None,
     ):
         super().__init__(message, status_code)
         self.model_name = model_name
         self.model_id = model_id
+        # Provider-native machine-readable error code (e.g. OpenAI "invalid_prompt",
+        # "context_length_exceeded"). Best-effort; None when the provider supplies no code.
+        self.code = code
 
         self.type = "model_provider_error"
         self.error_id = "model_provider_error"
@@ -125,12 +133,30 @@ class ModelProviderError(AgnoError):
 
         If the error is already a specific subclass (ModelRateLimitError,
         ContextWindowExceededError), it is returned as-is. Otherwise, the
-        error message and status code are inspected to determine if a more
-        specific subclass applies.
+        provider error code, error message and status code are inspected to
+        determine if a more specific subclass applies.
         """
         # Already classified
         if isinstance(error, (ModelRateLimitError, ContextWindowExceededError)):
             return error
+
+        # Provider error code fast-path (deterministic, preferred over message matching)
+        if error.code == "rate_limit_exceeded":
+            return ModelRateLimitError(
+                message=error.message,
+                status_code=error.status_code,
+                model_name=error.model_name,
+                model_id=error.model_id,
+                code=error.code,
+            )
+        if error.code == "context_length_exceeded":
+            return ContextWindowExceededError(
+                message=error.message,
+                status_code=error.status_code,
+                model_name=error.model_name,
+                model_id=error.model_id,
+                code=error.code,
+            )
 
         # Rate-limit detection (429 standard, 529 Anthropic OverloadedError)
         if error.status_code in {429, 529}:
@@ -139,6 +165,7 @@ class ModelProviderError(AgnoError):
                 status_code=error.status_code,
                 model_name=error.model_name,
                 model_id=error.model_id,
+                code=error.code,
             )
 
         # Context-window detection
@@ -149,6 +176,7 @@ class ModelProviderError(AgnoError):
                 status_code=error.status_code,
                 model_name=error.model_name,
                 model_id=error.model_id,
+                code=error.code,
             )
 
         return error
@@ -158,9 +186,14 @@ class ModelRateLimitError(ModelProviderError):
     """Exception raised when a model provider returns a rate limit error."""
 
     def __init__(
-        self, message: str, status_code: int = 429, model_name: Optional[str] = None, model_id: Optional[str] = None
+        self,
+        message: str,
+        status_code: int = 429,
+        model_name: Optional[str] = None,
+        model_id: Optional[str] = None,
+        code: Optional[str] = None,
     ):
-        super().__init__(message, status_code, model_name, model_id)
+        super().__init__(message, status_code, model_name, model_id, code)
         self.error_id = "model_rate_limit_error"
 
 
@@ -168,9 +201,14 @@ class ContextWindowExceededError(ModelProviderError):
     """Exception raised when the input exceeds a model's context window."""
 
     def __init__(
-        self, message: str, status_code: int = 400, model_name: Optional[str] = None, model_id: Optional[str] = None
+        self,
+        message: str,
+        status_code: int = 400,
+        model_name: Optional[str] = None,
+        model_id: Optional[str] = None,
+        code: Optional[str] = None,
     ):
-        super().__init__(message, status_code, model_name, model_id)
+        super().__init__(message, status_code, model_name, model_id, code)
         self.error_id = "context_window_exceeded_error"
 
 

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -465,16 +465,20 @@ class OpenAIChat(Model):
                     status_code=e.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from e
             raise ModelProviderError(
                 message=error_message,
                 status_code=e.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from e
         except ModelAuthenticationError as e:
             log_error(f"Model authentication error from OpenAI API: {str(e)}")
             raise e
+        except ModelProviderError:
+            raise
         except Exception as e:
             log_error(f"Error from OpenAI API: {str(e)}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
@@ -555,16 +559,20 @@ class OpenAIChat(Model):
                     status_code=e.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from e
             raise ModelProviderError(
                 message=error_message,
                 status_code=e.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from e
         except ModelAuthenticationError as e:
             log_error(f"Model authentication error from OpenAI API: {str(e)}")
             raise e
+        except ModelProviderError:
+            raise
         except Exception as e:
             log_error(f"Error from OpenAI API: {str(e)}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
@@ -642,16 +650,20 @@ class OpenAIChat(Model):
                     status_code=e.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from e
             raise ModelProviderError(
                 message=error_message,
                 status_code=e.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from e
         except ModelAuthenticationError as e:
             log_error(f"Model authentication error from OpenAI API: {str(e)}")
             raise e
+        except ModelProviderError:
+            raise
         except Exception as e:
             log_error(f"Error from OpenAI API: {str(e)}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
@@ -731,16 +743,20 @@ class OpenAIChat(Model):
                     status_code=e.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from e
             raise ModelProviderError(
                 message=error_message,
                 status_code=e.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from e
         except ModelAuthenticationError as e:
             log_error(f"Model authentication error from OpenAI API: {str(e)}")
             raise e
+        except ModelProviderError:
+            raise
         except Exception as e:
             log_error(f"Error from OpenAI API: {str(e)}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
@@ -815,6 +831,7 @@ class OpenAIChat(Model):
                 message=response.error.get("message", "Unknown model error"),  # type: ignore
                 model_name=self.name,
                 model_id=self.id,
+                code=response.error.get("code"),  # type: ignore
             )
 
         # Get response message

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -26,6 +26,15 @@ try:
 except ImportError as e:
     raise ImportError("`openai` not installed. Please install using `pip install openai -U`") from e
 
+# Response-level failures (``Response.error``) carry no HTTP status. Map the provider
+# error code to its HTTP equivalent so retry and fallback semantics treat client vs
+# server failures correctly; codes not listed here are client errors.
+RESPONSE_ERROR_STATUS_CODES: Dict[str, int] = {
+    "server_error": 502,
+    "rate_limit_exceeded": 429,
+    "vector_store_timeout": 504,
+}
+
 
 @dataclass
 class OpenAIResponses(Model):
@@ -193,6 +202,24 @@ class OpenAIResponses(Model):
 
         self.async_client = AsyncOpenAI(**client_params)
         return self.async_client
+
+    def _response_error(self, response: "Response") -> ModelProviderError:
+        """Build a ModelProviderError from a response that reports a provider-side error.
+
+        Response-level errors have no HTTP status and no underlying exception to chain
+        from, so the typed ``Response.error`` code is carried on the raised error and
+        mapped to an HTTP-equivalent status code.
+        """
+        error = response.error
+        if error is None:
+            return ModelProviderError(message=f"Response {response.id} failed", model_name=self.name, model_id=self.id)
+        return ModelProviderError(
+            message=error.message,
+            status_code=RESPONSE_ERROR_STATUS_CODES.get(error.code, 400),
+            model_name=self.name,
+            model_id=self.id,
+            code=error.code,
+        )
 
     def _poll_background_response(self, response_id: str) -> "Response":
         """Poll for a background response until it reaches a terminal state.
@@ -794,8 +821,7 @@ class OpenAIResponses(Model):
                 provider_response = self._poll_background_response(provider_response.id)
 
             if provider_response.status == "failed":
-                error_msg = provider_response.error.message if provider_response.error else "Background response failed"
-                raise ModelProviderError(message=error_msg, model_name=self.name, model_id=self.id)
+                raise self._response_error(provider_response)
             if provider_response.status == "cancelled":
                 raise ModelProviderError(
                     message=f"Background response {provider_response.id} was cancelled",
@@ -848,16 +874,20 @@ class OpenAIResponses(Model):
                     status_code=exc.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from exc
             raise ModelProviderError(
                 message=error_message,
                 status_code=exc.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from exc
         except ModelAuthenticationError as exc:
             log_error(f"Model authentication error from OpenAI API: {exc}")
             raise exc
+        except ModelProviderError:
+            raise
         except Exception as exc:
             log_error(f"Error from OpenAI API: {exc}")
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
@@ -899,8 +929,7 @@ class OpenAIResponses(Model):
                 provider_response = await self._apoll_background_response(provider_response.id)
 
             if provider_response.status == "failed":
-                error_msg = provider_response.error.message if provider_response.error else "Background response failed"
-                raise ModelProviderError(message=error_msg, model_name=self.name, model_id=self.id)
+                raise self._response_error(provider_response)
             if provider_response.status == "cancelled":
                 raise ModelProviderError(
                     message=f"Background response {provider_response.id} was cancelled",
@@ -953,16 +982,20 @@ class OpenAIResponses(Model):
                     status_code=exc.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from exc
             raise ModelProviderError(
                 message=error_message,
                 status_code=exc.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from exc
         except ModelAuthenticationError as exc:
             log_error(f"Model authentication error from OpenAI API: {exc}")
             raise exc
+        except ModelProviderError:
+            raise
         except Exception as exc:
             log_error(f"Error from OpenAI API: {exc}")
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
@@ -1042,16 +1075,20 @@ class OpenAIResponses(Model):
                     status_code=exc.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from exc
             raise ModelProviderError(
                 message=error_message,
                 status_code=exc.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from exc
         except ModelAuthenticationError as exc:
             log_error(f"Model authentication error from OpenAI API: {exc}")
             raise exc
+        except ModelProviderError:
+            raise
         except Exception as exc:
             log_error(f"Error from OpenAI API: {exc}")
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
@@ -1128,16 +1165,20 @@ class OpenAIResponses(Model):
                     status_code=exc.response.status_code,
                     model_name=self.name,
                     model_id=self.id,
+                    code=error_code,
                 ) from exc
             raise ModelProviderError(
                 message=error_message,
                 status_code=exc.response.status_code,
                 model_name=self.name,
                 model_id=self.id,
+                code=error_code,
             ) from exc
         except ModelAuthenticationError as exc:
             log_error(f"Model authentication error from OpenAI API: {exc}")
             raise exc
+        except ModelProviderError:
+            raise
         except Exception as exc:
             log_error(f"Error from OpenAI API: {exc}")
             raise ModelProviderError(message=str(exc), model_name=self.name, model_id=self.id) from exc
@@ -1172,11 +1213,7 @@ class OpenAIResponses(Model):
         model_response = ModelResponse()
 
         if response.error:
-            raise ModelProviderError(
-                message=response.error.message,
-                model_name=self.name,
-                model_id=self.id,
-            )
+            raise self._response_error(response)
 
         # Store the response ID for continuity
         if response.id:

--- a/libs/agno/tests/unit/models/openai/test_openai_error_codes.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_error_codes.py
@@ -1,0 +1,113 @@
+"""Tests for provider error code preservation on ModelProviderError (OpenAI models)."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from openai import APIStatusError
+
+from agno.exceptions import ContextWindowExceededError, ModelProviderError
+from agno.models.message import Message
+from agno.models.openai.chat import OpenAIChat
+from agno.models.openai.responses import OpenAIResponses
+
+
+def _make_fake_client() -> MagicMock:
+    client = MagicMock()
+    client.is_closed.return_value = False
+    return client
+
+
+def _api_status_error(status_code: int, code: str, message: str) -> APIStatusError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/test")
+    response = httpx.Response(
+        status_code,
+        json={"error": {"message": message, "type": "invalid_request_error", "param": None, "code": code}},
+        request=request,
+    )
+    return APIStatusError(message, response=response, body=None)
+
+
+def _make_assistant_message() -> Message:
+    return Message(role="assistant")
+
+
+class TestResponsesErrorCodePreserved:
+    def test_api_status_error_code_preserved(self):
+        """The provider error code from a 4xx response body is carried on ModelProviderError."""
+        model = OpenAIResponses(id="gpt-4.1-mini")
+        fake_client = _make_fake_client()
+        fake_client.responses.create.side_effect = _api_status_error(
+            400, "invalid_prompt", "Invalid prompt: your prompt was flagged"
+        )
+        model.client = fake_client
+
+        with patch.object(model, "_format_messages", return_value=[]):
+            with pytest.raises(ModelProviderError) as exc_info:
+                model.invoke(messages=[Message(role="user", content="hi")], assistant_message=_make_assistant_message())
+
+        assert exc_info.value.code == "invalid_prompt"
+        assert exc_info.value.status_code == 400
+        assert isinstance(exc_info.value.__cause__, APIStatusError)
+
+    def test_context_length_exceeded_code_preserved(self):
+        """context_length_exceeded still raises ContextWindowExceededError, now carrying the code."""
+        model = OpenAIResponses(id="gpt-4.1-mini")
+        fake_client = _make_fake_client()
+        fake_client.responses.create.side_effect = _api_status_error(
+            400, "context_length_exceeded", "This model's maximum context length is exceeded"
+        )
+        model.client = fake_client
+
+        with patch.object(model, "_format_messages", return_value=[]):
+            with pytest.raises(ContextWindowExceededError) as exc_info:
+                model.invoke(messages=[Message(role="user", content="hi")], assistant_message=_make_assistant_message())
+
+        assert exc_info.value.code == "context_length_exceeded"
+
+
+class TestChatErrorCodePreserved:
+    def test_api_status_error_code_preserved(self):
+        """The provider error code from a 4xx response body is carried on ModelProviderError."""
+        model = OpenAIChat(id="gpt-4o-mini")
+        fake_client = _make_fake_client()
+        fake_client.chat.completions.create.side_effect = _api_status_error(
+            400, "invalid_prompt", "Invalid prompt: your prompt was flagged"
+        )
+        model.client = fake_client
+
+        with pytest.raises(ModelProviderError) as exc_info:
+            model.invoke(messages=[Message(role="user", content="hi")], assistant_message=_make_assistant_message())
+
+        assert exc_info.value.code == "invalid_prompt"
+        assert exc_info.value.status_code == 400
+        assert isinstance(exc_info.value.__cause__, APIStatusError)
+
+    def test_context_length_exceeded_code_preserved(self):
+        model = OpenAIChat(id="gpt-4o-mini")
+        fake_client = _make_fake_client()
+        fake_client.chat.completions.create.side_effect = _api_status_error(
+            400, "context_length_exceeded", "This model's maximum context length is exceeded"
+        )
+        model.client = fake_client
+
+        with pytest.raises(ContextWindowExceededError) as exc_info:
+            model.invoke(messages=[Message(role="user", content="hi")], assistant_message=_make_assistant_message())
+
+        assert exc_info.value.code == "context_length_exceeded"
+
+    def test_error_without_code_defaults_to_none(self):
+        """A 4xx body with no code field yields code=None (best-effort contract)."""
+        model = OpenAIChat(id="gpt-4o-mini")
+        fake_client = _make_fake_client()
+        request = httpx.Request("POST", "https://api.openai.com/v1/test")
+        response = httpx.Response(
+            400, json={"error": {"message": "Bad request", "type": "invalid_request_error"}}, request=request
+        )
+        fake_client.chat.completions.create.side_effect = APIStatusError("Bad request", response=response, body=None)
+        model.client = fake_client
+
+        with pytest.raises(ModelProviderError) as exc_info:
+            model.invoke(messages=[Message(role="user", content="hi")], assistant_message=_make_assistant_message())
+
+        assert exc_info.value.code is None

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_background.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_background.py
@@ -11,8 +11,9 @@ from agno.models.openai.responses import OpenAIResponses
 
 
 class _FakeError:
-    def __init__(self, message: str):
+    def __init__(self, message: str, code: str = "server_error"):
         self.message = message
+        self.code = code
 
 
 class _FakeResponse:
@@ -265,6 +266,96 @@ def test_invoke_raises_on_failed_status():
                 messages=[Message(role="user", content="hi")],
                 assistant_message=assistant,
             )
+
+
+# ---------------------------------------------------------------------------
+# Failed-status error code and status mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "code,expected_status",
+    [
+        ("server_error", 502),
+        ("rate_limit_exceeded", 429),
+        ("vector_store_timeout", 504),
+        ("invalid_prompt", 400),
+        ("image_content_policy_violation", 400),
+    ],
+)
+def test_invoke_failed_status_maps_error_code(code, expected_status):
+    """Failed responses carry the provider error code and an HTTP-equivalent status.
+
+    Also guards against the error being re-wrapped by the generic exception handler,
+    which would flatten it back to a codeless 502.
+    """
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = _FakeResponse(
+        _id="resp_1",
+        status="failed",
+        error=_FakeError("response failed", code=code),
+    )
+    model.client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        with pytest.raises(ModelProviderError) as exc_info:
+            model.invoke(
+                messages=[Message(role="user", content="hi")],
+                assistant_message=assistant,
+            )
+
+    assert exc_info.value.code == code
+    assert exc_info.value.status_code == expected_status
+
+
+def test_invoke_failed_status_without_error_object():
+    """A failed response with no error object still raises with the 502 default."""
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = _FakeResponse(_id="resp_1", status="failed", error=None)
+    model.client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        with pytest.raises(ModelProviderError) as exc_info:
+            model.invoke(
+                messages=[Message(role="user", content="hi")],
+                assistant_message=assistant,
+            )
+
+    assert exc_info.value.code is None
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_failed_status_maps_error_code():
+    """Async failed responses carry the provider error code and an HTTP-equivalent status."""
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create = AsyncMock(
+        return_value=_FakeResponse(
+            _id="resp_1",
+            status="failed",
+            error=_FakeError("Invalid prompt: flagged by usage policy", code="invalid_prompt"),
+        )
+    )
+    model.async_client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        with pytest.raises(ModelProviderError) as exc_info:
+            await model.ainvoke(
+                messages=[Message(role="user", content="hi")],
+                assistant_message=assistant,
+            )
+
+    assert exc_info.value.code == "invalid_prompt"
+    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/libs/agno/tests/unit/test_fallback.py
+++ b/libs/agno/tests/unit/test_fallback.py
@@ -158,6 +158,29 @@ class TestGetFallbackModels:
         result = get_fallback_models(config, error)
         assert result == [general_model]
 
+    def test_get_fallback_models_routes_background_rate_limit(self):
+        """A response-level rate limit failure (no HTTP status) routes to on_rate_limit.
+
+        Mirrors what OpenAIResponses raises for a background response that failed
+        with error code rate_limit_exceeded: status 429 + the provider code.
+        """
+        rl_model = _make_model("rate-limit-fallback")
+        config = FallbackConfig(on_error=[_make_model("general")], on_rate_limit=[rl_model])
+        error = ModelProviderError("Rate limit exceeded", status_code=429, code="rate_limit_exceeded")
+        result = get_fallback_models(config, error)
+        assert result == [rl_model]
+
+    def test_get_fallback_models_blocks_background_client_error(self):
+        """A response-level client error (e.g. invalid_prompt) is not masked by on_error.
+
+        Mirrors what OpenAIResponses raises for a background response that failed
+        with a client-side error code: status 400 + the provider code.
+        """
+        config = FallbackConfig(on_error=[_make_model("fallback")])
+        error = ModelProviderError("Invalid prompt: flagged", status_code=400, code="invalid_prompt")
+        result = get_fallback_models(config, error)
+        assert result is None
+
 
 # =============================================================================
 # Group 3: call_model_with_fallback() (sync)
@@ -518,6 +541,41 @@ class TestClassifyError:
         classified = Model.classify_error(error)
         assert classified is error
         assert type(classified) is ModelProviderError
+
+    def test_classify_error_rate_limit_code_fast_path(self):
+        """A rate_limit_exceeded provider code classifies as ModelRateLimitError regardless of status."""
+        error = ModelProviderError("Rate limit exceeded", status_code=502, code="rate_limit_exceeded")
+        classified = Model.classify_error(error)
+        assert isinstance(classified, ModelRateLimitError)
+        assert classified.code == "rate_limit_exceeded"
+
+    def test_classify_error_context_window_code_fast_path(self):
+        """A context_length_exceeded provider code classifies as ContextWindowExceededError."""
+        error = ModelProviderError("Request rejected", status_code=400, code="context_length_exceeded")
+        classified = Model.classify_error(error)
+        assert isinstance(classified, ContextWindowExceededError)
+        assert classified.code == "context_length_exceeded"
+
+    def test_classify_error_preserves_code_on_status_path(self):
+        """Status-based classification carries the provider code onto the subclass."""
+        error = ModelProviderError("too many requests", status_code=429, code="rate_limit_exceeded")
+        classified = Model.classify_error(error)
+        assert isinstance(classified, ModelRateLimitError)
+        assert classified.code == "rate_limit_exceeded"
+
+    def test_classify_error_preserves_code_on_message_path(self):
+        """Message-pattern classification carries the provider code onto the subclass."""
+        error = ModelProviderError("maximum context length is 8192 tokens", status_code=400, code="some_code")
+        classified = Model.classify_error(error)
+        assert isinstance(classified, ContextWindowExceededError)
+        assert classified.code == "some_code"
+
+    def test_classify_error_code_defaults_to_none(self):
+        """Errors raised without a provider code keep code=None end to end."""
+        error = ModelProviderError("rate limited", status_code=429)
+        classified = Model.classify_error(error)
+        assert isinstance(classified, ModelRateLimitError)
+        assert classified.code is None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes #8869

`ModelProviderError` had no field for the provider-native error code, so OpenAI codes like `invalid_prompt`, `rate_limit_exceeded`, and `context_length_exceeded` were extracted at the wrap sites and then discarded. Separately, Responses `status == "failed"` errors were raised with no `status_code` (defaulting to 502) and no code, which routes response-level client errors to `FallbackConfig.on_error` and hides response-level rate limits from `on_rate_limit`, defeating the deliberate 4xx guard in `fallback.py`.

This PR makes the error transport correct. It does not change retry policy: `invalid_prompt` is still non-retryable by default.

### Change groups

**1. `code` field on `ModelProviderError` + classify threading (`exceptions.py`).**
Add an optional trailing `code: Optional[str] = None` to `ModelProviderError`, `ModelRateLimitError`, and `ContextWindowExceededError`. Thread it through `classify_error()`'s subclass reconstruction (which previously rebuilt subclasses passing only message/status_code/model_name/model_id, silently dropping any code) and add a code fast-path so `rate_limit_exceeded` classifies as `ModelRateLimitError` and `context_length_exceeded` as `ContextWindowExceededError` regardless of the HTTP status. This runs before the existing status/message matching. `classify_error` runs before `_is_retryable_error` in `base.py`, so without this threading a downstream hook would never see the code.

**2. Populate the code at the 8 OpenAI wrap sites + non-stream error paths.**
Pass the already-extracted `error_code` at each `except APIStatusError` handler in `chat.py` (4) and `responses.py` (4), plus the non-stream `response.error` parse paths.

**3. Failed-status mapping via `RESPONSE_ERROR_STATUS_CODES` + `_response_error` helper (`responses.py`).**
A response-level failure has no HTTP layer, so map the typed `Response.error.code` to an HTTP-equivalent status:

```python
RESPONSE_ERROR_STATUS_CODES = {
    "server_error": 502,
    "rate_limit_exceeded": 429,
    "vector_store_timeout": 504,
}
# codes not listed default to 400 (client error, non-retryable by base.py's non_retryable_codes)
```

`_response_error()` builds the `ModelProviderError` with that status and carries the code. No `from` chaining, since a response-level failure has no underlying exception to chain from. Used at both `status == "failed"` paths and `_parse_provider_response`.

**4. `except ModelProviderError: raise` passthrough (`chat.py`, `responses.py`).**
Add a passthrough before each `except Exception` so a corrected failed-status raise is not re-caught and flattened back to a codeless 502. This is load-bearing, not polish: without it, change group 3 is inert.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### AI-assistance disclosure

This change was developed with AI assistance (Claude Code). It has been human-reviewed, tested, and is held to the same quality bar as any other contribution: it adds test coverage, passes the existing suite, and the author understands and stands behind the change.

### Verification

- Affected suites on the patched source (fresh venv, `pip install -e "libs/agno[dev]"`): 162 passed across `test_openai_error_codes.py` (5), `test_openai_responses_background.py` (22), `test_fallback.py` (63), `test_retry_error_classification.py` (50), `test_context_window_patterns.py` (22).
- Regression proof: with the source changes reverted and the tests kept, the 14 new tests fail on v2.7.2 (`AttributeError: 'ModelProviderError' object has no attribute 'code'` / `TypeError: unexpected keyword argument 'code'`), including the fallback-routing tests.
- Wider sweep (`tests/unit/models/`, `tests/unit/models/openai/`, `test_fallback.py`): 963 passed; the only failures are pre-existing optional-SDK import errors (groq/cerebras/watsonx not installed), unrelated to this change.
- `./scripts/format.sh` clean. `./scripts/validate.sh`: ruff clean; mypy reports 26 errors in Gemini/Anthropic/`_genai_compat` files that reproduce identically on unmodified v2.7.2 in the same environment (newer optional SDK versions) — none in the files this PR touches, and the PR introduces no new mypy errors.
- Audited every constructor callsite of `ModelProviderError`/`ModelRateLimitError`/`ContextWindowExceededError` in `libs/agno`: none passes enough positional args to collide with the new trailing kwarg.

### Test coverage

- `tests/unit/models/openai/test_openai_error_codes.py` (new): a 4xx body carries the code onto `ModelProviderError` for both `OpenAIChat` and `OpenAIResponses`; `context_length_exceeded` still raises `ContextWindowExceededError` and now carries the code; a body with no code yields `code = None`; the `__cause__` chain to the original `APIStatusError` is preserved.
- `tests/unit/models/openai/test_openai_responses_background.py`: failed-status responses map `error.code` to the expected status (`server_error` -> 502, `rate_limit_exceeded` -> 429, `vector_store_timeout` -> 504, `invalid_prompt` / `image_content_policy_violation` -> 400); a failed response with no error object still raises 502 / `code = None`; async path covered; a test explicitly guards against the generic `except Exception` re-wrapping the raise back to a codeless 502.
- `tests/unit/test_fallback.py`: a background `rate_limit_exceeded` failure routes to `on_rate_limit`; a background client error (`invalid_prompt`) is not masked by `on_error`; `classify_error` fast-paths `rate_limit_exceeded` / `context_length_exceeded` regardless of status; the code is preserved on both the status and message classification paths and defaults to `None` when absent.

### Backward compatibility

The new `code` kwarg is trailing and defaults to `None`, so every existing HTTP/exception raise is unchanged except that it now carries an accurate code where the SDK provides one. Zero behavior change on the HTTP paths.

The one intended behavior change is on response-level failures (`status == "failed"` / `Response.error`), which previously all defaulted to 502 and now carry an accurate status and code. Calling this out honestly: this corrects fallback routing. Response-level client errors (for example `invalid_prompt`) are no longer masked by `on_error`, and response-level `rate_limit_exceeded` now reaches `on_rate_limit`. Anyone relying on the previous behavior, where every failed response routed to `on_error` as a 502, will see the new routing.

### Scoped-out follow-ups

- Streaming terminal events `response.failed` / `response.incomplete` in the stream parser (`invoke_stream` / `ainvoke_stream`) are still silently ignored. Real and separable, left for a follow-up.
- Populating `code` for non-OpenAI providers (Anthropic, Gemini). The field is generic; other providers can adopt it incrementally.

### Not in scope

This is error-transport correctness only. It deliberately does not make `invalid_prompt` (or any 400) retryable. With the code now carried on the exception, downstream integrators can implement retry or fallback policy via the documented `_is_retryable_error` override without matching message prose.
