### PR TITLE
fix: derive Cassandra vector dimension from embedder instead of hardcoding 1024

### DIFF
--- a/libs/agno/agno/vectordb/cassandra/cassandra.py
+++ b/libs/agno/agno/vectordb/cassandra/cassandra.py
@@ -40,13 +40,16 @@ class Cassandra(VectorDb):
         self.embedder: Embedder = embedder
         self.session = session
         self.keyspace: str = keyspace
+        self.dimensions: Optional[int] = self.embedder.dimensions
+        if self.dimensions is None:
+            raise ValueError("Embedder.dimensions must be set.")
         self.initialize_table()
 
     def initialize_table(self):
         self.table = AgnoMetadataVectorCassandraTable(
             session=self.session,
             keyspace=self.keyspace,
-            vector_dimension=1024,
+            vector_dimension=self.dimensions,
             table=self.table_name,
             primary_key_type="TEXT",
         )

--- a/libs/agno/tests/unit/vectordb/test_cassandra.py
+++ b/libs/agno/tests/unit/vectordb/test_cassandra.py
@@ -80,6 +80,37 @@ def test_initialization(mock_session):
         Cassandra(table_name="test_vectors", keyspace="test_vectordb", session=None)
 
 
+def test_vector_dimension_matches_embedder(mock_session):
+    """The table must be created with the embedder's dimension, not a hardcoded value."""
+    embedder = MagicMock()
+    embedder.dimensions = 1536
+
+    with patch("agno.vectordb.cassandra.cassandra.AgnoMetadataVectorCassandraTable") as mock_table_cls:
+        Cassandra(
+            table_name="test_vectors",
+            keyspace="test_vectordb",
+            embedder=embedder,
+            session=mock_session,
+        )
+
+    _, called_kwargs = mock_table_cls.call_args
+    assert called_kwargs["vector_dimension"] == 1536
+
+
+def test_missing_embedder_dimensions_raises(mock_session):
+    """A clear error must be raised when the embedder does not expose a dimension."""
+    embedder = MagicMock()
+    embedder.dimensions = None
+
+    with pytest.raises(ValueError):
+        Cassandra(
+            table_name="test_vectors",
+            keyspace="test_vectordb",
+            embedder=embedder,
+            session=mock_session,
+        )
+
+
 def test_insert_and_search(vector_db, mock_table):
     """Test document insertion and search functionality."""
     docs = create_test_documents(1)


### PR DESCRIPTION
## Summary

`Cassandra.initialize_table()` always created the table with `vector_dimension=1024`.
Configuring an embedder whose output dimension differs (e.g. `text-embedding-3-small`
at 1536 dims, or any 768-dim model) produced a schema that did not match the vectors,
so inserts and searches failed with a dimension mismatch.

This derives the dimension from `embedder.dimensions` — matching the existing
`pgvector` and `lancedb` vector stores — and raises a clear `ValueError` when the
embedder does not expose a dimension, instead of silently creating a mismatched table.

(Issue number: #8888)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`ruff format --check` / `ruff check` pass on changed files)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — n/a, no example touches this path
- [x] Tested in clean environment (`uv run pytest`, Python 3.12)
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach — n/a, no similar PR found
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This PR was generated by an autonomous coding agent (Claude), disclosed here per this
checklist. The fix, tests, and verification below were produced and checked by the
agent; a human reviewed the diff before submission.

Backward compatible for the common case: the default `OpenAIEmbedder` resolves to
1536 dims, and embedder subclasses already carry `dimensions`. Two unit tests were
added to `test_cassandra.py`:

- `test_vector_dimension_matches_embedder` — asserts the table is created with the
  embedder's actual dimension (1536 in the test), not the old hardcoded 1024.
- `test_missing_embedder_dimensions_raises` — asserts a clear `ValueError` when
  `embedder.dimensions` is `None`.

Both were independently confirmed to fail against the pre-fix code and pass with the
fix. Full `test_cassandra.py` suite: 22 passed (20 existing + 2 new).

Fixes #8888
