### PR TITLE
fix: derive Cassandra vector_dimension from the embedder

### DIFF
--- a/libs/agno/agno/vectordb/cassandra/cassandra.py
+++ b/libs/agno/agno/vectordb/cassandra/cassandra.py
@@ -38,6 +38,11 @@ class Cassandra(VectorDb):
 
         self.table_name: str = table_name
         self.embedder: Embedder = embedder
+        self.dimensions: Optional[int] = self.embedder.dimensions
+
+        if self.dimensions is None:
+            raise ValueError("Embedder.dimensions must be set.")
+
         self.session = session
         self.keyspace: str = keyspace
         self.initialize_table()
@@ -46,7 +51,7 @@ class Cassandra(VectorDb):
         self.table = AgnoMetadataVectorCassandraTable(
             session=self.session,
             keyspace=self.keyspace,
-            vector_dimension=1024,
+            vector_dimension=self.dimensions,
             table=self.table_name,
             primary_key_type="TEXT",
         )

--- a/libs/agno/tests/unit/vectordb/test_cassandra.py
+++ b/libs/agno/tests/unit/vectordb/test_cassandra.py
@@ -80,6 +80,37 @@ def test_initialization(mock_session):
         Cassandra(table_name="test_vectors", keyspace="test_vectordb", session=None)
 
 
+def test_table_uses_embedder_dimensions(mock_session):
+    """vector_dimension must come from the embedder, not a hardcoded value."""
+    embedder = MagicMock()
+    embedder.dimensions = 768
+
+    with patch.object(AgnoMetadataVectorCassandraTable, "__new__", return_value=MagicMock()) as mock_new:
+        db = Cassandra(
+            table_name="test_vectors",
+            keyspace="test_vectordb",
+            embedder=embedder,
+            session=mock_session,
+        )
+
+    assert db.dimensions == 768
+    assert mock_new.call_args.kwargs["vector_dimension"] == 768
+
+
+def test_missing_embedder_dimensions_raises(mock_session):
+    """A None embedder dimension must fail loudly instead of silently mis-sizing the table."""
+    embedder = MagicMock()
+    embedder.dimensions = None
+
+    with pytest.raises(ValueError):
+        Cassandra(
+            table_name="test_vectors",
+            keyspace="test_vectordb",
+            embedder=embedder,
+            session=mock_session,
+        )
+
+
 def test_insert_and_search(vector_db, mock_table):
     """Test document insertion and search functionality."""
     docs = create_test_documents(1)


### PR DESCRIPTION
## Summary

The Cassandra vector store hardcoded `vector_dimension=1024` in `initialize_table()`. Any embedder whose output size differs — `text-embedding-3-small` (1536), a 768-dim model, etc. — produced a mis-sized schema, and every vector insert/search then failed with a dimension mismatch.

This reads the dimension from `self.embedder.dimensions` instead, matching the pattern already used by the pgvector and lancedb stores, and raises a clear `ValueError` if the embedder does not expose a dimension.

Fixes #8888

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have added tests that prove my fix is effective
- [x] Existing unit tests pass locally with my changes

## Tests

Added `test_table_uses_embedder_dimensions` (a 768-dim embedder yields `vector_dimension=768` on the table) and `test_missing_embedder_dimensions_raises`. Full file passes:

```
libs/agno/tests/unit/vectordb/test_cassandra.py .... 22 passed
```