### PR TITLE
fix: emit separate AGUI message boundaries for nested team sources

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/agentic_chat_team_nested.py
+++ b/cookbook/05_agent_os/interfaces/agui/agentic_chat_team_nested.py
@@ -1,0 +1,168 @@
+"""
+E2E test for nested team AGUI message boundaries (issue #6141).
+
+Tests that when a nested team runs (ParentTeam → SubTeam → Agent),
+each source gets its own TEXT_MESSAGE_START with distinct messageId and name.
+"""
+
+import asyncio
+import json
+import time
+from threading import Thread
+
+import httpx
+import uvicorn
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.team import Team
+
+model = OpenAIResponses(id="gpt-4.1-mini")
+
+# Nested team structure: ParentTeam → SubTeam → Agent
+inner_agent = Agent(
+    name="NumberPicker",
+    role="Number picker",
+    instructions="Pick a random number between 1-100 and respond with just the number.",
+    model=model,
+)
+
+sub_team = Team(
+    name="SubTeam",
+    role="Sub team",
+    members=[inner_agent],
+    instructions="When asked for a number, delegate to NumberPicker and report their result.",
+    model=model,
+    stream_member_events=True,
+)
+
+parent_team = Team(
+    name="ParentTeam",
+    role="Parent team coordinator",
+    members=[sub_team],
+    instructions="When asked for a number, delegate to SubTeam and summarize.",
+    model=model,
+    stream_member_events=True,
+)
+
+agent_os = AgentOS(
+    teams=[parent_team],
+    interfaces=[
+        AGUI(team=parent_team, prefix="/team"),
+    ],
+)
+
+app = agent_os.get_app()
+
+
+async def test_nested_team_boundaries():
+    """Test that nested team responses have separate message boundaries."""
+
+    # Start server in background
+    config = uvicorn.Config(app=app, host="127.0.0.1", port=8765, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = Thread(target=server.run)
+    thread.daemon = True
+    thread.start()
+
+    # Wait for server to start
+    time.sleep(2)
+
+    request_body = {
+        "threadId": "test-thread-1",
+        "runId": "test-run-1",
+        "state": {},
+        "messages": [
+            {
+                "id": "msg-1",
+                "role": "user",
+                "content": "Pick a number for me",
+            }
+        ],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {},
+    }
+
+    events = []
+
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        async with client.stream(
+            "POST",
+            "http://127.0.0.1:8765/team/agui",
+            json=request_body,
+            headers={"Accept": "text/event-stream"},
+        ) as response:
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    try:
+                        event = json.loads(line[6:])
+                        events.append(event)
+                    except json.JSONDecodeError:
+                        pass
+
+    # Analyze events
+    print("\n" + "=" * 60)
+    print("EVENT ANALYSIS")
+    print("=" * 60)
+
+    starts = [e for e in events if e.get("type") == "TEXT_MESSAGE_START"]
+    ends = [e for e in events if e.get("type") == "TEXT_MESSAGE_END"]
+    contents = [e for e in events if e.get("type") == "TEXT_MESSAGE_CONTENT"]
+
+    print(f"\nTEXT_MESSAGE_START events: {len(starts)}")
+    print(f"TEXT_MESSAGE_END events: {len(ends)}")
+    print(f"TEXT_MESSAGE_CONTENT events: {len(contents)}")
+
+    print("\n--- TEXT_MESSAGE_START details ---")
+    message_ids = set()
+    names = []
+    for i, start in enumerate(starts):
+        msg_id = start.get("messageId", "")[:8]
+        name = start.get("name", "<none>")
+        message_ids.add(start.get("messageId"))
+        names.append(name)
+        print(f"  [{i + 1}] messageId={msg_id}... name={name}")
+
+    print(f"\nUnique messageIds: {len(message_ids)}")
+    print(f"Names found: {names}")
+
+    # Verify the fix
+    print("\n" + "=" * 60)
+    print("VERIFICATION")
+    print("=" * 60)
+
+    # We should have multiple message starts (one per source)
+    if len(starts) > 1:
+        print("✓ Multiple TEXT_MESSAGE_START events emitted")
+    else:
+        print("✗ Only 1 TEXT_MESSAGE_START (bug not fixed)")
+
+    # Each should have a unique messageId
+    if len(message_ids) == len(starts):
+        print("✓ Each message has a unique messageId")
+    else:
+        print("✗ Some messages share messageId (bug not fixed)")
+
+    # At least some should have the name field populated
+    named_starts = [n for n in names if n != "<none>"]
+    if named_starts:
+        print(f"✓ Messages have source names: {named_starts}")
+    else:
+        print("✗ No name fields populated")
+
+    # Balanced START/END
+    if len(starts) == len(ends):
+        print(f"✓ Balanced {len(starts)} STARTs and {len(ends)} ENDs")
+    else:
+        print(f"✗ Unbalanced: {len(starts)} STARTs vs {len(ends)} ENDs")
+
+    print("\n" + "=" * 60)
+
+    # Request server shutdown
+    server.should_exit = True
+
+
+if __name__ == "__main__":
+    asyncio.run(test_nested_team_boundaries())

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -67,6 +67,18 @@ def _extract_team_response_chunk_content(response: TeamRunContentEvent) -> str:
     return main_content + members_response
 
 
+def _extract_source_name(chunk: BaseRunOutputEvent) -> str:
+    # Extract agent or team name from chunk for message attribution
+    # Prefer team_name over agent_name (team events take precedence)
+    team_name = getattr(chunk, "team_name", None)
+    if team_name:
+        return team_name
+    agent_name = getattr(chunk, "agent_name", None)
+    if agent_name:
+        return agent_name
+    return ""
+
+
 def _format_reasoning_step(step: Optional[ReasoningStep], step_number: int = 0) -> str:
     """Format a ReasoningStep as text for REASONING_MESSAGE_CONTENT."""
     if step is None:
@@ -109,14 +121,34 @@ def on_run_content(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEv
     else:
         content = ""
 
-    if not state.text_message_open:
+    source_name = _extract_source_name(chunk)
+
+    # Source-change boundary: when a different agent/team starts streaming,
+    # close the current message and start a new one with the new source's name
+    if state.text_message_open and state.source_changed(source_name):
+        events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=state.text_message_id))
+        state.close_text_message()
+        state.clear_pending_tool_calls_parent_id()
         message_id = state.open_text_message()
+        state.current_source_name = source_name
+        events.append(
+            TextMessageStartEvent(
+                type=EventType.TEXT_MESSAGE_START,
+                message_id=message_id,
+                role="assistant",
+                name=source_name if source_name else None,
+            )
+        )
+    elif not state.text_message_open:
+        message_id = state.open_text_message()
+        state.current_source_name = source_name
         state.clear_pending_tool_calls_parent_id()
         events.append(
             TextMessageStartEvent(
                 type=EventType.TEXT_MESSAGE_START,
                 message_id=message_id,
                 role="assistant",
+                name=source_name if source_name else None,
             )
         )
 
@@ -149,11 +181,13 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     # Create empty parent message if none exists (AG-UI protocol requirement)
     if not parent_message_id:
         parent_message_id = str(uuid.uuid4())
+        source_name = _extract_source_name(chunk)
         events.append(
             TextMessageStartEvent(
                 type=EventType.TEXT_MESSAGE_START,
                 message_id=parent_message_id,
                 role="assistant",
+                name=source_name if source_name else None,
             )
         )
         events.append(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id=parent_message_id))
@@ -340,11 +374,13 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
         external_tools = chunk.tools_awaiting_external_execution
         if external_tools:
             assistant_message_id = str(uuid.uuid4())
+            source_name = _extract_source_name(chunk)
             events.append(
                 TextMessageStartEvent(
                     type=EventType.TEXT_MESSAGE_START,
                     message_id=assistant_message_id,
                     role="assistant",
+                    name=source_name if source_name else None,
                 )
             )
 

--- a/libs/agno/agno/os/interfaces/agui/state.py
+++ b/libs/agno/agno/os/interfaces/agui/state.py
@@ -24,6 +24,7 @@ class StreamState:
     # Text message tracking
     text_message_id: str = ""
     text_message_open: bool = False
+    current_source_name: str = ""
 
     # Tool call tracking
     active_tool_call_ids: Set[str] = field(default_factory=set)
@@ -50,6 +51,14 @@ class StreamState:
     def close_text_message(self) -> None:
         # ID persists for tool call parenting — only flag changes
         self.text_message_open = False
+        self.current_source_name = ""
+
+    def source_changed(self, new_source_name: str) -> bool:
+        # Returns True only when both names are non-empty AND differ
+        # Prevents spurious boundaries from anonymous chunks
+        if not new_source_name or not self.current_source_name:
+            return False
+        return new_source_name != self.current_source_name
 
     def start_tool_call(self, tool_call_id: str) -> None:
         self.active_tool_call_ids.add(tool_call_id)

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -2152,3 +2152,199 @@ def test_extract_context_preserves_none_value():
     item = MagicMock(description="empty", value=None)
     result = extract_context([item])
     assert result == {"empty": None}
+
+
+# ---------------------------------------------------------------------------
+# Source tracking + source-change boundary tests (issue #6141)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_state_source_changed():
+    """Test StreamState.source_changed() semantics."""
+    state = StreamState()
+    assert state.source_changed("Agent1") is False
+    state.current_source_name = "Team1"
+    assert state.source_changed("Team1") is False
+    assert state.source_changed("Agent1") is True
+    assert state.source_changed("") is False
+
+
+def test_stream_state_close_clears_source():
+    """Test that closing a message clears the current source name."""
+    state = StreamState()
+    state.open_text_message()
+    state.current_source_name = "Agent1"
+    state.close_text_message()
+    assert state.current_source_name == ""
+
+
+@pytest.mark.asyncio
+async def test_source_name_in_text_message_start():
+    """Agent chunks produce TEXT_MESSAGE_START with name field populated."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "hello"
+        text.agent_name = "MyAgent"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "name", None) == "MyAgent"
+
+
+@pytest.mark.asyncio
+async def test_team_name_takes_precedence_over_agent_name():
+    """When both agent_name and team_name are present, team_name wins."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "hello"
+        text.agent_name = "SomeAgent"
+        text.team_name = "MyTeam"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "name", None) == "MyTeam"
+
+
+@pytest.mark.asyncio
+async def test_no_name_when_source_absent():
+    """Chunks without agent_name or team_name produce no name on the start event."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "anonymous"
+        yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    assert len(starts) == 1
+    assert getattr(starts[0], "name", None) is None
+
+
+@pytest.mark.asyncio
+async def test_single_source_no_extra_boundary():
+    """Multiple chunks from same source produce exactly 1 START + 1 END."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        for chunk in ["hello", " world", "!"]:
+            text = RunContentEvent()
+            text.event = RunEvent.run_content
+            text.content = chunk
+            text.agent_name = "Agent1"
+            yield text
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == 1
+    assert len(ends) == 1
+
+
+@pytest.mark.asyncio
+async def test_source_change_emits_message_boundary():
+    """When source changes mid-stream, a TEXT_MESSAGE_END + new TEXT_MESSAGE_START
+    boundary is emitted with distinct messageIds. Regression guard for issue #6141.
+    """
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        team_chunk = RunContentEvent()
+        team_chunk.event = RunEvent.run_content
+        team_chunk.content = "from team"
+        team_chunk.team_name = "TeamA"
+        yield team_chunk
+
+        agent_chunk = RunContentEvent()
+        agent_chunk.event = RunEvent.run_content
+        agent_chunk.content = "from agent"
+        agent_chunk.agent_name = "AgentX"
+        yield agent_chunk
+
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == 2, f"Expected 2 STARTs (team + agent), got {len(starts)}"
+    assert len(ends) == 2, f"Expected 2 ENDs, got {len(ends)}"
+    assert starts[0].message_id != starts[1].message_id
+    assert getattr(starts[0], "name", None) == "TeamA"
+    assert getattr(starts[1], "name", None) == "AgentX"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_after_attributed_no_spurious_boundary():
+    """Anonymous chunks following attributed ones don't trigger spurious boundaries."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        c1 = RunContentEvent()
+        c1.event = RunEvent.run_content
+        c1.content = "from agent"
+        c1.agent_name = "Agent1"
+        yield c1
+
+        c2 = RunContentEvent()
+        c2.event = RunEvent.run_content
+        c2.content = " continuation"
+        yield c2
+
+        end = RunContentEvent()
+        end.event = RunEvent.run_completed
+        end.content = ""
+        yield end
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "t1", "r1"):
+        events.append(event)
+
+    starts = [e for e in events if e.type == EventType.TEXT_MESSAGE_START]
+    ends = [e for e in events if e.type == EventType.TEXT_MESSAGE_END]
+    assert len(starts) == 1
+    assert len(ends) == 1


### PR DESCRIPTION
## Summary

Fixes #6141 — In nested team architectures, AGUI streaming events now emit separate TEXT_MESSAGE_START events with unique `messageId`s and populated `name` fields for each source (agent/team), enabling UIs to render separate chat bubbles.

### Before
All agent/team responses merged into a single message:
- 1 `TEXT_MESSAGE_START`, 1 `messageId`
- `name` field: `None`
- UI: single bubble with all content concatenated

### After
Each source gets its own message:
- 3 `TEXT_MESSAGE_START` events with unique `messageId`s
- `name` field populated: `["ParentTeam", "NumberPicker", "ParentTeam"]`
- UI can render separate bubbles per source

## Changes

- **`state.py`** — Add `current_source_name` tracking and `source_changed()` method
- **`handlers.py`** — Add `_extract_source_name()` helper; detect source changes and emit message boundaries; populate `name` field from `team_name` (preferred) or `agent_name`
- **`test_agui_app.py`** — 8 new tests covering source boundaries and edge cases (66 total pass)
- **`agentic_chat_team_nested.py`** — E2E test cookbook demonstrating the fix

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Tests pass locally
- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Uses AG-UI protocol's standard `name` field (no custom fields)