### PR TITLE
feat(slack): multiplayer — per-participant thread sessions + peer-bot receive path

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/builders.py
+++ b/libs/agno/agno/os/interfaces/slack/builders.py
@@ -180,7 +180,12 @@ def _build_user_feedback_question_block(req_id: str, question: Any, q_index: int
 
 
 # Builds HITL confirmation card with Approve/Deny buttons for a tool execution
-def _build_confirmation_card(requirement: RunRequirement, run_id: str = "", awaiting_ts: Optional[str] = None) -> Card:
+def _build_confirmation_card(
+    requirement: RunRequirement,
+    run_id: str = "",
+    awaiting_ts: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Card:
     req_id = requirement.id or ""
     name = tool_name(requirement)
     args = tool_args(requirement)
@@ -210,7 +215,7 @@ def _build_confirmation_card(requirement: RunRequirement, run_id: str = "", awai
             ],
         )
 
-    button_value = encode_row_button_value(req_id, run_id, awaiting_ts)
+    button_value = encode_row_button_value(req_id, run_id, awaiting_ts, session_id)
     return Card(
         block_id=f"rowact:{req_id}:confirmation",
         title=MarkdownTextObject(text=f"*{name}*"),
@@ -276,8 +281,9 @@ def build_confirmation_toggle_card(
     tool_name: str,
     body_text: str,
     selected: str,
+    session_id: Optional[str] = None,
 ) -> Card:
-    button_value = encode_row_button_value(req_id, run_id, awaiting_ts)
+    button_value = encode_row_button_value(req_id, run_id, awaiting_ts, session_id)
     is_approved = selected == "approve"
     # Slack Block Kit section text has ~200 char limit
     body_text = truncate(body_text, 200)
@@ -314,12 +320,12 @@ def decision_marker(req_id: str, decision: str) -> Dict[str, Any]:
     }
 
 
-def build_submit_button(run_id: str, awaiting_ts: Optional[str]) -> Dict[str, Any]:
+def build_submit_button(run_id: str, awaiting_ts: Optional[str], session_id: Optional[str] = None) -> Dict[str, Any]:
     submit_btn = ButtonElement(
         action_id="submit_pause",
         text=PlainTextObject(text="Submit", emoji=True),
         style="primary",
-        value=encode_submit_button_value(run_id, awaiting_ts),
+        value=encode_submit_button_value(run_id, awaiting_ts, session_id),
     )
     return ActionsBlock(block_id=f"pause:{run_id}", elements=[submit_btn]).to_dict()
 
@@ -344,6 +350,7 @@ def select_confirmation_row(
                 tool_name=name,
                 body_text=body_text,
                 selected=selected,
+                session_id=ctx.session_id,
             )
             updated.append(block_to_dict(toggle_card))
             # Deny keeps card interactive so user can add optional reason before Submit
@@ -380,13 +387,14 @@ def append_submit_if_needed(
     blocks: List[Dict[str, Any]],
     run_id: str,
     awaiting_ts: Optional[str],
+    session_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     if not run_id:
         return blocks
     summary = confirmation_row_summary(blocks)
     if summary.pending_ids or summary.has_global_submit:
         return blocks
-    return blocks + [build_submit_button(run_id, awaiting_ts)]
+    return blocks + [build_submit_button(run_id, awaiting_ts, session_id)]
 
 
 # Builds InputBlocks for user_input pause type (text fields, dropdowns for bool/Enum/Literal)
@@ -429,6 +437,7 @@ def build_pause_message(
     run_id: str,
     requirements: List[RunRequirement],
     awaiting_ts: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> List[Any]:
     blocks: List[Any] = []
     processed = 0
@@ -440,7 +449,9 @@ def build_pause_message(
     for i, requirement in enumerate(requirements):
         kind = requirement.pause_type
         if kind == "confirmation":
-            row_blocks = [_build_confirmation_card(requirement, run_id=run_id, awaiting_ts=awaiting_ts)]
+            row_blocks = [
+                _build_confirmation_card(requirement, run_id=run_id, awaiting_ts=awaiting_ts, session_id=session_id)
+            ]
         else:
             # Input/feedback/external rows: just fields, global Submit handles submission
             if kind == "user_input":
@@ -484,7 +495,7 @@ def build_pause_message(
                         action_id=ACTION_SUBMIT,
                         text=PlainTextObject(text="Submit"),
                         style="primary",
-                        value=encode_submit_button_value(run_id, awaiting_ts),
+                        value=encode_submit_button_value(run_id, awaiting_ts, session_id),
                     ),
                 ],
             )

--- a/libs/agno/agno/os/interfaces/slack/event_handler.py
+++ b/libs/agno/agno/os/interfaces/slack/event_handler.py
@@ -11,6 +11,7 @@ from agno.os.interfaces.slack.events import process_event
 from agno.os.interfaces.slack.helpers import (
     BotNameResolver,
     build_run_metadata,
+    derive_session_id,
     download_event_files_async,
     extract_event_context,
     open_chat_stream,
@@ -88,14 +89,18 @@ class SlackEventHandler:
         if self.resolve_user_identity:
             resolved_user_id, display_name = await resolve_slack_user(client, raw_ctx["user"])
 
-        session_id = f"{self.entity_id}:{raw_ctx['thread_id']}"
-        if self.per_user_thread_sessions and resolved_user_id:
-            # One session per (thread, caller): agno sessions are single-user rows, so a
-            # shared thread key would let the first speaker claim the session and silently
-            # drop every other participant's history. Keying on the same resolved user id
-            # the run uses gives each participant their own session — history loads are
-            # scoped by session_id, so no caller can ever pull another caller's turns.
-            session_id = f"{session_id}:{resolved_user_id}"
+        # One session per (channel, thread) — and per caller when per_user_thread_sessions
+        # is on: agno sessions are single-user rows, so a shared thread key would let the
+        # first speaker claim the session and silently drop every other participant's
+        # history. Keying on the same resolved user id the run uses gives each participant
+        # their own session — history loads are scoped by session_id, so no caller can
+        # ever pull another caller's turns.
+        session_id = derive_session_id(
+            self.entity_id,
+            raw_ctx["channel_id"],
+            raw_ctx["thread_id"],
+            user_key=resolved_user_id if self.per_user_thread_sessions else None,
+        )
 
         channel_name = await resolve_channel_name(client, raw_ctx["channel_id"])
 

--- a/libs/agno/agno/os/interfaces/slack/event_handler.py
+++ b/libs/agno/agno/os/interfaces/slack/event_handler.py
@@ -64,6 +64,7 @@ class SlackEventHandler:
     task_display_mode: str
     buffer_size: int
     suggested_prompts: Optional[List[Dict[str, str]]] = None
+    per_user_thread_sessions: bool = False
 
     def _client(self) -> AsyncWebClient:
         return AsyncWebClient(token=self.slack_tools.token, ssl=self.ssl)
@@ -80,13 +81,21 @@ class SlackEventHandler:
         bot_name = await self.bot_name_resolver.resolve(client, bot_user_id) if bot_user_id else None
         message_text = strip_bot_mention(raw_ctx["message_text"], bot_user_id, bot_name)
 
-        session_id = f"{self.entity_id}:{raw_ctx['thread_id']}"
         team_id = data.get("team_id") or event.get("team")
 
         resolved_user_id = raw_ctx["user"]
         display_name = None
         if self.resolve_user_identity:
             resolved_user_id, display_name = await resolve_slack_user(client, raw_ctx["user"])
+
+        session_id = f"{self.entity_id}:{raw_ctx['thread_id']}"
+        if self.per_user_thread_sessions and resolved_user_id:
+            # One session per (thread, caller): agno sessions are single-user rows, so a
+            # shared thread key would let the first speaker claim the session and silently
+            # drop every other participant's history. Keying on the same resolved user id
+            # the run uses gives each participant their own session — history loads are
+            # scoped by session_id, so no caller can ever pull another caller's turns.
+            session_id = f"{session_id}:{resolved_user_id}"
 
         channel_name = await resolve_channel_name(client, raw_ctx["channel_id"])
 
@@ -240,11 +249,19 @@ class SlackEventHandler:
                 log_error(f"[HITL] Non-streaming awaiting indicator failed: {exc}")
 
         try:
-            await post_pause_card(client, response, ctx.channel_id, ctx.thread_id, awaiting_ts)
+            await post_pause_card(
+                client, response, ctx.channel_id, ctx.thread_id, awaiting_ts, session_id=self._pause_session_id(ctx)
+            )
         except Exception as exc:
             log_error(f"[HITL] Non-streaming pause card failed: {exc}")
 
         return True
+
+    def _pause_session_id(self, ctx: EventContext) -> Optional[str]:
+        # Embed the session id in the pause card only when the resume path can't re-derive
+        # it from the thread — i.e. when sessions are keyed per user. Keeps default-config
+        # cards byte-identical to before.
+        return ctx.session_id if self.per_user_thread_sessions else None
 
     async def _open_chat_stream(self, client: AsyncWebClient, ctx: EventContext) -> Any:
         return await open_chat_stream(
@@ -381,7 +398,14 @@ class SlackEventHandler:
             requirements=requirements,
         )
         try:
-            await post_pause_card(client, state.paused_event, ctx.channel_id, ctx.thread_id, awaiting_ts)
+            await post_pause_card(
+                client,
+                state.paused_event,
+                ctx.channel_id,
+                ctx.thread_id,
+                awaiting_ts,
+                session_id=self._pause_session_id(ctx),
+            )
         except Exception as exc:
             log_error(f"[HITL] Failed to post Card block (pause): {exc}")
 

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -17,6 +17,17 @@ def slack_error_code(exc: BaseException) -> Optional[str]:
     return None
 
 
+def derive_session_id(entity_id: str, channel_id: str, thread_ts: str, user_key: Optional[str] = None) -> str:
+    # The Slack session key. Channel-scoped because Slack `ts` values are only
+    # unique per channel — two threads in different channels can share a
+    # thread_ts. The per-user variant (per_user_thread_sessions) inserts the
+    # resolved caller so each participant in a thread gets their own session;
+    # thread_ts stays last so keys read naturally in session UIs.
+    if user_key:
+        return f"{entity_id}:{channel_id}:{user_key}:{thread_ts}"
+    return f"{entity_id}:{channel_id}:{thread_ts}"
+
+
 def task_id(agent_name: Optional[str], base_id: str) -> str:
     # Prefix card IDs per agent so concurrent tool calls from different
     # team members don't collide in the Slack stream

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -69,7 +69,9 @@ def extract_event_context(event: dict) -> Dict[str, Any]:
     return {
         "message_text": event.get("text", ""),
         "channel_id": event.get("channel", ""),
-        "user": event.get("user", ""),
+        # Bot-authored events may lack "user" (e.g. webhook posts); fall back to the
+        # bot_id so downstream identity handling always gets a stable, non-empty id
+        "user": event.get("user") or event.get("bot_id") or "",
         # Prefer existing thread; fall back to message ts for new conversations
         "thread_id": event.get("thread_ts") or event.get("ts", ""),
         # User-scoped token for assistant.search.context workspace search
@@ -102,7 +104,23 @@ async def resolve_slack_user(async_client: Any, slack_user_id: str) -> Tuple[str
 
     Returns the user's email as canonical_user_id if available, otherwise
     falls back to the raw Slack user ID. Display name is best-effort.
+
+    Bot senders resolve fail-closed to a stable identifier: a bot *user* id
+    ("U…") goes through ``users_info`` like any user (bots have no email, so
+    the id itself stays canonical and the bot's name becomes the display
+    name); a raw bot id ("B…", e.g. a webhook message with no ``user``) goes
+    through ``bots_info``. Never raises — any failure returns the raw id.
     """
+    # Slack ids are typed by prefix: users are "U"/"W", bots are "B"
+    if slack_user_id.startswith("B"):
+        try:
+            resp = await async_client.bots_info(bot=slack_user_id)
+            bot = resp.get("bot", {}) if resp else {}
+            return (slack_user_id, bot.get("name") or None)
+        except Exception as e:
+            log_warning(f"Failed to resolve Slack bot {slack_user_id}: {str(e)}")
+            return (slack_user_id, None)
+
     try:
         resp = await async_client.users_info(user=slack_user_id)
         user = resp.get("user", {}) if resp else {}

--- a/libs/agno/agno/os/interfaces/slack/hitl.py
+++ b/libs/agno/agno/os/interfaces/slack/hitl.py
@@ -192,9 +192,17 @@ class HITLHandler:
                     requirements=requirements,
                     log_prefix="re-",
                 )
+                # Embed the session id in the new card only when it can't be re-derived from
+                # the thread (per-user thread sessions) — same rule as the original card.
+                repause_session_id = ctx.session_id if ctx.session_id != f"{self.entity_id}:{ctx.thread_ts}" else None
                 try:
                     await post_pause_card(
-                        self._client(), state.paused_event, ctx.channel, ctx.thread_ts, new_awaiting_ts
+                        self._client(),
+                        state.paused_event,
+                        ctx.channel,
+                        ctx.thread_ts,
+                        new_awaiting_ts,
+                        session_id=repause_session_id,
                     )
                 except Exception as exc:
                     log_error(f"[HITL] Failed to post Card block (re-pause): {exc}")
@@ -224,7 +232,9 @@ class HITLHandler:
         await self.update_message(ctx.channel, ctx.card_ts, "Approval pending", result.blocks)
 
         if result.should_auto_submit:
-            await self.handle_submit(synthetic_submit_payload(payload, ctx.run_id, ctx.awaiting_ts, result.blocks))
+            await self.handle_submit(
+                synthetic_submit_payload(payload, ctx.run_id, ctx.awaiting_ts, result.blocks, ctx.session_id)
+            )
 
     async def handle_row_reject(self, payload: Dict[str, Any]) -> None:
         ctx = extract_row_action_context(payload)
@@ -232,26 +242,26 @@ class HITLHandler:
             return
 
         result = select_confirmation_row(ctx, selected="deny", include_reason_input=True)
-        blocks = append_submit_if_needed(result.blocks, ctx.run_id, ctx.awaiting_ts)
+        blocks = append_submit_if_needed(result.blocks, ctx.run_id, ctx.awaiting_ts, ctx.session_id)
         await self.update_message(ctx.channel, ctx.card_ts, "Rejection pending", blocks)
 
-    async def _get_approval_status(self, approval_id: str) -> str:
-        """Query approval status from DB."""
+    async def _get_approval(self, approval_id: str) -> Optional[Dict[str, Any]]:
+        """Query the approval record from DB."""
         db = getattr(self.entity, "db", None)
         if not db or not approval_id:
-            return "pending"
+            return None
         try:
             fn = getattr(db, "get_approval", None)
             if not fn:
-                return "pending"
+                return None
             if asyncio.iscoroutinefunction(fn):
                 approval = await fn(approval_id)
             else:
                 approval = fn(approval_id)
-            return approval.get("status", "pending") if approval else "pending"
+            return approval or None
         except Exception as exc:
             log_error(f"[HITL] Failed to get approval status: {exc}")
-            return "pending"
+            return None
 
     def _update_card_to_approved(self, blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Update approval card blocks to show approved status."""
@@ -273,9 +283,15 @@ class HITLHandler:
         thread_ts: str,
         msg_ts: str,
         awaiting_ts: Optional[str],
+        session_id: Optional[str] = None,
     ) -> None:
-        """Resume a paused run after admin approval."""
-        session_id = f"{self.entity_id}:{thread_ts}"
+        """Resume a paused run after admin approval.
+
+        session_id is the paused run's session id from the approval record — required to
+        find the run when sessions are keyed per user. Falls back to the thread-derived id
+        (the only possible session id before per-user thread sessions existed).
+        """
+        session_id = session_id or f"{self.entity_id}:{thread_ts}"
 
         try:
             run_output = await self.entity.aget_run_output(run_id=run_id, session_id=session_id)  # type: ignore[union-attr]
@@ -348,14 +364,24 @@ class HITLHandler:
                 body_text = block.get("body", {}).get("text") or ""
                 break
 
-        # 4. Query approval status
-        status = await self._get_approval_status(approval_id)
+        # 4. Query approval record (carries status + the paused run's session id)
+        approval = await self._get_approval(approval_id)
+        status = approval.get("status", "pending") if approval else "pending"
 
         # 5. Handle approved — delete indicator, update card, resume run
         if status == "approved":
             await self.delete_awaiting_indicator(channel, awaiting_ts)
             await self.update_message(channel, msg_ts, "Approved", self._update_card_to_approved(blocks))
-            await self._resume_after_approval(payload, run_id, approval_id, channel, thread_ts, msg_ts, awaiting_ts)
+            await self._resume_after_approval(
+                payload,
+                run_id,
+                approval_id,
+                channel,
+                thread_ts,
+                msg_ts,
+                awaiting_ts,
+                session_id=(approval or {}).get("session_id"),
+            )
             return
 
         # 6. Still pending/rejected — update card with current status

--- a/libs/agno/agno/os/interfaces/slack/hitl.py
+++ b/libs/agno/agno/os/interfaces/slack/hitl.py
@@ -16,7 +16,7 @@ from agno.os.interfaces.slack.builders import (
     select_confirmation_row,
 )
 from agno.os.interfaces.slack.events import process_event
-from agno.os.interfaces.slack.helpers import open_chat_stream, slack_error_code
+from agno.os.interfaces.slack.helpers import derive_session_id, open_chat_stream, slack_error_code
 from agno.os.interfaces.slack.ids import decode_admin_approval_button_value
 from agno.os.interfaces.slack.interactions import (
     apply_decisions,
@@ -194,7 +194,8 @@ class HITLHandler:
                 )
                 # Embed the session id in the new card only when it can't be re-derived from
                 # the thread (per-user thread sessions) — same rule as the original card.
-                repause_session_id = ctx.session_id if ctx.session_id != f"{self.entity_id}:{ctx.thread_ts}" else None
+                thread_derived = derive_session_id(self.entity_id, ctx.channel, ctx.thread_ts)
+                repause_session_id = ctx.session_id if ctx.session_id != thread_derived else None
                 try:
                     await post_pause_card(
                         self._client(),
@@ -289,9 +290,9 @@ class HITLHandler:
 
         session_id is the paused run's session id from the approval record — required to
         find the run when sessions are keyed per user. Falls back to the thread-derived id
-        (the only possible session id before per-user thread sessions existed).
+        (the only possible session id when the record predates per-user thread sessions).
         """
-        session_id = session_id or f"{self.entity_id}:{thread_ts}"
+        session_id = session_id or derive_session_id(self.entity_id, channel, thread_ts)
 
         try:
             run_output = await self.entity.aget_run_output(run_id=run_id, session_id=session_id)  # type: ignore[union-attr]

--- a/libs/agno/agno/os/interfaces/slack/ids.py
+++ b/libs/agno/agno/os/interfaces/slack/ids.py
@@ -83,32 +83,47 @@ def external_result_block_id(requirement_id: str) -> str:
 
 # --- Button value encoders/decoders ---
 # Pipe-delimited because Slack button values are opaque strings, not JSON — simpler to parse
+# The trailing session_id field is only written when the session id can't be re-derived from
+# the thread (per-user thread sessions), so default-config button values stay unchanged.
+# Decoders tolerate its absence (older cards, default config) and return None.
 
 
-def encode_row_button_value(req_id: str, run_id: str, awaiting_ts: Optional[str]) -> str:
-    return f"{req_id}|{run_id}|{awaiting_ts or ''}"
+def encode_row_button_value(
+    req_id: str, run_id: str, awaiting_ts: Optional[str], session_id: Optional[str] = None
+) -> str:
+    value = f"{req_id}|{run_id}|{awaiting_ts or ''}"
+    if session_id:
+        value = f"{value}|{session_id}"
+    return value
 
 
-def decode_row_button_value(value: str) -> Tuple[str, str, Optional[str]]:
-    # Limit split to 2 so awaiting_ts (which may contain pipes in edge cases) stays intact
-    parts = value.split("|", 2)
+def decode_row_button_value(value: str) -> Tuple[str, str, Optional[str], Optional[str]]:
+    # Limit split to 3 so session_id (last field) stays intact
+    parts = value.split("|", 3)
     if len(parts) == 2:
-        return parts[0], parts[1], None
+        return parts[0], parts[1], None, None
     if len(parts) == 3:
-        return parts[0], parts[1], parts[2] or None
-    return "", "", None
+        return parts[0], parts[1], parts[2] or None, None
+    if len(parts) == 4:
+        return parts[0], parts[1], parts[2] or None, parts[3] or None
+    return "", "", None, None
 
 
-def encode_submit_button_value(run_id: str, awaiting_ts: Optional[str]) -> str:
-    return f"{run_id}|{awaiting_ts or ''}"
+def encode_submit_button_value(run_id: str, awaiting_ts: Optional[str], session_id: Optional[str] = None) -> str:
+    value = f"{run_id}|{awaiting_ts or ''}"
+    if session_id:
+        value = f"{value}|{session_id}"
+    return value
 
 
-def decode_submit_button_value(value: str) -> Tuple[str, Optional[str]]:
-    # Limit split to 1 so awaiting_ts stays intact
-    parts = value.split("|", 1)
+def decode_submit_button_value(value: str) -> Tuple[str, Optional[str], Optional[str]]:
+    # Limit split to 2 so session_id (last field) stays intact
+    parts = value.split("|", 2)
     if len(parts) == 1:
-        return parts[0], None
-    return parts[0], parts[1] or None
+        return parts[0], None, None
+    if len(parts) == 2:
+        return parts[0], parts[1] or None, None
+    return parts[0], parts[1] or None, parts[2] or None
 
 
 # --- Admin approval button value (4 fields: approval_id, req_id, run_id, awaiting_ts) ---

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -141,7 +141,7 @@ def extract_row_action_context(payload: Dict[str, Any]) -> Optional[RowActionCon
     button_value = actions[0].get("value") or ""
     if "|" not in button_value:
         return None
-    req_id, run_id, awaiting_ts = decode_row_button_value(button_value)
+    req_id, run_id, awaiting_ts, session_id = decode_row_button_value(button_value)
 
     channel = (payload.get("channel") or {}).get("id")
     message = payload.get("message") or {}
@@ -156,6 +156,7 @@ def extract_row_action_context(payload: Dict[str, Any]) -> Optional[RowActionCon
         channel=channel,
         card_ts=card_ts,
         blocks=list(message.get("blocks") or []),
+        session_id=session_id,
     )
 
 
@@ -176,14 +177,16 @@ def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[
 
     thread_ts = message.get("thread_ts") or msg_ts
     button_value = actions[0].get("value") or ""
-    _, awaiting_ts = decode_submit_button_value(button_value)
+    _, awaiting_ts, button_session_id = decode_submit_button_value(button_value)
 
+    # The button carries the paused run's session id only when it can't be re-derived
+    # from the thread (per-user thread sessions); otherwise derive it as usual.
     return SubmitContext(
         run_id=run_id,
         channel=channel,
         msg_ts=msg_ts,
         thread_ts=thread_ts,
-        session_id=f"{entity_id}:{thread_ts}",
+        session_id=button_session_id or f"{entity_id}:{thread_ts}",
         awaiting_ts=awaiting_ts,
         user_id=(payload.get("user") or {}).get("id", ""),
         team_id=(payload.get("team") or {}).get("id"),
@@ -219,13 +222,14 @@ def synthetic_submit_payload(
     run_id: str,
     awaiting_ts: Optional[str],
     blocks: List[Dict[str, Any]],
+    session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     synthetic = dict(payload)
     synthetic["actions"] = [
         {
             "action_id": "submit_pause",
             "block_id": f"pause:{run_id}",
-            "value": encode_submit_button_value(run_id, awaiting_ts),
+            "value": encode_submit_button_value(run_id, awaiting_ts, session_id),
         }
     ]
     synthetic["message"] = {**(payload.get("message") or {}), "blocks": blocks}

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from agno.os.interfaces.slack.helpers import derive_session_id
 from agno.os.interfaces.slack.ids import (
     ACTION_EXTERNAL_RESULT,
     ACTION_REJECT_REASON,
@@ -186,7 +187,7 @@ def extract_submit_context(payload: Dict[str, Any], entity_id: str) -> Optional[
         channel=channel,
         msg_ts=msg_ts,
         thread_ts=thread_ts,
-        session_id=button_session_id or f"{entity_id}:{thread_ts}",
+        session_id=button_session_id or derive_session_id(entity_id, channel, thread_ts),
         awaiting_ts=awaiting_ts,
         user_id=(payload.get("user") or {}).get("id", ""),
         team_id=(payload.get("team") or {}).get("id"),

--- a/libs/agno/agno/os/interfaces/slack/pause.py
+++ b/libs/agno/agno/os/interfaces/slack/pause.py
@@ -64,14 +64,18 @@ async def post_pause_card(
     channel: str,
     thread_ts: str,
     awaiting_ts: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> Optional[str]:
+    # session_id: pass only when the paused run's session id can't be re-derived from the
+    # thread (per-user thread sessions) — it is embedded in the card's button values so the
+    # resume path can load the run from the right session.
     run_id = getattr(paused_event, "run_id", None)
     requirements = list(getattr(paused_event, "active_requirements", None) or [])
     if not run_id or not requirements:
         return None
 
     try:
-        blocks = build_pause_message(run_id, requirements, awaiting_ts)
+        blocks = build_pause_message(run_id, requirements, awaiting_ts, session_id)
         resp = await client.chat_postMessage(
             channel=channel,
             thread_ts=thread_ts,

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -68,6 +68,7 @@ def attach_routes(
     buffer_size: int = 100,
     max_file_size: int = 1_073_741_824,  # 1GB
     resolve_user_identity: bool = False,
+    per_user_thread_sessions: bool = False,
 ) -> APIRouter:
     # Inner functions capture config via closure to keep each instance isolated
     entity = agent or team or workflow
@@ -114,6 +115,7 @@ def attach_routes(
         task_display_mode=task_display_mode,
         buffer_size=buffer_size,
         suggested_prompts=suggested_prompts,
+        per_user_thread_sessions=per_user_thread_sessions,
     )
 
     @router.post(

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -42,6 +42,59 @@ _IGNORED_SUBTYPES = frozenset(
 )
 
 
+def _is_own_bot_event(event: dict, data: dict) -> bool:
+    """Best-effort check that a bot-authored event was produced by this app itself.
+
+    Own identity comes straight from the event envelope — ``authorizations[].user_id``
+    is this app's bot user id and ``api_app_id`` is this app's id — so no extra API
+    call is needed. Fails closed: if the sender can't be attributed (e.g. a legacy
+    webhook message carrying only ``bot_id``), it is treated as our own so the
+    echo-loop guard still holds.
+    """
+    message = event.get("message") or {}
+    sender_user_id = event.get("user") or message.get("user")
+    sender_app_id = event.get("app_id") or message.get("app_id")
+
+    own_bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
+    own_app_id = data.get("api_app_id")
+
+    if own_bot_user_id and sender_user_id:
+        return sender_user_id == own_bot_user_id
+    if own_app_id and sender_app_id:
+        return sender_app_id == own_app_id
+    return True
+
+
+def _should_ignore_event(event: dict, data: dict, respond_to_bot_messages: bool) -> bool:
+    """Decide whether an event is dropped before dispatch.
+
+    Default (``respond_to_bot_messages=False``): every bot-authored event and every
+    lifecycle subtype is dropped — self-loop protection, unchanged behavior.
+
+    Opt-in (``respond_to_bot_messages=True``): only this app's *own* messages are
+    dropped (the echo guard), so other bots' messages flow into normal processing.
+    ``bot_message`` is the delivery subtype for bot-authored channel messages, so it
+    passes; every other lifecycle subtype (edits, deletions, bot add/remove) stays
+    dropped. This can't ping-pong between two bots by default: a reply posted in a
+    thread doesn't @-mention the sender (so no ``app_mention`` fires back), and with
+    ``reply_to_mentions_only=True`` the receiving side only reacts to mentions and
+    DMs. Two bots that both subscribe to ``message.channels`` with
+    ``reply_to_mentions_only=False`` in a shared channel WILL loop — don't combine
+    those settings.
+    """
+    subtype = event.get("subtype")
+    is_bot_authored = bool(event.get("bot_id") or (event.get("message") or {}).get("bot_id"))
+
+    if not respond_to_bot_messages:
+        return is_bot_authored or subtype in _IGNORED_SUBTYPES
+
+    if is_bot_authored and _is_own_bot_event(event, data):
+        return True
+    if subtype in _IGNORED_SUBTYPES and not (is_bot_authored and subtype == "bot_message"):
+        return True
+    return False
+
+
 class SlackEventResponse(BaseModel):
     status: str = Field(default="ok")
 
@@ -69,6 +122,7 @@ def attach_routes(
     max_file_size: int = 1_073_741_824,  # 1GB
     resolve_user_identity: bool = False,
     per_user_thread_sessions: bool = False,
+    respond_to_bot_messages: bool = False,
 ) -> APIRouter:
     # Inner functions capture config via closure to keep each instance isolated
     entity = agent or team or workflow
@@ -166,12 +220,9 @@ def attach_routes(
             # AND inside message_changed's nested "message" object. Slack puts
             # bot_id at different nesting levels depending on event shape — the
             # nested check catches edited bot messages that would otherwise be
-            # reprocessed as new user events.
-            elif (
-                event.get("bot_id")
-                or (event.get("message") or {}).get("bot_id")
-                or event.get("subtype") in _IGNORED_SUBTYPES
-            ):
+            # reprocessed as new user events. With respond_to_bot_messages=True
+            # only this app's own messages are dropped; other bots' pass through.
+            elif _should_ignore_event(event, data, respond_to_bot_messages):
                 pass
             elif streaming:
                 background_tasks.add_task(event_handler.handle_streaming, data)

--- a/libs/agno/agno/os/interfaces/slack/slack.py
+++ b/libs/agno/agno/os/interfaces/slack/slack.py
@@ -46,6 +46,14 @@ class Slack(BaseInterface):
         # pull another's turns. The user id is the run's resolved identity (email when
         # resolve_user_identity resolves one, else the Slack id).
         per_user_thread_sessions: bool = False,
+        # Process messages authored by *other* Slack bots (mentions, DMs, and channel
+        # messages if subscribed). This app's own messages are always dropped (echo guard).
+        # Safe by default against ping-pong: replies don't @-mention the sender and with
+        # reply_to_mentions_only=True only mentions/DMs are processed — but two bots that
+        # both set reply_to_mentions_only=False + respond_to_bot_messages=True in a shared
+        # channel will loop. Slack may not deliver app_mention for bot-authored messages in
+        # all workspaces; subscribing to message.channels is the reliable bot-to-bot route.
+        respond_to_bot_messages: bool = False,
     ):
         self.agent = agent
         self.team = team
@@ -65,6 +73,7 @@ class Slack(BaseInterface):
         self.max_file_size = max_file_size
         self.resolve_user_identity = resolve_user_identity
         self.per_user_thread_sessions = per_user_thread_sessions
+        self.respond_to_bot_messages = respond_to_bot_messages
 
         if not (self.agent or self.team or self.workflow):
             raise ValueError("Slack requires an agent, team, or workflow")
@@ -88,6 +97,7 @@ class Slack(BaseInterface):
             max_file_size=self.max_file_size,
             resolve_user_identity=self.resolve_user_identity,
             per_user_thread_sessions=self.per_user_thread_sessions,
+            respond_to_bot_messages=self.respond_to_bot_messages,
         )
 
         return self.router

--- a/libs/agno/agno/os/interfaces/slack/slack.py
+++ b/libs/agno/agno/os/interfaces/slack/slack.py
@@ -38,6 +38,14 @@ class Slack(BaseInterface):
         buffer_size: int = 100,
         max_file_size: int = 1_073_741_824,  # 1GB
         resolve_user_identity: bool = False,
+        # Key sessions per (thread, caller) — <entity_id>:<thread_ts>:<user_id> — instead of
+        # one shared session per thread. Agno sessions are single-user rows, so the shared
+        # key lets the first speaker claim the session while every other participant's runs
+        # load no history and are never persisted. Per-user keys give each participant their
+        # own session; history loads are scoped by session_id, so no participant can ever
+        # pull another's turns. The user id is the run's resolved identity (email when
+        # resolve_user_identity resolves one, else the Slack id).
+        per_user_thread_sessions: bool = False,
     ):
         self.agent = agent
         self.team = team
@@ -56,6 +64,7 @@ class Slack(BaseInterface):
         self.buffer_size = buffer_size
         self.max_file_size = max_file_size
         self.resolve_user_identity = resolve_user_identity
+        self.per_user_thread_sessions = per_user_thread_sessions
 
         if not (self.agent or self.team or self.workflow):
             raise ValueError("Slack requires an agent, team, or workflow")
@@ -78,6 +87,7 @@ class Slack(BaseInterface):
             buffer_size=self.buffer_size,
             max_file_size=self.max_file_size,
             resolve_user_identity=self.resolve_user_identity,
+            per_user_thread_sessions=self.per_user_thread_sessions,
         )
 
         return self.router

--- a/libs/agno/agno/os/interfaces/slack/slack.py
+++ b/libs/agno/agno/os/interfaces/slack/slack.py
@@ -38,9 +38,9 @@ class Slack(BaseInterface):
         buffer_size: int = 100,
         max_file_size: int = 1_073_741_824,  # 1GB
         resolve_user_identity: bool = False,
-        # Key sessions per (thread, caller) — <entity_id>:<thread_ts>:<user_id> — instead of
-        # one shared session per thread. Agno sessions are single-user rows, so the shared
-        # key lets the first speaker claim the session while every other participant's runs
+        # Key sessions per (channel, thread, caller) — <entity_id>:<channel_id>:<user_id>:<thread_ts>
+        # — instead of one shared session per thread. Agno sessions are single-user rows, so the
+        # shared key lets the first speaker claim the session while every other participant's runs
         # load no history and are never persisted. Per-user keys give each participant their
         # own session; history loads are scoped by session_id, so no participant can ever
         # pull another's turns. The user id is the run's resolved identity (email when

--- a/libs/agno/agno/os/interfaces/slack/types.py
+++ b/libs/agno/agno/os/interfaces/slack/types.py
@@ -37,6 +37,9 @@ class RowActionContext:
     channel: str
     card_ts: str
     blocks: List[Dict[str, Any]]
+    # Decoded from button value — only present when the paused run's session id can't be
+    # re-derived from the thread (per-user thread sessions); propagated on re-encode.
+    session_id: Optional[str] = None
 
 
 @dataclass

--- a/libs/agno/tests/unit/os/routers/test_slack_blocks.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_blocks.py
@@ -9,6 +9,10 @@ from agno.os.interfaces.slack.ids import (
     ACTION_ROW_APPROVE,
     ACTION_ROW_REJECT,
     ACTION_SUBMIT,
+    decode_row_button_value,
+    decode_submit_button_value,
+    encode_row_button_value,
+    encode_submit_button_value,
     parse_row_block_id,
     pause_block_id,
     row_block_id,
@@ -94,6 +98,54 @@ class TestRowBlockId:
     def test_non_row_prefix_returns_none(self):
         assert parse_row_block_id("pause:A1") is None
         assert parse_row_block_id("rowact:r1:confirmation") is None
+
+
+# -- Button value encode/decode --
+
+
+class TestButtonValueSessionId:
+    def test_row_value_without_session_id_unchanged(self):
+        # Default config must keep the exact pre-session wire format
+        assert encode_row_button_value("r1", "run-1", "111.222") == "r1|run-1|111.222"
+        assert encode_row_button_value("r1", "run-1", "111.222", None) == "r1|run-1|111.222"
+
+    def test_row_value_round_trip_with_session_id(self):
+        value = encode_row_button_value("r1", "run-1", "111.222", "agent-1:111.222:user@example.com")
+        assert decode_row_button_value(value) == ("r1", "run-1", "111.222", "agent-1:111.222:user@example.com")
+
+    def test_row_value_decode_legacy_formats(self):
+        # Cards posted by older versions carry no session_id field
+        assert decode_row_button_value("r1|run-1|111.222") == ("r1", "run-1", "111.222", None)
+        assert decode_row_button_value("r1|run-1|") == ("r1", "run-1", None, None)
+        assert decode_row_button_value("r1|run-1") == ("r1", "run-1", None, None)
+        assert decode_row_button_value("garbage") == ("", "", None, None)
+
+    def test_submit_value_without_session_id_unchanged(self):
+        assert encode_submit_button_value("run-1", "111.222") == "run-1|111.222"
+        assert encode_submit_button_value("run-1", None) == "run-1|"
+
+    def test_submit_value_round_trip_with_session_id(self):
+        value = encode_submit_button_value("run-1", "111.222", "agent-1:111.222:U456")
+        assert decode_submit_button_value(value) == ("run-1", "111.222", "agent-1:111.222:U456")
+
+    def test_submit_value_decode_legacy_formats(self):
+        assert decode_submit_button_value("run-1|111.222") == ("run-1", "111.222", None)
+        assert decode_submit_button_value("run-1|") == ("run-1", None, None)
+        assert decode_submit_button_value("run-1") == ("run-1", None, None)
+
+    def test_pause_message_embeds_session_id_in_row_buttons(self):
+        card = build_pause_message("A1", [_make_requirement()], session_id="agent-1:111.222:user@example.com")[0]
+        assert card.actions[0].value == "r1|A1||agent-1:111.222:user@example.com"
+        assert card.actions[1].value == "r1|A1||agent-1:111.222:user@example.com"
+
+    def test_pause_message_embeds_session_id_in_global_submit(self):
+        req = _make_requirement(
+            requires_user_input=True,
+            user_input_schema=[UserInputField(name="reason", field_type=str)],
+        )
+        blocks = build_pause_message("A1", [req], session_id="agent-1:111.222:U456")
+        submit = next(b for b in blocks if getattr(b, "block_id", None) == pause_block_id("A1"))
+        assert submit.elements[0].value == "A1||agent-1:111.222:U456"
 
 
 # -- Confirmation row --

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -4,6 +4,7 @@ import pytest
 
 from agno.os.interfaces.slack.helpers import (
     BotNameResolver,
+    derive_session_id,
     download_event_files_async,
     extract_event_context,
     member_name,
@@ -414,3 +415,21 @@ class TestStripBotMention:
     def test_mention_only_with_bot_name(self):
         result = strip_bot_mention("<@U0APCSS3MDH>", "U0APCSS3MDH", "Scout")
         assert result == "Scout"
+
+
+class TestDeriveSessionId:
+    def test_channel_scoped(self):
+        # Slack ts values are only unique per channel — the same thread_ts in
+        # two channels must never share a session
+        a = derive_session_id("agent-1", "C1", "111.222")
+        b = derive_session_id("agent-1", "C2", "111.222")
+        assert a != b
+        assert a == "agent-1:C1:111.222"
+
+    def test_per_user_keeps_thread_ts_last(self):
+        key = derive_session_id("agent-1", "C1", "111.222", user_key="user@example.com")
+        assert key == "agent-1:C1:user@example.com:111.222"
+
+    def test_empty_user_key_falls_back_to_thread_key(self):
+        assert derive_session_id("agent-1", "C1", "111.222", user_key=None) == "agent-1:C1:111.222"
+        assert derive_session_id("agent-1", "C1", "111.222", user_key="") == "agent-1:C1:111.222"

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -69,6 +69,16 @@ class TestExtractEventContext:
         ctx = extract_event_context({"text": "hi", "channel": "C1", "user": "U1", "ts": "111"})
         assert ctx["thread_id"] == "111"
 
+    def test_user_falls_back_to_bot_id(self):
+        # Bot-authored events (e.g. webhook posts) may carry no "user" — bot_id keeps
+        # downstream identity handling non-empty
+        ctx = extract_event_context({"text": "hi", "channel": "C1", "bot_id": "B99", "ts": "111"})
+        assert ctx["user"] == "B99"
+
+    def test_user_wins_over_bot_id(self):
+        ctx = extract_event_context({"text": "hi", "channel": "C1", "user": "U1", "bot_id": "B99", "ts": "111"})
+        assert ctx["user"] == "U1"
+
 
 class TestDownloadEventFilesAsync:
     @pytest.mark.asyncio
@@ -274,6 +284,25 @@ class TestResolveSlackUser:
         client.users_info = AsyncMock(side_effect=RuntimeError("Slack API error"))
         resolved_id, display_name = await resolve_slack_user(client, "UFAIL")
         assert resolved_id == "UFAIL"
+        assert display_name is None
+
+    @pytest.mark.asyncio
+    async def test_bot_id_resolves_via_bots_info(self):
+        # A raw bot id ("B…") never hits users_info — bots_info gives the bot's name,
+        # and the bot id itself stays the canonical user_id (bots have no email)
+        client = AsyncMock()
+        client.bots_info = AsyncMock(return_value={"bot": {"id": "B42", "name": "peerbot"}})
+        resolved_id, display_name = await resolve_slack_user(client, "B42")
+        assert resolved_id == "B42"
+        assert display_name == "peerbot"
+        client.users_info.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bot_id_api_error_falls_back_gracefully(self):
+        client = AsyncMock()
+        client.bots_info = AsyncMock(side_effect=RuntimeError("Slack API error"))
+        resolved_id, display_name = await resolve_slack_user(client, "BFAIL")
+        assert resolved_id == "BFAIL"
         assert display_name is None
 
 

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -14,8 +14,10 @@ from agno.os.interfaces.slack.helpers import BotNameResolver
 from agno.os.interfaces.slack.hitl import HITLHandler
 from agno.os.interfaces.slack.ids import (
     ACTION_CHECK_STATUS,
+    ACTION_ROW_APPROVE,
     ACTION_SUBMIT,
     encode_admin_approval_button_value,
+    encode_row_button_value,
     encode_submit_button_value,
     row_block_id,
 )
@@ -82,7 +84,11 @@ def _make_requirement(req_id: str = "r1", **tool_overrides: Any) -> RunRequireme
     return RunRequirement(tool_execution=ToolExecution(**defaults), id=req_id)
 
 
-def _make_submit_payload(blocks: list[dict[str, Any]], awaiting_ts: str | None = "await-1") -> dict[str, Any]:
+def _make_submit_payload(
+    blocks: list[dict[str, Any]],
+    awaiting_ts: str | None = "await-1",
+    session_id: str | None = None,
+) -> dict[str, Any]:
     return {
         "type": "block_actions",
         "team": {"id": "T123"},
@@ -98,10 +104,23 @@ def _make_submit_payload(blocks: list[dict[str, Any]], awaiting_ts: str | None =
             {
                 "action_id": ACTION_SUBMIT,
                 "block_id": "pause:run-1",
-                "value": encode_submit_button_value("run-1", awaiting_ts),
+                "value": encode_submit_button_value("run-1", awaiting_ts, session_id),
             }
         ],
     }
+
+
+def _make_hitl_handler(entity: Any) -> HITLHandler:
+    return HITLHandler(
+        slack_tools=make_slack_mock(token="xoxb-test"),
+        ssl=None,
+        entity=entity,
+        entity_id="agent-1",
+        entity_name="Test Agent",
+        entity_type="agent",
+        task_display_mode="plan",
+        buffer_size=100,
+    )
 
 
 def _make_check_status_payload(
@@ -445,6 +464,122 @@ class TestNonStreamingRoutes:
         assert resp.status_code == 200
         await wait_for_call(agent_mock.arun)
         assert mock_client.assistant_threads_setStatus.call_args_list[-1].kwargs["status"] == ""
+
+
+class TestPerUserThreadSessions:
+    """per_user_thread_sessions=True keys sessions per (thread, caller).
+
+    Agno sessions are single-user rows (session_id is the PK, loads filter by user_id),
+    so a shared thread key lets the first speaker claim the session while every other
+    participant's runs load no history and are never persisted. Per-user keys give each
+    participant their own session — no caller can ever pull another caller's turns.
+    """
+
+    @pytest.mark.asyncio
+    async def test_session_id_includes_slack_user_id(self):
+        agent_mock = make_agent_mock()
+        agent_mock.name = "Research Bot"
+        agent_mock.id = "researcher"
+        mock_slack = make_slack_mock(token="xoxb-test")
+
+        with (
+            patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
+            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+        ):
+            app = build_app(agent_mock, reply_to_mentions_only=False, per_user_thread_sessions=True)
+            from fastapi.testclient import TestClient
+
+            client = TestClient(app)
+            thread_ts = "1708123456.000100"
+            body = {
+                "type": "event_callback",
+                "event": {
+                    "type": "message",
+                    "channel_type": "im",
+                    "text": "hello",
+                    "user": "U123",
+                    "channel": "C123",
+                    "ts": "1708123456.000200",
+                    "thread_ts": thread_ts,
+                },
+            }
+            resp = make_signed_request(client, body)
+
+        assert resp.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}:U123"
+
+    @pytest.mark.asyncio
+    async def test_session_id_uses_resolved_email_when_identity_resolved(self):
+        # The session key must match the run's user_id, or the Postgres upsert guard
+        # (user_id mismatch) would silently drop the write
+        agent_mock = make_agent_mock()
+        agent_mock.name = "Research Bot"
+        agent_mock.id = "researcher"
+        mock_slack = make_slack_mock(token="xoxb-test")
+
+        with (
+            patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
+            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+        ):
+            app = build_app(
+                agent_mock, reply_to_mentions_only=False, per_user_thread_sessions=True, resolve_user_identity=True
+            )
+            from fastapi.testclient import TestClient
+
+            client = TestClient(app)
+            thread_ts = "1708123456.000100"
+            body = {
+                "type": "event_callback",
+                "event": {
+                    "type": "message",
+                    "channel_type": "im",
+                    "text": "hello",
+                    "user": "U123",
+                    "channel": "C123",
+                    "ts": "1708123456.000200",
+                    "thread_ts": thread_ts,
+                },
+            }
+            resp = make_signed_request(client, body)
+
+        assert resp.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}:test@example.com"
+        assert agent_mock.arun.call_args.kwargs["user_id"] == "test@example.com"
+
+    @pytest.mark.asyncio
+    async def test_pause_card_embeds_session_id_when_enabled(self):
+        handler = _make_event_handler(per_user_thread_sessions=True)
+        ctx = _make_event_context(session_id="agent-1:1708123456.000100:user@example.com")
+        response = Mock(content="", active_requirements=[_make_requirement()], run_id="run-9")
+
+        with (
+            patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+            patch("agno.os.interfaces.slack.event_handler.post_pause_card", new=AsyncMock()) as mock_card,
+        ):
+            handled = await handler._handle_paused_non_streaming(ctx, response)
+
+        assert handled is True
+        assert mock_card.call_args.kwargs["session_id"] == "agent-1:1708123456.000100:user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_pause_card_omits_session_id_by_default(self):
+        # Default config keeps the pause card byte-identical to before
+        handler = _make_event_handler()
+        ctx = _make_event_context()
+        response = Mock(content="", active_requirements=[_make_requirement()], run_id="run-9")
+
+        with (
+            patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+            patch("agno.os.interfaces.slack.event_handler.post_pause_card", new=AsyncMock()) as mock_card,
+        ):
+            handled = await handler._handle_paused_non_streaming(ctx, response)
+
+        assert handled is True
+        assert mock_card.call_args.kwargs["session_id"] is None
 
 
 class TestRouterWiring:
@@ -983,6 +1118,116 @@ class TestHITLFlow:
         assert required_req.confirmation is None
         assert continued["called"] is True
 
+    @pytest.mark.asyncio
+    async def test_submit_uses_session_id_from_button_value(self):
+        """Per-user thread sessions: the resume must load the ORIGINAL run's session.
+
+        The thread-derived id can't include the user key (the clicker may not be the
+        original caller), so the pause card's button value carries the paused run's
+        session id and the submit path uses it for both the run lookup and the resume.
+        """
+        requirement = _make_requirement()
+        entity = AsyncMock()
+        entity.aget_run_output = AsyncMock(
+            return_value=Mock(active_requirements=[requirement], user_id="user@test.com")
+        )
+        captured: Dict[str, Any] = {}
+
+        async def _continue_run(*args: Any, **kwargs: Any):
+            captured.update(kwargs)
+            yield Mock(
+                event=RunEvent.run_content.value,
+                content="resumed",
+                images=None,
+                videos=None,
+                audio=None,
+                files=None,
+                tool=None,
+            )
+
+        entity.acontinue_run = _continue_run
+        handler = _make_hitl_handler(entity)
+        mock_client = make_async_client_mock()
+        mock_client.chat_delete = AsyncMock()
+        stream = make_stream_mock()
+        per_user_session = "agent-1:111.222:user@test.com"
+        payload = _make_submit_payload(
+            blocks=[{"type": "section", "block_id": row_block_id("r1", "confirmation", decided="approve")}],
+            session_id=per_user_session,
+        )
+
+        with (
+            patch("agno.os.interfaces.slack.hitl.AsyncWebClient", return_value=mock_client),
+            patch("agno.os.interfaces.slack.hitl.open_chat_stream", new=AsyncMock(return_value=stream)),
+        ):
+            await handler.handle_submit(payload)
+
+        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id=per_user_session)
+        assert captured["session_id"] == per_user_session
+        # The resume runs as the original run's user, not the clicker
+        assert captured["user_id"] == "user@test.com"
+
+    @pytest.mark.asyncio
+    async def test_row_approve_auto_submit_propagates_session_id(self):
+        """Approve-button clicks re-encode the session id into the synthetic submit."""
+        requirement = _make_requirement()
+        entity = AsyncMock()
+        entity.aget_run_output = AsyncMock(
+            return_value=Mock(active_requirements=[requirement], user_id="user@test.com")
+        )
+
+        async def _continue_run(*args: Any, **kwargs: Any):
+            yield Mock(
+                event=RunEvent.run_content.value,
+                content="resumed",
+                images=None,
+                videos=None,
+                audio=None,
+                files=None,
+                tool=None,
+            )
+
+        entity.acontinue_run = _continue_run
+        handler = _make_hitl_handler(entity)
+        mock_client = make_async_client_mock()
+        mock_client.chat_delete = AsyncMock()
+        stream = make_stream_mock()
+        per_user_session = "agent-1:111.222:user@test.com"
+        payload = {
+            "type": "block_actions",
+            "team": {"id": "T123"},
+            "user": {"id": "U123"},
+            "channel": {"id": "C123"},
+            "message": {
+                "ts": "222.333",
+                "thread_ts": "111.222",
+                "blocks": [
+                    {
+                        "type": "card",
+                        "block_id": "rowact:r1:confirmation",
+                        "title": {"text": "*delete_file*"},
+                        "body": {"text": "path: /tmp/demo.txt"},
+                    }
+                ],
+            },
+            "state": {"values": {}},
+            "actions": [
+                {
+                    "action_id": ACTION_ROW_APPROVE,
+                    "value": encode_row_button_value("r1", "run-1", "await-1", per_user_session),
+                }
+            ],
+        }
+
+        with (
+            patch("agno.os.interfaces.slack.hitl.AsyncWebClient", return_value=mock_client),
+            patch("agno.os.interfaces.slack.hitl.open_chat_stream", new=AsyncMock(return_value=stream)),
+        ):
+            await handler.handle_row_approve(payload)
+
+        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id=per_user_session)
+        assert requirement.confirmation is True
+
 
 class TestAdminApprovalFlow:
     """Tests for approval_type='required' tools resolved via admin dashboard + Check Status."""
@@ -1109,8 +1354,48 @@ class TestAdminApprovalFlow:
         assert call.kwargs["text"] == "Status: rejected"
 
     @pytest.mark.asyncio
+    async def test_check_status_approved_resumes_with_approval_record_session(self):
+        """Per-user thread sessions: the approval record carries the paused run's session id."""
+        requirement = _make_requirement(approval_type="required", approval_id="appr-1")
+        entity = AsyncMock()
+        entity.aget_run_output = AsyncMock(
+            return_value=Mock(active_requirements=[requirement], user_id="owner@test.com")
+        )
+
+        per_user_session = "agent-1:111.222:owner@test.com"
+        db = Mock()
+        db.get_approval = Mock(return_value={"id": "appr-1", "status": "approved", "session_id": per_user_session})
+        entity.db = db
+
+        async def _continue_run(*args: Any, **kwargs: Any):
+            yield Mock(
+                event=RunEvent.run_content.value,
+                content="resumed",
+                images=None,
+                videos=None,
+                audio=None,
+                files=None,
+                tool=None,
+            )
+
+        entity.acontinue_run = _continue_run
+        handler = _make_hitl_handler(entity)
+        mock_client = make_async_client_mock()
+        mock_client.chat_delete = AsyncMock()
+        stream = make_stream_mock()
+        payload = _make_check_status_payload()
+
+        with (
+            patch("agno.os.interfaces.slack.hitl.AsyncWebClient", return_value=mock_client),
+            patch("agno.os.interfaces.slack.hitl.open_chat_stream", new=AsyncMock(return_value=stream)),
+        ):
+            await handler.handle_check_status(payload)
+
+        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id=per_user_session)
+
+    @pytest.mark.asyncio
     async def test_check_status_no_db_returns_pending(self):
-        """Without a DB, _get_approval_status returns pending."""
+        """Without a DB, _get_approval returns None and status defaults to pending."""
         entity = AsyncMock()
         entity.db = None
 

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -21,6 +21,7 @@ from agno.os.interfaces.slack.ids import (
     encode_submit_button_value,
     row_block_id,
 )
+from agno.os.interfaces.slack.router import _should_ignore_event
 from agno.os.interfaces.slack.state import StreamState
 from agno.run.requirement import RunRequirement
 
@@ -580,6 +581,178 @@ class TestPerUserThreadSessions:
 
         assert handled is True
         assert mock_card.call_args.kwargs["session_id"] is None
+
+
+class TestBotMessageFiltering:
+    """respond_to_bot_messages: own messages always dropped; other bots' opt-in."""
+
+    def _human_event(self) -> dict[str, Any]:
+        return {"type": "message", "channel_type": "im", "text": "hi", "user": "U_HUMAN"}
+
+    def _own_bot_event(self) -> dict[str, Any]:
+        return {"type": "message", "channel_type": "im", "text": "echo", "user": "U_SELF", "bot_id": "B_SELF"}
+
+    def _peer_bot_event(self, **overrides: Any) -> dict[str, Any]:
+        event = {
+            "type": "message",
+            "channel_type": "im",
+            "text": "ping",
+            "user": "U_PEER",
+            "bot_id": "B_PEER",
+            "app_id": "A_PEER",
+        }
+        event.update(overrides)
+        return event
+
+    def _envelope(self) -> dict[str, Any]:
+        return {"api_app_id": "A_SELF", "authorizations": [{"user_id": "U_SELF"}]}
+
+    def test_human_event_never_ignored(self):
+        assert _should_ignore_event(self._human_event(), self._envelope(), respond_to_bot_messages=False) is False
+        assert _should_ignore_event(self._human_event(), self._envelope(), respond_to_bot_messages=True) is False
+
+    def test_any_bot_event_ignored_by_default(self):
+        assert _should_ignore_event(self._peer_bot_event(), self._envelope(), respond_to_bot_messages=False) is True
+        assert _should_ignore_event(self._own_bot_event(), self._envelope(), respond_to_bot_messages=False) is True
+
+    def test_peer_bot_event_processed_when_opted_in(self):
+        assert _should_ignore_event(self._peer_bot_event(), self._envelope(), respond_to_bot_messages=True) is False
+
+    def test_own_bot_event_ignored_even_when_opted_in(self):
+        # The echo-loop guard is not opt-out-able
+        assert _should_ignore_event(self._own_bot_event(), self._envelope(), respond_to_bot_messages=True) is True
+
+    def test_own_app_matched_by_app_id(self):
+        # Some bot messages carry no "user" — attribution falls back to app_id
+        event = self._peer_bot_event(app_id="A_SELF")
+        event.pop("user")
+        assert _should_ignore_event(event, self._envelope(), respond_to_bot_messages=True) is True
+
+    def test_unattributable_bot_event_fails_closed(self):
+        # No sender user/app_id (e.g. legacy webhook) — treated as own, dropped
+        event = {"type": "message", "channel_type": "im", "text": "??", "bot_id": "B_MYSTERY"}
+        assert _should_ignore_event(event, self._envelope(), respond_to_bot_messages=True) is True
+
+    def test_peer_bot_message_subtype_passes_when_opted_in(self):
+        # "bot_message" is the delivery subtype for bot-authored channel messages
+        event = self._peer_bot_event(subtype="bot_message")
+        assert _should_ignore_event(event, self._envelope(), respond_to_bot_messages=True) is False
+
+    def test_peer_bot_message_edits_still_ignored(self):
+        # message_changed must never be reprocessed, even from a peer bot
+        event = {
+            "type": "message",
+            "subtype": "message_changed",
+            "message": {"text": "edited", "user": "U_PEER", "bot_id": "B_PEER", "app_id": "A_PEER"},
+        }
+        assert _should_ignore_event(event, self._envelope(), respond_to_bot_messages=True) is True
+
+    def test_human_lifecycle_subtypes_still_ignored_when_opted_in(self):
+        event = {"type": "message", "subtype": "message_deleted", "channel_type": "im", "user": "U_HUMAN"}
+        assert _should_ignore_event(event, self._envelope(), respond_to_bot_messages=True) is True
+
+    @pytest.mark.asyncio
+    async def test_peer_bot_dm_processed_end_to_end(self):
+        agent_mock = make_agent_mock()
+        mock_slack = make_slack_mock(token="xoxb-test")
+
+        with (
+            patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
+            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+            patch("agno.os.interfaces.slack.event_handler.AsyncWebClient", return_value=make_async_client_mock()),
+        ):
+            app = build_app(agent_mock, reply_to_mentions_only=False, respond_to_bot_messages=True)
+            from fastapi.testclient import TestClient
+
+            client = TestClient(app)
+            body = {
+                "type": "event_callback",
+                "api_app_id": "A_SELF",
+                "authorizations": [{"user_id": "U_SELF"}],
+                "event": {
+                    "type": "message",
+                    "channel_type": "im",
+                    "text": "ping from peer",
+                    "user": "U_PEER",
+                    "bot_id": "B_PEER",
+                    "app_id": "A_PEER",
+                    "channel": "C123",
+                    "ts": str(time.time()),
+                },
+            }
+            resp = make_signed_request(client, body)
+
+        assert resp.status_code == 200
+        await wait_for_call(agent_mock.arun)
+        assert agent_mock.arun.call_args.kwargs["user_id"] == "U_PEER"
+
+    @pytest.mark.asyncio
+    async def test_own_bot_dm_dropped_end_to_end(self):
+        agent_mock = make_agent_mock()
+        mock_slack = make_slack_mock(token="xoxb-test")
+
+        with (
+            patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
+            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        ):
+            app = build_app(agent_mock, reply_to_mentions_only=False, respond_to_bot_messages=True)
+            from fastapi.testclient import TestClient
+
+            client = TestClient(app)
+            body = {
+                "type": "event_callback",
+                "api_app_id": "A_SELF",
+                "authorizations": [{"user_id": "U_SELF"}],
+                "event": {
+                    "type": "message",
+                    "channel_type": "im",
+                    "text": "own echo",
+                    "user": "U_SELF",
+                    "bot_id": "B_SELF",
+                    "app_id": "A_SELF",
+                    "channel": "C123",
+                    "ts": str(time.time()),
+                },
+            }
+            resp = make_signed_request(client, body)
+
+        assert resp.status_code == 200
+        await asyncio.sleep(0.1)
+        agent_mock.arun.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_peer_bot_dropped_without_opt_in_end_to_end(self):
+        agent_mock = make_agent_mock()
+        mock_slack = make_slack_mock(token="xoxb-test")
+
+        with (
+            patch("agno.os.interfaces.slack.router.verify_slack_signature", return_value=True),
+            patch("agno.os.interfaces.slack.router.SlackTools", return_value=mock_slack),
+        ):
+            app = build_app(agent_mock, reply_to_mentions_only=False)
+            from fastapi.testclient import TestClient
+
+            client = TestClient(app)
+            body = {
+                "type": "event_callback",
+                "api_app_id": "A_SELF",
+                "authorizations": [{"user_id": "U_SELF"}],
+                "event": {
+                    "type": "message",
+                    "channel_type": "im",
+                    "text": "ping from peer",
+                    "user": "U_PEER",
+                    "bot_id": "B_PEER",
+                    "app_id": "A_PEER",
+                    "channel": "C123",
+                    "ts": str(time.time()),
+                },
+            }
+            resp = make_signed_request(client, body)
+
+        assert resp.status_code == 200
+        await asyncio.sleep(0.1)
+        agent_mock.arun.assert_not_called()
 
 
 class TestRouterWiring:

--- a/libs/agno/tests/unit/os/routers/test_slack_router.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_router.py
@@ -68,7 +68,7 @@ def _make_event_context(**overrides: Any) -> EventContext:
         "thread_id": "1708123456.000100",
         "user": "U123",
         "message_text": "Summarize the incident timeline",
-        "session_id": "agent-1:1708123456.000100",
+        "session_id": "agent-1:C123:1708123456.000100",
         "team_id": "T123",
         "resolved_user_id": "U123",
         "display_name": None,
@@ -273,7 +273,7 @@ class TestNonStreamingRoutes:
 
         assert resp.status_code == 200
         await wait_for_call(agent_mock.arun)
-        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}"
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:C123:{thread_ts}"
 
     @pytest.mark.asyncio
     async def test_user_id_is_raw_slack_id_by_default(self):
@@ -509,7 +509,7 @@ class TestPerUserThreadSessions:
 
         assert resp.status_code == 200
         await wait_for_call(agent_mock.arun)
-        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}:U123"
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:C123:U123:{thread_ts}"
 
     @pytest.mark.asyncio
     async def test_session_id_uses_resolved_email_when_identity_resolved(self):
@@ -548,13 +548,13 @@ class TestPerUserThreadSessions:
 
         assert resp.status_code == 200
         await wait_for_call(agent_mock.arun)
-        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:{thread_ts}:test@example.com"
+        assert agent_mock.arun.call_args.kwargs["session_id"] == f"researcher:C123:test@example.com:{thread_ts}"
         assert agent_mock.arun.call_args.kwargs["user_id"] == "test@example.com"
 
     @pytest.mark.asyncio
     async def test_pause_card_embeds_session_id_when_enabled(self):
         handler = _make_event_handler(per_user_thread_sessions=True)
-        ctx = _make_event_context(session_id="agent-1:1708123456.000100:user@example.com")
+        ctx = _make_event_context(session_id="agent-1:C123:user@example.com:1708123456.000100")
         response = Mock(content="", active_requirements=[_make_requirement()], run_id="run-9")
 
         with (
@@ -564,7 +564,7 @@ class TestPerUserThreadSessions:
             handled = await handler._handle_paused_non_streaming(ctx, response)
 
         assert handled is True
-        assert mock_card.call_args.kwargs["session_id"] == "agent-1:1708123456.000100:user@example.com"
+        assert mock_card.call_args.kwargs["session_id"] == "agent-1:C123:user@example.com:1708123456.000100"
 
     @pytest.mark.asyncio
     async def test_pause_card_omits_session_id_by_default(self):
@@ -1231,7 +1231,7 @@ class TestHITLFlow:
         ):
             await handler.handle_submit(payload)
 
-        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id="agent-1:111.222")
+        entity.aget_run_output.assert_awaited_once_with(run_id="run-1", session_id="agent-1:C123:111.222")
         assert requirement.confirmation is True
         mock_client.chat_delete.assert_awaited_once_with(channel="C123", ts="await-1")
         mock_open.assert_awaited_once_with(mock_client, "C123", "111.222", "U123", "T123", "plan", 100)


### PR DESCRIPTION
Makes the Slack interface genuinely multiplayer: per-participant thread sessions (opt-in), a peer-bot receive path (opt-in), and channel-scoped session keys. Built for @context's "multiplayer Slack agent" launch; both behavioral changes are opt-in params, and defaults preserve current behavior (with one deliberate exception in the session-key format, noted under Upgrade notes).

## 1. Per-participant thread sessions (`per_user_thread_sessions`, default `False`)

### Why — the mechanics of the bug this fixes

Three facts about how the Slack interface and agno sessions compose today, each fine alone, broken together:

1. **The interface keys sessions per thread.** `session_id = f"{entity_id}:{thread_ts}"` — every person speaking in one Slack thread produces runs with the *same* session id.
2. **But an agno session row belongs to one user.** `session_id` is the primary key, and the row carries the `user_id` that created it. When a run starts, agno loads the session filtered by *both*: `WHERE session_id = X AND user_id = <caller>`.
3. **The save path enforces that ownership silently.** The Postgres upsert has a guard — update only where the stored row's `user_id` matches the incoming one. On mismatch it writes nothing and returns `None`. No error, no log.

Play that through a two-person channel thread:

- **Alice speaks first.** Run: session `agent:1720613385.1234`, user `alice@co.com`. No row exists → created, owned by Alice.
- **Bob @-mentions the bot in the same thread.** Run: same session id, user `bob@co.com`. The load filters by (that session AND bob@) → no match → Bob's run gets a *fresh, empty* session. The agent answers him with zero memory of the thread.
- **Bob's run finishes and tries to save.** The upsert hits the ownership guard: stored row is Alice's → **the write silently no-ops**. Bob's turn was never persisted — not in the session, not visible in tracing.
- **Bob asks a follow-up 30 seconds later.** Empty history again. The agent has no idea what he just asked it, in the same thread. It re-introduces itself, contradicts its previous answer, re-asks for details he already gave.
- **Mirror case:** if Bob speaks *first*, he owns the session — and Alice (in @context's case, the deployment's owner) is the one whose turns silently never persist.

So the bug isn't a leak — it's amnesia plus silent data loss for everyone after the first speaker. (The one accidental upside: because loads are user-filtered, Bob can never pull Alice's history. The fix keeps that property, by design instead of by accident.)

### The fix

With `per_user_thread_sessions=True`, the session key includes the resolved caller: one thread becomes one session *per participant* — Alice's strand and Bob's strand. Everyone gets continuity, every run persists, and no-cross-user-history is structural: another participant's history lives under a key your runs never load. The user component is the same resolved identity the run's `user_id` uses (email when `resolve_user_identity` resolves one, else the Slack id), so the key and the row owner can never disagree.

### HITL resume (the fiddly part)

Approval flows re-derive the session id from the thread, and the clicker may not be the original caller — so with per-user keys the resume must reconstruct the *original* run's session id:

- Row/submit paths: the paused run's session id travels **inside the approval card's button values**, written only when it differs from the thread-derived id (default-config cards stay byte-identical) and tolerated when absent (cards from older versions still resume). Propagated through every re-encode: approve/deny toggles, the deny→Submit button, the synthetic auto-submit, and re-pause cards.
- Admin-approval path: the approvals DB record carries `session_id` (and `user_id`); resume reads it from the record, falling back to the thread-derived id.
- The resume always executes as the original run's `user_id` (pre-existing behavior).

## 2. Peer-bot receive path (`respond_to_bot_messages`, default `False`)

The router dropped **any** event carrying a `bot_id` — correct as echo-loop protection, but over-broad: it structurally killed bot-to-bot messaging (one agno-powered bot @-mentioning another was never processed by the receiver).

Now the self-drop is precise: the event's sender is compared against the app's *own* identity (`authorizations[].user_id` / `api_app_id` from the event envelope — no extra API calls), **failing closed** (an unattributable bot event is treated as own and dropped). With the param on, other bots' mentions and DMs flow through to normal processing; with it off, behavior is unchanged (drop all bot events).

Identity resolution learned bot senders: `B…` ids resolve via `bots.info` to a stable identity, and events with no `user` fall back to `bot_id` instead of crashing.

Loop safety: replies don't @-mention their sender and `reply_to_mentions_only=True` only processes mentions/DMs — but two bots that both set `reply_to_mentions_only=False` + `respond_to_bot_messages=True` in a shared channel will loop (documented on the param).

## 3. Channel-scoped session keys, `thread_ts` last

Slack `ts` values are only unique **per channel**, so the old `{entity}:{thread_ts}` key could collide across channels. The key is now derived in one place (`helpers.derive_session_id`) as:

- default: `{entity}:{channel}:{thread_ts}`
- per-user: `{entity}:{channel}:{user}:{thread_ts}` (timestamp last, so keys read naturally in session UIs)

All four derivation sites (event handler, HITL re-pause embed rule, admin-approval resume fallback, submit-context fallback) use the helper.

### Design decisions (considered and rejected alternatives)

- **Per-user strands, not shared multi-user sessions.** A shared session with multi-user rows would need core schema surgery and would turn "no cross-user leak" from *structurally impossible* into *a filter that must never have a bug*. Per-user keys keep the storage model single-user and make isolation fall out of key derivation.
- **"The agent should see the whole visible thread" is a separate fix.** With per-user strands, a participant's session history doesn't contain other participants' exchanges — even though they're visible in the Slack thread. That content is public to everyone in the channel by Slack's own permissions, so the right fix is thread-transcript context (reading what's already on screen), not shared session storage. Deliberately **not** mixed into this PR.

## Upgrade notes

- The **default-mode key format changes** (`{entity}:{thread_ts}` → `{entity}:{channel}:{thread_ts}`): in-flight Slack threads re-key once on upgrade — the next message in an old thread starts a fresh session. One-time continuity blip, the price of fixing the cross-channel collision.
- Pause cards posted **before** this upgrade resume via the thread-derived fallback, which now computes the new format and won't match their pre-upgrade stored session — resume fails gracefully (logged). Blast radius: only runs paused across the upgrade.
- Cards posted before enabling `per_user_thread_sessions` resume correctly after enabling it (button value wins over derivation), and vice versa.

## Needs live verification

- Whether Slack delivers `app_mention` events when the mentioning message is bot-authored (unverified against a live workspace; noted on the param). `message.channels` (with the same param honored) is the reliable bot-to-bot delivery route if not.
- Streaming UX when the recipient is a bot user (`chat_stream` to a bot recipient) — failures fall into the existing streaming error handler.

## Tests

`tests/unit/os/routers/`: **532 passed** — per-user session e2e (raw id + email), pause-card session embedding on/off, HITL submit / row-approve / check-status with per-user keys, button-value round-trips incl. legacy decode, the full bot-filter matrix (own bot, foreign bot × param on/off, human, unattributable), bot-sender identity resolution, and channel-scoping of `derive_session_id`. `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
