### PR TITLE
fix: honor JSONReader's `chunk=False`

### DIFF
--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -17,11 +17,11 @@ class JSONReader(Reader):
 
     chunk: bool = False
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+    def __init__(self, chunk: bool = False, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
         if chunking_strategy is None:
             chunk_size = kwargs.get("chunk_size", 5000)
             chunking_strategy = FixedSizeChunking(chunk_size=chunk_size)
-        super().__init__(chunking_strategy=chunking_strategy, **kwargs)
+        super().__init__(chunk=chunk, chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:

--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -15,7 +15,7 @@ from agno.utils.log import log_debug, log_error
 class JSONReader(Reader):
     """Reader for JSON files"""
 
-    def __init__(self, chunk: bool = False, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+    def __init__(self, chunk: bool = True, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
         if chunking_strategy is None:
             chunk_size = kwargs.get("chunk_size", 5000)
             chunking_strategy = FixedSizeChunking(chunk_size=chunk_size)

--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -15,8 +15,6 @@ from agno.utils.log import log_debug, log_error
 class JSONReader(Reader):
     """Reader for JSON files"""
 
-    chunk: bool = False
-
     def __init__(self, chunk: bool = False, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
         if chunking_strategy is None:
             chunk_size = kwargs.get("chunk_size", 5000)

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -285,3 +285,27 @@ def test_json_reader_default_chunk_size():
     assert reader.chunk_size == 5000
     assert reader.chunking_strategy.chunk_size == 5000
     assert isinstance(reader.chunking_strategy, FixedSizeChunking)
+
+
+def test_json_reader_defaults_to_no_chunking():
+    """JSONReader should default to chunk=False."""
+    reader = JSONReader()
+    assert reader.chunk is False
+
+
+def test_large_objects_are_not_split_into_invalid_fragments():
+    """A JSON file with 2 large objects (each exceeding the chunk_size threshold)
+    should yield exactly 2 documents, each containing valid JSON."""
+    # Each object is larger than the default 5000-char chunk size.
+    big_value = "x" * 6000
+    test_data = [{"id": 1, "data": big_value}, {"id": 2, "data": big_value}]
+    json_bytes = BytesIO(json.dumps(test_data).encode())
+    json_bytes.name = "big.json"
+
+    reader = JSONReader()
+    documents = reader.read(json_bytes)
+
+    assert len(documents) == 2
+    parsed = [json.loads(doc.content) for doc in documents]
+    assert parsed == test_data
+    assert all("chunk" not in doc.meta_data for doc in documents)

--- a/libs/agno/tests/unit/reader/test_json_reader.py
+++ b/libs/agno/tests/unit/reader/test_json_reader.py
@@ -287,22 +287,24 @@ def test_json_reader_default_chunk_size():
     assert isinstance(reader.chunking_strategy, FixedSizeChunking)
 
 
-def test_json_reader_defaults_to_no_chunking():
-    """JSONReader should default to chunk=False."""
-    reader = JSONReader()
-    assert reader.chunk is False
+def test_json_reader_chunk_flag_is_forwarded():
+    """The chunk argument must be forwarded to the base Reader so callers 
+    can control chunking."""
+    assert JSONReader().chunk is True
+    assert JSONReader(chunk=False).chunk is False
+    assert JSONReader(chunk=True).chunk is True
 
 
-def test_large_objects_are_not_split_into_invalid_fragments():
-    """A JSON file with 2 large objects (each exceeding the chunk_size threshold)
-    should yield exactly 2 documents, each containing valid JSON."""
+def test_chunk_false_keeps_large_objects_whole():
+    """A JSON file with 2 large objects (each exceeding the chunk_size threshold) 
+    yields exactly 2 documents of valid JSON."""
     # Each object is larger than the default 5000-char chunk size.
     big_value = "x" * 6000
     test_data = [{"id": 1, "data": big_value}, {"id": 2, "data": big_value}]
     json_bytes = BytesIO(json.dumps(test_data).encode())
     json_bytes.name = "big.json"
 
-    reader = JSONReader()
+    reader = JSONReader(chunk=False)
     documents = reader.read(json_bytes)
 
     assert len(documents) == 2


### PR DESCRIPTION
## Summary

`JSONReader` declared `chunk: bool = False` as a class attribute, however the `__init__` was called without forwarding `chunk`, so the base reader would always chunk the JSON doc.                                                                                                                                            

With this PR `JSONReader` now honors `chunk=False`, matching the existing intent. Callers who want to opt-out chunking can do it via `JSONReader(chunk=False)`.   

Closes https://github.com/agno-agi/agno/issues/8679

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
