### PR TITLE
fix: stop redundant SessionContext extraction call

### DIFF
--- a/libs/agno/agno/learn/stores/session_context.py
+++ b/libs/agno/agno/learn/stores/session_context.py
@@ -872,6 +872,9 @@ class SessionContextStore(LearningStore):
 
                 func = Function.from_callable(tool, strict=True)
                 func.strict = True
+                # The save result is not consumed, so avoid a second model call for confirmation.
+                if func.name == "save_session_context":
+                    func.stop_after_tool_call = True
                 functions.append(func)
                 log_debug(f"Added function {func.name}")
             except Exception as e:

--- a/libs/agno/tests/unit/learn/test_session_context_store.py
+++ b/libs/agno/tests/unit/learn/test_session_context_store.py
@@ -1,0 +1,147 @@
+import json
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from agno.learn.config import SessionContextConfig
+from agno.learn.stores.session_context import SessionContextStore
+from agno.models.base import Model
+from agno.models.message import Message
+from agno.models.response import ModelResponse
+
+
+class RecordingLearningDb:
+    def __init__(self) -> None:
+        self.write_count = 0
+
+    def get_learning(self, **_: Any) -> None:
+        return None
+
+    def upsert_learning(self, **_: Any) -> None:
+        self.write_count += 1
+
+
+class SingleSaveToolModel(Model):
+    def __init__(self, provider_calls: list[int], planning: bool) -> None:
+        super().__init__(id="session-context-test", name="session-context-test", provider="test")
+        self.provider_calls = provider_calls
+        self.planning = planning
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> "SingleSaveToolModel":
+        return type(self)(provider_calls=self.provider_calls, planning=self.planning)
+
+    def _response_for_call(self) -> ModelResponse:
+        call_number = len(self.provider_calls) + 1
+        self.provider_calls.append(call_number)
+
+        if call_number == 1:
+            arguments: dict[str, Any] = {"summary": "The user is testing session context extraction."}
+            if self.planning:
+                arguments.update(
+                    goal="Verify session context extraction",
+                    plan=["Save the session context"],
+                    progress=[],
+                )
+
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "save-session-context",
+                        "type": "function",
+                        "function": {
+                            "name": "save_session_context",
+                            "arguments": json.dumps(arguments),
+                        },
+                    }
+                ],
+            )
+
+        return ModelResponse(role="assistant", content="Session context saved.")
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response_for_call()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._response_for_call()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[ModelResponse]:
+        yield self._response_for_call()
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[ModelResponse]:
+        yield self._response_for_call()
+
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
+def build_store(planning: bool) -> tuple[SessionContextStore, RecordingLearningDb, list[int]]:
+    provider_calls: list[int] = []
+    db = RecordingLearningDb()
+    store = SessionContextStore(
+        config=SessionContextConfig(
+            db=db,  # type: ignore[arg-type]
+            model=SingleSaveToolModel(provider_calls=provider_calls, planning=planning),
+            enable_planning=planning,
+        )
+    )
+    return store, db, provider_calls
+
+
+@pytest.mark.parametrize("planning", [False, True])
+def test_extract_and_save_stops_after_save_tool(planning: bool) -> None:
+    store, db, provider_calls = build_store(planning=planning)
+
+    result = store.extract_and_save(
+        messages=[Message(role="user", content="Remember the current task")],
+        session_id="session-1",
+    )
+
+    assert provider_calls == [1]
+    assert db.write_count == 1
+    assert store.context_updated is True
+    assert result == "Context updated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("planning", [False, True])
+async def test_aextract_and_save_stops_after_save_tool(planning: bool) -> None:
+    store, db, provider_calls = build_store(planning=planning)
+
+    result = await store.aextract_and_save(
+        messages=[Message(role="user", content="Remember the current task")],
+        session_id="session-1",
+    )
+
+    assert provider_calls == [1]
+    assert db.write_count == 1
+    assert store.context_updated is True
+    assert result == "Context updated"
+
+
+@pytest.mark.parametrize("planning", [False, True])
+def test_save_session_context_function_is_terminal(planning: bool) -> None:
+    store, _, _ = build_store(planning=planning)
+    tools = store._get_extraction_tools(session_id="session-1")
+
+    functions = store._build_functions_for_model(tools=tools)
+
+    assert len(functions) == 1
+    assert functions[0].name == "save_session_context"
+    assert functions[0].stop_after_tool_call is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("planning", [False, True])
+async def test_async_save_session_context_function_is_terminal(planning: bool) -> None:
+    store, _, _ = build_store(planning=planning)
+    tools = await store._aget_extraction_tools(session_id="session-1")
+
+    functions = store._build_functions_for_model(tools=tools)
+
+    assert len(functions) == 1
+    assert functions[0].name == "save_session_context"
+    assert functions[0].stop_after_tool_call is True


### PR DESCRIPTION
## Summary

- Mark the internal `save_session_context` extraction function as terminal with the existing `stop_after_tool_call` mechanism.
- Stop the model loop immediately after the save tool runs, removing the discarded confirmation invocation.
- Add regression coverage for the real sync and async model loops in both summary-only and planning modes.

Fixes #8853.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (not applicable; no public API change)
- [x] Examples and guides included or updated (not applicable; regression fix with unit coverage)
- [x] Tested in a clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I searched existing open pull requests and confirmed that #8907 also addresses #8853.
- [x] A similar PR exists; the implementation difference is explained below.
- [x] This PR was created with Codex assistance.

## Why a separate implementation from #8907

PR #8907 makes termination conditional on inferred persistence success and adds status-returning save helpers plus per-call post-hook mutation. The current `BaseDb.upsert_learning()` contract returns `None`, and primary adapters such as SQLite and PostgreSQL catch write exceptions internally, so callers cannot reliably infer persistence success without a broader database-contract change.

This PR stays within #8853 scope and uses the model layer native terminal-tool behavior directly. It does not change `save()`/`asave()`, database persistence semantics, subclass behavior, or `context_updated` handling.

## Validation

- Negative control: all 8 new tests fail without the fix; the sync and async model-loop cases record two provider calls (`[1, 2]`).
- `8 passed` in the focused SessionContext regression suite.
- `140 passed` across learning, function-call, and model-helper tests.
- Explicit Ruff and mypy checks pass for both changed files, including the new test file.
- `./scripts/format.sh` passes.
- `./scripts/validate.sh` passes.
- Fresh Python 3.12 environment: focused tests and full validation pass after installing the declared development dependencies from scratch.

## Additional Notes

A complete `libs/agno/tests/unit` collection was also attempted. It stops during collection because the development dependency set intentionally omits the provider-SDK bundle from `scripts/test_setup.sh` (90 missing optional packages across unrelated providers, tools, readers, and vector databases). No failure was related to this change.