### PR TITLE
fix: _extract_json_objects corrupts brace-depth on literal brace in string value

### DIFF
--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -70,7 +70,20 @@ def _extract_json_objects(text: str) -> list[str]:
     objs: list[str] = []
     brace_depth = 0
     start_idx: Optional[int] = None
+    in_string = False
+    escape_next = False
     for idx, ch in enumerate(text):
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\" and in_string:
+            escape_next = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
         if ch == "{" and brace_depth == 0:
             start_idx = idx
         if ch == "{":

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -2,7 +2,13 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from agno.utils.string import generate_id_from_name, parse_response_model_str, sanitize_postgres_string, url_safe_string
+from agno.utils.string import (
+    _extract_json_objects,
+    generate_id_from_name,
+    parse_response_model_str,
+    sanitize_postgres_string,
+    url_safe_string,
+)
 
 
 def test_url_safe_string_spaces():
@@ -142,6 +148,39 @@ def test_parse_json_with_quotes_in_values():
     assert result is not None
     assert result.name == 'test "quoted" text'
     assert result.value == 'some "quoted" value'
+
+
+def test_extract_json_objects_brace_inside_string_value():
+    """A literal '}' inside a string value must not corrupt brace-depth
+    tracking and truncate the object early (issue #8839)."""
+    content = '{"name": "a } braced value", "value": "123"}'
+    objs = _extract_json_objects(content)
+    assert objs == [content]
+
+
+def test_extract_json_objects_open_brace_inside_string_value():
+    """Same as above but with a literal '{' inside the string value."""
+    content = '{"name": "a { braced value", "value": "123"}'
+    objs = _extract_json_objects(content)
+    assert objs == [content]
+
+
+def test_extract_json_objects_escaped_quote_inside_string_value():
+    """An escaped quote inside a string must not be treated as the end of
+    the string (which would then miscount a later brace as unquoted)."""
+    content = r'{"name": "esc\"aped } quote", "value": "123"}'
+    objs = _extract_json_objects(content)
+    assert objs == [content]
+
+
+def test_parse_json_with_brace_in_value():
+    """End-to-end: a value containing a brace character should not corrupt
+    the JSON object and lose subsequent fields (issue #8839)."""
+    content = '{"name": "a } braced value", "value": "123"}'
+    result = parse_response_model_str(content, MockModel)
+    assert result is not None
+    assert result.name == "a } braced value"
+    assert result.value == "123"
 
 
 def test_parse_json_with_missing_required_field():


### PR DESCRIPTION
## Summary
Fixes #8839. `_extract_json_objects` in `libs/agno/agno/utils/string.py` counted `{`/`}` characters found inside quoted string *values* as structural JSON braces. A value like `"a } braced value"` would close the object early, truncating the extracted JSON and dropping any fields that followed.

The fix tracks in-string / escaped-quote state while scanning so braces inside quoted strings are ignored for depth-counting purposes.

## Test plan
- [x] Added unit tests covering: literal `}` in a string value, literal `{` in a string value, and an escaped `\"` inside a string value not being mistaken for the string terminator
- [x] Added an end-to-end test via `parse_response_model_str` confirming a value containing a brace no longer corrupts parsing or drops subsequent fields
- [x] `pytest libs/agno/tests/unit/utils/test_string.py` — 40 passed
- [x] `pytest libs/agno/tests/unit/utils/` (full dir) — no new failures introduced (3 pre-existing failures in `test_claude.py` are unrelated Windows CRLF line-ending issues, reproducible on `main` without this change)