### PR TITLE
[fix] Route streaming tool-call deltas by id when provider index values are unreliable

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -750,6 +750,16 @@ class OpenAIChat(Model):
         """
         Build tool calls from streamed tool call data.
 
+        Routing is index-based (OpenAI spec), with three corrections for
+        OpenAI-compatible providers that emit unreliable deltas (observed live with
+        deepseek served through OpenAI-compatible endpoints): a delta carrying an
+        already-seen id always belongs to that call; a NEW id whose index collides
+        with a DIFFERENT call is appended instead of merged (the collision would
+        concatenate the arguments of two calls into invalid JSON, which the provider
+        then rejects with 400 "invalid tool call arguments"); a fragment without id
+        nor index belongs to the call currently being streamed (`index or 0` used to
+        collapse it onto index 0).
+
         Args:
             tool_calls_data (List[ChoiceDeltaToolCall]): The tool call data to build from.
 
@@ -757,12 +767,34 @@ class OpenAIChat(Model):
             List[Dict[str, Any]]: The built tool calls.
         """
         tool_calls: List[Dict[str, Any]] = []
+        index_by_id: Dict[str, int] = {}
+        last_index: int = 0
         for _tool_call in tool_calls_data:
-            _index = _tool_call.index or 0
             _tool_call_id = _tool_call.id
             _tool_call_type = _tool_call.type
             _function_name = _tool_call.function.name if _tool_call.function else None
             _function_arguments = _tool_call.function.arguments if _tool_call.function else None
+
+            _index = _tool_call.index
+            if _tool_call_id and _tool_call_id in index_by_id:
+                # A delta carrying a known id belongs to that call, whatever its index says.
+                _index = index_by_id[_tool_call_id]
+            elif _tool_call_id:
+                # First delta of a new call. If the provider reuses an index already
+                # claimed by a different call, or omits the index, append instead of
+                # merging two calls into one entry.
+                if _index is None or (
+                    _index < len(tool_calls)
+                    and bool(tool_calls[_index])
+                    and tool_calls[_index].get("id") not in (None, "", _tool_call_id)
+                ):
+                    _index = len(tool_calls)
+                index_by_id[_tool_call_id] = _index
+            elif _index is None:
+                # Continuation fragment without id nor index: it belongs to the call
+                # currently being streamed (fragments arrive right after their head).
+                _index = last_index
+            last_index = _index
 
             if len(tool_calls) <= _index:
                 tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])

--- a/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
+++ b/libs/agno/tests/unit/models/openai/test_parse_tool_calls.py
@@ -12,7 +12,7 @@ class _FakeChoiceDeltaToolCallFunction:
 class _FakeChoiceDeltaToolCall:
     def __init__(
         self,
-        index: int,
+        index: Optional[int],
         tool_id: Optional[str] = None,
         tool_type: Optional[str] = None,
         func_name: Optional[str] = None,
@@ -69,6 +69,98 @@ def test_parse_tool_calls_multiple_tools_independent():
     assert result[0]["function"]["name"] == "tool_a"
     assert result[1]["function"]["name"] == "tool_b"
     assert result[0] is not result[1]
+
+
+# ---------------------------------------------------------------------------
+# Unreliable delta routing (OpenAI-compatible providers, e.g. deepseek behind
+# OpenAI-compatible endpoints): colliding/missing `index` values used to merge
+# the arguments of different tool calls into one entry -> invalid JSON -> the
+# provider rejects the follow-up request with 400 "invalid tool call arguments".
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tool_calls_id_collision_appends_instead_of_merging():
+    """Replay of a live capture: the head of the SECOND call arrives with index 0
+    (colliding with the first call) and its argument tail with index 1. The old
+    index-only routing produced entry0 = first_args + second_head (concatenated,
+    invalid JSON) and entry1 = orphan tail."""
+    import json
+
+    deltas = [
+        _FakeChoiceDeltaToolCall(
+            index=0, tool_id="call_kpi", tool_type="function", func_name="add_kpi", func_args='{"label":"Revenue"}'
+        ),
+        _FakeChoiceDeltaToolCall(
+            index=0, tool_id="call_chart", tool_type="function", func_name="add_chart", func_args='{"type":"bar","'
+        ),
+        _FakeChoiceDeltaToolCall(index=1, func_args='series":"2022=1; 2023=2"}'),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert len(result) == 2
+    assert result[0]["function"]["name"] == "add_kpi"
+    assert result[1]["function"]["name"] == "add_chart"
+    # both entries must hold valid, self-contained JSON arguments
+    assert json.loads(result[0]["function"]["arguments"]) == {"label": "Revenue"}
+    assert json.loads(result[1]["function"]["arguments"]) == {"type": "bar", "series": "2022=1; 2023=2"}
+
+
+def test_parse_tool_calls_known_id_wins_over_wrong_index():
+    """A delta carrying an already-seen id belongs to that call even if its index points elsewhere."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(index=0, tool_id="call_a", tool_type="function", func_name="tool_a", func_args='{"x"'),
+        _FakeChoiceDeltaToolCall(index=1, tool_id="call_b", tool_type="function", func_name="tool_b", func_args="{}"),
+        _FakeChoiceDeltaToolCall(index=1, tool_id="call_a", func_args=":1}"),  # wrong index, known id
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert result[0]["function"]["arguments"] == '{"x":1}'
+    assert result[1]["function"]["arguments"] == "{}"
+
+
+def test_parse_tool_calls_missing_index_two_calls_not_merged():
+    """Providers that omit `index`: `index or 0` used to collapse every call onto entry 0."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(
+            index=None, tool_id="call_a", tool_type="function", func_name="tool_a", func_args="{}"
+        ),
+        _FakeChoiceDeltaToolCall(
+            index=None, tool_id="call_b", tool_type="function", func_name="tool_b", func_args="{}"
+        ),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert len(result) == 2
+    assert [entry["function"]["name"] for entry in result] == ["tool_a", "tool_b"]
+
+
+def test_parse_tool_calls_missing_index_fragment_follows_current_call():
+    """A fragment without id nor index belongs to the call currently being streamed."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(
+            index=None, tool_id="call_a", tool_type="function", func_name="tool_a", func_args='{"x"'
+        ),
+        _FakeChoiceDeltaToolCall(index=None, func_args=":1}"),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert len(result) == 1
+    assert result[0]["function"]["arguments"] == '{"x":1}'
+
+
+def test_parse_tool_calls_spec_compliant_fragmenting_unchanged():
+    """OpenAI-spec streams (id on the head, index-only fragments) keep working as before."""
+    deltas = [
+        _FakeChoiceDeltaToolCall(index=0, tool_id="call_a", tool_type="function", func_name="tool_a", func_args='{"x"'),
+        _FakeChoiceDeltaToolCall(index=0, func_args=":1}"),
+        _FakeChoiceDeltaToolCall(index=1, tool_id="call_b", tool_type="function", func_name="tool_b", func_args='{"y"'),
+        _FakeChoiceDeltaToolCall(index=1, func_args=":2}"),
+    ]
+    result = OpenAIChat.parse_tool_calls(deltas)
+
+    assert len(result) == 2
+    assert result[0]["function"]["arguments"] == '{"x":1}'
+    assert result[1]["function"]["arguments"] == '{"y":2}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #8879.

`OpenAIChat.parse_tool_calls` routes streamed tool-call deltas only by `index` (`_index = _tool_call.index or 0`). Some OpenAI-compatible providers emit unreliable index values (captured live with deepseek-v4-flash behind an OpenAI-compatible endpoint): the head delta of a *second* tool call arrived with `index=0`, colliding with the first call, while its argument tail arrived with `index=1`. Index-only routing then concatenates the arguments of two different calls into one entry (invalid JSON) and the provider rejects the follow-up request with `400 invalid tool call arguments`, killing the run mid-stream. `index or 0` also collapses every call onto entry 0 for providers that omit `index` entirely.

This PR keeps the existing index-based routing (spec-compliant streams behave exactly as before, including the empty-dict padding asserted by the existing tests) and adds three corrections for unreliable deltas:

1. a delta carrying an **already-seen id** always belongs to that call, whatever its index says;
2. a **new id** whose index collides with a *different* call (or is missing) is **appended** instead of merged;
3. a fragment with **no id and no index** belongs to the call currently being streamed, instead of collapsing onto index 0.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff check` + `ruff format --check` pass on the touched files with the repo config)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

Tests: 5 new unit tests in `libs/agno/tests/unit/models/openai/test_parse_tool_calls.py`, including a deterministic replay of the captured broken stream and a spec-compliant fragmenting regression test. All pre-existing tests in the file keep passing (13/13 locally).

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue (closest merged work: #6811/#6989 on shared dict refs and name overwrites — different defects in the same function)
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

**AI disclosure:** this fix was developed with the assistance of Claude Code, driven and reviewed by the author. The defect was diagnosed on a real production system (raw deltas captured with a probe on the live stream), the fix semantics were derived from that evidence, and the tests replay the captured failure. The author has reviewed and understands every line.

---

## Additional Notes

- The routing logic of `parse_tool_calls` is byte-identical in 2.6.9 → 2.6.22 → 2.7.2, so the bug affects current releases.
- The non-streaming path is unaffected (arguments arrive whole), which is what isolated the bug to the streaming assembly.
- Captured failure log:

```
ERROR    Unable to decode function arguments:
         {"…kpi args…"}{"…chart args head…
         Error: invalid syntax (<unknown>, line 1)
ERROR    API status error from OpenAI API: Error code: 400 - {'error': {'message': 'invalid tool call arguments', ...}}
```
