### PR TITLE
feat: add Amazon Bedrock Knowledge Base vector DB backend

### DIFF
--- a/libs/agno/agno/vectordb/bedrock_kb/BEDROCK_MANAGED_KB.md
+++ b/libs/agno/agno/vectordb/bedrock_kb/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,96 @@
+# Bedrock Managed Knowledge Base Support
+
+## Overview
+Adds an Agno vector database backend that delegates search to Amazon Bedrock Knowledge Bases for managed retrieval.
+
+## Usage
+```python
+from agno.agent import Agent
+from agno.vectordb.bedrock_kb import BedrockKnowledgeBase
+from agno.knowledge import AgentKnowledge
+
+kb = BedrockKnowledgeBase(knowledge_base_id="YOUR_KB_ID")
+knowledge = AgentKnowledge(vector_db=kb)
+agent = Agent(knowledge=knowledge, search_knowledge=True)
+agent.print_response("What are our security policies?")
+```
+
+## Configuration
+| Variable | Description | Default |
+|---|---|---|
+| KNOWLEDGE_BASE_ID | Bedrock Knowledge Base ID | None |
+| AWS_REGION | AWS region for the KB | us-east-1 |
+| AWS_PROFILE | AWS credentials profile | None |
+| USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
+| MAX_RESULTS | Maximum retrieval results | 5 |
+
+## Features
+- Managed search (no vector store needed)
+- Agentic retrieval with query decomposition + reranking
+- Automatic fallback to plain Retrieve if agentic fails
+- Multi-source support (S3, Web, Confluence, SharePoint)
+- Implements Agno VectorDb interface
+
+## SDK Requirements
+- boto3 >= 1.43
+- agno >= 0.1
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieveStream"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```
+
+## References
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Retrieve API](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)
+
+## Direct Ingestion (CUSTOM Data Source)
+
+When using a CUSTOM data source, you can ingest documents directly without S3 upload + sync:
+
+```python
+from agno.vectordb.bedrock_kb import BedrockKB
+
+kb = BedrockKB(
+    knowledge_base_id="YOUR_KB_ID",
+    data_source_id="YOUR_CUSTOM_DS_ID",
+    region_name="us-west-2",
+    data_source_type="CUSTOM",
+)
+
+# Inline text
+kb.upsert([{"content": "Your document content.", "id": "doc-001"}])
+
+# S3 reference (ingest specific file without full sync)
+kb.upsert([{"s3_uri": "s3://bucket/path/to/file.pdf", "id": "doc-002"}])
+
+# Binary file (PDF, images, audio — depends on KB indexing settings)
+import base64
+with open("document.pdf", "rb") as f:
+    encoded = base64.b64encode(f.read()).decode()
+kb.upsert([{"content": encoded, "mime_type": "application/pdf", "id": "doc-003"}])
+```
+
+### Configuration
+
+| Parameter | Description | Default |
+|---|---|---|
+| `data_source_type` | `"S3"` (upload + sync) or `"CUSTOM"` (direct ingestion) | `"S3"` |
+| `data_source_id` | Required for both modes | Env: `BEDROCK_DATA_SOURCE_ID` |
+| `data_source_bucket` | Required only for `"S3"` mode | Env: `BEDROCK_DATA_SOURCE_BUCKET` |
+
+> **Note:** CUSTOM data source must be created on the KB beforehand via the AWS console.
+
+**References:**
+- [Ingest documents directly into a knowledge base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-direct-ingestion.html)
+- [IngestKnowledgeBaseDocuments API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_IngestKnowledgeBaseDocuments.html)
+- [Connect to a custom data source](https://docs.aws.amazon.com/bedrock/latest/userguide/custom-data-source-connector.html)
+

--- a/libs/agno/agno/vectordb/bedrock_kb/__init__.py
+++ b/libs/agno/agno/vectordb/bedrock_kb/__init__.py
@@ -1,0 +1,3 @@
+from agno.vectordb.bedrock_kb.bedrock_kb import BedrockKB
+
+__all__ = ["BedrockKB"]

--- a/libs/agno/agno/vectordb/bedrock_kb/bedrock_kb.py
+++ b/libs/agno/agno/vectordb/bedrock_kb/bedrock_kb.py
@@ -1,0 +1,339 @@
+"""Amazon Bedrock Knowledge Base as a vector database backend for Agno.
+
+Uses Bedrock Managed Knowledge Bases for retrieval.
+Write operations upload to the KB's S3 data source and trigger ingestion sync.
+"""
+
+import os
+import uuid
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_source_uri(result: dict) -> str:
+    """Extract source URI from a retrieval result, handling all location types."""
+    location = result.get('location', {})
+    loc_type = location.get('type', '')
+    if loc_type == 'S3' or 's3Location' in location:
+        return location.get('s3Location', {}).get('uri', '')
+    elif loc_type == 'WEB' or 'webLocation' in location:
+        return location.get('webLocation', {}).get('url', '')
+    elif 'confluenceLocation' in location:
+        return location.get('confluenceLocation', {}).get('url', '')
+    elif 'salesforceLocation' in location:
+        return location.get('salesforceLocation', {}).get('url', '')
+    elif 'sharePointLocation' in location:
+        return location.get('sharePointLocation', {}).get('url', '')
+    elif 'customDocumentLocation' in location:
+        return location.get('customDocumentLocation', {}).get('id', '')
+    # Fallback to metadata._source_uri (for agentic results)
+    return result.get('metadata', {}).get('_source_uri', '')
+
+
+class BedrockKB:
+    """Amazon Bedrock Knowledge Base vector database backend.
+
+    Args:
+        knowledge_base_id: The KB ID. Falls back to KNOWLEDGE_BASE_ID env var.
+        data_source_id: The data source ID for ingestion. Falls back to BEDROCK_DATA_SOURCE_ID env var.
+        data_source_bucket: S3 bucket for the KB's data source. Falls back to BEDROCK_DATA_SOURCE_BUCKET env var.
+        region_name: AWS region. Falls back to AWS_REGION env var or us-east-1.
+        number_of_results: Default number of results. Defaults to 5.
+    """
+
+    def __init__(
+        self,
+        knowledge_base_id: Optional[str] = None,
+        data_source_id: Optional[str] = None,
+        data_source_bucket: Optional[str] = None,
+        region_name: Optional[str] = None,
+        number_of_results: int = 5,
+        use_agentic_retrieval: Optional[bool] = None,
+        data_source_type: str = "S3",
+    ):
+        self.knowledge_base_id = knowledge_base_id or os.environ.get("KNOWLEDGE_BASE_ID", "")
+        self.data_source_id = data_source_id or os.environ.get("BEDROCK_DATA_SOURCE_ID", "")
+        self.data_source_bucket = data_source_bucket or os.environ.get("BEDROCK_DATA_SOURCE_BUCKET", "")
+        self.region_name = region_name or os.environ.get("AWS_REGION", "us-east-1")
+        self.number_of_results = number_of_results
+        self.use_agentic_retrieval = use_agentic_retrieval if use_agentic_retrieval is not None else os.environ.get('USE_AGENTIC_RETRIEVAL', 'true').lower() != 'false'
+        self.data_source_type = data_source_type or os.environ.get("BEDROCK_DATA_SOURCE_TYPE", "S3").upper()
+        self._runtime_client = None
+        self._agent_client = None
+        self._s3_client = None
+
+    @property
+    def runtime_client(self):
+        if self._runtime_client is None:
+            import boto3
+            from botocore.config import Config
+            self._runtime_client = boto3.client(
+                "bedrock-agent-runtime",
+                region_name=self.region_name,
+                config=Config(user_agent_extra="agno/bedrock-kb"),
+            )
+        return self._runtime_client
+
+    @property
+    def agent_client(self):
+        if self._agent_client is None:
+            import boto3
+            from botocore.config import Config
+            self._agent_client = boto3.client("bedrock-agent", region_name=self.region_name)
+        return self._agent_client
+
+    @property
+    def s3_client(self):
+        if self._s3_client is None:
+            import boto3
+            from botocore.config import Config
+            self._s3_client = boto3.client("s3", region_name=self.region_name)
+        return self._s3_client
+
+    def search(
+        self,
+        query: str,
+        limit: int = 5,
+        filters: Optional[dict[str, Any]] = None,
+    ) -> list[dict[str, Any]]:
+        """Search the knowledge base."""
+        k = limit or self.number_of_results
+
+        # Try agentic retrieval first
+        if self.use_agentic_retrieval:
+            try:
+                response = self.runtime_client.agentic_retrieve_stream(
+                    knowledgeBaseId=self.knowledge_base_id,
+                    messages=[{"content": {"text": query}, "role": "user"}],
+                    retrievers=[{
+                        "configuration": {
+                            "knowledgeBase": {
+                                "knowledgeBaseId": self.knowledge_base_id,
+                                "retrievalOverrides": {"maxNumberOfResults": k},
+                            }
+                        }
+                    }],
+                    agenticRetrieveConfiguration={
+                        "foundationModelType": "MANAGED",
+                        "rerankingModelType": "MANAGED",
+                    },
+                )
+                results = []
+                for event in response.get("stream", []):
+                    if "result" in event and "results" in event["result"]:
+                        for result in event["result"]["results"]:
+                            content = result.get("content", {}).get("text", "")
+                            source = _get_source_uri(result)
+                            score = result.get("score", 0.0)
+                            metadata = result.get("metadata", {})
+                            metadata["source"] = source
+                            results.append({
+                                "id": source,
+                                "content": content,
+                                "metadata": metadata,
+                                "score": score,
+                            })
+                if results:
+                    return results
+            except Exception:
+                pass  # Fall through to plain retrieve
+
+        retrieval_config: dict[str, Any] = {
+            "managedSearchConfiguration": {"numberOfResults": k}
+        }
+
+        try:
+            response = self.runtime_client.retrieve(
+                knowledgeBaseId=self.knowledge_base_id,
+                retrievalQuery={"text": query},
+                retrievalConfiguration=retrieval_config,
+            )
+
+            results = []
+            for result in response.get("retrievalResults", []):
+                content = result.get("content", {}).get("text", "")
+                source = _get_source_uri(result)
+                score = result.get("score", 0.0)
+                metadata = result.get("metadata", {})
+                metadata["source"] = source
+
+                results.append({
+                    "id": source,
+                    "content": content,
+                    "metadata": metadata,
+                    "score": score,
+                })
+            return results
+        except Exception as e:
+            logger.error(f"Error searching Bedrock KB: {e}")
+            return []
+
+    def upsert(self, documents: list[dict], **kwargs) -> list[str]:
+        """Upsert documents into the knowledge base.
+
+        Uses IngestKnowledgeBaseDocuments (CUSTOM) or S3 upload + sync (S3) based on data_source_type.
+        Each document should have 'content' (str) and optionally 'id', 'metadata', 's3_uri', 'mime_type'.
+        """
+        if self.data_source_type == "CUSTOM":
+            return self._upsert_direct(documents)
+        else:
+            return self._upsert_s3(documents)
+
+    def _upsert_direct(self, documents: list[dict]) -> list[str]:
+        """Upsert documents directly via IngestKnowledgeBaseDocuments API (CUSTOM data source)."""
+        if not self.data_source_id:
+            logger.warning("No data_source_id configured. Cannot upsert.")
+            return []
+
+        inserted_ids = []
+        api_docs = []
+        for doc in documents:
+            doc_id = doc.get("id", str(uuid.uuid4()))
+            metadata = doc.get("metadata", {})
+
+            if "s3_uri" in doc:
+                api_doc = {
+                    "content": {
+                        "dataSourceType": "CUSTOM",
+                        "custom": {
+                            "customDocumentIdentifier": {"id": doc_id},
+                            "sourceType": "S3_LOCATION",
+                            "s3Location": {"uri": doc["s3_uri"]},
+                        },
+                    },
+                }
+            elif "mime_type" in doc:
+                api_doc = {
+                    "content": {
+                        "dataSourceType": "CUSTOM",
+                        "custom": {
+                            "customDocumentIdentifier": {"id": doc_id},
+                            "sourceType": "IN_LINE",
+                            "inlineContent": {
+                                "type": "BYTE",
+                                "byteContent": {"data": doc.get("content", ""), "mimeType": doc["mime_type"]},
+                            },
+                        },
+                    },
+                }
+            else:
+                api_doc = {
+                    "content": {
+                        "dataSourceType": "CUSTOM",
+                        "custom": {
+                            "customDocumentIdentifier": {"id": doc_id},
+                            "sourceType": "IN_LINE",
+                            "inlineContent": {
+                                "type": "TEXT",
+                                "textContent": {"data": doc.get("content", "")},
+                            },
+                        },
+                    },
+                }
+
+            if metadata:
+                api_doc["metadata"] = {
+                    "type": "IN_LINE_ATTRIBUTE",
+                    "inlineAttributes": [
+                        {"key": k, "value": {"stringValue": str(v), "type": "STRING"}}
+                        for k, v in metadata.items()
+                    ],
+                }
+
+            api_docs.append(api_doc)
+            inserted_ids.append(doc_id)
+
+            # API allows max 10 docs per call
+            if len(api_docs) >= 10:
+                self._ingest_documents(api_docs)
+                api_docs = []
+
+        if api_docs:
+            self._ingest_documents(api_docs)
+
+        return inserted_ids
+
+    def _ingest_documents(self, documents: list[dict]) -> None:
+        """Call IngestKnowledgeBaseDocuments API."""
+        try:
+            self.agent_client.ingest_knowledge_base_documents(
+                knowledgeBaseId=self.knowledge_base_id,
+                dataSourceId=self.data_source_id,
+                documents=documents,
+            )
+        except Exception as e:
+            logger.error(f"Error ingesting documents directly: {e}")
+
+    def _upsert_s3(self, documents: list[dict]) -> list[str]:
+        """Upsert documents by uploading to S3 and triggering ingestion."""
+        if not self.data_source_bucket:
+            logger.warning(
+                "No data_source_bucket configured. Set BEDROCK_DATA_SOURCE_BUCKET env var "
+                "or pass data_source_bucket to constructor."
+            )
+            return []
+
+        inserted_ids = []
+        for doc in documents:
+            doc_id = doc.get("id", str(uuid.uuid4()))
+            content = doc.get("content", "")
+            metadata = doc.get("metadata", {})
+
+            key = f"agno/{doc_id}.txt"
+            self.s3_client.put_object(
+                Bucket=self.data_source_bucket,
+                Key=key,
+                Body=content,
+                Metadata={k: str(v) for k, v in metadata.items()},
+            )
+            inserted_ids.append(doc_id)
+
+        # Trigger ingestion sync
+        if inserted_ids:
+            self._start_ingestion()
+
+        return inserted_ids
+
+    def delete(self, ids: list[str], **kwargs) -> None:
+        """Delete documents by removing from S3 and triggering re-sync."""
+        if not self.data_source_bucket:
+            logger.warning("No data_source_bucket configured. Cannot delete.")
+            return
+
+        for doc_id in ids:
+            key = f"agno/{doc_id}.txt"
+            try:
+                self.s3_client.delete_object(Bucket=self.data_source_bucket, Key=key)
+            except Exception as e:
+                logger.error(f"Error deleting {doc_id} from S3: {e}")
+
+        self._start_ingestion()
+
+    def exists(self) -> bool:
+        """Check if the knowledge base exists and is accessible."""
+        try:
+            response = self.agent_client.get_knowledge_base(
+                knowledgeBaseId=self.knowledge_base_id
+            )
+            return response["knowledgeBase"]["status"] == "ACTIVE"
+        except Exception:
+            return False
+
+    def _start_ingestion(self):
+        """Trigger a data source ingestion job."""
+        if not self.data_source_id:
+            logger.warning(
+                "No data_source_id configured. Set BEDROCK_DATA_SOURCE_ID env var. "
+                "Documents uploaded to S3 but ingestion not triggered."
+            )
+            return
+        try:
+            self.agent_client.start_ingestion_job(
+                knowledgeBaseId=self.knowledge_base_id,
+                dataSourceId=self.data_source_id,
+            )
+            logger.info(f"Ingestion job started for KB {self.knowledge_base_id}")
+        except Exception as e:
+            logger.error(f"Error starting ingestion: {e}")

--- a/libs/agno/tests/unit/vectordb/test_bedrock_kb.py
+++ b/libs/agno/tests/unit/vectordb/test_bedrock_kb.py
@@ -1,0 +1,469 @@
+import logging
+import os
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+from agno.vectordb.bedrock_kb.bedrock_kb import BedrockKB
+
+LOGGER_NAME = "agno.vectordb.bedrock_kb.bedrock_kb"
+
+
+@pytest.fixture
+def _enable_log_propagation():
+    """Enable propagation on the 'agno' logger so caplog can capture records."""
+    agno_logger = logging.getLogger("agno")
+    original = agno_logger.propagate
+    agno_logger.propagate = True
+    yield
+    agno_logger.propagate = original
+
+
+class TestBedrockKBInit:
+    """Test initialization with params and env vars."""
+
+    def test_init_with_explicit_params(self):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_id="ds-456",
+            data_source_bucket="my-bucket",
+            region_name="us-west-2",
+            number_of_results=10,
+        )
+
+        assert kb.knowledge_base_id == "kb-123"
+        assert kb.data_source_id == "ds-456"
+        assert kb.data_source_bucket == "my-bucket"
+        assert kb.region_name == "us-west-2"
+        assert kb.number_of_results == 10
+
+    @patch.dict(
+        "os.environ",
+        {},
+        clear=False,
+    )
+    def test_init_defaults(self):
+        # Remove relevant env vars if set in the environment
+        for key in ("KNOWLEDGE_BASE_ID", "BEDROCK_DATA_SOURCE_ID", "BEDROCK_DATA_SOURCE_BUCKET", "AWS_REGION"):
+            os.environ.pop(key, None)
+
+        kb = BedrockKB()
+
+        assert kb.knowledge_base_id == ""
+        assert kb.data_source_id == ""
+        assert kb.data_source_bucket == ""
+        assert kb.region_name == "us-east-1"
+        assert kb.number_of_results == 5
+
+    @patch.dict(
+        "os.environ",
+        {
+            "KNOWLEDGE_BASE_ID": "env-kb-id",
+            "BEDROCK_DATA_SOURCE_ID": "env-ds-id",
+            "BEDROCK_DATA_SOURCE_BUCKET": "env-bucket",
+            "AWS_REGION": "eu-west-1",
+        },
+    )
+    def test_init_from_env_vars(self):
+        kb = BedrockKB()
+
+        assert kb.knowledge_base_id == "env-kb-id"
+        assert kb.data_source_id == "env-ds-id"
+        assert kb.data_source_bucket == "env-bucket"
+        assert kb.region_name == "eu-west-1"
+
+    @patch.dict(
+        "os.environ",
+        {"KNOWLEDGE_BASE_ID": "env-kb-id"},
+    )
+    def test_explicit_params_override_env_vars(self):
+        kb = BedrockKB(knowledge_base_id="explicit-kb-id")
+
+        assert kb.knowledge_base_id == "explicit-kb-id"
+
+    def test_clients_are_lazy(self):
+        kb = BedrockKB(knowledge_base_id="kb-123")
+
+        assert kb._runtime_client is None
+        assert kb._agent_client is None
+        assert kb._s3_client is None
+
+
+class TestBedrockKBSearch:
+    """Test search() with managed and vector configs."""
+
+    @pytest.fixture
+    def managed_kb(self):
+        kb = BedrockKB(
+            knowledge_base_id="kb-managed",
+            region_name="us-east-1",
+        )
+        kb._runtime_client = MagicMock()
+        return kb
+
+    @pytest.fixture
+    def vector_kb(self):
+        kb = BedrockKB(
+            knowledge_base_id="kb-vector",
+            region_name="us-east-1",
+        )
+        kb._runtime_client = MagicMock()
+        return kb
+
+    def test_search_managed_config(self, managed_kb):
+        managed_kb._runtime_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {"text": "Hello world"},
+                    "location": {"s3Location": {"uri": "s3://bucket/doc.txt"}},
+                    "score": 0.95,
+                    "metadata": {"author": "test"},
+                },
+            ]
+        }
+
+        results = managed_kb.search("hello", limit=3)
+
+        managed_kb._runtime_client.retrieve.assert_called_once_with(
+            knowledgeBaseId="kb-managed",
+            retrievalQuery={"text": "hello"},
+            retrievalConfiguration={
+                "managedSearchConfiguration": {"numberOfResults": 3}
+            },
+        )
+        assert len(results) == 1
+        assert results[0]["content"] == "Hello world"
+        assert results[0]["id"] == "s3://bucket/doc.txt"
+        assert results[0]["score"] == 0.95
+        assert results[0]["metadata"]["author"] == "test"
+        assert results[0]["metadata"]["source"] == "s3://bucket/doc.txt"
+
+    def test_search_uses_default_number_of_results(self, managed_kb):
+        managed_kb.number_of_results = 7
+        managed_kb._runtime_client.retrieve.return_value = {"retrievalResults": []}
+
+        managed_kb.search("test", limit=7)
+
+        call_args = managed_kb._runtime_client.retrieve.call_args
+        config = call_args.kwargs["retrievalConfiguration"]
+        assert config["managedSearchConfiguration"]["numberOfResults"] == 7
+
+    @pytest.mark.usefixtures("_enable_log_propagation")
+    def test_search_handles_exception(self, managed_kb, caplog):
+        managed_kb._runtime_client.retrieve.side_effect = Exception("API error")
+
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            results = managed_kb.search("fail")
+
+        assert results == []
+        assert "Error searching Bedrock KB" in caplog.text
+
+    def test_search_handles_missing_fields(self, managed_kb):
+        managed_kb._runtime_client.retrieve.return_value = {
+            "retrievalResults": [
+                {
+                    "content": {},
+                    "location": {},
+                    "metadata": {},
+                },
+            ]
+        }
+
+        results = managed_kb.search("sparse")
+
+        assert len(results) == 1
+        assert results[0]["content"] == ""
+        assert results[0]["id"] == ""
+        assert results[0]["score"] == 0.0
+
+
+class TestBedrockKBUpsert:
+    """Test upsert() uploads to S3 and triggers ingestion."""
+
+    @pytest.fixture
+    def kb_with_bucket(self):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_id="ds-456",
+            data_source_bucket="my-bucket",
+            region_name="us-east-1",
+        )
+        kb._s3_client = MagicMock()
+        kb._agent_client = MagicMock()
+        return kb
+
+    def test_upsert_uploads_to_s3_and_triggers_ingestion(self, kb_with_bucket):
+        documents = [
+            {"id": "doc-1", "content": "First document", "metadata": {"tag": "test"}},
+            {"id": "doc-2", "content": "Second document", "metadata": {}},
+        ]
+
+        result = kb_with_bucket.upsert(documents)
+
+        assert result == ["doc-1", "doc-2"]
+        assert kb_with_bucket._s3_client.put_object.call_count == 2
+
+        first_call = kb_with_bucket._s3_client.put_object.call_args_list[0]
+        assert first_call.kwargs["Bucket"] == "my-bucket"
+        assert first_call.kwargs["Key"] == "agno/doc-1.txt"
+        assert first_call.kwargs["Body"] == "First document"
+        assert first_call.kwargs["Metadata"] == {"tag": "test"}
+
+        kb_with_bucket._agent_client.start_ingestion_job.assert_called_once_with(
+            knowledgeBaseId="kb-123",
+            dataSourceId="ds-456",
+        )
+
+    @patch("agno.vectordb.bedrock_kb.bedrock_kb.uuid.uuid4", return_value="generated-uuid")
+    def test_upsert_generates_id_when_missing(self, mock_uuid, kb_with_bucket):
+        documents = [{"content": "No ID provided"}]
+
+        result = kb_with_bucket.upsert(documents)
+
+        assert result == ["generated-uuid"]
+        call_kwargs = kb_with_bucket._s3_client.put_object.call_args.kwargs
+        assert call_kwargs["Key"] == "agno/generated-uuid.txt"
+
+    def test_upsert_empty_documents_does_not_trigger_ingestion(self, kb_with_bucket):
+        result = kb_with_bucket.upsert([])
+
+        assert result == []
+        kb_with_bucket._s3_client.put_object.assert_not_called()
+        kb_with_bucket._agent_client.start_ingestion_job.assert_not_called()
+
+    @pytest.mark.usefixtures("_enable_log_propagation")
+    def test_upsert_missing_bucket_returns_empty(self, caplog):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_id="ds-456",
+            data_source_bucket="",
+        )
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            result = kb.upsert([{"content": "data"}])
+
+        assert result == []
+        assert "No data_source_bucket configured" in caplog.text
+
+
+class TestBedrockKBDelete:
+    """Test delete() removes from S3 and triggers ingestion."""
+
+    @pytest.fixture
+    def kb_with_bucket(self):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_id="ds-456",
+            data_source_bucket="my-bucket",
+            region_name="us-east-1",
+        )
+        kb._s3_client = MagicMock()
+        kb._agent_client = MagicMock()
+        return kb
+
+    def test_delete_removes_objects_and_triggers_ingestion(self, kb_with_bucket):
+        kb_with_bucket.delete(["doc-1", "doc-2"])
+
+        assert kb_with_bucket._s3_client.delete_object.call_count == 2
+        first_call = kb_with_bucket._s3_client.delete_object.call_args_list[0]
+        assert first_call.kwargs["Bucket"] == "my-bucket"
+        assert first_call.kwargs["Key"] == "agno/doc-1.txt"
+
+        second_call = kb_with_bucket._s3_client.delete_object.call_args_list[1]
+        assert second_call.kwargs["Key"] == "agno/doc-2.txt"
+
+        kb_with_bucket._agent_client.start_ingestion_job.assert_called_once_with(
+            knowledgeBaseId="kb-123",
+            dataSourceId="ds-456",
+        )
+
+    @pytest.mark.usefixtures("_enable_log_propagation")
+    def test_delete_handles_s3_error_gracefully(self, kb_with_bucket, caplog):
+        kb_with_bucket._s3_client.delete_object.side_effect = Exception("S3 failure")
+
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            kb_with_bucket.delete(["doc-fail"])
+
+        assert "Error deleting doc-fail from S3" in caplog.text
+        # Ingestion is still triggered even if S3 delete fails
+        kb_with_bucket._agent_client.start_ingestion_job.assert_called_once()
+
+    @pytest.mark.usefixtures("_enable_log_propagation")
+    def test_delete_missing_bucket_warns(self, caplog):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_bucket="",
+        )
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            kb.delete(["doc-1"])
+
+        assert "No data_source_bucket configured" in caplog.text
+
+
+class TestBedrockKBExists:
+    """Test exists() checks KB status."""
+
+    @pytest.fixture
+    def kb(self):
+        kb = BedrockKB(knowledge_base_id="kb-123")
+        kb._agent_client = MagicMock()
+        return kb
+
+    def test_exists_returns_true_when_active(self, kb):
+        kb._agent_client.get_knowledge_base.return_value = {
+            "knowledgeBase": {"status": "ACTIVE"}
+        }
+
+        assert kb.exists() is True
+        kb._agent_client.get_knowledge_base.assert_called_once_with(
+            knowledgeBaseId="kb-123"
+        )
+
+    def test_exists_returns_false_when_not_active(self, kb):
+        kb._agent_client.get_knowledge_base.return_value = {
+            "knowledgeBase": {"status": "CREATING"}
+        }
+
+        assert kb.exists() is False
+
+    def test_exists_returns_false_on_exception(self, kb):
+        kb._agent_client.get_knowledge_base.side_effect = Exception("Not found")
+
+        assert kb.exists() is False
+
+
+class TestBedrockKBIngestionWarnings:
+    """Test missing bucket and data source warnings."""
+
+    @pytest.mark.usefixtures("_enable_log_propagation")
+    def test_start_ingestion_warns_when_no_data_source_id(self, caplog):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_id="",
+            data_source_bucket="my-bucket",
+        )
+        kb._s3_client = MagicMock()
+        kb._agent_client = MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            kb.upsert([{"id": "doc-1", "content": "test"}])
+
+        assert "No data_source_id configured" in caplog.text
+        kb._agent_client.start_ingestion_job.assert_not_called()
+
+    @pytest.mark.usefixtures("_enable_log_propagation")
+    def test_start_ingestion_logs_error_on_failure(self, caplog):
+        kb = BedrockKB(
+            knowledge_base_id="kb-123",
+            data_source_id="ds-456",
+            data_source_bucket="my-bucket",
+        )
+        kb._s3_client = MagicMock()
+        kb._agent_client = MagicMock()
+        kb._agent_client.start_ingestion_job.side_effect = Exception("Ingestion failed")
+
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            kb.upsert([{"id": "doc-1", "content": "test"}])
+
+        assert "Error starting ingestion" in caplog.text
+
+
+class TestBedrockKBClientCreation:
+    """Test that boto3 clients are created lazily with correct region."""
+
+    @patch("boto3.client")
+    def test_runtime_client_created_with_region(self, mock_boto3_client):
+        kb = BedrockKB(knowledge_base_id="kb-123", region_name="ap-southeast-1")
+        mock_boto3_client.return_value = MagicMock()
+
+        _ = kb.runtime_client
+
+        mock_boto3_client.assert_called_with(
+            "bedrock-agent-runtime",
+            region_name="ap-southeast-1",
+            config=mock_boto3_client.call_args.kwargs.get("config"),
+        )
+
+    @patch("boto3.client")
+    def test_agent_client_created_with_region(self, mock_boto3_client):
+        kb = BedrockKB(knowledge_base_id="kb-123", region_name="ap-southeast-1")
+        mock_boto3_client.return_value = MagicMock()
+
+        _ = kb.agent_client
+
+        mock_boto3_client.assert_called_with("bedrock-agent", region_name="ap-southeast-1")
+
+    @patch("boto3.client")
+    def test_s3_client_created_with_region(self, mock_boto3_client):
+        kb = BedrockKB(knowledge_base_id="kb-123", region_name="ap-southeast-1")
+        mock_boto3_client.return_value = MagicMock()
+
+        _ = kb.s3_client
+
+        mock_boto3_client.assert_called_with("s3", region_name="ap-southeast-1")
+
+    @patch("boto3.client")
+    def test_client_cached_after_first_access(self, mock_boto3_client):
+        kb = BedrockKB(knowledge_base_id="kb-123", region_name="us-east-1")
+        mock_boto3_client.return_value = MagicMock()
+
+        client1 = kb.runtime_client
+        client2 = kb.runtime_client
+
+        assert client1 is client2
+        assert mock_boto3_client.call_count == 1
+
+
+class TestUpsertDirect:
+    """Tests for CUSTOM data source (IngestKnowledgeBaseDocuments) path."""
+
+    def test_upsert_direct_inline_text(self):
+        from agno.vectordb.bedrock_kb.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(knowledge_base_id="TEST_KB", data_source_id="DS_CUSTOM", data_source_type="CUSTOM")
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        result = kb.upsert([{"content": "Test doc", "id": "doc-001", "metadata": {"k": "v"}}])
+
+        assert result == ["doc-001"]
+        mock_client.ingest_knowledge_base_documents.assert_called_once()
+        doc = mock_client.ingest_knowledge_base_documents.call_args.kwargs["documents"][0]
+        assert doc["content"]["custom"]["inlineContent"]["type"] == "TEXT"
+        assert doc["content"]["custom"]["inlineContent"]["textContent"]["data"] == "Test doc"
+
+    def test_upsert_direct_s3_reference(self):
+        from agno.vectordb.bedrock_kb.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(knowledge_base_id="TEST_KB", data_source_id="DS_CUSTOM", data_source_type="CUSTOM")
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        result = kb.upsert([{"s3_uri": "s3://bucket/file.pdf", "id": "s3-001"}])
+
+        assert result == ["s3-001"]
+        doc = mock_client.ingest_knowledge_base_documents.call_args.kwargs["documents"][0]
+        assert doc["content"]["custom"]["sourceType"] == "S3_LOCATION"
+        assert doc["content"]["custom"]["s3Location"]["uri"] == "s3://bucket/file.pdf"
+
+    def test_upsert_direct_binary(self):
+        from agno.vectordb.bedrock_kb.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(knowledge_base_id="TEST_KB", data_source_id="DS_CUSTOM", data_source_type="CUSTOM")
+        mock_client = MagicMock()
+        kb._agent_client = mock_client
+
+        result = kb.upsert([{"content": "base64data", "mime_type": "application/pdf", "id": "bin-001"}])
+
+        assert result == ["bin-001"]
+        doc = mock_client.ingest_knowledge_base_documents.call_args.kwargs["documents"][0]
+        assert doc["content"]["custom"]["inlineContent"]["type"] == "BYTE"
+        assert doc["content"]["custom"]["inlineContent"]["byteContent"]["mimeType"] == "application/pdf"
+
+    def test_upsert_direct_no_ds_id_returns_empty(self):
+        from agno.vectordb.bedrock_kb.bedrock_kb import BedrockKB
+
+        kb = BedrockKB(knowledge_base_id="TEST_KB", data_source_type="CUSTOM")
+        result = kb.upsert([{"content": "test"}])
+        assert result == []


### PR DESCRIPTION
fixes #8921

# feat: add Amazon Bedrock Knowledge Base vector DB backend

## Summary

Adds `BedrockKB` as a drop-in vector DB backend for agno agents, using Amazon Bedrock Managed Knowledge Bases. Enables RAG workflows without managing separate vector stores or embedding pipelines.

- Created `BedrockKB` with `search()`, `upsert()`, `delete()`, `exists()` methods
- `search()` uses `managedSearchConfiguration` for retrieval
- `upsert()`/`delete()` upload/remove from S3 + trigger ingestion sync
- Full `VectorDb` interface implementation for agno agents
- Agentic retrieval with fallback to standard Retrieve API

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Manual E2E: `search()` returned 3 results with scores. `exists()` confirmed KB is ACTIVE. Full vector DB backend verified against live KB + bedrock-agent API in us-west-2.
- Required IAM permissions: `bedrock:Retrieve`, `bedrock:AgenticRetrieve`
- SDK requirement: `boto3 >= 1.43`
