### PR TITLE
fix: avoid redundant session context model calls

### DIFF
--- a/libs/agno/agno/learn/stores/session_context.py
+++ b/libs/agno/agno/learn/stores/session_context.py
@@ -872,6 +872,9 @@ class SessionContextStore(LearningStore):
 
                 func = Function.from_callable(tool, strict=True)
                 func.strict = True
+                # The save result is not consumed, so avoid a second model call for confirmation.
+                if func.name == "save_session_context":
+                    func.stop_after_tool_call = True
                 functions.append(func)
                 log_debug(f"Added function {func.name}")
             except Exception as e:

--- a/libs/agno/tests/unit/learn/test_session_context_store.py
+++ b/libs/agno/tests/unit/learn/test_session_context_store.py
@@ -1,0 +1,122 @@
+import json
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.learn.config import SessionContextConfig
+from agno.learn.stores.session_context import SessionContextStore
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+
+
+class RecordingLearningDb:
+    def __init__(self) -> None:
+        self.write_count = 0
+
+    def get_learning(self, **_: Any) -> None:
+        return None
+
+    def upsert_learning(self, **_: Any) -> None:
+        self.write_count += 1
+
+
+class SingleSaveToolModel(Model):
+    def __init__(self, provider_calls: list[int], planning: bool) -> None:
+        super().__init__(id="session-context-test", name="session-context-test", provider="test")
+        self.provider_calls = provider_calls
+        self.planning = planning
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "SingleSaveToolModel":
+        return type(self)(provider_calls=self.provider_calls, planning=self.planning)
+
+    def _response_for_call(self) -> ModelResponse:
+        call_number = len(self.provider_calls) + 1
+        self.provider_calls.append(call_number)
+
+        if call_number == 1:
+            arguments: dict[str, Any] = {"summary": "The user is testing session context extraction."}
+            if self.planning:
+                arguments.update(
+                    goal="Verify session context extraction",
+                    plan=["Save the session context"],
+                    progress=[],
+                )
+
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "save-session-context",
+                        "type": "function",
+                        "function": {
+                            "name": "save_session_context",
+                            "arguments": json.dumps(arguments),
+                        },
+                    }
+                ],
+            )
+
+        return ModelResponse(role="assistant", content="Session context saved.")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response_for_call()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response_for_call()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._response_for_call()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._response_for_call()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def build_store(planning: bool) -> tuple[SessionContextStore, RecordingLearningDb, list[int]]:
+    provider_calls: list[int] = []
+    db = RecordingLearningDb()
+    store = SessionContextStore(
+        config=SessionContextConfig(
+            db=db,  # type: ignore[arg-type]
+            model=SingleSaveToolModel(provider_calls=provider_calls, planning=planning),
+            enable_planning=planning,
+        )
+    )
+    return store, db, provider_calls
+
+
+@pytest.mark.parametrize("planning", [False, True])
+def test_extract_and_save_stops_after_save_tool(planning: bool) -> None:
+    store, db, provider_calls = build_store(planning=planning)
+
+    result = store.extract_and_save(
+        messages=[Message(role="user", content="Remember the current task")],
+        session_id="session-1",
+    )
+
+    assert provider_calls == [1]
+    assert db.write_count == 1
+    assert store.context_updated is True
+    assert result == "Context updated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("planning", [False, True])
+async def test_aextract_and_save_stops_after_save_tool(planning: bool) -> None:
+    store, db, provider_calls = build_store(planning=planning)
+
+    result = await store.aextract_and_save(
+        messages=[Message(role="user", content="Remember the current task")],
+        session_id="session-1",
+    )
+
+    assert provider_calls == [1]
+    assert db.write_count == 1
+    assert store.context_updated is True
+    assert result == "Context updated"


### PR DESCRIPTION
## Summary

Fixes #8853.

Session-context extraction currently makes a second provider call after
`save_session_context`. That call only confirms the tool result, and its
content is not used by the learning pipeline.

This change marks only the generated `save_session_context` function with
Agno's existing `stop_after_tool_call` flag. It therefore:

- stops the model loop after the save tool executes;
- leaves `save`/`asave` and database error-handling semantics unchanged;
- applies consistently to sync and async extraction in summary and planning
  modes.

The implementation does not try to infer write success because database
adapters own that error handling and may return normally after a failed write.
After feedback on the earlier implementation, the branch was reduced to this
narrower existing mechanism, matching the direction demonstrated in #8908.

## Performance

The focused evaluator exercises the real sync and async model tool loops in
both summary-only and planning modes.

| Path | Before | After | Change |
| --- | ---: | ---: | ---: |
| Session-context extraction | 2 provider calls | 1 provider call | -50% |

In the trace from #8853, the discarded confirmation call used 775 input and 66
output tokens. The provider-call metric is deterministic and independent of
hardware timing.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [ ] Documentation updated (not applicable; no public API change)
- [ ] Examples and guides included or updated (not applicable)
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests for #8853
- [x] A similar PR exists: #8908 was auto-closed as a duplicate and its narrow
  `stop_after_tool_call` direction is incorporated here
- [ ] This PR was entirely generated by an AI tool

## Validation

- `uvx ruff check --fix libs/agno/agno/learn/stores/session_context.py libs/agno/tests/unit/learn/test_session_context_store.py`
- `./scripts/validate.sh` (Ruff, mypy, agnoctl, and cookbook checks)
- focused SessionContext regression suite: 4 passed
- learning, function-call, and model-helper unit suites: 117 passed
- `git diff --check`
