### PR TITLE
feat: AG-UI workflow progress streaming with STATE_DELTA support

### DIFF
--- a/cookbook/05_agent_os/interfaces/agui/agentic_generative_ui.py
+++ b/cookbook/05_agent_os/interfaces/agui/agentic_generative_ui.py
@@ -89,7 +89,9 @@ def update_plan_step(
 
 agentic_generative_ui_agent = Agent(
     name="agentic_generative_ui",
-    model=OpenAIResponses(id="gpt-5.5"),
+    # Disable parallel tool calls so each update_plan_step is a separate turn,
+    # emitting STATE_DELTA events incrementally instead of in one burst
+    model=OpenAIResponses(id="gpt-5.5", parallel_tool_calls=False),
     db=SqliteDb(db_file="/tmp/agentic_generative_ui.db"),
     tools=[create_plan, update_plan_step],
     instructions="""\

--- a/cookbook/05_agent_os/interfaces/agui/agentic_generative_ui.py
+++ b/cookbook/05_agent_os/interfaces/agui/agentic_generative_ui.py
@@ -1,0 +1,108 @@
+"""
+Agentic Generative UI — Dojo Demo
+=================================
+
+Agent that creates and updates plans with steps, streaming state updates
+to the frontend for rendering a TaskProgress UI.
+
+Uses StateSnapshotEvent and StateDeltaEvent to update the UI state directly
+from tool returns.
+"""
+
+from typing import Any, Literal
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.tools import tool
+from pydantic import BaseModel, Field
+
+StepStatus = Literal["pending", "completed"]
+
+
+class Step(BaseModel):
+    description: str = Field(description="The description of the step")
+    status: StepStatus = Field(default="pending", description="The status of the step")
+
+
+class Plan(BaseModel):
+    steps: list[Step] = Field(default_factory=list, description="The steps in the plan")
+
+
+class JSONPatchOp(BaseModel):
+    op: Literal["add", "remove", "replace", "move", "copy", "test"]
+    path: str
+    value: Any = None
+
+
+@tool
+def create_plan(steps: list[str]) -> dict:
+    """Create a plan with multiple steps.
+
+    Args:
+        steps: List of step descriptions to create the plan.
+
+    Returns:
+        StateSnapshotEvent dict containing the initial state of the steps.
+    """
+    plan = Plan(steps=[Step(description=step) for step in steps])
+    return {
+        "type": "STATE_SNAPSHOT",
+        "snapshot": plan.model_dump(),
+    }
+
+
+@tool
+def update_plan_step(
+    index: int,
+    description: str | None = None,
+    status: StepStatus | None = None,
+) -> dict:
+    """Update a step in the plan.
+
+    Args:
+        index: The index of the step to update.
+        description: The new description for the step.
+        status: The new status for the step (pending or completed).
+
+    Returns:
+        StateDeltaEvent dict containing the JSON patch operations.
+    """
+    changes: list[dict] = []
+    if description is not None:
+        changes.append(
+            {
+                "op": "replace",
+                "path": f"/steps/{index}/description",
+                "value": description,
+            }
+        )
+    if status is not None:
+        changes.append(
+            {"op": "replace", "path": f"/steps/{index}/status", "value": status}
+        )
+    return {
+        "type": "STATE_DELTA",
+        "delta": changes,
+    }
+
+
+agentic_generative_ui_agent = Agent(
+    name="agentic_generative_ui",
+    model=OpenAIResponses(id="gpt-5.5"),
+    db=SqliteDb(db_file="/tmp/agentic_generative_ui.db"),
+    tools=[create_plan, update_plan_step],
+    instructions="""\
+You are a helpful assistant that creates and manages plans.
+
+When asked to do something, you MUST call create_plan to create a plan with steps.
+Do not offer to call the function. Simply make the plan, even for unrealistic tasks.
+
+After creating a plan, use update_plan_step to mark steps as completed one by one.
+Always mark all steps as completed after creating the plan.
+
+After calling the functions, give a very brief one-sentence summary with some emojis.
+Say you actually did the steps, not merely generated them.\
+""",
+    markdown=True,
+)

--- a/cookbook/05_agent_os/interfaces/agui/showcase.py
+++ b/cookbook/05_agent_os/interfaces/agui/showcase.py
@@ -10,6 +10,7 @@ Imports agents from individual files and mounts them at Dojo-compatible paths.
 
 from agent_with_media import media_agent
 from agentic_chat import agentic_chat_agent
+from agentic_generative_ui import agentic_generative_ui_agent
 from agno.os import AgentOS
 from agno.os.interfaces.agui import AGUI
 from backend_feedback import backend_feedback_agent
@@ -20,10 +21,12 @@ from shared_state import shared_state_agent
 from tool_based_generative_ui import generative_ui_agent
 from tool_confirmation import tool_confirmation_agent
 from user_input import user_input_agent
+from workflow_progress import stock_research_workflow
 
 agent_os = AgentOS(
     agents=[
         agentic_chat_agent,
+        agentic_generative_ui_agent,
         backend_tool_agent,
         hitl_agent,
         generative_ui_agent,
@@ -34,8 +37,10 @@ agent_os = AgentOS(
         user_input_agent,
         backend_feedback_agent,
     ],
+    workflows=[stock_research_workflow],
     interfaces=[
         AGUI(agent=agentic_chat_agent, prefix="/agentic_chat"),
+        AGUI(agent=agentic_generative_ui_agent, prefix="/agentic_generative_ui"),
         AGUI(agent=backend_tool_agent, prefix="/backend_tool_rendering"),
         AGUI(agent=hitl_agent, prefix="/human_in_the_loop"),
         AGUI(agent=generative_ui_agent, prefix="/tool_based_generative_ui"),
@@ -45,6 +50,7 @@ agent_os = AgentOS(
         AGUI(agent=tool_confirmation_agent, prefix="/tool_confirmation"),
         AGUI(agent=user_input_agent, prefix="/user_input"),
         AGUI(agent=backend_feedback_agent, prefix="/backend_feedback"),
+        AGUI(workflow=stock_research_workflow, prefix="/workflow"),
     ],
 )
 app = agent_os.get_app()
@@ -62,4 +68,6 @@ if __name__ == "__main__":
     print("  /tool_confirmation — Email/delete with confirmation")
     print("  /user_input — Text/secret input collection")
     print("  /backend_feedback — Multiple choice selection")
+    print("  /workflow — Workflow progress streaming")
+    print("  /agentic_generative_ui — Plan creation with step progress")
     agent_os.serve(app="showcase:app", reload=True, port=9001)

--- a/cookbook/05_agent_os/interfaces/agui/workflow_progress.py
+++ b/cookbook/05_agent_os/interfaces/agui/workflow_progress.py
@@ -1,0 +1,114 @@
+"""
+AG-UI Workflow Progress Demo
+============================
+Demonstrates workflow step streaming via STATE_DELTA + STEP_STARTED/STEP_FINISHED events.
+
+The frontend receives:
+1. STATE_DELTA events with workflow_progress updates (JSON patch)
+2. STEP_STARTED/STEP_FINISHED events for native step tracking
+3. RAW events with full workflow event details (metrics, executor info)
+
+Run: .venvs/demo/bin/python cookbook/05_agent_os/interfaces/agui/workflow_progress.py
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.interfaces.agui import AGUI
+from agno.tools.yfinance import YFinanceTools
+from agno.workflow import Step, Workflow
+
+# ---------------------------------------------------------------------------
+# Step 1: Data Gatherer
+# ---------------------------------------------------------------------------
+data_agent = Agent(
+    name="Data Gatherer",
+    model=OpenAIResponses(id="gpt-5.5"),
+    tools=[YFinanceTools(all=True)],
+    instructions="""\
+You are a data gathering agent. Fetch market data for the requested stock:
+- Current price and daily change
+- Market cap and volume
+- Key ratios (P/E, EPS)
+
+Present the raw data clearly. Don't analyze, just gather.\
+""",
+)
+
+data_step = Step(
+    name="Data Gathering",
+    agent=data_agent,
+    description="Fetch market data for the stock",
+)
+
+# ---------------------------------------------------------------------------
+# Step 2: Analyst
+# ---------------------------------------------------------------------------
+analyst_agent = Agent(
+    name="Analyst",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions="""\
+You are a financial analyst. Interpret the market data:
+- Is the P/E high or low for this sector?
+- Identify strengths and weaknesses
+- Note any red flags or positive signals
+
+Be objective and data-driven.\
+""",
+)
+
+analysis_step = Step(
+    name="Analysis",
+    agent=analyst_agent,
+    description="Analyze market data and identify insights",
+)
+
+# ---------------------------------------------------------------------------
+# Step 3: Report Writer
+# ---------------------------------------------------------------------------
+report_agent = Agent(
+    name="Report Writer",
+    model=OpenAIResponses(id="gpt-5.5"),
+    instructions="""\
+You are a report writer. Create a concise investment brief:
+- One-line summary
+- Recommendation (Buy/Hold/Sell) with rationale
+- Max 150 words
+- End with key metrics table
+
+Write for a busy investor.\
+""",
+    markdown=True,
+)
+
+report_step = Step(
+    name="Report Writing",
+    agent=report_agent,
+    description="Produce investment brief",
+)
+
+# ---------------------------------------------------------------------------
+# Workflow
+# ---------------------------------------------------------------------------
+stock_research_workflow = Workflow(
+    name="Stock Research",
+    description="Three-step research pipeline: Data -> Analysis -> Report",
+    steps=[data_step, analysis_step, report_step],
+)
+
+# ---------------------------------------------------------------------------
+# AgentOS with AGUI interface
+# ---------------------------------------------------------------------------
+agent_os = AgentOS(
+    workflows=[stock_research_workflow],
+    interfaces=[
+        AGUI(workflow=stock_research_workflow, prefix="/workflow"),
+    ],
+)
+
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    print("Workflow Progress Demo")
+    print("Endpoint: POST /workflow/agui")
+    agent_os.serve(app="workflow_progress:app", reload=True, port=8765)

--- a/libs/agno/agno/os/interfaces/agui/agui.py
+++ b/libs/agno/agno/os/interfaces/agui/agui.py
@@ -1,4 +1,4 @@
-"""Main class for the AG-UI app, used to expose an Agno Agent or Team in an AG-UI compatible format."""
+"""Main class for the AG-UI app, used to expose an Agno Agent, Team, or Workflow in an AG-UI compatible format."""
 
 from typing import List, Optional, Union
 
@@ -10,6 +10,7 @@ from agno.os.interfaces.agui.router import attach_routes
 from agno.os.interfaces.base import BaseInterface
 from agno.team import Team
 from agno.team.remote import RemoteTeam
+from agno.workflow import RemoteWorkflow, Workflow
 
 
 class AGUI(BaseInterface):
@@ -21,6 +22,7 @@ class AGUI(BaseInterface):
         self,
         agent: Optional[Union[Agent, RemoteAgent]] = None,
         team: Optional[Union[Team, RemoteTeam]] = None,
+        workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
         prefix: str = "",
         tags: Optional[List[str]] = None,
     ):
@@ -30,25 +32,31 @@ class AGUI(BaseInterface):
         Args:
             agent: The agent to expose via AG-UI
             team: The team to expose via AG-UI
+            workflow: The workflow to expose via AG-UI
             prefix: Custom prefix for the router (e.g., "/agui/v1", "/chat/public")
             tags: Custom tags for the router (e.g., ["AGUI", "Chat"], defaults to ["AGUI"])
         """
         self.agent = agent
         self.team = team
+        self.workflow = workflow
         self.prefix = prefix
         self.tags = tags or ["AGUI"]
 
-        if not (self.agent or self.team):
-            raise ValueError("AGUI requires an agent or a team")
+        if not (self.agent or self.team or self.workflow):
+            raise ValueError("AGUI requires an agent, team, or workflow")
 
     def get_router(self) -> APIRouter:
         self.router = APIRouter(prefix=self.prefix, tags=self.tags)  # type: ignore
 
-        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team)
+        self.router = attach_routes(router=self.router, agent=self.agent, team=self.team, workflow=self.workflow)
 
         return self.router
 
     def get_scope_mappings(self) -> dict:
-        # Agent-wins precedence must match router dispatch (entity = agent or team)
-        family = "agents" if self.agent is not None else "teams"
+        if self.agent is not None:
+            family = "agents"
+        elif self.team is not None:
+            family = "teams"
+        else:
+            family = "workflows"
         return {f"POST {self.prefix}/agui": [f"{family}:run"]}

--- a/libs/agno/agno/os/interfaces/agui/handlers.py
+++ b/libs/agno/agno/os/interfaces/agui/handlers.py
@@ -1,3 +1,4 @@
+import ast
 import copy
 import json
 import uuid
@@ -16,6 +17,8 @@ from ag_ui.core import (
     RunFinishedEvent,
     StateDeltaEvent,
     StateSnapshotEvent,
+    StepFinishedEvent,
+    StepStartedEvent,
     TextMessageContentEvent,
     TextMessageEndEvent,
     TextMessageStartEvent,
@@ -35,6 +38,7 @@ from agno.run.base import BaseRunOutputEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
 from agno.run.team import TeamRunEvent
+from agno.run.workflow import WorkflowRunEvent
 from agno.utils.message import get_text_from_message
 
 EventHandler = Callable[[BaseRunOutputEvent, StreamState], List[BaseEvent]]
@@ -181,6 +185,66 @@ def on_tool_call_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[
     return events
 
 
+def _parse_state_event_result(result: Any) -> Optional[Dict[str, Any]]:
+    """Parse tool result into a state event dict if applicable. Returns parsed dict or None."""
+    # Handle dict directly
+    if isinstance(result, dict):
+        if result.get("type") in ("STATE_SNAPSHOT", "STATE_DELTA"):
+            return result
+        return None
+
+    # Handle string that may be JSON or Python repr
+    if isinstance(result, str):
+        # Try JSON first
+        try:
+            parsed = json.loads(result)
+            if isinstance(parsed, dict) and parsed.get("type") in ("STATE_SNAPSHOT", "STATE_DELTA"):
+                return parsed
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        # Try Python literal (for repr-style strings with single quotes)
+        try:
+            parsed = ast.literal_eval(result)
+            if isinstance(parsed, dict) and parsed.get("type") in ("STATE_SNAPSHOT", "STATE_DELTA"):
+                return parsed
+        except (ValueError, SyntaxError):
+            pass
+
+    return None
+
+
+def _apply_json_patch(state: Dict[str, Any], ops: List[Dict[str, Any]]) -> None:
+    """Apply JSON patch operations to state in-place."""
+    try:
+        import jsonpatch
+
+        patch = jsonpatch.JsonPatch(ops)
+        patch.apply(state, in_place=True)
+    except Exception:
+        pass
+
+
+def _emit_state_event_from_tool_result(result: Dict[str, Any], state: StreamState) -> List[BaseEvent]:
+    """Convert a tool result state event dict to AG-UI events."""
+    event_type = result["type"]
+    if event_type == "STATE_SNAPSHOT":
+        snapshot = result.get("snapshot", {})
+        if state.run_state is None:
+            state.run_state = {}
+        state.run_state.update(snapshot)
+        state.set_state_snapshot(state.run_state)
+        return [StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=snapshot)]
+    elif event_type == "STATE_DELTA":
+        delta = result.get("delta", [])
+        # Apply delta to internal state so final snapshot is correct
+        if state.run_state is not None and delta:
+            _apply_json_patch(state.run_state, delta)
+            state.set_state_snapshot(state.run_state)
+        return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=delta)]
+    return []
+
+
 def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
     events: List[BaseEvent] = []
     tool = getattr(chunk, "tool", None)
@@ -194,17 +258,22 @@ def on_tool_call_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
     state.end_tool_call(tool.tool_call_id)
 
     if tool.result is not None:
-        content = to_json_str(tool.result)
-        events.append(
-            ToolCallResultEvent(
-                type=EventType.TOOL_CALL_RESULT,
-                tool_call_id=tool.tool_call_id,
-                content=content,
-                role="tool",
-                # Use tool_call_id as message_id so frontend can link result to the tool call
-                message_id=tool.tool_call_id,
+        # Check if tool returns a state event (for agentic_generative_ui pattern)
+        parsed_state_event = _parse_state_event_result(tool.result)
+        if parsed_state_event:
+            events.extend(_emit_state_event_from_tool_result(parsed_state_event, state))
+        else:
+            content = to_json_str(tool.result)
+            events.append(
+                ToolCallResultEvent(
+                    type=EventType.TOOL_CALL_RESULT,
+                    tool_call_id=tool.tool_call_id,
+                    content=content,
+                    role="tool",
+                    # Use tool_call_id as message_id so frontend can link result to the tool call
+                    message_id=tool.tool_call_id,
+                )
             )
-        )
 
     events.extend(_emit_state_delta(state))
     return events
@@ -290,6 +359,67 @@ def on_reasoning_completed(chunk: BaseRunOutputEvent, state: StreamState) -> Lis
         state.end_reasoning()
 
     return events
+
+
+# =============================================================================
+# Workflow Progress Handlers
+# =============================================================================
+
+
+def _init_workflow_progress(state: StreamState) -> Dict[str, Any]:
+    """Initialize workflow_progress in run_state if not present."""
+    if state.run_state is None:
+        state.run_state = {}
+    if "workflow_progress" not in state.run_state:
+        state.run_state["workflow_progress"] = {"status": "running", "steps": []}
+    return state.run_state["workflow_progress"]
+
+
+def _find_step(steps: List[Dict[str, Any]], step_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Find step by id."""
+    if step_id is None:
+        return None
+    for step in steps:
+        if step.get("id") == step_id:
+            return step
+    return None
+
+
+def on_workflow_step_started(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    progress = _init_workflow_progress(state)
+    step_id = getattr(chunk, "step_id", None)
+    step_name = getattr(chunk, "step_name", None) or "Step"
+
+    progress["steps"].append({"id": step_id, "name": step_name, "status": "running"})
+
+    events = _emit_state_delta(state)
+    events.append(StepStartedEvent(type=EventType.STEP_STARTED, step_name=step_name))
+    return events
+
+
+def on_workflow_step_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    progress = _init_workflow_progress(state)
+    step_id = getattr(chunk, "step_id", None)
+    step_name = getattr(chunk, "step_name", None) or "Step"
+
+    step = _find_step(progress["steps"], step_id)
+    if step:
+        step["status"] = "completed"
+
+    events = _emit_state_delta(state)
+    events.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name=step_name))
+    return events
+
+
+def on_workflow_step_error(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
+    progress = _init_workflow_progress(state)
+    step_id = getattr(chunk, "step_id", None)
+
+    step = _find_step(progress["steps"], step_id)
+    if step:
+        step["status"] = "error"
+
+    return _emit_state_delta(state)
 
 
 def on_custom_event(chunk: BaseRunOutputEvent, state: StreamState) -> List[BaseEvent]:
@@ -400,6 +530,17 @@ def on_run_completed(chunk: BaseRunOutputEvent, state: StreamState) -> List[Base
 
             events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tool.tool_call_id))
 
+    # Handle workflow terminal status
+    event_type = getattr(chunk, "event", None)
+    if event_type == WorkflowRunEvent.workflow_completed:
+        progress = _init_workflow_progress(state)
+        progress["status"] = "completed"
+        events.extend(_emit_state_delta(state))
+    elif event_type == WorkflowRunEvent.workflow_error:
+        progress = _init_workflow_progress(state)
+        progress["status"] = "error"
+        events.extend(_emit_state_delta(state))
+
     # Emit final state snapshot
     if state.run_state is not None:
         authoritative_state = getattr(chunk, "session_state", None)
@@ -417,6 +558,7 @@ def _normalize_event(event: str) -> str:
 
 # Maps normalized event names to handler functions
 HANDLERS: Dict[str, EventHandler] = {
+    # Agent/Team events
     RunEvent.run_content.value: on_run_content,
     RunEvent.tool_call_started.value: on_tool_call_started,
     RunEvent.tool_call_completed.value: on_tool_call_completed,
@@ -425,6 +567,10 @@ HANDLERS: Dict[str, EventHandler] = {
     RunEvent.reasoning_step.value: on_reasoning_step,
     RunEvent.reasoning_completed.value: on_reasoning_completed,
     RunEvent.custom_event.value: on_custom_event,
+    # Workflow step events
+    WorkflowRunEvent.step_started.value: on_workflow_step_started,
+    WorkflowRunEvent.step_completed.value: on_workflow_step_completed,
+    WorkflowRunEvent.step_error.value: on_workflow_step_error,
 }
 
 # Terminal events that trigger completion handling
@@ -434,6 +580,8 @@ _COMPLETION_EVENTS = frozenset(
         RunEvent.run_paused.value,
         TeamRunEvent.run_completed.value,
         TeamRunEvent.run_paused.value,
+        WorkflowRunEvent.workflow_completed.value,
+        WorkflowRunEvent.workflow_error.value,
     }
 )
 

--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -35,14 +35,15 @@ from agno.os.middleware.user_scope import resolve_run_user_id
 from agno.run.base import RunContext
 from agno.team.remote import RemoteTeam
 from agno.team.team import Team
+from agno.workflow import RemoteWorkflow, Workflow
 
 
 async def run_entity(
-    entity: Union[Agent, RemoteAgent, Team, RemoteTeam],
+    entity: Union[Agent, RemoteAgent, Team, RemoteTeam, Workflow, RemoteWorkflow],
     run_input: RunAgentInput,
     user_id: Optional[str] = None,
 ) -> AsyncIterator[BaseEvent]:
-    """Shared handler for running an Agent or Team with AG-UI input/output mapping.
+    """Shared handler for running an Agent, Team, or Workflow with AG-UI input/output mapping.
 
     ``user_id`` is the server-resolved identity (see the route handler). It is
     deliberately NOT read from ``run_input.forwarded_props`` here: an authenticated
@@ -85,14 +86,25 @@ async def run_entity(
             run_kwargs["add_dependencies_to_context"] = True
 
         # 4. Determine if this is a resume (trailing ToolMessages) or fresh run
-        if tool_messages:
+        if tool_messages and not isinstance(entity, Workflow):
             # Resume: frontend executed external tools and sent results back
+            # Note: Workflow resume is not yet supported via AG-UI
             response_stream = await resume_paused_run(
                 entity=entity,  # type: ignore[arg-type]
                 session_id=run_input.thread_id,
                 tool_messages=tool_messages,
                 run_context=run_context,
                 run_kwargs=run_kwargs,
+            )
+        elif isinstance(entity, (Workflow, RemoteWorkflow)):
+            # Workflow run
+            response_stream = entity.arun(
+                input=user_input,
+                stream=True,
+                stream_events=True,
+                session_id=run_input.thread_id,
+                user_id=user_id,
+                run_id=run_id,
             )
         else:
             # Fresh run: new user input
@@ -125,12 +137,15 @@ async def run_entity(
 
 
 def attach_routes(
-    router: APIRouter, agent: Optional[Union[Agent, RemoteAgent]] = None, team: Optional[Union[Team, RemoteTeam]] = None
+    router: APIRouter,
+    agent: Optional[Union[Agent, RemoteAgent]] = None,
+    team: Optional[Union[Team, RemoteTeam]] = None,
+    workflow: Optional[Union[Workflow, RemoteWorkflow]] = None,
 ) -> APIRouter:
-    if agent is None and team is None:
-        raise ValueError("Either agent or team must be provided.")
+    if agent is None and team is None and workflow is None:
+        raise ValueError("Either agent, team, or workflow must be provided.")
 
-    entity = agent or team
+    entity = agent or team or workflow
     encoder = EventEncoder()
 
     @router.post("/agui", name="run_agent")

--- a/libs/agno/agno/os/interfaces/agui/stream.py
+++ b/libs/agno/agno/os/interfaces/agui/stream.py
@@ -7,10 +7,11 @@ from agno.os.interfaces.agui.handlers import is_completion_event, process_comple
 from agno.os.interfaces.agui.state import StreamState
 from agno.run.agent import RunCompletedEvent, RunOutputEvent
 from agno.run.team import TeamRunOutputEvent
+from agno.run.workflow import WorkflowRunOutputEvent
 
 
 def stream_agno_response_as_agui_events(
-    response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRunOutputEvent]],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,
@@ -37,7 +38,7 @@ def stream_agno_response_as_agui_events(
 
 
 async def async_stream_agno_response_as_agui_events(
-    response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRunOutputEvent]],
     thread_id: str,
     run_id: str,
     run_state: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
## Summary
- Add STATE_SNAPSHOT/STATE_DELTA event support for real-time workflow progress tracking
- Support JSON patch (RFC 6902) operations to incrementally update session state
- Enable Workflow/RemoteWorkflow entities in AGUI router alongside agents
- Parse tool result strings back to dicts (handles Agno's `str()` serialization)
- Add two cookbook demos: `workflow_progress` (3-step stock research) and `agentic_generative_ui` (create_plan/update_plan_step tools)

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] Tests: Manually tested on Dojo UI with real-time step indicators
- [x] Both sync and async variants considered (uses existing async patterns)
- [x] Formatted with `./scripts/format.sh`
- [x] Validated with `./scripts/validate.sh`

## How it works

**Tool returns state events:**
```python
@tool
def create_plan(steps: list[str]) -> dict:
    return {"type": "STATE_SNAPSHOT", "snapshot": {"steps": [...]}}

@tool  
def update_plan_step(index: int, status: str) -> dict:
    return {"type": "STATE_DELTA", "delta": [
        {"op": "replace", "path": f"/steps/{index}/status", "value": status}
    ]}
```

**Handler detects and emits:**
- `_parse_state_event_result()` converts stringified tool results back to dicts
- `_emit_state_event_from_tool_result()` emits STATE_SNAPSHOT or STATE_DELTA events
- `_apply_json_patch()` applies deltas to internal state for accurate final snapshots

## Screenshots
Tested on Dojo with:
- **workflow** endpoint: 3-step progress (Data Gathering → Analysis → Report Writing)
- **agentic_generative_ui** endpoint: TaskProgress UI with 5/5 steps completing in real-time