### PR TITLE
fix(auth): fail closed when an authenticated JWT carries no user identity under user_isolation

### DIFF
--- a/libs/agno/agno/os/middleware/user_scope.py
+++ b/libs/agno/agno/os/middleware/user_scope.py
@@ -127,6 +127,27 @@ def get_scoped_user_id(request: Request) -> Optional[str]:
         return None
 
     if not user_id:
+        # Isolation is ON and the caller is neither admin nor a service account.
+        # An *authenticated* caller that resolves to no identity — a validly
+        # signed JWT that carries scopes but no ``sub``, or a deployment whose
+        # ``user_id_claim`` does not match the claim the token actually puts the
+        # identity in — must NOT be handed ``None`` here. ``None`` means "no owner
+        # filter": the unscoped, admin-equivalent view of *every* user's sessions,
+        # memories, and runs. Granting that to a token the server cannot attribute
+        # to any user silently defeats the isolation the operator opted into (the
+        # sanctioned cross-user path is the admin scope — see the docstring). Fail
+        # closed. Anonymous, unauthenticated callers keep the legacy ``None`` so
+        # open / no-JWT deployments are unchanged.
+        if getattr(request.state, "authenticated", False):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "This AgentOS enforces per-user isolation, but the presented token "
+                    "carries no user identity. Ensure the JWT includes the configured "
+                    "user-id claim (default 'sub'), or grant the admin scope for "
+                    "cross-user access."
+                ),
+            )
         return None
 
     return user_id

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -453,6 +453,29 @@ def get_websocket_router(
                                 )
                                 continue
 
+                            # Fail closed under per-user isolation: a validly signed
+                            # token that carries scopes but no identity (missing ``sub``,
+                            # or a ``user_id_claim`` that does not match the token) must
+                            # not authenticate as a non-admin WS client. Reconnect
+                            # ownership is keyed on this identity; with it absent the
+                            # dispatcher cannot pin ``user_id`` (see the reconnect branch)
+                            # and handle_workflow_subscription falls through to an
+                            # unscoped, run-id-keyed event replay of another user's run.
+                            # Admin tokens are exempt (they read across users by design);
+                            # isolation-off deployments are unchanged.
+                            ws_is_admin = ws_admin_scope in (claims.get("scopes") or [])
+                            if ws_user_isolation_enabled and not ws_is_admin and not claims.get("user_id"):
+                                await websocket.send_text(
+                                    json.dumps(
+                                        {
+                                            "event": "auth_error",
+                                            "error": "Invalid token subject",
+                                            "error_type": "invalid_token",
+                                        }
+                                    )
+                                )
+                                continue
+
                             await websocket_manager.authenticate_websocket(websocket)
 
                             # Store user context from JWT


### PR DESCRIPTION
## Summary

A validly-signed JWT that carries scopes but **no `sub`** — or a deployment whose `user_id_claim` doesn't match the claim the IdP actually puts identity in — authenticates with `request.state.user_id = None`. `JWTValidator.validate_token` verifies signature/exp/audience but does not require a subject, so the token is accepted and RBAC passes on its scopes. Under `AuthorizationConfig(user_isolation=True)`, `get_scoped_user_id()` returns `None` for that caller, and every scoped read treats `None` as **"no owner filter"** — the unscoped, admin-equivalent view of *every* user's data.

### Impact (only when `user_isolation=True`)
- **Reads:** a non-admin caller with e.g. `sessions:read` lists all tenants' sessions — `GET /sessions` → `resolve_db_and_scope(..., fallback_user_id=<omittable query param>)` → `db.get_sessions(user_id=None)`. Same for memories, `aget_run_output`, etc.
- **Run attribution:** the REST run routes keep a client-supplied `user_id` form field when `request.state.user_id is None`, with no `is_reserved_principal` check, so a run can be attributed to `sa:...` / `__scheduler__`.
- **WebSocket:** `/workflows/ws` reconnect only forces `user_id` from the authenticated identity when it's truthy; with `None`, the client controls it, and `handle_workflow_subscription`'s ownership gate (`... and user_id`) is skipped when the client omits `user_id`, replaying another user's run events by `run_id`.

### Why this is a bug, not by-design
The code's own stated intent is the opposite: the jwt.py decode-fallthrough comment and `test_jwt_validate_false_failclosed.py` both pin `user_id=None` *so that* "user-isolation scopes by owner", and the `get_scoped_user_id` docstring says the sanctioned cross-user path is the **admin scope** — not an absent subject. The #8752 `validate=False` fix only covered the **malformed-token** path (which sets `scopes=[]` and is blocked by RBAC); a *valid* no-`sub` token carries real scopes and slips through. #8760's reserved-principal rejection assumes a present `sub`.

## The fix (fail closed, narrowest choke-points)
- **`get_scoped_user_id`** (`os/middleware/user_scope.py`): when `user_isolation` is on and an *authenticated* non-admin, non-service-account caller resolves to no `user_id`, raise `403` instead of returning `None`. Anonymous / unauthenticated callers keep the legacy `None`, so open / no-JWT deployments are unchanged. This also closes the REST run routes, which call `get_scoped_user_id` before the form-`user_id` fallback.
- **`/workflows/ws`** (`os/router.py`): reject a non-admin JWT that carries no identity at auth time when `user_isolation` is enabled — mirrors the reserved-principal rejection already there.

Admin, service-account, isolation-off, and real-`sub` callers are **byte-identical** before/after (verified over the full input cross-product). 2 files, +44/-0.

## Type of change
- [x] Bug fix (security: incorrect authorization / cross-tenant isolation bypass, CWE-639 / CWE-862 / CWE-863)

## Checklist
- [x] Self-review completed
- [x] `python -m py_compile` clean on both changed files
- [x] No behavior change for admin / service-account / isolation-off / real-`sub` callers (equivalence checked across the full input matrix)
- [x] Existing suites pass: `test_user_isolation_01/02`, `test_agui_authorization` (incl. `test_authenticated_caller_identity_pinned`), `test_jwt_middleware`, `test_per_request_isolation`, `test_jwt_validate_false_failclosed`, `test_workflow_runs`
- [ ] Happy to add a regression test asserting the 403 on an authenticated no-identity caller under `user_isolation` if you'd like

## Duplicate check
- [x] Searched existing PRs — none addresses the authenticated-no-identity fail-open under `user_isolation`.
- [x] Found via independent local white-box review of the AgentOS auth surface.
