### PR TITLE
fix: copy user_input_schema per HITL tool call

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -2,6 +2,7 @@ import asyncio
 import collections.abc
 import json
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass, field
 from hashlib import md5
 from pathlib import Path
@@ -2347,7 +2348,10 @@ class Model(ABC):
 
             # The function requires user input (HITL)
             if fc.function.requires_user_input:
-                user_input_schema = fc.function.user_input_schema
+                # Copy the schema: the Function object is shared between parallel
+                # calls to the same tool, so writing values on it directly would
+                # leak one call's values into every other call's requirement.
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:
@@ -2544,7 +2548,10 @@ class Model(ABC):
                 )
             # If the function requires user input, we yield a message to the user
             if fc.function.requires_user_input and not skip_pause_check:
-                user_input_schema = fc.function.user_input_schema
+                # Copy the schema: the Function object is shared between parallel
+                # calls to the same tool, so writing values on it directly would
+                # leak one call's values into every other call's requirement.
+                user_input_schema = deepcopy(fc.function.user_input_schema)
                 if fc.arguments and user_input_schema:
                     for name, value in fc.arguments.items():
                         for user_input_field in user_input_schema:

--- a/libs/agno/tests/unit/models/test_hitl_user_input_schema.py
+++ b/libs/agno/tests/unit/models/test_hitl_user_input_schema.py
@@ -1,0 +1,79 @@
+"""Parallel HITL calls to the same function must not share one user_input_schema.
+
+The registered Function object is a singleton, so its user_input_schema used to be
+mutated in place by every paused call: with two parallel calls to the same HITL
+function, both paused ToolExecutions ended up pointing at the same schema with
+last-write-wins values.
+"""
+
+from typing import AsyncIterator, Iterator, List
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.tools.function import Function, FunctionCall, UserInputField
+
+
+class _StubModel(Model):
+    """Minimal concrete Model; run_function_calls does not touch provider methods."""
+
+    def invoke(self, *args, **kwargs) -> ModelResponse:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs) -> ModelResponse:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs) -> Iterator[ModelResponse]:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs) -> AsyncIterator[ModelResponse]:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def _parse_provider_response(self, response, **kwargs) -> ModelResponse:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def _parse_provider_response_delta(self, response) -> ModelResponse:  # pragma: no cover - unused
+        raise NotImplementedError
+
+
+def _make_hitl_function() -> Function:
+    def submit_comment(content: str) -> str:  # pragma: no cover - never executed
+        return content
+
+    function = Function.from_callable(submit_comment)
+    function.requires_user_input = True
+    function.user_input_schema = [UserInputField(name="content", field_type=str, description="msg")]
+    return function
+
+
+def _paused_executions(model: _StubModel, function_calls: List[FunctionCall]) -> list:
+    tool_executions = []
+    for response in model.run_function_calls(function_calls=function_calls, function_call_results=[]):
+        if (
+            isinstance(response, ModelResponse)
+            and response.event == ModelResponseEvent.tool_call_paused.value
+            and response.tool_executions
+        ):
+            tool_executions.extend(response.tool_executions)
+    return tool_executions
+
+
+def test_parallel_hitl_calls_get_independent_user_input_schemas():
+    model = _StubModel(id="stub")
+    function = _make_hitl_function()
+
+    calls = [
+        FunctionCall(function=function, arguments={"content": "1"}, call_id="call_1"),
+        FunctionCall(function=function, arguments={"content": "2"}, call_id="call_2"),
+    ]
+
+    executions = _paused_executions(model, calls)
+
+    assert len(executions) == 2
+    first, second = executions
+    assert first.user_input_schema is not second.user_input_schema
+    assert {f.name: f.value for f in first.user_input_schema} == {"content": "1"}
+    assert {f.name: f.value for f in second.user_input_schema} == {"content": "2"}
+
+    # The registered Function's own schema must stay untouched.
+    assert function.user_input_schema is not None
+    assert [f.value for f in function.user_input_schema] == [None]


### PR DESCRIPTION
## Summary

When the model emits two or more parallel tool calls to the same HITL function (`requires_user_input=True`), all paused `ToolExecution`s end up sharing one `user_input_schema` with last-write-wins values: the schema lives on the registered (singleton) `Function` object, and both `run_function_calls` and `arun_function_calls` write argument values into it in place. A frontend that renders one form per paused requirement shows the last call's values on every form (e.g. `submit_comment(content="1")` and `submit_comment(content="2")` both display `content="2"`).

The fix deep-copies the schema per call before filling in values, in both the sync and async paths, so each paused `ToolExecution` carries its own schema. The resume path (`agent/_tools.py`) reads the schema from the `ToolExecution`, not the `Function`, so continue/resume behavior is unchanged. The registered `Function`'s own schema no longer gets mutated at all.

Fixes #8546

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project (ruff format + ruff check pass on the touched files)
- [x] I have added tests that prove my fix is effective
- [x] Existing unit tests pass locally with my changes

## Tests

Added `libs/agno/tests/unit/models/test_hitl_user_input_schema.py`: drives `run_function_calls` on a stub model with two parallel calls to one HITL function and asserts the two paused executions carry distinct schemas with their own values (`content="1"` / `content="2"`), and that the registered Function's schema stays untouched.

```
test_hitl_user_input_schema.py::test_parallel_hitl_calls_get_independent_user_input_schemas PASSED
```