### PR TITLE
fix(agui): scope client-tools resume to the caller's user_id (missing ownership check on paused-run resume)

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/resume.py
+++ b/libs/agno/agno/os/interfaces/agui/resume.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Optional, Union
 
 from ag_ui.core.types import ToolMessage as AGUIToolMessage
 
@@ -41,6 +41,7 @@ async def resume_paused_run(
     tool_messages: list,
     run_context: RunContext,
     run_kwargs: dict,
+    user_id: Optional[str] = None,
 ):
     """Resume a paused run by applying frontend tool results and continuing."""
     # Remote entities don't support client_tools resume (no aget_session)
@@ -49,7 +50,9 @@ async def resume_paused_run(
             "Frontend tool resume requires a database. Set db=SqliteDb(...) or db=PgDb(...) on your Agent/Team."
         )
 
-    session = await entity.aget_session(session_id=session_id)
+    # Scope the lookup to the caller's resolved identity so a caller cannot load
+    # (and then continue) another user's session by supplying an arbitrary thread_id.
+    session = await entity.aget_session(session_id=session_id, user_id=user_id)
     if not session:
         raise ValueError(f"Session {session_id} not found")
     if not isinstance(session, (AgentSession, TeamSession)):
@@ -89,6 +92,7 @@ async def resume_paused_run(
         requirements=requirements,
         stream=True,
         stream_events=True,
+        user_id=user_id,
         run_context=run_context,
         **run_kwargs,
     )

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -93,6 +93,7 @@ async def run_entity(
                 tool_messages=tool_messages,
                 run_context=run_context,
                 run_kwargs=run_kwargs,
+                user_id=user_id,
             )
         else:
             # Fresh run: new user input


### PR DESCRIPTION
## Summary

The AG-UI **client-tools resume** path (`libs/agno/agno/os/interfaces/agui/resume.py`, added in #8565) does not thread the caller's resolved `user_id` into the session lookup/continuation, so under `authorization=True` a caller with the ordinary `agents:run`/`teams:run` scope can load and continue **another user's** paused session by supplying an arbitrary `thread_id`.

### The gap
`run_entity()` already resolves the caller identity, and the **fresh-run** branch passes it (`entity.arun(..., user_id=user_id)`, router.py:104). The **resume** branch does not:
- `router.py` calls `resume_paused_run(entity, session_id=thread_id, tool_messages, run_context, run_kwargs)` — no `user_id`.
- `resume.py` calls `entity.aget_session(session_id=session_id)` and `entity.acontinue_run(...)` — no `user_id`.
- `aget_session(..., user_id=None)` -> `db.get_session(session_id, user_id=None)`, where the owner filter is `if user_id is not None: stmt = stmt.where(table.c.user_id == user_id)` — **skipped** when `None` (e.g. `db/postgres/postgres.py` `get_session`). So the lookup returns *any* session for that id, and the continuation runs/persists against it.

Net effect (with `authorization=True`): a cross-tenant session-existence oracle for any authenticated non-admin, and — given a matching `tool_call_id` — a cross-tenant continuation where a frontend "tool result" is injected as trusted tool output into a stranger's live session. Independent of `user_isolation`. Not covered by the #8752/#8760 identity/ownership work: `resume.py` postdates those PRs and imports none of their helpers (`resolve_run_user_id`/`get_scoped_user_id`), and the two existing resume tests never assert `user_id`.

### The fix
Thread the already-resolved `user_id` (the same identity the fresh-run branch uses) through `resume_paused_run` into `aget_session` and `acontinue_run`. `user_id` is optional and defaults to `None`, so remote / no-`db` / no-isolation callers are unaffected; under `user_isolation` the paused-run lookup and continuation are now owner-scoped. Mirrors `router.py:104` exactly (2 files, +7/-2).

## Type of change
- [x] Bug fix (security: missing authorization / cross-tenant IDOR, CWE-639/CWE-862)

## Checklist
- [x] Self-review completed
- [x] `python -m py_compile` clean on both changed files
- [x] Style: change only threads an existing optional `user_id` param (ruff/mypy-neutral)
- [ ] Tests: happy to add a regression test asserting `user_id` is passed on resume if you'd like

### Duplicate check
- [x] Searched existing PRs — none addresses the resume-path `user_id` gap.
- [x] Found via independent local white-box review of the AgentOS auth surface.